### PR TITLE
[codex] Fix inherited mob tooling category caps

### DIFF
--- a/meerkat-mob/src/build.rs
+++ b/meerkat-mob/src/build.rs
@@ -49,6 +49,25 @@ pub(crate) fn resolve_profile_mob_operator_access(
     resolve_mob_operator_access(enable_mob, persisted_authority)
 }
 
+/// Open profile tool categories for an already-witnessed inherited filter.
+///
+/// `SpawnTooling::InheritParent` and `SpawnTooling::Minimal` derive the actual
+/// child-visible tool set from the parent's ToolScope snapshot. In that mode,
+/// the selected mob profile still contributes model/skills/runtime metadata,
+/// but its category booleans must not pre-disable tools before the inherited
+/// allow-list is applied.
+pub(crate) fn open_profile_tool_categories_for_inherited_filter(profile: &mut Profile) {
+    profile.tools.builtins = true;
+    profile.tools.shell = true;
+    profile.tools.comms = true;
+    profile.tools.memory = true;
+    profile.tools.mob = true;
+    profile.tools.mob_tasks = true;
+    profile.tools.schedule = true;
+    profile.tools.image_generation = true;
+    profile.tools.mcp.clear();
+}
+
 /// Parameters for building an agent config from a mob profile.
 pub struct BuildAgentConfigParams<'a> {
     pub mob_id: &'a MobId,
@@ -777,6 +796,68 @@ mod tests {
         assert_eq!(
             config.override_mob,
             meerkat_core::ToolCategoryOverride::Disable
+        );
+    }
+
+    #[tokio::test]
+    async fn test_inherited_tooling_opens_profile_category_caps() {
+        let def = sample_definition();
+        let mut profile = def.profiles[&ProfileName::from("worker")]
+            .as_inline()
+            .unwrap()
+            .clone();
+        profile.tools.mcp = vec!["narrow-mcp-source".to_string()];
+
+        open_profile_tool_categories_for_inherited_filter(&mut profile);
+        assert_eq!(
+            profile.tools.mcp,
+            Vec::<String>::new(),
+            "inherited tooling should not keep profile-level MCP source caps"
+        );
+
+        let inherited_filter = meerkat_core::tool_scope::ToolFilter::Allow(
+            ["bash".to_string(), "mob_spawn_member".to_string()]
+                .into_iter()
+                .collect(),
+        );
+        let inherited_authority =
+            witnessed_filter(inherited_filter.clone(), &["bash", "mob_spawn_member"]);
+        let config = build_agent_config(BuildAgentConfigParams {
+            mob_id: &def.id,
+            profile_name: &ProfileName::from("worker"),
+            agent_identity: &MeerkatId::from("w-inherit"),
+            profile: &profile,
+            definition: &def,
+            external_tools: None,
+            context: None,
+            labels: None,
+            additional_instructions: None,
+            shell_env: None,
+            mob_tool_authority_context: None,
+            inherited_tool_filter: Some(inherited_authority),
+        })
+        .await
+        .expect("build_agent_config");
+
+        assert_eq!(
+            config.override_builtins,
+            meerkat_core::ToolCategoryOverride::Enable
+        );
+        assert_eq!(
+            config.override_shell,
+            meerkat_core::ToolCategoryOverride::Enable
+        );
+        assert_eq!(
+            config.override_memory,
+            meerkat_core::ToolCategoryOverride::Enable
+        );
+        assert_eq!(
+            config.override_image_generation,
+            meerkat_core::ToolCategoryOverride::Enable
+        );
+        assert_eq!(
+            config.override_mob,
+            meerkat_core::ToolCategoryOverride::Enable
         );
     }
 

--- a/meerkat-mob/src/runtime/actor.rs
+++ b/meerkat-mob/src/runtime/actor.rs
@@ -4132,6 +4132,9 @@ impl MobActor {
                     .resolve_profile(&profile_name, self.realm_profile_store.as_ref())
                     .await?
             };
+            if inherited_tool_filter.is_some() && effective_profile_override.is_none() {
+                build::open_profile_tool_categories_for_inherited_filter(&mut profile);
+            }
             if let Some(model) = model_override {
                 profile.model = model;
             }


### PR DESCRIPTION
## Summary

Fix inherited mob tooling so profile-level tool category booleans do not silently cap a witnessed inherited parent tool snapshot before the inherited allow-list is applied.

## Root Cause

`delegate` and `mob_spawn_member` can resolve `tooling.mode = inherit_parent` into a witnessed parent-visible tool filter, but the member build path still compiled the selected profile's `ToolConfig` into hard category overrides first. The implicit delegate profile only enabled comms, so inherited helpers lost builtins, mob tools, shell, memory, schedule, image generation, and other category-controlled surfaces before the inherited filter could narrow them.

## Changes

- Open profile tool categories when spawning from an inherited/minimal witnessed tool filter without an explicit profile override.
- Keep `tooling.mode = profile` behavior unchanged: explicit profiles still define their own tool category caps.
- Add a regression test covering narrow worker profiles plus inherited tooling.

## Validation

- `./scripts/repo-cargo fmt --check`
- `./scripts/repo-cargo test -p meerkat-mob test_inherited_tooling_opens_profile_category_caps`
- Push pre-flight hooks: hardcoded secrets, formatting, clippy for changed crates, codegen verification, generated header audit, Bazel freshness, deterministic workspace gate
