### PR TITLE
[codex] Tune runtime attachment republish logging

### DIFF
--- a/meerkat-runtime/src/meerkat_machine/session_management.rs
+++ b/meerkat-runtime/src/meerkat_machine/session_management.rs
@@ -317,10 +317,11 @@ impl MeerkatMachine {
         session_id: SessionId,
         executor: Box<dyn meerkat_core::lifecycle::CoreExecutor>,
     ) {
+        let mut repaired_dead_attachment = false;
         let existing = {
             let mut sessions = self.sessions.write().await;
             sessions.get_mut(&session_id).map(|entry| {
-                entry.clear_dead_attachment();
+                repaired_dead_attachment = entry.clear_dead_attachment();
                 let occupied = entry.has_attachment_or_attaching();
                 if !occupied {
                     // Claim the attachment slot so concurrent callers see
@@ -396,7 +397,7 @@ impl MeerkatMachine {
                 // the entry while we were rebuilding runtime state.
                 let mut sessions = self.sessions.write().await;
                 if let Some(entry) = sessions.get_mut(&session_id) {
-                    entry.clear_dead_attachment();
+                    repaired_dead_attachment = entry.clear_dead_attachment();
                     if entry.has_attachment_or_attaching() {
                         return;
                     }
@@ -468,10 +469,17 @@ impl MeerkatMachine {
             match machine_executor_attach_projection(&mut driver_guard) {
                 Ok(true) => {}
                 Ok(false) => {
-                    tracing::warn!(
-                        %session_id,
-                        "runtime driver remained attached without a live published loop; republishing attachment"
-                    );
+                    if repaired_dead_attachment {
+                        tracing::warn!(
+                            %session_id,
+                            "runtime driver remained attached without a live published loop; republishing attachment"
+                        );
+                    } else {
+                        tracing::debug!(
+                            %session_id,
+                            "runtime driver already attached before live loop publication; publishing attachment"
+                        );
+                    }
                 }
                 Err(error) => {
                     tracing::warn!(


### PR DESCRIPTION
## Summary

- Keep the stale attached-driver repair message at `warn` only when `ensure_session_with_executor` actually cleared a dead published attachment.
- Log the expected prepared-binding attach path at `debug` when the runtime driver is already `Attached` before the live loop handle is published.

## Why

`prepare_bindings` can legitimately move the driver projection to `Attached` before a runtime loop is published. The shell-side `RegistrationPhase` remains the live-loop truth. Treating every `Attached`-without-loop publication as a warning made normal Mob/runtime-backed startup look like a consistency repair.

## Validation

- `make fmt`
- `./scripts/repo-cargo test -p meerkat-runtime --test meerkat_machine ensure_session_with_executor_repairs_stale_attached_driver`
- `./scripts/repo-cargo test -p meerkat-runtime --test meerkat_machine ensure_session_with_executor_upgrades_racy_registration`
- `./scripts/repo-cargo test -p meerkat-runtime --test meerkat_machine executor_attached_session_is_executor_ready`
- pre-push hook: secrets, whitespace, EOF, merge/large-file checks, `cargo fmt --check`, changed-crate clippy, machine codegen/verify, generated-header audit, bridge ResponseStatus gate, workspace deterministic gate
