### PR TITLE
Fix GCP submitter watchdog budget

### DIFF
--- a/.github/workflows/buildbuddy.yml
+++ b/.github/workflows/buildbuddy.yml
@@ -266,7 +266,7 @@ jobs:
       BUILDBUDDY_GRPC_URL: ${{ needs.gcp-control-plane-up.outputs.grpc_url }}
       BUILDBUDDY_HTTP_URL: ${{ needs.gcp-control-plane-up.outputs.http_url }}
       BUILDBUDDY_ENDPOINT: ${{ needs.gcp-control-plane-up.outputs.grpc_url }}
-      CI_STARTED_AT_EPOCH: ${{ inputs.ci_started_at_epoch || needs.gcp-control-plane-up.outputs.started_at_epoch }}
+      CI_STARTED_AT_EPOCH: ${{ needs.gcp-control-plane-up.outputs.started_at_epoch }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -302,7 +302,7 @@ jobs:
       BUILDBUDDY_GRPC_URL: ${{ needs.gcp-control-plane-up.outputs.grpc_url }}
       BUILDBUDDY_HTTP_URL: ${{ needs.gcp-control-plane-up.outputs.http_url }}
       BUILDBUDDY_ENDPOINT: ${{ needs.gcp-control-plane-up.outputs.grpc_url }}
-      CI_STARTED_AT_EPOCH: ${{ inputs.ci_started_at_epoch || needs.gcp-control-plane-up.outputs.started_at_epoch }}
+      CI_STARTED_AT_EPOCH: ${{ needs.gcp-control-plane-up.outputs.started_at_epoch }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -375,7 +375,7 @@ jobs:
       BUILDBUDDY_GRPC_URL: ${{ needs.gcp-control-plane-up.outputs.grpc_url }}
       BUILDBUDDY_HTTP_URL: ${{ needs.gcp-control-plane-up.outputs.http_url }}
       BUILDBUDDY_ENDPOINT: ${{ needs.gcp-control-plane-up.outputs.grpc_url }}
-      CI_STARTED_AT_EPOCH: ${{ inputs.ci_started_at_epoch || needs.gcp-control-plane-up.outputs.started_at_epoch }}
+      CI_STARTED_AT_EPOCH: ${{ needs.gcp-control-plane-up.outputs.started_at_epoch }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/scripts/buildbuddy-doctor
+++ b/scripts/buildbuddy-doctor
@@ -406,7 +406,7 @@ if job_has_line .github/workflows/ci.yml select_backend 'runs-on: ubuntu-latest'
   job_has_line .github/workflows/buildbuddy.yml gcp-native-submit 'fetch-depth: 1' &&
   job_has_line .github/workflows/buildbuddy.yml gcp-native-submit 'Select GCP BuildBuddy lanes' &&
   job_has_line .github/workflows/buildbuddy.yml gcp-native-submit 'run-buildbuddy-ci-lane-batch' &&
-  job_has_line .github/workflows/buildbuddy.yml gcp-native-submit "CI_STARTED_AT_EPOCH: \${{ inputs.ci_started_at_epoch || needs.gcp-control-plane-up.outputs.started_at_epoch }}" &&
+  job_has_line .github/workflows/buildbuddy.yml gcp-native-submit "CI_STARTED_AT_EPOCH: \${{ needs.gcp-control-plane-up.outputs.started_at_epoch }}" &&
   job_has_line .github/workflows/buildbuddy.yml gcp-native-submit 'group: gcp' &&
   job_has_line .github/workflows/buildbuddy.yml gcp-native-submit 'profile: submitter' &&
   job_has_line .github/workflows/buildbuddy.yml gcp-native-submit "mode: \${{ inputs.mode || vars.MEERKAT_BUILDBUDDY_CI_MODE || 'full-fresh' }}" &&
@@ -416,18 +416,19 @@ if job_has_line .github/workflows/ci.yml select_backend 'runs-on: ubuntu-latest'
   job_has_line .github/workflows/buildbuddy.yml gcp-governance-submit 'runs-on: ubuntu-latest' &&
   job_has_line .github/workflows/buildbuddy.yml gcp-governance-submit 'timeout-minutes: 20' &&
   job_has_line .github/workflows/buildbuddy.yml gcp-governance-submit 'fetch-depth: 1' &&
-  job_has_line .github/workflows/buildbuddy.yml gcp-governance-submit "CI_STARTED_AT_EPOCH: \${{ inputs.ci_started_at_epoch || needs.gcp-control-plane-up.outputs.started_at_epoch }}" &&
+  job_has_line .github/workflows/buildbuddy.yml gcp-governance-submit "CI_STARTED_AT_EPOCH: \${{ needs.gcp-control-plane-up.outputs.started_at_epoch }}" &&
   job_has_line .github/workflows/buildbuddy.yml gcp-governance-submit 'group: gcp-governance' &&
   job_has_line .github/workflows/buildbuddy.yml gcp-governance-submit 'profile: submitter' &&
   job_has_line .github/workflows/buildbuddy.yml gcp-governance-submit "mode: \${{ inputs.mode || vars.MEERKAT_BUILDBUDDY_CI_MODE || 'full-fresh' }}" &&
   job_has_line .github/workflows/buildbuddy.yml gcp-wasm-feature-submit 'runs-on: ubuntu-latest' &&
   job_has_line .github/workflows/buildbuddy.yml gcp-wasm-feature-submit 'timeout-minutes: 20' &&
   job_has_line .github/workflows/buildbuddy.yml gcp-wasm-feature-submit 'fetch-depth: 1' &&
-  job_has_line .github/workflows/buildbuddy.yml gcp-wasm-feature-submit "CI_STARTED_AT_EPOCH: \${{ inputs.ci_started_at_epoch || needs.gcp-control-plane-up.outputs.started_at_epoch }}" &&
+  job_has_line .github/workflows/buildbuddy.yml gcp-wasm-feature-submit "CI_STARTED_AT_EPOCH: \${{ needs.gcp-control-plane-up.outputs.started_at_epoch }}" &&
   job_has_line .github/workflows/buildbuddy.yml gcp-wasm-feature-submit 'group: gcp-wasm-feature' &&
   job_has_line .github/workflows/buildbuddy.yml gcp-wasm-feature-submit 'profile: submitter' &&
   job_has_line .github/workflows/buildbuddy.yml gcp-wasm-feature-submit "mode: \${{ inputs.mode || vars.MEERKAT_BUILDBUDDY_CI_MODE || 'full-fresh' }}" &&
-  job_has_line .github/workflows/buildbuddy.yml gate 'runs-on: ubuntu-latest'; then
+  job_has_line .github/workflows/buildbuddy.yml gate 'runs-on: ubuntu-latest' &&
+  job_has_line .github/workflows/buildbuddy.yml gate "CI_STARTED_AT_EPOCH: \${{ inputs.ci_started_at_epoch || needs.gcp-control-plane-up.outputs.started_at_epoch }}"; then
   pass "GCP BuildBuddy CI uses a few GitHub-hosted submitters with Bazel lane fanout"
 else
   bad "GCP BuildBuddy CI is not using the bounded few-submitter GCP fanout shape"


### PR DESCRIPTION
## Summary
- use the self-hosted BuildBuddy control-plane timestamp for GCP lane-batch submitter watchdogs
- keep the final GCP CI duration gate on the parent CI timestamp
- update BuildBuddy doctor so the regression is checked explicitly

## Verification
- ruby -e "require 'yaml'; YAML.load_file('.github/workflows/buildbuddy.yml'); YAML.load_file('.github/workflows/ci.yml'); puts 'yaml=ok'"
- bash -n scripts/buildbuddy-doctor scripts/buildbuddy-ci-lane-batch
- git diff --check
- make buildbuddy-doctor