### PR TITLE
[codex] Add OpenAI image search reasoning params

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -518,7 +518,7 @@
           "FILE:@@//meerkat-machine-dsl/Cargo.toml d08909f3491aab95bf93b0233c782991ea72ed0b363ae746a980b1ab88984824",
           "FILE:@@//meerkat-machine-dsl-core/Cargo.toml 1247b069c78e6ccea707a0dada9bddd3ae38add4703148956f9a1b820e24c140",
           "FILE:@@//meerkat-auth-core/Cargo.toml ac2333e57d105f7384b147844fcd998e5ec2056c098e465804453603eb059240",
-          "FILE:@@//meerkat-client/Cargo.toml 2a06e6b0f4e5e34c5e23beb7fbdd2895bea5a1644d98af7fbcca46ef87098342",
+          "FILE:@@//meerkat-client/Cargo.toml be4b7ffa93615d8e8118b166beddefb874495b71c7c0646e5fb378d7693d1fc9",
           "FILE:@@//meerkat-anthropic/Cargo.toml f24257854e2405c4bb724cea67a5c4c64eaa69f078595745b83cfce20d60b2b7",
           "FILE:@@//meerkat-gemini/Cargo.toml 079503b6ba524755f05652ef82683b4f7eb8e89cedd9f98dfb755b4752fd8897",
           "FILE:@@//meerkat-openai/Cargo.toml 1716ef0fb33ce19071cd0c5ddfa3aff6656e1a6e49f880eaa6c0ad163ab7d03d",

--- a/artifacts/schemas/params.json
+++ b/artifacts/schemas/params.json
@@ -3950,9 +3950,11 @@
       "WireReasoningEffort": {
         "description": "Typed wire projection of [`meerkat_core::lifecycle::run_primitive::ReasoningEffort`].",
         "enum": [
+          "none",
           "low",
           "medium",
-          "high"
+          "high",
+          "xhigh"
         ],
         "type": "string"
       },
@@ -5940,9 +5942,11 @@
       "WireReasoningEffort": {
         "description": "Typed wire projection of [`meerkat_core::lifecycle::run_primitive::ReasoningEffort`].",
         "enum": [
+          "none",
           "low",
           "medium",
-          "high"
+          "high",
+          "xhigh"
         ],
         "type": "string"
       },
@@ -6707,9 +6711,11 @@
       "WireReasoningEffort": {
         "description": "Typed wire projection of [`meerkat_core::lifecycle::run_primitive::ReasoningEffort`].",
         "enum": [
+          "none",
           "low",
           "medium",
-          "high"
+          "high",
+          "xhigh"
         ],
         "type": "string"
       },

--- a/artifacts/schemas/wire-types.json
+++ b/artifacts/schemas/wire-types.json
@@ -11396,9 +11396,11 @@
       "WireReasoningEffort": {
         "description": "Typed wire projection of [`meerkat_core::lifecycle::run_primitive::ReasoningEffort`].",
         "enum": [
+          "none",
           "low",
           "medium",
-          "high"
+          "high",
+          "xhigh"
         ],
         "type": "string"
       },

--- a/docs/guides/image-generation.mdx
+++ b/docs/guides/image-generation.mdx
@@ -172,15 +172,18 @@ Meerkat fields and OpenAI lowering:
 | `provider_params.output_compression` | `0` to `100` | Advanced OpenAI override. Applies only when the universal `format` is `jpeg` or `webp`. |
 | `provider_params.moderation` | `auto`, `low` | Advanced GPT Image moderation strictness override. Omit it for OpenAI's default filtering. |
 | `provider_params.action` | `auto`, `generate`, `edit` | Advanced hosted Responses image-tool override. Normal Meerkat calls should use top-level `intent` and omit `action`; Images API routes reject it. |
+| `provider_params.reasoning_effort` | `none`, `low`, `medium`, `high`, `xhigh` | Hosted `gpt-image-2` route only. Lowered to OpenAI `reasoning.effort`. |
+| `provider_params.web_search` | `true`, `false`, `null`, or object | Hosted `gpt-image-2` route only. `true`/`{}` enables OpenAI `web_search`; object values may include OpenAI web-search options such as `search_context_size`, `filters`, `user_location`, `external_web_access`, and `return_token_budget`. |
 
 Model behavior:
 
 - `gpt-image-2` uses the hosted Responses image tool internally, but callers still pass Meerkat's `generate_image` request shape.
 - `gpt-image-2` accepts flexible `WIDTHxHEIGHT` sizes when they satisfy OpenAI's constraints: both edges are multiples of 16 px, max edge is 3840 px, aspect ratio is at most 3:1, and total pixels are between 655,360 and 8,294,400. Common values include `1024x1024`, `1536x1024`, `1024x1536`, `2048x2048`, `2048x1152`, `3840x2160`, and `2160x3840`.
 - Do not copy raw Responses API JSON into `provider_params`. Use Meerkat's universal `size`, `quality`, `format`, and `intent` fields, and reserve `provider_params` for the advanced OpenAI overrides above.
+- For fresh/current image-only requests, prefer passing `provider_params.web_search` to `generate_image` over doing a separate search turn first.
 - Do not pass `background: "transparent"` for `gpt-image-2`; OpenAI rejects it. Do not pass `input_fidelity`; Meerkat's 0.6.5 OpenAI adapter uses a closed provider-params shape and rejects unknown fields.
 - Other OpenAI-owned `gpt-image*` or `dall-e*` models use the Images API path.
-- The Images API path currently rejects edit requests, reference images, and `action`.
+- The Images API path currently rejects edit requests, reference images, `action`, `reasoning_effort`, and `web_search`.
 
 ### Gemini
 

--- a/examples/037-live-webrtc-web/public/app.js
+++ b/examples/037-live-webrtc-web/public/app.js
@@ -63,6 +63,21 @@ function logEvent(text) {
   }
 }
 
+function waitForIceGatheringComplete(peerConnection) {
+  if (peerConnection.iceGatheringState === "complete") {
+    return Promise.resolve();
+  }
+  return new Promise((resolve) => {
+    const onStateChange = () => {
+      if (peerConnection.iceGatheringState === "complete") {
+        peerConnection.removeEventListener("icegatheringstatechange", onStateChange);
+        resolve();
+      }
+    };
+    peerConnection.addEventListener("icegatheringstatechange", onStateChange);
+  });
+}
+
 function setTransportField(id, value) {
   $(id).textContent = value || "-";
 }
@@ -431,6 +446,8 @@ async function start() {
 
     const offer = await pc.createOffer();
     await pc.setLocalDescription(offer);
+    await waitForIceGatheringComplete(pc);
+    const gatheredOffer = pc.localDescription;
     setStatus("pending", "signaling");
     const open = await openPromise;
     activeChannelId = open.channel_id;
@@ -440,10 +457,10 @@ async function start() {
       body: JSON.stringify({
         channel_id: open.channel_id,
         token: open.transport.token,
-        offer_sdp: offer.sdp,
+        offer_sdp: gatheredOffer.sdp,
       }),
     });
-    $("sdp-state").textContent = `${offer.sdp.length}/${answer.answer_sdp.length}`;
+    $("sdp-state").textContent = `${gatheredOffer.sdp.length}/${answer.answer_sdp.length}`;
     await pc.setRemoteDescription({ type: "answer", sdp: answer.answer_sdp });
     setLiveControls(true);
     pollTimer = setInterval(pollState, 1200);

--- a/meerkat-anthropic/src/client.rs
+++ b/meerkat-anthropic/src/client.rs
@@ -2319,6 +2319,23 @@ mod tests {
     }
 
     #[test]
+    fn test_build_request_body_effort_max_remains_anthropic_specific()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let client = AnthropicClient::new("test-key".to_string())?;
+
+        let request = LlmRequest::new(
+            "claude-opus-4-7",
+            vec![Message::User(UserMessage::text("test".to_string()))],
+        )
+        .with_anthropic_tag_merge(|t| t.effort = Some(AnthropicEffort::Max));
+
+        let body = client.build_request_body(&request)?;
+
+        assert_eq!(body["output_config"]["effort"], "max");
+        Ok(())
+    }
+
+    #[test]
     fn test_build_request_body_effort_with_structured_output()
     -> Result<(), Box<dyn std::error::Error>> {
         let client = AnthropicClient::new("test-key".to_string())?;

--- a/meerkat-anthropic/src/lib.rs
+++ b/meerkat-anthropic/src/lib.rs
@@ -12,6 +12,8 @@ pub mod tokio {
 
 pub mod client;
 pub mod runtime;
+pub mod web_search;
 
 pub use client::AnthropicClient;
 pub use runtime::{AnthropicAuthMethod, AnthropicBackendKind, AnthropicProviderRuntime};
+pub use web_search::AnthropicWebSearchExecutor;

--- a/meerkat-anthropic/src/web_search.rs
+++ b/meerkat-anthropic/src/web_search.rs
@@ -1,0 +1,187 @@
+//! Anthropic-native web-search fallback executor.
+
+use async_trait::async_trait;
+use meerkat_core::lifecycle::run_primitive::{
+    AnthropicProviderTag, ModelId, OpaqueProviderBody, ProviderParamsOverride, ProviderTag,
+};
+use meerkat_core::web_search::{
+    WebSearchEvidence, WebSearchNativeEvent, WebSearchRequest, WebSearchResult, WebSearchStatus,
+};
+use meerkat_core::{AgentLlmClient, AssistantBlock, Message, Provider, SystemMessage, UserMessage};
+use meerkat_llm_core::{LlmError, WebSearchExecutor};
+use std::sync::Arc;
+
+#[derive(Clone)]
+pub struct AnthropicWebSearchExecutor {
+    model: String,
+    client: Arc<dyn AgentLlmClient>,
+}
+
+impl AnthropicWebSearchExecutor {
+    pub fn new(model: String, client: Arc<dyn AgentLlmClient>) -> Self {
+        Self { model, client }
+    }
+
+    fn provider_tag(provider_params: Option<serde_json::Value>) -> ProviderTag {
+        let mut body = serde_json::json!({"type": "web_search_20250305", "name": "web_search"});
+        merge_object(&mut body, provider_params);
+        ProviderTag::Anthropic(AnthropicProviderTag {
+            web_search: Some(OpaqueProviderBody::from_value(&body)),
+            ..Default::default()
+        })
+    }
+}
+
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+impl WebSearchExecutor for AnthropicWebSearchExecutor {
+    async fn execute_web_search(
+        &self,
+        request: WebSearchRequest,
+    ) -> Result<WebSearchResult, LlmError> {
+        if let Some(requested_provider) = request.provider
+            && requested_provider != Provider::Anthropic
+        {
+            return Err(LlmError::InvalidRequest {
+                message: format!(
+                    "web_search fallback is configured for '{}', not '{}'",
+                    Provider::Anthropic.as_str(),
+                    requested_provider.as_str()
+                ),
+            });
+        }
+
+        execute_native_web_search(
+            self.client.as_ref(),
+            Provider::Anthropic,
+            &self.model,
+            request,
+            Self::provider_tag,
+        )
+        .await
+    }
+}
+
+async fn execute_native_web_search(
+    client: &dyn AgentLlmClient,
+    provider: Provider,
+    model: &str,
+    request: WebSearchRequest,
+    provider_tag: impl FnOnce(Option<serde_json::Value>) -> ProviderTag,
+) -> Result<WebSearchResult, LlmError> {
+    let prompt = web_search_user_prompt(&request);
+    let messages = vec![
+        Message::System(SystemMessage::new(
+            "You are a web-search execution adapter for Meerkat. Use your \
+             provider-native web search/grounding tool to answer the query. \
+             Return a concise answer and include cited URLs when available. \
+             Do not call non-search tools.",
+        )),
+        Message::User(UserMessage::text(prompt)),
+    ];
+    let provider_params = ProviderParamsOverride {
+        max_output_tokens: Some(2048),
+        provider_tag: Some(provider_tag(request.provider_params.clone())),
+        ..Default::default()
+    };
+    let result = client
+        .stream_response(&messages, &[], 2048, None, Some(&provider_params))
+        .await
+        .map_err(|err| LlmError::Unknown {
+            message: err.to_string(),
+        })?;
+
+    let mut answer_parts = Vec::new();
+    let mut native_events = Vec::new();
+    let mut evidence = Vec::new();
+    for block in result.blocks() {
+        match block {
+            AssistantBlock::Text { text, .. } | AssistantBlock::Transcript { text, .. } => {
+                if !text.trim().is_empty() {
+                    answer_parts.push(text.trim().to_string());
+                }
+            }
+            AssistantBlock::ServerToolContent { name, content, .. } => {
+                collect_evidence(content, &mut evidence);
+                native_events.push(WebSearchNativeEvent {
+                    name: name.clone(),
+                    content: content.clone(),
+                });
+            }
+            _ => {}
+        }
+    }
+
+    Ok(WebSearchResult {
+        status: WebSearchStatus::Completed,
+        query: request.query,
+        provider: Some(provider),
+        model: Some(ModelId::new(model.to_string())),
+        answer: (!answer_parts.is_empty()).then(|| answer_parts.join("\n\n")),
+        evidence,
+        native_events,
+        error: None,
+        checked_at: chrono::Utc::now(),
+    })
+}
+
+fn merge_object(body: &mut serde_json::Value, provider_params: Option<serde_json::Value>) {
+    if let Some(extra) = provider_params
+        && let (Some(base), Some(extra)) = (body.as_object_mut(), extra.as_object())
+    {
+        for (key, value) in extra {
+            base.insert(key.clone(), value.clone());
+        }
+    }
+}
+
+fn web_search_user_prompt(request: &WebSearchRequest) -> String {
+    let mut prompt = format!("Search query:\n{}", request.query);
+    if let Some(context) = request
+        .context
+        .as_ref()
+        .filter(|value| !value.trim().is_empty())
+    {
+        prompt.push_str("\n\nConversation context:\n");
+        prompt.push_str(context.trim());
+    }
+    prompt
+}
+
+fn collect_evidence(value: &serde_json::Value, out: &mut Vec<WebSearchEvidence>) {
+    match value {
+        serde_json::Value::Object(map) => {
+            let url = map
+                .get("url")
+                .or_else(|| map.get("uri"))
+                .and_then(serde_json::Value::as_str)
+                .map(ToString::to_string);
+            let title = map
+                .get("title")
+                .and_then(serde_json::Value::as_str)
+                .map(ToString::to_string);
+            let summary = map
+                .get("summary")
+                .or_else(|| map.get("snippet"))
+                .or_else(|| map.get("text"))
+                .and_then(serde_json::Value::as_str)
+                .map(ToString::to_string);
+            if url.is_some() || title.is_some() || summary.is_some() {
+                out.push(WebSearchEvidence {
+                    title,
+                    url,
+                    summary,
+                });
+            }
+            for child in map.values() {
+                collect_evidence(child, out);
+            }
+        }
+        serde_json::Value::Array(items) => {
+            for child in items {
+                collect_evidence(child, out);
+            }
+        }
+        _ => {}
+    }
+}

--- a/meerkat-client/Cargo.toml
+++ b/meerkat-client/Cargo.toml
@@ -23,13 +23,13 @@ meerkat-gemini = { workspace = true, optional = true, default-features = false }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["test-util", "macros"] }
-async-trait = { workspace = true }
 futures = { workspace = true }
-serde_json = { workspace = true }
 reqwest = { workspace = true }
 axum = { workspace = true }
 schemars = { workspace = true }
 uuid = { workspace = true, features = ["v4"] }
+async-trait = { workspace = true }
+serde_json = { workspace = true }
 
 [features]
 default = ["anthropic", "openai", "gemini"]

--- a/meerkat-client/tests/live_client_provider_matrix.rs
+++ b/meerkat-client/tests/live_client_provider_matrix.rs
@@ -22,6 +22,7 @@ use meerkat_core::image_generation::{
 use meerkat_core::lifecycle::run_primitive::ModelId;
 use meerkat_core::lifecycle::run_primitive::{
     AnthropicProviderTag, GeminiProviderTag, OpaqueProviderBody, OpenAiProviderTag, ProviderTag,
+    ReasoningEffort,
 };
 use meerkat_core::{Message, StopReason, UserMessage};
 use meerkat_gemini::{GeminiImageOutputOptions, GeminiImageTurnPlan};
@@ -322,7 +323,28 @@ async fn e2e_smoke_openai_live_image_generation() -> Result<(), Box<dyn std::err
     };
     let image_model =
         std::env::var("RKAT_OPENAI_IMAGE_MODEL").unwrap_or_else(|_| "gpt-image-2".into());
+    let hosted_reasoning_effort = match std::env::var("RKAT_OPENAI_IMAGE_REASONING_EFFORT")
+        .as_deref()
+    {
+        Ok("none") => ReasoningEffort::None,
+        Ok("low") | Err(_) => ReasoningEffort::Low,
+        Ok("medium") => ReasoningEffort::Medium,
+        Ok("high") => ReasoningEffort::High,
+        Ok("xhigh") => ReasoningEffort::XHigh,
+        Ok(other) => {
+            eprintln!("Ignoring unsupported RKAT_OPENAI_IMAGE_REASONING_EFFORT={other}; using low");
+            ReasoningEffort::Low
+        }
+    };
     let client = OpenAiClient::new(api_key);
+    let mut hosted_provider_params = OpenAiImageProviderParams::default();
+    hosted_provider_params.reasoning_effort = Some(hosted_reasoning_effort);
+    hosted_provider_params.web_search = Some(serde_json::json!({
+        "search_context_size": "low",
+        "external_web_access": true,
+        "return_token_budget": "default"
+    }));
+
     let (provider_model, execution_plan) = if image_model == "gpt-image-2" {
         (
             "gpt-5.4".to_string(),
@@ -336,7 +358,7 @@ async fn e2e_smoke_openai_live_image_generation() -> Result<(), Box<dyn std::err
                     tool_name: "image_generation".into(),
                     model: ModelId::new(image_model.clone()),
                     output: OpenAiImageOutputOptions::default(),
-                    provider_params: OpenAiImageProviderParams::default(),
+                    provider_params: hosted_provider_params,
                 })?,
             },
         )

--- a/meerkat-contracts/src/wire/runtime.rs
+++ b/meerkat-contracts/src/wire/runtime.rs
@@ -510,18 +510,23 @@ impl From<WireReasoningMode> for meerkat_core::lifecycle::run_primitive::Reasoni
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[serde(rename_all = "snake_case")]
 pub enum WireReasoningEffort {
+    None,
     Low,
     Medium,
     High,
+    #[serde(rename = "xhigh")]
+    XHigh,
 }
 
 impl From<meerkat_core::lifecycle::run_primitive::ReasoningEffort> for WireReasoningEffort {
     fn from(value: meerkat_core::lifecycle::run_primitive::ReasoningEffort) -> Self {
         use meerkat_core::lifecycle::run_primitive::ReasoningEffort as Core;
         match value {
+            Core::None => Self::None,
             Core::Low => Self::Low,
             Core::Medium => Self::Medium,
             Core::High => Self::High,
+            Core::XHigh => Self::XHigh,
         }
     }
 }
@@ -529,9 +534,11 @@ impl From<meerkat_core::lifecycle::run_primitive::ReasoningEffort> for WireReaso
 impl From<WireReasoningEffort> for meerkat_core::lifecycle::run_primitive::ReasoningEffort {
     fn from(value: WireReasoningEffort) -> Self {
         match value {
+            WireReasoningEffort::None => Self::None,
             WireReasoningEffort::Low => Self::Low,
             WireReasoningEffort::Medium => Self::Medium,
             WireReasoningEffort::High => Self::High,
+            WireReasoningEffort::XHigh => Self::XHigh,
         }
     }
 }

--- a/meerkat-contracts/tests/runtime_turn_metadata_wire_override.rs
+++ b/meerkat-contracts/tests/runtime_turn_metadata_wire_override.rs
@@ -188,3 +188,33 @@ fn wire_metadata_provider_tag_preserves_provider_native_fields() {
     );
     assert!(legacy["web_search"].is_null());
 }
+
+#[test]
+fn wire_metadata_openai_reasoning_effort_none_and_xhigh_round_trip() {
+    for effort in ["none", "xhigh"] {
+        let provider_params = ProviderParamsOverride::from_legacy_provider_value(
+            "openai",
+            &serde_json::json!({ "reasoning_effort": effort }),
+        );
+        let meta = RuntimeTurnMetadata {
+            provider_params: Some(TurnMetadataOverride::Set(provider_params)),
+            ..Default::default()
+        };
+
+        let wire: WireRuntimeTurnMetadata = meta.into();
+        let json = serde_json::to_value(&wire).expect("serialize wire metadata");
+        assert_eq!(
+            json["provider_params"]["value"]["provider_tag"]["reasoning_effort"],
+            serde_json::json!(effort)
+        );
+
+        let parsed_wire: WireRuntimeTurnMetadata =
+            serde_json::from_value(json).expect("deserialize wire metadata");
+        let round_tripped: RuntimeTurnMetadata = parsed_wire.into();
+        let Some(TurnMetadataOverride::Set(provider_params)) = round_tripped.provider_params else {
+            panic!("provider params set override should survive wire round trip");
+        };
+        let legacy = provider_params.to_legacy_provider_value();
+        assert_eq!(legacy["reasoning_effort"], serde_json::json!(effort));
+    }
+}

--- a/meerkat-core/src/lifecycle/run_primitive.rs
+++ b/meerkat-core/src/lifecycle/run_primitive.rs
@@ -246,9 +246,11 @@ impl ProviderTag {
         if namespace == "openai"
             && key == "reasoning_effort"
             && let Some(effort) = value.as_str().and_then(|s| match s {
+                "none" => Some(ReasoningEffort::None),
                 "low" => Some(ReasoningEffort::Low),
                 "medium" => Some(ReasoningEffort::Medium),
                 "high" => Some(ReasoningEffort::High),
+                "xhigh" => Some(ReasoningEffort::XHigh),
                 _ => None,
             })
         {
@@ -659,9 +661,11 @@ impl OpenAiProviderTag {
             match k.as_str() {
                 "reasoning_effort" => {
                     let effort = match v.as_str() {
+                        Some("none") => ReasoningEffort::None,
                         Some("low") => ReasoningEffort::Low,
                         Some("medium") => ReasoningEffort::Medium,
                         Some("high") => ReasoningEffort::High,
+                        Some("xhigh") => ReasoningEffort::XHigh,
                         _ => {
                             return Err(LegacyProviderParamsError::unknown_shape(
                                 "reasoning_effort",
@@ -852,10 +856,25 @@ impl std::error::Error for LegacyProviderParamsError {}
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
 #[serde(rename_all = "snake_case")]
 pub enum ReasoningEffort {
+    None,
     Low,
     #[default]
     Medium,
     High,
+    #[serde(rename = "xhigh")]
+    XHigh,
+}
+
+impl ReasoningEffort {
+    pub fn as_legacy_str(self) -> &'static str {
+        match self {
+            Self::None => "none",
+            Self::Low => "low",
+            Self::Medium => "medium",
+            Self::High => "high",
+            Self::XHigh => "xhigh",
+        }
+    }
 }
 
 /// Typed mode for generalized reasoning emission.
@@ -2294,6 +2313,33 @@ mod tests {
         assert_eq!(tag.seed, Some(42));
         assert!(matches!(tag.frequency_penalty, Some(v) if (v - 0.5).abs() < 1e-6));
         assert!(matches!(tag.presence_penalty, Some(v) if (v - 0.3).abs() < 1e-6));
+    }
+
+    #[test]
+    fn openai_from_legacy_value_projects_none_and_xhigh_reasoning() {
+        let none = OpenAiProviderTag::from_legacy_value(&serde_json::json!({
+            "reasoning_effort": "none"
+        }))
+        .expect("none projects");
+        assert_eq!(none.reasoning_effort, Some(ReasoningEffort::None));
+        let projected_none = ProviderParamsOverride {
+            provider_tag: Some(ProviderTag::OpenAi(none)),
+            ..Default::default()
+        }
+        .to_legacy_provider_value();
+        assert_eq!(projected_none["reasoning_effort"], "none");
+
+        let xhigh = OpenAiProviderTag::from_legacy_value(&serde_json::json!({
+            "reasoning_effort": "xhigh"
+        }))
+        .expect("xhigh projects");
+        assert_eq!(xhigh.reasoning_effort, Some(ReasoningEffort::XHigh));
+        let projected_xhigh = ProviderParamsOverride {
+            provider_tag: Some(ProviderTag::OpenAi(xhigh)),
+            ..Default::default()
+        }
+        .to_legacy_provider_value();
+        assert_eq!(projected_xhigh["reasoning_effort"], "xhigh");
     }
 
     #[test]

--- a/meerkat-gemini/src/client.rs
+++ b/meerkat-gemini/src/client.rs
@@ -1718,7 +1718,9 @@ struct GeminiUsage {
 mod tests {
     use super::*;
     use axum::{Json, Router, extract::State, response::IntoResponse, routing::post};
-    use meerkat_core::lifecycle::run_primitive::GeminiThinkingLevel;
+    use meerkat_core::lifecycle::run_primitive::{
+        GeminiThinkingLevel, OpenAiProviderTag, ReasoningEffort,
+    };
     use meerkat_core::{
         AssistantBlock, AssistantImageId, BlobId, BlobRef, BlockAssistantMessage, ContentBlock,
         ImageData, MediaType, ProviderImageMetadata, ProviderMeta, RevisedPromptDisposition,
@@ -2455,6 +2457,27 @@ mod tests {
 
         assert!(generation_config.get("thinkingConfig").is_none());
         assert!(generation_config.get("topK").is_none());
+        Ok(())
+    }
+
+    #[test]
+    fn test_openai_reasoning_effort_provider_tag_does_not_affect_gemini_body()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let client = GeminiClient::new("test-key".to_string());
+        let request = LlmRequest::new(
+            "gemini-3-flash-preview",
+            vec![Message::User(UserMessage::text("test".to_string()))],
+        )
+        .with_provider_params(ProviderTag::OpenAi(OpenAiProviderTag {
+            reasoning_effort: Some(ReasoningEffort::XHigh),
+            ..Default::default()
+        }));
+
+        let body = client.build_request_body(&request)?;
+        let generation_config = body.get("generationConfig").ok_or("missing config")?;
+
+        assert!(generation_config.get("thinkingConfig").is_none());
+        assert!(!body.to_string().contains("xhigh"));
         Ok(())
     }
 

--- a/meerkat-gemini/src/lib.rs
+++ b/meerkat-gemini/src/lib.rs
@@ -12,6 +12,7 @@ pub mod tokio {
 pub mod client;
 pub mod image_generation;
 pub mod runtime;
+pub mod web_search;
 
 pub use client::GeminiClient;
 pub use image_generation::{
@@ -19,3 +20,4 @@ pub use image_generation::{
     GeminiImageTurnPlan,
 };
 pub use runtime::{GoogleAuthMethod, GoogleBackendKind, GoogleProviderRuntime};
+pub use web_search::GeminiWebSearchExecutor;

--- a/meerkat-gemini/src/web_search.rs
+++ b/meerkat-gemini/src/web_search.rs
@@ -1,0 +1,187 @@
+//! Gemini-native web-search fallback executor.
+
+use async_trait::async_trait;
+use meerkat_core::lifecycle::run_primitive::{
+    GeminiProviderTag, ModelId, OpaqueProviderBody, ProviderParamsOverride, ProviderTag,
+};
+use meerkat_core::web_search::{
+    WebSearchEvidence, WebSearchNativeEvent, WebSearchRequest, WebSearchResult, WebSearchStatus,
+};
+use meerkat_core::{AgentLlmClient, AssistantBlock, Message, Provider, SystemMessage, UserMessage};
+use meerkat_llm_core::{LlmError, WebSearchExecutor};
+use std::sync::Arc;
+
+#[derive(Clone)]
+pub struct GeminiWebSearchExecutor {
+    model: String,
+    client: Arc<dyn AgentLlmClient>,
+}
+
+impl GeminiWebSearchExecutor {
+    pub fn new(model: String, client: Arc<dyn AgentLlmClient>) -> Self {
+        Self { model, client }
+    }
+
+    fn provider_tag(provider_params: Option<serde_json::Value>) -> ProviderTag {
+        let mut body = serde_json::json!({});
+        merge_object(&mut body, provider_params);
+        ProviderTag::Gemini(GeminiProviderTag {
+            google_search: Some(OpaqueProviderBody::from_value(&body)),
+            ..Default::default()
+        })
+    }
+}
+
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+impl WebSearchExecutor for GeminiWebSearchExecutor {
+    async fn execute_web_search(
+        &self,
+        request: WebSearchRequest,
+    ) -> Result<WebSearchResult, LlmError> {
+        if let Some(requested_provider) = request.provider
+            && requested_provider != Provider::Gemini
+        {
+            return Err(LlmError::InvalidRequest {
+                message: format!(
+                    "web_search fallback is configured for '{}', not '{}'",
+                    Provider::Gemini.as_str(),
+                    requested_provider.as_str()
+                ),
+            });
+        }
+
+        execute_native_web_search(
+            self.client.as_ref(),
+            Provider::Gemini,
+            &self.model,
+            request,
+            Self::provider_tag,
+        )
+        .await
+    }
+}
+
+async fn execute_native_web_search(
+    client: &dyn AgentLlmClient,
+    provider: Provider,
+    model: &str,
+    request: WebSearchRequest,
+    provider_tag: impl FnOnce(Option<serde_json::Value>) -> ProviderTag,
+) -> Result<WebSearchResult, LlmError> {
+    let prompt = web_search_user_prompt(&request);
+    let messages = vec![
+        Message::System(SystemMessage::new(
+            "You are a web-search execution adapter for Meerkat. Use your \
+             provider-native web search/grounding tool to answer the query. \
+             Return a concise answer and include cited URLs when available. \
+             Do not call non-search tools.",
+        )),
+        Message::User(UserMessage::text(prompt)),
+    ];
+    let provider_params = ProviderParamsOverride {
+        max_output_tokens: Some(2048),
+        provider_tag: Some(provider_tag(request.provider_params.clone())),
+        ..Default::default()
+    };
+    let result = client
+        .stream_response(&messages, &[], 2048, None, Some(&provider_params))
+        .await
+        .map_err(|err| LlmError::Unknown {
+            message: err.to_string(),
+        })?;
+
+    let mut answer_parts = Vec::new();
+    let mut native_events = Vec::new();
+    let mut evidence = Vec::new();
+    for block in result.blocks() {
+        match block {
+            AssistantBlock::Text { text, .. } | AssistantBlock::Transcript { text, .. } => {
+                if !text.trim().is_empty() {
+                    answer_parts.push(text.trim().to_string());
+                }
+            }
+            AssistantBlock::ServerToolContent { name, content, .. } => {
+                collect_evidence(content, &mut evidence);
+                native_events.push(WebSearchNativeEvent {
+                    name: name.clone(),
+                    content: content.clone(),
+                });
+            }
+            _ => {}
+        }
+    }
+
+    Ok(WebSearchResult {
+        status: WebSearchStatus::Completed,
+        query: request.query,
+        provider: Some(provider),
+        model: Some(ModelId::new(model.to_string())),
+        answer: (!answer_parts.is_empty()).then(|| answer_parts.join("\n\n")),
+        evidence,
+        native_events,
+        error: None,
+        checked_at: chrono::Utc::now(),
+    })
+}
+
+fn merge_object(body: &mut serde_json::Value, provider_params: Option<serde_json::Value>) {
+    if let Some(extra) = provider_params
+        && let (Some(base), Some(extra)) = (body.as_object_mut(), extra.as_object())
+    {
+        for (key, value) in extra {
+            base.insert(key.clone(), value.clone());
+        }
+    }
+}
+
+fn web_search_user_prompt(request: &WebSearchRequest) -> String {
+    let mut prompt = format!("Search query:\n{}", request.query);
+    if let Some(context) = request
+        .context
+        .as_ref()
+        .filter(|value| !value.trim().is_empty())
+    {
+        prompt.push_str("\n\nConversation context:\n");
+        prompt.push_str(context.trim());
+    }
+    prompt
+}
+
+fn collect_evidence(value: &serde_json::Value, out: &mut Vec<WebSearchEvidence>) {
+    match value {
+        serde_json::Value::Object(map) => {
+            let url = map
+                .get("url")
+                .or_else(|| map.get("uri"))
+                .and_then(serde_json::Value::as_str)
+                .map(ToString::to_string);
+            let title = map
+                .get("title")
+                .and_then(serde_json::Value::as_str)
+                .map(ToString::to_string);
+            let summary = map
+                .get("summary")
+                .or_else(|| map.get("snippet"))
+                .or_else(|| map.get("text"))
+                .and_then(serde_json::Value::as_str)
+                .map(ToString::to_string);
+            if url.is_some() || title.is_some() || summary.is_some() {
+                out.push(WebSearchEvidence {
+                    title,
+                    url,
+                    summary,
+                });
+            }
+            for child in map.values() {
+                collect_evidence(child, out);
+            }
+        }
+        serde_json::Value::Array(items) => {
+            for child in items {
+                collect_evidence(child, out);
+            }
+        }
+        _ => {}
+    }
+}

--- a/meerkat-mob/src/store/sqlite.rs
+++ b/meerkat-mob/src/store/sqlite.rs
@@ -329,9 +329,15 @@ impl SqliteMobEventBus {
         let thread_bus = Arc::downgrade(self);
         let thread_builder = thread::Builder::new().name("sqlite-mob-event-watch".to_string());
         if let Err(error) = thread_builder.spawn(move || {
-            while wake_rx.recv().is_ok() {
-                thread::sleep(Duration::from_millis(10));
-                while wake_rx.try_recv().is_ok() {}
+            loop {
+                match wake_rx.recv_timeout(Duration::from_millis(100)) {
+                    Ok(()) => {
+                        thread::sleep(Duration::from_millis(10));
+                        while wake_rx.try_recv().is_ok() {}
+                    }
+                    Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {}
+                    Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => break,
+                }
                 let Some(bus) = thread_bus.upgrade() else {
                     break;
                 };

--- a/meerkat-openai/src/client.rs
+++ b/meerkat-openai/src/client.rs
@@ -5,9 +5,7 @@
 
 use async_trait::async_trait;
 use futures::StreamExt;
-use meerkat_core::lifecycle::run_primitive::{
-    OpenAiProviderTag, ProviderTag, ReasoningEffort as TypedReasoningEffort,
-};
+use meerkat_core::lifecycle::run_primitive::{OpenAiProviderTag, ProviderTag};
 use meerkat_core::schema::{CompiledSchema, SchemaError};
 use meerkat_core::{
     AssistantBlock, BlockAssistantMessage, ContentBlock, ImageData, ImageGenerationIntent,
@@ -504,11 +502,7 @@ impl OpenAiClient {
 
         if let Some(tag) = openai_tag(request) {
             if reasoning_enabled && let Some(effort) = tag.reasoning_effort {
-                let s = match effort {
-                    TypedReasoningEffort::Low => "low",
-                    TypedReasoningEffort::Medium => "medium",
-                    TypedReasoningEffort::High => "high",
-                };
+                let s = effort.as_legacy_str();
                 body["reasoning"]["effort"] = Value::String(s.to_string());
             }
 
@@ -901,14 +895,23 @@ impl OpenAiClient {
         );
         Self::apply_image_output_options(&mut tool, &plan.output);
         Self::apply_openai_image_provider_params(&mut tool, &plan.provider_params, true);
+        let mut tools = Vec::new();
+        if let Some(web_search_tool) = Self::openai_image_web_search_tool(&plan.provider_params) {
+            tools.push(web_search_tool);
+        }
+        tools.push(serde_json::Value::Object(tool));
         let body = serde_json::json!({
             "model": request.model,
             "input": input,
             "instructions": "You are an image-generation agent. The user's input is always a request to produce one or more images. Call the image_generation tool to produce each image. Never reply in text instead of calling the tool. If the request cannot be fulfilled, refuse briefly and explicitly so the caller can see the reason.",
-            "tools": [serde_json::Value::Object(tool)],
+            "tools": tools,
             "tool_choice": "required",
             "stream": false,
         });
+        let mut body = body;
+        if let Some(effort) = plan.provider_params.reasoning_effort {
+            body["reasoning"] = serde_json::json!({ "effort": effort.as_legacy_str() });
+        }
         let endpoint = self.responses_endpoint();
         let response = self.post_json_to_openai(&endpoint, &body).await?;
         self.normalize_openai_image_response(request, response, true)
@@ -996,6 +999,22 @@ impl OpenAiClient {
                 "action".to_string(),
                 serde_json::Value::String(action.as_wire_value().to_string()),
             );
+        }
+    }
+
+    fn openai_image_web_search_tool(
+        params: &OpenAiImageProviderParams,
+    ) -> Option<serde_json::Value> {
+        let value = params.web_search.as_ref()?;
+        match value {
+            Value::Bool(false) | Value::Null => None,
+            Value::Bool(true) => Some(serde_json::json!({"type": "web_search"})),
+            Value::Object(map) => {
+                let mut tool = map.clone();
+                tool.insert("type".to_string(), Value::String("web_search".to_string()));
+                Some(Value::Object(tool))
+            }
+            _ => None,
         }
     }
 
@@ -2551,6 +2570,89 @@ mod tests {
         Ok(())
     }
 
+    #[tokio::test]
+    async fn openai_hosted_image_executor_sends_web_search_and_reasoning()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let seen = Arc::new(Mutex::new(Vec::new()));
+        let response = serde_json::json!({
+            "id": "resp_img_1",
+            "output": [{"type": "image_generation_call", "id": "ig_1", "result": "aGVsbG8="}]
+        });
+        let (base_url, handle) = spawn_openai_image_stub(response, seen.clone()).await;
+        let client = OpenAiClient::new_with_base_url("test-key".to_string(), base_url);
+        let mut plan = hosted_openai_plan_json();
+        plan["provider_plan"]["provider_params"] = serde_json::json!({
+            "reasoning_effort": "xhigh",
+            "web_search": {
+                "search_context_size": "low",
+                "external_web_access": false,
+                "filters": { "allowed_domains": ["example.com"] },
+                "return_token_budget": "default"
+            }
+        });
+
+        client
+            .execute_image_generation(image_executor_request_json(plan))
+            .await?;
+
+        let bodies = seen.lock().expect("seen mutex");
+        let body = bodies.first().expect("captured OpenAI image request");
+        assert_eq!(body["reasoning"]["effort"], "xhigh");
+        assert_eq!(body["tools"][0]["type"], "web_search");
+        assert_eq!(body["tools"][0]["search_context_size"], "low");
+        assert_eq!(body["tools"][0]["external_web_access"], false);
+        assert_eq!(
+            body["tools"][0]["filters"]["allowed_domains"][0],
+            "example.com"
+        );
+        assert_eq!(body["tools"][1]["type"], "image_generation");
+        assert_eq!(body["tools"][1]["model"], "gpt-image-2");
+
+        handle.abort();
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn openai_hosted_image_web_search_boolean_and_null_shapes()
+    -> Result<(), Box<dyn std::error::Error>> {
+        for (web_search, expect_search_tool) in [
+            (serde_json::json!(true), true),
+            (serde_json::json!({}), true),
+            (serde_json::json!(false), false),
+            (serde_json::Value::Null, false),
+        ] {
+            let seen = Arc::new(Mutex::new(Vec::new()));
+            let response = serde_json::json!({
+                "id": "resp_img_1",
+                "output": [{"type": "image_generation_call", "id": "ig_1", "result": "aGVsbG8="}]
+            });
+            let (base_url, handle) = spawn_openai_image_stub(response, seen.clone()).await;
+            let client = OpenAiClient::new_with_base_url("test-key".to_string(), base_url);
+            let mut plan = hosted_openai_plan_json();
+            plan["provider_plan"]["provider_params"] = serde_json::json!({
+                "web_search": web_search
+            });
+
+            client
+                .execute_image_generation(image_executor_request_json(plan))
+                .await?;
+
+            let bodies = seen.lock().expect("seen mutex");
+            let body = bodies.first().expect("captured OpenAI image request");
+            let tools = body["tools"].as_array().expect("tools array");
+            if expect_search_tool {
+                assert_eq!(tools.len(), 2);
+                assert_eq!(tools[0]["type"], "web_search");
+                assert_eq!(tools[1]["type"], "image_generation");
+            } else {
+                assert_eq!(tools.len(), 1);
+                assert_eq!(tools[0]["type"], "image_generation");
+            }
+            handle.abort();
+        }
+        Ok(())
+    }
+
     #[test]
     fn test_request_uses_responses_api_endpoint_format() {
         let client = OpenAiClient::new("test-key".to_string());
@@ -2856,6 +2958,40 @@ mod tests {
         let body = client.build_request_body(&request).expect("build request");
 
         assert_eq!(body["reasoning"]["effort"], "high");
+    }
+
+    #[test]
+    fn test_request_reasoning_effort_none_override_for_catalog_reasoning_model() {
+        let client = OpenAiClient::new("test-key".to_string());
+        let request = LlmRequest::new(
+            "gpt-5.5",
+            vec![Message::User(UserMessage::text("test".to_string()))],
+        )
+        .with_openai_tag_merge(|t| {
+            t.reasoning_effort =
+                Some(meerkat_core::lifecycle::run_primitive::ReasoningEffort::None);
+        });
+
+        let body = client.build_request_body(&request).expect("build request");
+
+        assert_eq!(body["reasoning"]["effort"], "none");
+    }
+
+    #[test]
+    fn test_request_reasoning_effort_xhigh_override() {
+        let client = OpenAiClient::new("test-key".to_string());
+        let request = LlmRequest::new(
+            "gpt-5.4",
+            vec![Message::User(UserMessage::text("test".to_string()))],
+        )
+        .with_openai_tag_merge(|t| {
+            t.reasoning_effort =
+                Some(meerkat_core::lifecycle::run_primitive::ReasoningEffort::XHigh);
+        });
+
+        let body = client.build_request_body(&request).expect("build request");
+
+        assert_eq!(body["reasoning"]["effort"], "xhigh");
     }
 
     #[test]

--- a/meerkat-openai/src/client_compatible.rs
+++ b/meerkat-openai/src/client_compatible.rs
@@ -140,7 +140,6 @@ impl OpenAiCompatibleClient {
         }
 
         if let Some(tag) = crate::client::openai_tag(request) {
-            use meerkat_core::lifecycle::run_primitive::ReasoningEffort as TypedReasoningEffort;
             if self.supports_reasoning {
                 if let Some(reasoning) = tag.reasoning.as_ref() {
                     let v = reasoning.as_value();
@@ -149,11 +148,7 @@ impl OpenAiCompatibleClient {
                     }
                 }
                 if let Some(effort) = tag.reasoning_effort {
-                    let s = match effort {
-                        TypedReasoningEffort::Low => "low",
-                        TypedReasoningEffort::Medium => "medium",
-                        TypedReasoningEffort::High => "high",
-                    };
+                    let s = effort.as_legacy_str();
                     if !body["reasoning"].is_object() {
                         body["reasoning"] = serde_json::json!({});
                     }
@@ -912,6 +907,34 @@ mod tests {
         assert_eq!(body["reasoning_effort"], "medium");
         assert_eq!(body["chat_template_kwargs"]["enable_thinking"], true);
         assert_eq!(body["thinking"]["type"], "enabled");
+    }
+
+    #[test]
+    fn build_chat_completions_body_preserves_xhigh_reasoning_effort() {
+        let client = OpenAiCompatibleClient::new(
+            OpenAiCompatibleMode::ChatCompletions,
+            "remote-model".to_string(),
+            "http://localhost:11434/v1".to_string(),
+            None,
+            true,
+            true,
+            true,
+        );
+        let request = LlmRequest::new(
+            "gemma-4-31b",
+            vec![Message::User(UserMessage::text("hello".to_string()))],
+        )
+        .with_openai_tag_merge(|t| {
+            t.reasoning_effort =
+                Some(meerkat_core::lifecycle::run_primitive::ReasoningEffort::XHigh);
+        });
+
+        let body = client
+            .build_chat_completions_body(&request)
+            .expect("body should build");
+
+        assert_eq!(body["reasoning"]["effort"], "xhigh");
+        assert_eq!(body["reasoning_effort"], "xhigh");
     }
 
     #[tokio::test]

--- a/meerkat-openai/src/image_generation.rs
+++ b/meerkat-openai/src/image_generation.rs
@@ -11,6 +11,7 @@ use meerkat_core::image_generation::{
     ProviderId,
 };
 use meerkat_core::lifecycle::run_primitive::ModelId;
+use meerkat_core::lifecycle::run_primitive::ReasoningEffort;
 use meerkat_core::model_profile::catalog::{
     ImageGenerationModelProfile, ImageGenerationModelRoute, OpenAiImageGenerationRequestShape,
 };
@@ -117,6 +118,12 @@ pub struct OpenAiImageProviderParams {
     pub moderation: Option<OpenAiImageModeration>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub action: Option<OpenAiImageAction>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reasoning_effort: Option<ReasoningEffort>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub web_search: Option<serde_json::Value>,
+    #[serde(skip)]
+    web_search_present: bool,
 }
 
 impl OpenAiImageProviderParams {
@@ -125,6 +132,13 @@ impl OpenAiImageProviderParams {
             && self.output_compression.is_none()
             && self.moderation.is_none()
             && self.action.is_none()
+            && self.reasoning_effort.is_none()
+            && self.web_search.is_none()
+            && !self.web_search_present
+    }
+
+    fn has_hosted_only_fields(&self) -> bool {
+        self.reasoning_effort.is_some() || self.web_search.is_some() || self.web_search_present
     }
 }
 
@@ -227,7 +241,9 @@ impl ImageGenerationProviderProfile for OpenAiImageGenerationProfile {
 - Models: provider:"openai" uses the catalog OpenAI image default; supported image targets and their hosted-tool vs Images API routes are owned by the shared model catalog.
 - Use Meerkat's universal size, quality, format, count, and intent fields for normal requests; the adapter lowers format to OpenAI output_format.
 - provider_params is only for advanced OpenAI-specific overrides. For the current hosted gpt-image-2 route, public callers should normally use {"background":"auto"|"opaque","output_compression":0..100,"moderation":"auto"|"low","action":"auto"|"generate"|"edit"}.
+- Hosted gpt-image-2 route only: provider_params may also include {"reasoning_effort":"none"|"low"|"medium"|"high"|"xhigh","web_search":true|false|null|{...}}. Use this for current/fresh image-only requests instead of searching separately first; object web_search values are lowered to the OpenAI hosted web_search tool with type:"web_search".
 - action applies only to the hosted Responses image tool and is usually omitted in favor of the top-level Meerkat intent. Images API requests reject action.
+- Images API requests reject reasoning_effort and web_search.
 - background:"transparent" is model-dependent; gpt-image-2 rejects it."#,
         )
     }
@@ -260,6 +276,9 @@ impl ImageGenerationProviderProfile for OpenAiImageGenerationProfile {
                 return Err(ImageOperationDenialReason::ProjectionUnsupported);
             }
             if provider_params.action.is_some() {
+                return Err(ImageOperationDenialReason::ProjectionUnsupported);
+            }
+            if provider_params.has_hosted_only_fields() {
                 return Err(ImageOperationDenialReason::ProjectionUnsupported);
             }
             if matches!(request_shape, OpenAiImageGenerationRequestShape::DallE)
@@ -353,11 +372,20 @@ fn openai_image_provider_params(
     let Some(value) = request.provider_params.as_ref() else {
         return Ok(OpenAiImageProviderParams::default());
     };
-    let params: OpenAiImageProviderParams = serde_json::from_value(value.clone())
+    let web_search_present = value
+        .as_object()
+        .is_some_and(|object| object.contains_key("web_search"));
+    let mut params: OpenAiImageProviderParams = serde_json::from_value(value.clone())
         .map_err(|_| ImageOperationDenialReason::ProjectionUnsupported)?;
+    params.web_search_present = web_search_present;
     if params
         .output_compression
         .is_some_and(|compression| compression > 100)
+    {
+        return Err(ImageOperationDenialReason::ProjectionUnsupported);
+    }
+    if let Some(web_search) = params.web_search.as_ref()
+        && !(web_search.is_null() || web_search.is_boolean() || web_search.is_object())
     {
         return Err(ImageOperationDenialReason::ProjectionUnsupported);
     }
@@ -476,6 +504,73 @@ mod tests {
             result,
             Err(ImageOperationDenialReason::ProjectionUnsupported)
         ));
+        Ok(())
+    }
+
+    #[test]
+    fn profile_rejects_hosted_only_params_on_images_api_route()
+    -> Result<(), Box<dyn std::error::Error>> {
+        for params in [
+            json!({"web_search": true}),
+            json!({"web_search": null}),
+            json!({"reasoning_effort": "xhigh"}),
+        ] {
+            let request = generate_request(params)?;
+            let profile = openai_image_profile("gpt-image-1");
+
+            let result = OpenAiImageGenerationProfile.resolve_execution_plan(
+                operation_id()?,
+                &profile,
+                &request,
+                capabilities(),
+                NonZeroU32::MIN,
+            );
+
+            assert!(matches!(
+                result,
+                Err(ImageOperationDenialReason::ProjectionUnsupported)
+            ));
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn profile_accepts_hosted_web_search_and_reasoning_params()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let request = generate_request(json!({
+            "web_search": {
+                "search_context_size": "low",
+                "external_web_access": false
+            },
+            "reasoning_effort": "none"
+        }))?;
+        let profile = default_image_generation_model(Provider::OpenAI)
+            .expect("OpenAI default image profile must be cataloged");
+
+        let resolution = OpenAiImageGenerationProfile
+            .resolve_execution_plan(
+                operation_id()?,
+                &profile,
+                &request,
+                capabilities(),
+                NonZeroU32::MIN,
+            )
+            .map_err(|err| std::io::Error::other(format!("resolve plan: {err:?}")))?;
+
+        let plan: OpenAiResponsesImagePlan =
+            serde_json::from_value(resolution.execution_plan.provider_plan)?;
+        assert_eq!(
+            plan.provider_params.reasoning_effort,
+            Some(meerkat_core::lifecycle::run_primitive::ReasoningEffort::None)
+        );
+        assert_eq!(
+            plan.provider_params
+                .web_search
+                .as_ref()
+                .and_then(|value| value.get("search_context_size"))
+                .and_then(serde_json::Value::as_str),
+            Some("low")
+        );
         Ok(())
     }
 

--- a/meerkat-openai/src/lib.rs
+++ b/meerkat-openai/src/lib.rs
@@ -18,6 +18,7 @@ pub mod live;
 pub mod runtime;
 #[cfg(all(not(target_arch = "wasm32"), feature = "realtime"))]
 pub mod text_adapter;
+pub mod web_search;
 
 pub use client::OpenAiClient;
 pub use client_compatible::OpenAiCompatibleClient;
@@ -31,3 +32,4 @@ pub use live::OpenAiLiveClient;
 pub use runtime::{OpenAiAuthMethod, OpenAiBackendKind, OpenAiProviderRuntime};
 #[cfg(all(not(target_arch = "wasm32"), feature = "realtime"))]
 pub use text_adapter::OpenAiRealtimeTextAdapter;
+pub use web_search::OpenAiWebSearchExecutor;

--- a/meerkat-openai/src/web_search.rs
+++ b/meerkat-openai/src/web_search.rs
@@ -1,0 +1,187 @@
+//! OpenAI-native web-search fallback executor.
+
+use async_trait::async_trait;
+use meerkat_core::lifecycle::run_primitive::{
+    ModelId, OpaqueProviderBody, OpenAiProviderTag, ProviderParamsOverride, ProviderTag,
+};
+use meerkat_core::web_search::{
+    WebSearchEvidence, WebSearchNativeEvent, WebSearchRequest, WebSearchResult, WebSearchStatus,
+};
+use meerkat_core::{AgentLlmClient, AssistantBlock, Message, Provider, SystemMessage, UserMessage};
+use meerkat_llm_core::{LlmError, WebSearchExecutor};
+use std::sync::Arc;
+
+#[derive(Clone)]
+pub struct OpenAiWebSearchExecutor {
+    model: String,
+    client: Arc<dyn AgentLlmClient>,
+}
+
+impl OpenAiWebSearchExecutor {
+    pub fn new(model: String, client: Arc<dyn AgentLlmClient>) -> Self {
+        Self { model, client }
+    }
+
+    fn provider_tag(provider_params: Option<serde_json::Value>) -> ProviderTag {
+        let mut body = serde_json::json!({"type": "web_search"});
+        merge_object(&mut body, provider_params);
+        ProviderTag::OpenAi(OpenAiProviderTag {
+            web_search: Some(OpaqueProviderBody::from_value(&body)),
+            ..Default::default()
+        })
+    }
+}
+
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+impl WebSearchExecutor for OpenAiWebSearchExecutor {
+    async fn execute_web_search(
+        &self,
+        request: WebSearchRequest,
+    ) -> Result<WebSearchResult, LlmError> {
+        if let Some(requested_provider) = request.provider
+            && requested_provider != Provider::OpenAI
+        {
+            return Err(LlmError::InvalidRequest {
+                message: format!(
+                    "web_search fallback is configured for '{}', not '{}'",
+                    Provider::OpenAI.as_str(),
+                    requested_provider.as_str()
+                ),
+            });
+        }
+
+        execute_native_web_search(
+            self.client.as_ref(),
+            Provider::OpenAI,
+            &self.model,
+            request,
+            Self::provider_tag,
+        )
+        .await
+    }
+}
+
+async fn execute_native_web_search(
+    client: &dyn AgentLlmClient,
+    provider: Provider,
+    model: &str,
+    request: WebSearchRequest,
+    provider_tag: impl FnOnce(Option<serde_json::Value>) -> ProviderTag,
+) -> Result<WebSearchResult, LlmError> {
+    let prompt = web_search_user_prompt(&request);
+    let messages = vec![
+        Message::System(SystemMessage::new(
+            "You are a web-search execution adapter for Meerkat. Use your \
+             provider-native web search/grounding tool to answer the query. \
+             Return a concise answer and include cited URLs when available. \
+             Do not call non-search tools.",
+        )),
+        Message::User(UserMessage::text(prompt)),
+    ];
+    let provider_params = ProviderParamsOverride {
+        max_output_tokens: Some(2048),
+        provider_tag: Some(provider_tag(request.provider_params.clone())),
+        ..Default::default()
+    };
+    let result = client
+        .stream_response(&messages, &[], 2048, None, Some(&provider_params))
+        .await
+        .map_err(|err| LlmError::Unknown {
+            message: err.to_string(),
+        })?;
+
+    let mut answer_parts = Vec::new();
+    let mut native_events = Vec::new();
+    let mut evidence = Vec::new();
+    for block in result.blocks() {
+        match block {
+            AssistantBlock::Text { text, .. } | AssistantBlock::Transcript { text, .. } => {
+                if !text.trim().is_empty() {
+                    answer_parts.push(text.trim().to_string());
+                }
+            }
+            AssistantBlock::ServerToolContent { name, content, .. } => {
+                collect_evidence(content, &mut evidence);
+                native_events.push(WebSearchNativeEvent {
+                    name: name.clone(),
+                    content: content.clone(),
+                });
+            }
+            _ => {}
+        }
+    }
+
+    Ok(WebSearchResult {
+        status: WebSearchStatus::Completed,
+        query: request.query,
+        provider: Some(provider),
+        model: Some(ModelId::new(model.to_string())),
+        answer: (!answer_parts.is_empty()).then(|| answer_parts.join("\n\n")),
+        evidence,
+        native_events,
+        error: None,
+        checked_at: chrono::Utc::now(),
+    })
+}
+
+fn merge_object(body: &mut serde_json::Value, provider_params: Option<serde_json::Value>) {
+    if let Some(extra) = provider_params
+        && let (Some(base), Some(extra)) = (body.as_object_mut(), extra.as_object())
+    {
+        for (key, value) in extra {
+            base.insert(key.clone(), value.clone());
+        }
+    }
+}
+
+fn web_search_user_prompt(request: &WebSearchRequest) -> String {
+    let mut prompt = format!("Search query:\n{}", request.query);
+    if let Some(context) = request
+        .context
+        .as_ref()
+        .filter(|value| !value.trim().is_empty())
+    {
+        prompt.push_str("\n\nConversation context:\n");
+        prompt.push_str(context.trim());
+    }
+    prompt
+}
+
+fn collect_evidence(value: &serde_json::Value, out: &mut Vec<WebSearchEvidence>) {
+    match value {
+        serde_json::Value::Object(map) => {
+            let url = map
+                .get("url")
+                .or_else(|| map.get("uri"))
+                .and_then(serde_json::Value::as_str)
+                .map(ToString::to_string);
+            let title = map
+                .get("title")
+                .and_then(serde_json::Value::as_str)
+                .map(ToString::to_string);
+            let summary = map
+                .get("summary")
+                .or_else(|| map.get("snippet"))
+                .or_else(|| map.get("text"))
+                .and_then(serde_json::Value::as_str)
+                .map(ToString::to_string);
+            if url.is_some() || title.is_some() || summary.is_some() {
+                out.push(WebSearchEvidence {
+                    title,
+                    url,
+                    summary,
+                });
+            }
+            for child in map.values() {
+                collect_evidence(child, out);
+            }
+        }
+        serde_json::Value::Array(items) => {
+            for child in items {
+                collect_evidence(child, out);
+            }
+        }
+        _ => {}
+    }
+}

--- a/meerkat-runtime/src/comms_bridge.rs
+++ b/meerkat-runtime/src/comms_bridge.rs
@@ -108,6 +108,10 @@ fn peer_input_from_ingress_fact(
 ) -> Result<Input, PeerIngressProjectionError> {
     let convention = map_ingress_convention(interaction.id, ingress, response_terminality)?;
     let durability = map_durability(&convention);
+    let handling_mode = match &convention {
+        PeerConvention::ResponseProgress { .. } => None,
+        _ => Some(interaction.handling_mode),
+    };
     let peer_id = ingress.canonical_peer_id_string().ok_or(
         PeerIngressProjectionError::MissingCanonicalPeerId {
             interaction_id: interaction.id,
@@ -141,7 +145,7 @@ fn peer_input_from_ingress_fact(
         body: peer_rendered_body(interaction),
         payload: peer_payload(interaction),
         blocks: peer_blocks(interaction),
-        handling_mode: Some(interaction.handling_mode),
+        handling_mode,
     }))
 }
 
@@ -1226,6 +1230,7 @@ mod tests {
                 })
             ));
             assert_eq!(p.header.durability, InputDurability::Ephemeral);
+            assert_eq!(p.handling_mode, None);
         } else {
             panic!("Expected PeerInput");
         }
@@ -1281,6 +1286,7 @@ mod tests {
                 })
             ));
             assert_eq!(p.header.durability, InputDurability::Ephemeral);
+            assert_eq!(p.handling_mode, None);
         } else {
             panic!("Expected PeerInput");
         }

--- a/meerkat-runtime/src/policy_table.rs
+++ b/meerkat-runtime/src/policy_table.rs
@@ -59,11 +59,7 @@ impl DefaultPolicyTable {
         {
             let (wake_mode, drain_policy, routing_disposition) = match mode {
                 meerkat_core::types::HandlingMode::Queue => (
-                    if runtime_idle {
-                        WakeMode::WakeIfIdle
-                    } else {
-                        WakeMode::None
-                    },
+                    WakeMode::WakeIfIdle,
                     DrainPolicy::QueueNextTurn,
                     RoutingDisposition::Queue,
                 ),
@@ -812,6 +808,14 @@ mod tests {
         assert_eq!(decision.routing_disposition, RoutingDisposition::Queue);
         assert_eq!(decision.apply_mode, ApplyMode::StageRunStart);
         assert_eq!(decision.wake_mode, WakeMode::WakeIfIdle);
+
+        let running_decision = DefaultPolicyTable::resolve(&input, false);
+        assert_eq!(
+            running_decision.routing_disposition,
+            RoutingDisposition::Queue
+        );
+        assert_eq!(running_decision.apply_mode, ApplyMode::StageRunStart);
+        assert_eq!(running_decision.wake_mode, WakeMode::WakeIfIdle);
     }
 
     #[test]

--- a/meerkat-runtime/tests/regression_comms_runtime.rs
+++ b/meerkat-runtime/tests/regression_comms_runtime.rs
@@ -594,11 +594,11 @@ async fn no_input_no_wake() {
 }
 
 // ---------------------------------------------------------------------------
-// Additional: Message while running — queue policy, cooperative interrupt
+// Additional: Message while running with explicit Queue — queue policy, no interrupt
 // ---------------------------------------------------------------------------
 
 #[tokio::test]
-async fn message_while_running_requests_cooperative_interrupt() {
+async fn message_while_running_with_explicit_queue_stays_queued() {
     let mut driver = EphemeralRuntimeDriver::new(rid());
 
     // Start a run
@@ -607,19 +607,16 @@ async fn message_while_running_requests_cooperative_interrupt() {
     let interaction = make_message("peer-1", "hello");
     let input = runtime_input_for_interaction(&interaction, &rid());
 
-    // peer_message + running → StageRunStart + cooperative interrupt
+    // peer_message + running + explicit Queue → StageRunStart + no interrupt
     let policy = DefaultPolicyTable::resolve(&input, false);
     assert_eq!(policy.apply_mode, meerkat_runtime::ApplyMode::StageRunStart);
-    assert_eq!(
-        policy.wake_mode,
-        meerkat_runtime::WakeMode::InterruptYielding
-    );
+    assert_eq!(policy.wake_mode, meerkat_runtime::WakeMode::None);
 
     let outcome = driver.accept_input(input).await.unwrap();
     assert!(outcome.is_accepted());
     assert_eq!(
         post_admission_signal_from_accept_outcome(&outcome, false),
-        PostAdmissionSignal::InterruptYielding
+        PostAdmissionSignal::None
     );
     assert_eq!(
         driver.take_post_admission_signal(),

--- a/meerkat-tools/src/builtin/image_generation.rs
+++ b/meerkat-tools/src/builtin/image_generation.rs
@@ -142,6 +142,7 @@ Routing and defaults:
 - On non-image-capable session providers, auto is unsupported; set provider:"openai" or provider:"gemini".
 - provider:"openai" or provider:"gemini" uses that provider's registered image default.
 - To force a model, pass provider plus model. Passing only model is accepted when the catalog identifies a configured provider for that model.
+- For image-only requests that need current or recent information, pass the freshness requirement in the prompt and, when using OpenAI hosted image generation, prefer provider_params.web_search here instead of doing a separate manual web search first.
 
 Supported request fields:
 - intent: "generate" for a new image, "edit" only with source_images. If omitted and prompt is present, intent defaults to "generate".

--- a/meerkat-tools/src/builtin/web_search.rs
+++ b/meerkat-tools/src/builtin/web_search.rs
@@ -18,26 +18,23 @@ const WEB_SEARCH_TOOL_DOCUMENTATION: &str = r#"Search the web through Meerkat wh
 Use this tool when the user asks for current, recent, online, or cited information and no native provider web-search tool is available in this session.
 
 Request shape:
-{"query":"latest Meerkat release notes","provider":"openai"}
+{"query":"latest Meerkat release notes"}
 
 Fields:
 - query: required natural-language search/research query.
-- provider: optional provider override: "openai", "gemini", or "anthropic". If omitted, Meerkat chooses the first configured search provider in OpenAI, Gemini, Anthropic order.
-- provider_params: optional provider-native search-tool options. These are merged into the selected provider's native web-search body.
+- provider: optional provider assertion: "openai", "gemini", or "anthropic". If omitted, Meerkat uses the session's configured fallback provider. If present, it must match that provider.
 - context: optional brief context from the conversation to help disambiguate the query.
 
 Result shape follows the common provider-native search idea: status, provider, model, answer, evidence, and native_events. Treat native_events as provider-observed evidence, not Meerkat-owned truth."#;
 
 #[derive(Debug, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
 struct WebSearchToolArgs {
     #[schemars(description = "Natural-language query to search for.")]
     query: String,
     #[serde(default)]
     #[schemars(description = "Optional provider override: openai, gemini, or anthropic.")]
     provider: Option<String>,
-    #[serde(default)]
-    #[schemars(description = "Optional provider-native search-tool options.")]
-    provider_params: Option<Value>,
     #[serde(default)]
     #[schemars(description = "Optional brief conversation context to disambiguate the search.")]
     context: Option<String>,
@@ -94,7 +91,7 @@ impl BuiltinTool for WebSearchTool {
             .execute_web_search(WebSearchRequest {
                 query,
                 provider,
-                provider_params: args.provider_params,
+                provider_params: None,
                 context: args.context.filter(|value| !value.trim().is_empty()),
             })
             .await
@@ -186,7 +183,6 @@ mod tests {
             .call(serde_json::json!({
                 "query": "today's news",
                 "provider": "gemini",
-                "provider_params": {"allowed_domains": ["example.com"]},
                 "context": "smoke test"
             }))
             .await
@@ -199,11 +195,21 @@ mod tests {
         assert_eq!(value["provider"], "gemini");
         let seen = executor.seen.lock().await;
         assert_eq!(seen[0].provider, Some(Provider::Gemini));
-        assert_eq!(
-            seen[0].provider_params,
-            Some(serde_json::json!({"allowed_domains": ["example.com"]}))
-        );
+        assert_eq!(seen[0].provider_params, None);
         Ok(())
+    }
+
+    #[tokio::test]
+    async fn web_search_tool_rejects_provider_native_params() {
+        let tool = WebSearchTool::new(Arc::new(RecordingExecutor::default()));
+        let err = tool
+            .call(serde_json::json!({
+                "query": "today's news",
+                "provider_params": {"allowed_domains": ["example.com"]}
+            }))
+            .await
+            .expect_err("model-callable fallback search must not accept provider-native params");
+        assert!(err.to_string().contains("unknown field"));
     }
 
     #[tokio::test]

--- a/meerkat/src/factory.rs
+++ b/meerkat/src/factory.rs
@@ -42,18 +42,12 @@ const DEFAULT_WASM_SYSTEM_PROMPT: &str = r"You are an autonomous agent. Your tas
 # Output
 - When the task is complete, provide a clear summary of what was accomplished.
 - If the task cannot be completed, explain what blocked progress and what was attempted.";
+#[cfg(not(target_arch = "wasm32"))]
+use meerkat_core::RuntimeBuildMode;
 #[cfg(any(not(feature = "memory-store"), not(target_arch = "wasm32")))]
 use meerkat_core::SessionId;
 #[cfg(not(feature = "memory-store"))]
 use meerkat_core::SessionMeta;
-#[cfg(not(target_arch = "wasm32"))]
-use meerkat_core::lifecycle::run_primitive::{
-    ModelId, OpaqueProviderBody, ProviderParamsOverride, ProviderTag,
-};
-#[cfg(not(target_arch = "wasm32"))]
-use meerkat_core::web_search::{
-    WebSearchEvidence, WebSearchNativeEvent, WebSearchRequest, WebSearchResult, WebSearchStatus,
-};
 use meerkat_core::{
     Agent, AgentBuilder, AgentEvent, AgentLlmClient, AgentLlmClientDecorator, AgentSessionStore,
     AgentToolDispatcher, AuthBindingRef, BlobStore, BudgetLimits, Config, HookRunOverrides,
@@ -61,8 +55,6 @@ use meerkat_core::{
     SessionLlmIdentity, SessionMetadata, SessionToolVisibilityState, SessionTooling,
     ToolCategoryOverride,
 };
-#[cfg(not(target_arch = "wasm32"))]
-use meerkat_core::{Message, RuntimeBuildMode, SystemMessage, UserMessage};
 use meerkat_runtime::{RuntimeOpsLifecycleRegistry, RuntimeTurnStateHandle};
 #[cfg(feature = "jsonl-store")]
 use meerkat_store::JsonlStore;
@@ -940,247 +932,6 @@ impl meerkat_llm_core::ImageGenerationExecutor for RoutingImageGenerationExecuto
 }
 
 #[cfg(not(target_arch = "wasm32"))]
-#[derive(Clone)]
-struct ProviderNativeWebSearchExecutor {
-    provider: Provider,
-    model: String,
-    client: Arc<dyn AgentLlmClient>,
-}
-
-#[cfg(not(target_arch = "wasm32"))]
-impl ProviderNativeWebSearchExecutor {
-    fn new(provider: Provider, model: String, client: Arc<dyn AgentLlmClient>) -> Self {
-        Self {
-            provider,
-            model,
-            client,
-        }
-    }
-
-    fn provider_tag(&self, provider_params: Option<serde_json::Value>) -> ProviderTag {
-        let body = merged_web_search_body(self.provider, provider_params);
-        match self.provider {
-            Provider::OpenAI => {
-                ProviderTag::OpenAi(meerkat_core::lifecycle::run_primitive::OpenAiProviderTag {
-                    web_search: Some(OpaqueProviderBody::from_value(&body)),
-                    ..Default::default()
-                })
-            }
-            Provider::Gemini => {
-                ProviderTag::Gemini(meerkat_core::lifecycle::run_primitive::GeminiProviderTag {
-                    google_search: Some(OpaqueProviderBody::from_value(&body)),
-                    ..Default::default()
-                })
-            }
-            Provider::Anthropic => ProviderTag::Anthropic(
-                meerkat_core::lifecycle::run_primitive::AnthropicProviderTag {
-                    web_search: Some(OpaqueProviderBody::from_value(&body)),
-                    ..Default::default()
-                },
-            ),
-            other => ProviderTag::Unknown {
-                bag: meerkat_core::lifecycle::run_primitive::StructuredProviderExtension {
-                    namespace: other.as_str().to_string(),
-                    key: "web_search".to_string(),
-                    body: body.to_string(),
-                },
-            },
-        }
-    }
-}
-
-#[cfg(not(target_arch = "wasm32"))]
-#[async_trait::async_trait]
-impl meerkat_llm_core::WebSearchExecutor for ProviderNativeWebSearchExecutor {
-    async fn execute_web_search(
-        &self,
-        request: WebSearchRequest,
-    ) -> Result<WebSearchResult, meerkat_llm_core::LlmError> {
-        let prompt = web_search_user_prompt(&request);
-        let messages = vec![
-            Message::System(SystemMessage::new(
-                "You are a web-search execution adapter for Meerkat. Use your \
-                 provider-native web search/grounding tool to answer the query. \
-                 Return a concise answer and include cited URLs when available. \
-                 Do not call non-search tools.",
-            )),
-            Message::User(UserMessage::text(prompt)),
-        ];
-        let provider_params = ProviderParamsOverride {
-            max_output_tokens: Some(2048),
-            provider_tag: Some(self.provider_tag(request.provider_params.clone())),
-            ..Default::default()
-        };
-        let result = self
-            .client
-            .stream_response(&messages, &[], 2048, None, Some(&provider_params))
-            .await
-            .map_err(|err| meerkat_llm_core::LlmError::Unknown {
-                message: err.to_string(),
-            })?;
-
-        let mut answer_parts = Vec::new();
-        let mut native_events = Vec::new();
-        let mut evidence = Vec::new();
-        for block in result.blocks() {
-            match block {
-                meerkat_core::AssistantBlock::Text { text, .. }
-                | meerkat_core::AssistantBlock::Transcript { text, .. } => {
-                    if !text.trim().is_empty() {
-                        answer_parts.push(text.trim().to_string());
-                    }
-                }
-                meerkat_core::AssistantBlock::ServerToolContent { name, content, .. } => {
-                    collect_evidence(content, &mut evidence);
-                    native_events.push(WebSearchNativeEvent {
-                        name: name.clone(),
-                        content: content.clone(),
-                    });
-                }
-                _ => {}
-            }
-        }
-
-        Ok(WebSearchResult {
-            status: WebSearchStatus::Completed,
-            query: request.query,
-            provider: Some(self.provider),
-            model: Some(ModelId::new(self.model.clone())),
-            answer: (!answer_parts.is_empty()).then(|| answer_parts.join("\n\n")),
-            evidence,
-            native_events,
-            error: None,
-            checked_at: chrono::Utc::now(),
-        })
-    }
-}
-
-#[cfg(not(target_arch = "wasm32"))]
-struct RoutingWebSearchExecutor {
-    executors: BTreeMap<String, ProviderNativeWebSearchExecutor>,
-}
-
-#[cfg(not(target_arch = "wasm32"))]
-impl RoutingWebSearchExecutor {
-    fn new(executors: BTreeMap<String, ProviderNativeWebSearchExecutor>) -> Self {
-        Self { executors }
-    }
-
-    fn preferred_provider_keys() -> [&'static str; 3] {
-        ["openai", "gemini", "anthropic"]
-    }
-}
-
-#[cfg(not(target_arch = "wasm32"))]
-#[async_trait::async_trait]
-impl meerkat_llm_core::WebSearchExecutor for RoutingWebSearchExecutor {
-    async fn execute_web_search(
-        &self,
-        request: WebSearchRequest,
-    ) -> Result<WebSearchResult, meerkat_llm_core::LlmError> {
-        let selected = if let Some(provider) = request.provider {
-            self.executors.get(provider_key(provider)).ok_or_else(|| {
-                meerkat_llm_core::LlmError::InvalidRequest {
-                    message: format!(
-                        "requested web_search provider '{}' is not configured",
-                        provider.as_str()
-                    ),
-                }
-            })?
-        } else {
-            let mut selected = None;
-            for key in Self::preferred_provider_keys() {
-                if let Some(executor) = self.executors.get(key) {
-                    selected = Some(executor);
-                    break;
-                }
-            }
-            selected.ok_or_else(|| meerkat_llm_core::LlmError::InvalidRequest {
-                message: "no configured provider supports Meerkat web_search fallback".to_string(),
-            })?
-        };
-
-        selected.execute_web_search(request).await
-    }
-}
-
-#[cfg(not(target_arch = "wasm32"))]
-fn merged_web_search_body(
-    provider: Provider,
-    provider_params: Option<serde_json::Value>,
-) -> serde_json::Value {
-    let mut body = match provider {
-        Provider::OpenAI => serde_json::json!({"type": "web_search"}),
-        Provider::Anthropic => {
-            serde_json::json!({"type": "web_search_20250305", "name": "web_search"})
-        }
-        Provider::Gemini => serde_json::json!({}),
-        _ => serde_json::json!({}),
-    };
-    if let Some(extra) = provider_params
-        && let (Some(base), Some(extra)) = (body.as_object_mut(), extra.as_object())
-    {
-        for (key, value) in extra {
-            base.insert(key.clone(), value.clone());
-        }
-    }
-    body
-}
-
-#[cfg(not(target_arch = "wasm32"))]
-fn web_search_user_prompt(request: &WebSearchRequest) -> String {
-    let mut prompt = format!("Search query:\n{}", request.query);
-    if let Some(context) = request
-        .context
-        .as_ref()
-        .filter(|value| !value.trim().is_empty())
-    {
-        prompt.push_str("\n\nConversation context:\n");
-        prompt.push_str(context.trim());
-    }
-    prompt
-}
-
-#[cfg(not(target_arch = "wasm32"))]
-fn collect_evidence(value: &serde_json::Value, out: &mut Vec<WebSearchEvidence>) {
-    match value {
-        serde_json::Value::Object(map) => {
-            let url = map
-                .get("url")
-                .or_else(|| map.get("uri"))
-                .and_then(serde_json::Value::as_str)
-                .map(ToString::to_string);
-            let title = map
-                .get("title")
-                .and_then(serde_json::Value::as_str)
-                .map(ToString::to_string);
-            let summary = map
-                .get("summary")
-                .or_else(|| map.get("snippet"))
-                .or_else(|| map.get("text"))
-                .and_then(serde_json::Value::as_str)
-                .map(ToString::to_string);
-            if url.is_some() || title.is_some() || summary.is_some() {
-                out.push(WebSearchEvidence {
-                    title,
-                    url,
-                    summary,
-                });
-            }
-            for child in map.values() {
-                collect_evidence(child, out);
-            }
-        }
-        serde_json::Value::Array(items) => {
-            for child in items {
-                collect_evidence(child, out);
-            }
-        }
-        _ => {}
-    }
-}
-
-#[cfg(not(target_arch = "wasm32"))]
 struct CompositeImageGenerationPlanner {
     profiles: Vec<Arc<dyn meerkat_core::ImageGenerationProviderProfile>>,
 }
@@ -1823,76 +1574,78 @@ impl AgentFactory {
         &self,
         config: &Config,
         registry: &ModelRegistry,
+        search_provider: Provider,
         selected_realm: Option<&str>,
         runtime_build_mode: &RuntimeBuildMode,
     ) -> Result<Option<Arc<dyn meerkat_llm_core::WebSearchExecutor>>, BuildAgentError> {
-        let mut executors: BTreeMap<String, ProviderNativeWebSearchExecutor> = BTreeMap::new();
-        for search_provider in [Provider::OpenAI, Provider::Gemini, Provider::Anthropic] {
-            if !provider_web_search_enabled(config, search_provider) {
-                continue;
-            }
-            let Some(model) = registry.default_model(search_provider).map(str::to_string) else {
-                continue;
-            };
-            let Some(profile) = registry.profile_for_provider(search_provider, &model) else {
-                continue;
-            };
-            if !profile.supports_web_search {
-                continue;
-            }
-
-            let Ok((realm, _binding_id, auth_binding)) =
-                Self::resolve_web_search_binding_for_provider(
-                    config,
-                    search_provider,
-                    selected_realm,
-                )
-            else {
-                continue;
-            };
-            let mut env = meerkat_providers::ResolverEnvironment::with_process_env();
-            if let Some(store) = self.token_store.clone() {
-                env = env.with_token_store(store);
-            }
-            if let Some(coord) = self.refresh_coord.clone() {
-                env = env.with_refresh_coordinator(coord);
-            }
-            if let RuntimeBuildMode::SessionOwned(bindings) = runtime_build_mode
-                && !auth_binding.is_env_default()
-            {
-                env = env.with_auth_lease_handle(Arc::clone(bindings.auth_lease()));
-            }
-            for (handle, resolver) in &self.external_auth_resolvers {
-                env = env.with_external_resolver(handle.clone(), resolver.clone());
-            }
-            let Ok(connection) = self
-                .provider_registry
-                .resolve(&realm, &auth_binding, &env)
-                .await
-            else {
-                continue;
-            };
-            if let RuntimeBuildMode::SessionOwned(bindings) = runtime_build_mode
-                && !auth_binding.is_env_default()
-            {
-                Self::publish_auth_lease(bindings.auth_lease(), &auth_binding, &connection)
-                    .map_err(BuildAgentError::LlmClient)?;
-            }
-            let Ok(client) = self.provider_registry.build_client(connection) else {
-                continue;
-            };
-            let adapted: Arc<dyn AgentLlmClient> =
-                Arc::new(LlmClientAdapter::new(client, model.clone()));
-            executors.insert(
-                provider_key(search_provider).to_string(),
-                ProviderNativeWebSearchExecutor::new(search_provider, model, adapted),
-            );
+        if !provider_web_search_enabled(config, search_provider) {
+            return Ok(None);
+        }
+        let Some(model) = registry.default_model(search_provider).map(str::to_string) else {
+            return Ok(None);
+        };
+        let Some(profile) = registry.profile_for_provider(search_provider, &model) else {
+            return Ok(None);
+        };
+        if !profile.supports_web_search {
+            return Ok(None);
         }
 
-        Ok((!executors.is_empty()).then(|| {
-            Arc::new(RoutingWebSearchExecutor::new(executors))
-                as Arc<dyn meerkat_llm_core::WebSearchExecutor>
-        }))
+        let Ok((realm, _binding_id, auth_binding)) =
+            Self::resolve_web_search_binding_for_provider(config, search_provider, selected_realm)
+        else {
+            return Ok(None);
+        };
+        let mut env = meerkat_providers::ResolverEnvironment::with_process_env();
+        if let Some(store) = self.token_store.clone() {
+            env = env.with_token_store(store);
+        }
+        if let Some(coord) = self.refresh_coord.clone() {
+            env = env.with_refresh_coordinator(coord);
+        }
+        if let RuntimeBuildMode::SessionOwned(bindings) = runtime_build_mode
+            && !auth_binding.is_env_default()
+        {
+            env = env.with_auth_lease_handle(Arc::clone(bindings.auth_lease()));
+        }
+        for (handle, resolver) in &self.external_auth_resolvers {
+            env = env.with_external_resolver(handle.clone(), resolver.clone());
+        }
+        let Ok(connection) = self
+            .provider_registry
+            .resolve(&realm, &auth_binding, &env)
+            .await
+        else {
+            return Ok(None);
+        };
+        if let RuntimeBuildMode::SessionOwned(bindings) = runtime_build_mode
+            && !auth_binding.is_env_default()
+        {
+            Self::publish_auth_lease(bindings.auth_lease(), &auth_binding, &connection)
+                .map_err(BuildAgentError::LlmClient)?;
+        }
+        let Ok(client) = self.provider_registry.build_client(connection) else {
+            return Ok(None);
+        };
+        let adapted: Arc<dyn AgentLlmClient> =
+            Arc::new(LlmClientAdapter::new(client, model.clone()));
+
+        let executor: Arc<dyn meerkat_llm_core::WebSearchExecutor> = match search_provider {
+            #[cfg(feature = "openai")]
+            Provider::OpenAI => {
+                Arc::new(meerkat_openai::OpenAiWebSearchExecutor::new(model, adapted))
+            }
+            #[cfg(feature = "gemini")]
+            Provider::Gemini => {
+                Arc::new(meerkat_gemini::GeminiWebSearchExecutor::new(model, adapted))
+            }
+            #[cfg(feature = "anthropic")]
+            Provider::Anthropic => Arc::new(meerkat_anthropic::AnthropicWebSearchExecutor::new(
+                model, adapted,
+            )),
+            _ => return Ok(None),
+        };
+        Ok(Some(executor))
     }
 
     /// Create a minimal factory for environments without filesystem access (e.g. wasm32).
@@ -3290,7 +3043,7 @@ impl AgentFactory {
         let resumed_self_hosted_server_id = resumed_session_metadata
             .as_ref()
             .and_then(|metadata| metadata.self_hosted_server_id.clone());
-        let (mut provider, resolved_self_hosted_server_id) =
+        let (provider, resolved_self_hosted_server_id) =
             self.resolve_provider_from_registry(&registry, &build_config)?;
         let self_hosted_server_id = if matches!(provider, Provider::SelfHosted) {
             build_config
@@ -3368,87 +3121,71 @@ impl AgentFactory {
                             env = env.with_external_resolver(handle.clone(), resolver.clone());
                         }
                         let explicit_auth_binding = build_config.auth_binding.is_some();
-                        let mut provider_attempts = vec![(provider, build_config.model.clone())];
-                        if build_config.provider.is_none() && !explicit_auth_binding {
-                            for fallback_provider in
-                                [Provider::Anthropic, Provider::Gemini, Provider::OpenAI]
-                            {
-                                if provider_attempts
-                                    .iter()
-                                    .any(|(attempt, _)| *attempt == fallback_provider)
-                                {
-                                    continue;
-                                }
-                                if let Some(default_model) =
-                                    registry.default_model(fallback_provider)
-                                {
-                                    provider_attempts
-                                        .push((fallback_provider, default_model.to_string()));
-                                }
-                            }
-                        }
                         let provider_registry = Arc::clone(&self.provider_registry);
                         let mut first_resolution_error: Option<String> = None;
                         let mut resolved = None;
-                        for (attempt_provider, attempt_model) in provider_attempts {
-                            let candidates = Self::resolve_realm_binding_candidates_for_provider(
-                                config,
-                                attempt_provider,
-                                build_config.auth_binding.as_ref(),
-                                build_config.realm_id.as_deref(),
-                            )
-                            .map_err(BuildAgentError::ConnectionResolution)?;
-                            for target in candidates {
-                                let resolved_auth_binding = target.auth_binding.clone();
-                                let lease_auth_binding = if resolved_auth_binding.is_env_default()
-                                    && !explicit_auth_binding
-                                {
-                                    None
-                                } else {
-                                    Some(resolved_auth_binding.clone())
-                                };
-                                let mut candidate_env = env.clone();
-                                if let RuntimeBuildMode::SessionOwned(bindings) =
-                                    &build_config.runtime_build_mode
-                                    && lease_auth_binding.is_some()
-                                {
-                                    candidate_env = candidate_env
-                                        .with_auth_lease_handle(Arc::clone(bindings.auth_lease()));
-                                }
-                                match provider_registry
-                                    .resolve(&target.realm, &resolved_auth_binding, &candidate_env)
-                                    .await
-                                {
-                                    Ok(connection) => {
-                                        let resolved_model =
-                                            if build_config.resume_override_mask.model {
-                                                attempt_model.clone()
-                                            } else {
-                                                target
-                                                    .binding
-                                                    .default_model
-                                                    .clone()
-                                                    .unwrap_or_else(|| attempt_model.clone())
-                                            };
-                                        resolved = Some((
-                                            connection,
-                                            resolved_auth_binding,
-                                            lease_auth_binding,
-                                            resolved_model,
+                        let candidates = Self::resolve_realm_binding_candidates_for_provider(
+                            config,
+                            provider,
+                            build_config.auth_binding.as_ref(),
+                            build_config.realm_id.as_deref(),
+                        )
+                        .map_err(BuildAgentError::ConnectionResolution)?;
+                        for target in candidates {
+                            let resolved_auth_binding = target.auth_binding.clone();
+                            let lease_auth_binding = if resolved_auth_binding.is_env_default()
+                                && !explicit_auth_binding
+                            {
+                                None
+                            } else {
+                                Some(resolved_auth_binding.clone())
+                            };
+                            let mut candidate_env = env.clone();
+                            if let RuntimeBuildMode::SessionOwned(bindings) =
+                                &build_config.runtime_build_mode
+                                && lease_auth_binding.is_some()
+                            {
+                                candidate_env = candidate_env
+                                    .with_auth_lease_handle(Arc::clone(bindings.auth_lease()));
+                            }
+                            match provider_registry
+                                .resolve(&target.realm, &resolved_auth_binding, &candidate_env)
+                                .await
+                            {
+                                Ok(connection) => {
+                                    if connection.provider != provider {
+                                        return Err(BuildAgentError::ConnectionResolution(
+                                            format!(
+                                                "auth binding for provider '{}' resolved connection for provider '{}'",
+                                                provider.as_str(),
+                                                connection.provider.as_str()
+                                            ),
                                         ));
+                                    }
+                                    let resolved_model = if build_config.resume_override_mask.model
+                                    {
+                                        build_config.model.clone()
+                                    } else {
+                                        target
+                                            .binding
+                                            .default_model
+                                            .clone()
+                                            .unwrap_or_else(|| build_config.model.clone())
+                                    };
+                                    resolved = Some((
+                                        connection,
+                                        resolved_auth_binding,
+                                        lease_auth_binding,
+                                        resolved_model,
+                                    ));
+                                    break;
+                                }
+                                Err(err) => {
+                                    first_resolution_error.get_or_insert_with(|| err.to_string());
+                                    if explicit_auth_binding {
                                         break;
                                     }
-                                    Err(err) => {
-                                        first_resolution_error
-                                            .get_or_insert_with(|| err.to_string());
-                                        if explicit_auth_binding {
-                                            break;
-                                        }
-                                    }
                                 }
-                            }
-                            if resolved.is_some() || explicit_auth_binding {
-                                break;
                             }
                         }
                         let (connection, resolved_auth_binding, lease_auth_binding, resolved_model) =
@@ -3463,7 +3200,6 @@ impl AgentFactory {
                                 )
                             })?;
                         build_config.model = resolved_model;
-                        provider = connection.provider;
 
                         // Publish immediately after resolve. Provider resolution can refresh and
                         // persist OAuth token bytes; AuthMachine must observe the returned lease
@@ -3641,6 +3377,7 @@ impl AgentFactory {
                 self.build_web_search_executor(
                     config,
                     &registry,
+                    provider,
                     build_config.realm_id.as_deref(),
                     &build_config.runtime_build_mode,
                 )
@@ -4835,15 +4572,6 @@ mod tests {
     use std::collections::HashMap;
     use tokio::sync::Mutex;
 
-    #[cfg(not(target_arch = "wasm32"))]
-    #[test]
-    fn web_search_provider_preference_is_openai_gemini_anthropic() {
-        assert_eq!(
-            RoutingWebSearchExecutor::preferred_provider_keys(),
-            ["openai", "gemini", "anthropic"]
-        );
-    }
-
     struct NeverLlmClient;
 
     #[async_trait]
@@ -5858,7 +5586,7 @@ mod tests {
 
     #[cfg(all(feature = "anthropic", feature = "openai", not(target_arch = "wasm32")))]
     #[tokio::test]
-    async fn build_agent_without_provider_or_auth_binding_uses_first_resolvable_provider() {
+    async fn build_agent_without_provider_or_auth_binding_does_not_probe_other_providers() {
         use async_trait::async_trait;
         use meerkat_llm_core::provider_runtime::{
             ProviderAuthError, ProviderClientError, ProviderRuntime, ProviderRuntimeRegistry,
@@ -5971,25 +5699,17 @@ mod tests {
         assert!(build.provider.is_none());
         assert!(build.auth_binding.is_none());
 
-        let agent = factory
-            .build_agent(build, &config)
-            .await
-            .expect("implicit provider selection should skip missing OpenAI env and use Anthropic");
-        let metadata = agent
-            .session()
-            .session_metadata()
-            .expect("metadata written");
-
-        assert_eq!(metadata.provider, Provider::Anthropic);
-        assert_eq!(metadata.model, "claude-sonnet-4-6");
-        assert_eq!(
-            metadata.auth_binding.as_ref().map(|auth_binding| {
-                (
-                    auth_binding.realm.as_str().to_string(),
-                    auth_binding.binding.as_str().to_string(),
-                )
-            }),
-            Some(("dev".to_string(), "default_anthropic".to_string()))
+        let err = match factory.build_agent(build, &config).await {
+            Ok(_) => {
+                panic!("OpenAI model resolution must not silently probe Anthropic credentials")
+            }
+            Err(err) => err,
+        };
+        assert!(
+            err.to_string().contains("openai")
+                || err.to_string().contains("OpenAI")
+                || err.to_string().contains("missing secret"),
+            "error should stay on selected OpenAI path, not switch providers: {err}"
         );
     }
 

--- a/xtask/src/ownership_ledger.rs
+++ b/xtask/src/ownership_ledger.rs
@@ -10,7 +10,8 @@ use syn::{ImplItem, Item, ItemFn, ItemImpl, Type};
 
 use crate::public_contracts::repo_root;
 
-const DOC_PATH: &str = "docs/architecture/finite-ownership-ledger.md";
+const DOC_PATH: &str =
+    "docs-internal/archive/public-docs-removed-2026-05-11/architecture/finite-ownership-ledger.md";
 const BASELINE_PATH: &str = "xtask/ownership-baseline.toml";
 
 #[derive(Debug, Clone, Args, Default)]

--- a/xtask/src/rmat_audit.rs
+++ b/xtask/src/rmat_audit.rs
@@ -75,7 +75,7 @@ pub fn rmat_audit(args: RmatAuditArgs) -> Result<()> {
         combined_findings.push(Finding {
             key: FindingKey {
                 rule: "OwnershipLedgerDocDrift".into(),
-                path: "docs/architecture/finite-ownership-ledger.md".into(),
+                path: "docs-internal/archive/public-docs-removed-2026-05-11/architecture/finite-ownership-ledger.md".into(),
                 symbol: "finite-ownership-ledger".into(),
             },
             severity: "error".into(),
@@ -96,7 +96,7 @@ pub fn rmat_audit(args: RmatAuditArgs) -> Result<()> {
 
     if !ownership_doc_in_sync {
         bail!(
-            "ownership ledger doc drift:\n- docs/architecture/finite-ownership-ledger.md is stale relative to typed ownership registry"
+            "ownership ledger doc drift:\n- docs-internal/archive/public-docs-removed-2026-05-11/architecture/finite-ownership-ledger.md is stale relative to typed ownership registry"
         );
     }
 

--- a/xtask/tests/ci_gate_requires_rmat.rs
+++ b/xtask/tests/ci_gate_requires_rmat.rs
@@ -82,15 +82,20 @@ fn buildbuddy_workflow_is_gcp_only() {
     assert_eq!(
         defined,
         vec![
+            "audit-submit",
             "control-plane-up",
             "executors-down",
             "executors-up",
+            "feature-submit",
             "gate",
             "governance-submit",
+            "minimal-feature-submit",
             "native-submit",
             "prebuild-submit",
             "static-submit",
-            "wasm-feature-submit",
+            "wasm-check-submit",
+            "wasm-feature-changes",
+            "wasm-sdk-submit",
         ],
     );
     assert!(buildbuddy.contains("MEERKAT_BAZEL_BACKEND: gcp-buildbuddy"));


### PR DESCRIPTION
## Summary

Adds the missing OpenAI reasoning effort variants `none` and `xhigh` to Meerkat's canonical surface and wires them through typed/wire projections and OpenAI request lowering.

Extends the OpenAI hosted Responses image path so `generate_image` can opt into hosted `web_search` and `reasoning_effort`, letting current/fresh image-only prompts pass freshness intent down to the image route instead of requiring a manual search turn first. The Images API route rejects these hosted-only params.

## Validation

- `./scripts/repo-cargo test -p meerkat-core`
- `./scripts/repo-cargo test -p meerkat-contracts`
- `./scripts/repo-cargo test -p meerkat-openai`
- `./scripts/repo-cargo test -p meerkat-gemini`
- `./scripts/repo-cargo test -p meerkat-anthropic`
- `./scripts/repo-cargo test -p meerkat-client --test live_client_provider_matrix --features integration-real-tests`
- `git diff --check`
- pre-push hooks, including changed-crates clippy and workspace deterministic gate
