### PR TITLE
Split BuildBuddy edge lane triggers

### DIFF
--- a/.github/workflows/buildbuddy.yml
+++ b/.github/workflows/buildbuddy.yml
@@ -376,7 +376,12 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     outputs:
-      changed: ${{ steps.wasm-feature-changes.outputs.changed }}
+      changed: ${{ steps.edge-changes.outputs.changed }}
+      wasm_changed: ${{ steps.edge-changes.outputs.wasm_changed }}
+      sdk_changed: ${{ steps.edge-changes.outputs.sdk_changed }}
+      minimal_changed: ${{ steps.edge-changes.outputs.minimal_changed }}
+      feature_changed: ${{ steps.edge-changes.outputs.feature_changed }}
+      audit_changed: ${{ steps.edge-changes.outputs.audit_changed }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -384,43 +389,17 @@ jobs:
           fetch-depth: 1
 
       - name: Detect WASM, SDK, feature, or audit changes
-        id: wasm-feature-changes
+        id: edge-changes
         shell: bash
         env:
           BASE_SHA: ${{ inputs.machine_authority_base_sha || '' }}
           HEAD_SHA: ${{ inputs.machine_authority_head_sha || github.sha }}
-        run: |
-          changed=true
-          if [[ -n "${BASE_SHA}" && "${BASE_SHA}" != "0000000000000000000000000000000000000000" ]]; then
-            if ! git cat-file -e "${BASE_SHA}^{commit}" 2>/dev/null; then
-              git fetch --no-tags --depth=1 origin "${BASE_SHA}" || true
-            fi
-            changed=false
-            while IFS= read -r path; do
-              case "${path}" in
-                Cargo.toml|Cargo.lock|MODULE.bazel|.bazelrc)
-                  changed=true
-                  break
-                  ;;
-                meerkat-web-runtime/*|meerkat-cli/src/web_runtime_template/*|sdks/*|tools/sdk-builder/*|tools/sdk-codegen/*|tools/buildbuddy/*)
-                  changed=true
-                  break
-                  ;;
-                scripts/run-surface-feature-matrix)
-                  changed=true
-                  break
-                  ;;
-              esac
-            done < <(git diff --name-only "${BASE_SHA}" "${HEAD_SHA}" --)
-          else
-            echo "No reliable diff base; running WASM/SDK/feature/audit lanes."
-          fi
-          echo "changed=${changed}" >> "${GITHUB_OUTPUT}"
+        run: scripts/buildbuddy-edge-changes "${BASE_SHA}" "${HEAD_SHA}" >> "${GITHUB_OUTPUT}"
 
   wasm-sdk-submit:
     name: SDK suites submitter
     needs: [control-plane-up, executors-up, wasm-feature-changes]
-    if: ${{ needs.wasm-feature-changes.outputs.changed == 'true' }}
+    if: ${{ needs.wasm-feature-changes.outputs.sdk_changed == 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 20
     env:
@@ -442,10 +421,10 @@ jobs:
           lanes: |
             sdk-suites
 
-  wasm-compile-submit:
-    name: WASM and minimal feature submitter
+  wasm-check-submit:
+    name: WASM check submitter
     needs: [control-plane-up, executors-up, wasm-feature-changes]
-    if: ${{ needs.wasm-feature-changes.outputs.changed == 'true' }}
+    if: ${{ needs.wasm-feature-changes.outputs.wasm_changed == 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 20
     env:
@@ -461,17 +440,16 @@ jobs:
 
       - uses: ./.github/actions/run-buildbuddy-ci-lane-batch
         with:
-          group: gcp-wasm-compile
+          group: gcp-wasm-check
           profile: submitter
           mode: ${{ inputs.mode || 'full-fresh' }}
           lanes: |
             wasm-check
-            test-minimal
 
-  wasm-feature-submit:
-    name: Feature matrix and audit submitter
+  minimal-feature-submit:
+    name: Minimal feature submitter
     needs: [control-plane-up, executors-up, wasm-feature-changes]
-    if: ${{ needs.wasm-feature-changes.outputs.changed == 'true' }}
+    if: ${{ needs.wasm-feature-changes.outputs.minimal_changed == 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 20
     env:
@@ -487,12 +465,61 @@ jobs:
 
       - uses: ./.github/actions/run-buildbuddy-ci-lane-batch
         with:
-          group: gcp-feature-audit
+          group: gcp-minimal-feature
+          profile: submitter
+          mode: ${{ inputs.mode || 'full-fresh' }}
+          lanes: |
+            test-minimal
+
+  feature-submit:
+    name: Feature matrix submitter
+    needs: [control-plane-up, executors-up, wasm-feature-changes]
+    if: ${{ needs.wasm-feature-changes.outputs.feature_changed == 'true' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    env:
+      BUILDBUDDY_GRPC_URL: ${{ needs.control-plane-up.outputs.grpc_url }}
+      BUILDBUDDY_HTTP_URL: ${{ needs.control-plane-up.outputs.http_url }}
+      BUILDBUDDY_ENDPOINT: ${{ needs.control-plane-up.outputs.grpc_url }}
+      CI_STARTED_AT_EPOCH: ${{ needs.control-plane-up.outputs.started_at_epoch }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
+      - uses: ./.github/actions/run-buildbuddy-ci-lane-batch
+        with:
+          group: gcp-feature-matrix
           profile: submitter
           mode: ${{ inputs.mode || 'full-fresh' }}
           lanes: |
             test-feature-matrix-lib
             test-feature-matrix-surface-checks
+
+  audit-submit:
+    name: Security audit submitter
+    needs: [control-plane-up, executors-up, wasm-feature-changes]
+    if: ${{ needs.wasm-feature-changes.outputs.audit_changed == 'true' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    env:
+      BUILDBUDDY_GRPC_URL: ${{ needs.control-plane-up.outputs.grpc_url }}
+      BUILDBUDDY_HTTP_URL: ${{ needs.control-plane-up.outputs.http_url }}
+      BUILDBUDDY_ENDPOINT: ${{ needs.control-plane-up.outputs.grpc_url }}
+      CI_STARTED_AT_EPOCH: ${{ needs.control-plane-up.outputs.started_at_epoch }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
+      - uses: ./.github/actions/run-buildbuddy-ci-lane-batch
+        with:
+          group: gcp-security-audit
+          profile: submitter
+          mode: ${{ inputs.mode || 'full-fresh' }}
+          lanes: |
             audit
 
   executors-down:
@@ -506,8 +533,10 @@ jobs:
       - governance-submit
       - wasm-feature-changes
       - wasm-sdk-submit
-      - wasm-compile-submit
-      - wasm-feature-submit
+      - wasm-check-submit
+      - minimal-feature-submit
+      - feature-submit
+      - audit-submit
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -563,8 +592,10 @@ jobs:
       - governance-submit
       - wasm-feature-changes
       - wasm-sdk-submit
-      - wasm-compile-submit
-      - wasm-feature-submit
+      - wasm-check-submit
+      - minimal-feature-submit
+      - feature-submit
+      - audit-submit
       - executors-down
     runs-on: ubuntu-latest
     timeout-minutes: 10

--- a/scripts/buildbuddy-doctor
+++ b/scripts/buildbuddy-doctor
@@ -404,40 +404,59 @@ if job_has_line .github/workflows/ci.yml cargo 'name: GHA Cargo' &&
   job_has_line .github/workflows/buildbuddy.yml governance-submit 'name: Governance submitter' &&
   job_has_line .github/workflows/buildbuddy.yml wasm-feature-changes 'name: WASM, SDK, and feature change detection' &&
   job_has_line .github/workflows/buildbuddy.yml wasm-sdk-submit 'name: SDK suites submitter' &&
-  job_has_line .github/workflows/buildbuddy.yml wasm-compile-submit 'name: WASM and minimal feature submitter' &&
-  job_has_line .github/workflows/buildbuddy.yml wasm-feature-submit 'name: Feature matrix and audit submitter' &&
+  job_has_line .github/workflows/buildbuddy.yml wasm-check-submit 'name: WASM check submitter' &&
+  job_has_line .github/workflows/buildbuddy.yml minimal-feature-submit 'name: Minimal feature submitter' &&
+  job_has_line .github/workflows/buildbuddy.yml feature-submit 'name: Feature matrix submitter' &&
+  job_has_line .github/workflows/buildbuddy.yml audit-submit 'name: Security audit submitter' &&
   job_has_line .github/workflows/buildbuddy.yml native-submit 'needs: [control-plane-up, executors-up, prebuild-submit]' &&
   job_has_line .github/workflows/buildbuddy.yml governance-submit 'needs: [control-plane-up, executors-up]' &&
   job_has_line .github/workflows/buildbuddy.yml wasm-feature-changes 'needs: [control-plane-up]' &&
   job_has_line .github/workflows/buildbuddy.yml wasm-sdk-submit 'needs: [control-plane-up, executors-up, wasm-feature-changes]' &&
-  job_has_line .github/workflows/buildbuddy.yml wasm-compile-submit 'needs: [control-plane-up, executors-up, wasm-feature-changes]' &&
-  job_has_line .github/workflows/buildbuddy.yml wasm-feature-submit 'needs: [control-plane-up, executors-up, wasm-feature-changes]' &&
+  job_has_line .github/workflows/buildbuddy.yml wasm-check-submit 'needs: [control-plane-up, executors-up, wasm-feature-changes]' &&
+  job_has_line .github/workflows/buildbuddy.yml minimal-feature-submit 'needs: [control-plane-up, executors-up, wasm-feature-changes]' &&
+  job_has_line .github/workflows/buildbuddy.yml feature-submit 'needs: [control-plane-up, executors-up, wasm-feature-changes]' &&
+  job_has_line .github/workflows/buildbuddy.yml audit-submit 'needs: [control-plane-up, executors-up, wasm-feature-changes]' &&
   job_has_line .github/workflows/buildbuddy.yml native-submit 'CI_STARTED_AT_EPOCH:' &&
   job_has_line .github/workflows/buildbuddy.yml governance-submit 'CI_STARTED_AT_EPOCH:' &&
   job_has_line .github/workflows/buildbuddy.yml wasm-sdk-submit 'CI_STARTED_AT_EPOCH:' &&
-  job_has_line .github/workflows/buildbuddy.yml wasm-compile-submit 'CI_STARTED_AT_EPOCH:' &&
-  job_has_line .github/workflows/buildbuddy.yml wasm-feature-submit 'CI_STARTED_AT_EPOCH:' &&
+  job_has_line .github/workflows/buildbuddy.yml wasm-check-submit 'CI_STARTED_AT_EPOCH:' &&
+  job_has_line .github/workflows/buildbuddy.yml minimal-feature-submit 'CI_STARTED_AT_EPOCH:' &&
+  job_has_line .github/workflows/buildbuddy.yml feature-submit 'CI_STARTED_AT_EPOCH:' &&
+  job_has_line .github/workflows/buildbuddy.yml audit-submit 'CI_STARTED_AT_EPOCH:' &&
   job_has_line .github/workflows/buildbuddy.yml native-submit 'group: gcp' &&
   job_has_line .github/workflows/buildbuddy.yml native-submit 'batch_jobs: "2"' &&
   ! job_has_line .github/workflows/buildbuddy.yml native-submit 'fmt-static' &&
   job_has_line .github/workflows/buildbuddy.yml governance-submit 'group: gcp-governance' &&
   job_has_line .github/workflows/buildbuddy.yml wasm-sdk-submit 'group: gcp-sdk-suites' &&
-  job_has_line .github/workflows/buildbuddy.yml wasm-compile-submit 'group: gcp-wasm-compile' &&
-  job_has_line .github/workflows/buildbuddy.yml wasm-feature-submit 'group: gcp-feature-audit' &&
+  job_has_line .github/workflows/buildbuddy.yml wasm-check-submit 'group: gcp-wasm-check' &&
+  job_has_line .github/workflows/buildbuddy.yml minimal-feature-submit 'group: gcp-minimal-feature' &&
+  job_has_line .github/workflows/buildbuddy.yml feature-submit 'group: gcp-feature-matrix' &&
+  job_has_line .github/workflows/buildbuddy.yml audit-submit 'group: gcp-security-audit' &&
   job_has_line .github/workflows/buildbuddy.yml governance-submit 'Detect machine-authority changes' &&
   job_has_line .github/workflows/buildbuddy.yml wasm-feature-changes 'Detect WASM, SDK, feature, or audit changes' &&
+  job_has_line .github/workflows/buildbuddy.yml wasm-feature-changes 'wasm_changed:' &&
+  job_has_line .github/workflows/buildbuddy.yml wasm-feature-changes 'sdk_changed:' &&
+  job_has_line .github/workflows/buildbuddy.yml wasm-feature-changes 'minimal_changed:' &&
+  job_has_line .github/workflows/buildbuddy.yml wasm-feature-changes 'feature_changed:' &&
+  job_has_line .github/workflows/buildbuddy.yml wasm-feature-changes 'audit_changed:' &&
+  job_has_line .github/workflows/buildbuddy.yml wasm-feature-changes 'scripts/buildbuddy-edge-changes' &&
   job_has_line .github/workflows/buildbuddy.yml wasm-sdk-submit 'sdk-suites' &&
-  job_has_line .github/workflows/buildbuddy.yml wasm-compile-submit 'wasm-check' &&
-  job_has_line .github/workflows/buildbuddy.yml wasm-compile-submit 'test-minimal' &&
-  job_has_line .github/workflows/buildbuddy.yml wasm-feature-submit 'test-feature-matrix-lib' &&
-  job_has_line .github/workflows/buildbuddy.yml wasm-feature-submit 'test-feature-matrix-surface-checks' &&
-  job_has_line .github/workflows/buildbuddy.yml wasm-feature-submit 'audit' &&
+  job_has_line .github/workflows/buildbuddy.yml wasm-check-submit 'wasm-check' &&
+  ! job_has_line .github/workflows/buildbuddy.yml wasm-check-submit 'test-minimal' &&
+  job_has_line .github/workflows/buildbuddy.yml minimal-feature-submit 'test-minimal' &&
+  job_has_line .github/workflows/buildbuddy.yml feature-submit 'test-feature-matrix-lib' &&
+  job_has_line .github/workflows/buildbuddy.yml feature-submit 'test-feature-matrix-surface-checks' &&
+  job_has_line .github/workflows/buildbuddy.yml audit-submit 'audit' &&
   ! ./scripts/machine-authority-changed MODULE.bazel.lock >/dev/null 2>&1 &&
   ! job_has_line .github/workflows/buildbuddy.yml wasm-feature-changes 'MODULE.bazel.lock' &&
   ! job_has_line .github/workflows/buildbuddy.yml governance-submit "steps.machine-changes.outputs.changed != 'true'" &&
-  ! job_has_line .github/workflows/buildbuddy.yml wasm-feature-submit 'seam-inventory' &&
-  ! job_has_line .github/workflows/buildbuddy.yml wasm-feature-submit 'rmat-audit' &&
-  ! job_has_line .github/workflows/buildbuddy.yml wasm-feature-submit 'machine-authority' &&
+  ! job_has_line .github/workflows/buildbuddy.yml feature-submit 'audit' &&
+  ! job_has_line .github/workflows/buildbuddy.yml audit-submit 'test-feature-matrix-lib' &&
+  ! job_has_line .github/workflows/buildbuddy.yml wasm-check-submit 'sdk-suites' &&
+  ! job_has_line .github/workflows/buildbuddy.yml minimal-feature-submit 'wasm-check' &&
+  ! job_has_line .github/workflows/buildbuddy.yml feature-submit 'seam-inventory' &&
+  ! job_has_line .github/workflows/buildbuddy.yml feature-submit 'rmat-audit' &&
+  ! job_has_line .github/workflows/buildbuddy.yml feature-submit 'machine-authority' &&
   grep -Fq 'MEERKAT_BUILDBUDDY_BATCH_JOBS' .github/workflows/buildbuddy.yml &&
   grep -Fq 'MEERKAT_BUILDBUDDY_BATCH_JOBS: ${{ inputs.batch_jobs || env.MEERKAT_BUILDBUDDY_BATCH_JOBS }}' .github/actions/run-buildbuddy-ci-lane-batch/action.yml &&
   grep -Fq 'Check GCP CI duration SLO' .github/workflows/buildbuddy.yml &&
@@ -450,16 +469,39 @@ if job_has_line .github/workflows/ci.yml cargo 'name: GHA Cargo' &&
   grep -Fq 'scripts/buildbuddy-ci-lane-batch' .github/actions/run-buildbuddy-ci-lane-batch/action.yml &&
   job_has_line .github/workflows/buildbuddy.yml executors-down '- wasm-feature-changes' &&
   job_has_line .github/workflows/buildbuddy.yml executors-down '- wasm-sdk-submit' &&
-  job_has_line .github/workflows/buildbuddy.yml executors-down '- wasm-compile-submit' &&
+  job_has_line .github/workflows/buildbuddy.yml executors-down '- wasm-check-submit' &&
+  job_has_line .github/workflows/buildbuddy.yml executors-down '- minimal-feature-submit' &&
+  job_has_line .github/workflows/buildbuddy.yml executors-down '- feature-submit' &&
+  job_has_line .github/workflows/buildbuddy.yml executors-down '- audit-submit' &&
   job_has_line .github/workflows/buildbuddy.yml gate '- wasm-feature-changes' &&
   job_has_line .github/workflows/buildbuddy.yml gate '- wasm-sdk-submit' &&
-  job_has_line .github/workflows/buildbuddy.yml gate '- wasm-compile-submit' &&
+  job_has_line .github/workflows/buildbuddy.yml gate '- wasm-check-submit' &&
+  job_has_line .github/workflows/buildbuddy.yml gate '- minimal-feature-submit' &&
+  job_has_line .github/workflows/buildbuddy.yml gate '- feature-submit' &&
+  job_has_line .github/workflows/buildbuddy.yml gate '- audit-submit' &&
   grep -Fq 'default_target="//..."' scripts/buildbuddy-bazel-poc &&
   grep -Fq -- '--build_tag_filters=-local,-manual,-e2e,-system,-live,-slow,-required-feature,-trybuild,-snapshot,-fixture,-cargo-equivalent,-requires-network' scripts/buildbuddy-bazel-poc &&
   job_has_line .github/workflows/buildbuddy.yml gate 'runs-on: ubuntu-latest'; then
   pass "GCP BuildBuddy CI uses a broad Bazel-native prebuild plus path-aware edge lanes"
 else
   bad "GCP BuildBuddy CI is not using the broad-prebuild/path-aware edge-lane shape"
+fi
+
+sdk_only="$(printf 'sdks/typescript/src/runtime.ts\n' | scripts/buildbuddy-edge-changes --paths-from-stdin)"
+wasm_only="$(printf 'meerkat-web-runtime/src/lib.rs\n' | scripts/buildbuddy-edge-changes --paths-from-stdin)"
+feature_only="$(printf 'scripts/run-surface-feature-matrix\n' | scripts/buildbuddy-edge-changes --paths-from-stdin)"
+audit_only="$(printf 'deny.toml\n' | scripts/buildbuddy-edge-changes --paths-from-stdin)"
+if grep -Fq 'sdk_changed=true' <<<"${sdk_only}" &&
+  grep -Fq 'wasm_changed=false' <<<"${sdk_only}" &&
+  grep -Fq 'wasm_changed=true' <<<"${wasm_only}" &&
+  grep -Fq 'sdk_changed=false' <<<"${wasm_only}" &&
+  grep -Fq 'feature_changed=true' <<<"${feature_only}" &&
+  grep -Fq 'wasm_changed=false' <<<"${feature_only}" &&
+  grep -Fq 'audit_changed=true' <<<"${audit_only}" &&
+  grep -Fq 'wasm_changed=false' <<<"${audit_only}"; then
+  pass "BuildBuddy edge lane detector keeps WASM separate from SDK, feature, and audit-only changes"
+else
+  bad "BuildBuddy edge lane detector is over-triggering WASM edge lanes"
 fi
 
 if grep -Fq 'full-fresh' .github/workflows/buildbuddy.yml &&

--- a/scripts/buildbuddy-edge-changes
+++ b/scripts/buildbuddy-edge-changes
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+usage:
+  scripts/buildbuddy-edge-changes [BASE_SHA HEAD_SHA]
+  scripts/buildbuddy-edge-changes --paths-from-stdin
+
+Prints GitHub-output-compatible booleans for expensive GCP BuildBuddy edge
+lanes. With no reliable base revision, every edge lane is enabled.
+USAGE
+}
+
+wasm_changed=false
+sdk_changed=false
+minimal_changed=false
+feature_changed=false
+audit_changed=false
+
+mark_all() {
+  wasm_changed=true
+  sdk_changed=true
+  minimal_changed=true
+  feature_changed=true
+  audit_changed=true
+}
+
+mark_path() {
+  local path="$1"
+
+  case "${path}" in
+    Cargo.toml|Cargo.lock|rust-toolchain.toml|MODULE.bazel|.bazelrc)
+      mark_all
+      return
+      ;;
+    .github/workflows/ci.yml|.github/workflows/buildbuddy.yml|.github/actions/run-buildbuddy-ci-lane-batch/*|.github/actions/setup-buildbuddy-ci/*|scripts/buildbuddy-*|tools/buildbuddy/*)
+      mark_all
+      return
+      ;;
+    deny.toml)
+      audit_changed=true
+      ;;
+  esac
+
+  case "${path}" in
+    meerkat-web-runtime/*|meerkat-cli/src/web_runtime_template/*)
+      wasm_changed=true
+      ;;
+    meerkat/*|meerkat-anthropic/*|meerkat-auth-core/*|meerkat-client/*|meerkat-comms/*|meerkat-contracts/*|meerkat-core/*|meerkat-gemini/*|meerkat-hooks/*|meerkat-llm-core/*|meerkat-machine-derive/*|meerkat-machine-dsl/*|meerkat-machine-dsl-core/*|meerkat-machine-kernels/*|meerkat-machine-schema/*|meerkat-mob/*|meerkat-mob-mcp/*|meerkat-mob-pack/*|meerkat-models/*|meerkat-openai/*|meerkat-providers/*|meerkat-runtime/*|meerkat-schedule/*|meerkat-session/*|meerkat-skills/*|meerkat-store/*|meerkat-tools/*)
+      wasm_changed=true
+      ;;
+  esac
+
+  case "${path}" in
+    sdks/*|tools/sdk-builder/*|tools/sdk-codegen/*)
+      sdk_changed=true
+      ;;
+    meerkat-rpc/*|meerkat-client/*|meerkat-contracts/*|meerkat-core/*|meerkat-llm-core/*|meerkat-models/*)
+      sdk_changed=true
+      ;;
+  esac
+
+  case "${path}" in
+    meerkat/*|meerkat-client/*|meerkat-core/*|meerkat-store/*|meerkat-tools/*)
+      minimal_changed=true
+      ;;
+  esac
+
+  case "${path}" in
+    scripts/run-surface-feature-matrix|meerkat/*|meerkat-comms/*|meerkat-gemini/*|meerkat-mob/*|meerkat-mob-mcp/*|meerkat-openai/*|meerkat-providers/*|meerkat-tools/*)
+      feature_changed=true
+      ;;
+  esac
+}
+
+emit_outputs() {
+  local changed=false
+  if [[ "${wasm_changed}" == "true" ||
+    "${sdk_changed}" == "true" ||
+    "${minimal_changed}" == "true" ||
+    "${feature_changed}" == "true" ||
+    "${audit_changed}" == "true" ]]; then
+    changed=true
+  fi
+
+  printf 'changed=%s\n' "${changed}"
+  printf 'wasm_changed=%s\n' "${wasm_changed}"
+  printf 'sdk_changed=%s\n' "${sdk_changed}"
+  printf 'minimal_changed=%s\n' "${minimal_changed}"
+  printf 'feature_changed=%s\n' "${feature_changed}"
+  printf 'audit_changed=%s\n' "${audit_changed}"
+}
+
+if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
+  usage
+  exit 0
+fi
+
+if [[ "${1:-}" == "--paths-from-stdin" ]]; then
+  while IFS= read -r path; do
+    [[ -n "${path}" ]] || continue
+    mark_path "${path}"
+  done
+  emit_outputs
+  exit 0
+fi
+
+base_sha="${1:-${BASE_SHA:-}}"
+head_sha="${2:-${HEAD_SHA:-HEAD}}"
+
+if [[ -z "${base_sha}" || "${base_sha}" == "0000000000000000000000000000000000000000" ]]; then
+  echo "No reliable diff base; running all WASM/SDK/feature/audit edge lanes." >&2
+  mark_all
+  emit_outputs
+  exit 0
+fi
+
+if ! git cat-file -e "${base_sha}^{commit}" 2>/dev/null; then
+  git fetch --no-tags --depth=1 origin "${base_sha}" >&2 || true
+fi
+
+while IFS= read -r path; do
+  [[ -n "${path}" ]] || continue
+  mark_path "${path}"
+done < <(git diff --name-only "${base_sha}" "${head_sha}" --)
+
+emit_outputs

--- a/xtask/tests/buildbuddy_static_lanes.rs
+++ b/xtask/tests/buildbuddy_static_lanes.rs
@@ -297,13 +297,17 @@ fn gcp_feature_matrix_lane_fans_out_remote_cargo_actions() {
     );
     assert!(
         workflow.contains("group: gcp-sdk-suites\n          profile: submitter")
-            && workflow.contains("group: gcp-wasm-compile\n          profile: submitter")
-            && workflow.contains("group: gcp-feature-audit\n          profile: submitter"),
-        "GCP WASM/SDK/feature submitters should stay split into separate visible jobs"
+            && workflow.contains("group: gcp-wasm-check\n          profile: submitter")
+            && workflow.contains("group: gcp-minimal-feature\n          profile: submitter")
+            && workflow.contains("group: gcp-feature-matrix\n          profile: submitter")
+            && workflow.contains("group: gcp-security-audit\n          profile: submitter"),
+        "GCP WASM/SDK/feature/audit submitters should stay split into separate visible jobs"
     );
     assert!(
-        !workflow.contains("group: gcp-wasm-feature\n          profile: submitter"),
-        "GCP WASM/SDK/feature submitters must not collapse back into one serial batch"
+        !workflow.contains("group: gcp-wasm-feature\n          profile: submitter")
+            && !workflow.contains("group: gcp-wasm-compile\n          profile: submitter")
+            && !workflow.contains("group: gcp-feature-audit\n          profile: submitter"),
+        "GCP WASM/SDK/feature/audit submitters must not collapse back into serial batches"
     );
 }
 


### PR DESCRIPTION
## Summary
- replace the coarse WASM/SDK/feature change bit with per-lane outputs
- split WASM check, minimal feature, feature matrix, and security audit into independently gated submitter jobs
- add a reusable edge-change detector plus doctor/static guardrails so SDK, feature, and audit-only edits do not trigger the wasm32 check

## Verification
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/buildbuddy.yml"); YAML.load_file(".github/workflows/ci.yml"); puts "yaml ok"'\n- bash -n scripts/buildbuddy-doctor scripts/buildbuddy-edge-changes\n- git diff --check\n- ./scripts/repo-cargo test -p xtask --test buildbuddy_static_lanes gcp_feature_matrix_lane_fans_out_remote_cargo_actions -- --exact\n- make buildbuddy-doctor\n- pre-push hooks\n