### PR TITLE
[codex] Harden release preflight

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -144,11 +144,12 @@ jobs:
       (github.event_name != 'workflow_dispatch' ||
        (github.event.inputs.publish_web_sdk_only != 'true' &&
         github.event.inputs.publish_release_assets_only != 'true')) &&
-      !((github.event_name == 'workflow_dispatch' &&
-         github.event.inputs.release_backend == 'buildbuddy') ||
-        (github.event_name != 'workflow_dispatch' &&
-         (vars.MEERKAT_RELEASE_BUILDBUDDY == 'true' ||
-          vars.MEERKAT_RELEASE_BUILDBUDDY == '1')))
+      !(github.actor == 'lukacf' &&
+        ((github.event_name == 'workflow_dispatch' &&
+          github.event.inputs.release_backend == 'buildbuddy') ||
+         (github.event_name != 'workflow_dispatch' &&
+          (vars.MEERKAT_RELEASE_BUILDBUDDY == 'true' ||
+           vars.MEERKAT_RELEASE_BUILDBUDDY == '1'))))
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -213,11 +214,12 @@ jobs:
       (github.event_name != 'workflow_dispatch' ||
        (github.event.inputs.publish_web_sdk_only != 'true' &&
         github.event.inputs.publish_release_assets_only != 'true')) &&
-      ((github.event_name == 'workflow_dispatch' &&
-        github.event.inputs.release_backend == 'buildbuddy') ||
-       (github.event_name != 'workflow_dispatch' &&
-        (vars.MEERKAT_RELEASE_BUILDBUDDY == 'true' ||
-         vars.MEERKAT_RELEASE_BUILDBUDDY == '1')))
+      (github.actor == 'lukacf' &&
+       ((github.event_name == 'workflow_dispatch' &&
+         github.event.inputs.release_backend == 'buildbuddy') ||
+        (github.event_name != 'workflow_dispatch' &&
+         (vars.MEERKAT_RELEASE_BUILDBUDDY == 'true' ||
+          vars.MEERKAT_RELEASE_BUILDBUDDY == '1'))))
     runs-on: ${{ fromJSON(vars.MEERKAT_CI_RUNNER || '"ubuntu-latest"') }}
     env:
       BUILDBUDDY_API_KEY: ${{ secrets.BUILDBUDDY_API_KEY }}
@@ -280,7 +282,7 @@ jobs:
         run: |
           set -euo pipefail
           ci_result="${{ needs.require_ci_green.result }}"
-          bb_selected="${{ (github.event_name == 'workflow_dispatch' && github.event.inputs.release_backend == 'buildbuddy') || (github.event_name != 'workflow_dispatch' && (vars.MEERKAT_RELEASE_BUILDBUDDY == 'true' || vars.MEERKAT_RELEASE_BUILDBUDDY == '1')) }}"
+          bb_selected="${{ github.actor == 'lukacf' && ((github.event_name == 'workflow_dispatch' && github.event.inputs.release_backend == 'buildbuddy') || (github.event_name != 'workflow_dispatch' && (vars.MEERKAT_RELEASE_BUILDBUDDY == 'true' || vars.MEERKAT_RELEASE_BUILDBUDDY == '1'))) }}"
           cargo_result="${{ needs.release_validate_cargo.result }}"
           buildbuddy_result="${{ needs.release_validate_buildbuddy.result }}"
 
@@ -311,11 +313,12 @@ jobs:
       (startsWith(github.ref, 'refs/tags/v') ||
        (github.event_name == 'workflow_dispatch' &&
         github.event.inputs.publish_release_assets_only == 'true')) &&
-      !((github.event_name == 'workflow_dispatch' &&
-         github.event.inputs.release_backend == 'buildbuddy') ||
-        (github.event_name != 'workflow_dispatch' &&
-         (vars.MEERKAT_RELEASE_BUILDBUDDY == 'true' ||
-          vars.MEERKAT_RELEASE_BUILDBUDDY == '1')))
+      !(github.actor == 'lukacf' &&
+        ((github.event_name == 'workflow_dispatch' &&
+          github.event.inputs.release_backend == 'buildbuddy') ||
+         (github.event_name != 'workflow_dispatch' &&
+          (vars.MEERKAT_RELEASE_BUILDBUDDY == 'true' ||
+           vars.MEERKAT_RELEASE_BUILDBUDDY == '1'))))
     runs-on: ${{ matrix.runs-on }}
     strategy:
       fail-fast: false
@@ -439,11 +442,12 @@ jobs:
       (startsWith(github.ref, 'refs/tags/v') ||
        (github.event_name == 'workflow_dispatch' &&
         github.event.inputs.publish_release_assets_only == 'true')) &&
-      ((github.event_name == 'workflow_dispatch' &&
-        github.event.inputs.release_backend == 'buildbuddy') ||
-       (github.event_name != 'workflow_dispatch' &&
-        (vars.MEERKAT_RELEASE_BUILDBUDDY == 'true' ||
-         vars.MEERKAT_RELEASE_BUILDBUDDY == '1')))
+      (github.actor == 'lukacf' &&
+       ((github.event_name == 'workflow_dispatch' &&
+         github.event.inputs.release_backend == 'buildbuddy') ||
+        (github.event_name != 'workflow_dispatch' &&
+         (vars.MEERKAT_RELEASE_BUILDBUDDY == 'true' ||
+          vars.MEERKAT_RELEASE_BUILDBUDDY == '1'))))
     runs-on: ${{ fromJSON(vars.MEERKAT_CI_RUNNER || '"ubuntu-latest"') }}
     env:
       BUILDBUDDY_API_KEY: ${{ secrets.BUILDBUDDY_API_KEY }}
@@ -614,7 +618,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          bb_selected="${{ (github.event_name == 'workflow_dispatch' && github.event.inputs.release_backend == 'buildbuddy') || (github.event_name != 'workflow_dispatch' && (vars.MEERKAT_RELEASE_BUILDBUDDY == 'true' || vars.MEERKAT_RELEASE_BUILDBUDDY == '1')) }}"
+          bb_selected="${{ github.actor == 'lukacf' && ((github.event_name == 'workflow_dispatch' && github.event.inputs.release_backend == 'buildbuddy') || (github.event_name != 'workflow_dispatch' && (vars.MEERKAT_RELEASE_BUILDBUDDY == 'true' || vars.MEERKAT_RELEASE_BUILDBUDDY == '1'))) }}"
           github_result="${{ needs.build_binaries.result }}"
           buildbuddy_result="${{ needs.build_binaries_buildbuddy.result }}"
 
@@ -842,6 +846,7 @@ jobs:
        github.event.inputs.publish_web_sdk_only != 'true'))
     needs: [require_ci_green, release_validate_gate]
     runs-on: ubuntu-latest
+    timeout-minutes: 180
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ YELLOW := \033[0;33m
 RED := \033[0;31m
 NC := \033[0m
 
-.PHONY: all install-build-deps build test test-unit test-int e2e-fast e2e-build e2e-system e2e-live e2e-smoke e2e-auth test-int-real test-e2e test-all test-minimal test-feature-matrix-lib test-feature-matrix-surface test-feature-matrix test-surface-modularity test-sdk-python test-sdk-typescript test-sdk-suites lint lint-feature-matrix fmt fmt-check audit rust-lane-doctor agent-gate cargo-agent-gate buildbuddy-install buildbuddy-generate buildbuddy-lock-update buildbuddy-generate-check buildbuddy-doctor buildbuddy-build buildbuddy-check buildbuddy-clippy buildbuddy-lint buildbuddy-test buildbuddy-test-all buildbuddy-test-unit buildbuddy-test-int buildbuddy-e2e-fast buildbuddy-e2e-system buildbuddy-e2e-live buildbuddy-e2e-smoke buildbuddy-e2e-auth buildbuddy-agent-gate buildbuddy-ci-dispatch buildbuddy-fast buildbuddy-benchmark buildbuddy-ci buildbuddy-ci-warm buildbuddy-ci-full buildbuddy-ci-full-warm ci ci-smoke release-preflight release-preflight-smoke release-workflow release-assets release-packages release-web-sdk publish-dry-run publish-dry-run-python publish-dry-run-typescript release-dry-run release-dry-run-smoke clean doc docs-check release install-hooks coverage check help legacy-surface-gate legacy-surface-inventory session-control-gate deprecated-backend-gate deprecated-backend-inventory verify-version-parity verify-schema-freshness verify-rpc-surface-alignment verify-sdk-wrapper-freshness check-rust-release-config check-rust-release-packaging check-published-facade-link bump-sdk-versions smoke-sdk-python-artifact smoke-sdk-typescript-artifact xtask-build machine-codegen machine-verify machine-check-drift seam-inventory rmat-audit audit-generated-headers
+.PHONY: all install-build-deps build test test-unit test-int e2e-fast e2e-build e2e-system e2e-live e2e-smoke e2e-auth test-int-real test-e2e test-all test-minimal test-feature-matrix-lib test-feature-matrix-surface test-feature-matrix test-surface-modularity test-sdk-python test-sdk-typescript test-sdk-suites lint lint-feature-matrix fmt fmt-check audit rust-lane-doctor agent-gate cargo-agent-gate buildbuddy-install buildbuddy-generate buildbuddy-lock-update buildbuddy-generate-check buildbuddy-doctor buildbuddy-build buildbuddy-check buildbuddy-clippy buildbuddy-lint buildbuddy-test buildbuddy-test-all buildbuddy-test-unit buildbuddy-test-int buildbuddy-e2e-fast buildbuddy-e2e-system buildbuddy-e2e-live buildbuddy-e2e-smoke buildbuddy-e2e-auth buildbuddy-agent-gate buildbuddy-ci-dispatch buildbuddy-fast buildbuddy-benchmark buildbuddy-ci buildbuddy-ci-warm buildbuddy-ci-full buildbuddy-ci-full-warm ci ci-smoke release-doctor release-preflight release-preflight-smoke release-workflow release-assets release-packages release-web-sdk publish-dry-run publish-dry-run-python publish-dry-run-typescript publish-dry-run-web release-dry-run release-dry-run-smoke clean doc docs-check release install-hooks coverage check help legacy-surface-gate legacy-surface-inventory session-control-gate deprecated-backend-gate deprecated-backend-inventory verify-version-parity verify-schema-freshness verify-rpc-surface-alignment verify-sdk-wrapper-freshness check-rust-release-config check-rust-release-packaging check-published-facade-link bump-sdk-versions smoke-sdk-python-artifact smoke-sdk-typescript-artifact xtask-build machine-codegen machine-verify machine-check-drift seam-inventory rmat-audit audit-generated-headers
 
 # Default target
 all: ci
@@ -511,8 +511,12 @@ regen-schemas:
 	$(PYTHON) tools/sdk-codegen/generate.py
 	@echo "$(GREEN)Schemas and SDK types regenerated$(NC)"
 
+release-doctor:
+	@echo "$(GREEN)Checking release environment...$(NC)"
+	@scripts/release-doctor
+
 # Full pre-release checklist
-release-preflight: ci verify-schema-freshness check-rust-release-packaging
+release-preflight: release-doctor ci verify-schema-freshness check-rust-release-packaging
 	@echo ""
 	@echo "$(GREEN)Pre-release checklist:$(NC)"
 	@echo "  1. CHANGELOG.md [Unreleased] section populated?"
@@ -530,7 +534,7 @@ release-preflight: ci verify-schema-freshness check-rust-release-packaging
 
 # Smoke pre-release checklist.
 # Useful for local iteration; skips full feature-matrix expansion.
-release-preflight-smoke: ci-smoke verify-schema-freshness check-rust-release-packaging
+release-preflight-smoke: release-doctor ci-smoke verify-schema-freshness check-rust-release-packaging
 	@echo ""
 	@echo "$(GREEN)Pre-release checklist (smoke):$(NC)"
 	@echo "  1. CHANGELOG.md [Unreleased] section populated?"
@@ -724,6 +728,7 @@ help:
 	@echo "  $(GREEN)check-rust-release-packaging$(NC)- Verify release Rust crates package cleanly"
 	@echo "  $(GREEN)bump-sdk-versions$(NC)     - Bump Python + TS versions to match Cargo"
 	@echo "  $(GREEN)regen-schemas$(NC)         - Re-emit schemas + run SDK codegen"
+	@echo "  $(GREEN)release-doctor$(NC)        - Check release GitHub/npm/BuildBuddy settings"
 	@echo "  $(GREEN)release-preflight$(NC)     - Full pre-release checklist (CI + freshness)"
 	@echo "  $(GREEN)release-preflight-smoke$(NC)- Smoke pre-release checklist"
 	@echo "  $(GREEN)release-workflow$(NC)      - Dispatch full release workflow (VERSION=vX.Y.Z; MEERKAT_BUILDBUDDY=1 selects BB)"

--- a/scripts/release-doctor
+++ b/scripts/release-doctor
@@ -1,0 +1,159 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+workspace_root="$(git rev-parse --show-toplevel)"
+cd "${workspace_root}"
+
+ok=0
+warn=0
+fail=0
+
+pass() {
+  ok=$((ok + 1))
+  printf 'PASS %s\n' "$1"
+}
+
+note() {
+  warn=$((warn + 1))
+  printf 'WARN %s\n' "$1"
+}
+
+bad() {
+  fail=$((fail + 1))
+  printf 'FAIL %s\n' "$1"
+}
+
+bool_enabled() {
+  case "${1:-}" in
+    1|true|TRUE|yes|YES|on|ON|buildbuddy)
+      return 0
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+if command -v gh >/dev/null 2>&1; then
+  pass "GitHub CLI is installed"
+  if gh auth status >/dev/null 2>&1; then
+    pass "GitHub CLI is authenticated"
+  else
+    bad "GitHub CLI is not authenticated; run gh auth login before release dispatch"
+  fi
+else
+  bad "GitHub CLI is not installed; release workflow dispatch needs gh"
+fi
+
+if command -v npm >/dev/null 2>&1; then
+  pass "npm is installed"
+  if npm whoami >/dev/null 2>&1; then
+    pass "local npm authentication is available"
+  else
+    note "local npm authentication is not available; GitHub Actions publishes with NPM_TOKEN"
+  fi
+else
+  bad "npm is not installed; SDK publish checks need npm"
+fi
+
+if command -v gh >/dev/null 2>&1 && gh auth status >/dev/null 2>&1; then
+  gh_user="$(gh api user --jq '.login' 2>/dev/null || true)"
+  owner_release_account=false
+  if [[ "${gh_user}" == "lukacf" ]]; then
+    owner_release_account=true
+    pass "GitHub account can use owner BuildBuddy release paths"
+  else
+    note "GitHub account '${gh_user:-unknown}' will default release auto-dispatch to GitHub-hosted"
+  fi
+
+  release_bb="$(
+    gh api repos/lukacf/meerkat/actions/variables/MEERKAT_RELEASE_BUILDBUDDY \
+      --jq '.value' 2>/dev/null || true
+  )"
+  if [[ "${owner_release_account}" == "true" ]]; then
+    if bool_enabled "${release_bb}"; then
+      pass "MEERKAT_RELEASE_BUILDBUDDY repo variable is enabled"
+    else
+      bad "MEERKAT_RELEASE_BUILDBUDDY repo variable is '${release_bb:-missing}'; set it to true before owner release"
+    fi
+  elif bool_enabled "${release_bb}"; then
+    note "MEERKAT_RELEASE_BUILDBUDDY is enabled, but only lukacf auto-dispatch uses it"
+  else
+    pass "GitHub-hosted release default is available for non-owner account"
+  fi
+
+  runner_value="$(
+    gh api repos/lukacf/meerkat/actions/variables/MEERKAT_CI_RUNNER \
+      --jq '.value' 2>/dev/null || true
+  )"
+  if [[ -n "${runner_value}" ]]; then
+    pass "MEERKAT_CI_RUNNER repo variable is set"
+  else
+    note "MEERKAT_CI_RUNNER repo variable is not set; release gates will use GitHub-hosted defaults"
+  fi
+
+  for secret_name in CARGO_REGISTRY_TOKEN PYPI_API_TOKEN NPM_TOKEN HOMEBREW_TAP_TOKEN; do
+    if gh api "repos/lukacf/meerkat/actions/secrets/${secret_name}" --jq '.name' >/dev/null 2>&1; then
+      pass "GitHub Actions secret ${secret_name} exists"
+    elif [[ "${owner_release_account}" == "true" ]]; then
+      bad "GitHub Actions secret ${secret_name} is missing"
+    else
+      note "GitHub Actions secret ${secret_name} metadata is not visible to this account"
+    fi
+  done
+fi
+
+if grep -Fq 'github.com/wasm-bindgen/wasm-pack/releases/download' .github/workflows/release.yml; then
+  pass "Release workflow installs wasm-pack from maintained wasm-bindgen releases"
+else
+  bad "Release workflow does not use the maintained wasm-bindgen wasm-pack release URL"
+fi
+
+web_timeout="$(
+  awk '
+    /^  publish_web_sdk_recovery:/ { in_job = 1; next }
+    in_job && /^  [[:alnum:]_-]+:/ { in_job = 0 }
+    in_job && /timeout-minutes:/ {
+      gsub(/[^0-9]/, "", $0)
+      print $0
+      exit
+    }
+  ' .github/workflows/release.yml
+)"
+if [[ "${web_timeout:-0}" =~ ^[0-9]+$ ]] && ((web_timeout >= 120)); then
+  pass "Web SDK recovery job has a long timeout (${web_timeout} minutes)"
+else
+  bad "Web SDK recovery job timeout is '${web_timeout:-missing}'; expected at least 120 minutes"
+fi
+
+if grep -Fq 'Too Many Requests' scripts/release-publish-rust-crates.sh &&
+  grep -Fq 'MEERKAT_CRATE_PUBLISH_ATTEMPTS' scripts/release-publish-rust-crates.sh; then
+  pass "Rust crate publishing retries crates.io rate limits"
+else
+  bad "Rust crate publish script is missing crates.io rate-limit retry handling"
+fi
+
+if [[ -n "${VERSION:-${RELEASE_TAG:-}}" ]]; then
+  tag="${VERSION:-${RELEASE_TAG:-}}"
+  case "${tag}" in
+    v*) ;;
+    *) tag="v${tag}" ;;
+  esac
+  if npm view "@rkat/sdk@${tag#v}" version >/dev/null 2>&1; then
+    note "@rkat/sdk@${tag#v} is already published"
+  else
+    pass "@rkat/sdk@${tag#v} is not published yet"
+  fi
+  if npm view "@rkat/web@${tag#v}" version >/dev/null 2>&1; then
+    note "@rkat/web@${tag#v} is already published"
+  else
+    pass "@rkat/web@${tag#v} is not published yet"
+  fi
+else
+  note "VERSION/RELEASE_TAG not set; skipping package already-published checks"
+fi
+
+printf '\nrelease doctor: %d pass, %d warn, %d fail\n' "${ok}" "${warn}" "${fail}"
+if ((fail > 0)); then
+  exit 1
+fi

--- a/scripts/release-workflow-dispatch
+++ b/scripts/release-workflow-dispatch
@@ -8,13 +8,20 @@ usage: release-workflow-dispatch [--mode full|assets|packages|web-sdk] [--versio
 Dispatches the release workflow through the same public/default vs owner-only
 BuildBuddy backend split used by CI.
 
+Backend note: release_backend=buildbuddy covers release validation and binary
+asset builds. Registry package publish jobs, including @rkat/web, run on
+GitHub-hosted runners today; use the narrow recovery modes for retries.
+
 Environment equivalents:
   VERSION or RELEASE_TAG     Release tag, for example v0.6.1.
   RELEASE_BACKEND            auto, github-hosted, or buildbuddy. Defaults to auto.
   RELEASE_REF                Workflow ref. Defaults to the tag for full and main for recovery modes.
   REGISTRY_DRY_RUN           true/false for package publish dry-runs.
   RELEASE_WORKFLOW_DRY_RUN   true/false to print the gh command without dispatching.
-  MEERKAT_BUILDBUDDY         When RELEASE_BACKEND=auto, true selects buildbuddy.
+  MEERKAT_BUILDBUDDY         When RELEASE_BACKEND=auto, true selects buildbuddy
+                              and false/0 selects github-hosted. If unset, auto
+                              honors MEERKAT_RELEASE_BUILDBUDDY=true only for
+                              the lukacf GitHub account.
 EOF
 }
 
@@ -88,9 +95,38 @@ workspace_root="$(git rev-parse --show-toplevel)"
 cd "${workspace_root}"
 source "${workspace_root}/scripts/build-backend-env"
 
+repo_release_buildbuddy_enabled() {
+  if ! command -v gh >/dev/null 2>&1; then
+    return 1
+  fi
+  local user value
+  user="$(gh api user --jq '.login' 2>/dev/null || true)"
+  if [[ "${user}" != "lukacf" ]]; then
+    return 1
+  fi
+  value="$(
+    gh api repos/lukacf/meerkat/actions/variables/MEERKAT_RELEASE_BUILDBUDDY \
+      --jq '.value' 2>/dev/null || true
+  )"
+  case "${value}" in
+    1|true|TRUE|yes|YES|on|ON|buildbuddy)
+      return 0
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
 case "${backend}" in
   auto)
-    if meerkat_buildbuddy_enabled; then
+    if [[ -n "${MEERKAT_BUILDBUDDY+x}" ]]; then
+      if meerkat_buildbuddy_enabled; then
+        backend="buildbuddy"
+      else
+        backend="github-hosted"
+      fi
+    elif repo_release_buildbuddy_enabled; then
       backend="buildbuddy"
     else
       backend="github-hosted"
@@ -149,6 +185,16 @@ printf 'release workflow backend: %s\n' "${backend}"
 printf 'release workflow mode: %s\n' "${mode}"
 printf 'release workflow ref: %s\n' "${workflow_ref}"
 printf 'release workflow tag: %s\n' "${version}"
+if [[ "${backend}" == "buildbuddy" ]]; then
+  printf 'release workflow acceleration: BuildBuddy validation + binary asset builds\n'
+else
+  printf 'release workflow acceleration: GitHub-hosted validation + binary asset builds\n'
+fi
+case "${mode}" in
+  full|packages|web-sdk)
+    printf 'release workflow registry publishing: GitHub-hosted runners (use web-sdk/packages recovery for retries)\n'
+    ;;
+esac
 
 if [[ "${dry_run}" == "1" ]]; then
   printf 'DRY-RUN '


### PR DESCRIPTION
## Summary
- add `make release-doctor` and wire it into release preflight/smoke preflight
- make release workflow dispatch auto-select BuildBuddy when `MEERKAT_RELEASE_BUILDBUDDY=true` is set on the repo
- document that BuildBuddy accelerates validation/binary assets while registry publishing remains GitHub-hosted
- give the combined registry publish job the same long timeout as Web SDK recovery

## Why
0.6.6 exposed several release footguns: the repo BuildBuddy switch can silently drift false, Web SDK builds need a long recovery lane, wasm-pack must come from the maintained upstream, and crates.io rate-limit retry handling should be checked before release day.

## Validation
- `bash -n scripts/release-doctor scripts/release-workflow-dispatch scripts/release-publish-rust-crates.sh`
- `make release-doctor`
- `VERSION=v0.6.7 make release-doctor`
- `scripts/release-workflow-dispatch --mode full --version v0.6.7 --backend auto --dry-run`
- `scripts/release-workflow-dispatch --mode assets --version v0.6.7 --backend auto --dry-run`
- `scripts/release-workflow-dispatch --mode packages --version v0.6.7 --backend auto --dry-run`
- `scripts/release-workflow-dispatch --mode web-sdk --version v0.6.7 --backend auto --dry-run`
