### PR TITLE
[codex] Fix auth binding fallback resolution

### DIFF
--- a/meerkat-cli/src/main.rs
+++ b/meerkat-cli/src/main.rs
@@ -2073,6 +2073,8 @@ async fn handle_run_command(
     let (config, config_base_dir) = load_config(scope).await?;
     let (config, runtime_preload_skills) = resolve_runtime_skills(config, skills).await?;
 
+    let model_was_explicit = model.is_some();
+    let provider_was_explicit = provider.is_some();
     let auth_binding_selection = auth_binding
         .as_ref()
         .map(|binding| resolve_cli_auth_binding_selection(&config, binding))
@@ -2090,6 +2092,9 @@ async fn handle_run_command(
         provider,
         auth_binding_selection.as_ref(),
     )?;
+    let build_provider_override =
+        (provider.is_some() || auth_binding.is_some() || model_was_explicit)
+            .then_some(resolved_provider);
 
     let duration = max_duration.map(|s| parse_duration(&s)).transpose();
     let provider_params = parse_provider_params(&params);
@@ -2131,6 +2136,9 @@ async fn handle_run_command(
                 system_prompt,
                 &model,
                 resolved_provider,
+                build_provider_override,
+                model_was_explicit,
+                provider_was_explicit,
                 max_tokens,
                 limits,
                 &output,
@@ -6387,6 +6395,9 @@ async fn run_agent(
     system_prompt: Option<String>,
     model: &str,
     provider: Provider,
+    build_provider_override: Option<Provider>,
+    model_was_explicit: bool,
+    provider_was_explicit: bool,
     max_tokens: u32,
     limits: BudgetLimits,
     output: &str,
@@ -6424,6 +6435,9 @@ async fn run_agent(
             system_prompt,
             model,
             provider,
+            build_provider_override,
+            model_was_explicit,
+            provider_was_explicit,
             max_tokens,
             limits,
             output,
@@ -6620,7 +6634,7 @@ async fn run_agent(
             CliOutputPipeline::new(stream, verbose, stream_policy.clone(), primary_scope_path)?;
 
         let mut build = SessionBuildOptions {
-            provider: Some(provider.as_core()),
+            provider: build_provider_override.map(Provider::as_core),
             self_hosted_server_id: None,
             output_schema,
             structured_output_retries,
@@ -6660,7 +6674,12 @@ async fn run_agent(
             shell_env: None,
             runtime_build_mode: meerkat_core::RuntimeBuildMode::SessionOwned(bindings),
             initial_turn_metadata: None,
-            resume_override_mask: Default::default(),
+            resume_override_mask: meerkat_core::service::ResumeOverrideMask {
+                model: model_was_explicit,
+                provider: provider_was_explicit,
+                auth_binding: auth_binding.is_some(),
+                ..Default::default()
+            },
             call_timeout_override: Default::default(),
             blob_store_override: None,
             mob_tools: mob_tools_factory,

--- a/meerkat-core/src/agent/state.rs
+++ b/meerkat-core/src/agent/state.rs
@@ -1821,6 +1821,24 @@ where
                     let assistant_msg = BlockAssistantMessage::new(blocks, stop_reason);
                     let assistant_text = assistant_msg.to_string();
 
+                    if !assistant_msg.has_visible_or_actionable_output() {
+                        let error = AgentError::llm_empty_response(self.client.provider());
+                        if in_extraction {
+                            return self
+                                .complete_extraction_failed(
+                                    &run_id,
+                                    turn_count,
+                                    tool_call_count,
+                                    error.to_string(),
+                                    &event_tx,
+                                )
+                                .await;
+                        }
+                        self.terminalize_fatal_error(&run_id, turn_count, &event_tx, &error)
+                            .await?;
+                        return Err(error);
+                    }
+
                     let post_llm_invocation = HookInvocation {
                         point: HookPoint::PostLlmResponse,
                         session_id: self.session.id().clone(),
@@ -5965,6 +5983,81 @@ mod tests {
         fn model(&self) -> &'static str {
             "mock-model"
         }
+    }
+
+    struct ReasoningOnlyLlmClient;
+
+    #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+    #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+    impl AgentLlmClient for ReasoningOnlyLlmClient {
+        async fn stream_response(
+            &self,
+            _messages: &[Message],
+            _tools: &[Arc<ToolDef>],
+            _max_tokens: u32,
+            _temperature: Option<f32>,
+            _provider_params: Option<&crate::lifecycle::run_primitive::ProviderParamsOverride>,
+        ) -> Result<super::LlmStreamResult, AgentError> {
+            Ok(super::LlmStreamResult::new(
+                vec![AssistantBlock::Reasoning {
+                    text: "I should call a tool".to_string(),
+                    meta: None,
+                }],
+                StopReason::EndTurn,
+                Usage::default(),
+            ))
+        }
+
+        fn provider(&self) -> &'static str {
+            "mock"
+        }
+
+        fn model(&self) -> &'static str {
+            "mock-model"
+        }
+    }
+
+    #[tokio::test]
+    async fn reasoning_only_llm_response_does_not_complete_turn() {
+        let mut agent = build_agent(Arc::new(ReasoningOnlyLlmClient)).await;
+        agent.config.max_turns = Some(1);
+
+        let err = agent
+            .run("Use a tool".to_string().into())
+            .await
+            .expect_err("reasoning-only LLM response should terminalize as a failure");
+
+        match err {
+            AgentError::Llm {
+                reason, message, ..
+            } => {
+                assert!(
+                    message.contains("user-visible text"),
+                    "unexpected message: {message}"
+                );
+                assert!(matches!(
+                    reason,
+                    crate::error::LlmFailureReason::ProviderError(crate::error::LlmProviderError {
+                        kind: crate::error::LlmProviderErrorKind::IncompleteResponse,
+                        ..
+                    })
+                ));
+            }
+            other => panic!("expected LLM incomplete-response failure, got {other:?}"),
+        }
+
+        let snapshot = agent
+            .execution_snapshot()
+            .expect("test turn-state handle should expose a snapshot");
+        assert_eq!(snapshot.turn_phase, crate::TurnPhase::Failed);
+        assert_eq!(
+            snapshot.terminal_outcome,
+            crate::TurnTerminalOutcome::Failed
+        );
+        assert_eq!(
+            snapshot.terminal_cause_kind,
+            Some(crate::TurnTerminalCauseKind::LlmFailure)
+        );
     }
 
     #[tokio::test]

--- a/meerkat-core/src/connection.rs
+++ b/meerkat-core/src/connection.rs
@@ -8,7 +8,7 @@
 //! `auth_method` as strings until they are normalized at the provider-runtime
 //! catalog boundary.
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::path::PathBuf;
 
 use serde::{Deserialize, Serialize};
@@ -455,6 +455,166 @@ pub fn resolve_auth_binding_or_default_for_provider(
         preferred_realm,
         allow_env_default,
     )
+}
+
+fn selected_binding_id_for_provider(
+    realm: &RealmConnectionSet,
+    provider: Provider,
+) -> Result<Option<BindingId>, ConnectionTargetError> {
+    let mut provider_bindings = Vec::new();
+    for (binding_id, binding) in &realm.bindings {
+        let backend = realm
+            .backends
+            .get(&binding.backend_profile)
+            .ok_or_else(|| ConnectionTargetError::BindingInvalid {
+                realm: realm.realm_id.clone(),
+                binding: binding_id.clone(),
+                source: ProviderBindingError::UnknownBackend(binding.backend_profile.clone()),
+            })?;
+        let auth = realm
+            .auth_profiles
+            .get(&binding.auth_profile)
+            .ok_or_else(|| ConnectionTargetError::BindingInvalid {
+                realm: realm.realm_id.clone(),
+                binding: binding_id.clone(),
+                source: ProviderBindingError::UnknownAuth(binding.auth_profile.clone()),
+            })?;
+        if backend.provider == provider && auth.provider == provider {
+            provider_bindings.push(binding_id.as_str());
+        }
+    }
+
+    if let Some(default_binding) = realm.default_binding.as_deref()
+        && provider_bindings.contains(&default_binding)
+    {
+        return BindingId::parse(default_binding.to_string())
+            .map(Some)
+            .map_err(|source| ConnectionTargetError::InvalidBindingId {
+                binding: default_binding.to_string(),
+                source,
+            });
+    }
+
+    let provider_default_binding = format!("default_{}", provider.as_str());
+    if provider_bindings
+        .iter()
+        .any(|binding_id| *binding_id == provider_default_binding)
+    {
+        return BindingId::parse(provider_default_binding.clone())
+            .map(Some)
+            .map_err(|source| ConnectionTargetError::InvalidBindingId {
+                binding: provider_default_binding,
+                source,
+            });
+    }
+
+    match provider_bindings.as_slice() {
+        [binding_id] => BindingId::parse((*binding_id).to_string())
+            .map(Some)
+            .map_err(|source| ConnectionTargetError::InvalidBindingId {
+                binding: (*binding_id).to_string(),
+                source,
+            }),
+        _ => Ok(None),
+    }
+}
+
+fn push_candidate_realm_ids<'a>(
+    ids: &mut Vec<&'a str>,
+    seen: &mut BTreeSet<&'a str>,
+    id: Option<&'a str>,
+) {
+    if let Some(id) = id
+        && seen.insert(id)
+    {
+        ids.push(id);
+    }
+}
+
+/// Resolve ordered connection candidates for an omitted `auth_binding`.
+///
+/// The returned order is the shared "best available" policy used by all
+/// factory-backed surfaces:
+/// 1. configured provider binding in the preferred realm
+/// 2. configured provider binding in the `default` realm
+/// 3. configured provider binding in any remaining realm
+/// 4. synthetic env-var fallback when allowed
+///
+/// Within a realm, `default_binding` wins when it resolves to the requested
+/// provider, then `default_<provider>`, then a single unambiguous provider
+/// binding. Explicit `auth_binding` still resolves to one strict target.
+pub fn resolve_auth_binding_candidates_for_provider(
+    config: &Config,
+    provider: Provider,
+    auth_binding: Option<&AuthBindingRef>,
+    preferred_realm: Option<&RealmId>,
+    allow_env_default: bool,
+) -> Result<Vec<ResolvedConnectionTarget>, ConnectionTargetError> {
+    if auth_binding.is_some() {
+        return resolve_auth_binding_or_default_for_provider(
+            config,
+            provider,
+            auth_binding,
+            preferred_realm,
+            allow_env_default,
+        )
+        .map(|target| vec![target]);
+    }
+
+    let mut realm_ids = Vec::new();
+    let mut seen = BTreeSet::new();
+    push_candidate_realm_ids(
+        &mut realm_ids,
+        &mut seen,
+        preferred_realm.map(RealmId::as_str),
+    );
+    push_candidate_realm_ids(&mut realm_ids, &mut seen, Some("default"));
+    for realm_id in config.realm.keys() {
+        push_candidate_realm_ids(&mut realm_ids, &mut seen, Some(realm_id.as_str()));
+    }
+
+    let mut candidates = Vec::new();
+    let mut missing_default: Option<String> = None;
+    for realm_id in realm_ids {
+        let Some(section) = config.realm.get(realm_id) else {
+            if preferred_realm.is_some_and(|preferred| preferred.as_str() == realm_id) {
+                missing_default.get_or_insert_with(|| realm_id.to_string());
+            }
+            continue;
+        };
+        let realm = RealmConnectionSet::from_config(realm_id, section).map_err(|source| {
+            ConnectionTargetError::RealmConfigInvalid {
+                realm: realm_id.to_string(),
+                source,
+            }
+        })?;
+        if let Some(binding_id) = selected_binding_id_for_provider(&realm, provider)? {
+            candidates.push(materialize_connection_target(
+                realm, provider, binding_id, None,
+            )?);
+        }
+    }
+
+    if allow_env_default {
+        let realm = RealmConnectionSet::synthesize_env_default(provider);
+        let binding = BindingId::parse("default").map_err(|source| {
+            ConnectionTargetError::InvalidBindingId {
+                binding: "default".to_string(),
+                source,
+            }
+        })?;
+        candidates.push(materialize_connection_target(
+            realm, provider, binding, None,
+        )?);
+    }
+
+    if !candidates.is_empty() {
+        return Ok(candidates);
+    }
+    if let Some(realm) = missing_default {
+        return Err(ConnectionTargetError::MissingDefaultBinding { realm });
+    }
+    Err(ConnectionTargetError::MissingRealm)
 }
 
 fn materialize_connection_target(
@@ -1121,6 +1281,83 @@ auth_profile = "default_profile"
                 ..
             }
         ));
+    }
+
+    #[test]
+    fn auth_binding_candidates_prefer_provider_binding_in_preferred_realm() {
+        let config = config_with_realms(
+            r#"
+[dev]
+default_binding = "openai_oauth"
+
+[dev.backend.openai_chatgpt]
+provider = "openai"
+backend_kind = "openai_chatgpt"
+
+[dev.auth.openai_oauth]
+provider = "openai"
+auth_method = "chatgpt_oauth"
+source = { kind = "managed_store" }
+
+[dev.binding.openai_oauth]
+backend_profile = "openai_chatgpt"
+auth_profile = "openai_oauth"
+default_model = "gpt-5.4"
+"#,
+        );
+        let preferred_realm = RealmId::parse("dev").unwrap();
+
+        let candidates = resolve_auth_binding_candidates_for_provider(
+            &config,
+            Provider::OpenAI,
+            None,
+            Some(&preferred_realm),
+            true,
+        )
+        .expect("candidates resolve");
+
+        assert_eq!(candidates[0].auth_binding.realm.as_str(), "dev");
+        assert_eq!(candidates[0].auth_binding.binding.as_str(), "openai_oauth");
+        assert!(!candidates[0].auth_binding.is_env_default());
+    }
+
+    #[test]
+    fn auth_binding_candidates_scan_configured_realms_before_env_default() {
+        let config = config_with_realms(
+            r#"
+[dev]
+
+[dev.backend.openai_chatgpt]
+provider = "openai"
+backend_kind = "openai_chatgpt"
+
+[dev.auth.openai_oauth]
+provider = "openai"
+auth_method = "chatgpt_oauth"
+source = { kind = "managed_store" }
+
+[dev.binding.openai_oauth]
+backend_profile = "openai_chatgpt"
+auth_profile = "openai_oauth"
+"#,
+        );
+        let preferred_realm = RealmId::parse("missing").unwrap();
+
+        let candidates = resolve_auth_binding_candidates_for_provider(
+            &config,
+            Provider::OpenAI,
+            None,
+            Some(&preferred_realm),
+            true,
+        )
+        .expect("candidates resolve");
+
+        assert_eq!(candidates[0].auth_binding.realm.as_str(), "dev");
+        assert_eq!(candidates[0].auth_binding.binding.as_str(), "openai_oauth");
+        assert_eq!(
+            candidates.last().unwrap().auth_binding.realm.as_str(),
+            "env_default"
+        );
     }
 
     #[test]

--- a/meerkat-core/src/error.rs
+++ b/meerkat-core/src/error.rs
@@ -401,6 +401,20 @@ impl AgentError {
             message: message.into(),
         }
     }
+
+    pub fn llm_empty_response(provider: &'static str) -> Self {
+        Self::llm(
+            provider,
+            LlmFailureReason::ProviderError(LlmProviderError::non_retryable(
+                LlmProviderErrorKind::IncompleteResponse,
+                serde_json::json!({
+                    "reason": "provider completed without user-visible text, images, or tool calls"
+                }),
+            )),
+            "LLM completed without user-visible text, images, or tool calls",
+        )
+    }
+
     pub fn is_graceful(&self) -> bool {
         matches!(
             self,

--- a/meerkat-core/src/lib.rs
+++ b/meerkat-core/src/lib.rs
@@ -332,5 +332,6 @@ pub use connection::{
     BindingId, BindingPolicy, ConnectionTargetError, CredentialSourceSpec, IdentityError,
     ProfileId, ProviderBinding, ProviderBindingConfig, ProviderBindingError, RealmConfigSection,
     RealmConnectionSet, RealmId, ResolvedConnectionTarget,
-    resolve_auth_binding_or_default_for_provider, resolve_realm_binding_target_for_provider,
+    resolve_auth_binding_candidates_for_provider, resolve_auth_binding_or_default_for_provider,
+    resolve_realm_binding_target_for_provider,
 };

--- a/meerkat-core/src/lib.rs
+++ b/meerkat-core/src/lib.rs
@@ -299,8 +299,9 @@ pub use types::{
     RunResult, SUPPORTED_VIDEO_MEDIA_TYPES, SecurityMode, SessionId, StopReason, SystemMessage,
     SystemNoticeKind, SystemNoticeMessage, ToolCall, ToolCallIter, ToolCallView, ToolDef,
     ToolIdentity, ToolName, ToolNameSet, ToolProvenance, ToolResult, ToolSourceId, ToolSourceKind,
-    TranscriptSource, Usage, UserMessage, VideoData, has_images, has_non_text_content, has_video,
-    is_supported_video_media_type, validate_inline_video_blocks,
+    TranscriptSource, Usage, UserMessage, VideoData,
+    assistant_blocks_have_visible_or_actionable_output, has_images, has_non_text_content,
+    has_video, is_supported_video_media_type, validate_inline_video_blocks,
 };
 
 // === Provider auth v2 (landed ahead of wiring — see

--- a/meerkat-core/src/types.rs
+++ b/meerkat-core/src/types.rs
@@ -560,6 +560,16 @@ pub enum AssistantBlock {
     },
 }
 
+pub fn assistant_blocks_have_visible_or_actionable_output(blocks: &[AssistantBlock]) -> bool {
+    blocks.iter().any(|block| match block {
+        AssistantBlock::Text { text, .. } | AssistantBlock::Transcript { text, .. } => {
+            !text.trim().is_empty()
+        }
+        AssistantBlock::ToolUse { .. } | AssistantBlock::Image { .. } => true,
+        AssistantBlock::Reasoning { .. } | AssistantBlock::ServerToolContent { .. } => false,
+    })
+}
+
 impl PartialEq for AssistantBlock {
     fn eq(&self, other: &Self) -> bool {
         match (self, other) {
@@ -1230,6 +1240,10 @@ impl BlockAssistantMessage {
         self.blocks
             .iter()
             .any(|b| matches!(b, AssistantBlock::ToolUse { .. }))
+    }
+
+    pub fn has_visible_or_actionable_output(&self) -> bool {
+        assistant_blocks_have_visible_or_actionable_output(&self.blocks)
     }
 
     /// Get tool use block by ID.

--- a/meerkat-llm-core/src/adapter.rs
+++ b/meerkat-llm-core/src/adapter.rs
@@ -420,11 +420,17 @@ mod tests {
                 }
             };
             *seen = Some(request.messages.clone());
-            Box::pin(stream::iter([Ok(LlmEvent::Done {
-                outcome: LlmDoneOutcome::Success {
-                    stop_reason: StopReason::EndTurn,
-                },
-            })]))
+            Box::pin(stream::iter([
+                Ok(LlmEvent::TextDelta {
+                    delta: "ok".to_string(),
+                    meta: None,
+                }),
+                Ok(LlmEvent::Done {
+                    outcome: LlmDoneOutcome::Success {
+                        stop_reason: StopReason::EndTurn,
+                    },
+                }),
+            ]))
         }
 
         fn provider(&self) -> &'static str {

--- a/meerkat-openai/src/client.rs
+++ b/meerkat-openai/src/client.rs
@@ -27,7 +27,7 @@ use meerkat_llm_core::{http, streaming};
 use serde::Deserialize;
 use serde_json::Value;
 use serde_json::value::RawValue;
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 
 use crate::image_generation::{
     OpenAiImageOutputOptions, OpenAiImageProviderParams, OpenAiImagesApiEndpoint,
@@ -1271,6 +1271,8 @@ impl LlmClient for OpenAiClient {
             let mut usage = Usage::default();
             let mut saw_stream_text_delta = false;
             let mut streamed_tool_ids: HashSet<String> = HashSet::with_capacity(4);
+            let mut response_item_tool_calls: HashMap<String, (String, String)> =
+                HashMap::with_capacity(4);
             let mut streamed_reasoning_ids: HashSet<String> = HashSet::with_capacity(2);
             let mut done_emitted = false;
 
@@ -1494,6 +1496,21 @@ impl LlmClient for OpenAiClient {
                             }
                         }
                         // Handle streaming delta events
+                        else if event.event_type == "response.output_item.added" {
+                            if let Some(item) = &event.item
+                                && item.get("type").and_then(Value::as_str) == Some("function_call")
+                                && let (Some(item_id), Some(call_id), Some(name)) = (
+                                    item.get("id").and_then(Value::as_str),
+                                    item.get("call_id").and_then(Value::as_str),
+                                    item.get("name").and_then(Value::as_str),
+                                )
+                            {
+                                response_item_tool_calls.insert(
+                                    item_id.to_string(),
+                                    (call_id.to_string(), name.to_string()),
+                                );
+                            }
+                        }
                         else if event.event_type == "response.output_text.delta" {
                             if let Some(delta) = &event.delta {
                                 saw_stream_text_delta = true;
@@ -1507,8 +1524,22 @@ impl LlmClient for OpenAiClient {
                             }
                         }
                         else if event.event_type == "response.function_call_arguments.delta" {
-                            if let (Some(call_id), Some(delta)) = (&event.call_id, &event.delta) {
-                                let name = event.name.clone();
+                            if let Some(delta) = &event.delta {
+                                let item_lookup = event
+                                    .item_id
+                                    .as_ref()
+                                    .and_then(|item_id| response_item_tool_calls.get(item_id));
+                                let call_id = event
+                                    .call_id
+                                    .as_ref()
+                                    .or_else(|| item_lookup.map(|(call_id, _)| call_id));
+                                let Some(call_id) = call_id else {
+                                    continue;
+                                };
+                                let name = event
+                                    .name
+                                    .clone()
+                                    .or_else(|| item_lookup.map(|(_, name)| name.clone()));
                                 yield LlmEvent::ToolCallDelta {
                                     id: call_id.clone(),
                                     name,
@@ -1517,8 +1548,23 @@ impl LlmClient for OpenAiClient {
                             }
                         }
                         else if event.event_type == "response.function_call_arguments.done" {
-                            if let (Some(call_id), Some(arguments)) = (&event.call_id, &event.arguments) {
-                                let name = event.name.clone().unwrap_or_default();
+                            if let Some(arguments) = &event.arguments {
+                                let item_lookup = event
+                                    .item_id
+                                    .as_ref()
+                                    .and_then(|item_id| response_item_tool_calls.get(item_id));
+                                let call_id = event
+                                    .call_id
+                                    .as_ref()
+                                    .or_else(|| item_lookup.map(|(call_id, _)| call_id));
+                                let Some(call_id) = call_id else {
+                                    continue;
+                                };
+                                let name = event
+                                    .name
+                                    .clone()
+                                    .or_else(|| item_lookup.map(|(_, name)| name.clone()))
+                                    .unwrap_or_default();
                                 let (args, args_value) =
                                     parse_tool_call_arguments(arguments, call_id)?;
 
@@ -1534,6 +1580,49 @@ impl LlmClient for OpenAiClient {
                                 yield LlmEvent::ToolCallComplete {
                                     id: call_id.clone(),
                                     name,
+                                    args: args_value,
+                                    meta: None,
+                                };
+                            }
+                        }
+                        else if event.event_type == "response.output_item.done" {
+                            if let Some(item) = &event.item
+                                && item.get("type").and_then(Value::as_str) == Some("function_call")
+                            {
+                                let Some(call_id) = item.get("call_id").and_then(Value::as_str)
+                                else {
+                                    tracing::warn!("function_call output item missing call_id");
+                                    continue;
+                                };
+                                if streamed_tool_ids.contains(call_id) {
+                                    continue;
+                                }
+                                let Some(name) = item.get("name").and_then(Value::as_str) else {
+                                    tracing::warn!(call_id, "function_call output item missing name");
+                                    continue;
+                                };
+                                let (args, args_value) = match item
+                                    .get("arguments")
+                                    .and_then(Value::as_str)
+                                {
+                                    Some(arguments) => {
+                                        parse_tool_call_arguments(arguments, call_id)?
+                                    }
+                                    None => (empty_tool_args_raw_value(), serde_json::json!({})),
+                                };
+
+                                let _ = assembler.on_tool_call_start(call_id.to_string());
+                                let _ = assembler.on_tool_call_complete(
+                                    call_id.to_string(),
+                                    name.to_string(),
+                                    args,
+                                    None,
+                                );
+
+                                streamed_tool_ids.insert(call_id.to_string());
+                                yield LlmEvent::ToolCallComplete {
+                                    id: call_id.to_string(),
+                                    name: name.to_string(),
                                     args: args_value,
                                     meta: None,
                                 };
@@ -4065,6 +4154,44 @@ mod tests {
         // Should only get one ToolCallComplete, not duplicated from response.completed
         assert_eq!(tool_completes.len(), 1);
         assert_eq!(tool_completes[0], "call_1");
+    }
+
+    #[tokio::test]
+    async fn test_stream_function_call_arguments_can_reference_output_item_id() {
+        let payload = [
+            r#"data: {"type":"response.output_item.added","item":{"id":"fc_1","type":"function_call","status":"in_progress","arguments":"","call_id":"call_1","name":"datetime"},"output_index":0,"sequence_number":1}"#,
+            r#"data: {"type":"response.function_call_arguments.delta","delta":"{}","item_id":"fc_1","output_index":0,"sequence_number":2}"#,
+            r#"data: {"type":"response.function_call_arguments.done","arguments":"{}","item_id":"fc_1","output_index":0,"sequence_number":3}"#,
+            r#"data: {"type":"response.output_item.done","item":{"id":"fc_1","type":"function_call","status":"completed","arguments":"{}","call_id":"call_1","name":"datetime"},"output_index":0,"sequence_number":4}"#,
+            r#"data: {"type":"response.completed","response":{"status":"completed","output":[],"usage":{"input_tokens":10,"output_tokens":5}}}"#,
+            "data: [DONE]",
+            "",
+        ]
+        .join("\n");
+        let (base_url, server) = spawn_openai_stub_server(payload).await;
+        let client = OpenAiClient::new_with_base_url("test-key".to_string(), base_url);
+        let request = LlmRequest::new(
+            "gpt-5-mini",
+            vec![Message::User(UserMessage::text("date".to_string()))],
+        );
+
+        let mut stream = client.stream(&request);
+        let mut tool_completes = Vec::new();
+        while let Some(event) = stream.next().await {
+            match event.expect("stream event") {
+                LlmEvent::ToolCallComplete { id, name, args, .. } => {
+                    tool_completes.push((id, name, args));
+                }
+                LlmEvent::Done { .. } => break,
+                _ => {}
+            }
+        }
+        server.abort();
+
+        assert_eq!(tool_completes.len(), 1);
+        assert_eq!(tool_completes[0].0, "call_1");
+        assert_eq!(tool_completes[0].1, "datetime");
+        assert_eq!(tool_completes[0].2, serde_json::json!({}));
     }
 
     #[tokio::test]

--- a/meerkat-rest/src/lib.rs
+++ b/meerkat-rest/src/lib.rs
@@ -3760,6 +3760,8 @@ async fn create_session_inner(
     };
     // Create: no persisted session to inherit from, so None → false.
     let keep_alive = keep_alive_override.unwrap_or(false);
+    let model_was_explicit = req.model.is_some();
+    let provider_was_explicit = req.provider.is_some();
     let model = req.model.unwrap_or_else(|| state.default_model.clone());
     let max_tokens = req.max_tokens.unwrap_or(state.max_tokens);
     let skill_references = match canonical_skill_keys_for_state(state, req.skill_refs.clone()).await
@@ -3916,7 +3918,8 @@ async fn create_session_inner(
             }
         };
     let mut build = SessionBuildOptions {
-        provider: req.provider,
+        provider: (provider_was_explicit || model_was_explicit)
+            .then_some(initial_identity.provider),
         self_hosted_server_id: initial_identity.self_hosted_server_id.clone(),
         output_schema: req.output_schema,
         structured_output_retries: req
@@ -3957,6 +3960,7 @@ async fn create_session_inner(
         additional_instructions: req.additional_instructions,
         shell_env: req.shell_env,
         resume_override_mask: ResumeOverrideMask {
+            model: model_was_explicit,
             provider: req.provider.is_some(),
             max_tokens: req.max_tokens.is_some(),
             structured_output_retries: req.structured_output_retries.is_some(),

--- a/meerkat-rpc/src/handlers/session.rs
+++ b/meerkat-rpc/src/handlers/session.rs
@@ -259,6 +259,7 @@ pub async fn handle_create(
         return RpcResponse::error(id, error::INVALID_PARAMS, err);
     }
 
+    let model_was_explicit = params.model.is_some();
     let runtime_default_model = if let Some(config_runtime) = runtime.config_runtime() {
         config_runtime
             .get()
@@ -277,6 +278,7 @@ pub async fn handle_create(
                 .unwrap_or("claude-sonnet-4-5")
                 .to_string()
         });
+    let provider_was_explicit = params.provider.is_some();
     let provider = match params
         .provider
         .as_deref()
@@ -303,7 +305,13 @@ pub async fn handle_create(
     };
 
     let mut build_config = AgentBuildConfig::new(model_name);
-    build_config.provider = provider;
+    build_config.provider = if provider_was_explicit || model_was_explicit {
+        provider
+    } else {
+        None
+    };
+    build_config.resume_override_mask.model = model_was_explicit;
+    build_config.resume_override_mask.provider = provider_was_explicit;
     build_config.max_tokens = params.max_tokens;
     build_config.system_prompt = params.system_prompt;
     build_config.output_schema = output_schema;
@@ -323,6 +331,7 @@ pub async fn handle_create(
     // it at build time.
     build_config.budget_limits = params.budget_limits;
     build_config.provider_params = params.provider_params;
+    build_config.resume_override_mask.auth_binding = params.auth_binding.is_some();
     build_config.auth_binding = params.auth_binding;
     build_config.additional_instructions = params.additional_instructions;
     build_config.app_context = params.app_context;

--- a/meerkat-rpc/tests/integration_server.rs
+++ b/meerkat-rpc/tests/integration_server.rs
@@ -98,11 +98,17 @@ impl LlmClient for RecordingToolClient {
                 .map(|tool| tool.name.to_string())
                 .collect(),
         );
-        Box::pin(stream::iter(vec![Ok(meerkat_client::LlmEvent::Done {
-            outcome: meerkat_client::LlmDoneOutcome::Success {
-                stop_reason: StopReason::EndTurn,
-            },
-        })]))
+        Box::pin(stream::iter(vec![
+            Ok(meerkat_client::LlmEvent::TextDelta {
+                delta: "tools recorded".to_string(),
+                meta: None,
+            }),
+            Ok(meerkat_client::LlmEvent::Done {
+                outcome: meerkat_client::LlmDoneOutcome::Success {
+                    stop_reason: StopReason::EndTurn,
+                },
+            }),
+        ]))
     }
 
     fn provider(&self) -> &'static str {

--- a/meerkat/src/factory.rs
+++ b/meerkat/src/factory.rs
@@ -1233,6 +1233,26 @@ impl AgentFactory {
         ))
     }
 
+    fn resolve_realm_binding_candidates_for_provider(
+        config: &Config,
+        provider: Provider,
+        auth_binding: Option<&AuthBindingRef>,
+        preferred_realm: Option<&str>,
+    ) -> Result<Vec<meerkat_core::ResolvedConnectionTarget>, String> {
+        let preferred_realm = preferred_realm
+            .map(RealmId::parse)
+            .transpose()
+            .map_err(|e| e.to_string())?;
+        meerkat_core::resolve_auth_binding_candidates_for_provider(
+            config,
+            provider,
+            auth_binding,
+            preferred_realm.as_ref(),
+            true,
+        )
+        .map_err(|e| e.to_string())
+    }
+
     #[cfg(not(target_arch = "wasm32"))]
     fn selected_image_binding_id_for_provider(
         realm: &RealmConnectionSet,
@@ -2867,28 +2887,6 @@ impl AgentFactory {
                         build_config.auth_binding = resolved.durable_auth_binding;
                         resolved.client
                     } else {
-                        let (realm, _binding_id, resolved_auth_binding) =
-                            Self::resolve_realm_binding_for_provider(
-                                config,
-                                provider,
-                                build_config.auth_binding.as_ref(),
-                                build_config.realm_id.as_deref(),
-                            )
-                            .map_err(BuildAgentError::ConnectionResolution)?;
-                        let lease_auth_binding = if resolved_auth_binding.is_env_default()
-                            && build_config
-                                .auth_binding
-                                .as_ref()
-                                .map(AuthBindingRef::is_env_default)
-                                .unwrap_or(true)
-                        {
-                            build_config.auth_binding = None;
-                            None
-                        } else {
-                            build_config.auth_binding = Some(resolved_auth_binding.clone());
-                            Some(resolved_auth_binding.clone())
-                        };
-
                         // Provider-runtime registry needs the OAuth-backed
                         // TokenStore attached so persisted tokens (written by
                         // `rkat auth login`, server-side OAuth completion, etc.)
@@ -2904,20 +2902,105 @@ impl AgentFactory {
                                 env = env.with_refresh_coordinator(coord);
                             }
                         }
-                        if let RuntimeBuildMode::SessionOwned(bindings) =
-                            &build_config.runtime_build_mode
-                            && lease_auth_binding.is_some()
-                        {
-                            env = env.with_auth_lease_handle(Arc::clone(bindings.auth_lease()));
-                        }
                         for (handle, resolver) in &self.external_auth_resolvers {
                             env = env.with_external_resolver(handle.clone(), resolver.clone());
                         }
+                        let explicit_auth_binding = build_config.auth_binding.is_some();
+                        let mut provider_attempts = vec![(provider, build_config.model.clone())];
+                        if build_config.provider.is_none() && !explicit_auth_binding {
+                            for fallback_provider in
+                                [Provider::Anthropic, Provider::Gemini, Provider::OpenAI]
+                            {
+                                if provider_attempts
+                                    .iter()
+                                    .any(|(attempt, _)| *attempt == fallback_provider)
+                                {
+                                    continue;
+                                }
+                                if let Some(default_model) =
+                                    registry.default_model(fallback_provider)
+                                {
+                                    provider_attempts
+                                        .push((fallback_provider, default_model.to_string()));
+                                }
+                            }
+                        }
                         let provider_registry = Arc::clone(&self.provider_registry);
-                        let connection = provider_registry
-                            .resolve(&realm, &resolved_auth_binding, &env)
-                            .await
-                            .map_err(|e| BuildAgentError::ConnectionResolution(e.to_string()))?;
+                        let mut first_resolution_error: Option<String> = None;
+                        let mut resolved = None;
+                        for (attempt_provider, attempt_model) in provider_attempts {
+                            let candidates = Self::resolve_realm_binding_candidates_for_provider(
+                                config,
+                                attempt_provider,
+                                build_config.auth_binding.as_ref(),
+                                build_config.realm_id.as_deref(),
+                            )
+                            .map_err(BuildAgentError::ConnectionResolution)?;
+                            for target in candidates {
+                                let resolved_auth_binding = target.auth_binding.clone();
+                                let lease_auth_binding = if resolved_auth_binding.is_env_default()
+                                    && !explicit_auth_binding
+                                {
+                                    None
+                                } else {
+                                    Some(resolved_auth_binding.clone())
+                                };
+                                let mut candidate_env = env.clone();
+                                if let RuntimeBuildMode::SessionOwned(bindings) =
+                                    &build_config.runtime_build_mode
+                                    && lease_auth_binding.is_some()
+                                {
+                                    candidate_env = candidate_env
+                                        .with_auth_lease_handle(Arc::clone(bindings.auth_lease()));
+                                }
+                                match provider_registry
+                                    .resolve(&target.realm, &resolved_auth_binding, &candidate_env)
+                                    .await
+                                {
+                                    Ok(connection) => {
+                                        let resolved_model =
+                                            if build_config.resume_override_mask.model {
+                                                attempt_model.clone()
+                                            } else {
+                                                target
+                                                    .binding
+                                                    .default_model
+                                                    .clone()
+                                                    .unwrap_or_else(|| attempt_model.clone())
+                                            };
+                                        resolved = Some((
+                                            connection,
+                                            resolved_auth_binding,
+                                            lease_auth_binding,
+                                            resolved_model,
+                                        ));
+                                        break;
+                                    }
+                                    Err(err) => {
+                                        first_resolution_error
+                                            .get_or_insert_with(|| err.to_string());
+                                        if explicit_auth_binding {
+                                            break;
+                                        }
+                                    }
+                                }
+                            }
+                            if resolved.is_some() || explicit_auth_binding {
+                                break;
+                            }
+                        }
+                        let (connection, resolved_auth_binding, lease_auth_binding, resolved_model) =
+                            resolved.ok_or_else(|| {
+                                BuildAgentError::ConnectionResolution(
+                                    first_resolution_error.unwrap_or_else(|| {
+                                        format!(
+                                            "no auth binding candidates resolved for provider '{}'",
+                                            provider.as_str()
+                                        )
+                                    }),
+                                )
+                            })?;
+                        build_config.model = resolved_model;
                         provider = connection.provider;
 
                         // Publish immediately after resolve. Provider resolution can refresh and
@@ -2955,6 +3038,12 @@ impl AgentFactory {
                                     "skipping image executor reuse for LLM connection outside selected realm"
                                 );
                             }
+                        }
+
+                        if lease_auth_binding.is_some() {
+                            build_config.auth_binding = Some(resolved_auth_binding);
+                        } else {
+                            build_config.auth_binding = None;
                         }
 
                         // Realtime-capable OpenAI models (e.g. gpt-realtime-2)
@@ -5097,6 +5186,277 @@ mod tests {
         assert_eq!(binding_id, "default_anthropic");
         assert_eq!(auth_binding.realm.as_str(), "dev");
         assert_eq!(auth_binding.binding.as_str(), "default_anthropic");
+    }
+
+    #[cfg(all(feature = "openai", not(target_arch = "wasm32")))]
+    #[tokio::test]
+    async fn build_agent_without_auth_binding_scans_configured_realms_before_env_default() {
+        let temp = tempfile::tempdir().unwrap();
+        let factory = AgentFactory::new(temp.path().join("sessions"));
+        let mut config = Config::default();
+        let mut section = RealmConfigSection::default();
+        section.backend.insert(
+            "openai_api".to_string(),
+            BackendProfileConfig {
+                provider: "openai".to_string(),
+                backend_kind: "openai_api".to_string(),
+                base_url: None,
+                options: serde_json::Value::Null,
+            },
+        );
+        section.auth.insert(
+            "openai_key".to_string(),
+            meerkat_core::AuthProfileConfig {
+                provider: "openai".to_string(),
+                auth_method: "api_key".to_string(),
+                source: CredentialSourceSpec::InlineSecret {
+                    secret: "sk-test-openai".to_string(),
+                },
+                constraints: Default::default(),
+                metadata_defaults: Default::default(),
+            },
+        );
+        section.binding.insert(
+            "openai_oauth".to_string(),
+            ProviderBindingConfig {
+                backend_profile: "openai_api".to_string(),
+                auth_profile: "openai_key".to_string(),
+                default_model: Some("gpt-5.4".to_string()),
+                policy: Default::default(),
+            },
+        );
+        config.realm.insert("dev".to_string(), section);
+
+        let mut build = AgentBuildConfig::new("gpt-5.4");
+        build.realm_id = Some("missing".to_string());
+        assert!(build.auth_binding.is_none());
+
+        let agent = factory
+            .build_agent(build, &config)
+            .await
+            .expect("configured realm binding should beat env fallback");
+        let metadata = agent
+            .session()
+            .session_metadata()
+            .expect("metadata written");
+
+        assert_eq!(metadata.provider, Provider::OpenAI);
+        assert_eq!(
+            metadata.auth_binding.as_ref().map(|auth_binding| {
+                (
+                    auth_binding.realm.as_str().to_string(),
+                    auth_binding.binding.as_str().to_string(),
+                )
+            }),
+            Some(("dev".to_string(), "openai_oauth".to_string()))
+        );
+    }
+
+    #[cfg(all(feature = "openai", not(target_arch = "wasm32")))]
+    #[tokio::test]
+    async fn explicit_model_beats_binding_default_model() {
+        let temp = tempfile::tempdir().unwrap();
+        let factory = AgentFactory::new(temp.path().join("sessions"));
+        let mut config = Config::default();
+        let mut section = RealmConfigSection::default();
+        section.backend.insert(
+            "openai_api".to_string(),
+            BackendProfileConfig {
+                provider: "openai".to_string(),
+                backend_kind: "openai_api".to_string(),
+                base_url: None,
+                options: serde_json::Value::Null,
+            },
+        );
+        section.auth.insert(
+            "openai_key".to_string(),
+            meerkat_core::AuthProfileConfig {
+                provider: "openai".to_string(),
+                auth_method: "api_key".to_string(),
+                source: CredentialSourceSpec::InlineSecret {
+                    secret: "sk-test-openai".to_string(),
+                },
+                constraints: Default::default(),
+                metadata_defaults: Default::default(),
+            },
+        );
+        section.binding.insert(
+            "openai_oauth".to_string(),
+            ProviderBindingConfig {
+                backend_profile: "openai_api".to_string(),
+                auth_profile: "openai_key".to_string(),
+                default_model: Some("gpt-5.4".to_string()),
+                policy: Default::default(),
+            },
+        );
+        config.realm.insert("dev".to_string(), section);
+
+        let mut build = AgentBuildConfig::new("gpt-5.5");
+        build.provider = Some(Provider::OpenAI);
+        build.auth_binding = Some(AuthBindingRef {
+            realm: meerkat_core::RealmId::parse("dev").unwrap(),
+            binding: meerkat_core::BindingId::parse("openai_oauth").unwrap(),
+            profile: None,
+        });
+        build.resume_override_mask.model = true;
+
+        let agent = factory
+            .build_agent(build, &config)
+            .await
+            .expect("explicit model should resolve through explicit binding");
+        let metadata = agent
+            .session()
+            .session_metadata()
+            .expect("metadata written");
+
+        assert_eq!(metadata.provider, Provider::OpenAI);
+        assert_eq!(metadata.model, "gpt-5.5");
+        assert_eq!(
+            metadata.auth_binding.as_ref().map(|auth_binding| {
+                (
+                    auth_binding.realm.as_str().to_string(),
+                    auth_binding.binding.as_str().to_string(),
+                )
+            }),
+            Some(("dev".to_string(), "openai_oauth".to_string()))
+        );
+    }
+
+    #[cfg(all(feature = "anthropic", feature = "openai", not(target_arch = "wasm32")))]
+    #[tokio::test]
+    async fn build_agent_without_provider_or_auth_binding_uses_first_resolvable_provider() {
+        use async_trait::async_trait;
+        use meerkat_llm_core::provider_runtime::{
+            ProviderAuthError, ProviderClientError, ProviderRuntime, ProviderRuntimeRegistry,
+            ResolvedConnection, ResolverEnvironment, StaticLease, ValidatedBinding,
+        };
+
+        struct FailingOpenAiRuntime;
+
+        #[async_trait]
+        impl ProviderRuntime for FailingOpenAiRuntime {
+            fn provider_id(&self) -> Provider {
+                Provider::OpenAI
+            }
+
+            async fn resolve_binding(
+                &self,
+                _binding: &ValidatedBinding,
+                _env: &ResolverEnvironment,
+            ) -> Result<ResolvedConnection, ProviderAuthError> {
+                Err(ProviderAuthError::Auth(
+                    meerkat_core::AuthError::MissingSecret,
+                ))
+            }
+
+            fn build_client(
+                &self,
+                _connection: ResolvedConnection,
+            ) -> Result<Arc<dyn LlmClient>, ProviderClientError> {
+                unreachable!("failing runtime never resolves")
+            }
+        }
+
+        struct SucceedingAnthropicRuntime;
+
+        #[async_trait]
+        impl ProviderRuntime for SucceedingAnthropicRuntime {
+            fn provider_id(&self) -> Provider {
+                Provider::Anthropic
+            }
+
+            async fn resolve_binding(
+                &self,
+                binding: &ValidatedBinding,
+                _env: &ResolverEnvironment,
+            ) -> Result<ResolvedConnection, ProviderAuthError> {
+                Ok(ResolvedConnection {
+                    provider: Provider::Anthropic,
+                    backend: binding.backend(),
+                    backend_profile: Arc::clone(binding.backend_profile()),
+                    auth_lease: Arc::new(StaticLease::inline_secret(
+                        "sk-ant-test".to_string(),
+                        meerkat_core::AuthMetadata::default(),
+                        None,
+                        "anthropic:test",
+                    )),
+                })
+            }
+
+            fn build_client(
+                &self,
+                _connection: ResolvedConnection,
+            ) -> Result<Arc<dyn LlmClient>, ProviderClientError> {
+                Ok(Arc::new(meerkat_client::TestClient::default()))
+            }
+        }
+
+        let temp = tempfile::tempdir().unwrap();
+        let mut factory = AgentFactory::new(temp.path().join("sessions"));
+        factory.provider_registry = Arc::new(
+            ProviderRuntimeRegistry::empty()
+                .with_runtime(Arc::new(FailingOpenAiRuntime))
+                .with_runtime(Arc::new(SucceedingAnthropicRuntime)),
+        );
+        let mut config = Config::default();
+        let mut section = RealmConfigSection::default();
+        section.backend.insert(
+            "anthropic_api".to_string(),
+            BackendProfileConfig {
+                provider: "anthropic".to_string(),
+                backend_kind: "anthropic_api".to_string(),
+                base_url: None,
+                options: serde_json::Value::Null,
+            },
+        );
+        section.auth.insert(
+            "anthropic_key".to_string(),
+            meerkat_core::AuthProfileConfig {
+                provider: "anthropic".to_string(),
+                auth_method: "api_key".to_string(),
+                source: CredentialSourceSpec::InlineSecret {
+                    secret: "sk-ant-test".to_string(),
+                },
+                constraints: Default::default(),
+                metadata_defaults: Default::default(),
+            },
+        );
+        section.binding.insert(
+            "default_anthropic".to_string(),
+            ProviderBindingConfig {
+                backend_profile: "anthropic_api".to_string(),
+                auth_profile: "anthropic_key".to_string(),
+                default_model: Some("claude-sonnet-4-6".to_string()),
+                policy: Default::default(),
+            },
+        );
+        config.realm.insert("dev".to_string(), section);
+
+        let mut build = AgentBuildConfig::new("gpt-5.4");
+        build.realm_id = Some("missing".to_string());
+        assert!(build.provider.is_none());
+        assert!(build.auth_binding.is_none());
+
+        let agent = factory
+            .build_agent(build, &config)
+            .await
+            .expect("implicit provider selection should skip missing OpenAI env and use Anthropic");
+        let metadata = agent
+            .session()
+            .session_metadata()
+            .expect("metadata written");
+
+        assert_eq!(metadata.provider, Provider::Anthropic);
+        assert_eq!(metadata.model, "claude-sonnet-4-6");
+        assert_eq!(
+            metadata.auth_binding.as_ref().map(|auth_binding| {
+                (
+                    auth_binding.realm.as_str().to_string(),
+                    auth_binding.binding.as_str().to_string(),
+                )
+            }),
+            Some(("dev".to_string(), "default_anthropic".to_string()))
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Move no-binding auth candidate selection into shared core connection logic.
- Teach agent construction to scan configured realm bindings and, when provider/model are omitted, fall through to the first resolvable provider.
- Preserve explicit intent across CLI, REST, and RPC so explicit model/provider/auth binding remains strict.
- Keep explicit model selections ahead of binding `default_model` values after a binding resolves.

## Root Cause

When no auth binding was supplied, the build path resolved a single provider target too early. With `OPENAI_API_KEY` unset, the synthetic env-default OpenAI path failed before configured OAuth bindings or alternate providers could be considered.

A follow-up review caught that the first implementation let a resolved binding `default_model` override an explicitly requested model. The factory now uses the shared explicit-override mask to distinguish explicit model requests from implicit fallback/default selection.

## Impact

Plain invocations such as `rkat "hello world"` can now resolve to the best available configured binding/provider across surfaces, while commands that explicitly select a model, provider, or auth binding keep deterministic behavior.

## Validation

- `./scripts/repo-cargo test -p meerkat-core auth_binding_candidates`
- `./scripts/repo-cargo test -p meerkat build_agent_without_auth_binding_scans_configured_realms_before_env_default`
- `./scripts/repo-cargo test -p meerkat build_agent_without_provider_or_auth_binding_uses_first_resolvable_provider`
- `./scripts/repo-cargo test -p meerkat explicit_model_beats_binding_default_model`
- `./scripts/repo-cargo check -p rkat -p meerkat-rest -p meerkat-rpc`
- `./scripts/repo-cargo fmt --check -p meerkat -p rkat -p meerkat-rest -p meerkat-rpc`
- `git diff --check`
- pre-push hooks: hardcoded secrets, whitespace, fmt, changed-crates clippy, codegen/header checks, Bazel freshness, deterministic gate
