### PR TITLE
LUC-514: Make terminal truth singular

### DIFF
--- a/meerkat-mob-pack/src/archive.rs
+++ b/meerkat-mob-pack/src/archive.rs
@@ -203,7 +203,10 @@ skills = ["skills/review.md"]
 "#
                 .to_vec(),
             ),
-            ("definition.json".to_string(), br#"{"id":"mob"}"#.to_vec()),
+            (
+                "definition.json".to_string(),
+                br#"{"id":"mob","profiles":{"worker":{"model":"gpt-5"}}}"#.to_vec(),
+            ),
             ("skills/review.md".to_string(), b"selected".to_vec()),
             (
                 "skills/unreferenced.md".to_string(),
@@ -236,17 +239,19 @@ skills = ["skills/missing.md"]
 "#
                 .to_vec(),
             ),
-            ("definition.json".to_string(), br#"{"id":"mob"}"#.to_vec()),
+            (
+                "definition.json".to_string(),
+                br#"{"id":"mob","profiles":{"worker":{"model":"gpt-5"}}}"#.to_vec(),
+            ),
         ]);
         let archive_bytes = create_targz(&files).unwrap();
-        let archive = MobpackArchive::from_archive_bytes(&archive_bytes).unwrap();
-
-        let err = archive.manifest_profile_skill_texts().unwrap_err();
+        let err = MobpackArchive::from_archive_bytes(&archive_bytes).unwrap_err();
 
         assert!(matches!(
             err,
-            PackValidationError::MissingSkillFile { skill_name, path }
-                if skill_name == "worker" && path == "skills/missing.md"
+            PackValidationError::InvalidManifestField { field, reason }
+                if field == "profiles.worker.skills[0]"
+                    && reason.contains("skill file 'skills/missing.md' missing from archive")
         ));
     }
 

--- a/meerkat-web-runtime/src/lib.rs
+++ b/meerkat-web-runtime/src/lib.rs
@@ -3084,7 +3084,11 @@ skills = ["skills/review.md"]
         let encoder = flate2::write::GzEncoder::new(Vec::new(), flate2::Compression::default());
         let mut builder = tar::Builder::new(encoder);
         append_test_mobpack_file(&mut builder, "manifest.toml", manifest);
-        append_test_mobpack_file(&mut builder, "definition.json", br#"{"id":"browser-test"}"#);
+        append_test_mobpack_file(
+            &mut builder,
+            "definition.json",
+            br#"{"id":"browser-test","profiles":{"worker":{"model":"gpt-5"}}}"#,
+        );
         append_test_mobpack_file(&mut builder, "skills/review.md", b"selected");
         append_test_mobpack_file(&mut builder, "skills/unreferenced.md", b"not selected");
         builder.finish().expect("finish tar archive");


### PR DESCRIPTION
## Summary
- Preserve typed terminal/error truth across core runtime, tool, mob, comms, WASM/Web, REST/RPC/MCP, provider, completion, and bridge paths covered by LUC-514.
- Add focused owner and public-surface regressions for terminal/error propagation.
- Prove obsolete retired realtime rows per the current-main dogma delta recorded on Linear.

## Validation
- PASS: `MEERKAT_BUILDBUDDY=1 make check`
- PASS: `MEERKAT_BUILDBUDDY=1 make lint`
- PASS: `MEERKAT_BUILDBUDDY=1 make test`
- BLOCKED: `MEERKAT_BUILDBUDDY=1 make e2e-smoke` ran 38 cases; 19 passed, then later scenarios failed with local ENOSPC while creating Cargo target dirs/writing artifacts, and browser WASM scenarios timed out/terminated under the same disk pressure.

Linear: LUC-514