### PR TITLE
Fix GCP BuildBuddy CI warm cache shape

### DIFF
--- a/.github/actions/run-buildbuddy-ci-lane-batch/action.yml
+++ b/.github/actions/run-buildbuddy-ci-lane-batch/action.yml
@@ -15,6 +15,10 @@ inputs:
     description: BuildBuddy CI mode.
     required: false
     default: full-fresh
+  batch_jobs:
+    description: Maximum number of local lane submitters to run in parallel.
+    required: false
+    default: ""
 
 runs:
   using: composite
@@ -30,6 +34,7 @@ runs:
         LANES: ${{ inputs.lanes }}
         MEERKAT_BUILDBUDDY_CI_MODE: ${{ inputs.mode }}
         MEERKAT_BUILDBUDDY_LOG_ROOT: ${{ runner.temp }}/buildbuddy-logs
+        MEERKAT_BUILDBUDDY_BATCH_JOBS: ${{ inputs.batch_jobs || env.MEERKAT_BUILDBUDDY_BATCH_JOBS }}
         MEERKAT_BUILDBUDDY_OUTPUT_ROOT: ${{ env.MEERKAT_BAZEL_BACKEND == 'gcp-local' && '/home/gha/.cache/meerkat/gcp-bazel-output-roots' || '' }}
         MEERKAT_BUILDBUDDY_REPOSITORY_CACHE: ${{ env.MEERKAT_BAZEL_BACKEND == 'gcp-local' && '/home/gha/.cache/meerkat/gcp-bazel-repository-cache' || format('{0}/buildbuddy-repository-cache', runner.temp) }}
         MEERKAT_BAZEL_DISK_CACHE: ${{ env.MEERKAT_BAZEL_BACKEND == 'gcp-local' && '/home/gha/.cache/meerkat/gcp-bazel-disk-cache' || '' }}

--- a/.github/workflows/buildbuddy.yml
+++ b/.github/workflows/buildbuddy.yml
@@ -346,16 +346,6 @@ jobs:
             rmat-audit
             machine-authority
 
-      - uses: ./.github/actions/run-buildbuddy-ci-lane-batch
-        if: ${{ steps.machine-changes.outputs.changed != 'true' }}
-        with:
-          group: gcp-governance
-          profile: submitter
-          mode: ${{ inputs.mode || 'full-fresh' }}
-          lanes: |
-            seam-inventory
-            rmat-audit
-
   wasm-feature-submit:
     name: WASM and feature submitter
     needs: [control-plane-up, executors-up, prebuild-submit]
@@ -372,7 +362,42 @@ jobs:
         with:
           fetch-depth: 1
 
+      - name: Detect WASM, SDK, feature, or audit changes
+        id: wasm-feature-changes
+        shell: bash
+        env:
+          BASE_SHA: ${{ inputs.machine_authority_base_sha || '' }}
+          HEAD_SHA: ${{ inputs.machine_authority_head_sha || github.sha }}
+        run: |
+          changed=true
+          if [[ -n "${BASE_SHA}" && "${BASE_SHA}" != "0000000000000000000000000000000000000000" ]]; then
+            if ! git cat-file -e "${BASE_SHA}^{commit}" 2>/dev/null; then
+              git fetch --no-tags --depth=1 origin "${BASE_SHA}" || true
+            fi
+            changed=false
+            while IFS= read -r path; do
+              case "${path}" in
+                Cargo.toml|Cargo.lock|MODULE.bazel|MODULE.bazel.lock|.bazelrc)
+                  changed=true
+                  break
+                  ;;
+                meerkat-web-runtime/*|meerkat-cli/src/web_runtime_template/*|sdks/*|tools/sdk-builder/*|tools/sdk-codegen/*|tools/buildbuddy/*)
+                  changed=true
+                  break
+                  ;;
+                scripts/run-surface-feature-matrix)
+                  changed=true
+                  break
+                  ;;
+              esac
+            done < <(git diff --name-only "${BASE_SHA}" "${HEAD_SHA}" --)
+          else
+            echo "No reliable diff base; running WASM/SDK/feature/audit lanes."
+          fi
+          echo "changed=${changed}" >> "${GITHUB_OUTPUT}"
+
       - uses: ./.github/actions/run-buildbuddy-ci-lane-batch
+        if: ${{ steps.wasm-feature-changes.outputs.changed == 'true' }}
         with:
           group: gcp-wasm-feature
           profile: submitter
@@ -397,6 +422,11 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
       - name: Authenticate to GCP with Workload Identity
         if: ${{ vars.MEERKAT_GCP_WORKLOAD_IDENTITY_PROVIDER != '' && vars.MEERKAT_GCP_SERVICE_ACCOUNT != '' }}
         uses: google-github-actions/auth@v3
@@ -407,11 +437,6 @@ jobs:
 
       - name: Setup gcloud
         uses: google-github-actions/setup-gcloud@v3
-
-      - name: Checkout
-        uses: actions/checkout@v6
-        with:
-          fetch-depth: 1
 
       - name: Authenticate to GCP with JSON fallback
         shell: bash

--- a/.github/workflows/buildbuddy.yml
+++ b/.github/workflows/buildbuddy.yml
@@ -283,7 +283,7 @@ jobs:
 
   governance-submit:
     name: Governance submitter
-    needs: [control-plane-up, executors-up, prebuild-submit]
+    needs: [control-plane-up, executors-up]
     runs-on: ubuntu-latest
     timeout-minutes: 20
     env:
@@ -348,7 +348,7 @@ jobs:
 
   wasm-feature-submit:
     name: WASM and feature submitter
-    needs: [control-plane-up, executors-up, prebuild-submit]
+    needs: [control-plane-up, executors-up]
     runs-on: ubuntu-latest
     timeout-minutes: 20
     env:

--- a/.github/workflows/buildbuddy.yml
+++ b/.github/workflows/buildbuddy.yml
@@ -377,7 +377,7 @@ jobs:
             changed=false
             while IFS= read -r path; do
               case "${path}" in
-                Cargo.toml|Cargo.lock|MODULE.bazel|MODULE.bazel.lock|.bazelrc)
+                Cargo.toml|Cargo.lock|MODULE.bazel|.bazelrc)
                   changed=true
                   break
                   ;;

--- a/.github/workflows/buildbuddy.yml
+++ b/.github/workflows/buildbuddy.yml
@@ -279,6 +279,7 @@ jobs:
           group: gcp
           profile: submitter
           mode: ${{ inputs.mode || 'full-fresh' }}
+          batch_jobs: "4"
           lanes: ${{ steps.lanes.outputs.lanes }}
 
   governance-submit:

--- a/.github/workflows/buildbuddy.yml
+++ b/.github/workflows/buildbuddy.yml
@@ -244,6 +244,30 @@ jobs:
           lanes: |
             ci-prebuild
 
+  static-submit:
+    name: Static submitter
+    needs: [control-plane-up, executors-up]
+    runs-on: ubuntu-latest
+    timeout-minutes: 12
+    env:
+      BUILDBUDDY_GRPC_URL: ${{ needs.control-plane-up.outputs.grpc_url }}
+      BUILDBUDDY_HTTP_URL: ${{ needs.control-plane-up.outputs.http_url }}
+      BUILDBUDDY_ENDPOINT: ${{ needs.control-plane-up.outputs.grpc_url }}
+      CI_STARTED_AT_EPOCH: ${{ needs.control-plane-up.outputs.started_at_epoch }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
+      - uses: ./.github/actions/run-buildbuddy-ci-lane-batch
+        with:
+          group: gcp-static
+          profile: submitter
+          mode: ${{ inputs.mode || 'full-fresh' }}
+          lanes: |
+            fmt-static
+
   native-submit:
     name: Native submitter
     needs: [control-plane-up, executors-up, prebuild-submit]
@@ -267,7 +291,6 @@ jobs:
           {
             echo "lanes<<LANES"
             printf '%s\n' \
-              fmt-static \
               cargo-all-features-clippy \
               test-unit \
               integration-fast
@@ -417,6 +440,7 @@ jobs:
     needs:
       - executors-up
       - prebuild-submit
+      - static-submit
       - native-submit
       - governance-submit
       - wasm-feature-submit
@@ -470,6 +494,7 @@ jobs:
       - control-plane-up
       - executors-up
       - prebuild-submit
+      - static-submit
       - native-submit
       - governance-submit
       - wasm-feature-submit

--- a/.github/workflows/buildbuddy.yml
+++ b/.github/workflows/buildbuddy.yml
@@ -74,7 +74,10 @@ env:
   MEERKAT_GCP_BUILDBUDDY_MIG: ${{ vars.MEERKAT_GCP_BUILDBUDDY_MIG || 'meerkat-bb-exec' }}
   MEERKAT_GCP_BUILDBUDDY_TARGET_SIZE: ${{ vars.MEERKAT_GCP_BUILDBUDDY_TARGET_SIZE || '12' }}
   MEERKAT_GCP_BUILDBUDDY_MACHINE_TYPE: ${{ vars.MEERKAT_GCP_BUILDBUDDY_MACHINE_TYPE || 'c3d-standard-30' }}
-  MEERKAT_GCP_BUILDBUDDY_BOOT_DISK_GB: ${{ vars.MEERKAT_GCP_BUILDBUDDY_BOOT_DISK_GB || '1000' }}
+  MEERKAT_GCP_BUILDBUDDY_BOOT_DISK_GB: ${{ vars.MEERKAT_GCP_BUILDBUDDY_BOOT_DISK_GB || '100' }}
+  MEERKAT_GCP_BUILDBUDDY_CACHE_DISK_GB: ${{ vars.MEERKAT_GCP_BUILDBUDDY_CACHE_DISK_GB || '1000' }}
+  MEERKAT_GCP_BUILDBUDDY_CACHE_DISK_TYPE: ${{ vars.MEERKAT_GCP_BUILDBUDDY_CACHE_DISK_TYPE || 'pd-ssd' }}
+  MEERKAT_GCP_BUILDBUDDY_DOWN_MODE: ${{ vars.MEERKAT_GCP_BUILDBUDDY_DOWN_MODE || 'stopped' }}
   MEERKAT_GCP_BUILDBUDDY_CI_MAX_SECONDS: ${{ vars.MEERKAT_GCP_BUILDBUDDY_CI_MAX_SECONDS || '600' }}
   MEERKAT_BUILDBUDDY_EXECUTOR_POOL: ${{ vars.MEERKAT_BUILDBUDDY_EXECUTOR_POOL || 'meerkat-ci' }}
   MEERKAT_BUILDBUDDY_CI_IMAGE: ${{ vars.MEERKAT_BUILDBUDDY_CI_IMAGE || 'europe-west1-docker.pkg.dev/king-dnn-training-dev/meerkat-ci/meerkat-ci-rust:1.94.0' }}
@@ -92,7 +95,8 @@ env:
   MEERKAT_E2E_AUTH_GEMINI_MODEL: ${{ secrets.MEERKAT_E2E_AUTH_GEMINI_MODEL }}
   MEERKAT_E2E_AUTH_VERTEX_CANARY: ${{ secrets.MEERKAT_E2E_AUTH_VERTEX_CANARY }}
   MEERKAT_CLEAN_E2E_SCENARIO_TARGETS: "1"
-  MEERKAT_BUILDBUDDY_CI_JOBS: ${{ vars.MEERKAT_BUILDBUDDY_CI_JOBS || '8' }}
+  MEERKAT_BUILDBUDDY_CI_JOBS: ${{ vars.MEERKAT_BUILDBUDDY_CI_JOBS || '192' }}
+  MEERKAT_BUILDBUDDY_BATCH_JOBS: ${{ vars.MEERKAT_BUILDBUDDY_BATCH_JOBS || '1' }}
 
 jobs:
   control-plane-up:
@@ -216,9 +220,33 @@ jobs:
         shell: bash
         run: scripts/gcp-buildbuddy-executor-pool up
 
+  prebuild-submit:
+    name: Prebuild submitter
+    needs: [control-plane-up, executors-up]
+    runs-on: ubuntu-latest
+    timeout-minutes: 12
+    env:
+      BUILDBUDDY_GRPC_URL: ${{ needs.control-plane-up.outputs.grpc_url }}
+      BUILDBUDDY_HTTP_URL: ${{ needs.control-plane-up.outputs.http_url }}
+      BUILDBUDDY_ENDPOINT: ${{ needs.control-plane-up.outputs.grpc_url }}
+      CI_STARTED_AT_EPOCH: ${{ needs.control-plane-up.outputs.started_at_epoch }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
+      - uses: ./.github/actions/run-buildbuddy-ci-lane-batch
+        with:
+          group: gcp-prebuild
+          profile: submitter
+          mode: ${{ inputs.mode || 'full-fresh' }}
+          lanes: |
+            ci-prebuild
+
   native-submit:
     name: Native submitter
-    needs: [control-plane-up, executors-up]
+    needs: [control-plane-up, executors-up, prebuild-submit]
     runs-on: ubuntu-latest
     timeout-minutes: 20
     env:
@@ -255,7 +283,7 @@ jobs:
 
   governance-submit:
     name: Governance submitter
-    needs: [control-plane-up, executors-up]
+    needs: [control-plane-up, executors-up, prebuild-submit]
     runs-on: ubuntu-latest
     timeout-minutes: 20
     env:
@@ -330,7 +358,7 @@ jobs:
 
   wasm-feature-submit:
     name: WASM and feature submitter
-    needs: [control-plane-up, executors-up]
+    needs: [control-plane-up, executors-up, prebuild-submit]
     runs-on: ubuntu-latest
     timeout-minutes: 20
     env:
@@ -356,15 +384,13 @@ jobs:
             test-feature-matrix-lib
             test-feature-matrix-surface-checks
             audit
-            seam-inventory
-            rmat-audit
-            machine-authority
 
   executors-down:
     name: Executors down
     if: ${{ always() }}
     needs:
       - executors-up
+      - prebuild-submit
       - native-submit
       - governance-submit
       - wasm-feature-submit
@@ -381,6 +407,11 @@ jobs:
 
       - name: Setup gcloud
         uses: google-github-actions/setup-gcloud@v3
+
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
 
       - name: Authenticate to GCP with JSON fallback
         shell: bash
@@ -404,25 +435,7 @@ jobs:
         env:
           MEERKAT_GCP_BUILDBUDDY_WAIT_ON_DOWN: ${{ vars.MEERKAT_GCP_BUILDBUDDY_WAIT_ON_DOWN || '0' }}
           MEERKAT_GCP_BUILDBUDDY_WAIT_TIMEOUT: ${{ vars.MEERKAT_GCP_BUILDBUDDY_WAIT_TIMEOUT || '900' }}
-        run: |
-          gcloud compute instance-groups managed resize "${MEERKAT_GCP_BUILDBUDDY_MIG}" \
-            --project "${MEERKAT_GCP_PROJECT_ID}" \
-            --zone "${MEERKAT_GCP_ZONE}" \
-            --size 0 \
-            --quiet
-
-          case "${MEERKAT_GCP_BUILDBUDDY_WAIT_ON_DOWN}" in
-            0|false|False|FALSE|no|No|NO)
-              echo "Skipping wait for executor pool scale-down; target size is set to 0."
-              ;;
-            *)
-              gcloud compute instance-groups managed wait-until "${MEERKAT_GCP_BUILDBUDDY_MIG}" \
-                --project "${MEERKAT_GCP_PROJECT_ID}" \
-                --zone "${MEERKAT_GCP_ZONE}" \
-                --stable \
-                --timeout "${MEERKAT_GCP_BUILDBUDDY_WAIT_TIMEOUT}"
-              ;;
-          esac
+        run: scripts/gcp-buildbuddy-executor-pool down
 
   gate:
     name: GCP BuildBuddy gate
@@ -430,6 +443,7 @@ jobs:
     needs:
       - control-plane-up
       - executors-up
+      - prebuild-submit
       - native-submit
       - governance-submit
       - wasm-feature-submit

--- a/.github/workflows/buildbuddy.yml
+++ b/.github/workflows/buildbuddy.yml
@@ -279,7 +279,7 @@ jobs:
           group: gcp
           profile: submitter
           mode: ${{ inputs.mode || 'full-fresh' }}
-          batch_jobs: "4"
+          batch_jobs: "2"
           lanes: ${{ steps.lanes.outputs.lanes }}
 
   governance-submit:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,3 +84,37 @@ jobs:
         run: |
           echo "::error::Only lukacf can run the secret-backed GCP BuildBuddy lane."
           exit 1
+
+  gate:
+    name: CI gate
+    if: ${{ always() }}
+    needs:
+      - cargo
+      - gcp-buildbuddy
+      - unauthorized-gcp-buildbuddy
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check selected CI backend
+        shell: bash
+        env:
+          CARGO_RESULT: ${{ needs.cargo.result }}
+          GCP_BUILDBUDDY_RESULT: ${{ needs.gcp-buildbuddy.result }}
+          UNAUTHORIZED_GCP_BUILDBUDDY_RESULT: ${{ needs.unauthorized-gcp-buildbuddy.result }}
+        run: |
+          echo "GHA Cargo result: ${CARGO_RESULT}"
+          echo "GCP BuildBuddy result: ${GCP_BUILDBUDDY_RESULT}"
+          echo "GCP BuildBuddy authorization result: ${UNAUTHORIZED_GCP_BUILDBUDDY_RESULT}"
+
+          for result in "${CARGO_RESULT}" "${GCP_BUILDBUDDY_RESULT}" "${UNAUTHORIZED_GCP_BUILDBUDDY_RESULT}"; do
+            case "${result}" in
+              failure|cancelled)
+                echo "::error::A CI backend failed or was cancelled."
+                exit 1
+                ;;
+            esac
+          done
+
+          if [[ "${CARGO_RESULT}" != "success" && "${GCP_BUILDBUDDY_RESULT}" != "success" ]]; then
+            echo "::error::No CI backend completed successfully."
+            exit 1
+          fi

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -531,7 +531,7 @@
           "FILE:@@//meerkat-hooks/Cargo.toml 6da56c7c41d606a48e54f21de2c6d15e5b21f73180d0a1c757275aae14edecab",
           "FILE:@@//meerkat-memory/Cargo.toml a203ffd94d2c168d0518a064d59fa749edff5d0fe5cd1ad15f919765c932093e",
           "FILE:@@//meerkat-session/Cargo.toml 6d128d06c90144c8ccd25156b3e596c0262cb86a3323fe0b5f5277c8483fb248",
-          "FILE:@@//meerkat-mob/Cargo.toml c82dfe87b1491bf788a34f31c7330b3ddcfac99ecd36613485c846769e0f04f8",
+          "FILE:@@//meerkat-mob/Cargo.toml 3b179a4a8c42465be69057dcfb51c4e68bb7ad2451e3f42557d98d95d92c5f0f",
           "FILE:@@//meerkat-mob-mcp/Cargo.toml 7fdefc275c143d979f47f075cdc1d72a0a327ae7071331384589832457ed281a",
           "FILE:@@//meerkat-cli/Cargo.toml a494f3a4bd19348cc807a5aac0fe02949c805548c5adb01755253e64c4e385c1",
           "FILE:@@//meerkat-mob-pack/Cargo.toml d89fdc02b833d9b86e0fa262e723f5679d9c0dccbd95384b6c000bd828d86dc5",

--- a/docs/architecture/buildbuddy-bazel-poc.md
+++ b/docs/architecture/buildbuddy-bazel-poc.md
@@ -257,17 +257,19 @@ only the submitter/coordinator:
    Secret Manager for the executors, creates the executor managed instance group
    if it is missing, and scales it to
    `MEERKAT_GCP_BUILDBUDDY_TARGET_SIZE` (default `12`).
-3. `prebuild-submit` runs one remote Bazel prebuild over the shared CI
-   build graph. This is the cache-warming step: one Bazel invocation fans out
-   compile/link/test-wrapper actions across the GCP executor pool, so common
+3. `prebuild-submit` runs one remote Bazel build of the non-live workspace
+   graph. This is the cache-warming step: one Bazel invocation fans out
+   compile/link/test-binary actions across the GCP executor pool, so common
    artifacts enter the self-hosted BuildBuddy CAS before targeted validation
-   lanes start.
-4. The targeted submitter jobs then run format/static, clippy, unit,
-   integration-fast, SDK, WASM, feature-matrix, audit, RMAT, seam-inventory,
-   and machine-authority checks against the warmed graph. GCP batches default
-   to one local submitter per job because the desired parallelism is Bazel
-   action-level remote execution, not several GitHub jobs racing the same
-   first-touch compile actions.
+   lanes start. It deliberately does not execute TLC/RMAT/governance or
+   cargo-equivalent WASM/SDK wrappers; those are policy/shell lanes, not the
+   shared Bazel-native compilation graph.
+4. The targeted submitter jobs then run format/static, clippy, unit, and
+   integration-fast checks against the warmed graph. GCP batches default to one
+   local submitter per job because the desired parallelism is Bazel action-level
+   remote execution, not several GitHub jobs racing the same first-touch compile
+   actions. Governance and WASM/SDK/feature/audit lanes are path-aware edge
+   lanes; they run only when their inputs changed.
 5. Bazel uses `--config=buildbuddy-linux-gcp-ci-rbe`, which selects
    `//platforms:linux_x86_64_gcp_ci`. That platform routes actions to
    BuildBuddy pool `meerkat-ci`, enables external network, and runs actions in

--- a/docs/architecture/buildbuddy-bazel-poc.md
+++ b/docs/architecture/buildbuddy-bazel-poc.md
@@ -264,12 +264,13 @@ only the submitter/coordinator:
    lanes start. It deliberately does not execute TLC/RMAT/governance or
    cargo-equivalent WASM/SDK wrappers; those are policy/shell lanes, not the
    shared Bazel-native compilation graph.
-4. The targeted submitter jobs then run format/static, clippy, unit, and
+4. The native submitter then runs format/static, clippy, unit, and
    integration-fast checks against the warmed graph. GCP batches default to one
    local submitter per job because the desired parallelism is Bazel action-level
    remote execution, not several GitHub jobs racing the same first-touch compile
-   actions. Governance and WASM/SDK/feature/audit lanes are path-aware edge
-   lanes; they run only when their inputs changed.
+   actions. Governance and WASM/SDK/feature/audit are path-aware edge lanes;
+   they start in parallel after the executor pool is up and do not wait for the
+   prebuild, because they do not consume the shared Bazel-native prebuild output.
 5. Bazel uses `--config=buildbuddy-linux-gcp-ci-rbe`, which selects
    `//platforms:linux_x86_64_gcp_ci`. That platform routes actions to
    BuildBuddy pool `meerkat-ci`, enables external network, and runs actions in

--- a/docs/architecture/buildbuddy-bazel-poc.md
+++ b/docs/architecture/buildbuddy-bazel-poc.md
@@ -271,6 +271,8 @@ only the submitter/coordinator:
    actions. Governance and WASM/SDK/feature/audit are path-aware edge lanes;
    they start in parallel after the executor pool is up and do not wait for the
    prebuild, because they do not consume the shared Bazel-native prebuild output.
+   Governance is intentionally keyed to the machine DSL/generated-machine
+   surfaces, not broad Bazel metadata such as `MODULE.bazel.lock`.
 5. Bazel uses `--config=buildbuddy-linux-gcp-ci-rbe`, which selects
    `//platforms:linux_x86_64_gcp_ci`. That platform routes actions to
    BuildBuddy pool `meerkat-ci`, enables external network, and runs actions in

--- a/docs/architecture/buildbuddy-bazel-poc.md
+++ b/docs/architecture/buildbuddy-bazel-poc.md
@@ -257,26 +257,37 @@ only the submitter/coordinator:
    Secret Manager for the executors, creates the executor managed instance group
    if it is missing, and scales it to
    `MEERKAT_GCP_BUILDBUDDY_TARGET_SIZE` (default `12`).
-3. One thin submitter job batches the Bazel lanes, including format/static,
-   clippy, unit, integration-fast, SDK, WASM, feature-matrix, audit, RMAT,
-   seam-inventory, and machine-authority checks.
-4. Bazel uses `--config=buildbuddy-linux-gcp-ci-rbe`, which selects
+3. `prebuild-submit` runs one remote Bazel prebuild over the shared CI
+   build graph. This is the cache-warming step: one Bazel invocation fans out
+   compile/link/test-wrapper actions across the GCP executor pool, so common
+   artifacts enter the self-hosted BuildBuddy CAS before targeted validation
+   lanes start.
+4. The targeted submitter jobs then run format/static, clippy, unit,
+   integration-fast, SDK, WASM, feature-matrix, audit, RMAT, seam-inventory,
+   and machine-authority checks against the warmed graph. GCP batches default
+   to one local submitter per job because the desired parallelism is Bazel
+   action-level remote execution, not several GitHub jobs racing the same
+   first-touch compile actions.
+5. Bazel uses `--config=buildbuddy-linux-gcp-ci-rbe`, which selects
    `//platforms:linux_x86_64_gcp_ci`. That platform routes actions to
    BuildBuddy pool `meerkat-ci`, enables external network, and runs actions in
    the pre-baked Artifact Registry image
    `europe-west1-docker.pkg.dev/king-dnn-training-dev/meerkat-ci/meerkat-ci-rust:1.94.0`.
-5. `gcp-executors-down` always scales the managed instance group back to zero
-   after the submitters finish. In GitHub CI it sets target size to zero and
-   skips waiting for every VM deletion to settle, so teardown does not inflate
-   the required CI status. Manual `scripts/gcp-buildbuddy-executor-pool down`
-   still waits by default; set `MEERKAT_GCP_BUILDBUDDY_WAIT_ON_DOWN=0` for the
-   asynchronous behavior.
+6. `executors-down` parks the managed instance group with stopped standby
+   VMs after the submitters finish. In GitHub CI it sets running size to zero,
+   preserves the configured stopped size, and can skip waiting for every stop to
+   settle so teardown does not inflate the required CI status. Manual
+   `scripts/gcp-buildbuddy-executor-pool down` still waits by default; set
+   `MEERKAT_GCP_BUILDBUDDY_WAIT_ON_DOWN=0` for the asynchronous behavior.
 
 The intended steady-state cost shape is one small always-on BuildBuddy
-backend/cache plus zero idle executor VMs. A CI run bursts the executor MIG to
-the configured size, then parks it again. BuildBuddy CAS/action cache is the
-shared cache across the fleet; the executor VMs get large local SSD-backed boot
-disks for per-VM action/container/cache locality.
+backend/cache plus stopped executor VMs with durable cache disks. A CI run
+starts the parked executor MIG to the configured running size, then parks it
+again. BuildBuddy CAS/action cache is the shared cache across the fleet; each
+executor also has its own stateful SSD-backed `/buildbuddy` disk for
+per-executor action/container/file-cache locality. The cache disk is not a
+multi-writer shared filesystem; sharing happens through BuildBuddy CAS/action
+cache, while stopped stateful disks avoid re-cold-starting every executor.
 The `gcp-buildbuddy` submitter jobs restore GitHub Actions' Bazel repository
 cache for fast local analysis/fetch setup, but intentionally skip the cache save
 at job teardown because uploading runner-local cache tarballs adds latency and

--- a/docs/architecture/buildbuddy-bazel-poc.md
+++ b/docs/architecture/buildbuddy-bazel-poc.md
@@ -265,10 +265,10 @@ only the submitter/coordinator:
    cargo-equivalent WASM/SDK wrappers; those are policy/shell lanes, not the
    shared Bazel-native compilation graph.
 4. The native submitter then runs format/static, clippy, unit, and
-   integration-fast checks against the warmed graph. GCP batches default to one
-   local submitter per job because the desired parallelism is Bazel action-level
-   remote execution, not several GitHub jobs racing the same first-touch compile
-   actions. Governance and WASM/SDK/feature/audit are path-aware edge lanes;
+   integration-fast checks against the warmed graph. It uses a small number of
+   local lane submitters so the post-prebuild validation lanes can overlap
+   without several GitHub jobs racing the same first-touch compile actions.
+   Governance and WASM/SDK/feature/audit are path-aware edge lanes;
    they start in parallel after the executor pool is up and do not wait for the
    prebuild, because they do not consume the shared Bazel-native prebuild output.
    Governance is intentionally keyed to the machine DSL/generated-machine

--- a/docs/architecture/buildbuddy-bazel-poc.md
+++ b/docs/architecture/buildbuddy-bazel-poc.md
@@ -264,11 +264,13 @@ only the submitter/coordinator:
    lanes start. It deliberately does not execute TLC/RMAT/governance or
    cargo-equivalent WASM/SDK wrappers; those are policy/shell lanes, not the
    shared Bazel-native compilation graph.
-4. The native submitter then runs format/static, clippy, unit, and
-   integration-fast checks against the warmed graph. It uses a small number of
-   local lane submitters so the post-prebuild validation lanes can overlap
-   without several GitHub jobs racing the same first-touch compile actions.
-   Governance and WASM/SDK/feature/audit are path-aware edge lanes;
+4. The static submitter runs format/static source checks in parallel with the
+   prebuild because it does not consume warmed Rust test binaries. The native
+   submitter then runs clippy, unit, and integration-fast checks against the
+   warmed graph. It uses a small number of local lane submitters so the
+   post-prebuild validation lanes can overlap without several GitHub jobs racing
+   the same first-touch compile actions. Governance and
+   WASM/SDK/feature/audit are path-aware edge lanes;
    they start in parallel after the executor pool is up and do not wait for the
    prebuild, because they do not consume the shared Bazel-native prebuild output.
    Governance is intentionally keyed to the machine DSL/generated-machine

--- a/meerkat-mob/BUILD.bazel
+++ b/meerkat-mob/BUILD.bazel
@@ -545,6 +545,73 @@ rust_test(
 )
 
 rust_test(
+    name = "smoke_mob_generated_image_comms_test",
+    aliases = aliases(
+        package_name = "meerkat-mob",
+        normal = True,
+        normal_dev = True,
+        proc_macro = True,
+        proc_macro_dev = True,
+    ),
+    crate_name = "smoke_mob_generated_image_comms",
+    crate_root = "tests/smoke_mob_generated_image_comms.rs",
+    crate_features = [
+        "integration-real-tests",
+        "runtime-adapter",
+    ],
+    edition = "2024",
+    compile_data = [
+        "Cargo.toml",
+        "src/runtime/actor.rs",
+        "src/runtime/builder.rs",
+        "src/runtime/flow_frame_engine.rs",
+        "src/runtime/recovery.rs",
+    ],
+    srcs = [
+        "tests/smoke_mob_generated_image_comms.rs",
+    ],
+    visibility = ["//visibility:public"],
+    rustc_env = {
+        "CARGO_PKG_VERSION": "0.6.4",
+        "CARGO_BIN_NAME": "smoke_mob_generated_image_comms",
+        "CARGO_MANIFEST_DIR": "./meerkat-mob",
+    },
+    tags = [
+        "integration",
+        "required-feature",
+    ],
+    data = [],
+    env = {
+        "RUST_MIN_STACK": "16777216",
+    },
+    proc_macro_deps = [
+        "//meerkat-machine-derive:meerkat_machine_derive",
+        "//meerkat-machine-dsl:meerkat_machine_dsl",
+    ] + all_crate_deps(
+        package_name = "meerkat-mob",
+        proc_macro = True,
+        proc_macro_dev = True,
+    ),
+    deps = [
+        "//meerkat-mob:meerkat_mob",
+        "//meerkat:meerkat",
+        "//meerkat:meerkat_client_agent_factory_build",
+        "//meerkat:meerkat_comms_agent_factory_build",
+        "//meerkat:meerkat_contracts_agent_factory_build",
+        "//meerkat:meerkat_core_agent_factory_build",
+        "//meerkat:meerkat_machine_kernels_agent_factory_build",
+        "//meerkat:meerkat_machine_schema_agent_factory_build",
+        "//meerkat:meerkat_runtime_agent_factory_build",
+        "//meerkat:meerkat_session_agent_factory_build",
+        "//meerkat:meerkat_store_agent_factory_build",
+    ] + all_crate_deps(
+        package_name = "meerkat-mob",
+        normal = True,
+        normal_dev = True,
+    ),
+)
+
+rust_test(
     name = "smoke_mob_pictionary_test",
     aliases = aliases(
         package_name = "meerkat-mob",

--- a/scripts/buildbuddy-bazel-poc
+++ b/scripts/buildbuddy-bazel-poc
@@ -18,7 +18,7 @@ Common commands:
                             Integration-fast remote workspace test lane.
   workspace-fast-clippy-rbe  Fast tests plus clippy aspect.
   workspace-build-clippy-rbe Build/clippy labels for the workspace build set.
-  ci-prebuild-rbe          Build common CI binaries/test wrappers once to warm remote cache.
+  ci-prebuild-rbe          Build the non-live CI workspace graph to warm remote cache.
   e2e-system-rbe           Bazel-native system e2e suite with runfile binaries.
   e2e-fast-rbe             Bazel-native fast e2e lane.
   e2e-live-rbe             Bazel-native live e2e lane.
@@ -249,10 +249,9 @@ case "${command}" in
   ci-prebuild-rbe)
     command="build"
     config="${BUILDBUDDY_BAZEL_CONFIG:-buildbuddy-macos-rbe}"
-    workspace_build_targets="$("./scripts/bazel-affected-fast-tests.mjs" --all --build)"
-    default_target="${workspace_build_targets} //:surface_feature_matrix_builds //xtask:buildbuddy_static_lanes_test //tools/buildbuddy:sdk_suites_cargo_equivalent_test //tools/buildbuddy:wasm_check_cargo_equivalent_test //tools/buildbuddy:minimal_feature_builds_cargo_equivalent_test //tools/buildbuddy:feature_matrix_lib_cargo_equivalent_tests //tools/buildbuddy:security_audit_cargo_equivalent_test //xtask:machine_verify_all_tlc_test //xtask:machines_contracts_test //xtask:protocol_codegen_drift_test //meerkat-machine-codegen:render_contracts_test //meerkat-machine-codegen:runtime_alphabet_parity_test //meerkat-machine-codegen:runtime_schema_parity_test //:audit_effect_authority_test //xtask:rmat_audit_test //xtask:rmat_strict_test //xtask:seam_inventory_strict_test"
+    default_target="//..."
     extra_args+=(
-      --build_tag_filters=-local,-manual
+      --build_tag_filters=-local,-manual,-e2e,-system,-live,-slow,-required-feature,-trybuild,-snapshot,-fixture,-cargo-equivalent,-requires-network
       --remote_download_minimal
       --color=no
       --curses=no

--- a/scripts/buildbuddy-bazel-poc
+++ b/scripts/buildbuddy-bazel-poc
@@ -18,6 +18,7 @@ Common commands:
                             Integration-fast remote workspace test lane.
   workspace-fast-clippy-rbe  Fast tests plus clippy aspect.
   workspace-build-clippy-rbe Build/clippy labels for the workspace build set.
+  ci-prebuild-rbe          Build common CI binaries/test wrappers once to warm remote cache.
   e2e-system-rbe           Bazel-native system e2e suite with runfile binaries.
   e2e-fast-rbe             Bazel-native fast e2e lane.
   e2e-live-rbe             Bazel-native live e2e lane.
@@ -243,6 +244,18 @@ case "${command}" in
       --aspects="@rules_rust//rust:defs.bzl%rust_clippy_aspect"
       --output_groups="+clippy_checks"
       --@rules_rust//rust/settings:clippy_flag=-Dwarnings
+    )
+    ;;
+  ci-prebuild-rbe)
+    command="build"
+    config="${BUILDBUDDY_BAZEL_CONFIG:-buildbuddy-macos-rbe}"
+    workspace_build_targets="$("./scripts/bazel-affected-fast-tests.mjs" --all --build)"
+    default_target="${workspace_build_targets} //:surface_feature_matrix_builds //xtask:buildbuddy_static_lanes_test //tools/buildbuddy:sdk_suites_cargo_equivalent_test //tools/buildbuddy:wasm_check_cargo_equivalent_test //tools/buildbuddy:minimal_feature_builds_cargo_equivalent_test //tools/buildbuddy:feature_matrix_lib_cargo_equivalent_tests //tools/buildbuddy:security_audit_cargo_equivalent_test //xtask:machine_verify_all_tlc_test //xtask:machines_contracts_test //xtask:protocol_codegen_drift_test //meerkat-machine-codegen:render_contracts_test //meerkat-machine-codegen:runtime_alphabet_parity_test //meerkat-machine-codegen:runtime_schema_parity_test //:audit_effect_authority_test //xtask:rmat_audit_test //xtask:rmat_strict_test //xtask:seam_inventory_strict_test"
+    extra_args+=(
+      --build_tag_filters=-local,-manual
+      --remote_download_minimal
+      --color=no
+      --curses=no
     )
     ;;
   e2e-system-rbe)

--- a/scripts/buildbuddy-ci-dispatch
+++ b/scripts/buildbuddy-ci-dispatch
@@ -143,7 +143,7 @@ case "${mode}" in
       exec scripts/buildbuddy-ci-lane native-e2e-system --mode e2e-system
     fi
     ;;
-  release-validate|fmt-lint|sdk-suites|rust-release-packaging|machine-authority|rmat-audit|seam-inventory|wasm-contract-tests|test-unit|integration-fast|e2e-fast|e2e-system|e2e-live|e2e-smoke|test-minimal|test-feature-matrix-lib|test-feature-matrix-surface-checks|wasm-check|audit|native-build-clippy|native-unit-tests|native-integration-fast|native-e2e-system|fmt-static|cargo-all-features-clippy|feature-clippy|unused-deps|wasm-contract|minimal-feature-builds|feature-matrix-lib|feature-matrix-surface|security-audit)
+  release-validate|ci-prebuild|fmt-lint|sdk-suites|rust-release-packaging|machine-authority|rmat-audit|seam-inventory|wasm-contract-tests|test-unit|integration-fast|e2e-fast|e2e-system|e2e-live|e2e-smoke|test-minimal|test-feature-matrix-lib|test-feature-matrix-surface-checks|wasm-check|audit|native-build-clippy|native-unit-tests|native-integration-fast|native-e2e-system|fmt-static|cargo-all-features-clippy|feature-clippy|unused-deps|wasm-contract|minimal-feature-builds|feature-matrix-lib|feature-matrix-surface|security-audit)
     lane_args=("${mode}" --mode "${mode}")
     if [[ "${dry_run}" -eq 1 ]]; then
       lane_args+=(--dry-run)

--- a/scripts/buildbuddy-ci-lane
+++ b/scripts/buildbuddy-ci-lane
@@ -86,7 +86,7 @@ source_local_secrets_env
 
 is_native_lane=0
 case "${lane}" in
-  native-build-clippy|native-unit-tests|native-integration-fast|native-e2e-system|test-unit|integration-fast|e2e-system|e2e-fast|e2e-live|e2e-smoke|machine-authority|rmat-audit|seam-inventory)
+  ci-prebuild|native-build-clippy|native-unit-tests|native-integration-fast|native-e2e-system|test-unit|integration-fast|e2e-system|e2e-fast|e2e-live|e2e-smoke|machine-authority|rmat-audit|seam-inventory)
     is_native_lane=1
     ;;
 esac
@@ -225,6 +225,9 @@ run_bazel_lane() {
 }
 
 case "${lane}" in
+  ci-prebuild)
+    run_bazel_lane ci-prebuild-rbe --jobs="${bazel_jobs}" --color=no --curses=no
+    ;;
   native-build-clippy)
     run_bazel_lane workspace-build-clippy-rbe --jobs="${bazel_jobs}" --color=no --curses=no
     ;;

--- a/scripts/buildbuddy-doctor
+++ b/scripts/buildbuddy-doctor
@@ -336,6 +336,11 @@ rm -rf "${dispatch_log_root}"
 if grep -Fq 'name: CI' .github/workflows/ci.yml &&
   grep -Fq 'name: GHA Cargo' .github/workflows/ci.yml &&
   grep -Fq 'name: GCP BuildBuddy' .github/workflows/ci.yml &&
+  job_has_line .github/workflows/ci.yml gate 'name: CI gate' &&
+  job_has_line .github/workflows/ci.yml gate 'name: Check selected CI backend' &&
+  job_has_line .github/workflows/ci.yml gate 'CARGO_RESULT:' &&
+  job_has_line .github/workflows/ci.yml gate 'GCP_BUILDBUDDY_RESULT:' &&
+  job_has_line .github/workflows/ci.yml gate 'No CI backend completed successfully.' &&
   grep -Fq "github.actor == 'lukacf'" .github/workflows/ci.yml &&
   grep -Fq 'Only lukacf can run the secret-backed GCP BuildBuddy lane.' .github/workflows/ci.yml &&
   grep -Fq 'uses: ./.github/workflows/cargo.yml' .github/workflows/ci.yml &&
@@ -387,6 +392,7 @@ fi
 
 if job_has_line .github/workflows/ci.yml cargo 'name: GHA Cargo' &&
   job_has_line .github/workflows/ci.yml gcp-buildbuddy 'name: GCP BuildBuddy' &&
+  job_has_line .github/workflows/ci.yml gate 'name: CI gate' &&
   job_has_line .github/workflows/buildbuddy.yml prebuild-submit 'name: Prebuild submitter' &&
   job_has_line .github/workflows/buildbuddy.yml prebuild-submit 'group: gcp-prebuild' &&
   job_has_line .github/workflows/buildbuddy.yml prebuild-submit 'ci-prebuild' &&

--- a/scripts/buildbuddy-doctor
+++ b/scripts/buildbuddy-doctor
@@ -404,6 +404,8 @@ if job_has_line .github/workflows/ci.yml cargo 'name: GHA Cargo' &&
   job_has_line .github/workflows/buildbuddy.yml wasm-feature-submit 'group: gcp-wasm-feature' &&
   job_has_line .github/workflows/buildbuddy.yml governance-submit 'Detect machine-authority changes' &&
   job_has_line .github/workflows/buildbuddy.yml wasm-feature-submit 'Detect WASM, SDK, feature, or audit changes' &&
+  ! ./scripts/machine-authority-changed MODULE.bazel.lock >/dev/null 2>&1 &&
+  ! job_has_line .github/workflows/buildbuddy.yml wasm-feature-submit 'MODULE.bazel.lock' &&
   ! job_has_line .github/workflows/buildbuddy.yml governance-submit "steps.machine-changes.outputs.changed != 'true'" &&
   ! job_has_line .github/workflows/buildbuddy.yml wasm-feature-submit 'seam-inventory' &&
   ! job_has_line .github/workflows/buildbuddy.yml wasm-feature-submit 'rmat-audit' &&

--- a/scripts/buildbuddy-doctor
+++ b/scripts/buildbuddy-doctor
@@ -394,8 +394,8 @@ if job_has_line .github/workflows/ci.yml cargo 'name: GHA Cargo' &&
   job_has_line .github/workflows/buildbuddy.yml governance-submit 'name: Governance submitter' &&
   job_has_line .github/workflows/buildbuddy.yml wasm-feature-submit 'name: WASM and feature submitter' &&
   job_has_line .github/workflows/buildbuddy.yml native-submit 'needs: [control-plane-up, executors-up, prebuild-submit]' &&
-  job_has_line .github/workflows/buildbuddy.yml governance-submit 'needs: [control-plane-up, executors-up, prebuild-submit]' &&
-  job_has_line .github/workflows/buildbuddy.yml wasm-feature-submit 'needs: [control-plane-up, executors-up, prebuild-submit]' &&
+  job_has_line .github/workflows/buildbuddy.yml governance-submit 'needs: [control-plane-up, executors-up]' &&
+  job_has_line .github/workflows/buildbuddy.yml wasm-feature-submit 'needs: [control-plane-up, executors-up]' &&
   job_has_line .github/workflows/buildbuddy.yml native-submit 'CI_STARTED_AT_EPOCH:' &&
   job_has_line .github/workflows/buildbuddy.yml governance-submit 'CI_STARTED_AT_EPOCH:' &&
   job_has_line .github/workflows/buildbuddy.yml wasm-feature-submit 'CI_STARTED_AT_EPOCH:' &&

--- a/scripts/buildbuddy-doctor
+++ b/scripts/buildbuddy-doctor
@@ -402,6 +402,9 @@ if job_has_line .github/workflows/ci.yml cargo 'name: GHA Cargo' &&
   job_has_line .github/workflows/buildbuddy.yml native-submit 'group: gcp' &&
   job_has_line .github/workflows/buildbuddy.yml governance-submit 'group: gcp-governance' &&
   job_has_line .github/workflows/buildbuddy.yml wasm-feature-submit 'group: gcp-wasm-feature' &&
+  job_has_line .github/workflows/buildbuddy.yml governance-submit 'Detect machine-authority changes' &&
+  job_has_line .github/workflows/buildbuddy.yml wasm-feature-submit 'Detect WASM, SDK, feature, or audit changes' &&
+  ! job_has_line .github/workflows/buildbuddy.yml governance-submit "steps.machine-changes.outputs.changed != 'true'" &&
   ! job_has_line .github/workflows/buildbuddy.yml wasm-feature-submit 'seam-inventory' &&
   ! job_has_line .github/workflows/buildbuddy.yml wasm-feature-submit 'rmat-audit' &&
   ! job_has_line .github/workflows/buildbuddy.yml wasm-feature-submit 'machine-authority' &&
@@ -410,10 +413,12 @@ if job_has_line .github/workflows/ci.yml cargo 'name: GHA Cargo' &&
   grep -Fq 'Active BuildBuddy lane heartbeat' scripts/buildbuddy-ci-lane-batch &&
   grep -Fq "inputs.profile == 'submitter' || inputs.profile == 'doctor'" .github/actions/setup-buildbuddy-ci/action.yml &&
   grep -Fq 'scripts/buildbuddy-ci-lane-batch' .github/actions/run-buildbuddy-ci-lane-batch/action.yml &&
+  grep -Fq 'default_target="//..."' scripts/buildbuddy-bazel-poc &&
+  grep -Fq -- '--build_tag_filters=-local,-manual,-e2e,-system,-live,-slow,-required-feature,-trybuild,-snapshot,-fixture,-cargo-equivalent,-requires-network' scripts/buildbuddy-bazel-poc &&
   job_has_line .github/workflows/buildbuddy.yml gate 'runs-on: ubuntu-latest'; then
-  pass "GCP BuildBuddy CI uses one remote prebuild before bounded split-submit validation"
+  pass "GCP BuildBuddy CI uses a broad Bazel-native prebuild plus path-aware edge lanes"
 else
-  bad "GCP BuildBuddy CI is not using the prebuild-plus-bounded-validation shape"
+  bad "GCP BuildBuddy CI is not using the broad-prebuild/path-aware edge-lane shape"
 fi
 
 if grep -Fq 'full-fresh' .github/workflows/buildbuddy.yml &&

--- a/scripts/buildbuddy-doctor
+++ b/scripts/buildbuddy-doctor
@@ -390,6 +390,10 @@ if job_has_line .github/workflows/ci.yml cargo 'name: GHA Cargo' &&
   job_has_line .github/workflows/buildbuddy.yml prebuild-submit 'name: Prebuild submitter' &&
   job_has_line .github/workflows/buildbuddy.yml prebuild-submit 'group: gcp-prebuild' &&
   job_has_line .github/workflows/buildbuddy.yml prebuild-submit 'ci-prebuild' &&
+  job_has_line .github/workflows/buildbuddy.yml static-submit 'name: Static submitter' &&
+  job_has_line .github/workflows/buildbuddy.yml static-submit 'needs: [control-plane-up, executors-up]' &&
+  job_has_line .github/workflows/buildbuddy.yml static-submit 'group: gcp-static' &&
+  job_has_line .github/workflows/buildbuddy.yml static-submit 'fmt-static' &&
   job_has_line .github/workflows/buildbuddy.yml native-submit 'name: Native submitter' &&
   job_has_line .github/workflows/buildbuddy.yml governance-submit 'name: Governance submitter' &&
   job_has_line .github/workflows/buildbuddy.yml wasm-feature-submit 'name: WASM and feature submitter' &&
@@ -401,6 +405,7 @@ if job_has_line .github/workflows/ci.yml cargo 'name: GHA Cargo' &&
   job_has_line .github/workflows/buildbuddy.yml wasm-feature-submit 'CI_STARTED_AT_EPOCH:' &&
   job_has_line .github/workflows/buildbuddy.yml native-submit 'group: gcp' &&
   job_has_line .github/workflows/buildbuddy.yml native-submit 'batch_jobs: "2"' &&
+  ! job_has_line .github/workflows/buildbuddy.yml native-submit 'fmt-static' &&
   job_has_line .github/workflows/buildbuddy.yml governance-submit 'group: gcp-governance' &&
   job_has_line .github/workflows/buildbuddy.yml wasm-feature-submit 'group: gcp-wasm-feature' &&
   job_has_line .github/workflows/buildbuddy.yml governance-submit 'Detect machine-authority changes' &&

--- a/scripts/buildbuddy-doctor
+++ b/scripts/buildbuddy-doctor
@@ -400,7 +400,7 @@ if job_has_line .github/workflows/ci.yml cargo 'name: GHA Cargo' &&
   job_has_line .github/workflows/buildbuddy.yml governance-submit 'CI_STARTED_AT_EPOCH:' &&
   job_has_line .github/workflows/buildbuddy.yml wasm-feature-submit 'CI_STARTED_AT_EPOCH:' &&
   job_has_line .github/workflows/buildbuddy.yml native-submit 'group: gcp' &&
-  job_has_line .github/workflows/buildbuddy.yml native-submit 'batch_jobs: "4"' &&
+  job_has_line .github/workflows/buildbuddy.yml native-submit 'batch_jobs: "2"' &&
   job_has_line .github/workflows/buildbuddy.yml governance-submit 'group: gcp-governance' &&
   job_has_line .github/workflows/buildbuddy.yml wasm-feature-submit 'group: gcp-wasm-feature' &&
   job_has_line .github/workflows/buildbuddy.yml governance-submit 'Detect machine-authority changes' &&

--- a/scripts/buildbuddy-doctor
+++ b/scripts/buildbuddy-doctor
@@ -400,6 +400,7 @@ if job_has_line .github/workflows/ci.yml cargo 'name: GHA Cargo' &&
   job_has_line .github/workflows/buildbuddy.yml governance-submit 'CI_STARTED_AT_EPOCH:' &&
   job_has_line .github/workflows/buildbuddy.yml wasm-feature-submit 'CI_STARTED_AT_EPOCH:' &&
   job_has_line .github/workflows/buildbuddy.yml native-submit 'group: gcp' &&
+  job_has_line .github/workflows/buildbuddy.yml native-submit 'batch_jobs: "4"' &&
   job_has_line .github/workflows/buildbuddy.yml governance-submit 'group: gcp-governance' &&
   job_has_line .github/workflows/buildbuddy.yml wasm-feature-submit 'group: gcp-wasm-feature' &&
   job_has_line .github/workflows/buildbuddy.yml governance-submit 'Detect machine-authority changes' &&
@@ -411,6 +412,7 @@ if job_has_line .github/workflows/ci.yml cargo 'name: GHA Cargo' &&
   ! job_has_line .github/workflows/buildbuddy.yml wasm-feature-submit 'rmat-audit' &&
   ! job_has_line .github/workflows/buildbuddy.yml wasm-feature-submit 'machine-authority' &&
   grep -Fq 'MEERKAT_BUILDBUDDY_BATCH_JOBS' .github/workflows/buildbuddy.yml &&
+  grep -Fq 'MEERKAT_BUILDBUDDY_BATCH_JOBS: ${{ inputs.batch_jobs || env.MEERKAT_BUILDBUDDY_BATCH_JOBS }}' .github/actions/run-buildbuddy-ci-lane-batch/action.yml &&
   grep -Fq 'Check GCP CI duration SLO' .github/workflows/buildbuddy.yml &&
   grep -Fq 'Active BuildBuddy lane heartbeat' scripts/buildbuddy-ci-lane-batch &&
   grep -Fq "inputs.profile == 'submitter' || inputs.profile == 'doctor'" .github/actions/setup-buildbuddy-ci/action.yml &&

--- a/scripts/buildbuddy-doctor
+++ b/scripts/buildbuddy-doctor
@@ -361,9 +361,12 @@ fi
 if grep -Fq 'MEERKAT_GCP_BUILDBUDDY_CI_MAX_SECONDS' .github/workflows/buildbuddy.yml &&
   grep -Fq 'buildbuddy-gcp-executors' .github/workflows/buildbuddy.yml &&
   grep -Fq 'MEERKAT_GCP_BUILDBUDDY_WAIT_ON_DOWN' .github/workflows/buildbuddy.yml &&
-  grep -Fq 'gcloud compute instance-groups managed resize "${MEERKAT_GCP_BUILDBUDDY_MIG}"' .github/workflows/buildbuddy.yml &&
-  grep -Fq 'resize_existing_pool 0' scripts/gcp-buildbuddy-executor-pool &&
-  grep -Fq 'Skipping wait for executor pool scale-down' scripts/gcp-buildbuddy-executor-pool &&
+  grep -Fq 'scripts/gcp-buildbuddy-executor-pool down' .github/workflows/buildbuddy.yml &&
+  grep -Fq 'MEERKAT_GCP_BUILDBUDDY_DOWN_MODE' .github/workflows/buildbuddy.yml &&
+  grep -Fq 'MEERKAT_GCP_BUILDBUDDY_CACHE_DISK_GB' .github/workflows/buildbuddy.yml &&
+  grep -Fq -- '--stateful-disk "device-name=${cache_disk_device},auto-delete=never"' scripts/gcp-buildbuddy-executor-pool &&
+  grep -Fq -- '--stopped-size "${parked_size}"' scripts/gcp-buildbuddy-executor-pool &&
+  grep -Fq 'Parking executor pool with' scripts/gcp-buildbuddy-executor-pool &&
   ! grep -Fq "mode: \${{ (github.event_name == 'workflow_dispatch'" .github/workflows/buildbuddy.yml &&
   grep -Fq 'MEERKAT_BUILDBUDDY=1' CLAUDE.md &&
   grep -Fq 'MEERKAT_BUILDBUDDY=1' AGENTS.md &&
@@ -384,26 +387,37 @@ fi
 
 if job_has_line .github/workflows/ci.yml cargo 'name: GHA Cargo' &&
   job_has_line .github/workflows/ci.yml gcp-buildbuddy 'name: GCP BuildBuddy' &&
+  job_has_line .github/workflows/buildbuddy.yml prebuild-submit 'name: Prebuild submitter' &&
+  job_has_line .github/workflows/buildbuddy.yml prebuild-submit 'group: gcp-prebuild' &&
+  job_has_line .github/workflows/buildbuddy.yml prebuild-submit 'ci-prebuild' &&
   job_has_line .github/workflows/buildbuddy.yml native-submit 'name: Native submitter' &&
   job_has_line .github/workflows/buildbuddy.yml governance-submit 'name: Governance submitter' &&
   job_has_line .github/workflows/buildbuddy.yml wasm-feature-submit 'name: WASM and feature submitter' &&
+  job_has_line .github/workflows/buildbuddy.yml native-submit 'needs: [control-plane-up, executors-up, prebuild-submit]' &&
+  job_has_line .github/workflows/buildbuddy.yml governance-submit 'needs: [control-plane-up, executors-up, prebuild-submit]' &&
+  job_has_line .github/workflows/buildbuddy.yml wasm-feature-submit 'needs: [control-plane-up, executors-up, prebuild-submit]' &&
   job_has_line .github/workflows/buildbuddy.yml native-submit 'CI_STARTED_AT_EPOCH:' &&
   job_has_line .github/workflows/buildbuddy.yml governance-submit 'CI_STARTED_AT_EPOCH:' &&
   job_has_line .github/workflows/buildbuddy.yml wasm-feature-submit 'CI_STARTED_AT_EPOCH:' &&
   job_has_line .github/workflows/buildbuddy.yml native-submit 'group: gcp' &&
   job_has_line .github/workflows/buildbuddy.yml governance-submit 'group: gcp-governance' &&
   job_has_line .github/workflows/buildbuddy.yml wasm-feature-submit 'group: gcp-wasm-feature' &&
+  ! job_has_line .github/workflows/buildbuddy.yml wasm-feature-submit 'seam-inventory' &&
+  ! job_has_line .github/workflows/buildbuddy.yml wasm-feature-submit 'rmat-audit' &&
+  ! job_has_line .github/workflows/buildbuddy.yml wasm-feature-submit 'machine-authority' &&
+  grep -Fq 'MEERKAT_BUILDBUDDY_BATCH_JOBS' .github/workflows/buildbuddy.yml &&
   grep -Fq 'Check GCP CI duration SLO' .github/workflows/buildbuddy.yml &&
   grep -Fq 'Active BuildBuddy lane heartbeat' scripts/buildbuddy-ci-lane-batch &&
   grep -Fq "inputs.profile == 'submitter' || inputs.profile == 'doctor'" .github/actions/setup-buildbuddy-ci/action.yml &&
   grep -Fq 'scripts/buildbuddy-ci-lane-batch' .github/actions/run-buildbuddy-ci-lane-batch/action.yml &&
   job_has_line .github/workflows/buildbuddy.yml gate 'runs-on: ubuntu-latest'; then
-  pass "GCP BuildBuddy CI uses split GitHub-hosted submitters with SLO and live heartbeat"
+  pass "GCP BuildBuddy CI uses one remote prebuild before bounded split-submit validation"
 else
-  bad "GCP BuildBuddy CI is not using the bounded split-submitter shape"
+  bad "GCP BuildBuddy CI is not using the prebuild-plus-bounded-validation shape"
 fi
 
 if grep -Fq 'full-fresh' .github/workflows/buildbuddy.yml &&
+  grep -Fq 'ci-prebuild' .github/workflows/buildbuddy.yml &&
   grep -Fq 'fmt-static' .github/workflows/buildbuddy.yml &&
   grep -Fq 'test-unit' .github/workflows/buildbuddy.yml &&
   grep -Fq 'integration-fast' .github/workflows/buildbuddy.yml &&
@@ -416,6 +430,7 @@ if grep -Fq 'full-fresh' .github/workflows/buildbuddy.yml &&
   ! grep -Fq '(compat)' .github/workflows/buildbuddy.yml &&
   ! grep -Fq 'strategy:' .github/workflows/buildbuddy.yml &&
   grep -Fq 'run-buildbuddy-ci-lane-batch' .github/workflows/buildbuddy.yml &&
+  grep -Fq 'ci-prebuild-rbe' scripts/buildbuddy-bazel-poc &&
   grep -Fq 'workspace-unit-rbe' scripts/buildbuddy-bazel-poc &&
   grep -Fq 'workspace-integration-fast-rbe' scripts/buildbuddy-bazel-poc &&
   grep -Fq 'machine-authority-rbe' scripts/buildbuddy-bazel-poc &&

--- a/scripts/gcp-buildbuddy-executor-pool
+++ b/scripts/gcp-buildbuddy-executor-pool
@@ -17,7 +17,10 @@ Environment:
   MEERKAT_GCP_BUILDBUDDY_TEMPLATE        Instance template name
   MEERKAT_GCP_BUILDBUDDY_TARGET_SIZE     Executor VM count for up (default: 12)
   MEERKAT_GCP_BUILDBUDDY_MACHINE_TYPE    Executor machine (default: c3d-standard-30)
-  MEERKAT_GCP_BUILDBUDDY_BOOT_DISK_GB    Boot/cache disk size (default: 1000)
+  MEERKAT_GCP_BUILDBUDDY_BOOT_DISK_GB    Boot disk size (default: 100)
+  MEERKAT_GCP_BUILDBUDDY_CACHE_DISK_GB   Stateful cache disk size (default: 1000)
+  MEERKAT_GCP_BUILDBUDDY_CACHE_DISK_TYPE Stateful cache disk type (default: pd-ssd)
+  MEERKAT_GCP_BUILDBUDDY_DOWN_MODE       stopped or delete (default: stopped)
   MEERKAT_BUILDBUDDY_EXECUTOR_POOL       BuildBuddy pool name (default: meerkat-ci)
   MEERKAT_BUILDBUDDY_EXECUTOR_IMAGE      BuildBuddy executor image
   MEERKAT_BUILDBUDDY_CI_IMAGE            Bazel action container image
@@ -32,10 +35,14 @@ project="${MEERKAT_GCP_PROJECT_ID:-${GCP_PROJECT_ID:-king-dnn-training-dev}}"
 region="${MEERKAT_GCP_REGION:-europe-west1}"
 zone="${MEERKAT_GCP_ZONE:-europe-west1-b}"
 mig="${MEERKAT_GCP_BUILDBUDDY_MIG:-meerkat-bb-exec}"
-template="${MEERKAT_GCP_BUILDBUDDY_TEMPLATE:-${mig}-template-v3}"
+template="${MEERKAT_GCP_BUILDBUDDY_TEMPLATE:-${mig}-template-v4}"
 target_size="${MEERKAT_GCP_BUILDBUDDY_TARGET_SIZE:-12}"
 machine_type="${MEERKAT_GCP_BUILDBUDDY_MACHINE_TYPE:-c3d-standard-30}"
-boot_disk_gb="${MEERKAT_GCP_BUILDBUDDY_BOOT_DISK_GB:-1000}"
+boot_disk_gb="${MEERKAT_GCP_BUILDBUDDY_BOOT_DISK_GB:-100}"
+cache_disk_gb="${MEERKAT_GCP_BUILDBUDDY_CACHE_DISK_GB:-1000}"
+cache_disk_type="${MEERKAT_GCP_BUILDBUDDY_CACHE_DISK_TYPE:-pd-ssd}"
+cache_disk_device="${MEERKAT_GCP_BUILDBUDDY_CACHE_DISK_DEVICE:-bb-exec-cache}"
+down_mode="${MEERKAT_GCP_BUILDBUDDY_DOWN_MODE:-stopped}"
 pool="${MEERKAT_BUILDBUDDY_EXECUTOR_POOL:-meerkat-ci}"
 executor_image="${MEERKAT_BUILDBUDDY_EXECUTOR_IMAGE:-buildbuddy.bbcr.io/public/buildbuddy-executor-enterprise:enterprise-v2.265.0}"
 ci_image="${MEERKAT_BUILDBUDDY_CI_IMAGE:-europe-west1-docker.pkg.dev/king-dnn-training-dev/meerkat-ci/meerkat-ci-rust:1.94.0}"
@@ -191,10 +198,11 @@ API_KEY_SECRET="${api_key_secret}"
 ENDPOINT_SECRET="${endpoint_secret}"
 EXECUTOR_IMAGE="${executor_image}"
 CI_IMAGE="${ci_image}"
+CACHE_DISK_DEVICE="${cache_disk_device}"
 LOCAL_CACHE_SIZE_BYTES="${MEERKAT_GCP_BUILDBUDDY_LOCAL_CACHE_BYTES:-700000000000}"
 
 apt-get update -y
-DEBIAN_FRONTEND=noninteractive apt-get install -y ca-certificates curl docker.io python3
+DEBIAN_FRONTEND=noninteractive apt-get install -y ca-certificates curl docker.io e2fsprogs python3
 systemctl enable --now docker
 
 metadata() {
@@ -243,6 +251,38 @@ printf '%s' "\${registry_token}" |
     --username oauth2accesstoken \
     --password-stdin
 
+mount_cache_disk() {
+  local device="/dev/disk/by-id/google-\${CACHE_DISK_DEVICE}"
+  local mount_point="/buildbuddy"
+
+  for _ in {1..60}; do
+    if [[ -e "\${device}" ]]; then
+      break
+    fi
+    sleep 2
+  done
+
+  if [[ ! -e "\${device}" ]]; then
+    echo "Stateful cache disk device is missing: \${device}" >&2
+    exit 1
+  fi
+
+  if ! blkid "\${device}" >/dev/null 2>&1; then
+    mkfs.ext4 -F -m 0 "\${device}"
+  fi
+
+  mkdir -p "\${mount_point}"
+  if ! grep -q " \${mount_point} " /etc/fstab; then
+    uuid="\$(blkid -s UUID -o value "\${device}")"
+    printf 'UUID=%s %s ext4 discard,defaults,nofail 0 2\n' "\${uuid}" "\${mount_point}" >> /etc/fstab
+  fi
+
+  if ! findmnt -rn "\${mount_point}" >/dev/null 2>&1; then
+    mount "\${mount_point}"
+  fi
+}
+
+mount_cache_disk
 mkdir -p /etc/buildbuddy /buildbuddy/remotebuilds /buildbuddy/filecache
 chmod -R a+rwX /buildbuddy
 
@@ -340,6 +380,7 @@ ensure_template_and_mig() {
       --machine-type "${machine_type}" \
       --boot-disk-size "${boot_disk_gb}GB" \
       --boot-disk-type pd-ssd \
+      --create-disk "auto-delete=no,boot=no,device-name=${cache_disk_device},mode=rw,size=${cache_disk_gb}GB,type=${cache_disk_type}" \
       --image-family debian-12 \
       --image-project debian-cloud \
       --maintenance-policy TERMINATE \
@@ -357,34 +398,96 @@ ensure_template_and_mig() {
       --zone "${zone}" \
       --base-instance-name "${mig}" \
       --size 0 \
+      --stopped-size 0 \
+      --stateful-disk "device-name=${cache_disk_device},auto-delete=never" \
+      --standby-policy-mode manual \
       --template "${template}" \
       --quiet
   else
     ensure_mig_template
+    ensure_mig_stateful_policy
   fi
 }
 
-resize_pool() {
+ensure_mig_stateful_policy() {
+  gcloud compute instance-groups managed update "${mig}" \
+    --project "${project}" \
+    --zone "${zone}" \
+    --stateful-disk "device-name=${cache_disk_device},auto-delete=never" \
+    --standby-policy-mode manual \
+    --quiet >/dev/null
+}
+
+resume_pool() {
   local size="$1"
   ensure_template_and_mig
-  gcloud compute instance-groups managed resize "${mig}" \
+  gcloud compute instance-groups managed update "${mig}" \
     --project "${project}" \
     --zone "${zone}" \
     --size "${size}" \
+    --stopped-size 0 \
+    --suspended-size 0 \
     --quiet
 }
 
-resize_existing_pool() {
-  local size="$1"
+target_field() {
+  local field="$1"
+  gcloud compute instance-groups managed describe "${mig}" \
+    --project "${project}" \
+    --zone "${zone}" \
+    --format="value(${field})" 2>/dev/null || true
+}
+
+park_existing_pool() {
   require_gcloud
   if ! mig_exists; then
     echo "MIG ${mig}: absent"
     return
   fi
-  gcloud compute instance-groups managed resize "${mig}" \
+
+  case "${down_mode}" in
+    delete)
+      echo "Deleting executor VMs and their non-stateful resources; preserved stateful cache disks may remain attached to MIG state."
+      gcloud compute instance-groups managed resize "${mig}" \
+        --project "${project}" \
+        --zone "${zone}" \
+        --size 0 \
+        --quiet
+      return
+      ;;
+    stopped|stop|park)
+      ;;
+    *)
+      echo "error: unknown MEERKAT_GCP_BUILDBUDDY_DOWN_MODE='${down_mode}' (expected stopped or delete)" >&2
+      exit 2
+      ;;
+  esac
+
+  local running stopped parked_size
+  running="$(target_field targetSize)"
+  stopped="$(target_field targetStoppedSize)"
+  running="${running:-0}"
+  stopped="${stopped:-0}"
+  parked_size="${MEERKAT_GCP_BUILDBUDDY_PARKED_SIZE:-}"
+  if [[ -z "${parked_size}" ]]; then
+    if [[ "${running}" =~ ^[0-9]+$ ]] && ((running > 0)); then
+      parked_size="${running}"
+    else
+      parked_size="${stopped}"
+    fi
+  fi
+  if ! [[ "${parked_size}" =~ ^[0-9]+$ ]]; then
+    echo "error: invalid parked executor size '${parked_size}'" >&2
+    exit 2
+  fi
+
+  echo "Parking executor pool with ${parked_size} stopped VMs so per-executor caches survive between CI runs."
+  gcloud compute instance-groups managed update "${mig}" \
     --project "${project}" \
     --zone "${zone}" \
-    --size "${size}" \
+    --size 0 \
+    --stopped-size "${parked_size}" \
+    --suspended-size 0 \
     --quiet
 }
 
@@ -403,12 +506,12 @@ wait_stable() {
 
 status() {
   require_gcloud
-  echo "project=${project} zone=${zone} mig=${mig} template=${template} pool=${pool}"
+  echo "project=${project} zone=${zone} mig=${mig} template=${template} pool=${pool} cache_disk=${cache_disk_device}:${cache_disk_gb}GB:${cache_disk_type} down_mode=${down_mode}"
   if mig_exists; then
     gcloud compute instance-groups managed describe "${mig}" \
       --project "${project}" \
       --zone "${zone}" \
-      --format='table(name,targetSize,currentActions.creating,currentActions.deleting,currentActions.recreating,currentActions.refreshing,currentActions.restarting,currentActions.verifying)'
+      --format='table(name,targetSize,targetStoppedSize,targetSuspendedSize,standbyPolicy.mode,currentActions.creating,currentActions.deleting,currentActions.starting,currentActions.stopping,currentActions.recreating,currentActions.refreshing,currentActions.restarting,currentActions.verifying)'
     gcloud compute instance-groups managed list-instances "${mig}" \
       --project "${project}" \
       --zone "${zone}" \
@@ -432,15 +535,15 @@ case "${command}" in
     ;;
   up)
     size="${2:-${target_size}}"
-    resize_pool "${size}"
+    resume_pool "${size}"
     wait_stable
     status
     ;;
   down)
-    resize_existing_pool 0
+    park_existing_pool
     case "${MEERKAT_GCP_BUILDBUDDY_WAIT_ON_DOWN:-1}" in
       0|false|False|FALSE|no|No|NO)
-        echo "Skipping wait for executor pool scale-down; target size is set to 0."
+        echo "Skipping wait for executor pool park; target running size is set to 0."
         ;;
       *)
         wait_stable

--- a/scripts/machine-authority-changed
+++ b/scripts/machine-authority-changed
@@ -96,12 +96,6 @@ machine_authority_path() {
     xtask/tests/machine_verify_all_tlc_test.sh|xtask/tests/machines_contracts.rs|xtask/tests/protocol_codegen_drift.rs)
       return 0
       ;;
-    scripts/machine-authority-changed|scripts/pre-push-machines.sh|scripts/pre-push-audit-generated-headers.sh|scripts/buildbuddy-bazel-poc|scripts/buildbuddy-ci-lane|scripts/buildbuddy-doctor|scripts/generate-bazel-rust-builds.mjs|scripts/compare-machine-verify-stats.sh)
-      return 0
-      ;;
-    .github/workflows/ci.yml|.github/workflows/cargo.yml|.github/workflows/buildbuddy.yml|.github/actions/run-buildbuddy-ci-lane/*|.github/actions/setup-buildbuddy-ci/*)
-      return 0
-      ;;
     Cargo.toml|Cargo.lock|BUILD.bazel|MODULE.bazel|MODULE.bazel.lock|.bazelrc)
       return 0
       ;;

--- a/scripts/machine-authority-changed
+++ b/scripts/machine-authority-changed
@@ -96,9 +96,6 @@ machine_authority_path() {
     xtask/tests/machine_verify_all_tlc_test.sh|xtask/tests/machines_contracts.rs|xtask/tests/protocol_codegen_drift.rs)
       return 0
       ;;
-    Cargo.toml|Cargo.lock|BUILD.bazel|MODULE.bazel|MODULE.bazel.lock|.bazelrc)
-      return 0
-      ;;
   esac
   return 1
 }


### PR DESCRIPTION
## Summary
- add a GCP BuildBuddy prebuild submitter so Bazel warms the shared remote cache once before targeted validation lanes run
- default GCP CI to action-level Bazel fanout (`MEERKAT_BUILDBUDDY_CI_JOBS=192`) and bounded local submitter fanout (`MEERKAT_BUILDBUDDY_BATCH_JOBS=1`)
- move executor teardown from destructive raw MIG resize to the executor-pool script, with stateful cache disks and stopped-VM parking support
- document the intended cache model: shared BuildBuddy CAS plus per-executor stateful `/buildbuddy` disks

## Validation
- `bash -n scripts/gcp-buildbuddy-executor-pool scripts/buildbuddy-bazel-poc scripts/buildbuddy-ci-lane scripts/buildbuddy-ci-dispatch scripts/buildbuddy-ci-lane-batch scripts/buildbuddy-doctor`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/buildbuddy.yml"); YAML.load_file(".github/workflows/ci.yml"); puts "syntax ok"'`\n- `git diff --cached --check`\n- `make buildbuddy-doctor` -> 39 pass, 1 expected dirty-tree warn, 0 fail\n- GCP `scripts/gcp-buildbuddy-executor-pool ensure` created `meerkat-bb-exec-template-v4` and applied stateful `bb-exec-cache` policy\n\n## Notes\nExisting running CI was cancelled and old v3 executor VMs were deleted. BuildBuddy control-plane VM was stopped after cleanup; next GCP CI run will start it and create v4 executor VMs.