### PR TITLE
Split WASM feature CI submitters

### DIFF
--- a/.github/workflows/buildbuddy.yml
+++ b/.github/workflows/buildbuddy.yml
@@ -370,16 +370,13 @@ jobs:
             rmat-audit
             machine-authority
 
-  wasm-feature-submit:
-    name: WASM and feature submitter
-    needs: [control-plane-up, executors-up]
+  wasm-feature-changes:
+    name: WASM, SDK, and feature change detection
+    needs: [control-plane-up]
     runs-on: ubuntu-latest
     timeout-minutes: 20
-    env:
-      BUILDBUDDY_GRPC_URL: ${{ needs.control-plane-up.outputs.grpc_url }}
-      BUILDBUDDY_HTTP_URL: ${{ needs.control-plane-up.outputs.http_url }}
-      BUILDBUDDY_ENDPOINT: ${{ needs.control-plane-up.outputs.grpc_url }}
-      CI_STARTED_AT_EPOCH: ${{ needs.control-plane-up.outputs.started_at_epoch }}
+    outputs:
+      changed: ${{ steps.wasm-feature-changes.outputs.changed }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -420,16 +417,80 @@ jobs:
           fi
           echo "changed=${changed}" >> "${GITHUB_OUTPUT}"
 
-      - uses: ./.github/actions/run-buildbuddy-ci-lane-batch
-        if: ${{ steps.wasm-feature-changes.outputs.changed == 'true' }}
+  wasm-sdk-submit:
+    name: SDK suites submitter
+    needs: [control-plane-up, executors-up, wasm-feature-changes]
+    if: ${{ needs.wasm-feature-changes.outputs.changed == 'true' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    env:
+      BUILDBUDDY_GRPC_URL: ${{ needs.control-plane-up.outputs.grpc_url }}
+      BUILDBUDDY_HTTP_URL: ${{ needs.control-plane-up.outputs.http_url }}
+      BUILDBUDDY_ENDPOINT: ${{ needs.control-plane-up.outputs.grpc_url }}
+      CI_STARTED_AT_EPOCH: ${{ needs.control-plane-up.outputs.started_at_epoch }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
         with:
-          group: gcp-wasm-feature
+          fetch-depth: 1
+
+      - uses: ./.github/actions/run-buildbuddy-ci-lane-batch
+        with:
+          group: gcp-sdk-suites
           profile: submitter
           mode: ${{ inputs.mode || 'full-fresh' }}
           lanes: |
             sdk-suites
+
+  wasm-compile-submit:
+    name: WASM and minimal feature submitter
+    needs: [control-plane-up, executors-up, wasm-feature-changes]
+    if: ${{ needs.wasm-feature-changes.outputs.changed == 'true' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    env:
+      BUILDBUDDY_GRPC_URL: ${{ needs.control-plane-up.outputs.grpc_url }}
+      BUILDBUDDY_HTTP_URL: ${{ needs.control-plane-up.outputs.http_url }}
+      BUILDBUDDY_ENDPOINT: ${{ needs.control-plane-up.outputs.grpc_url }}
+      CI_STARTED_AT_EPOCH: ${{ needs.control-plane-up.outputs.started_at_epoch }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
+      - uses: ./.github/actions/run-buildbuddy-ci-lane-batch
+        with:
+          group: gcp-wasm-compile
+          profile: submitter
+          mode: ${{ inputs.mode || 'full-fresh' }}
+          lanes: |
             wasm-check
             test-minimal
+
+  wasm-feature-submit:
+    name: Feature matrix and audit submitter
+    needs: [control-plane-up, executors-up, wasm-feature-changes]
+    if: ${{ needs.wasm-feature-changes.outputs.changed == 'true' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    env:
+      BUILDBUDDY_GRPC_URL: ${{ needs.control-plane-up.outputs.grpc_url }}
+      BUILDBUDDY_HTTP_URL: ${{ needs.control-plane-up.outputs.http_url }}
+      BUILDBUDDY_ENDPOINT: ${{ needs.control-plane-up.outputs.grpc_url }}
+      CI_STARTED_AT_EPOCH: ${{ needs.control-plane-up.outputs.started_at_epoch }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
+      - uses: ./.github/actions/run-buildbuddy-ci-lane-batch
+        with:
+          group: gcp-feature-audit
+          profile: submitter
+          mode: ${{ inputs.mode || 'full-fresh' }}
+          lanes: |
             test-feature-matrix-lib
             test-feature-matrix-surface-checks
             audit
@@ -443,6 +504,9 @@ jobs:
       - static-submit
       - native-submit
       - governance-submit
+      - wasm-feature-changes
+      - wasm-sdk-submit
+      - wasm-compile-submit
       - wasm-feature-submit
     runs-on: ubuntu-latest
     timeout-minutes: 10
@@ -497,6 +561,9 @@ jobs:
       - static-submit
       - native-submit
       - governance-submit
+      - wasm-feature-changes
+      - wasm-sdk-submit
+      - wasm-compile-submit
       - wasm-feature-submit
       - executors-down
     runs-on: ubuntu-latest

--- a/scripts/buildbuddy-doctor
+++ b/scripts/buildbuddy-doctor
@@ -402,22 +402,38 @@ if job_has_line .github/workflows/ci.yml cargo 'name: GHA Cargo' &&
   job_has_line .github/workflows/buildbuddy.yml static-submit 'fmt-static' &&
   job_has_line .github/workflows/buildbuddy.yml native-submit 'name: Native submitter' &&
   job_has_line .github/workflows/buildbuddy.yml governance-submit 'name: Governance submitter' &&
-  job_has_line .github/workflows/buildbuddy.yml wasm-feature-submit 'name: WASM and feature submitter' &&
+  job_has_line .github/workflows/buildbuddy.yml wasm-feature-changes 'name: WASM, SDK, and feature change detection' &&
+  job_has_line .github/workflows/buildbuddy.yml wasm-sdk-submit 'name: SDK suites submitter' &&
+  job_has_line .github/workflows/buildbuddy.yml wasm-compile-submit 'name: WASM and minimal feature submitter' &&
+  job_has_line .github/workflows/buildbuddy.yml wasm-feature-submit 'name: Feature matrix and audit submitter' &&
   job_has_line .github/workflows/buildbuddy.yml native-submit 'needs: [control-plane-up, executors-up, prebuild-submit]' &&
   job_has_line .github/workflows/buildbuddy.yml governance-submit 'needs: [control-plane-up, executors-up]' &&
-  job_has_line .github/workflows/buildbuddy.yml wasm-feature-submit 'needs: [control-plane-up, executors-up]' &&
+  job_has_line .github/workflows/buildbuddy.yml wasm-feature-changes 'needs: [control-plane-up]' &&
+  job_has_line .github/workflows/buildbuddy.yml wasm-sdk-submit 'needs: [control-plane-up, executors-up, wasm-feature-changes]' &&
+  job_has_line .github/workflows/buildbuddy.yml wasm-compile-submit 'needs: [control-plane-up, executors-up, wasm-feature-changes]' &&
+  job_has_line .github/workflows/buildbuddy.yml wasm-feature-submit 'needs: [control-plane-up, executors-up, wasm-feature-changes]' &&
   job_has_line .github/workflows/buildbuddy.yml native-submit 'CI_STARTED_AT_EPOCH:' &&
   job_has_line .github/workflows/buildbuddy.yml governance-submit 'CI_STARTED_AT_EPOCH:' &&
+  job_has_line .github/workflows/buildbuddy.yml wasm-sdk-submit 'CI_STARTED_AT_EPOCH:' &&
+  job_has_line .github/workflows/buildbuddy.yml wasm-compile-submit 'CI_STARTED_AT_EPOCH:' &&
   job_has_line .github/workflows/buildbuddy.yml wasm-feature-submit 'CI_STARTED_AT_EPOCH:' &&
   job_has_line .github/workflows/buildbuddy.yml native-submit 'group: gcp' &&
   job_has_line .github/workflows/buildbuddy.yml native-submit 'batch_jobs: "2"' &&
   ! job_has_line .github/workflows/buildbuddy.yml native-submit 'fmt-static' &&
   job_has_line .github/workflows/buildbuddy.yml governance-submit 'group: gcp-governance' &&
-  job_has_line .github/workflows/buildbuddy.yml wasm-feature-submit 'group: gcp-wasm-feature' &&
+  job_has_line .github/workflows/buildbuddy.yml wasm-sdk-submit 'group: gcp-sdk-suites' &&
+  job_has_line .github/workflows/buildbuddy.yml wasm-compile-submit 'group: gcp-wasm-compile' &&
+  job_has_line .github/workflows/buildbuddy.yml wasm-feature-submit 'group: gcp-feature-audit' &&
   job_has_line .github/workflows/buildbuddy.yml governance-submit 'Detect machine-authority changes' &&
-  job_has_line .github/workflows/buildbuddy.yml wasm-feature-submit 'Detect WASM, SDK, feature, or audit changes' &&
+  job_has_line .github/workflows/buildbuddy.yml wasm-feature-changes 'Detect WASM, SDK, feature, or audit changes' &&
+  job_has_line .github/workflows/buildbuddy.yml wasm-sdk-submit 'sdk-suites' &&
+  job_has_line .github/workflows/buildbuddy.yml wasm-compile-submit 'wasm-check' &&
+  job_has_line .github/workflows/buildbuddy.yml wasm-compile-submit 'test-minimal' &&
+  job_has_line .github/workflows/buildbuddy.yml wasm-feature-submit 'test-feature-matrix-lib' &&
+  job_has_line .github/workflows/buildbuddy.yml wasm-feature-submit 'test-feature-matrix-surface-checks' &&
+  job_has_line .github/workflows/buildbuddy.yml wasm-feature-submit 'audit' &&
   ! ./scripts/machine-authority-changed MODULE.bazel.lock >/dev/null 2>&1 &&
-  ! job_has_line .github/workflows/buildbuddy.yml wasm-feature-submit 'MODULE.bazel.lock' &&
+  ! job_has_line .github/workflows/buildbuddy.yml wasm-feature-changes 'MODULE.bazel.lock' &&
   ! job_has_line .github/workflows/buildbuddy.yml governance-submit "steps.machine-changes.outputs.changed != 'true'" &&
   ! job_has_line .github/workflows/buildbuddy.yml wasm-feature-submit 'seam-inventory' &&
   ! job_has_line .github/workflows/buildbuddy.yml wasm-feature-submit 'rmat-audit' &&
@@ -432,6 +448,12 @@ if job_has_line .github/workflows/ci.yml cargo 'name: GHA Cargo' &&
   grep -Fq 'All BuildBuddy lanes completed successfully before the SLO watchdog was reaped' scripts/buildbuddy-ci-lane-batch &&
   grep -Fq "inputs.profile == 'submitter' || inputs.profile == 'doctor'" .github/actions/setup-buildbuddy-ci/action.yml &&
   grep -Fq 'scripts/buildbuddy-ci-lane-batch' .github/actions/run-buildbuddy-ci-lane-batch/action.yml &&
+  job_has_line .github/workflows/buildbuddy.yml executors-down '- wasm-feature-changes' &&
+  job_has_line .github/workflows/buildbuddy.yml executors-down '- wasm-sdk-submit' &&
+  job_has_line .github/workflows/buildbuddy.yml executors-down '- wasm-compile-submit' &&
+  job_has_line .github/workflows/buildbuddy.yml gate '- wasm-feature-changes' &&
+  job_has_line .github/workflows/buildbuddy.yml gate '- wasm-sdk-submit' &&
+  job_has_line .github/workflows/buildbuddy.yml gate '- wasm-compile-submit' &&
   grep -Fq 'default_target="//..."' scripts/buildbuddy-bazel-poc &&
   grep -Fq -- '--build_tag_filters=-local,-manual,-e2e,-system,-live,-slow,-required-feature,-trybuild,-snapshot,-fixture,-cargo-equivalent,-requires-network' scripts/buildbuddy-bazel-poc &&
   job_has_line .github/workflows/buildbuddy.yml gate 'runs-on: ubuntu-latest'; then

--- a/xtask/tests/buildbuddy_static_lanes.rs
+++ b/xtask/tests/buildbuddy_static_lanes.rs
@@ -296,8 +296,14 @@ fn gcp_feature_matrix_lane_fans_out_remote_cargo_actions() {
         "GCP governance submitter should remain a separate visible job"
     );
     assert!(
-        workflow.contains("group: gcp-wasm-feature\n          profile: submitter"),
-        "GCP WASM/feature submitter should remain a separate visible job"
+        workflow.contains("group: gcp-sdk-suites\n          profile: submitter")
+            && workflow.contains("group: gcp-wasm-compile\n          profile: submitter")
+            && workflow.contains("group: gcp-feature-audit\n          profile: submitter"),
+        "GCP WASM/SDK/feature submitters should stay split into separate visible jobs"
+    );
+    assert!(
+        !workflow.contains("group: gcp-wasm-feature\n          profile: submitter"),
+        "GCP WASM/SDK/feature submitters must not collapse back into one serial batch"
     );
 }
 


### PR DESCRIPTION
## Summary
- split the former serial WASM/SDK/feature/audit submitter into three parallel submitters
- keep one shared path-change detection job so skipped runs stay cheap
- make executor cleanup and the GCP gate wait for all three submitters
- extend buildbuddy-doctor coverage for the split submitter shape

## Why
Run 25635653040 showed sdk-suites and wasm-check passing, then test-minimal timing out because six lanes were serialized under one 10-minute CI budget.

## Verification
- ruby YAML parse for ci.yml and buildbuddy.yml
- bash -n scripts/buildbuddy-doctor
- git diff --check
- make buildbuddy-doctor
- pre-push hooks