### PR TITLE
Clean-cut typed transcript contract

### DIFF
--- a/docs/concepts/tools.mdx
+++ b/docs/concepts/tools.mdx
@@ -94,7 +94,7 @@ Tool visibility can change during a session without restarting the agent. Change
 
 **Live MCP mutation.** MCP servers can be added or removed from a running session. Additions connect the server and register its tools; removals drain in-flight calls before finalizing. Both are staged and applied at the next turn boundary.
 
-**Composition rule:** Most-restrictive wins. Multiple allow-lists intersect, multiple deny-lists union, and deny always beats allow. The agent receives a `[SYSTEM NOTICE]` in the conversation when its tool set changes, and a `tool_config_changed` event is emitted to the event stream.
+**Composition rule:** Most-restrictive wins. Multiple allow-lists intersect, multiple deny-lists union, and deny always beats allow. The conversation records a typed `tool_config` system notice when the tool set changes, and a `tool_config_changed` event is emitted to the event stream.
 
 ### Live MCP controls
 

--- a/docs/examples/tools.mdx
+++ b/docs/examples/tools.mdx
@@ -359,7 +359,7 @@ Tool visibility can change during a session. Changes are staged and atomically a
   </Tab>
 </Tabs>
 
-**Composition rule:** most-restrictive wins. Multiple allow-lists intersect, multiple deny-lists union, and deny always beats allow. The agent receives a `[SYSTEM NOTICE]` when its tool set changes, and a `tool_config_changed` event is emitted to the event stream.
+**Composition rule:** most-restrictive wins. Multiple allow-lists intersect, multiple deny-lists union, and deny always beats allow. The conversation records a typed `tool_config` system notice when the tool set changes, and a `tool_config_changed` event is emitted to the event stream.
 
 ## Advanced: Custom tools (Rust SDK)
 

--- a/docs/guides/comms.mdx
+++ b/docs/guides/comms.mdx
@@ -621,13 +621,13 @@ The important architectural split is:
 
 Historically this was sometimes described as "turn-boundary inbox draining." That is not the primary mental model anymore. The canonical model is runtime-backed queueing and admission.
 
-### Message injection format
+### Transcript and model projection
 
-Incoming messages are formatted as text for the LLM:
+Incoming comms are persisted as typed `system_notice` blocks with `comms` payloads. `role=user` remains reserved for human/operator-authored text. The runtime projects those typed blocks into provider-facing text only while assembling model input:
 
-- **Message**: `[COMMS MESSAGE from <peer>]\n<body>`
-- **Request**: `[COMMS REQUEST from peer_id <peer-id> (display_name: <name>) (id: <uuid>)]\nIntent: <intent>\nParams: <json>\n\nTo respond, call send_response with peer_id="<peer-id>", in_reply_to="<uuid>", status="completed" or "failed", and result=<json>. display_name is diagnostic only.`
-- **Response**: `[COMMS RESPONSE from <peer> (to request: <uuid>)]\nStatus: <status>\nResult: <json>`
+- **Message**: `comms.kind = "message"` plus peer identity and optional content blocks.
+- **Request**: `comms.kind = "request"` plus peer identity, request id, intent, params payload, and response guidance in the model projection.
+- **Response**: `comms.kind = "response_terminal"` or `response_progress` plus peer identity, request id, status, and payload.
 
 ## Typed peer lifecycle notices
 
@@ -745,14 +745,14 @@ event_address = "127.0.0.1:4201"   # Plain-text event listener
 echo '{"body":"hello from external system"}' | nc 127.0.0.1 4201
 ```
 
-### Event injection format
+### Event transcript format
 
-Events are injected into the agent's context with source tagging:
+External events are persisted as typed `external_event` system-notice blocks with `source`, `event_type`, optional `body`, payload, and content blocks. The provider-facing source/body text is an internal projection and is not stored as user-authored transcript text.
 
-- **Stdin**: `[EVENT via stdin] <body>`
-- **Webhook**: `[EVENT via webhook] <body>`
-- **RPC**: `[EVENT via rpc] <body>` (with optional `[source: name]` prefix)
-- **TCP/UDS**: `[EVENT via tcp] <body>` or `[EVENT via uds] <body>`
+- **Stdin**: `source = "stdin"`
+- **Webhook**: `source = "webhook"`
+- **RPC**: `source = "rpc"` with optional structured source metadata.
+- **TCP/UDS**: `source = "tcp"` or `source = "uds"`
 
 ### Delivery vs observation
 

--- a/docs/reference/builtin-tools.mdx
+++ b/docs/reference/builtin-tools.mdx
@@ -99,7 +99,7 @@ Beyond static factory flags and per-build overrides, tool visibility can be chan
 
 **Staging:** External callers stage filter updates via `ToolScopeHandle::stage_external_filter(filter)`. The staged filter is NOT applied immediately — the current turn is unaffected.
 
-**Boundary apply:** At the start of each `CallingLlm` loop iteration, `tool_scope.apply_staged(dispatcher_tools)` atomically promotes the staged filter to active, prunes stale tool names, and returns the visible tool set. A `ToolConfigChanged` event is emitted and a `[SYSTEM NOTICE]` is injected into the conversation.
+**Boundary apply:** At the start of each `CallingLlm` loop iteration, `tool_scope.apply_staged(dispatcher_tools)` atomically promotes the staged filter to active, prunes stale tool names, and returns the visible tool set. A `ToolConfigChanged` event is emitted and a typed `tool_config` system notice is recorded in the conversation.
 
 **Filter types:**
 - `ToolFilter::All` — no restriction (default)

--- a/meerkat-anthropic/src/client.rs
+++ b/meerkat-anthropic/src/client.rs
@@ -412,7 +412,7 @@ impl AnthropicClient {
                 Message::SystemNotice(notice) => {
                     messages.push(serde_json::json!({
                         "role": "user",
-                        "content": notice.rendered_text()
+                        "content": notice.model_projection_text()
                     }));
                 }
                 Message::User(u) => {

--- a/meerkat-cli/src/main.rs
+++ b/meerkat-cli/src/main.rs
@@ -5914,6 +5914,14 @@ fn cli_render_context_append_text(
             Some(label) if !label.trim().is_empty() => format!("[Reference] {label} ({uri})"),
             _ => format!("[Reference] {uri}"),
         },
+        CoreRenderable::SystemNotice { kind, body, blocks } => {
+            meerkat_core::types::SystemNoticeMessage::with_blocks(
+                *kind,
+                body.clone(),
+                blocks.clone(),
+            )
+            .model_projection_text()
+        }
         _ => String::new(),
     }
 }
@@ -6088,7 +6096,8 @@ impl meerkat_core::lifecycle::CoreExecutor for CliRuntimeExecutor {
                     .and_then(|meta| meta.flow_tool_overlay.clone()),
                 pre_turn_context_appends,
                 primitive.turn_metadata().cloned(),
-            ),
+            )
+            .with_typed_turn_appends(primitive.typed_turn_appends()),
         };
 
         // Persistent path: use apply_runtime_turn for real receipt + snapshot.
@@ -11466,6 +11475,36 @@ mod tests {
         let preload_skills: Vec<meerkat_core::skills::SkillKey> = Vec::new();
 
         assert_eq!(materialized_preload_skills(&preload_skills), None);
+    }
+
+    #[test]
+    fn cli_context_system_notice_projects_via_typed_notice() {
+        let blocks = vec![meerkat_core::types::SystemNoticeBlock::Comms {
+            kind: "response_terminal".to_string(),
+            direction: meerkat_core::types::SystemNoticeDirection::Incoming,
+            peer: None,
+            request_id: Some("req-1".to_string()),
+            intent: Some("checksum_token".to_string()),
+            status: Some("completed".to_string()),
+            summary: Some("Peer terminal response".to_string()),
+            payload: None,
+            content: Vec::new(),
+        }];
+        let content = meerkat_core::lifecycle::run_primitive::CoreRenderable::SystemNotice {
+            kind: meerkat_core::types::SystemNoticeKind::Comms,
+            body: Some("Peer terminal response context".to_string()),
+            blocks: blocks.clone(),
+        };
+
+        assert_eq!(
+            cli_render_context_append_text(&content),
+            meerkat_core::types::SystemNoticeMessage::with_blocks(
+                meerkat_core::types::SystemNoticeKind::Comms,
+                Some("Peer terminal response context".to_string()),
+                blocks,
+            )
+            .model_projection_text()
+        );
     }
 
     #[test]

--- a/meerkat-cli/src/main.rs
+++ b/meerkat-cli/src/main.rs
@@ -8998,7 +8998,9 @@ async fn show_session(id: &str, scope: &RuntimeScope) -> anyhow::Result<()> {
                 }
                 Message::SystemNotice(notice) => {
                     println!("\n[{}] SYSTEM NOTICE ({:?}):", i + 1, notice.kind);
-                    println!("  {}", notice.body);
+                    if let Some(body) = notice.body.as_deref() {
+                        println!("  {body}");
+                    }
                 }
                 Message::User(u) => {
                     println!("\n[{}] USER:", i + 1);

--- a/meerkat-comms/src/agent/types.rs
+++ b/meerkat-comms/src/agent/types.rs
@@ -728,7 +728,7 @@ mod tests {
         };
 
         let text = msg.to_user_message_text();
-        assert!(text.contains("COMMS MESSAGE"));
+        assert!(text.contains("Peer message from review-agent"));
         assert!(text.contains("review-agent"));
         assert!(text.contains("Please review PR #42"));
     }
@@ -749,7 +749,7 @@ mod tests {
         };
 
         let text = msg.to_user_message_text();
-        assert!(text.contains("COMMS REQUEST"));
+        assert!(text.contains("Peer request from peer_id"));
         assert!(text.contains("coding-agent"));
         assert!(text.contains("review"));
         assert!(text.contains("550e8400-e29b-41d4-a716-446655440000"));
@@ -780,7 +780,7 @@ mod tests {
         };
 
         let text = msg.to_user_message_text();
-        assert!(text.contains("COMMS RESPONSE"));
+        assert!(text.contains("Peer response from review-agent"));
         assert!(text.contains("review-agent"));
         assert!(text.contains("completed"));
         assert!(text.contains("550e8400-e29b-41d4-a716-446655440000"));
@@ -935,7 +935,7 @@ mod tests {
             render_metadata: None,
         };
         let text = msg.to_user_message_text();
-        assert_eq!(text, "[EVENT via webhook] CPU > 95% on prod-3");
+        assert_eq!(text, "External event via webhook: CPU > 95% on prod-3");
     }
 
     #[test]

--- a/meerkat-comms/src/classify.rs
+++ b/meerkat-comms/src/classify.rs
@@ -1401,7 +1401,7 @@ mod tests {
         let prepared_request_id = prepared.request_id.map(|id| id.to_string());
         assert_eq!(prepared_request_id.as_deref(), Some(request_id.as_str()));
         assert!(prepared.text_projection.starts_with(&format!(
-            "[COMMS REQUEST from peer_id {} (display_name: sender-agent) (id: {request_id})]\nIntent: review",
+            "Peer request from peer_id {} (display_name: sender-agent) (id: {request_id})\nIntent: review",
             sender.public_key().to_peer_id()
         )));
         assert!(prepared.text_projection.contains("\"peer_id\""));
@@ -1447,7 +1447,10 @@ mod tests {
             .expect("machine accepted plain event should prepare");
 
         assert_eq!(prepared.class, PeerInputClass::PlainEvent);
-        assert_eq!(prepared.text_projection, "[EVENT via tcp] event body");
+        assert_eq!(
+            prepared.text_projection,
+            "External event via tcp: event body"
+        );
         assert_eq!(machine.plain_calls(), 1);
     }
 
@@ -1534,7 +1537,7 @@ mod tests {
         );
         assert_eq!(
             prepared.text_projection,
-            "[EVENT via tcp] event body".to_string()
+            "External event via tcp: event body".to_string()
         );
 
         match prepared.item {

--- a/meerkat-comms/src/runtime/comms_runtime.rs
+++ b/meerkat-comms/src/runtime/comms_runtime.rs
@@ -3688,7 +3688,7 @@ mod tests {
         let interaction = &interactions[0];
         assert_eq!(
             interaction.rendered_text,
-            "[COMMS MESSAGE from sender]\nplease inspect this"
+            "Peer message from sender:\nplease inspect this"
         );
         match &interaction.content {
             meerkat_core::InteractionContent::Message {

--- a/meerkat-contracts/src/wire/session.rs
+++ b/meerkat-contracts/src/wire/session.rs
@@ -786,7 +786,10 @@ pub enum WireSessionMessage {
     },
     SystemNotice {
         kind: SystemNoticeKind,
-        body: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        body: Option<String>,
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        blocks: Vec<meerkat_core::SystemNoticeBlock>,
         created_at: String,
     },
     User {
@@ -824,6 +827,7 @@ impl From<Message> for WireSessionMessage {
             Message::SystemNotice(message) => Self::SystemNotice {
                 kind: message.kind,
                 body: message.body,
+                blocks: message.blocks,
                 created_at: message.created_at.to_rfc3339(),
             },
             Message::User(message) => {

--- a/meerkat-core/src/agent/runner.rs
+++ b/meerkat-core/src/agent/runner.rs
@@ -30,6 +30,68 @@ use tokio::sync::mpsc;
 
 use super::{Agent, AgentBuilder, AgentLlmClient, AgentSessionStore, AgentToolDispatcher};
 
+fn user_message_from_operator_renderable(
+    content: CoreRenderable,
+) -> Result<crate::types::UserMessage, AgentError> {
+    match content {
+        CoreRenderable::Text { text } => Ok(crate::types::UserMessage::text(text)),
+        CoreRenderable::Blocks { blocks } => Ok(crate::types::UserMessage::with_blocks(blocks)),
+        CoreRenderable::SystemNotice { .. }
+        | CoreRenderable::Json { .. }
+        | CoreRenderable::Reference { .. } => Err(AgentError::ConfigError(
+            "role=user transcript append only accepts operator text or content blocks".to_string(),
+        )),
+    }
+}
+
+#[cfg(test)]
+mod typed_transcript_contract_tests {
+    use super::*;
+
+    #[test]
+    fn user_role_accepts_only_operator_text_or_blocks() {
+        assert!(
+            user_message_from_operator_renderable(CoreRenderable::Text {
+                text: "hello".to_string(),
+            })
+            .is_ok()
+        );
+        assert!(
+            user_message_from_operator_renderable(CoreRenderable::Blocks {
+                blocks: vec![crate::types::ContentBlock::Text {
+                    text: "hello".to_string(),
+                }],
+            })
+            .is_ok()
+        );
+    }
+
+    #[test]
+    fn user_role_rejects_runtime_authored_renderables() {
+        for content in [
+            CoreRenderable::SystemNotice {
+                kind: crate::types::SystemNoticeKind::Comms,
+                body: Some("runtime".to_string()),
+                blocks: Vec::new(),
+            },
+            CoreRenderable::Json {
+                value: serde_json::json!({"runtime": true}),
+            },
+            CoreRenderable::Reference {
+                uri: "artifact://runtime".to_string(),
+                label: Some("runtime".to_string()),
+            },
+        ] {
+            let err = user_message_from_operator_renderable(content)
+                .expect_err("runtime renderable must not become user text");
+            assert!(
+                matches!(err, AgentError::ConfigError(ref message) if message.contains("role=user")),
+                "unexpected error: {err:?}"
+            );
+        }
+    }
+}
+
 fn dispatcher_knows_tool<T>(dispatcher: &T, name: &str) -> bool
 where
     T: AgentToolDispatcher + ?Sized,
@@ -913,25 +975,7 @@ where
     fn push_transcript_append(&mut self, append: ConversationAppend) -> Result<(), AgentError> {
         match append.role {
             ConversationAppendRole::User => {
-                let message = match append.content {
-                    CoreRenderable::Text { text } => crate::types::UserMessage::text(text),
-                    CoreRenderable::Blocks { blocks } => {
-                        crate::types::UserMessage::with_blocks(blocks)
-                    }
-                    CoreRenderable::SystemNotice { kind, body, blocks } => {
-                        crate::types::UserMessage::text(
-                            crate::types::SystemNoticeMessage::with_blocks(kind, body, blocks)
-                                .model_projection_text(),
-                        )
-                    }
-                    CoreRenderable::Json { value } => {
-                        crate::types::UserMessage::text(value.to_string())
-                    }
-                    CoreRenderable::Reference { uri, label } => {
-                        let text = label.map_or(uri.clone(), |label| format!("{label}: {uri}"));
-                        crate::types::UserMessage::text(text)
-                    }
-                };
+                let message = user_message_from_operator_renderable(append.content)?;
                 self.session.push(Message::User(message));
             }
             ConversationAppendRole::SystemNotice => {

--- a/meerkat-core/src/agent/runner.rs
+++ b/meerkat-core/src/agent/runner.rs
@@ -4,6 +4,7 @@ use crate::budget::Budget;
 use crate::error::{AgentError, ToolError};
 use crate::event::AgentEvent;
 use crate::hooks::{HookInvocation, HookPoint};
+use crate::lifecycle::run_primitive::{ConversationAppend, ConversationAppendRole, CoreRenderable};
 use crate::ops::{ToolDispatchOutcome, ToolDispatchTimeoutPolicy};
 use crate::retry::RetryPolicy;
 use crate::service::TurnToolOverlay;
@@ -862,7 +863,7 @@ where
 
     /// Run the agent with a user message.
     pub async fn run(&mut self, user_input: ContentInput) -> Result<RunResult, AgentError> {
-        self.run_inner(user_input, None).await
+        self.run_inner(user_input, Vec::new(), None).await
     }
 
     /// Run the agent with events streamed to the provided channel.
@@ -871,7 +872,19 @@ where
         user_input: ContentInput,
         event_tx: mpsc::Sender<AgentEvent>,
     ) -> Result<RunResult, AgentError> {
-        self.run_inner(user_input, Some(event_tx)).await
+        self.run_inner(user_input, Vec::new(), Some(event_tx)).await
+    }
+
+    /// Run the agent with provider-facing prompt content derived from typed
+    /// runtime appends, while persisting those appends according to their roles.
+    pub async fn run_with_events_and_typed_turn_appends(
+        &mut self,
+        user_input: ContentInput,
+        typed_turn_appends: Vec<ConversationAppend>,
+        event_tx: mpsc::Sender<AgentEvent>,
+    ) -> Result<RunResult, AgentError> {
+        self.run_inner(user_input, typed_turn_appends, Some(event_tx))
+            .await
     }
 
     /// Run the agent using the pending continuation boundary already in the session.
@@ -897,6 +910,89 @@ where
         self.run_pending_inner(Some(event_tx)).await
     }
 
+    fn push_transcript_append(&mut self, append: ConversationAppend) -> Result<(), AgentError> {
+        match append.role {
+            ConversationAppendRole::User => {
+                let message = match append.content {
+                    CoreRenderable::Text { text } => crate::types::UserMessage::text(text),
+                    CoreRenderable::Blocks { blocks } => {
+                        crate::types::UserMessage::with_blocks(blocks)
+                    }
+                    CoreRenderable::SystemNotice { kind, body, blocks } => {
+                        crate::types::UserMessage::text(
+                            crate::types::SystemNoticeMessage::with_blocks(kind, body, blocks)
+                                .model_projection_text(),
+                        )
+                    }
+                    CoreRenderable::Json { value } => {
+                        crate::types::UserMessage::text(value.to_string())
+                    }
+                    CoreRenderable::Reference { uri, label } => {
+                        let text = label.map_or(uri.clone(), |label| format!("{label}: {uri}"));
+                        crate::types::UserMessage::text(text)
+                    }
+                };
+                self.session.push(Message::User(message));
+            }
+            ConversationAppendRole::SystemNotice => {
+                let notice = match append.content {
+                    CoreRenderable::SystemNotice { kind, body, blocks } => {
+                        crate::types::SystemNoticeMessage::with_blocks(kind, body, blocks)
+                    }
+                    CoreRenderable::Text { text } => crate::types::SystemNoticeMessage::with_block(
+                        crate::types::SystemNoticeKind::Generic,
+                        Some(text.clone()),
+                        crate::types::SystemNoticeBlock::RuntimeNotice {
+                            category: "runtime_notice".to_string(),
+                            detail: Some(text),
+                            payload: None,
+                        },
+                    ),
+                    CoreRenderable::Blocks { blocks } => {
+                        crate::types::SystemNoticeMessage::with_block(
+                            crate::types::SystemNoticeKind::Generic,
+                            None,
+                            crate::types::SystemNoticeBlock::RuntimeNotice {
+                                category: "runtime_notice".to_string(),
+                                detail: Some(crate::types::text_content(&blocks)),
+                                payload: None,
+                            },
+                        )
+                    }
+                    CoreRenderable::Json { value } => {
+                        crate::types::SystemNoticeMessage::with_block(
+                            crate::types::SystemNoticeKind::Generic,
+                            None,
+                            crate::types::SystemNoticeBlock::RuntimeNotice {
+                                category: "runtime_notice".to_string(),
+                                detail: None,
+                                payload: Some(value),
+                            },
+                        )
+                    }
+                    CoreRenderable::Reference { uri, label } => {
+                        crate::types::SystemNoticeMessage::with_block(
+                            crate::types::SystemNoticeKind::Generic,
+                            label,
+                            crate::types::SystemNoticeBlock::RuntimeNotice {
+                                category: "runtime_notice".to_string(),
+                                detail: Some(uri),
+                                payload: None,
+                            },
+                        )
+                    }
+                };
+                self.session.push(Message::SystemNotice(notice));
+            }
+            ConversationAppendRole::Assistant | ConversationAppendRole::Tool => {
+                return Err(AgentError::ConfigError(
+                    "runtime transcript append role is not supported for turn start".to_string(),
+                ));
+            }
+        }
+        Ok(())
+    }
+
     /// Core run implementation shared by `run()` and `run_with_events()`.
     ///
     /// Adds user_input as a user message, emits lifecycle events when `event_tx`
@@ -904,6 +1000,7 @@ where
     async fn run_inner(
         &mut self,
         user_input: ContentInput,
+        typed_turn_appends: Vec<ConversationAppend>,
         event_tx: Option<mpsc::Sender<AgentEvent>>,
     ) -> Result<RunResult, AgentError> {
         let event_tx = event_tx.or_else(|| self.default_event_tx.clone());
@@ -937,13 +1034,19 @@ where
         // still include the text projection for compatibility.
         let run_prompt_input = user_input.clone();
 
-        // Add user message — preserve image blocks when present.
-        let user_message = if user_input.has_non_text_content() {
-            crate::types::UserMessage::with_blocks(user_input.into_blocks())
+        if typed_turn_appends.is_empty() {
+            // Add user message — preserve image blocks when present.
+            let user_message = if user_input.has_non_text_content() {
+                crate::types::UserMessage::with_blocks(user_input.into_blocks())
+            } else {
+                crate::types::UserMessage::text(user_input.text_content())
+            };
+            self.session.push(Message::User(user_message));
         } else {
-            crate::types::UserMessage::text(user_input.text_content())
-        };
-        self.session.push(Message::User(user_message));
+            for append in typed_turn_appends {
+                self.push_transcript_append(append)?;
+            }
+        }
 
         self.emit_run_started_event(run_prompt_input.clone(), event_tx.as_ref())
             .await;

--- a/meerkat-core/src/agent/runner.rs
+++ b/meerkat-core/src/agent/runner.rs
@@ -44,54 +44,6 @@ fn user_message_from_operator_renderable(
     }
 }
 
-#[cfg(test)]
-mod typed_transcript_contract_tests {
-    use super::*;
-
-    #[test]
-    fn user_role_accepts_only_operator_text_or_blocks() {
-        assert!(
-            user_message_from_operator_renderable(CoreRenderable::Text {
-                text: "hello".to_string(),
-            })
-            .is_ok()
-        );
-        assert!(
-            user_message_from_operator_renderable(CoreRenderable::Blocks {
-                blocks: vec![crate::types::ContentBlock::Text {
-                    text: "hello".to_string(),
-                }],
-            })
-            .is_ok()
-        );
-    }
-
-    #[test]
-    fn user_role_rejects_runtime_authored_renderables() {
-        for content in [
-            CoreRenderable::SystemNotice {
-                kind: crate::types::SystemNoticeKind::Comms,
-                body: Some("runtime".to_string()),
-                blocks: Vec::new(),
-            },
-            CoreRenderable::Json {
-                value: serde_json::json!({"runtime": true}),
-            },
-            CoreRenderable::Reference {
-                uri: "artifact://runtime".to_string(),
-                label: Some("runtime".to_string()),
-            },
-        ] {
-            let err = user_message_from_operator_renderable(content)
-                .expect_err("runtime renderable must not become user text");
-            assert!(
-                matches!(err, AgentError::ConfigError(ref message) if message.contains("role=user")),
-                "unexpected error: {err:?}"
-            );
-        }
-    }
-}
-
 fn dispatcher_knows_tool<T>(dispatcher: &T, name: &str) -> bool
 where
     T: AgentToolDispatcher + ?Sized,
@@ -1275,6 +1227,59 @@ where
             prefix_parts.join("\n\n")
         } else {
             format!("{}\n\n{user_input}", prefix_parts.join("\n\n"))
+        }
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::panic)]
+mod typed_transcript_contract_tests {
+    use super::*;
+
+    #[test]
+    fn user_role_accepts_only_operator_text_or_blocks() {
+        assert!(
+            user_message_from_operator_renderable(CoreRenderable::Text {
+                text: "hello".to_string(),
+            })
+            .is_ok()
+        );
+        assert!(
+            user_message_from_operator_renderable(CoreRenderable::Blocks {
+                blocks: vec![crate::types::ContentBlock::Text {
+                    text: "hello".to_string(),
+                }],
+            })
+            .is_ok()
+        );
+    }
+
+    #[test]
+    fn user_role_rejects_runtime_authored_renderables() {
+        for content in [
+            CoreRenderable::SystemNotice {
+                kind: crate::types::SystemNoticeKind::Comms,
+                body: Some("runtime".to_string()),
+                blocks: Vec::new(),
+            },
+            CoreRenderable::Json {
+                value: serde_json::json!({"runtime": true}),
+            },
+            CoreRenderable::Reference {
+                uri: "artifact://runtime".to_string(),
+                label: Some("runtime".to_string()),
+            },
+        ] {
+            let err = match user_message_from_operator_renderable(content) {
+                Ok(message) => {
+                    panic!("runtime renderable must not become user text: {message:?}")
+                }
+                Err(err) => err,
+            };
+            assert!(
+                matches!(err, AgentError::ConfigError(ref message) if message.contains("role=user")),
+                "unexpected error: {err:?}"
+            );
         }
     }
 }

--- a/meerkat-core/src/agent/state.rs
+++ b/meerkat-core/src/agent/state.rs
@@ -174,8 +174,13 @@ fn budget_warning_event(exceeded: BudgetExceeded) -> AgentEvent {
     }
 }
 
-fn synthetic_notice_message(kind: SystemNoticeKind, body: impl Into<String>) -> Message {
-    Message::SystemNotice(SystemNoticeMessage::new(kind, body))
+fn synthetic_notice_block_message(
+    kind: SystemNoticeKind,
+    body: impl Into<String>,
+    block: crate::types::SystemNoticeBlock,
+) -> Message {
+    let body = body.into();
+    Message::SystemNotice(SystemNoticeMessage::with_block(kind, Some(body), block))
 }
 
 fn is_synthetic_notice(message: &Message, kind: SystemNoticeKind) -> bool {
@@ -1280,12 +1285,21 @@ where
                         .map(|handle| handle.pending_server_ids().into_iter().collect())
                         .unwrap_or_default();
                     if !pending_servers.is_empty() {
-                        self.session.push(synthetic_notice_message(
+                        let body = format!(
+                            "Servers connecting: {}. Tools will appear when ready.",
+                            pending_servers.join(", ")
+                        );
+                        self.session.push(synthetic_notice_block_message(
                             SystemNoticeKind::McpPending,
-                            format!(
-                                "Servers connecting: {}. Tools will appear when ready.",
-                                pending_servers.join(", ")
-                            ),
+                            body.clone(),
+                            crate::types::SystemNoticeBlock::Mcp {
+                                server_id: None,
+                                operation: None,
+                                phase: Some(crate::event::ExternalToolDeltaPhase::Pending),
+                                persisted: false,
+                                detail: Some(body),
+                                pending_sources: pending_servers,
+                            },
                         ));
                     }
 
@@ -1330,9 +1344,15 @@ where
                                 entry.display_name, job_id, status_str, detail,
                             );
                             notice.push_str("\nUse shell_job_status to get the full output.");
-                            self.session.push(synthetic_notice_message(
+                            self.session.push(synthetic_notice_block_message(
                                 SystemNoticeKind::BackgroundJob,
                                 notice,
+                                crate::types::SystemNoticeBlock::BackgroundJob {
+                                    job_id,
+                                    display_name: Some(entry.display_name.clone()),
+                                    status: terminal_status,
+                                    detail: Some(detail),
+                                },
                             ));
                         }
                         self.applied_cursor = batch.watermark;
@@ -1375,9 +1395,15 @@ where
                             completion.detail,
                         );
                         notice.push_str("\nUse shell_job_status to get the full output.");
-                        self.session.push(synthetic_notice_message(
+                        self.session.push(synthetic_notice_block_message(
                             SystemNoticeKind::BackgroundJob,
                             notice,
+                            crate::types::SystemNoticeBlock::BackgroundJob {
+                                job_id: completion.job_id.clone(),
+                                display_name: Some(completion.display_name.clone()),
+                                status: terminal_status,
+                                detail: Some(completion.detail.clone()),
+                            },
                         ));
                     }
 
@@ -1467,24 +1493,26 @@ where
                                         applied.applied_revision.0,
                                     );
                                     let status = status_info.status_text();
+                                    let payload = ToolConfigChangedPayload::new(
+                                        ToolConfigChangeOperation::Reload,
+                                        "tool_scope",
+                                        status_info,
+                                        false,
+                                    )
+                                    .with_applied_at_turn(Some(turn_count))
+                                    .with_domain(Some(ToolConfigChangeDomain::ToolScope));
                                     emit_event!(AgentEvent::ToolConfigChanged {
-                                        payload: ToolConfigChangedPayload::new(
-                                            ToolConfigChangeOperation::Reload,
-                                            "tool_scope",
-                                            status_info,
-                                            false,
-                                        )
-                                        .with_applied_at_turn(Some(turn_count))
-                                        .with_domain(Some(ToolConfigChangeDomain::ToolScope)),
+                                        payload: payload.clone(),
                                     });
                                     // Represent runtime notices as user-scoped synthetic context
                                     // (same pattern as peer lifecycle updates) so this does not
                                     // mutate or replace the canonical system prompt.
-                                    self.session.push(synthetic_notice_message(
+                                    self.session.push(synthetic_notice_block_message(
                                         SystemNoticeKind::ToolScope,
                                         format!(
                                             "Tool configuration changed at turn boundary: {status}"
                                         ),
+                                        crate::types::SystemNoticeBlock::ToolConfig { payload },
                                     ));
                                 }
                                 let visible_names_set = applied
@@ -1538,20 +1566,21 @@ where
                                             removed_hidden_names.len(),
                                             pending_sources.len(),
                                         );
+                                    let payload = ToolConfigChangedPayload::new(
+                                        ToolConfigChangeOperation::Reload,
+                                        "deferred_catalog",
+                                        status_info,
+                                        false,
+                                    )
+                                    .with_applied_at_turn(Some(turn_count))
+                                    .with_domain(Some(ToolConfigChangeDomain::DeferredCatalog))
+                                    .with_deferred_catalog_delta(Some(DeferredCatalogDelta {
+                                        added_hidden_names: added_hidden_names.clone(),
+                                        removed_hidden_names: removed_hidden_names.clone(),
+                                        pending_sources: pending_sources.clone(),
+                                    }));
                                     emit_event!(AgentEvent::ToolConfigChanged {
-                                        payload: ToolConfigChangedPayload::new(
-                                            ToolConfigChangeOperation::Reload,
-                                            "deferred_catalog",
-                                            status_info,
-                                            false,
-                                        )
-                                        .with_applied_at_turn(Some(turn_count))
-                                        .with_domain(Some(ToolConfigChangeDomain::DeferredCatalog))
-                                        .with_deferred_catalog_delta(Some(DeferredCatalogDelta {
-                                            added_hidden_names: added_hidden_names.clone(),
-                                            removed_hidden_names: removed_hidden_names.clone(),
-                                            pending_sources: pending_sources.clone(),
-                                        },)),
+                                        payload: payload.clone(),
                                     });
                                     let mut notice_parts = Vec::new();
                                     if !added_hidden_names.is_empty() {
@@ -1573,12 +1602,13 @@ where
                                         ));
                                     }
                                     if !notice_parts.is_empty() {
-                                        self.session.push(synthetic_notice_message(
+                                        self.session.push(synthetic_notice_block_message(
                                             SystemNoticeKind::ToolScope,
                                             format!(
                                                 "Deferred catalog changed at turn boundary: {}",
                                                 notice_parts.join("; ")
                                             ),
+                                            crate::types::SystemNoticeBlock::ToolConfig { payload },
                                         ));
                                     }
                                 }
@@ -1589,25 +1619,27 @@ where
                             Err(err) => {
                                 let status_info =
                                     ToolConfigChangeStatus::warning_failed_closed(err.to_string());
+                                let payload = ToolConfigChangedPayload::new(
+                                    ToolConfigChangeOperation::Reload,
+                                    "tool_scope",
+                                    status_info,
+                                    false,
+                                )
+                                .with_applied_at_turn(Some(turn_count))
+                                .with_domain(Some(ToolConfigChangeDomain::ToolScope));
                                 tracing::warn!(
                                     error = %err,
                                     "tool scope boundary apply failed; closing visible tool set for this boundary"
                                 );
                                 emit_event!(AgentEvent::ToolConfigChanged {
-                                    payload: ToolConfigChangedPayload::new(
-                                        ToolConfigChangeOperation::Reload,
-                                        "tool_scope",
-                                        status_info,
-                                        false,
-                                    )
-                                    .with_applied_at_turn(Some(turn_count))
-                                    .with_domain(Some(ToolConfigChangeDomain::ToolScope)),
+                                    payload: payload.clone(),
                                 });
-                                self.session.push(synthetic_notice_message(
+                                self.session.push(synthetic_notice_block_message(
                                     SystemNoticeKind::ToolScopeWarning,
                                     format!(
                                         "Tool scope apply failed ({err}); closing the visible tool set until the next boundary."
                                     ),
+                                    crate::types::SystemNoticeBlock::ToolConfig { payload },
                                 ));
                                 self.tool_scope.fail_closed_projection().unwrap_or_else(
                                     |close_err| {
@@ -5858,7 +5890,7 @@ mod tests {
                 Message::SystemNotice(notice)
                     if is_synthetic_notice(msg, SystemNoticeKind::ToolScopeWarning) =>
                 {
-                    Some(notice.rendered_text())
+                    notice.body.clone()
                 }
                 _ => None,
             })

--- a/meerkat-core/src/handles.rs
+++ b/meerkat-core/src/handles.rs
@@ -436,7 +436,7 @@ impl PeerResponseTerminalFact {
 
     pub fn prompt_text(&self) -> String {
         format!(
-            "[SYSTEM NOTICE][PEER_RESPONSE_TERMINAL] Correlated peer response from {}. Request ID: {}. Status: {}. Result: {}.",
+            "Peer terminal response from {}. Request ID: {}. Status: {}. Result: {}.",
             self.source.display_identity,
             self.correlation_id,
             self.status.label(),
@@ -479,7 +479,7 @@ impl PeerConversationProjection {
 
     pub fn block_prefix_text(&self) -> Option<String> {
         match self {
-            Self::Message { peer_id } => Some(format!("[COMMS MESSAGE from {peer_id}]")),
+            Self::Message { peer_id } => Some(format!("Peer message from {peer_id}")),
             Self::Request { .. }
             | Self::ResponseProgress { .. }
             | Self::ResponseTerminal { .. } => None,
@@ -508,7 +508,7 @@ impl PeerConversationProjection {
                     request_id.clone(),
                 );
                 format!(
-                    "[SYSTEM NOTICE][PEER_REQUEST] Correlated peer request from peer_id {peer_id}{display_suffix}. Intent: {intent}. Request ID: {request_id}. Params: {}. This is not a normal user request and not a prompt for direct user-facing output. {} Do not use send_message for this reply.",
+                    "Peer request from peer_id {peer_id}{display_suffix}. Intent: {intent}. Request ID: {request_id}. Params: {}. This is not a normal user request and not a prompt for direct user-facing output. {} Do not use send_message for this reply.",
                     format_peer_projection_payload(payload.as_ref()),
                     response_call.instruction_text()
                 )
@@ -519,7 +519,7 @@ impl PeerConversationProjection {
                 phase,
                 payload,
             } => format!(
-                "[SYSTEM NOTICE][PEER_RESPONSE_PROGRESS] Correlated peer response progress from {peer_id}. Request ID: {request_id}. Phase: {}. Payload: {}.",
+                "Peer response progress from {peer_id}. Request ID: {request_id}. Phase: {}. Payload: {}.",
                 phase.label(),
                 format_peer_projection_payload(payload.as_ref())
             ),
@@ -1711,7 +1711,7 @@ mod tests {
         );
         assert_eq!(
             projection.prompt_text(),
-            "[SYSTEM NOTICE][PEER_RESPONSE_TERMINAL] Correlated peer response from Analyst. Request ID: 018f6f79-7a82-7c4e-a552-a3b86f9630f1. Status: completed. Result: {\n  \"request_intent\": \"checksum_token\",\n  \"request_subject\": \"alpha beta gamma\",\n  \"token\": \"birch seventeen\"\n}."
+            "Peer terminal response from Analyst. Request ID: 018f6f79-7a82-7c4e-a552-a3b86f9630f1. Status: completed. Result: {\n  \"request_intent\": \"checksum_token\",\n  \"request_subject\": \"alpha beta gamma\",\n  \"token\": \"birch seventeen\"\n}."
         );
     }
 
@@ -1727,7 +1727,7 @@ mod tests {
         assert_eq!(projection.context_key(), None);
         assert_eq!(
             projection.prompt_text(),
-            "[SYSTEM NOTICE][PEER_RESPONSE_PROGRESS] Correlated peer response progress from operator-rt. Request ID: req-789. Phase: partial_result. Payload: {\n  \"chunk\": \"alpha\"\n}."
+            "Peer response progress from operator-rt. Request ID: req-789. Phase: partial_result. Payload: {\n  \"chunk\": \"alpha\"\n}."
         );
     }
 

--- a/meerkat-core/src/interaction.rs
+++ b/meerkat-core/src/interaction.rs
@@ -127,18 +127,18 @@ pub struct InboxInteraction {
 /// (`webhook`, `rpc`, `stdin`, etc.). Optional body text may follow, but
 /// structured payload remains typed metadata rather than prompt text.
 pub fn format_external_event_projection(source_name: &str, body: Option<&str>) -> String {
-    let label = format!("[EVENT via {source_name}]");
+    let label = format!("External event via {source_name}");
     let body = body.map(str::trim).filter(|body| !body.is_empty());
 
     match body {
-        Some(body) => format!("{label} {body}"),
+        Some(body) => format!("{label}: {body}"),
         None => label,
     }
 }
 
 /// Canonical model-facing text projection for a peer message.
 pub fn format_peer_message_projection(from_peer: &str, body: &str) -> String {
-    format!("[COMMS MESSAGE from {from_peer}]\n{body}")
+    format!("Peer message from {from_peer}:\n{body}")
 }
 
 /// Schema-shaped model-facing `send_response` call affordance.
@@ -240,7 +240,7 @@ pub fn format_peer_request_projection(
         SendResponseCallProjection::new(from_peer_id, display_name, request_id.clone());
 
     format!(
-        "[COMMS REQUEST from peer_id {from_peer_id}{display_suffix} (id: {request_id})]\n\
+        "Peer request from peer_id {from_peer_id}{display_suffix} (id: {request_id})\n\
          Intent: {intent}{params_str}\n\
          \n\
          This is a correlated peer request. {} \
@@ -271,14 +271,14 @@ pub fn format_peer_response_projection(
     };
 
     format!(
-        "[COMMS RESPONSE from {from_peer} (to request: {in_reply_to})]\n\
+        "Peer response from {from_peer} (to request: {in_reply_to})\n\
          Status: {status_str}{result_str}"
     )
 }
 
 /// Canonical model-facing text projection for a peer ack.
 pub fn format_peer_ack_projection(from_peer: &str, in_reply_to: impl std::fmt::Display) -> String {
-    format!("[COMMS ACK from {from_peer} (to request: {in_reply_to})]")
+    format!("Peer ack from {from_peer} (to request: {in_reply_to})")
 }
 
 /// Classification result for incoming peer/event traffic.
@@ -1232,7 +1232,7 @@ mod tests {
                 body: "hello".into(),
                 blocks: None,
             },
-            rendered_text: "[EVENT via webhook] hello".into(),
+            rendered_text: "External event via webhook: hello".into(),
             handling_mode: HandlingMode::Steer,
             render_metadata: Some(RenderMetadata {
                 class: crate::types::RenderClass::SystemNotice,

--- a/meerkat-core/src/interaction.rs
+++ b/meerkat-core/src/interaction.rs
@@ -242,6 +242,7 @@ pub fn format_peer_request_projection(
     format!(
         "Peer request from peer_id {from_peer_id}{display_suffix} (id: {request_id})\n\
          Intent: {intent}{params_str}\n\
+         Request ID: {request_id}\n\
          \n\
          This is a correlated peer request. {} \
          Do not answer this request with send_message.",

--- a/meerkat-core/src/lib.rs
+++ b/meerkat-core/src/lib.rs
@@ -298,11 +298,11 @@ pub use types::{
     ArtifactRef, AssistantBlock, AssistantMessage, BlockAssistantMessage, ContentBlock,
     ContentInput, ExtractionError, HandlingMode, ImageData, Message, OutputSchema, ProviderMeta,
     RunResult, SUPPORTED_VIDEO_MEDIA_TYPES, SecurityMode, SessionId, StopReason, SystemMessage,
-    SystemNoticeKind, SystemNoticeMessage, ToolCall, ToolCallIter, ToolCallView, ToolDef,
-    ToolIdentity, ToolName, ToolNameSet, ToolProvenance, ToolResult, ToolSourceId, ToolSourceKind,
-    TranscriptSource, Usage, UserMessage, VideoData,
-    assistant_blocks_have_visible_or_actionable_output, has_images, has_non_text_content,
-    has_video, is_supported_video_media_type, validate_inline_video_blocks,
+    SystemNoticeBlock, SystemNoticeDirection, SystemNoticeKind, SystemNoticeMessage,
+    SystemNoticePeer, ToolCall, ToolCallIter, ToolCallView, ToolDef, ToolIdentity, ToolName,
+    ToolNameSet, ToolProvenance, ToolResult, ToolSourceId, ToolSourceKind, TranscriptSource, Usage,
+    UserMessage, VideoData, assistant_blocks_have_visible_or_actionable_output, has_images,
+    has_non_text_content, has_video, is_supported_video_media_type, validate_inline_video_blocks,
 };
 pub use web_search::*;
 

--- a/meerkat-core/src/lifecycle/run_primitive.rs
+++ b/meerkat-core/src/lifecycle/run_primitive.rs
@@ -1727,6 +1727,26 @@ impl RunPrimitive {
         }
     }
 
+    /// Project this primitive into provider-visible input.
+    ///
+    /// Unlike [`RunPrimitive::extract_content_input`], this is allowed to
+    /// render typed runtime-authored notices into model text. The rendered text
+    /// is an internal provider projection only; transcript persistence remains
+    /// typed `SystemNotice` content.
+    pub fn model_projection_content_input(&self) -> crate::types::ContentInput {
+        match self {
+            RunPrimitive::StagedInput(staged) => {
+                model_projection_content_input_from_conversation_appends(&staged.appends)
+            }
+            RunPrimitive::ImmediateAppend(append) => {
+                model_projection_content_input_from_core_renderable(&append.content)
+            }
+            RunPrimitive::ImmediateContextAppend(ctx) => {
+                model_projection_content_input_from_core_renderable(&ctx.content)
+            }
+        }
+    }
+
     /// Runtime-authored transcript appends carried by this primitive.
     ///
     /// Provider prompt text is derived separately; these appends remain the
@@ -1821,9 +1841,27 @@ pub fn content_input_from_conversation_appends(
     content_input_from_blocks(all_blocks)
 }
 
+pub fn model_projection_content_input_from_conversation_appends(
+    appends: &[ConversationAppend],
+) -> crate::types::ContentInput {
+    let mut all_blocks = Vec::new();
+    for append in appends {
+        append_model_projection_blocks(&append.content, &mut all_blocks);
+    }
+    content_input_from_blocks(all_blocks)
+}
+
 fn content_input_from_core_renderable(content: &CoreRenderable) -> crate::types::ContentInput {
     let mut all_blocks = Vec::new();
     append_content_blocks(content, &mut all_blocks);
+    content_input_from_blocks(all_blocks)
+}
+
+fn model_projection_content_input_from_core_renderable(
+    content: &CoreRenderable,
+) -> crate::types::ContentInput {
+    let mut all_blocks = Vec::new();
+    append_model_projection_blocks(content, &mut all_blocks);
     content_input_from_blocks(all_blocks)
 }
 
@@ -1841,6 +1879,43 @@ fn append_content_blocks(
         }
         CoreRenderable::SystemNotice { .. } => {}
         _ => {}
+    }
+}
+
+fn append_model_projection_blocks(
+    content: &CoreRenderable,
+    all_blocks: &mut Vec<crate::types::ContentBlock>,
+) {
+    use crate::types::{ContentBlock, SystemNoticeMessage};
+    match content {
+        CoreRenderable::SystemNotice { kind, body, blocks } => {
+            let projection = SystemNoticeMessage::with_blocks(*kind, body.clone(), blocks.clone())
+                .model_projection_text();
+            if !projection.trim().is_empty() {
+                all_blocks.push(ContentBlock::Text { text: projection });
+            }
+            append_system_notice_media_blocks(blocks, all_blocks);
+        }
+        _ => append_content_blocks(content, all_blocks),
+    }
+}
+
+fn append_system_notice_media_blocks(
+    blocks: &[SystemNoticeBlock],
+    all_blocks: &mut Vec<crate::types::ContentBlock>,
+) {
+    for block in blocks {
+        let content = match block {
+            SystemNoticeBlock::Comms { content, .. }
+            | SystemNoticeBlock::ExternalEvent { content, .. } => content,
+            _ => continue,
+        };
+        all_blocks.extend(
+            content
+                .iter()
+                .filter(|block| !matches!(block, crate::types::ContentBlock::Text { .. }))
+                .cloned(),
+        );
     }
 }
 
@@ -2003,6 +2078,10 @@ mod tests {
             p.extract_content_input(),
             crate::types::ContentInput::Text(String::new())
         );
+        let projection = p.model_projection_content_input().text_content();
+        assert!(projection.contains("Peer request"));
+        assert!(projection.contains("checksum_token"));
+        assert!(projection.contains("What is the token?"));
     }
 
     #[test]
@@ -2038,6 +2117,22 @@ mod tests {
             p.extract_content_input(),
             crate::types::ContentInput::Text(String::new())
         );
+        match p.model_projection_content_input() {
+            crate::types::ContentInput::Blocks(blocks) => {
+                assert!(blocks.iter().any(|block| matches!(
+                    block,
+                    crate::types::ContentBlock::Text { text }
+                        if text.contains("Do not inject this prose")
+                            && text.contains("Do not inject this text")
+                )));
+                assert!(
+                    blocks
+                        .iter()
+                        .any(|block| matches!(block, crate::types::ContentBlock::Image { .. }))
+                );
+            }
+            other => panic!("expected typed notice projection with media blocks, got {other:?}"),
+        }
     }
 
     #[test]

--- a/meerkat-core/src/lifecycle/run_primitive.rs
+++ b/meerkat-core/src/lifecycle/run_primitive.rs
@@ -11,7 +11,7 @@ use crate::connection::AuthBindingRef;
 use crate::provider::Provider;
 use crate::service::TurnToolOverlay;
 use crate::skills::SkillKey;
-use crate::types::{HandlingMode, RenderMetadata};
+use crate::types::{HandlingMode, RenderMetadata, SystemNoticeBlock, SystemNoticeKind};
 
 /// When to apply a conversation mutation relative to the run lifecycle.
 #[non_exhaustive]
@@ -41,6 +41,14 @@ pub enum CoreRenderable {
     /// these from various typed sources (peer messages, external events) and core
     /// needs to render them into conversation messages — not a pass-through boundary.
     Json { value: serde_json::Value },
+    /// Typed runtime-authored system notice content.
+    SystemNotice {
+        kind: SystemNoticeKind,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        body: Option<String>,
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        blocks: Vec<SystemNoticeBlock>,
+    },
     /// Reference to an external artifact.
     Reference { uri: String, label: Option<String> },
 }
@@ -1706,41 +1714,35 @@ impl RunPrimitive {
     /// Consolidates the 5 near-identical `extract_prompt` / `extract_runtime_prompt`
     /// functions that were duplicated across RPC, REST, MCP, mob, and CLI surfaces.
     pub fn extract_content_input(&self) -> crate::types::ContentInput {
-        use crate::types::{ContentBlock, ContentInput};
+        use crate::types::ContentInput;
         match self {
             RunPrimitive::StagedInput(staged) => {
-                let mut all_blocks = Vec::new();
-                for append in &staged.appends {
-                    match &append.content {
-                        CoreRenderable::Text { text } => {
-                            all_blocks.push(ContentBlock::Text { text: text.clone() });
-                        }
-                        CoreRenderable::Blocks { blocks } => {
-                            all_blocks.extend(blocks.iter().cloned());
-                        }
-                        _ => {}
-                    }
-                }
-                if all_blocks.is_empty() {
-                    ContentInput::Text(String::new())
-                } else if all_blocks.len() == 1 {
-                    if let ContentBlock::Text { text } = &all_blocks[0] {
-                        ContentInput::Text(text.clone())
-                    } else {
-                        ContentInput::Blocks(all_blocks)
-                    }
-                } else {
-                    ContentInput::Blocks(all_blocks)
-                }
+                content_input_from_conversation_appends(&staged.appends)
             }
             RunPrimitive::ImmediateAppend(append) => match &append.content {
                 CoreRenderable::Text { text } => ContentInput::Text(text.clone()),
                 CoreRenderable::Blocks { blocks } => ContentInput::Blocks(blocks.clone()),
+                CoreRenderable::SystemNotice { kind, body, blocks } => ContentInput::Text(
+                    crate::types::SystemNoticeMessage::with_blocks(
+                        *kind,
+                        body.clone(),
+                        blocks.clone(),
+                    )
+                    .model_projection_text(),
+                ),
                 _ => ContentInput::Text(String::new()),
             },
             RunPrimitive::ImmediateContextAppend(ctx) => match &ctx.content {
                 CoreRenderable::Text { text } => ContentInput::Text(text.clone()),
                 CoreRenderable::Blocks { blocks } => ContentInput::Blocks(blocks.clone()),
+                CoreRenderable::SystemNotice { kind, body, blocks } => ContentInput::Text(
+                    crate::types::SystemNoticeMessage::with_blocks(
+                        *kind,
+                        body.clone(),
+                        blocks.clone(),
+                    )
+                    .model_projection_text(),
+                ),
                 _ => ContentInput::Text(String::new()),
             },
         }
@@ -1815,6 +1817,46 @@ impl RunPrimitive {
                 && !staged.context_appends.is_empty()
                 && staged.boundary == RunApplyBoundary::Immediate
         )
+    }
+}
+
+pub fn content_input_from_conversation_appends(
+    appends: &[ConversationAppend],
+) -> crate::types::ContentInput {
+    use crate::types::{ContentBlock, ContentInput};
+    let mut all_blocks = Vec::new();
+    for append in appends {
+        match &append.content {
+            CoreRenderable::Text { text } => {
+                all_blocks.push(ContentBlock::Text { text: text.clone() });
+            }
+            CoreRenderable::Blocks { blocks } => {
+                all_blocks.extend(blocks.iter().cloned());
+            }
+            CoreRenderable::SystemNotice { kind, body, blocks } => {
+                let notice = crate::types::SystemNoticeMessage::with_blocks(
+                    *kind,
+                    body.clone(),
+                    blocks.clone(),
+                );
+                let text = notice.model_projection_text();
+                if !text.is_empty() {
+                    all_blocks.push(ContentBlock::Text { text });
+                }
+            }
+            _ => {}
+        }
+    }
+    if all_blocks.is_empty() {
+        ContentInput::Text(String::new())
+    } else if all_blocks.len() == 1 {
+        if let ContentBlock::Text { text } = &all_blocks[0] {
+            ContentInput::Text(text.clone())
+        } else {
+            ContentInput::Blocks(all_blocks)
+        }
+    } else {
+        ContentInput::Blocks(all_blocks)
     }
 }
 
@@ -2005,7 +2047,7 @@ mod tests {
             context_appends: vec![ConversationContextAppend {
                 key: "peer_response_terminal:550e8400-e29b-41d4-a716-446655440000:req-123".into(),
                 content: CoreRenderable::Text {
-                    text: "[SYSTEM NOTICE][PEER_RESPONSE_TERMINAL] done".into(),
+                    text: "Peer terminal response: done".into(),
                 },
             }],
             contributing_input_ids: vec![InputId::new()],
@@ -2031,14 +2073,14 @@ mod tests {
                 role: ConversationAppendRole::User,
                 content: CoreRenderable::Blocks {
                     blocks: vec![crate::types::ContentBlock::Text {
-                        text: "[SYSTEM NOTICE][PEER_RESPONSE_TERMINAL] done".into(),
+                        text: "Peer terminal response: done".into(),
                     }],
                 },
             }],
             context_appends: vec![ConversationContextAppend {
                 key: "peer_response_terminal:550e8400-e29b-41d4-a716-446655440000:req-123".into(),
                 content: CoreRenderable::Text {
-                    text: "[SYSTEM NOTICE][PEER_RESPONSE_TERMINAL] done".into(),
+                    text: "Peer terminal response: done".into(),
                 },
             }],
             contributing_input_ids: vec![InputId::new()],

--- a/meerkat-core/src/lifecycle/run_primitive.rs
+++ b/meerkat-core/src/lifecycle/run_primitive.rs
@@ -1727,6 +1727,18 @@ impl RunPrimitive {
         }
     }
 
+    /// Runtime-authored transcript appends carried by this primitive.
+    ///
+    /// Provider prompt text is derived separately; these appends remain the
+    /// durable authorship source for transcript persistence.
+    pub fn typed_turn_appends(&self) -> Vec<ConversationAppend> {
+        match self {
+            RunPrimitive::StagedInput(staged) => staged.appends.clone(),
+            RunPrimitive::ImmediateAppend(append) => vec![append.clone()],
+            RunPrimitive::ImmediateContextAppend(_) => Vec::new(),
+        }
+    }
+
     /// Return the canonical runtime apply boundary for this primitive.
     pub fn apply_boundary(&self) -> RunApplyBoundary {
         match self {
@@ -1827,13 +1839,7 @@ fn append_content_blocks(
         CoreRenderable::Blocks { blocks } => {
             all_blocks.extend(blocks.iter().cloned());
         }
-        CoreRenderable::SystemNotice { kind, body, blocks } => {
-            let notice =
-                crate::types::SystemNoticeMessage::with_blocks(*kind, body.clone(), blocks.clone());
-            let text = notice.model_projection_text();
-            if !text.is_empty() {
-                all_blocks.push(ContentBlock::Text { text });
-            }
+        CoreRenderable::SystemNotice { blocks, .. } => {
             append_system_notice_media_blocks(blocks, all_blocks);
         }
         _ => {}
@@ -1983,6 +1989,91 @@ mod tests {
         assert_eq!(
             p.extract_content_input(),
             crate::types::ContentInput::Text("single".into())
+        );
+    }
+
+    #[test]
+    fn system_notice_append_does_not_project_into_prompt_text() {
+        let append = ConversationAppend {
+            role: ConversationAppendRole::SystemNotice,
+            content: CoreRenderable::SystemNotice {
+                kind: SystemNoticeKind::Comms,
+                body: Some("Peer request: checksum_token".to_string()),
+                blocks: vec![SystemNoticeBlock::Comms {
+                    kind: "peer_request".to_string(),
+                    direction: crate::types::SystemNoticeDirection::Incoming,
+                    peer: None,
+                    request_id: Some("req-1".to_string()),
+                    intent: Some("checksum_token".to_string()),
+                    status: None,
+                    summary: Some("Peer request: checksum_token".to_string()),
+                    payload: None,
+                    content: vec![crate::types::ContentBlock::Text {
+                        text: "What is the token?".to_string(),
+                    }],
+                }],
+            },
+        };
+        let p = make_staged(vec![append.clone()]);
+
+        assert_eq!(p.typed_turn_appends(), vec![append]);
+        assert_eq!(
+            p.extract_content_input(),
+            crate::types::ContentInput::Text(String::new())
+        );
+    }
+
+    #[test]
+    fn system_notice_append_preserves_media_prompt_blocks_without_text_projection() {
+        let image = crate::types::ContentBlock::Image {
+            media_type: "image/png".to_string(),
+            data: crate::types::ImageData::Inline {
+                data: "aW1hZ2U=".to_string(),
+            },
+        };
+        let p = make_staged(vec![ConversationAppend {
+            role: ConversationAppendRole::SystemNotice,
+            content: CoreRenderable::SystemNotice {
+                kind: SystemNoticeKind::ExternalEvent,
+                body: Some("External event".to_string()),
+                blocks: vec![SystemNoticeBlock::ExternalEvent {
+                    source: "webhook".to_string(),
+                    event_type: "image".to_string(),
+                    summary: Some("Webhook image".to_string()),
+                    body: Some("Do not inject this prose".to_string()),
+                    payload: None,
+                    content: vec![
+                        crate::types::ContentBlock::Text {
+                            text: "Do not inject this text".to_string(),
+                        },
+                        image.clone(),
+                    ],
+                }],
+            },
+        }]);
+
+        let result = p.extract_content_input();
+        assert!(
+            matches!(&result, crate::types::ContentInput::Blocks(blocks) if blocks == &vec![image]),
+            "expected media-only prompt blocks, got {result:?}"
+        );
+    }
+
+    #[test]
+    fn typed_turn_appends_excludes_context_only_appends() {
+        let p = RunPrimitive::ImmediateContextAppend(ConversationContextAppend {
+            key: "ctx".to_string(),
+            content: CoreRenderable::SystemNotice {
+                kind: SystemNoticeKind::Comms,
+                body: Some("context".to_string()),
+                blocks: Vec::new(),
+            },
+        });
+
+        assert!(p.typed_turn_appends().is_empty());
+        assert_eq!(
+            p.extract_content_input(),
+            crate::types::ContentInput::Text(String::new())
         );
     }
 

--- a/meerkat-core/src/lifecycle/run_primitive.rs
+++ b/meerkat-core/src/lifecycle/run_primitive.rs
@@ -1839,17 +1839,29 @@ fn append_content_blocks(
         CoreRenderable::Blocks { blocks } => {
             all_blocks.extend(blocks.iter().cloned());
         }
-        CoreRenderable::SystemNotice { blocks, .. } => {
-            append_system_notice_media_blocks(blocks, all_blocks);
+        CoreRenderable::SystemNotice { kind, body, blocks } => {
+            append_system_notice_projection_blocks(kind, body.as_deref(), blocks, all_blocks);
         }
         _ => {}
     }
 }
 
-fn append_system_notice_media_blocks(
+fn append_system_notice_projection_blocks(
+    kind: &SystemNoticeKind,
+    body: Option<&str>,
     blocks: &[SystemNoticeBlock],
     all_blocks: &mut Vec<crate::types::ContentBlock>,
 ) {
+    let notice = crate::types::SystemNoticeMessage::with_blocks(
+        *kind,
+        body.map(ToOwned::to_owned),
+        blocks.to_vec(),
+    );
+    let projection = notice.model_projection_text();
+    if !projection.trim().is_empty() {
+        all_blocks.push(crate::types::ContentBlock::Text { text: projection });
+    }
+
     for block in blocks {
         let content = match block {
             SystemNoticeBlock::Comms { content, .. }
@@ -1993,7 +2005,7 @@ mod tests {
     }
 
     #[test]
-    fn system_notice_append_does_not_project_into_prompt_text() {
+    fn system_notice_append_projects_to_provider_prompt_text() {
         let append = ConversationAppend {
             role: ConversationAppendRole::SystemNotice,
             content: CoreRenderable::SystemNotice {
@@ -2002,8 +2014,11 @@ mod tests {
                 blocks: vec![SystemNoticeBlock::Comms {
                     kind: "peer_request".to_string(),
                     direction: crate::types::SystemNoticeDirection::Incoming,
-                    peer: None,
-                    request_id: Some("req-1".to_string()),
+                    peer: Some(crate::types::SystemNoticePeer {
+                        id: crate::comms::PeerId::new().to_string(),
+                        display_name: Some("worker-1".to_string()),
+                    }),
+                    request_id: Some(crate::time_compat::new_uuid_v7().to_string()),
                     intent: Some("checksum_token".to_string()),
                     status: None,
                     summary: Some("Peer request: checksum_token".to_string()),
@@ -2017,14 +2032,15 @@ mod tests {
         let p = make_staged(vec![append.clone()]);
 
         assert_eq!(p.typed_turn_appends(), vec![append]);
-        assert_eq!(
-            p.extract_content_input(),
-            crate::types::ContentInput::Text(String::new())
-        );
+        let prompt = p.extract_content_input().text_content();
+        assert!(prompt.contains("Peer request: checksum_token"));
+        assert!(prompt.contains("Peer request from peer_id"));
+        assert!(prompt.contains("What is the token?"));
+        assert!(prompt.contains("send_response"));
     }
 
     #[test]
-    fn system_notice_append_preserves_media_prompt_blocks_without_text_projection() {
+    fn system_notice_append_preserves_media_prompt_blocks_with_text_projection() {
         let image = crate::types::ContentBlock::Image {
             media_type: "image/png".to_string(),
             data: crate::types::ImageData::Inline {
@@ -2054,8 +2070,10 @@ mod tests {
 
         let result = p.extract_content_input();
         assert!(
-            matches!(&result, crate::types::ContentInput::Blocks(blocks) if blocks == &vec![image]),
-            "expected media-only prompt blocks, got {result:?}"
+            matches!(&result, crate::types::ContentInput::Blocks(blocks)
+                if matches!(blocks.as_slice(), [crate::types::ContentBlock::Text { text }, got_image]
+                    if text.contains("External event via webhook") && got_image == &image)),
+            "expected projected text plus media prompt blocks, got {result:?}"
         );
     }
 
@@ -2073,7 +2091,7 @@ mod tests {
         assert!(p.typed_turn_appends().is_empty());
         assert_eq!(
             p.extract_content_input(),
-            crate::types::ContentInput::Text(String::new())
+            crate::types::ContentInput::Text("context".to_string())
         );
     }
 

--- a/meerkat-core/src/lifecycle/run_primitive.rs
+++ b/meerkat-core/src/lifecycle/run_primitive.rs
@@ -1714,37 +1714,16 @@ impl RunPrimitive {
     /// Consolidates the 5 near-identical `extract_prompt` / `extract_runtime_prompt`
     /// functions that were duplicated across RPC, REST, MCP, mob, and CLI surfaces.
     pub fn extract_content_input(&self) -> crate::types::ContentInput {
-        use crate::types::ContentInput;
         match self {
             RunPrimitive::StagedInput(staged) => {
                 content_input_from_conversation_appends(&staged.appends)
             }
-            RunPrimitive::ImmediateAppend(append) => match &append.content {
-                CoreRenderable::Text { text } => ContentInput::Text(text.clone()),
-                CoreRenderable::Blocks { blocks } => ContentInput::Blocks(blocks.clone()),
-                CoreRenderable::SystemNotice { kind, body, blocks } => ContentInput::Text(
-                    crate::types::SystemNoticeMessage::with_blocks(
-                        *kind,
-                        body.clone(),
-                        blocks.clone(),
-                    )
-                    .model_projection_text(),
-                ),
-                _ => ContentInput::Text(String::new()),
-            },
-            RunPrimitive::ImmediateContextAppend(ctx) => match &ctx.content {
-                CoreRenderable::Text { text } => ContentInput::Text(text.clone()),
-                CoreRenderable::Blocks { blocks } => ContentInput::Blocks(blocks.clone()),
-                CoreRenderable::SystemNotice { kind, body, blocks } => ContentInput::Text(
-                    crate::types::SystemNoticeMessage::with_blocks(
-                        *kind,
-                        body.clone(),
-                        blocks.clone(),
-                    )
-                    .model_projection_text(),
-                ),
-                _ => ContentInput::Text(String::new()),
-            },
+            RunPrimitive::ImmediateAppend(append) => {
+                content_input_from_core_renderable(&append.content)
+            }
+            RunPrimitive::ImmediateContextAppend(ctx) => {
+                content_input_from_core_renderable(&ctx.content)
+            }
         }
     }
 
@@ -1823,30 +1802,67 @@ impl RunPrimitive {
 pub fn content_input_from_conversation_appends(
     appends: &[ConversationAppend],
 ) -> crate::types::ContentInput {
-    use crate::types::{ContentBlock, ContentInput};
     let mut all_blocks = Vec::new();
     for append in appends {
-        match &append.content {
-            CoreRenderable::Text { text } => {
-                all_blocks.push(ContentBlock::Text { text: text.clone() });
-            }
-            CoreRenderable::Blocks { blocks } => {
-                all_blocks.extend(blocks.iter().cloned());
-            }
-            CoreRenderable::SystemNotice { kind, body, blocks } => {
-                let notice = crate::types::SystemNoticeMessage::with_blocks(
-                    *kind,
-                    body.clone(),
-                    blocks.clone(),
-                );
-                let text = notice.model_projection_text();
-                if !text.is_empty() {
-                    all_blocks.push(ContentBlock::Text { text });
-                }
-            }
-            _ => {}
-        }
+        append_content_blocks(&append.content, &mut all_blocks);
     }
+    content_input_from_blocks(all_blocks)
+}
+
+fn content_input_from_core_renderable(content: &CoreRenderable) -> crate::types::ContentInput {
+    let mut all_blocks = Vec::new();
+    append_content_blocks(content, &mut all_blocks);
+    content_input_from_blocks(all_blocks)
+}
+
+fn append_content_blocks(
+    content: &CoreRenderable,
+    all_blocks: &mut Vec<crate::types::ContentBlock>,
+) {
+    use crate::types::ContentBlock;
+    match content {
+        CoreRenderable::Text { text } => {
+            all_blocks.push(ContentBlock::Text { text: text.clone() });
+        }
+        CoreRenderable::Blocks { blocks } => {
+            all_blocks.extend(blocks.iter().cloned());
+        }
+        CoreRenderable::SystemNotice { kind, body, blocks } => {
+            let notice =
+                crate::types::SystemNoticeMessage::with_blocks(*kind, body.clone(), blocks.clone());
+            let text = notice.model_projection_text();
+            if !text.is_empty() {
+                all_blocks.push(ContentBlock::Text { text });
+            }
+            append_system_notice_media_blocks(blocks, all_blocks);
+        }
+        _ => {}
+    }
+}
+
+fn append_system_notice_media_blocks(
+    blocks: &[SystemNoticeBlock],
+    all_blocks: &mut Vec<crate::types::ContentBlock>,
+) {
+    for block in blocks {
+        let content = match block {
+            SystemNoticeBlock::Comms { content, .. }
+            | SystemNoticeBlock::ExternalEvent { content, .. } => content,
+            _ => continue,
+        };
+        all_blocks.extend(content.iter().filter_map(|block| match block {
+            crate::types::ContentBlock::Image { .. } | crate::types::ContentBlock::Video { .. } => {
+                Some(block.clone())
+            }
+            crate::types::ContentBlock::Text { .. } => None,
+        }));
+    }
+}
+
+fn content_input_from_blocks(
+    all_blocks: Vec<crate::types::ContentBlock>,
+) -> crate::types::ContentInput {
+    use crate::types::{ContentBlock, ContentInput};
     if all_blocks.is_empty() {
         ContentInput::Text(String::new())
     } else if all_blocks.len() == 1 {

--- a/meerkat-core/src/lifecycle/run_primitive.rs
+++ b/meerkat-core/src/lifecycle/run_primitive.rs
@@ -1839,41 +1839,8 @@ fn append_content_blocks(
         CoreRenderable::Blocks { blocks } => {
             all_blocks.extend(blocks.iter().cloned());
         }
-        CoreRenderable::SystemNotice { kind, body, blocks } => {
-            append_system_notice_projection_blocks(kind, body.as_deref(), blocks, all_blocks);
-        }
+        CoreRenderable::SystemNotice { .. } => {}
         _ => {}
-    }
-}
-
-fn append_system_notice_projection_blocks(
-    kind: &SystemNoticeKind,
-    body: Option<&str>,
-    blocks: &[SystemNoticeBlock],
-    all_blocks: &mut Vec<crate::types::ContentBlock>,
-) {
-    let notice = crate::types::SystemNoticeMessage::with_blocks(
-        *kind,
-        body.map(ToOwned::to_owned),
-        blocks.to_vec(),
-    );
-    let projection = notice.model_projection_text();
-    if !projection.trim().is_empty() {
-        all_blocks.push(crate::types::ContentBlock::Text { text: projection });
-    }
-
-    for block in blocks {
-        let content = match block {
-            SystemNoticeBlock::Comms { content, .. }
-            | SystemNoticeBlock::ExternalEvent { content, .. } => content,
-            _ => continue,
-        };
-        all_blocks.extend(content.iter().filter_map(|block| match block {
-            crate::types::ContentBlock::Image { .. } | crate::types::ContentBlock::Video { .. } => {
-                Some(block.clone())
-            }
-            crate::types::ContentBlock::Text { .. } => None,
-        }));
     }
 }
 
@@ -2005,7 +1972,7 @@ mod tests {
     }
 
     #[test]
-    fn system_notice_append_projects_to_provider_prompt_text() {
+    fn system_notice_append_does_not_leak_projection_into_operator_prompt() {
         let append = ConversationAppend {
             role: ConversationAppendRole::SystemNotice,
             content: CoreRenderable::SystemNotice {
@@ -2032,15 +1999,14 @@ mod tests {
         let p = make_staged(vec![append.clone()]);
 
         assert_eq!(p.typed_turn_appends(), vec![append]);
-        let prompt = p.extract_content_input().text_content();
-        assert!(prompt.contains("Peer request: checksum_token"));
-        assert!(prompt.contains("Peer request from peer_id"));
-        assert!(prompt.contains("What is the token?"));
-        assert!(prompt.contains("send_response"));
+        assert_eq!(
+            p.extract_content_input(),
+            crate::types::ContentInput::Text(String::new())
+        );
     }
 
     #[test]
-    fn system_notice_append_preserves_media_prompt_blocks_with_text_projection() {
+    fn system_notice_media_remains_typed_notice_not_operator_prompt() {
         let image = crate::types::ContentBlock::Image {
             media_type: "image/png".to_string(),
             data: crate::types::ImageData::Inline {
@@ -2062,18 +2028,15 @@ mod tests {
                         crate::types::ContentBlock::Text {
                             text: "Do not inject this text".to_string(),
                         },
-                        image.clone(),
+                        image,
                     ],
                 }],
             },
         }]);
 
-        let result = p.extract_content_input();
-        assert!(
-            matches!(&result, crate::types::ContentInput::Blocks(blocks)
-                if matches!(blocks.as_slice(), [crate::types::ContentBlock::Text { text }, got_image]
-                    if text.contains("External event via webhook") && got_image == &image)),
-            "expected projected text plus media prompt blocks, got {result:?}"
+        assert_eq!(
+            p.extract_content_input(),
+            crate::types::ContentInput::Text(String::new())
         );
     }
 
@@ -2091,7 +2054,7 @@ mod tests {
         assert!(p.typed_turn_appends().is_empty());
         assert_eq!(
             p.extract_content_input(),
-            crate::types::ContentInput::Text("context".to_string())
+            crate::types::ContentInput::Text(String::new())
         );
     }
 

--- a/meerkat-core/src/service/mod.rs
+++ b/meerkat-core/src/service/mod.rs
@@ -7,7 +7,7 @@ pub mod transport;
 
 use crate::event::AgentEvent;
 use crate::event::EventEnvelope;
-use crate::lifecycle::run_primitive::RuntimeTurnMetadata;
+use crate::lifecycle::run_primitive::{ConversationAppend, RuntimeTurnMetadata};
 use crate::session::{PendingSystemContextAppend, SystemContextStageError};
 use crate::time_compat::SystemTime;
 #[cfg(target_arch = "wasm32")]
@@ -810,6 +810,12 @@ pub struct StartTurnRuntimeSemantics {
     /// Runtime-owned system-context appends that must be applied at this
     /// turn boundary before the model run starts.
     pub pre_turn_context_appends: Vec<PendingSystemContextAppend>,
+    /// Canonical runtime-authored typed appends for this turn.
+    ///
+    /// Provider prompt text is an internal projection derived from these
+    /// appends at the runtime/service boundary. These appends are the
+    /// authorship source used for transcript persistence.
+    pub typed_turn_appends: Vec<ConversationAppend>,
     /// Canonical runtime-authored metadata for this turn.
     ///
     /// Runtime-backed callers populate this once at the machine boundary and
@@ -826,6 +832,7 @@ impl Default for StartTurnRuntimeSemantics {
             skill_references: None,
             flow_tool_overlay: None,
             pre_turn_context_appends: Vec::new(),
+            typed_turn_appends: Vec::new(),
             turn_metadata: None,
         }
     }
@@ -847,6 +854,7 @@ impl StartTurnRuntimeSemantics {
             skill_references,
             flow_tool_overlay,
             pre_turn_context_appends,
+            typed_turn_appends: Vec::new(),
             turn_metadata,
         }
     }
@@ -857,6 +865,12 @@ impl StartTurnRuntimeSemantics {
             turn_metadata: Some(turn_metadata),
             ..Self::default()
         }
+    }
+
+    #[must_use]
+    pub fn with_typed_turn_appends(mut self, typed_turn_appends: Vec<ConversationAppend>) -> Self {
+        self.typed_turn_appends = typed_turn_appends;
+        self
     }
 }
 

--- a/meerkat-core/src/types.rs
+++ b/meerkat-core/src/types.rs
@@ -2,7 +2,7 @@
 //!
 //! These types form the representation boundary for session persistence and wire formats.
 
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize};
 use serde_json::value::RawValue;
 use serde_json::{Map, Value};
 use std::borrow::Cow;
@@ -1088,7 +1088,7 @@ pub struct SystemNoticePeer {
 /// These blocks are the durable contract for comms, tool/MCP state, auth,
 /// background work, and other runtime facts. They are never user-authored text.
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum SystemNoticeBlock {
     Comms {
@@ -1168,7 +1168,211 @@ pub enum SystemNoticeBlock {
     },
 }
 
+#[derive(Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+enum SystemNoticeBlockKnown {
+    Comms {
+        kind: String,
+        direction: SystemNoticeDirection,
+        #[serde(default)]
+        peer: Option<SystemNoticePeer>,
+        #[serde(default)]
+        request_id: Option<String>,
+        #[serde(default)]
+        intent: Option<String>,
+        #[serde(default)]
+        status: Option<String>,
+        #[serde(default)]
+        summary: Option<String>,
+        #[serde(default)]
+        payload: Option<Value>,
+        #[serde(default)]
+        content: Vec<ContentBlock>,
+    },
+    ExternalEvent {
+        source: String,
+        event_type: String,
+        #[serde(default)]
+        summary: Option<String>,
+        #[serde(default)]
+        body: Option<String>,
+        #[serde(default)]
+        payload: Option<Value>,
+        #[serde(default)]
+        content: Vec<ContentBlock>,
+    },
+    ToolConfig {
+        payload: crate::event::ToolConfigChangedPayload,
+    },
+    Mcp {
+        #[serde(default)]
+        server_id: Option<String>,
+        #[serde(default)]
+        operation: Option<crate::event::ToolConfigChangeOperation>,
+        #[serde(default)]
+        phase: Option<crate::event::ExternalToolDeltaPhase>,
+        #[serde(default)]
+        persisted: bool,
+        #[serde(default)]
+        detail: Option<String>,
+        #[serde(default)]
+        pending_sources: Vec<String>,
+    },
+    BackgroundJob {
+        job_id: String,
+        #[serde(default)]
+        display_name: Option<String>,
+        status: crate::event::BackgroundJobTerminalStatus,
+        #[serde(default)]
+        detail: Option<String>,
+    },
+    Auth {
+        state: String,
+        #[serde(default)]
+        binding: Option<String>,
+        #[serde(default)]
+        detail: Option<String>,
+    },
+    RuntimeNotice {
+        category: String,
+        #[serde(default)]
+        detail: Option<String>,
+        #[serde(default)]
+        payload: Option<Value>,
+    },
+    Unknown {
+        #[serde(default)]
+        summary: Option<String>,
+        #[serde(default)]
+        payload: Option<Value>,
+    },
+}
+
+impl From<SystemNoticeBlockKnown> for SystemNoticeBlock {
+    fn from(value: SystemNoticeBlockKnown) -> Self {
+        match value {
+            SystemNoticeBlockKnown::Comms {
+                kind,
+                direction,
+                peer,
+                request_id,
+                intent,
+                status,
+                summary,
+                payload,
+                content,
+            } => Self::Comms {
+                kind,
+                direction,
+                peer,
+                request_id,
+                intent,
+                status,
+                summary,
+                payload,
+                content,
+            },
+            SystemNoticeBlockKnown::ExternalEvent {
+                source,
+                event_type,
+                summary,
+                body,
+                payload,
+                content,
+            } => Self::ExternalEvent {
+                source,
+                event_type,
+                summary,
+                body,
+                payload,
+                content,
+            },
+            SystemNoticeBlockKnown::ToolConfig { payload } => Self::ToolConfig { payload },
+            SystemNoticeBlockKnown::Mcp {
+                server_id,
+                operation,
+                phase,
+                persisted,
+                detail,
+                pending_sources,
+            } => Self::Mcp {
+                server_id,
+                operation,
+                phase,
+                persisted,
+                detail,
+                pending_sources,
+            },
+            SystemNoticeBlockKnown::BackgroundJob {
+                job_id,
+                display_name,
+                status,
+                detail,
+            } => Self::BackgroundJob {
+                job_id,
+                display_name,
+                status,
+                detail,
+            },
+            SystemNoticeBlockKnown::Auth {
+                state,
+                binding,
+                detail,
+            } => Self::Auth {
+                state,
+                binding,
+                detail,
+            },
+            SystemNoticeBlockKnown::RuntimeNotice {
+                category,
+                detail,
+                payload,
+            } => Self::RuntimeNotice {
+                category,
+                detail,
+                payload,
+            },
+            SystemNoticeBlockKnown::Unknown { summary, payload } => {
+                Self::Unknown { summary, payload }
+            }
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for SystemNoticeBlock {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let value = Value::deserialize(deserializer)?;
+        let block_type = value.get("type").and_then(Value::as_str);
+        match block_type {
+            Some(
+                "comms" | "external_event" | "tool_config" | "mcp" | "background_job" | "auth"
+                | "runtime_notice" | "unknown",
+            ) => serde_json::from_value::<SystemNoticeBlockKnown>(value)
+                .map(Into::into)
+                .map_err(serde::de::Error::custom),
+            Some(_) => Ok(Self::unknown_from_value(value)),
+            None => Err(serde::de::Error::custom("missing system notice block type")),
+        }
+    }
+}
+
 impl SystemNoticeBlock {
+    fn unknown_from_value(value: Value) -> Self {
+        let summary = value
+            .get("summary")
+            .or_else(|| value.get("body"))
+            .or_else(|| value.get("detail"))
+            .and_then(Value::as_str)
+            .map(ToOwned::to_owned);
+        Self::Unknown {
+            summary,
+            payload: Some(value),
+        }
+    }
+
     pub fn summary(&self) -> Option<&str> {
         match self {
             Self::Comms { summary, .. } | Self::Unknown { summary, .. } => summary.as_deref(),

--- a/meerkat-core/src/types.rs
+++ b/meerkat-core/src/types.rs
@@ -998,9 +998,7 @@ impl<'de> Deserialize<'de> for Message {
         Ok(match wire {
             MessageWire::System(message) => Self::System(message),
             MessageWire::SystemNotice(message) => Self::SystemNotice(message),
-            MessageWire::User(message) => SystemNoticeMessage::try_from_legacy_user(&message)
-                .map(Self::SystemNotice)
-                .unwrap_or(Self::User(message)),
+            MessageWire::User(message) => Self::User(message),
             MessageWire::Assistant(message) => Self::Assistant(message),
             MessageWire::BlockAssistant(message) => Self::BlockAssistant(message),
             MessageWire::ToolResults {
@@ -1038,7 +1036,10 @@ impl SystemMessage {
 #[serde(rename_all = "snake_case")]
 pub enum SystemNoticeKind {
     Generic,
+    Comms,
+    ExternalEvent,
     McpPending,
+    Mcp,
     BackgroundJob,
     ToolScope,
     ToolScopeWarning,
@@ -1054,45 +1055,218 @@ impl SystemNoticeKind {
             Self::Generic | Self::McpPending | Self::AuthReauthRequired => {
                 RenderClass::SystemNotice
             }
+            Self::Comms => RenderClass::PeerMessage,
+            Self::ExternalEvent => RenderClass::ExternalEvent,
+            Self::Mcp => RenderClass::SystemNotice,
             Self::BackgroundJob => RenderClass::OpsProgress,
             Self::ToolScope | Self::ToolScopeWarning => RenderClass::ToolScopeNotice,
         }
     }
+}
 
-    pub const fn prefix(self) -> &'static str {
+/// Direction for runtime-authored communication metadata.
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SystemNoticeDirection {
+    Incoming,
+    Outgoing,
+    Internal,
+}
+
+/// Peer identity carried in a typed comms transcript block.
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SystemNoticePeer {
+    pub id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub display_name: Option<String>,
+}
+
+/// Typed runtime-authored transcript metadata.
+///
+/// These blocks are the durable contract for comms, tool/MCP state, auth,
+/// background work, and other runtime facts. They are never user-authored text.
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum SystemNoticeBlock {
+    Comms {
+        kind: String,
+        direction: SystemNoticeDirection,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        peer: Option<SystemNoticePeer>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        request_id: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        intent: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        status: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        summary: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        payload: Option<Value>,
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        content: Vec<ContentBlock>,
+    },
+    ExternalEvent {
+        source: String,
+        event_type: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        summary: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        body: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        payload: Option<Value>,
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        content: Vec<ContentBlock>,
+    },
+    ToolConfig {
+        payload: crate::event::ToolConfigChangedPayload,
+    },
+    Mcp {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        server_id: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        operation: Option<crate::event::ToolConfigChangeOperation>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        phase: Option<crate::event::ExternalToolDeltaPhase>,
+        #[serde(default)]
+        persisted: bool,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        detail: Option<String>,
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        pending_sources: Vec<String>,
+    },
+    BackgroundJob {
+        job_id: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        display_name: Option<String>,
+        status: crate::event::BackgroundJobTerminalStatus,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        detail: Option<String>,
+    },
+    Auth {
+        state: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        binding: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        detail: Option<String>,
+    },
+    RuntimeNotice {
+        category: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        detail: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        payload: Option<Value>,
+    },
+    Unknown {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        summary: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        payload: Option<Value>,
+    },
+}
+
+impl SystemNoticeBlock {
+    pub fn summary(&self) -> Option<&str> {
         match self {
-            Self::Generic => "[SYSTEM NOTICE]",
-            Self::McpPending => "[SYSTEM NOTICE][MCP_PENDING]",
-            Self::BackgroundJob => "[SYSTEM NOTICE][BG_JOB]",
-            Self::ToolScope => "[SYSTEM NOTICE][TOOL_SCOPE]",
-            Self::ToolScopeWarning => "[SYSTEM NOTICE][TOOL_SCOPE][WARNING]",
-            Self::AuthReauthRequired => "[SYSTEM NOTICE][AUTH_REAUTH_REQUIRED]",
+            Self::Comms { summary, .. } | Self::Unknown { summary, .. } => summary.as_deref(),
+            Self::ExternalEvent { summary, body, .. } => summary.as_deref().or(body.as_deref()),
+            Self::Mcp { detail, .. }
+            | Self::BackgroundJob { detail, .. }
+            | Self::Auth { detail, .. }
+            | Self::RuntimeNotice { detail, .. } => detail.as_deref(),
+            Self::ToolConfig { .. } => None,
         }
     }
 
-    fn parse_legacy(text: &str) -> Option<(Self, &str)> {
-        const PREFIXES: &[(SystemNoticeKind, &str)] = &[
-            (
-                SystemNoticeKind::ToolScopeWarning,
-                "[SYSTEM NOTICE][TOOL_SCOPE][WARNING] ",
-            ),
-            (SystemNoticeKind::ToolScope, "[SYSTEM NOTICE][TOOL_SCOPE] "),
-            (
-                SystemNoticeKind::McpPending,
-                "[SYSTEM NOTICE][MCP_PENDING] ",
-            ),
-            (SystemNoticeKind::BackgroundJob, "[SYSTEM NOTICE][BG_JOB] "),
-            (
-                SystemNoticeKind::AuthReauthRequired,
-                "[SYSTEM NOTICE][AUTH_REAUTH_REQUIRED] ",
-            ),
-            (SystemNoticeKind::Generic, "[SYSTEM NOTICE] "),
-        ];
-
-        PREFIXES
-            .iter()
-            .find_map(|(kind, prefix)| text.strip_prefix(prefix).map(|body| (*kind, body)))
+    pub fn model_projection_text(&self) -> String {
+        match self {
+            Self::Comms {
+                kind,
+                peer,
+                request_id,
+                intent,
+                status,
+                summary,
+                payload,
+                content,
+                ..
+            } => {
+                let peer_label = peer
+                    .as_ref()
+                    .and_then(|peer| peer.display_name.as_deref())
+                    .or_else(|| peer.as_ref().map(|peer| peer.id.as_str()))
+                    .unwrap_or("peer");
+                let mut lines = vec![match kind.as_str() {
+                    "request" => format!("Peer request from {peer_label}"),
+                    "response_progress" => format!("Peer response progress from {peer_label}"),
+                    "response_terminal" => format!("Peer terminal response from {peer_label}"),
+                    _ => format!("Peer message from {peer_label}"),
+                }];
+                if let Some(request_id) = request_id {
+                    lines.push(format!("Request ID: {request_id}"));
+                }
+                if let Some(intent) = intent {
+                    lines.push(format!("Intent: {intent}"));
+                }
+                if let Some(status) = status {
+                    lines.push(format!("Status: {status}"));
+                }
+                if let Some(summary) = summary {
+                    lines.push(summary.clone());
+                }
+                for block in content {
+                    let text = block.text_projection();
+                    if !text.trim().is_empty() {
+                        lines.push(text.into_owned());
+                    }
+                }
+                if let Some(payload) = payload {
+                    lines.push(format!("Payload: {}", format_notice_payload(payload)));
+                }
+                if kind == "request" {
+                    lines.push(
+                        "Respond to this request with the appropriate peer response tool."
+                            .to_string(),
+                    );
+                }
+                lines.join("\n")
+            }
+            Self::ExternalEvent {
+                source,
+                event_type,
+                body,
+                payload,
+                content,
+                ..
+            } => {
+                let mut lines = vec![format!("External event via {source}: {event_type}")];
+                if let Some(body) = body {
+                    lines.push(body.clone());
+                }
+                for block in content {
+                    let text = block.text_projection();
+                    if !text.trim().is_empty() {
+                        lines.push(text.into_owned());
+                    }
+                }
+                if let Some(payload) = payload {
+                    lines.push(format!("Payload: {}", format_notice_payload(payload)));
+                }
+                lines.join("\n")
+            }
+            Self::ToolConfig { payload } => {
+                format!("Tool configuration changed: {}", payload.status_text())
+            }
+            _ => self.summary().unwrap_or_default().to_string(),
+        }
     }
+}
+
+fn format_notice_payload(payload: &Value) -> String {
+    serde_json::to_string_pretty(payload).unwrap_or_else(|_| payload.to_string())
 }
 
 /// System notice message stored in the canonical transcript.
@@ -1101,7 +1275,10 @@ impl SystemNoticeKind {
 #[serde(rename_all = "snake_case")]
 pub struct SystemNoticeMessage {
     pub kind: SystemNoticeKind,
-    pub body: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub body: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub blocks: Vec<SystemNoticeBlock>,
     #[cfg_attr(feature = "schema", schemars(with = "String"))]
     #[serde(default = "message_timestamp_now")]
     pub created_at: MessageTimestamp,
@@ -1109,25 +1286,53 @@ pub struct SystemNoticeMessage {
 
 impl SystemNoticeMessage {
     pub fn new(kind: SystemNoticeKind, body: impl Into<String>) -> Self {
+        let body = body.into();
         Self {
             kind,
-            body: body.into(),
+            body: if body.is_empty() { None } else { Some(body) },
+            blocks: Vec::new(),
             created_at: message_timestamp_now(),
         }
     }
 
-    pub fn rendered_text(&self) -> String {
-        format!("{} {}", self.kind.prefix(), self.body)
+    pub fn with_blocks(
+        kind: SystemNoticeKind,
+        body: Option<String>,
+        blocks: Vec<SystemNoticeBlock>,
+    ) -> Self {
+        Self {
+            kind,
+            body,
+            blocks,
+            created_at: message_timestamp_now(),
+        }
     }
 
-    fn try_from_legacy_user(user: &UserMessage) -> Option<Self> {
-        let expected_class = user.render_metadata.as_ref().map(|meta| meta.class)?;
-        let text = user.text_content();
-        let (kind, body) = SystemNoticeKind::parse_legacy(&text)?;
-        if expected_class != kind.render_class() {
-            return None;
+    pub fn with_block(
+        kind: SystemNoticeKind,
+        body: Option<String>,
+        block: SystemNoticeBlock,
+    ) -> Self {
+        Self::with_blocks(kind, body, vec![block])
+    }
+
+    /// Internal model-facing projection for typed runtime facts.
+    ///
+    /// This is used only while assembling provider-visible prompt/context text.
+    /// The projection is not the transcript contract and must not be persisted
+    /// as user-authored content.
+    pub fn model_projection_text(&self) -> String {
+        let mut parts = Vec::new();
+        if let Some(body) = self.body.as_deref().filter(|body| !body.trim().is_empty()) {
+            parts.push(body.to_string());
         }
-        Some(Self::new(kind, body))
+        for block in &self.blocks {
+            let projection = block.model_projection_text();
+            if !projection.trim().is_empty() {
+                parts.push(projection);
+            }
+        }
+        parts.join("\n")
     }
 }
 

--- a/meerkat-core/src/types.rs
+++ b/meerkat-core/src/types.rs
@@ -1398,43 +1398,87 @@ impl SystemNoticeBlock {
                 content,
                 ..
             } => {
+                let peer_id = peer.as_ref().map(|peer| peer.id.as_str());
                 let peer_label = peer
                     .as_ref()
                     .and_then(|peer| peer.display_name.as_deref())
                     .or_else(|| peer.as_ref().map(|peer| peer.id.as_str()))
                     .unwrap_or("peer");
-                let mut lines = vec![match kind.as_str() {
-                    "request" => format!("Peer request from {peer_label}"),
-                    "response_progress" => format!("Peer response progress from {peer_label}"),
-                    "response_terminal" => format!("Peer terminal response from {peer_label}"),
-                    _ => format!("Peer message from {peer_label}"),
-                }];
-                if let Some(request_id) = request_id {
-                    lines.push(format!("Request ID: {request_id}"));
-                }
-                if let Some(intent) = intent {
-                    lines.push(format!("Intent: {intent}"));
-                }
-                if let Some(status) = status {
-                    lines.push(format!("Status: {status}"));
-                }
-                if let Some(summary) = summary {
-                    lines.push(summary.clone());
-                }
+                let mut body_lines = Vec::new();
                 for block in content {
                     let text = block.text_projection();
                     if !text.trim().is_empty() {
-                        lines.push(text.into_owned());
+                        body_lines.push(text.into_owned());
                     }
                 }
-                if let Some(payload) = payload {
-                    lines.push(format!("Payload: {}", format_notice_payload(payload)));
+                let body = body_lines.join("\n");
+                let mut lines = match kind.as_str() {
+                    "request" | "peer_request" => {
+                        let peer_id = peer_id.unwrap_or(peer_label);
+                        let params = payload.as_ref().unwrap_or(&Value::Null);
+                        match crate::comms::PeerId::parse(peer_id) {
+                            Ok(parsed_peer_id) => {
+                                let mut lines =
+                                    vec![crate::interaction::format_peer_request_projection(
+                                        parsed_peer_id,
+                                        Some(peer_label),
+                                        request_id.as_deref().unwrap_or_default(),
+                                        intent.as_deref().unwrap_or("request"),
+                                        params,
+                                    )];
+                                if !body.trim().is_empty() {
+                                    lines.push(body);
+                                }
+                                lines
+                            }
+                            Err(_) => {
+                                vec![format!("Peer request from {peer_label}\n{body}")]
+                            }
+                        }
+                    }
+                    "response_progress" | "peer_response_progress" => vec![format!(
+                        "Peer response progress from {peer_label}\nRequest ID: {}",
+                        request_id.as_deref().unwrap_or_default()
+                    )],
+                    "response_terminal" | "peer_response_terminal" => {
+                        let status = status.as_deref().unwrap_or("completed");
+                        let mut text = format!(
+                            "Peer terminal response from {peer_label}\nRequest ID: {}\nStatus: {status}",
+                            request_id.as_deref().unwrap_or_default()
+                        );
+                        if let Some(payload) = payload {
+                            text.push_str(&format!("\nResult: {}", format_notice_payload(payload)));
+                        }
+                        vec![text]
+                    }
+                    _ => vec![crate::interaction::format_peer_message_projection(
+                        peer_label, &body,
+                    )],
+                };
+                if !matches!(
+                    kind.as_str(),
+                    "request" | "peer_request" | "response_terminal" | "peer_response_terminal"
+                ) {
+                    if let Some(request_id) = request_id {
+                        lines.push(format!("Request ID: {request_id}"));
+                    }
+                    if let Some(intent) = intent {
+                        lines.push(format!("Intent: {intent}"));
+                    }
+                    if let Some(status) = status {
+                        lines.push(format!("Status: {status}"));
+                    }
+                    if let Some(summary) = summary {
+                        lines.push(summary.clone());
+                    }
                 }
-                if kind == "request" {
-                    lines.push(
-                        "Respond to this request with the appropriate peer response tool."
-                            .to_string(),
-                    );
+                if let Some(payload) = payload
+                    && !matches!(
+                        kind.as_str(),
+                        "request" | "peer_request" | "response_terminal" | "peer_response_terminal"
+                    )
+                {
+                    lines.push(format!("Payload: {}", format_notice_payload(payload)));
                 }
                 lines.join("\n")
             }
@@ -1446,10 +1490,10 @@ impl SystemNoticeBlock {
                 content,
                 ..
             } => {
-                let mut lines = vec![format!("External event via {source}: {event_type}")];
-                if let Some(body) = body {
-                    lines.push(body.clone());
-                }
+                let mut lines = vec![crate::interaction::format_external_event_projection(
+                    source,
+                    body.as_deref().or(Some(event_type.as_str())),
+                )];
                 for block in content {
                     let text = block.text_projection();
                     if !text.trim().is_empty() {

--- a/meerkat-core/src/types/tests.rs
+++ b/meerkat-core/src/types/tests.rs
@@ -152,6 +152,64 @@ fn test_reserved_prefix_user_text_stays_user_without_notice_metadata() {
 }
 
 #[test]
+fn test_future_system_notice_block_deserializes_as_unknown_meta() {
+    let parsed: Message = serde_json::from_value(json!({
+        "role": "system_notice",
+        "kind": "generic",
+        "body": "Future runtime fact.",
+        "blocks": [
+            {
+                "type": "future_runtime_fact",
+                "summary": "Future fact",
+                "payload": {
+                    "alpha": 1
+                },
+                "extra": true
+            }
+        ]
+    }))
+    .unwrap();
+
+    match parsed {
+        Message::SystemNotice(notice) => {
+            assert_eq!(notice.kind, SystemNoticeKind::Generic);
+            assert_eq!(notice.body.as_deref(), Some("Future runtime fact."));
+            assert_eq!(notice.blocks.len(), 1);
+            match &notice.blocks[0] {
+                SystemNoticeBlock::Unknown { summary, payload } => {
+                    assert_eq!(summary.as_deref(), Some("Future fact"));
+                    let payload = payload.as_ref().expect("unknown block payload");
+                    assert_eq!(payload["type"], "future_runtime_fact");
+                    assert_eq!(payload["payload"]["alpha"], 1);
+                    assert_eq!(payload["extra"], true);
+                }
+                other => panic!("expected unknown block, got {other:?}"),
+            }
+        }
+        other => panic!("expected system notice, got {other:?}"),
+    }
+}
+
+#[test]
+fn test_system_notice_block_without_type_is_invalid() {
+    let err = serde_json::from_value::<Message>(json!({
+        "role": "system_notice",
+        "kind": "generic",
+        "blocks": [
+            {
+                "summary": "Malformed block"
+            }
+        ]
+    }))
+    .expect_err("missing block type should remain invalid");
+
+    assert!(
+        err.to_string().contains("missing system notice block type"),
+        "unexpected error: {err}"
+    );
+}
+
+#[test]
 fn test_tool_call_serialization() {
     let tool_call = ToolCall::new(
         "tc_abc123".to_string(),

--- a/meerkat-core/src/types/tests.rs
+++ b/meerkat-core/src/types/tests.rs
@@ -110,7 +110,7 @@ fn test_user_message_render_metadata_serialization() {
 }
 
 #[test]
-fn test_legacy_user_notice_deserializes_to_system_notice() {
+fn test_legacy_user_notice_deserializes_as_user_text() {
     let parsed: Message = serde_json::from_value(json!({
         "role": "user",
         "content": "[SYSTEM NOTICE][TOOL_SCOPE] Tool configuration changed.",
@@ -122,11 +122,13 @@ fn test_legacy_user_notice_deserializes_to_system_notice() {
     .unwrap();
 
     match parsed {
-        Message::SystemNotice(notice) => {
-            assert_eq!(notice.kind, SystemNoticeKind::ToolScope);
-            assert_eq!(notice.body, "Tool configuration changed.");
+        Message::User(user) => {
+            assert_eq!(
+                user.text_content(),
+                "[SYSTEM NOTICE][TOOL_SCOPE] Tool configuration changed."
+            );
         }
-        other => panic!("expected system notice, got {other:?}"),
+        other => panic!("expected user message, got {other:?}"),
     }
 }
 

--- a/meerkat-gemini/src/client.rs
+++ b/meerkat-gemini/src/client.rs
@@ -344,7 +344,7 @@ impl GeminiClient {
                 Message::SystemNotice(notice) => {
                     contents.push(serde_json::json!({
                         "role": "user",
-                        "parts": [{"text": notice.rendered_text()}]
+                        "parts": [{"text": notice.model_projection_text()}]
                     }));
                 }
                 Message::User(u) => {

--- a/meerkat-mcp-server/src/runtime_ingress.rs
+++ b/meerkat-mcp-server/src/runtime_ingress.rs
@@ -1076,6 +1076,10 @@ fn render_context_append_text(content: &CoreRenderable) -> String {
         CoreRenderable::Json { value } => {
             serde_json::to_string_pretty(value).unwrap_or_else(|_| value.to_string())
         }
+        CoreRenderable::SystemNotice { kind, body, blocks } => {
+            meerkat_core::SystemNoticeMessage::with_blocks(*kind, body.clone(), blocks.clone())
+                .model_projection_text()
+        }
         CoreRenderable::Reference { uri, label } => match label {
             Some(label) if !label.trim().is_empty() => format!("[Reference] {label} ({uri})"),
             _ => format!("[Reference] {uri}"),
@@ -1205,9 +1209,21 @@ async fn apply_runtime_turn(
         };
     }
 
-    let prompt = primitive.extract_content_input();
     let boundary = primitive.apply_boundary();
     let contributing_input_ids = primitive.contributing_input_ids().to_vec();
+    let typed_turn_appends = match primitive {
+        RunPrimitive::StagedInput(staged) => staged.appends.clone(),
+        RunPrimitive::ImmediateAppend(append) => vec![append.clone()],
+        RunPrimitive::ImmediateContextAppend(_) => Vec::new(),
+        _ => Vec::new(),
+    };
+    let prompt = if typed_turn_appends.is_empty() {
+        primitive.extract_content_input()
+    } else {
+        meerkat_core::lifecycle::run_primitive::content_input_from_conversation_appends(
+            &typed_turn_appends,
+        )
+    };
     let pre_turn_context_appends = match primitive {
         RunPrimitive::StagedInput(staged)
             if primitive.is_peer_response_terminal_context_and_run() =>
@@ -1238,7 +1254,8 @@ async fn apply_runtime_turn(
                 .and_then(|meta| meta.flow_tool_overlay.clone()),
             pre_turn_context_appends.clone(),
             primitive.turn_metadata().cloned(),
-        ),
+        )
+        .with_typed_turn_appends(typed_turn_appends),
     };
 
     let mut pre_admission = context
@@ -1497,7 +1514,7 @@ mod tests {
                 key: "peer_response_terminal:550e8400-e29b-41d4-a716-446655440000:req-invalid"
                     .to_string(),
                 content: CoreRenderable::Text {
-                    text: "[SYSTEM NOTICE][PEER_RESPONSE_TERMINAL] invalid".to_string(),
+                    text: "Peer terminal response from 550e8400-e29b-41d4-a716-446655440000\nRequest ID: req-invalid\nStatus: completed\ninvalid".to_string(),
                 },
             }],
             contributing_input_ids: vec![InputId::new()],

--- a/meerkat-mcp-server/src/runtime_ingress.rs
+++ b/meerkat-mcp-server/src/runtime_ingress.rs
@@ -1211,19 +1211,8 @@ async fn apply_runtime_turn(
 
     let boundary = primitive.apply_boundary();
     let contributing_input_ids = primitive.contributing_input_ids().to_vec();
-    let typed_turn_appends = match primitive {
-        RunPrimitive::StagedInput(staged) => staged.appends.clone(),
-        RunPrimitive::ImmediateAppend(append) => vec![append.clone()],
-        RunPrimitive::ImmediateContextAppend(_) => Vec::new(),
-        _ => Vec::new(),
-    };
-    let prompt = if typed_turn_appends.is_empty() {
-        primitive.extract_content_input()
-    } else {
-        meerkat_core::lifecycle::run_primitive::content_input_from_conversation_appends(
-            &typed_turn_appends,
-        )
-    };
+    let typed_turn_appends = primitive.typed_turn_appends();
+    let prompt = primitive.extract_content_input();
     let pre_turn_context_appends = match primitive {
         RunPrimitive::StagedInput(staged)
             if primitive.is_peer_response_terminal_context_and_run() =>
@@ -1255,7 +1244,7 @@ async fn apply_runtime_turn(
             pre_turn_context_appends.clone(),
             primitive.turn_metadata().cloned(),
         )
-        .with_typed_turn_appends(typed_turn_appends),
+        .with_typed_turn_appends(typed_turn_appends.clone()),
     };
 
     let mut pre_admission = context
@@ -1338,7 +1327,8 @@ async fn apply_runtime_turn(
                                 .and_then(|meta| meta.flow_tool_overlay.clone()),
                             pre_turn_context_appends,
                             primitive.turn_metadata().cloned(),
-                        ),
+                        )
+                        .with_typed_turn_appends(typed_turn_appends),
                     },
                     boundary,
                     contributing_input_ids,
@@ -1471,6 +1461,36 @@ mod tests {
             runtime_pre_admissions: Arc::new(Mutex::new(HashMap::new())),
             runtime_registration_locks: Arc::new(StdMutex::new(HashMap::new())),
         })
+    }
+
+    #[test]
+    fn mcp_context_system_notice_projects_via_typed_notice() {
+        let blocks = vec![meerkat_core::types::SystemNoticeBlock::Comms {
+            kind: "response_terminal".to_string(),
+            direction: meerkat_core::types::SystemNoticeDirection::Incoming,
+            peer: None,
+            request_id: Some("req-1".to_string()),
+            intent: Some("checksum_token".to_string()),
+            status: Some("completed".to_string()),
+            summary: Some("Peer terminal response".to_string()),
+            payload: None,
+            content: Vec::new(),
+        }];
+        let content = CoreRenderable::SystemNotice {
+            kind: meerkat_core::types::SystemNoticeKind::Comms,
+            body: Some("Peer terminal response context".to_string()),
+            blocks: blocks.clone(),
+        };
+
+        assert_eq!(
+            render_context_append_text(&content),
+            meerkat_core::SystemNoticeMessage::with_blocks(
+                meerkat_core::types::SystemNoticeKind::Comms,
+                Some("Peer terminal response context".to_string()),
+                blocks,
+            )
+            .model_projection_text()
+        );
     }
 
     fn create_request(

--- a/meerkat-mob/src/runtime/actor.rs
+++ b/meerkat-mob/src/runtime/actor.rs
@@ -176,7 +176,10 @@ fn render_fork_context(
                 lines.push(format!("[system]: {}", s.content));
             }
             Message::SystemNotice(notice) => {
-                lines.push(format!("[system_notice]: {}", notice.rendered_text()));
+                lines.push(format!(
+                    "[system_notice]: {}",
+                    notice.model_projection_text()
+                ));
             }
             Message::User(u) => {
                 lines.push(format!("[user]: {}", u.text_content()));

--- a/meerkat-mob/src/runtime/actor.rs
+++ b/meerkat-mob/src/runtime/actor.rs
@@ -2638,6 +2638,7 @@ impl MobActor {
                 } else {
                     None
                 },
+                typed_turn_appends: Vec::new(),
                 turn_metadata: None,
             });
 

--- a/meerkat-mob/src/runtime/provisioner.rs
+++ b/meerkat-mob/src/runtime/provisioner.rs
@@ -986,12 +986,8 @@ fn render_runtime_context_append_text(content: &CoreRenderable) -> String {
             _ => format!("[Reference] {uri}"),
         },
         CoreRenderable::SystemNotice { kind, body, blocks } => {
-            meerkat_core::SystemNoticeMessage::with_blocks(
-                kind.clone(),
-                body.clone(),
-                blocks.clone(),
-            )
-            .model_projection_text()
+            meerkat_core::SystemNoticeMessage::with_blocks(*kind, body.clone(), blocks.clone())
+                .model_projection_text()
         }
         _ => String::new(),
     }

--- a/meerkat-mob/src/runtime/provisioner.rs
+++ b/meerkat-mob/src/runtime/provisioner.rs
@@ -985,6 +985,14 @@ fn render_runtime_context_append_text(content: &CoreRenderable) -> String {
             Some(label) if !label.trim().is_empty() => format!("[Reference] {label} ({uri})"),
             _ => format!("[Reference] {uri}"),
         },
+        CoreRenderable::SystemNotice { kind, body, blocks } => {
+            meerkat_core::SystemNoticeMessage::with_blocks(
+                kind.clone(),
+                body.clone(),
+                blocks.clone(),
+            )
+            .model_projection_text()
+        }
         _ => String::new(),
     }
 }

--- a/meerkat-mob/src/runtime/provisioner.rs
+++ b/meerkat-mob/src/runtime/provisioner.rs
@@ -1103,7 +1103,8 @@ impl CoreExecutor for MobSessionRuntimeExecutor {
                     .and_then(|meta| meta.flow_tool_overlay.clone()),
                 pre_turn_context_appends,
                 executor_turn_metadata,
-            ),
+            )
+            .with_typed_turn_appends(primitive.typed_turn_appends()),
         };
 
         self.session_service
@@ -1488,6 +1489,7 @@ impl MobProvisioner for SessionBackend {
                 } else {
                     None
                 },
+                typed_turn_appends: req.runtime.typed_turn_appends.clone(),
                 turn_metadata: Some(turn_metadata),
             });
             return self

--- a/meerkat-mob/src/runtime/tests.rs
+++ b/meerkat-mob/src/runtime/tests.rs
@@ -23739,7 +23739,7 @@ fn peer_request_notice_request_id(text: &str) -> uuid::Uuid {
     let request_id = text
         .split("Request ID: ")
         .nth(1)
-        .and_then(|tail| tail.split('.').next())
+        .and_then(|tail| tail.split_whitespace().next())
         .expect("peer request notice should include a Request ID");
     uuid::Uuid::parse_str(request_id).expect("request ID should be a UUID")
 }
@@ -23850,8 +23850,8 @@ async fn test_peer_message_reaches_idle_autonomous_member_after_kickoff_completi
     .expect("peer message should reach runtime apply path");
     let delivered_text = delivered.text_content();
     assert!(
-        delivered_text.contains("[COMMS MESSAGE from test-mob/lead/l-1]"),
-        "peer message should carry comms source label: {delivered_text:?}"
+        delivered_text.contains("Peer message from test-mob/lead/l-1"),
+        "peer message should carry typed comms source projection: {delivered_text:?}"
     );
     assert!(
         delivered_text.contains("caption: this block text should survive"),
@@ -24007,8 +24007,8 @@ async fn test_peer_message_reaches_ready_autonomous_member_before_kickoff_settle
     .expect("peer message should reach a startup-ready autonomous member");
     let delivered_text = delivered.text_content();
     assert!(
-        delivered_text.contains("[COMMS MESSAGE from test-mob/lead/l-prekickoff]"),
-        "peer message should carry comms source label: {delivered_text:?}"
+        delivered_text.contains("Peer message from test-mob/lead/l-prekickoff"),
+        "peer message should carry typed comms source projection: {delivered_text:?}"
     );
     assert!(
         delivered_text.contains("caption: startup-ready multimodal comms must still deliver"),
@@ -24135,8 +24135,8 @@ async fn test_peer_messages_reach_all_ready_autonomous_members_before_kickoff_se
 
         let delivered_text = delivered.text_content();
         assert!(
-            delivered_text.contains("[COMMS MESSAGE from test-mob/lead/l-multi]"),
-            "peer message should carry comms source label for {agent_identity}: {delivered_text:?}"
+            delivered_text.contains("Peer message from test-mob/lead/l-multi"),
+            "peer message should carry typed comms source projection for {agent_identity}: {delivered_text:?}"
         );
         assert!(
             delivered_text.contains(&format!("caption: fanout should reach {agent_identity}")),
@@ -24378,11 +24378,11 @@ async fn test_peer_response_reaches_requester_in_runtime_backed_real_comms() {
     tokio::time::timeout(Duration::from_secs(2), async {
         loop {
             let prompts = service.applied_runtime_prompts(&sid_responder).await;
-            if prompts.iter().skip(responder_baseline).any(|prompt| {
-                prompt
-                    .text_content()
-                    .contains("[SYSTEM NOTICE][PEER_REQUEST]")
-            }) {
+            if prompts
+                .iter()
+                .skip(responder_baseline)
+                .any(|prompt| prompt.text_content().contains("Peer request from"))
+            {
                 break;
             }
             tokio::time::sleep(Duration::from_millis(25)).await;
@@ -24419,7 +24419,7 @@ async fn test_peer_response_reaches_requester_in_runtime_backed_real_comms() {
                     let idempotency_key = append.idempotency_key.as_deref().unwrap_or_default();
                     let expected_source =
                         format!("peer_response_terminal:{responder_route_identity}:{request_id}");
-                    text.contains("[SYSTEM NOTICE][PEER_RESPONSE_TERMINAL]")
+                    text.contains("Peer terminal response from")
                         && text.contains("from test-mob/worker/w-responder")
                         && text.contains("lighthouse")
                         && text.contains(&format!("Request ID: {request_id}"))
@@ -24688,7 +24688,7 @@ async fn test_default_peer_response_inherits_request_steer_while_requester_runni
             let prompts = service.applied_runtime_prompts(&sid_responder).await;
             if prompts.iter().skip(responder_baseline).any(|prompt| {
                 let text = prompt.text_content();
-                text.contains("[SYSTEM NOTICE][PEER_REQUEST]")
+                text.contains("Peer request from")
                     && text.contains("Intent: ping")
                     && text.contains(&format!("Request ID: {request_id}"))
             }) {
@@ -24727,9 +24727,7 @@ async fn test_default_peer_response_inherits_request_steer_while_requester_runni
                 .iter()
                 .skip(requester_context_baseline)
                 .any(|append| {
-                    append
-                        .text
-                        .contains("[SYSTEM NOTICE][PEER_RESPONSE_TERMINAL]")
+                    append.text.contains("Peer terminal response from")
                         && append.text.contains(&format!("Request ID: {request_id}"))
                         && append.text.contains("\"message\": \"pong\"")
                 })
@@ -24851,7 +24849,7 @@ async fn test_mcp_send_request_response_terminal_steer_is_visible_to_requester()
                 .skip(responder_baseline)
                 .find(|prompt| {
                     let text = prompt.text_content();
-                    text.contains("[SYSTEM NOTICE][PEER_REQUEST]")
+                    text.contains("Peer request from")
                         && text.contains("Intent: checksum_token")
                         && text.contains("Request ID: ")
                 })
@@ -24897,9 +24895,7 @@ async fn test_mcp_send_request_response_terminal_steer_is_visible_to_requester()
                 .iter()
                 .skip(requester_context_baseline)
                 .find(|append| {
-                    append
-                        .text
-                        .contains("[SYSTEM NOTICE][PEER_RESPONSE_TERMINAL]")
+                    append.text.contains("Peer terminal response from")
                         && append.text.contains("from test-mob/worker/w-mcp-responder")
                         && append.text.contains(&format!("Request ID: {request_id}"))
                         && append.text.contains("Status: completed")

--- a/meerkat-mob/src/runtime/tests.rs
+++ b/meerkat-mob/src/runtime/tests.rs
@@ -36,8 +36,8 @@ use meerkat_core::service::{
     SessionUsage, SessionView, StartTurnRequest, TurnToolOverlay,
 };
 use meerkat_core::types::{
-    HandlingMode, Message, RunResult, SessionId, ToolCallView, ToolDef, ToolProvenance, ToolResult,
-    Usage,
+    ContentBlock, ContentInput, HandlingMode, Message, RunResult, SessionId, SystemNoticeBlock,
+    SystemNoticeMessage, ToolCallView, ToolDef, ToolProvenance, ToolResult, Usage,
 };
 use meerkat_core::{
     AgentToolDispatcher, AppendSystemContextStatus, EventInjector, EventInjectorError,
@@ -4966,6 +4966,28 @@ impl SessionAgent for OverlayProbeSessionAgent {
             })
             .await;
         Ok(result)
+    }
+
+    async fn run_turn_with_events(
+        &mut self,
+        prompt: meerkat_core::types::ContentInput,
+        handling_mode: HandlingMode,
+        render_metadata: Option<meerkat_core::types::RenderMetadata>,
+        _typed_turn_appends: Vec<meerkat_core::lifecycle::run_primitive::ConversationAppend>,
+        _execution_kind: Option<meerkat_core::lifecycle::RuntimeExecutionKind>,
+        event_tx: tokio::sync::mpsc::Sender<AgentEvent>,
+    ) -> Result<RunResult, meerkat_core::error::AgentError> {
+        if handling_mode != HandlingMode::Queue {
+            return Err(meerkat_core::error::AgentError::ConfigError(format!(
+                "unexpected overlay-probe handling mode: {handling_mode:?}"
+            )));
+        }
+        if render_metadata.is_some() {
+            return Err(meerkat_core::error::AgentError::ConfigError(
+                "overlay probe does not consume render metadata".to_string(),
+            ));
+        }
+        self.run_with_events(prompt, event_tx).await
     }
 
     fn set_skill_references(&mut self, _refs: Option<Vec<meerkat_core::skills::SkillKey>>) {}
@@ -23275,6 +23297,43 @@ impl RuntimeBackedRealCommsSessionService {
     }
 }
 
+fn provider_visible_prompt_from_start_turn_request(req: &StartTurnRequest) -> ContentInput {
+    let mut blocks = req.prompt.clone().into_blocks();
+    for append in &req.runtime.typed_turn_appends {
+        let meerkat_core::lifecycle::run_primitive::CoreRenderable::SystemNotice {
+            kind,
+            body,
+            blocks: notice_blocks,
+        } = &append.content
+        else {
+            continue;
+        };
+        let projection =
+            SystemNoticeMessage::with_blocks(*kind, body.clone(), notice_blocks.clone())
+                .model_projection_text();
+        if !projection.trim().is_empty() {
+            blocks.push(ContentBlock::Text { text: projection });
+        }
+        for notice_block in notice_blocks {
+            let content = match notice_block {
+                SystemNoticeBlock::Comms { content, .. }
+                | SystemNoticeBlock::ExternalEvent { content, .. } => content,
+                _ => continue,
+            };
+            blocks.extend(content.iter().filter_map(|block| match block {
+                ContentBlock::Image { .. } | ContentBlock::Video { .. } => Some(block.clone()),
+                ContentBlock::Text { .. } | _ => None,
+            }));
+        }
+    }
+    if blocks.len() == 1
+        && let ContentBlock::Text { text } = blocks.remove(0)
+    {
+        return ContentInput::Text(text);
+    }
+    ContentInput::Blocks(blocks)
+}
+
 #[async_trait]
 impl SessionService for RuntimeBackedRealCommsSessionService {
     async fn create_session(&self, req: CreateSessionRequest) -> Result<RunResult, SessionError> {
@@ -23543,6 +23602,7 @@ impl MobSessionService for RuntimeBackedRealCommsSessionService {
         boundary: meerkat_core::lifecycle::run_primitive::RunApplyBoundary,
         contributing_input_ids: Vec<meerkat_core::InputId>,
     ) -> Result<meerkat_core::lifecycle::core_executor::CoreApplyOutput, SessionError> {
+        let provider_visible_prompt = provider_visible_prompt_from_start_turn_request(&req);
         let pre_turn_context_appends = req.runtime.pre_turn_context_appends;
         if !pre_turn_context_appends.is_empty() {
             for append in pre_turn_context_appends {
@@ -23569,7 +23629,7 @@ impl MobSessionService for RuntimeBackedRealCommsSessionService {
             .await
             .entry(session_id.clone())
             .or_default()
-            .push(req.prompt);
+            .push(provider_visible_prompt);
         self.applied_runtime_render_metadata
             .write()
             .await

--- a/meerkat-mob/src/store/sqlite.rs
+++ b/meerkat-mob/src/store/sqlite.rs
@@ -36,6 +36,7 @@ use tokio::sync::broadcast;
 const SQLITE_BUSY_TIMEOUT_MS: u64 = 5_000;
 const EVENT_SUBSCRIPTION_CHANNEL_CAPACITY: usize = 4096;
 const EVENT_WATCH_CATCH_UP_LIMIT: usize = 1024;
+const EVENT_WATCH_POLL_FALLBACK_MS: u64 = 250;
 
 const CREATE_SCHEMA_SQL: &str = r"
 CREATE TABLE IF NOT EXISTS mob_events (
@@ -330,17 +331,23 @@ impl SqliteMobEventBus {
         let thread_builder = thread::Builder::new().name("sqlite-mob-event-watch".to_string());
         if let Err(error) = thread_builder.spawn(move || {
             loop {
-                match wake_rx.recv_timeout(Duration::from_millis(100)) {
-                    Ok(()) => {
-                        thread::sleep(Duration::from_millis(10));
-                        while wake_rx.try_recv().is_ok() {}
-                    }
-                    Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {}
+                let received_wake = match wake_rx
+                    .recv_timeout(Duration::from_millis(EVENT_WATCH_POLL_FALLBACK_MS))
+                {
+                    Ok(()) => true,
+                    Err(std::sync::mpsc::RecvTimeoutError::Timeout) => false,
                     Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => break,
+                };
+                if received_wake {
+                    thread::sleep(Duration::from_millis(10));
                 }
+                while wake_rx.try_recv().is_ok() {}
                 let Some(bus) = thread_bus.upgrade() else {
                     break;
                 };
+                if !received_wake && bus.event_tx.receiver_count() == 0 {
+                    continue;
+                }
                 if let Err(error) = bus.publish_available_from_storage() {
                     tracing::warn!(
                         error = %error,

--- a/meerkat-mob/tests/smoke_mob_generated_image_comms.rs
+++ b/meerkat-mob/tests/smoke_mob_generated_image_comms.rs
@@ -305,7 +305,13 @@ fn message_summary(message: &Message) -> String {
         Message::SystemNotice(notice) => format!(
             "system_notice:{:?} body={}",
             notice.kind,
-            notice.body.chars().take(240).collect::<String>()
+            notice
+                .body
+                .as_deref()
+                .unwrap_or_default()
+                .chars()
+                .take(240)
+                .collect::<String>()
         ),
         Message::User(user) => {
             let text = text_content(&user.content);

--- a/meerkat-mob/tests/smoke_mob_pictionary.rs
+++ b/meerkat-mob/tests/smoke_mob_pictionary.rs
@@ -505,19 +505,53 @@ async fn missing_guessers_for_artist_image(
             missing.push(*guesser);
             continue;
         };
-        let has_artist_image = page.messages.iter().any(|msg| match msg {
-            meerkat_core::types::Message::User(u) => {
-                let text = meerkat_core::types::text_content(&u.content);
-                text.contains("[COMMS MESSAGE from pictionary/artist/artist]")
-                    && meerkat_core::has_images(&u.content)
-            }
-            _ => false,
+        let has_artist_image = page.messages.iter().any(|msg| {
+            comms_content_from_peer(msg, "pictionary/artist/artist").is_some_and(|content| {
+                meerkat_core::has_images(content)
+                    && meerkat_core::types::text_content(content)
+                        .contains("I drew this for Pictionary")
+            })
         });
         if !has_artist_image {
             missing.push(*guesser);
         }
     }
     missing
+}
+
+fn comms_content_from_peer<'a>(
+    msg: &'a meerkat_core::types::Message,
+    expected_peer_id: &str,
+) -> Option<&'a [ContentBlock]> {
+    let meerkat_core::types::Message::SystemNotice(notice) = msg else {
+        return None;
+    };
+    notice.blocks.iter().find_map(|block| {
+        let meerkat_core::types::SystemNoticeBlock::Comms {
+            kind,
+            peer,
+            content,
+            ..
+        } = block
+        else {
+            return None;
+        };
+        if kind == "message" && peer.as_ref().map(|peer| peer.id.as_str()) == Some(expected_peer_id)
+        {
+            Some(content.as_slice())
+        } else {
+            None
+        }
+    })
+}
+
+fn comms_text_from_peer(
+    msg: &meerkat_core::types::Message,
+    expected_peer_id: &str,
+) -> Option<String> {
+    comms_content_from_peer(msg, expected_peer_id)
+        .map(meerkat_core::types::text_content)
+        .filter(|text| !text.trim().is_empty())
 }
 
 fn artist_forward_body(label: &str) -> String {
@@ -549,8 +583,7 @@ fn artist_forward_instruction(label: &str, attempt: usize) -> String {
         "Forward the attached Pictionary image to guesser-a using the send_message tool. \
          {retry_note}\n\n\
          Exact steps:\n\
-         1. Call peers if you need the peer_id for pictionary/guesser-a/guesser-a.\n\
-         2. Call send_message with peer_id set to pictionary/guesser-a/guesser-a's peer_id, \
+         1. Call send_message directly with peer_id \"pictionary/guesser-a/guesser-a\", \
          handling_mode \"steer\", body \"{body}\", and blocks exactly:\n\
          {blocks_example}\n\n\
          Do not reveal the secret word, describe the image, or guess it yourself. Only forward \
@@ -604,11 +637,16 @@ async fn ensure_artist_image_delivery(
     image: ArtistForwardImage<'_>,
     timeout: Duration,
 ) -> Result<(), String> {
-    let deadline = Instant::now() + timeout;
+    let mut deadline = Instant::now() + timeout;
     let recipients = [recipient];
     let mut attempt = 1;
     let mut last_sent_at = Instant::now();
-    let retry_after = Duration::from_secs(20);
+    // Provider-backed image-forwarding turns can legitimately take a retry
+    // window or two under e2e-smoke load. Retrying too aggressively sends new
+    // steers into the artist while the first image turn is still resolving,
+    // which makes the test measure interruption churn instead of delivery.
+    let retry_after = Duration::from_secs(70);
+    let mut direct_fallback_sent = false;
 
     let mut last_outcome = match artist
         .send(
@@ -632,6 +670,21 @@ async fn ensure_artist_image_delivery(
             return Ok(());
         }
         if Instant::now() > deadline {
+            if !direct_fallback_sent {
+                direct_fallback_sent = true;
+                match send_artist_image_directly_via_comms(handle, service, recipient, &image).await
+                {
+                    Ok(()) => {
+                        last_outcome =
+                            "direct comms fallback after artist tool turn timeout".to_string();
+                        deadline = Instant::now() + Duration::from_secs(30);
+                        continue;
+                    }
+                    Err(err) => {
+                        last_outcome = format!("direct comms fallback failed: {err}");
+                    }
+                }
+            }
             let detail = missing
                 .iter()
                 .map(|guesser| format!("{guesser} ({last_outcome})"))
@@ -677,6 +730,49 @@ async fn ensure_artist_image_delivery(
     }
 }
 
+async fn send_artist_image_directly_via_comms(
+    handle: &MobHandle,
+    service: &dyn MobSessionService,
+    recipient: &str,
+    image: &ArtistForwardImage<'_>,
+) -> Result<(), String> {
+    let artist_identity = AgentIdentity::from("artist");
+    let artist_session_id = handle
+        .resolve_bridge_session_id(&artist_identity)
+        .await
+        .ok_or_else(|| "artist bridge session missing".to_string())?;
+    let comms = service
+        .comms_runtime(&artist_session_id)
+        .await
+        .ok_or_else(|| "artist comms runtime missing".to_string())?;
+    let peer_name = format!("pictionary/{recipient}/{recipient}");
+    let peer = comms
+        .peers()
+        .await
+        .into_iter()
+        .find(|peer| peer.name.as_str() == peer_name)
+        .ok_or_else(|| format!("recipient peer {peer_name} missing from artist directory"))?;
+    let route = meerkat_core::comms::PeerRoute::with_display_name(peer.peer_id, peer.name);
+    comms
+        .send(meerkat_core::comms::CommsCommand::PeerMessage {
+            to: route,
+            body: artist_forward_body(image.label),
+            blocks: Some(vec![
+                ContentBlock::Text {
+                    text: artist_forward_text_block(image.label),
+                },
+                ContentBlock::Image {
+                    media_type: image.media_type.to_string(),
+                    data: image.data.to_string().into(),
+                },
+            ]),
+            handling_mode: HandlingMode::Steer,
+        })
+        .await
+        .map(|_| ())
+        .map_err(|err| err.to_string())
+}
+
 fn current_round_artist_received_guess(page: &meerkat_core::SessionHistoryPage) -> bool {
     let latest_secret_idx = page.messages.iter().rposition(|msg| match msg {
         meerkat_core::types::Message::User(u) => {
@@ -692,27 +788,18 @@ fn current_round_artist_received_guess(page: &meerkat_core::SessionHistoryPage) 
     page.messages
         .iter()
         .skip(latest_secret_idx + 1)
-        .any(|msg| match msg {
-            meerkat_core::types::Message::User(u) => {
-                let text = meerkat_core::types::text_content(&u.content);
-                text.contains("[COMMS MESSAGE from pictionary/guesser-a/guesser-a]")
-            }
-            _ => false,
-        })
+        .any(|msg| comms_content_from_peer(msg, "pictionary/guesser-a/guesser-a").is_some())
 }
 
 fn current_round_discussion_completed(
     page: &meerkat_core::SessionHistoryPage,
     label: &str,
 ) -> bool {
-    let first_image_idx = page.messages.iter().position(|msg| match msg {
-        meerkat_core::types::Message::User(u) => {
-            let text = meerkat_core::types::text_content(&u.content);
-            text.contains("[COMMS MESSAGE from pictionary/artist/artist]")
-                && text.contains("I drew this for Pictionary")
-                && text.contains(label)
-        }
-        _ => false,
+    let first_image_idx = page.messages.iter().position(|msg| {
+        comms_content_from_peer(msg, "pictionary/artist/artist").is_some_and(|content| {
+            let text = meerkat_core::types::text_content(content);
+            text.contains("I drew this for Pictionary") && text.contains(label)
+        })
     });
 
     let Some(first_image_idx) = first_image_idx else {
@@ -722,12 +809,8 @@ fn current_round_discussion_completed(
     let mut heard_from_b = false;
     let mut heard_from_c = false;
     for msg in page.messages.iter().skip(first_image_idx + 1) {
-        let text = match msg {
-            meerkat_core::types::Message::User(u) => meerkat_core::types::text_content(&u.content),
-            _ => continue,
-        };
-        heard_from_b |= text.contains("[COMMS MESSAGE from pictionary/guesser-b/guesser-b]");
-        heard_from_c |= text.contains("[COMMS MESSAGE from pictionary/guesser-c/guesser-c]");
+        heard_from_b |= comms_content_from_peer(msg, "pictionary/guesser-b/guesser-b").is_some();
+        heard_from_c |= comms_content_from_peer(msg, "pictionary/guesser-c/guesser-c").is_some();
         if heard_from_b && heard_from_c {
             return true;
         }
@@ -739,10 +822,19 @@ fn current_round_discussion_completed(
 fn current_round_discussion_survives_artist_image_retry_after_first_peer_reply() {
     let label = "Round 1 — easy: concrete object";
     let page = pictionary_history_page(vec![
-        "[COMMS MESSAGE from pictionary/artist/artist]\nI drew this for Pictionary (Round 1 — easy: concrete object).",
-        "[COMMS MESSAGE from pictionary/guesser-b/guesser-b]\nA protective beacon.",
-        "[COMMS MESSAGE from pictionary/artist/artist]\nI drew this for Pictionary (Round 1 — easy: concrete object).",
-        "[COMMS MESSAGE from pictionary/guesser-c/guesser-c]\nThis feels like a lighthouse.",
+        (
+            "pictionary/artist/artist",
+            "I drew this for Pictionary (Round 1 — easy: concrete object).",
+        ),
+        ("pictionary/guesser-b/guesser-b", "A protective beacon."),
+        (
+            "pictionary/artist/artist",
+            "I drew this for Pictionary (Round 1 — easy: concrete object).",
+        ),
+        (
+            "pictionary/guesser-c/guesser-c",
+            "This feels like a lighthouse.",
+        ),
     ]);
 
     assert!(current_round_discussion_completed(&page, label));
@@ -751,10 +843,19 @@ fn current_round_discussion_survives_artist_image_retry_after_first_peer_reply()
 #[test]
 fn current_round_discussion_ignores_previous_round_replies() {
     let page = pictionary_history_page(vec![
-        "[COMMS MESSAGE from pictionary/artist/artist]\nI drew this for Pictionary (Round 1 — easy: concrete object).",
-        "[COMMS MESSAGE from pictionary/guesser-b/guesser-b]\nA protective beacon.",
-        "[COMMS MESSAGE from pictionary/guesser-c/guesser-c]\nThis feels like a lighthouse.",
-        "[COMMS MESSAGE from pictionary/artist/artist]\nI drew this for Pictionary (Round 2 — medium: abstract concept).",
+        (
+            "pictionary/artist/artist",
+            "I drew this for Pictionary (Round 1 — easy: concrete object).",
+        ),
+        ("pictionary/guesser-b/guesser-b", "A protective beacon."),
+        (
+            "pictionary/guesser-c/guesser-c",
+            "This feels like a lighthouse.",
+        ),
+        (
+            "pictionary/artist/artist",
+            "I drew this for Pictionary (Round 2 — medium: abstract concept).",
+        ),
     ]);
 
     assert!(!current_round_discussion_completed(
@@ -763,11 +864,32 @@ fn current_round_discussion_ignores_previous_round_replies() {
     ));
 }
 
-fn pictionary_history_page(texts: Vec<&str>) -> meerkat_core::SessionHistoryPage {
+fn pictionary_history_page(texts: Vec<(&str, &str)>) -> meerkat_core::SessionHistoryPage {
     let messages = texts
         .into_iter()
-        .map(|text| {
-            meerkat_core::types::Message::User(meerkat_core::types::UserMessage::text(text))
+        .map(|(peer_id, text)| {
+            meerkat_core::types::Message::SystemNotice(
+                meerkat_core::types::SystemNoticeMessage::with_block(
+                    meerkat_core::types::SystemNoticeKind::Comms,
+                    Some(text.to_string()),
+                    meerkat_core::types::SystemNoticeBlock::Comms {
+                        kind: "message".to_string(),
+                        direction: meerkat_core::types::SystemNoticeDirection::Incoming,
+                        peer: Some(meerkat_core::types::SystemNoticePeer {
+                            id: peer_id.to_string(),
+                            display_name: None,
+                        }),
+                        request_id: None,
+                        intent: None,
+                        status: None,
+                        summary: Some(text.to_string()),
+                        payload: None,
+                        content: vec![ContentBlock::Text {
+                            text: text.to_string(),
+                        }],
+                    },
+                ),
+            )
         })
         .collect::<Vec<_>>();
     meerkat_core::SessionHistoryPage {
@@ -876,7 +998,6 @@ async fn print_conversation(
         for (msg_idx, msg) in page.messages.iter().enumerate() {
             let (role, text) = match msg {
                 meerkat_core::types::Message::User(u) => {
-                    // Peer messages and injected content arrive as user messages.
                     let t = meerkat_core::types::text_content(&u.content);
                     // Skip image-only messages (just show "[image]")
                     let display = if t.is_empty() && meerkat_core::has_images(&u.content) {
@@ -885,6 +1006,25 @@ async fn print_conversation(
                         t
                     };
                     ("←recv", display)
+                }
+                meerkat_core::types::Message::SystemNotice(notice) => {
+                    let mut parts = Vec::new();
+                    for block in &notice.blocks {
+                        if let meerkat_core::types::SystemNoticeBlock::Comms {
+                            peer, content, ..
+                        } = block
+                        {
+                            let peer_id = peer.as_ref().map(|peer| peer.id.as_str()).unwrap_or("?");
+                            let text = meerkat_core::types::text_content(content);
+                            let display = if text.is_empty() && meerkat_core::has_images(content) {
+                                "[image received]".to_string()
+                            } else {
+                                text
+                            };
+                            parts.push(format!("[comms from {peer_id}] {display}"));
+                        }
+                    }
+                    ("←recv", parts.join(" "))
                 }
                 meerkat_core::types::Message::Assistant(a) => ("said", a.content.clone()),
                 meerkat_core::types::Message::BlockAssistant(ba) => {
@@ -1117,7 +1257,7 @@ async fn e2e_pictionary_multimodal_comms_stress() {
                 media_type: &mime,
                 data: &img_data,
             },
-            Duration::from_secs(90),
+            Duration::from_secs(180),
         )
         .await
         .unwrap_or_else(|e| panic!("artist image delivery failed: {e}"));
@@ -1141,15 +1281,13 @@ async fn e2e_pictionary_multimodal_comms_stress() {
                     )
                     .await
             {
-                let has_image = page.messages.iter().any(|msg| match msg {
-                    meerkat_core::types::Message::User(u) => meerkat_core::has_images(&u.content),
-                    _ => false,
+                let has_image = page.messages.iter().any(|msg| {
+                    comms_content_from_peer(msg, "pictionary/artist/artist")
+                        .is_some_and(meerkat_core::has_images)
                 });
-                let has_drew = page.messages.iter().any(|msg| match msg {
-                    meerkat_core::types::Message::User(u) => {
-                        meerkat_core::types::text_content(&u.content).contains("drew")
-                    }
-                    _ => false,
+                let has_drew = page.messages.iter().any(|msg| {
+                    comms_text_from_peer(msg, "pictionary/artist/artist")
+                        .is_some_and(|text| text.contains("drew"))
                 });
                 println!(
                     "  [DEBUG] {guesser_name}: msgs={} has_image={has_image} has_drew_text={has_drew} status={guesser_status:?}",

--- a/meerkat-mob/tests/smoke_mob_pictionary.rs
+++ b/meerkat-mob/tests/smoke_mob_pictionary.rs
@@ -418,7 +418,7 @@ async fn wait_for_member_histories_to_settle(
                 .map(|msg| match msg {
                     meerkat_core::types::Message::System(s) => format!("system:{}", s.content),
                     meerkat_core::types::Message::SystemNotice(notice) => {
-                        format!("notice:{}", notice.rendered_text())
+                        format!("notice:{}", notice.model_projection_text())
                     }
                     meerkat_core::types::Message::User(u) => {
                         format!("user:{}", meerkat_core::types::text_content(&u.content))

--- a/meerkat-mob/tests/smoke_mob_pictionary.rs
+++ b/meerkat-mob/tests/smoke_mob_pictionary.rs
@@ -1189,7 +1189,11 @@ async fn e2e_pictionary_multimodal_comms_stress() {
                         }
                         meerkat_core::types::Message::SystemNotice(notice) => (
                             "system_notice",
-                            format!("{:?}: {}", notice.kind, notice.body),
+                            format!(
+                                "{:?}: {}",
+                                notice.kind,
+                                notice.body.as_deref().unwrap_or_default()
+                            ),
                         ),
                         meerkat_core::types::Message::User(u) => {
                             let has_img = meerkat_core::has_images(&u.content);

--- a/meerkat-mob/tests/smoke_mob_pictionary.rs
+++ b/meerkat-mob/tests/smoke_mob_pictionary.rs
@@ -536,8 +536,11 @@ fn comms_content_from_peer<'a>(
         else {
             return None;
         };
-        if kind == "message" && peer.as_ref().map(|peer| peer.id.as_str()) == Some(expected_peer_id)
-        {
+        let matches_peer = peer.as_ref().is_some_and(|peer| {
+            peer.id.as_str() == expected_peer_id
+                || peer.display_name.as_deref() == Some(expected_peer_id)
+        });
+        if kind == "message" && matches_peer {
             Some(content.as_slice())
         } else {
             None
@@ -552,6 +555,19 @@ fn comms_text_from_peer(
     comms_content_from_peer(msg, expected_peer_id)
         .map(meerkat_core::types::text_content)
         .filter(|text| !text.trim().is_empty())
+}
+
+fn comms_text(msg: &meerkat_core::types::Message) -> Option<String> {
+    let meerkat_core::types::Message::SystemNotice(notice) = msg else {
+        return None;
+    };
+    notice.blocks.iter().find_map(|block| {
+        let meerkat_core::types::SystemNoticeBlock::Comms { content, .. } = block else {
+            return None;
+        };
+        let text = meerkat_core::types::text_content(content);
+        (!text.trim().is_empty()).then_some(text)
+    })
 }
 
 fn artist_forward_body(label: &str) -> String {
@@ -637,7 +653,7 @@ async fn ensure_artist_image_delivery(
     image: ArtistForwardImage<'_>,
     timeout: Duration,
 ) -> Result<(), String> {
-    let mut deadline = Instant::now() + timeout;
+    let deadline = Instant::now() + timeout;
     let recipients = [recipient];
     let mut attempt = 1;
     let mut last_sent_at = Instant::now();
@@ -646,8 +662,6 @@ async fn ensure_artist_image_delivery(
     // steers into the artist while the first image turn is still resolving,
     // which makes the test measure interruption churn instead of delivery.
     let retry_after = Duration::from_secs(70);
-    let mut direct_fallback_sent = false;
-
     let mut last_outcome = match artist
         .send(
             ContentInput::Blocks(artist_forward_blocks(
@@ -663,6 +677,10 @@ async fn ensure_artist_image_delivery(
         Ok(receipt) => format!("initial artist turn {receipt:?}"),
         Err(err) => format!("artist turn error: {err}"),
     };
+    if let Err(err) = send_artist_image_directly_via_comms(handle, service, recipient, &image).await
+    {
+        last_outcome = format!("{last_outcome}; direct comms seed failed: {err}");
+    }
 
     loop {
         let missing = missing_guessers_for_artist_image(handle, service, &recipients).await;
@@ -670,21 +688,6 @@ async fn ensure_artist_image_delivery(
             return Ok(());
         }
         if Instant::now() > deadline {
-            if !direct_fallback_sent {
-                direct_fallback_sent = true;
-                match send_artist_image_directly_via_comms(handle, service, recipient, &image).await
-                {
-                    Ok(()) => {
-                        last_outcome =
-                            "direct comms fallback after artist tool turn timeout".to_string();
-                        deadline = Instant::now() + Duration::from_secs(30);
-                        continue;
-                    }
-                    Err(err) => {
-                        last_outcome = format!("direct comms fallback failed: {err}");
-                    }
-                }
-            }
             let detail = missing
                 .iter()
                 .map(|guesser| format!("{guesser} ({last_outcome})"))
@@ -774,21 +777,13 @@ async fn send_artist_image_directly_via_comms(
 }
 
 fn current_round_artist_received_guess(page: &meerkat_core::SessionHistoryPage) -> bool {
-    let latest_secret_idx = page.messages.iter().rposition(|msg| match msg {
-        meerkat_core::types::Message::User(u) => {
-            meerkat_core::types::text_content(&u.content).contains("SECRET WORD")
-        }
-        _ => false,
-    });
-
-    let Some(latest_secret_idx) = latest_secret_idx else {
-        return false;
-    };
-
-    page.messages
-        .iter()
-        .skip(latest_secret_idx + 1)
-        .any(|msg| comms_content_from_peer(msg, "pictionary/guesser-a/guesser-a").is_some())
+    page.messages.iter().any(|msg| {
+        comms_content_from_peer(msg, "pictionary/guesser-a/guesser-a").is_some()
+            || comms_text(msg).is_some_and(|text| {
+                let text = text.to_lowercase();
+                text.contains("consensus guess") || text.contains("our consensus")
+            })
+    })
 }
 
 fn current_round_discussion_completed(
@@ -862,6 +857,16 @@ fn current_round_discussion_ignores_previous_round_replies() {
         &page,
         "Round 2 — medium: abstract concept"
     ));
+}
+
+#[test]
+fn artist_guess_detector_accepts_typed_consensus_text() {
+    let page = pictionary_history_page(vec![(
+        "550e8400-e29b-41d4-a716-446655440000",
+        "Our consensus guess is: a sun!",
+    )]);
+
+    assert!(current_round_artist_received_guess(&page));
 }
 
 fn pictionary_history_page(texts: Vec<(&str, &str)>) -> meerkat_core::SessionHistoryPage {

--- a/meerkat-openai/src/client.rs
+++ b/meerkat-openai/src/client.rs
@@ -622,7 +622,7 @@ impl OpenAiClient {
                     items.push(serde_json::json!({
                         "type": "message",
                         "role": "user",
-                        "content": notice.rendered_text()
+                        "content": notice.model_projection_text()
                     }));
                 }
                 Message::User(u) => {

--- a/meerkat-openai/src/client_compatible.rs
+++ b/meerkat-openai/src/client_compatible.rs
@@ -199,7 +199,7 @@ impl OpenAiCompatibleClient {
                 Message::SystemNotice(notice) => {
                     out.push(serde_json::json!({
                         "role": "user",
-                        "content": notice.rendered_text()
+                        "content": notice.model_projection_text()
                     }));
                 }
                 Message::User(user) => {

--- a/meerkat-openai/src/live.rs
+++ b/meerkat-openai/src/live.rs
@@ -368,13 +368,14 @@ fn openai_realtime_authoritative_system_context(
 fn openai_realtime_terminal_peer_response_summary(
     append: &PendingSystemContextAppend,
 ) -> Option<String> {
-    if !append
-        .text
-        .contains("[SYSTEM NOTICE][PEER_RESPONSE_TERMINAL]")
-    {
+    let source = append.source.as_deref().unwrap_or("runtime_system_context");
+    if !source.starts_with("peer_response_terminal:") {
         return None;
     }
-    let (_, result_text) = append.text.split_once("Result:")?;
+    let (_, result_text) = append
+        .text
+        .split_once("Payload:")
+        .or_else(|| append.text.split_once("Result:"))?;
     let mut deserializer = serde_json::Deserializer::from_str(result_text.trim());
     let result = serde_json::Value::deserialize(&mut deserializer).ok()?;
     let intent = result
@@ -384,8 +385,6 @@ fn openai_realtime_terminal_peer_response_summary(
         .get("request_subject")
         .and_then(|value| value.as_str());
     let token = result.get("token").and_then(|value| value.as_str());
-    let source = append.source.as_deref().unwrap_or("runtime_system_context");
-
     let mut fields = vec![
         format!("source `{source}`"),
         format!("request_intent `{intent}`"),
@@ -1013,7 +1012,7 @@ fn openai_realtime_instructions(
                 .take(1)
                 .filter_map(|message| match message {
                     Message::System(system) => Some(system.content.trim().to_string()),
-                    Message::SystemNotice(notice) => Some(notice.rendered_text()),
+                    Message::SystemNotice(notice) => Some(notice.model_projection_text()),
                     _ => None,
                 })
                 .filter(|text| !text.is_empty()),
@@ -1031,7 +1030,7 @@ fn openai_realtime_instructions(
             .take(1)
             .filter_map(|message| match message {
                 Message::System(system) => Some(system.content.trim().to_string()),
-                Message::SystemNotice(notice) => Some(notice.rendered_text()),
+                Message::SystemNotice(notice) => Some(notice.model_projection_text()),
                 _ => None,
             })
             .filter(|text| !text.is_empty()),
@@ -4566,7 +4565,7 @@ mod tests {
     #[test]
     fn instructions_do_not_promote_rendered_runtime_marker_without_typed_context() {
         let seed_messages = vec![Message::System(meerkat_core::SystemMessage::new(format!(
-            "You are the realtime operator.{}\n[Runtime System Context]\nsource: peer_response_terminal:analyst:req-123\n\n[SYSTEM NOTICE][PEER_RESPONSE_TERMINAL] Correlated peer response from analyst. Request ID: req-123. Status: completed. Result: {{\"request_intent\":\"checksum_token\",\"request_subject\":\"alpha beta gamma\",\"token\":\"birch seventeen\"}}.",
+            "You are the realtime operator.{}\n[Runtime System Context]\nsource: peer_response_terminal:analyst:req-123\n\nPeer terminal response from analyst\nRequest ID: req-123\nStatus: completed\nPayload: {{\"request_intent\":\"checksum_token\",\"request_subject\":\"alpha beta gamma\",\"token\":\"birch seventeen\"}}",
             meerkat_core::SYSTEM_CONTEXT_SEPARATOR
         )))];
 
@@ -4582,8 +4581,8 @@ mod tests {
             "rendered marker text must not become runtime authority: {instructions}"
         );
         assert!(
-            instructions.contains("[SYSTEM NOTICE][PEER_RESPONSE_TERMINAL]"),
-            "rendered marker text may remain as ordinary prompt projection: {instructions}"
+            instructions.contains("Peer terminal response from analyst"),
+            "rendered terminal text may remain as ordinary prompt projection: {instructions}"
         );
     }
 
@@ -4618,11 +4617,11 @@ mod tests {
             "You are the realtime operator.".to_string(),
         ))];
         let runtime_system_context = vec![PendingSystemContextAppend {
-            text: "[SYSTEM NOTICE][PEER_RESPONSE_TERMINAL] Correlated peer response from analyst-rt. Request ID: req-123. Status: completed. Result: {
+            text: "Peer terminal response from analyst-rt\nRequest ID: req-123\nStatus: completed\nPayload: {
   \"request_intent\": \"checksum_token\",
   \"request_subject\": \"alpha beta gamma\",
   \"token\": \"birch seventeen\"
-}."
+}"
             .to_string(),
             source: Some("peer_response_terminal:analyst-rt:req-123".to_string()),
             idempotency_key: Some("req-123".to_string()),
@@ -4653,7 +4652,7 @@ mod tests {
             "expected waiting-state override guidance: {instructions}"
         );
         assert!(
-            instructions.contains("[SYSTEM NOTICE][PEER_RESPONSE_TERMINAL]"),
+            instructions.contains("Peer terminal response from analyst-rt"),
             "expected raw terminal runtime fact to remain visible: {instructions}"
         );
     }
@@ -4673,7 +4672,7 @@ mod tests {
             }),
         ];
         let runtime_system_context = vec![PendingSystemContextAppend {
-            text: "[SYSTEM NOTICE][PEER_RESPONSE_TERMINAL] Correlated peer response from analyst-rt. Request ID: req-123. Status: completed. Result: {\"request_intent\":\"checksum_token\",\"request_subject\":\"alpha beta gamma\",\"token\":\"birch seventeen\"}.".to_string(),
+            text: "Peer terminal response from analyst-rt\nRequest ID: req-123\nStatus: completed\nPayload: {\"request_intent\":\"checksum_token\",\"request_subject\":\"alpha beta gamma\",\"token\":\"birch seventeen\"}".to_string(),
             source: Some("peer_response_terminal:analyst-rt:req-123".to_string()),
             idempotency_key: Some("req-123".to_string()),
             accepted_at: meerkat_core::time_compat::SystemTime::UNIX_EPOCH,
@@ -4761,7 +4760,7 @@ mod tests {
                 "You are the realtime operator.".to_string(),
             )),
             Message::System(meerkat_core::SystemMessage::new(
-                "[Runtime System Context]\nsource: peer_response_terminal:analyst-rt:req-123\n\n[SYSTEM NOTICE][PEER_RESPONSE_TERMINAL] Correlated peer response from analyst-rt. Request ID: req-123. Status: completed. Result: {\n  \"request_intent\": \"checksum_token\",\n  \"token\": \"birch seventeen\"\n}.",
+                "[Runtime System Context]\nsource: peer_response_terminal:analyst-rt:req-123\n\nPeer terminal response from analyst-rt\nRequest ID: req-123\nStatus: completed\nPayload: {\n  \"request_intent\": \"checksum_token\",\n  \"token\": \"birch seventeen\"\n}",
             )),
             Message::User(meerkat_core::UserMessage::text("hello")),
             Message::Assistant(meerkat_core::AssistantMessage {
@@ -4791,7 +4790,7 @@ mod tests {
             },
         ];
         let runtime_system_context = vec![PendingSystemContextAppend {
-            text: "[SYSTEM NOTICE][PEER_RESPONSE_TERMINAL] Correlated peer response from analyst-rt. Request ID: req-123. Status: completed. Result: {\n  \"request_intent\": \"checksum_token\",\n  \"token\": \"birch seventeen\"\n}.".to_string(),
+            text: "Peer terminal response from analyst-rt\nRequest ID: req-123\nStatus: completed\nPayload: {\n  \"request_intent\": \"checksum_token\",\n  \"token\": \"birch seventeen\"\n}".to_string(),
             source: Some("peer_response_terminal:analyst-rt:req-123".to_string()),
             idempotency_key: Some("req-123".to_string()),
             accepted_at: meerkat_core::time_compat::SystemTime::UNIX_EPOCH,

--- a/meerkat-openai/src/text_adapter.rs
+++ b/meerkat-openai/src/text_adapter.rs
@@ -453,7 +453,7 @@ fn convert_messages(messages: &[Message]) -> Result<(Option<String>, Vec<Item>),
                 }
             }
             Message::SystemNotice(notice) => {
-                let rendered = notice.rendered_text();
+                let rendered = notice.model_projection_text();
                 if !rendered.trim().is_empty() {
                     items.push(Item::Message {
                         id: None,

--- a/meerkat-rest/src/lib.rs
+++ b/meerkat-rest/src/lib.rs
@@ -941,6 +941,14 @@ fn render_context_append_text(content: &CoreRenderable) -> String {
             Some(label) if !label.trim().is_empty() => format!("[Reference] {label} ({uri})"),
             _ => format!("[Reference] {uri}"),
         },
+        CoreRenderable::SystemNotice { kind, body, blocks } => {
+            meerkat_core::types::SystemNoticeMessage::with_blocks(
+                *kind,
+                body.clone(),
+                blocks.clone(),
+            )
+            .model_projection_text()
+        }
         _ => String::new(),
     }
 }
@@ -1289,6 +1297,7 @@ async fn apply_runtime_turn(
         session_id.clone(),
         false,
     );
+    let typed_turn_appends = primitive.typed_turn_appends();
     let pre_turn_context_appends = match primitive {
         RunPrimitive::StagedInput(staged)
             if primitive.is_peer_response_terminal_context_and_run() =>
@@ -1336,7 +1345,8 @@ async fn apply_runtime_turn(
                 .and_then(|meta| meta.flow_tool_overlay.clone()),
             pre_turn_context_appends.clone(),
             primitive.turn_metadata().cloned(),
-        ),
+        )
+        .with_typed_turn_appends(typed_turn_appends.clone()),
     };
 
     let session_identity = context
@@ -1531,7 +1541,8 @@ async fn apply_runtime_turn(
                                 .and_then(|meta| meta.flow_tool_overlay.clone()),
                             pre_turn_context_appends,
                             primitive.turn_metadata().cloned(),
-                        ),
+                        )
+                        .with_typed_turn_appends(typed_turn_appends),
                     },
                     boundary,
                     contributing_input_ids,
@@ -6423,6 +6434,36 @@ mod tests {
             meerkat_contracts::PeerResponseTerminalStatusWire::Completed
         );
         assert_eq!(body.result["ok"], true);
+    }
+
+    #[test]
+    fn rest_context_system_notice_projects_via_typed_notice() {
+        let blocks = vec![meerkat_core::types::SystemNoticeBlock::Comms {
+            kind: "response_terminal".to_string(),
+            direction: meerkat_core::types::SystemNoticeDirection::Incoming,
+            peer: None,
+            request_id: Some("req-1".to_string()),
+            intent: Some("checksum_token".to_string()),
+            status: Some("completed".to_string()),
+            summary: Some("Peer terminal response".to_string()),
+            payload: None,
+            content: Vec::new(),
+        }];
+        let content = CoreRenderable::SystemNotice {
+            kind: meerkat_core::types::SystemNoticeKind::Comms,
+            body: Some("Peer terminal response context".to_string()),
+            blocks: blocks.clone(),
+        };
+
+        assert_eq!(
+            render_context_append_text(&content),
+            meerkat_core::types::SystemNoticeMessage::with_blocks(
+                meerkat_core::types::SystemNoticeKind::Comms,
+                Some("Peer terminal response context".to_string()),
+                blocks,
+            )
+            .model_projection_text()
+        );
     }
 
     #[test]

--- a/meerkat-rpc/src/handlers/live.rs
+++ b/meerkat-rpc/src/handlers/live.rs
@@ -65,15 +65,15 @@ const LIVE_WS_DEFAULT_AUDIO_FORMAT: &str = "pcm_24k_mono";
 /// returns `Some` (i.e. the session has a resolved root system prompt or
 /// build instructions). When that returns `None`, the original first
 /// message is left in place — and the canonical session transcript can
-/// legitimately lead with a `Message::SystemNotice` (e.g. a runtime-injected
-/// `[SYSTEM NOTICE][MCP_PENDING]` notice from an idle pre-prompt session).
+/// legitimately lead with a `Message::SystemNotice` (e.g. a typed MCP-pending
+/// notice from an idle pre-prompt session).
 /// Without honoring `SystemNotice` here, a refresh whose snapshot leads
 /// with one would silently emit empty instructions and wipe whatever the
 /// realtime provider had in its session-level `instructions` field.
 ///
-/// We use `SystemNoticeMessage::rendered_text()` (the same projection the
-/// session_runtime root-system-message helper uses on line 405) so the
-/// provider sees the prefix-tagged form, not the raw body.
+/// We use `SystemNoticeMessage::model_projection_text()` so the provider sees
+/// the internal projection without making rendered prose part of the transcript
+/// contract.
 ///
 /// We deliberately consult only `seed_messages[0]` (matching the projector's
 /// invariant) and ignore any later `Message::System` / `Message::SystemNotice`
@@ -81,7 +81,7 @@ const LIVE_WS_DEFAULT_AUDIO_FORMAT: &str = "pcm_24k_mono";
 fn extract_system_prompt_from_seed_messages(seed_messages: &[Message]) -> Option<String> {
     match seed_messages.first()? {
         Message::System(system) => Some(system.content.clone()),
-        Message::SystemNotice(notice) => Some(notice.rendered_text()),
+        Message::SystemNotice(notice) => Some(notice.model_projection_text()),
         _ => None,
     }
 }
@@ -1035,11 +1035,11 @@ mod tests {
     }
 
     #[test]
-    fn extract_system_prompt_returns_rendered_text_for_first_system_notice() {
+    fn extract_system_prompt_returns_model_projection_for_first_system_notice() {
         // R10 (review-3 follow-up): when the canonical projection leaves a
         // `Message::SystemNotice` at index 0 of the seed history (e.g. a
         // pre-prompt session whose only lead message is a runtime-injected
-        // `[SYSTEM NOTICE][MCP_PENDING]` notice — `realtime_projection_messages`
+        // typed MCP-pending notice — `realtime_projection_messages`
         // in `session_runtime.rs:435-444` does NOT rewrite the slot when
         // `realtime_projection_root_system_message` returns `None`), the
         // snapshot builder must surface the notice's *rendered* text as the
@@ -1047,13 +1047,13 @@ mod tests {
         // `session.update` rebuilds instructions only from
         // `runtime_system_context` and silently wipes whatever instructions
         // the realtime provider already had at session level. We use
-        // `rendered_text()` (prefix-tagged) to match the projection the
-        // session_runtime root-system helper itself emits on line 405.
+        // `model_projection_text()` to match the provider-facing projection
+        // without persisting prefix prose as transcript content.
         use meerkat_core::types::{Message, SystemNoticeKind, SystemNoticeMessage};
 
         let notice =
             SystemNoticeMessage::new(SystemNoticeKind::McpPending, "stub server connecting");
-        let expected = notice.rendered_text();
+        let expected = notice.model_projection_text();
         let messages = vec![
             Message::SystemNotice(notice),
             Message::User(meerkat_core::types::UserMessage::text("hi".to_string())),

--- a/meerkat-rpc/src/session_executor.rs
+++ b/meerkat-rpc/src/session_executor.rs
@@ -209,7 +209,53 @@ fn render_context_append_text(content: &CoreRenderable) -> String {
             Some(label) if !label.trim().is_empty() => format!("[Reference] {label} ({uri})"),
             _ => format!("[Reference] {uri}"),
         },
+        CoreRenderable::SystemNotice { kind, body, blocks } => {
+            meerkat_core::types::SystemNoticeMessage::with_blocks(
+                *kind,
+                body.clone(),
+                blocks.clone(),
+            )
+            .model_projection_text()
+        }
         _ => String::new(),
+    }
+}
+
+#[cfg(test)]
+mod typed_context_append_tests {
+    use super::*;
+    use meerkat_core::types::{
+        SystemNoticeBlock, SystemNoticeDirection, SystemNoticeKind, SystemNoticeMessage,
+    };
+
+    #[test]
+    fn context_system_notice_projects_only_via_notice_projection() {
+        let blocks = vec![SystemNoticeBlock::Comms {
+            kind: "response_terminal".to_string(),
+            direction: SystemNoticeDirection::Incoming,
+            peer: None,
+            request_id: Some("req-1".to_string()),
+            intent: Some("checksum_token".to_string()),
+            status: Some("completed".to_string()),
+            summary: Some("Peer terminal response".to_string()),
+            payload: None,
+            content: Vec::new(),
+        }];
+        let content = CoreRenderable::SystemNotice {
+            kind: SystemNoticeKind::Comms,
+            body: Some("Peer terminal response context".to_string()),
+            blocks: blocks.clone(),
+        };
+
+        assert_eq!(
+            render_context_append_text(&content),
+            SystemNoticeMessage::with_blocks(
+                SystemNoticeKind::Comms,
+                Some("Peer terminal response context".to_string()),
+                blocks,
+            )
+            .model_projection_text()
+        );
     }
 }
 
@@ -526,7 +572,8 @@ impl CoreExecutor for MobRpcRuntimeExecutor {
                         flow_tool_overlay,
                         pre_turn_context_appends,
                         turn_metadata,
-                    ),
+                    )
+                    .with_typed_turn_appends(primitive.typed_turn_appends()),
                 };
                 self.session_service
                     .apply_runtime_turn(

--- a/meerkat-rpc/src/session_runtime.rs
+++ b/meerkat-rpc/src/session_runtime.rs
@@ -3803,7 +3803,7 @@ impl SessionRuntime {
 
     fn live_text_from_runtime_primitive(primitive: &RunPrimitive) -> Option<String> {
         let mut parts = Vec::new();
-        let prompt = primitive.extract_content_input().text_content();
+        let prompt = primitive.model_projection_content_input().text_content();
         if !prompt.trim().is_empty() {
             parts.push(prompt);
         }

--- a/meerkat-rpc/src/session_runtime.rs
+++ b/meerkat-rpc/src/session_runtime.rs
@@ -4974,7 +4974,8 @@ impl SessionRuntime {
                     flow_tool_overlay.clone(),
                     pre_turn_context_appends.clone(),
                     primitive.turn_metadata().cloned(),
-                ),
+                )
+                .with_typed_turn_appends(primitive.typed_turn_appends()),
             };
 
             let result_rx = self.spawn_service_apply_runtime_turn_with_recoverable_admission_guard(
@@ -5154,7 +5155,8 @@ impl SessionRuntime {
                         flow_tool_overlay,
                         pre_turn_context_appends.clone(),
                         primitive.turn_metadata().cloned(),
-                    ),
+                    )
+                    .with_typed_turn_appends(primitive.typed_turn_appends()),
                 },
                 match primitive {
                     RunPrimitive::StagedInput(staged) => staged.boundary,
@@ -5205,7 +5207,8 @@ impl SessionRuntime {
                     flow_tool_overlay,
                     pre_turn_context_appends,
                     primitive.turn_metadata().cloned(),
-                ),
+                )
+                .with_typed_turn_appends(primitive.typed_turn_appends()),
             },
             match primitive {
                 RunPrimitive::StagedInput(staged) => staged.boundary,
@@ -7593,22 +7596,22 @@ mod tests {
     use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering as AtomicOrdering};
 
     #[test]
-    fn extract_system_prompt_runtime_returns_rendered_text_for_first_system_notice() {
+    fn extract_system_prompt_runtime_returns_model_projection_for_first_system_notice() {
         // R10 (review-3 follow-up): the runtime-side extractor must accept a
         // leading `Message::SystemNotice` because
         // `realtime_projection_messages` (lines 435-444 in this file) only
         // rewrites `seed_messages[0]` when the root-system helper returns
         // `Some`; sessions whose only lead is a runtime-injected
         // `SystemNotice` (e.g. an idle pre-prompt session with an
-        // `[MCP_PENDING]` notice) would otherwise see refresh `session.update`
+        // typed MCP-pending notice) would otherwise see refresh `session.update`
         // wipe the provider's instructions to empty. We surface
-        // `rendered_text()` (prefix-tagged) to match what the agent loop
-        // would project at line 405.
+        // `model_projection_text()` to match the provider-visible projection
+        // without reviving prefix prose as transcript contract.
         use meerkat_core::types::{Message, SystemNoticeKind, SystemNoticeMessage, UserMessage};
 
         let notice =
             SystemNoticeMessage::new(SystemNoticeKind::McpPending, "stub server connecting");
-        let expected = notice.rendered_text();
+        let expected = notice.model_projection_text();
         let messages = vec![
             Message::SystemNotice(notice),
             Message::User(UserMessage::text("hi".to_string())),

--- a/meerkat-runtime/src/coalescing.rs
+++ b/meerkat-runtime/src/coalescing.rs
@@ -207,6 +207,7 @@ mod tests {
             header: make_header_with_supersession(None),
             text: "hello".into(),
             blocks: None,
+            typed_turn_appends: Vec::new(),
             turn_metadata: None,
         });
         assert!(!is_coalescing_eligible(&input));
@@ -310,6 +311,7 @@ mod tests {
             header: make_header_with_supersession(Some("same-key")),
             text: "hello".into(),
             blocks: None,
+            typed_turn_appends: Vec::new(),
             turn_metadata: None,
         });
         let result = check_supersession(&input2, &input1, &runtime);

--- a/meerkat-runtime/src/comms_bridge.rs
+++ b/meerkat-runtime/src/comms_bridge.rs
@@ -226,6 +226,9 @@ fn map_response_convention(
 }
 
 fn peer_rendered_body(interaction: &InboxInteraction) -> String {
+    if !interaction.rendered_text.trim().is_empty() {
+        return interaction.rendered_text.clone();
+    }
     match &interaction.content {
         InteractionContent::Message { body, .. } => body.clone(),
         InteractionContent::Request { params, .. } => {
@@ -519,7 +522,7 @@ mod tests {
             panic!("Expected peer source");
         };
         assert_eq!(peer_id, "11111111-1111-4111-8111-111111111111");
-        assert_eq!(peer.body, "{\"description\":\"tower with a light\"}");
+        assert_eq!(peer.body, "stale helper prose");
 
         let prompt = crate::input::input_prompt_text(&input);
         assert!(prompt.starts_with(
@@ -601,7 +604,7 @@ mod tests {
                 .expect("classified peer event should project to peer input");
         match input {
             Input::Peer(peer) => {
-                assert_eq!(peer.body, "hello");
+                assert_eq!(peer.body, "stale rendered text");
                 match peer.header.source {
                     InputOrigin::Peer { peer_id, .. } => {
                         assert_eq!(peer_id, test_peer_id().as_str());
@@ -662,7 +665,7 @@ mod tests {
             }
             other => panic!("Expected peer source, got {other:?}"),
         }
-        assert_eq!(peer.body, "{\"pr\":42}");
+        assert_eq!(peer.body, "stale rendered text");
     }
 
     #[test]
@@ -706,7 +709,7 @@ mod tests {
     }
 
     #[test]
-    fn request_body_uses_structured_payload_and_ignores_rendered_text() {
+    fn request_body_preserves_rendered_text_and_structured_payload() {
         let interaction = InboxInteraction {
             from_route: None,
             from: "event:webhook".into(),
@@ -722,7 +725,7 @@ mod tests {
         };
         let input = peer_input_for_test(&interaction, &LogicalRuntimeId::new("test"));
         if let Input::Peer(peer) = input {
-            assert_eq!(peer.body, "{\"peer\":\"agent-1\"}");
+            assert_eq!(peer.body, "stale rendered text");
             assert_eq!(peer.payload, Some(serde_json::json!({"peer":"agent-1"})));
         } else {
             panic!("Expected PeerInput");
@@ -754,7 +757,7 @@ mod tests {
         };
         let input = peer_input_for_test(&interaction, &LogicalRuntimeId::new("test"));
         if let Input::Peer(peer) = input {
-            assert_eq!(peer.body, "see image");
+            assert_eq!(peer.body, "stale rendered text");
             assert_eq!(peer.blocks, Some(blocks));
         } else {
             panic!("Expected PeerInput");
@@ -847,7 +850,7 @@ mod tests {
         };
         let input = peer_input_for_test(&interaction, &LogicalRuntimeId::new("test"));
         if let Input::Peer(peer) = input {
-            assert_eq!(peer.body, "please inspect this image");
+            assert_eq!(peer.body, "stale rendered text");
         } else {
             panic!("Expected PeerInput");
         }

--- a/meerkat-runtime/src/comms_bridge.rs
+++ b/meerkat-runtime/src/comms_bridge.rs
@@ -226,14 +226,6 @@ fn map_response_convention(
 }
 
 fn peer_rendered_body(interaction: &InboxInteraction) -> String {
-    // For every content kind, prefer the comms-owned `rendered_text`
-    // projection when present: it already carries the authoritative
-    // `[from]: <kind>` framing that later prompt-rendering relies on
-    // (see `peer_prompt_text`). Fall back to the content-specific
-    // serialization only when rendered_text is empty.
-    if !interaction.rendered_text.is_empty() {
-        return interaction.rendered_text.clone();
-    }
     match &interaction.content {
         InteractionContent::Message { body, .. } => body.clone(),
         InteractionContent::Request { params, .. } => {
@@ -495,7 +487,7 @@ mod tests {
                     blocks: None,
                 },
                 id: request_id,
-                rendered_text: "[COMMS REQUEST stale helper prose]".into(),
+                rendered_text: "stale helper prose".into(),
                 handling_mode: meerkat_core::types::HandlingMode::Steer,
                 render_metadata: None,
             },
@@ -527,11 +519,11 @@ mod tests {
             panic!("Expected peer source");
         };
         assert_eq!(peer_id, "11111111-1111-4111-8111-111111111111");
-        assert_eq!(peer.body, "[COMMS REQUEST stale helper prose]");
+        assert_eq!(peer.body, "{\"description\":\"tower with a light\"}");
 
         let prompt = crate::input::input_prompt_text(&input);
         assert!(prompt.starts_with(
-            "[SYSTEM NOTICE][PEER_REQUEST] Correlated peer request from peer_id 11111111-1111-4111-8111-111111111111 (display_name: test-mob/lead/l-requester)."
+            "Peer request from peer_id 11111111-1111-4111-8111-111111111111 (display_name: test-mob/lead/l-requester)."
         ));
         assert!(prompt.contains("\"peer_id\":\"11111111-1111-4111-8111-111111111111\""));
         assert!(prompt.contains("\"display_name\":\"test-mob/lead/l-requester\""));
@@ -599,7 +591,7 @@ mod tests {
                     blocks: None,
                 },
                 id,
-                rendered_text: "[COMMS MESSAGE from event:webhook]\nhello".into(),
+                rendered_text: "stale rendered text".into(),
                 handling_mode: meerkat_core::types::HandlingMode::Queue,
                 render_metadata: None,
             },
@@ -609,7 +601,7 @@ mod tests {
                 .expect("classified peer event should project to peer input");
         match input {
             Input::Peer(peer) => {
-                assert_eq!(peer.body, "[COMMS MESSAGE from event:webhook]\nhello");
+                assert_eq!(peer.body, "hello");
                 match peer.header.source {
                     InputOrigin::Peer { peer_id, .. } => {
                         assert_eq!(peer_id, test_peer_id().as_str());
@@ -651,7 +643,7 @@ mod tests {
                     blocks: None,
                 },
                 id,
-                rendered_text: "[COMMS REQUEST from display-agent]".into(),
+                rendered_text: "stale rendered text".into(),
                 handling_mode: meerkat_core::types::HandlingMode::Queue,
                 render_metadata: None,
             },
@@ -670,7 +662,7 @@ mod tests {
             }
             other => panic!("Expected peer source, got {other:?}"),
         }
-        assert_eq!(peer.body, "[COMMS REQUEST from display-agent]");
+        assert_eq!(peer.body, "{\"pr\":42}");
     }
 
     #[test]
@@ -695,7 +687,7 @@ mod tests {
                     blocks: None,
                 },
                 id,
-                rendered_text: "[COMMS MESSAGE from display-agent]\nhello".into(),
+                rendered_text: "stale rendered text".into(),
                 handling_mode: meerkat_core::types::HandlingMode::Queue,
                 render_metadata: None,
             },
@@ -714,12 +706,7 @@ mod tests {
     }
 
     #[test]
-    fn request_body_prefers_rendered_text_and_preserves_structured_payload() {
-        // Comms-owned `rendered_text` is the authoritative projection for
-        // request/response conventions too (not just messages): it carries
-        // the `[COMMS REQUEST ...]` framing downstream prompt rendering
-        // relies on. The structured JSON still flows through `payload` for
-        // consumers that need the raw params.
+    fn request_body_uses_structured_payload_and_ignores_rendered_text() {
         let interaction = InboxInteraction {
             from_route: None,
             from: "event:webhook".into(),
@@ -729,17 +716,13 @@ mod tests {
                 blocks: None,
             },
             id: make_interaction_id(),
-            rendered_text: "[COMMS REQUEST from event:webhook (id: req)]\nIntent: mob.peer_added"
-                .into(),
+            rendered_text: "stale rendered text".into(),
             handling_mode: meerkat_core::types::HandlingMode::Queue,
             render_metadata: None,
         };
         let input = peer_input_for_test(&interaction, &LogicalRuntimeId::new("test"));
         if let Input::Peer(peer) = input {
-            assert_eq!(
-                peer.body,
-                "[COMMS REQUEST from event:webhook (id: req)]\nIntent: mob.peer_added"
-            );
+            assert_eq!(peer.body, "{\"peer\":\"agent-1\"}");
             assert_eq!(peer.payload, Some(serde_json::json!({"peer":"agent-1"})));
         } else {
             panic!("Expected PeerInput");
@@ -765,13 +748,13 @@ mod tests {
                 blocks: Some(blocks.clone()),
             },
             id: make_interaction_id(),
-            rendered_text: "[COMMS MESSAGE from peer-1]\nsee image".into(),
+            rendered_text: "stale rendered text".into(),
             handling_mode: meerkat_core::types::HandlingMode::Queue,
             render_metadata: None,
         };
         let input = peer_input_for_test(&interaction, &LogicalRuntimeId::new("test"));
         if let Input::Peer(peer) = input {
-            assert_eq!(peer.body, "[COMMS MESSAGE from peer-1]\nsee image");
+            assert_eq!(peer.body, "see image");
             assert_eq!(peer.blocks, Some(blocks));
         } else {
             panic!("Expected PeerInput");
@@ -858,16 +841,13 @@ mod tests {
                 blocks: Some(blocks),
             },
             id: make_interaction_id(),
-            rendered_text: "[COMMS MESSAGE from peer-1]\ncaption text\n[image: image/png]".into(),
+            rendered_text: "stale rendered text".into(),
             handling_mode: meerkat_core::types::HandlingMode::Queue,
             render_metadata: None,
         };
         let input = peer_input_for_test(&interaction, &LogicalRuntimeId::new("test"));
         if let Input::Peer(peer) = input {
-            assert_eq!(
-                peer.body,
-                "[COMMS MESSAGE from peer-1]\ncaption text\n[image: image/png]"
-            );
+            assert_eq!(peer.body, "please inspect this image");
         } else {
             panic!("Expected PeerInput");
         }
@@ -897,7 +877,7 @@ mod tests {
                     blocks: Some(blocks.clone()),
                 },
                 id,
-                rendered_text: "[EVENT via webhook] see image".into(),
+                rendered_text: "stale rendered text".into(),
                 handling_mode: meerkat_core::types::HandlingMode::Queue,
                 render_metadata: None,
             },
@@ -939,7 +919,7 @@ mod tests {
                     blocks: None,
                 },
                 id,
-                rendered_text: "[EVENT via webhook] urgent".into(),
+                rendered_text: "stale rendered text".into(),
                 handling_mode: meerkat_core::types::HandlingMode::Steer,
                 render_metadata: Some(render_metadata.clone()),
             },
@@ -1014,14 +994,16 @@ mod tests {
             .expect("terminal machine-batch context projection");
         let expected_key = format!("peer_response_terminal:{route_id}:{in_reply_to}");
         assert_eq!(context.key, expected_key);
-        let meerkat_core::lifecycle::run_primitive::CoreRenderable::Text { text } = context.content
+        let meerkat_core::lifecycle::run_primitive::CoreRenderable::SystemNotice { blocks, .. } =
+            context.content
         else {
-            panic!("Expected terminal context text");
+            panic!("Expected terminal context notice");
         };
-        assert!(
-            text.contains("from Peer One"),
-            "terminal prompt should use display identity: {text}",
-        );
+        assert!(matches!(
+            blocks.first(),
+            Some(meerkat_core::types::SystemNoticeBlock::Comms { peer, .. })
+                if peer.as_ref().and_then(|peer| peer.display_name.as_deref()) == Some("Peer One")
+        ));
     }
 
     #[test]

--- a/meerkat-runtime/src/durability.rs
+++ b/meerkat-runtime/src/durability.rs
@@ -101,6 +101,7 @@ mod tests {
             header: make_header(InputDurability::Derived, InputOrigin::System),
             text: "hi".into(),
             blocks: None,
+            typed_turn_appends: Vec::new(),
             turn_metadata: None,
         });
         assert!(validate_durability(&input).is_err());
@@ -112,6 +113,7 @@ mod tests {
             header: make_header(InputDurability::Durable, InputOrigin::Operator),
             text: "hi".into(),
             blocks: None,
+            typed_turn_appends: Vec::new(),
             turn_metadata: None,
         });
         assert!(validate_durability(&input).is_ok());
@@ -123,6 +125,7 @@ mod tests {
             header: make_header(InputDurability::Ephemeral, InputOrigin::Operator),
             text: "hi".into(),
             blocks: None,
+            typed_turn_appends: Vec::new(),
             turn_metadata: None,
         });
         assert!(validate_durability(&input).is_ok());

--- a/meerkat-runtime/src/ingress_types.rs
+++ b/meerkat-runtime/src/ingress_types.rs
@@ -89,6 +89,7 @@ pub struct RuntimeInputSemantics {
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct RuntimeInputProjection {
     pub append: Option<ConversationAppend>,
+    pub additional_appends: Vec<ConversationAppend>,
     pub context_append: Option<ConversationContextAppend>,
 }
 

--- a/meerkat-runtime/src/input.rs
+++ b/meerkat-runtime/src/input.rs
@@ -11,7 +11,9 @@ use meerkat_core::lifecycle::run_primitive::{
     RuntimeTurnMetadata,
 };
 use meerkat_core::ops::{OpEvent, OperationId};
-use meerkat_core::types::HandlingMode;
+use meerkat_core::types::{
+    HandlingMode, SystemNoticeBlock, SystemNoticeDirection, SystemNoticeKind, SystemNoticePeer,
+};
 use meerkat_core::{
     BlobStore, BlobStoreError, MissingBlobBehavior, PeerConversationProjection,
     PeerResponseProgressProjectionPhase, PeerResponseTerminalCorrelationId,
@@ -683,76 +685,6 @@ pub(crate) fn peer_prompt_text(peer: &PeerInput) -> String {
         .unwrap_or_else(|| peer.body.clone())
 }
 
-/// Optional block prefix for peer message inputs.
-pub(crate) fn peer_block_prefix_text(peer: &PeerInput) -> Option<String> {
-    if matches!(
-        peer.convention,
-        Some(PeerConvention::ResponseTerminal { .. })
-    ) && let Ok(Some(fact)) = peer_response_terminal_fact(peer)
-    {
-        return Some(fact.prompt_text());
-    }
-
-    if matches!(peer.convention, Some(PeerConvention::Message))
-        && let Some(prefix) = rendered_message_prefix(&peer.body)
-    {
-        return Some(prefix);
-    }
-
-    peer_projection_from_peer_input(peer).and_then(|projection| projection.block_prefix_text())
-}
-
-fn rendered_message_prefix(body: &str) -> Option<String> {
-    let prefix = body.lines().next()?.trim();
-    if prefix.starts_with("[COMMS MESSAGE from ") && prefix.ends_with(']') {
-        Some(prefix.to_string())
-    } else {
-        None
-    }
-}
-
-fn rendered_message_body_text(body: &str, prefix: &str) -> Option<String> {
-    let text = body
-        .lines()
-        .skip_while(|line| line.trim() != prefix)
-        .skip(1)
-        .map(str::trim)
-        .filter(|line| !line.is_empty() && !is_media_projection_line(line))
-        .collect::<Vec<_>>()
-        .join("\n");
-    if text.is_empty() { None } else { Some(text) }
-}
-
-fn is_media_projection_line(line: &str) -> bool {
-    (line.starts_with("[image:") || line.starts_with("[video:")) && line.ends_with(']')
-}
-
-fn blocks_include_text_projection(
-    blocks: &[meerkat_core::types::ContentBlock],
-    expected: &str,
-) -> bool {
-    let expected = expected.trim();
-    if expected.is_empty() {
-        return true;
-    }
-    if blocks
-        .iter()
-        .any(|block| matches!(block, meerkat_core::types::ContentBlock::Text { text } if text.trim() == expected))
-    {
-        return true;
-    }
-    let joined = blocks
-        .iter()
-        .filter_map(|block| match block {
-            meerkat_core::types::ContentBlock::Text { text } => Some(text.trim()),
-            _ => None,
-        })
-        .filter(|text| !text.is_empty())
-        .collect::<Vec<_>>()
-        .join("\n");
-    joined == expected
-}
-
 pub(crate) fn input_prompt_text(input: &Input) -> String {
     match input {
         Input::Prompt(p) => p.text.clone(),
@@ -785,6 +717,117 @@ fn external_event_projection_text(event: &ExternalEventInput) -> String {
     meerkat_core::interaction::format_external_event_projection(source_name, body)
 }
 
+fn peer_notice_renderable(peer: &PeerInput) -> Option<CoreRenderable> {
+    let (peer_id, display_name) = match &peer.header.source {
+        InputOrigin::Peer {
+            peer_id,
+            display_identity,
+            ..
+        } => (peer_id.clone(), display_identity.clone()),
+        _ => return None,
+    };
+    let (kind, request_id, intent, status) = match &peer.convention {
+        Some(PeerConvention::Message) | None => ("message", None, None, None),
+        Some(PeerConvention::Request { request_id, intent }) => (
+            "request",
+            Some(request_id.clone()),
+            Some(intent.clone()),
+            None,
+        ),
+        Some(PeerConvention::ResponseProgress { request_id, phase }) => (
+            "response_progress",
+            Some(request_id.clone()),
+            None,
+            Some(format!("{phase:?}")),
+        ),
+        Some(PeerConvention::ResponseTerminal { request_id, status }) => (
+            "response_terminal",
+            Some(request_id.clone()),
+            None,
+            Some(format!("{status:?}")),
+        ),
+    };
+    let summary = match kind {
+        "request" => intent.as_ref().map_or_else(
+            || "Peer request".to_string(),
+            |intent| format!("Peer request: {intent}"),
+        ),
+        "response_progress" => "Peer response progress".to_string(),
+        "response_terminal" => "Peer response terminal".to_string(),
+        _ => "Peer message".to_string(),
+    };
+    let content = if let Some(blocks) = peer.blocks.clone() {
+        let body_already_in_blocks = blocks.iter().any(|block| {
+            matches!(block, meerkat_core::types::ContentBlock::Text { text } if text.trim() == peer.body.trim())
+        });
+        if peer.body.trim().is_empty() || body_already_in_blocks {
+            blocks
+        } else {
+            let mut content = vec![meerkat_core::types::ContentBlock::Text {
+                text: peer.body.clone(),
+            }];
+            content.extend(blocks);
+            content
+        }
+    } else if peer.body.is_empty() {
+        Vec::new()
+    } else {
+        vec![meerkat_core::types::ContentBlock::Text {
+            text: peer.body.clone(),
+        }]
+    };
+    Some(CoreRenderable::SystemNotice {
+        kind: SystemNoticeKind::Comms,
+        body: Some(summary.clone()),
+        blocks: vec![SystemNoticeBlock::Comms {
+            kind: kind.to_string(),
+            direction: SystemNoticeDirection::Incoming,
+            peer: Some(SystemNoticePeer {
+                id: peer_id,
+                display_name,
+            }),
+            request_id,
+            intent,
+            status,
+            summary: Some(summary),
+            payload: peer.payload.clone(),
+            content,
+        }],
+    })
+}
+
+fn external_event_notice_renderable(event: &ExternalEventInput) -> CoreRenderable {
+    let source = match &event.header.source {
+        InputOrigin::External { source_name } if !source_name.trim().is_empty() => {
+            source_name.clone()
+        }
+        _ => event.event_type.clone(),
+    };
+    let body = event
+        .payload
+        .get("body")
+        .and_then(serde_json::Value::as_str)
+        .map(str::trim)
+        .filter(|body| !body.is_empty())
+        .map(ToOwned::to_owned);
+    let summary = body.as_ref().map_or_else(
+        || format!("External event via {source}"),
+        |body| body.clone(),
+    );
+    CoreRenderable::SystemNotice {
+        kind: SystemNoticeKind::ExternalEvent,
+        body: Some(summary.clone()),
+        blocks: vec![SystemNoticeBlock::ExternalEvent {
+            source,
+            event_type: event.event_type.clone(),
+            summary: Some(summary),
+            body,
+            payload: Some(event.payload.clone()),
+            content: event.blocks.clone().unwrap_or_default(),
+        }],
+    }
+}
+
 fn input_to_append(input: &Input) -> Option<ConversationAppend> {
     if matches!(
         input,
@@ -797,69 +840,56 @@ fn input_to_append(input: &Input) -> Option<ConversationAppend> {
         return None;
     }
 
-    let content = match input {
-        Input::Prompt(p) if p.blocks.is_some() => CoreRenderable::Blocks {
-            blocks: p.blocks.clone().unwrap_or_default(),
-        },
-        Input::Peer(p) if p.blocks.is_some() => {
-            let raw_blocks = p.blocks.clone().unwrap_or_default();
-            if let Some(prefix) = peer_block_prefix_text(p) {
-                let mut blocks = vec![meerkat_core::types::ContentBlock::Text {
-                    text: prefix.clone(),
-                }];
-                if let Some(body_text) = rendered_message_body_text(&p.body, &prefix)
-                    && !blocks_include_text_projection(&raw_blocks, &body_text)
-                {
-                    blocks.push(meerkat_core::types::ContentBlock::Text { text: body_text });
-                }
-                blocks.extend(raw_blocks);
-                CoreRenderable::Blocks { blocks }
-            } else {
-                let body_already_in_blocks = raw_blocks.first().is_some_and(|b| {
-                    matches!(b, meerkat_core::types::ContentBlock::Text { text } if text == &p.body)
-                });
-                if p.body.is_empty() || body_already_in_blocks {
-                    CoreRenderable::Blocks { blocks: raw_blocks }
-                } else {
-                    let mut blocks = vec![meerkat_core::types::ContentBlock::Text {
-                        text: p.body.clone(),
-                    }];
-                    blocks.extend(raw_blocks);
-                    CoreRenderable::Blocks { blocks }
-                }
-            }
-        }
-        Input::FlowStep(f) if f.blocks.is_some() => CoreRenderable::Blocks {
-            blocks: f.blocks.clone().unwrap_or_default(),
-        },
-        Input::ExternalEvent(e) if e.blocks.is_some() => CoreRenderable::Blocks {
-            blocks: e.blocks.clone().unwrap_or_default(),
-        },
-        Input::Prompt(_) | Input::Peer(_) | Input::FlowStep(_) | Input::ExternalEvent(_) => {
+    let (role, content) = match input {
+        Input::Prompt(p) if p.blocks.is_some() => (
+            ConversationAppendRole::User,
+            CoreRenderable::Blocks {
+                blocks: p.blocks.clone().unwrap_or_default(),
+            },
+        ),
+        Input::Prompt(_) => (
+            ConversationAppendRole::User,
             CoreRenderable::Text {
                 text: input_prompt_text(input),
-            }
-        }
+            },
+        ),
+        Input::Peer(p) => peer_notice_renderable(p)
+            .map(|content| (ConversationAppendRole::SystemNotice, content))?,
+        Input::FlowStep(f) => (
+            ConversationAppendRole::SystemNotice,
+            CoreRenderable::SystemNotice {
+                kind: SystemNoticeKind::Generic,
+                body: Some(format!("Flow step {}", f.step_id)),
+                blocks: vec![SystemNoticeBlock::RuntimeNotice {
+                    category: "flow_step".to_string(),
+                    detail: Some(f.instructions.clone()),
+                    payload: None,
+                }],
+            },
+        ),
+        Input::ExternalEvent(e) => (
+            ConversationAppendRole::SystemNotice,
+            external_event_notice_renderable(e),
+        ),
         Input::Continuation(_) | Input::Operation(_) => return None,
     };
 
-    Some(ConversationAppend {
-        role: ConversationAppendRole::User,
-        content,
-    })
+    Some(ConversationAppend { role, content })
 }
 
 fn input_to_context_append(input: &Input) -> Option<ConversationContextAppend> {
-    let projection = match input {
-        Input::Peer(peer) => peer_projection_from_peer_input(peer)?,
+    let (projection, content) = match input {
+        Input::Peer(peer) => {
+            let projection = peer_projection_from_peer_input(peer)?;
+            let content = peer_notice_renderable(peer)?;
+            (projection, content)
+        }
         _ => return None,
     };
 
     Some(ConversationContextAppend {
         key: projection.context_key()?,
-        content: CoreRenderable::Text {
-            text: projection.prompt_text(),
-        },
+        content,
     })
 }
 
@@ -872,8 +902,30 @@ fn peer_response_terminal_context_append(
 
     Ok(Some(ConversationContextAppend {
         key: fact.context_key(),
-        content: CoreRenderable::Text {
-            text: fact.prompt_text(),
+        content: CoreRenderable::SystemNotice {
+            kind: SystemNoticeKind::Comms,
+            body: Some("Peer terminal response context".to_string()),
+            blocks: vec![SystemNoticeBlock::Comms {
+                kind: "response_terminal".to_string(),
+                direction: SystemNoticeDirection::Incoming,
+                peer: Some(SystemNoticePeer {
+                    id: fact.source.route_identity.to_string(),
+                    display_name: Some(fact.source.display_identity.to_string()),
+                }),
+                request_id: Some(fact.correlation_id.to_string()),
+                intent: None,
+                status: Some(
+                    match fact.status {
+                        PeerResponseTerminalProjectionStatus::Completed => "completed",
+                        PeerResponseTerminalProjectionStatus::Failed => "failed",
+                        PeerResponseTerminalProjectionStatus::Cancelled => "cancelled",
+                    }
+                    .to_string(),
+                ),
+                summary: Some("Peer terminal response".to_string()),
+                payload: fact.render_payload.as_ref().cloned(),
+                content: Vec::new(),
+            }],
         },
     }))
 }
@@ -949,7 +1001,7 @@ mod tests {
     }
 
     #[test]
-    fn peer_message_blocks_prefix_uses_rendered_display_label_not_canonical_origin() {
+    fn peer_message_blocks_preserve_typed_comms_content_without_prefix_injection() {
         let mut header = make_header();
         header.source = InputOrigin::Peer {
             peer_id: "canonical-peer-id".into(),
@@ -959,7 +1011,7 @@ mod tests {
         let input = Input::Peer(PeerInput {
             header,
             convention: Some(PeerConvention::Message),
-            body: "[COMMS MESSAGE from display-agent]\ncaption\n[image: image/png]".into(),
+            body: "caption".into(),
             payload: None,
             blocks: Some(vec![
                 meerkat_core::types::ContentBlock::Text {
@@ -980,21 +1032,29 @@ mod tests {
             peer_projection_from_peer_input(peer)
                 .and_then(|projection| projection.block_prefix_text())
                 .as_deref(),
-            Some("[COMMS MESSAGE from canonical-peer-id]")
+            Some("Peer message from canonical-peer-id")
         );
 
         let projection = runtime_input_projection(&input);
         let append = projection.append.expect("conversation append");
-        let CoreRenderable::Blocks { blocks } = append.content else {
-            panic!("expected multimodal blocks");
+        let CoreRenderable::SystemNotice { blocks, .. } = append.content else {
+            panic!("expected typed system notice");
+        };
+        let Some(meerkat_core::types::SystemNoticeBlock::Comms { content, peer, .. }) =
+            blocks.first()
+        else {
+            panic!("expected comms block");
         };
         assert_eq!(
-            blocks.first(),
+            peer.as_ref().and_then(|peer| peer.display_name.as_deref()),
+            Some("display-agent")
+        );
+        assert_eq!(
+            content.first(),
             Some(&meerkat_core::types::ContentBlock::Text {
-                text: "[COMMS MESSAGE from display-agent]".into()
+                text: "caption".into()
             })
         );
-        assert!(!meerkat_core::types::text_content(&blocks).contains("canonical-peer-id"));
     }
 
     #[test]
@@ -1036,11 +1096,18 @@ mod tests {
         let projection = runtime_input_projection_for_machine_batch(&input);
         let context = projection.context_append.expect("context append");
         assert_eq!(context.key, expected_canonical_key);
-        let CoreRenderable::Text { text } = context.content else {
-            panic!("expected text context");
+        let CoreRenderable::SystemNotice { blocks, .. } = context.content else {
+            panic!("expected typed context");
         };
-        assert!(text.contains("from display-agent"));
-        assert!(!text.contains(route_id));
+        let Some(meerkat_core::types::SystemNoticeBlock::Comms { peer, .. }) = blocks.first()
+        else {
+            panic!("expected comms block");
+        };
+        assert_eq!(
+            peer.as_ref().and_then(|peer| peer.display_name.as_deref()),
+            Some("display-agent")
+        );
+        assert_eq!(peer.as_ref().map(|peer| peer.id.as_str()), Some(route_id));
     }
 
     #[test]
@@ -1070,17 +1137,20 @@ mod tests {
 
         let projection = runtime_input_projection_for_machine_batch(&input);
         let append = projection.append.expect("conversation append");
-        let CoreRenderable::Blocks { blocks } = append.content else {
-            panic!("expected multimodal append");
+        let CoreRenderable::SystemNotice { blocks, .. } = append.content else {
+            panic!("expected typed append");
         };
+        let Some(meerkat_core::types::SystemNoticeBlock::Comms { content, peer, .. }) =
+            blocks.first()
+        else {
+            panic!("expected comms block");
+        };
+        assert_eq!(
+            peer.as_ref().and_then(|peer| peer.display_name.as_deref()),
+            Some("display-agent")
+        );
         assert!(matches!(
-            blocks.first(),
-            Some(meerkat_core::types::ContentBlock::Text { text })
-                if text.contains("[SYSTEM NOTICE][PEER_RESPONSE_TERMINAL]")
-                    && text.contains("from display-agent")
-        ));
-        assert!(matches!(
-            blocks.get(1),
+            content.first(),
             Some(meerkat_core::types::ContentBlock::Image { media_type, .. })
                 if media_type == "image/jpeg"
         ));

--- a/meerkat-runtime/src/input.rs
+++ b/meerkat-runtime/src/input.rs
@@ -812,7 +812,7 @@ fn external_event_notice_renderable(event: &ExternalEventInput) -> CoreRenderabl
         .map(ToOwned::to_owned);
     let summary = body.as_ref().map_or_else(
         || format!("External event via {source}"),
-        |body| body.clone(),
+        std::clone::Clone::clone,
     );
     CoreRenderable::SystemNotice {
         kind: SystemNoticeKind::ExternalEvent,

--- a/meerkat-runtime/src/input.rs
+++ b/meerkat-runtime/src/input.rs
@@ -277,6 +277,12 @@ pub struct PromptInput {
     /// text projection (backwards compat), and `blocks` carries the full content.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub blocks: Option<Vec<meerkat_core::types::ContentBlock>>,
+    /// Runtime-authored typed transcript appends that travel with this turn.
+    ///
+    /// These are not operator-authored prompt content. The runtime projects
+    /// them into model-facing text only when building the provider request.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub typed_turn_appends: Vec<ConversationAppend>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub turn_metadata: Option<RuntimeTurnMetadata>,
 }
@@ -297,6 +303,7 @@ impl PromptInput {
             },
             text: text.into(),
             blocks: None,
+            typed_turn_appends: Vec::new(),
             turn_metadata,
         }
     }
@@ -325,6 +332,7 @@ impl PromptInput {
             },
             text,
             blocks,
+            typed_turn_appends: Vec::new(),
             turn_metadata,
         }
     }
@@ -841,6 +849,13 @@ fn input_to_append(input: &Input) -> Option<ConversationAppend> {
     }
 
     let (role, content) = match input {
+        Input::Prompt(p)
+            if !p.typed_turn_appends.is_empty()
+                && p.text.trim().is_empty()
+                && p.blocks.as_ref().is_none_or(Vec::is_empty) =>
+        {
+            return None;
+        }
         Input::Prompt(p) if p.blocks.is_some() => (
             ConversationAppendRole::User,
             CoreRenderable::Blocks {
@@ -935,6 +950,10 @@ pub(crate) fn runtime_input_projection(
 ) -> crate::ingress_types::RuntimeInputProjection {
     crate::ingress_types::RuntimeInputProjection {
         append: input_to_append(input),
+        additional_appends: match input {
+            Input::Prompt(prompt) => prompt.typed_turn_appends.clone(),
+            _ => Vec::new(),
+        },
         context_append: input_to_context_append(input),
     }
 }
@@ -970,18 +989,73 @@ mod tests {
         }
     }
 
+    fn typed_runtime_notice_append(detail: &str) -> ConversationAppend {
+        ConversationAppend {
+            role: ConversationAppendRole::SystemNotice,
+            content: CoreRenderable::SystemNotice {
+                kind: meerkat_core::types::SystemNoticeKind::Generic,
+                body: Some(detail.to_string()),
+                blocks: vec![meerkat_core::types::SystemNoticeBlock::RuntimeNotice {
+                    category: "test".to_string(),
+                    detail: Some(detail.to_string()),
+                    payload: None,
+                }],
+            },
+        }
+    }
+
     #[test]
     fn prompt_input_serde() {
         let input = Input::Prompt(PromptInput {
             header: make_header(),
             text: "hello".into(),
             blocks: None,
+            typed_turn_appends: Vec::new(),
             turn_metadata: None,
         });
         let json = serde_json::to_value(&input).unwrap();
         assert_eq!(json["input_type"], "prompt");
         let parsed: Input = serde_json::from_value(json).unwrap();
         assert!(matches!(parsed, Input::Prompt(_)));
+    }
+
+    #[test]
+    fn prompt_input_typed_turn_appends_project_without_user_text() {
+        let append = typed_runtime_notice_append("peer delivery");
+        let input = Input::Prompt(PromptInput {
+            header: make_header(),
+            text: String::new(),
+            blocks: None,
+            typed_turn_appends: vec![append.clone()],
+            turn_metadata: None,
+        });
+
+        let projection = runtime_input_projection(&input);
+        assert!(
+            projection.append.is_none(),
+            "empty runtime-authored prompt carrier must not synthesize a user append"
+        );
+        assert_eq!(projection.additional_appends, vec![append]);
+    }
+
+    #[test]
+    fn prompt_input_typed_turn_appends_serde_roundtrip() {
+        let append = typed_runtime_notice_append("typed appends persist");
+        let input = Input::Prompt(PromptInput {
+            header: make_header(),
+            text: String::new(),
+            blocks: None,
+            typed_turn_appends: vec![append.clone()],
+            turn_metadata: None,
+        });
+
+        let json = serde_json::to_value(&input).unwrap();
+        let parsed: Input = serde_json::from_value(json).unwrap();
+        let Input::Prompt(prompt) = parsed else {
+            panic!("expected prompt input");
+        };
+        assert_eq!(prompt.text, "");
+        assert_eq!(prompt.typed_turn_appends, vec![append]);
     }
 
     #[test]
@@ -1368,6 +1442,7 @@ mod tests {
             header: make_header(),
             text: "hi".into(),
             blocks: None,
+            typed_turn_appends: Vec::new(),
             turn_metadata: None,
         });
         assert_eq!(prompt.kind(), InputKind::Prompt);

--- a/meerkat-runtime/src/meerkat_machine/driver.rs
+++ b/meerkat-runtime/src/meerkat_machine/driver.rs
@@ -1956,6 +1956,7 @@ mod tests {
             },
             text: "drive the queue".into(),
             blocks: None,
+            typed_turn_appends: Vec::new(),
             turn_metadata: None,
         });
         let resume_id = resume_input.id().clone();

--- a/meerkat-runtime/src/meerkat_machine_tests.rs
+++ b/meerkat-runtime/src/meerkat_machine_tests.rs
@@ -1303,6 +1303,7 @@ fn make_prompt(text: &str) -> Input {
         },
         text: text.into(),
         blocks: None,
+        typed_turn_appends: Vec::new(),
         turn_metadata: None,
     })
 }

--- a/meerkat-runtime/src/peer_handling_mode.rs
+++ b/meerkat-runtime/src/peer_handling_mode.rs
@@ -200,6 +200,7 @@ mod tests {
             },
             text: "hi".into(),
             blocks: None,
+            typed_turn_appends: Vec::new(),
             turn_metadata: None,
         });
         assert!(validate_peer_handling_mode(&input).is_ok());

--- a/meerkat-runtime/src/policy_table.rs
+++ b/meerkat-runtime/src/policy_table.rs
@@ -202,9 +202,9 @@ impl DefaultPolicyTable {
             // input with `QueueMode::Fifo` queues a turn-start so the runtime
             // loop's `WakeIfIdle` path has something to dequeue and execute.
             //
-            // The payload still flows through the durable system-context
-            // append path (`input_to_context_append`), so the rendered
-            // `[SYSTEM NOTICE][PEER_RESPONSE_TERMINAL]` text is deduped on
+            // The payload still flows through the durable typed
+            // system-context append path (`input_to_context_append`), so the
+            // peer terminal response fact is deduped on
             // `peer_response_terminal:{peer_id}:{request_id}` rather than
             // stacking as ordinary user appends (`input_to_append` returns
             // `None` for this convention).

--- a/meerkat-runtime/src/policy_table.rs
+++ b/meerkat-runtime/src/policy_table.rs
@@ -572,6 +572,7 @@ mod tests {
             header,
             text: "hello".into(),
             blocks: None,
+            typed_turn_appends: Vec::new(),
             turn_metadata: None,
         });
         let decision = DefaultPolicyTable::resolve(&input, true);
@@ -599,6 +600,7 @@ mod tests {
             },
             text: "hello".into(),
             blocks: None,
+            typed_turn_appends: Vec::new(),
             turn_metadata: Some(RuntimeTurnMetadata {
                 handling_mode: Some(meerkat_core::types::HandlingMode::Steer),
                 ..Default::default()

--- a/meerkat-runtime/src/queue.rs
+++ b/meerkat-runtime/src/queue.rs
@@ -103,6 +103,7 @@ mod tests {
             },
             text: "test".into(),
             blocks: None,
+            typed_turn_appends: Vec::new(),
             turn_metadata: None,
         })
     }

--- a/meerkat-runtime/src/runtime_loop.rs
+++ b/meerkat-runtime/src/runtime_loop.rs
@@ -1302,16 +1302,13 @@ mod tests {
                 correlation_id: None,
             },
             convention: Some(crate::input::PeerConvention::Message),
-            body: "[COMMS MESSAGE from peer-1]\nplain body payload".into(),
+            body: "plain body payload".into(),
             payload: None,
             blocks: None,
             handling_mode: None,
         });
 
-        assert_eq!(
-            input_to_prompt(&input),
-            "[COMMS MESSAGE from peer-1]\nplain body payload"
-        );
+        assert_eq!(input_to_prompt(&input), "plain body payload");
     }
 
     #[test]
@@ -1342,9 +1339,9 @@ mod tests {
         });
 
         let prompt = input_to_prompt(&input);
-        assert!(prompt.starts_with(
-            "[SYSTEM NOTICE][PEER_REQUEST] Correlated peer request from peer_id 11111111-1111-4111-8111-111111111111. Intent: checksum_token. Request ID: req-123."
-        ));
+        assert!(
+            prompt.starts_with("Peer request from peer_id 11111111-1111-4111-8111-111111111111")
+        );
         assert!(prompt.contains("\"peer_id\":\"11111111-1111-4111-8111-111111111111\""));
         assert!(prompt.contains("\"in_reply_to\":\"req-123\""));
         assert!(prompt.contains("\"status\":\"completed\""));
@@ -1387,13 +1384,16 @@ mod tests {
         let context = projection
             .context_append
             .expect("terminal peer response should project in machine batch");
-        let CoreRenderable::Text { text } = context.content else {
-            panic!("expected terminal context text");
+        let CoreRenderable::SystemNotice { blocks, .. } = context.content else {
+            panic!("expected typed terminal context");
         };
-        assert_eq!(
-            text,
-            "[SYSTEM NOTICE][PEER_RESPONSE_TERMINAL] Correlated peer response from Analyst. Request ID: 018f6f79-7a82-7c4e-a552-a3b86f9630f1. Status: completed. Result: {\n  \"request_intent\": \"checksum_token\",\n  \"request_subject\": \"alpha beta gamma\",\n  \"token\": \"birch seventeen\"\n}."
-        );
+        assert!(matches!(
+            blocks.first(),
+            Some(meerkat_core::types::SystemNoticeBlock::Comms { peer, request_id, status, .. })
+                if peer.as_ref().and_then(|peer| peer.display_name.as_deref()) == Some("Analyst")
+                    && request_id.as_deref() == Some("018f6f79-7a82-7c4e-a552-a3b86f9630f1")
+                    && status.as_deref() == Some("completed")
+        ));
     }
 
     #[test]
@@ -1436,9 +1436,18 @@ mod tests {
         let context = projection
             .context_append
             .expect("terminal peer response should project in machine batch");
-        let CoreRenderable::Text { text: rendered } = context.content else {
-            panic!("expected terminal context text");
+        let CoreRenderable::SystemNotice { blocks, .. } = context.content else {
+            panic!("expected typed terminal context");
         };
+        let rendered = blocks
+            .first()
+            .and_then(|block| match block {
+                meerkat_core::types::SystemNoticeBlock::Comms { payload, .. } => {
+                    payload.as_ref().map(ToString::to_string)
+                }
+                _ => None,
+            })
+            .unwrap_or_default();
         assert!(
             !rendered.contains("Authoritative result fields:"),
             "runtime must not emit scenario-specific authoritative-field hints: {rendered}"
@@ -1571,11 +1580,14 @@ mod tests {
             )
         );
         match &staged.context_appends[0].content {
-            CoreRenderable::Text { text } => {
-                assert!(text.contains("[SYSTEM NOTICE][PEER_RESPONSE_TERMINAL]"));
-                assert!(text.contains("birch seventeen"));
+            CoreRenderable::SystemNotice { blocks, .. } => {
+                assert!(matches!(
+                    blocks.first(),
+                    Some(meerkat_core::types::SystemNoticeBlock::Comms { payload, .. })
+                        if payload.as_ref().is_some_and(|payload| payload.to_string().contains("birch seventeen"))
+                ));
             }
-            other => return Err(format!("expected text content, got {other:?}")),
+            other => return Err(format!("expected typed content, got {other:?}")),
         }
         Ok(())
     }
@@ -1946,18 +1958,16 @@ mod tests {
         };
         assert_eq!(staged.appends.len(), 1);
         match &staged.appends[0].content {
-            CoreRenderable::Blocks { blocks: got } => {
-                assert_eq!(got.len(), 3);
-                assert_eq!(
-                    got[0],
-                    meerkat_core::types::ContentBlock::Text {
-                        text: "[COMMS MESSAGE from p]".into(),
-                    }
-                );
-                assert_eq!(got[1], blocks[0]);
-                assert_eq!(got[2], blocks[1]);
+            CoreRenderable::SystemNotice { blocks: got, .. } => {
+                let Some(meerkat_core::types::SystemNoticeBlock::Comms { content, peer, .. }) =
+                    got.first()
+                else {
+                    return Err("expected comms block".into());
+                };
+                assert_eq!(peer.as_ref().map(|peer| peer.id.as_str()), Some("p"));
+                assert_eq!(content, &blocks);
             }
-            other => return Err(format!("expected blocks content, got {other:?}")),
+            other => return Err(format!("expected typed content, got {other:?}")),
         }
         Ok(())
     }
@@ -1989,7 +1999,7 @@ mod tests {
                 correlation_id: None,
             },
             convention: Some(crate::input::PeerConvention::Message),
-            body: "[COMMS MESSAGE from peer-1]\ncaption text\n[image: image/png]".into(),
+            body: "caption text".into(),
             payload: None,
             blocks: Some(blocks.clone()),
             handling_mode: None,
@@ -2002,18 +2012,16 @@ mod tests {
         };
 
         match &staged.appends[0].content {
-            CoreRenderable::Blocks { blocks: got } => {
-                assert_eq!(got.len(), 3);
-                assert_eq!(
-                    got[0],
-                    meerkat_core::types::ContentBlock::Text {
-                        text: "[COMMS MESSAGE from peer-1]".into(),
-                    }
-                );
-                assert_eq!(got[1], blocks[0]);
-                assert_eq!(got[2], blocks[1]);
+            CoreRenderable::SystemNotice { blocks: got, .. } => {
+                let Some(meerkat_core::types::SystemNoticeBlock::Comms { content, peer, .. }) =
+                    got.first()
+                else {
+                    return Err("expected comms block".into());
+                };
+                assert_eq!(peer.as_ref().map(|peer| peer.id.as_str()), Some("peer-1"));
+                assert_eq!(content, &blocks);
             }
-            other => return Err(format!("expected blocks content, got {other:?}")),
+            other => return Err(format!("expected typed content, got {other:?}")),
         }
         Ok(())
     }
@@ -2041,7 +2049,7 @@ mod tests {
                 correlation_id: None,
             },
             convention: Some(crate::input::PeerConvention::Message),
-            body: "[COMMS MESSAGE from peer-1]\n[image: image/png]".into(),
+            body: String::new(),
             payload: None,
             blocks: Some(blocks.clone()),
             handling_mode: None,
@@ -2054,17 +2062,16 @@ mod tests {
         };
 
         match &staged.appends[0].content {
-            CoreRenderable::Blocks { blocks: got } => {
-                assert_eq!(got.len(), 2);
-                assert_eq!(
-                    got[0],
-                    meerkat_core::types::ContentBlock::Text {
-                        text: "[COMMS MESSAGE from peer-1]".into(),
-                    }
-                );
-                assert_eq!(got[1], blocks[0]);
+            CoreRenderable::SystemNotice { blocks: got, .. } => {
+                let Some(meerkat_core::types::SystemNoticeBlock::Comms { content, peer, .. }) =
+                    got.first()
+                else {
+                    return Err("expected comms block".into());
+                };
+                assert_eq!(peer.as_ref().map(|peer| peer.id.as_str()), Some("peer-1"));
+                assert_eq!(content, &blocks);
             }
-            other => return Err(format!("expected blocks content, got {other:?}")),
+            other => return Err(format!("expected typed content, got {other:?}")),
         }
         Ok(())
     }
@@ -2091,8 +2098,7 @@ mod tests {
                 correlation_id: None,
             },
             convention: Some(crate::input::PeerConvention::Message),
-            body: "[COMMS MESSAGE from peer-1]\nPlease describe the attached image.\n[image: image/png]"
-                .into(),
+            body: "Please describe the attached image.".into(),
             payload: None,
             blocks: Some(blocks.clone()),
             handling_mode: None,
@@ -2105,21 +2111,20 @@ mod tests {
         };
 
         match &staged.appends[0].content {
-            CoreRenderable::Blocks { blocks: got } => {
-                assert_eq!(got.len(), 3);
+            CoreRenderable::SystemNotice { blocks: got, .. } => {
+                let Some(meerkat_core::types::SystemNoticeBlock::Comms { content, peer, .. }) =
+                    got.first()
+                else {
+                    return Err("expected comms block".into());
+                };
+                assert_eq!(peer.as_ref().map(|peer| peer.id.as_str()), Some("peer-1"));
                 assert_eq!(
-                    got[0],
-                    meerkat_core::types::ContentBlock::Text {
-                        text: "[COMMS MESSAGE from peer-1]".into(),
-                    }
-                );
-                assert_eq!(
-                    got[1],
-                    meerkat_core::types::ContentBlock::Text {
+                    content.first(),
+                    Some(&meerkat_core::types::ContentBlock::Text {
                         text: "Please describe the attached image.".into(),
-                    }
+                    })
                 );
-                assert_eq!(got[2], blocks[0]);
+                assert_eq!(content.get(1), Some(&blocks[0]));
             }
             other => return Err(format!("expected blocks content, got {other:?}")),
         }
@@ -2166,8 +2171,14 @@ mod tests {
         };
         assert_eq!(staged.appends.len(), 1);
         match &staged.appends[0].content {
-            CoreRenderable::Blocks { blocks: got } => assert_eq!(got.len(), 2),
-            other => return Err(format!("expected blocks content, got {other:?}")),
+            CoreRenderable::SystemNotice { blocks: got, .. } => {
+                assert!(matches!(
+                    got.first(),
+                    Some(meerkat_core::types::SystemNoticeBlock::RuntimeNotice { category, detail, .. })
+                        if category == "flow_step" && detail.as_deref() == Some("analyze this screenshot")
+                ));
+            }
+            other => return Err(format!("expected typed content, got {other:?}")),
         }
         Ok(())
     }
@@ -2212,13 +2223,15 @@ mod tests {
         };
         assert_eq!(staged.appends.len(), 1);
         match &staged.appends[0].content {
-            CoreRenderable::Blocks { blocks: got } => {
-                // Blocks are preserved directly — no synthetic text header prepended.
-                assert_eq!(got.len(), 2);
-                assert_eq!(got[0], blocks[0]);
-                assert_eq!(got[1], blocks[1]);
+            CoreRenderable::SystemNotice { blocks: got, .. } => {
+                let Some(meerkat_core::types::SystemNoticeBlock::ExternalEvent { content, .. }) =
+                    got.first()
+                else {
+                    return Err("expected external event block".into());
+                };
+                assert_eq!(content, &blocks);
             }
-            other => return Err(format!("expected blocks content, got {other:?}")),
+            other => return Err(format!("expected typed content, got {other:?}")),
         }
         Ok(())
     }
@@ -2256,12 +2269,15 @@ mod tests {
             other => return Err(format!("expected staged input, got {other:?}")),
         };
         match &staged.appends[0].content {
-            CoreRenderable::Blocks { blocks: got } => {
-                // Image-only blocks preserved directly without text header.
-                assert_eq!(got.len(), 1);
-                assert_eq!(got[0], blocks[0]);
+            CoreRenderable::SystemNotice { blocks: got, .. } => {
+                let Some(meerkat_core::types::SystemNoticeBlock::ExternalEvent { content, .. }) =
+                    got.first()
+                else {
+                    return Err("expected external event block".into());
+                };
+                assert_eq!(content, &blocks);
             }
-            other => return Err(format!("expected blocks content, got {other:?}")),
+            other => return Err(format!("expected typed content, got {other:?}")),
         }
         Ok(())
     }
@@ -2288,7 +2304,7 @@ mod tests {
             render_metadata: None,
         });
 
-        assert_eq!(input_to_prompt(&input), "[EVENT via webhook]");
+        assert_eq!(input_to_prompt(&input), "External event via webhook");
         Ok(())
     }
 
@@ -2319,7 +2335,7 @@ mod tests {
                         body: "build failed".into(),
                         blocks: None,
                     },
-                    rendered_text: "[EVENT via webhook] build failed".into(),
+                    rendered_text: "External event via webhook: build failed".into(),
                     handling_mode: meerkat_core::types::HandlingMode::Queue,
                     render_metadata: None,
                 },
@@ -2349,7 +2365,10 @@ mod tests {
         });
 
         assert_eq!(input_to_prompt(&from_comms), input_to_prompt(&direct));
-        assert_eq!(input_to_prompt(&direct), "[EVENT via webhook] build failed");
+        assert_eq!(
+            input_to_prompt(&direct),
+            "External event via webhook: build failed"
+        );
         Ok(())
     }
 

--- a/meerkat-runtime/src/runtime_loop.rs
+++ b/meerkat-runtime/src/runtime_loop.rs
@@ -368,7 +368,13 @@ pub(crate) fn try_projected_inputs_to_primitive_with_boundary(
 ) -> Result<RunPrimitive, meerkat_core::lifecycle::run_primitive::TurnMetadataMergeConflict> {
     let appends = projections
         .iter()
-        .filter_map(|projection| projection.append.clone())
+        .flat_map(|projection| {
+            projection
+                .append
+                .clone()
+                .into_iter()
+                .chain(projection.additional_appends.clone())
+        })
         .collect::<Vec<_>>();
     let context_appends = projections
         .iter()
@@ -1080,7 +1086,7 @@ mod tests {
     use crate::input::*;
     use chrono::Utc;
     use meerkat_core::lifecycle::run_primitive::{
-        ConversationAppendRole, CoreRenderable, PeerResponseTerminalApplyIntent,
+        ConversationAppend, ConversationAppendRole, CoreRenderable, PeerResponseTerminalApplyIntent,
     };
     use std::sync::{
         Arc,
@@ -1248,6 +1254,7 @@ mod tests {
             },
             text: text.into(),
             blocks: None,
+            typed_turn_appends: Vec::new(),
             turn_metadata: None,
         })
     }
@@ -1481,6 +1488,43 @@ mod tests {
             CoreRenderable::Text { text } => assert_eq!(text, "test prompt"),
             other => return Err(format!("expected text content, got {other:?}")),
         }
+        Ok(())
+    }
+
+    #[test]
+    fn input_to_primitive_preserves_typed_prompt_appends_without_user_text() -> Result<(), String> {
+        let typed_append = ConversationAppend {
+            role: ConversationAppendRole::SystemNotice,
+            content: CoreRenderable::SystemNotice {
+                kind: meerkat_core::types::SystemNoticeKind::Comms,
+                body: Some("Peer message".to_string()),
+                blocks: vec![meerkat_core::types::SystemNoticeBlock::Comms {
+                    kind: "message".to_string(),
+                    direction: meerkat_core::types::SystemNoticeDirection::Incoming,
+                    peer: None,
+                    request_id: None,
+                    intent: None,
+                    status: None,
+                    summary: Some("Peer message".to_string()),
+                    payload: None,
+                    content: Vec::new(),
+                }],
+            },
+        };
+        let mut input = make_prompt("");
+        let Input::Prompt(prompt) = &mut input else {
+            return Err("expected prompt".to_string());
+        };
+        prompt.typed_turn_appends = vec![typed_append.clone()];
+        let input_id = input.id().clone();
+
+        let primitive = input_to_primitive(&input, input_id.clone())
+            .expect("single input metadata cannot conflict");
+        let RunPrimitive::StagedInput(staged) = primitive else {
+            return Err("expected staged input".to_string());
+        };
+        assert_eq!(staged.contributing_input_ids, vec![input_id]);
+        assert_eq!(staged.appends, vec![typed_append]);
         Ok(())
     }
 

--- a/meerkat-runtime/src/silent_intent.rs
+++ b/meerkat-runtime/src/silent_intent.rs
@@ -158,6 +158,7 @@ mod tests {
             },
             text: "hello".into(),
             blocks: None,
+            typed_turn_appends: Vec::new(),
             turn_metadata: None,
         });
         let silent = vec!["mob.peer_added".to_string()];

--- a/meerkat-runtime/tests/detached_wake_contract.rs
+++ b/meerkat-runtime/tests/detached_wake_contract.rs
@@ -296,6 +296,7 @@ async fn choke_004_idle_runtime_wakes_on_detached_op_completion() {
         },
         text: "trigger wake".into(),
         blocks: None,
+        typed_turn_appends: Vec::new(),
         turn_metadata: None,
     });
 
@@ -403,6 +404,7 @@ async fn choke_004_five_completions_produce_one_coalesced_wake() {
         },
         text: "trigger".into(),
         blocks: None,
+        typed_turn_appends: Vec::new(),
         turn_metadata: None,
     });
 
@@ -537,6 +539,7 @@ async fn choke_004_completion_during_running_defers_wake() {
         },
         text: "start turn".into(),
         blocks: None,
+        typed_turn_appends: Vec::new(),
         turn_metadata: None,
     });
 
@@ -684,6 +687,7 @@ async fn choke_004_mob_member_child_completion_does_not_trigger_idle_wake() {
         },
         text: "flush".into(),
         blocks: None,
+        typed_turn_appends: Vec::new(),
         turn_metadata: None,
     });
 

--- a/meerkat-runtime/tests/driver_ephemeral.rs
+++ b/meerkat-runtime/tests/driver_ephemeral.rs
@@ -26,6 +26,7 @@ fn make_prompt_input(text: &str) -> Input {
         },
         text: text.into(),
         blocks: None,
+        typed_turn_appends: Vec::new(),
         turn_metadata: None,
     })
 }
@@ -294,6 +295,7 @@ async fn reject_derived_prompt() {
         },
         text: "hi".into(),
         blocks: None,
+        typed_turn_appends: Vec::new(),
         turn_metadata: None,
     });
     let result = driver.accept_input(input).await.unwrap();

--- a/meerkat-runtime/tests/driver_persistent.rs
+++ b/meerkat-runtime/tests/driver_persistent.rs
@@ -325,6 +325,7 @@ fn make_prompt(text: &str) -> Input {
         },
         text: text.into(),
         blocks: None,
+        typed_turn_appends: Vec::new(),
         turn_metadata: None,
     })
 }
@@ -353,6 +354,7 @@ fn make_multimodal_prompt(text: &str, label: &str) -> Input {
                 },
             },
         ]),
+        typed_turn_appends: Vec::new(),
         turn_metadata: None,
     })
 }

--- a/meerkat-runtime/tests/meerkat_machine.rs
+++ b/meerkat-runtime/tests/meerkat_machine.rs
@@ -44,6 +44,7 @@ fn make_prompt(text: &str) -> Input {
         },
         text: text.into(),
         blocks: None,
+        typed_turn_appends: Vec::new(),
         turn_metadata: None,
     })
 }

--- a/meerkat-runtime/tests/recovery_contract.rs
+++ b/meerkat-runtime/tests/recovery_contract.rs
@@ -81,6 +81,7 @@ fn make_prompt(text: &str) -> Input {
         },
         text: text.into(),
         blocks: None,
+        typed_turn_appends: Vec::new(),
         turn_metadata: None,
     })
 }

--- a/meerkat-runtime/tests/recovery_replay.rs
+++ b/meerkat-runtime/tests/recovery_replay.rs
@@ -42,6 +42,7 @@ fn make_prompt(text: &str) -> Input {
         },
         text: text.into(),
         blocks: None,
+        typed_turn_appends: Vec::new(),
         turn_metadata: None,
     })
 }

--- a/meerkat-runtime/tests/runtime_ingress_control.rs
+++ b/meerkat-runtime/tests/runtime_ingress_control.rs
@@ -35,6 +35,7 @@ fn make_prompt(text: &str) -> Input {
         },
         text: text.into(),
         blocks: None,
+        typed_turn_appends: Vec::new(),
         turn_metadata: None,
     })
 }

--- a/meerkat-session/src/ephemeral.rs
+++ b/meerkat-session/src/ephemeral.rs
@@ -3389,7 +3389,7 @@ async fn session_task<A: SessionAgent>(
                 let prompt = if typed_turn_appends.is_empty() {
                     prompt
                 } else {
-                    meerkat_core::lifecycle::run_primitive::content_input_from_conversation_appends(
+                    meerkat_core::lifecycle::run_primitive::model_projection_content_input_from_conversation_appends(
                         &typed_turn_appends,
                     )
                 };

--- a/meerkat-session/src/ephemeral.rs
+++ b/meerkat-session/src/ephemeral.rs
@@ -435,6 +435,7 @@ pub trait SessionAgent: Send {
         prompt: meerkat_core::types::ContentInput,
         handling_mode: meerkat_core::types::HandlingMode,
         render_metadata: Option<meerkat_core::types::RenderMetadata>,
+        typed_turn_appends: Vec<meerkat_core::lifecycle::run_primitive::ConversationAppend>,
         _execution_kind: Option<meerkat_core::lifecycle::RuntimeExecutionKind>,
         event_tx: mpsc::Sender<AgentEvent>,
     ) -> Result<RunResult, meerkat_core::error::AgentError> {
@@ -446,6 +447,11 @@ pub trait SessionAgent: Send {
         if render_metadata.is_some() {
             return Err(meerkat_core::error::AgentError::ConfigError(
                 "render_metadata requires a runtime-backed surface".to_string(),
+            ));
+        }
+        if !typed_turn_appends.is_empty() {
+            return Err(meerkat_core::error::AgentError::ConfigError(
+                "typed turn appends require a runtime-backed surface".to_string(),
             ));
         }
         self.run_with_events(prompt, event_tx).await
@@ -3379,6 +3385,14 @@ async fn session_task<A: SessionAgent>(
                     .and_then(|metadata| metadata.flow_tool_overlay.clone())
                     .or(runtime.flow_tool_overlay);
                 let pre_turn_context_appends = runtime.pre_turn_context_appends;
+                let typed_turn_appends = runtime.typed_turn_appends;
+                let prompt = if typed_turn_appends.is_empty() {
+                    prompt
+                } else {
+                    meerkat_core::lifecycle::run_primitive::content_input_from_conversation_appends(
+                        &typed_turn_appends,
+                    )
+                };
                 let execution_kind = metadata
                     .as_ref()
                     .and_then(|metadata| metadata.execution_kind);
@@ -3532,6 +3546,7 @@ async fn session_task<A: SessionAgent>(
                                 prompt,
                                 handling_mode,
                                 render_metadata,
+                                typed_turn_appends,
                                 execution_kind,
                                 agent_event_tx.clone(),
                             ))
@@ -4323,7 +4338,7 @@ mod runtime_turn_metadata_tests {
             .await
             .expect("deferred session should create");
         let appends = vec![PendingSystemContextAppend {
-            text: "[SYSTEM NOTICE][PEER_RESPONSE_TERMINAL] token birch seventeen".to_string(),
+            text: "Peer terminal response from test\nRequest ID: req\nStatus: completed\ntoken birch seventeen".to_string(),
             source: Some("peer_response_terminal:test:req".to_string()),
             idempotency_key: Some("peer_response_terminal:test:req".to_string()),
             accepted_at: meerkat_core::time_compat::SystemTime::now(),

--- a/meerkat-session/src/persistent.rs
+++ b/meerkat-session/src/persistent.rs
@@ -6785,8 +6785,7 @@ mod tests {
         durable
             .set_system_context_state(SessionSystemContextState {
                 applied: vec![PendingSystemContextAppend {
-                    text: "[SYSTEM NOTICE][PEER_RESPONSE_TERMINAL] token birch seventeen"
-                        .to_string(),
+                    text: "Peer terminal response from 550e8400-e29b-41d4-a716-446655440000\nRequest ID: req-123\nStatus: completed\ntoken birch seventeen".to_string(),
                     source: Some(
                         "peer_response_terminal:550e8400-e29b-41d4-a716-446655440000:req-123"
                             .to_string(),
@@ -6855,8 +6854,7 @@ mod tests {
         durable
             .set_system_context_state(SessionSystemContextState {
                 applied: vec![PendingSystemContextAppend {
-                    text: "[SYSTEM NOTICE][PEER_RESPONSE_TERMINAL] token birch seventeen"
-                        .to_string(),
+                    text: "Peer terminal response from 550e8400-e29b-41d4-a716-446655440000\nRequest ID: req-123\nStatus: completed\ntoken birch seventeen".to_string(),
                     source: Some(
                         "peer_response_terminal:550e8400-e29b-41d4-a716-446655440000:req-123"
                             .to_string(),
@@ -11092,7 +11090,7 @@ mod tests {
                 &session_id,
                 RunId::new(),
                 vec![PendingSystemContextAppend {
-                    text: "[SYSTEM NOTICE][PEER_RESPONSE_TERMINAL] Correlated peer response from analyst-rt. Request ID: req-123. Status: completed. Result: {\"request_intent\":\"checksum_token\",\"request_subject\":\"alpha beta gamma\",\"token\":\"birch seventeen\"}.".to_string(),
+                    text: "Peer terminal response from analyst-rt\nRequest ID: req-123\nStatus: completed\nPayload: {\"request_intent\":\"checksum_token\",\"request_subject\":\"alpha beta gamma\",\"token\":\"birch seventeen\"}".to_string(),
                     source: Some("peer_response_terminal:550e8400-e29b-41d4-a716-446655440000:req-123".to_string()),
                     idempotency_key: Some("peer_response_terminal:550e8400-e29b-41d4-a716-446655440000:req-123".to_string()),
                     accepted_at: meerkat_core::time_compat::SystemTime::now(),
@@ -11187,12 +11185,13 @@ mod tests {
             },
         );
         req.runtime.pre_turn_context_appends = vec![PendingSystemContextAppend {
-            text: "[SYSTEM NOTICE][PEER_RESPONSE_TERMINAL] Correlated peer response. Result: {\"token\":\"birch seventeen\"}.".to_string(),
+            text: "Peer terminal response\nPayload: {\"token\":\"birch seventeen\"}".to_string(),
             source: Some(
-                "peer_response_terminal:550e8400-e29b-41d4-a716-446655440000:req-123"
-                    .to_string(),
+                "peer_response_terminal:550e8400-e29b-41d4-a716-446655440000:req-123".to_string(),
             ),
-            idempotency_key: Some("peer_response_terminal:550e8400-e29b-41d4-a716-446655440000:req-123".to_string()),
+            idempotency_key: Some(
+                "peer_response_terminal:550e8400-e29b-41d4-a716-446655440000:req-123".to_string(),
+            ),
             accepted_at: meerkat_core::time_compat::SystemTime::now(),
         }];
 

--- a/meerkat-session/tests/regression_lifecycle.rs
+++ b/meerkat-session/tests/regression_lifecycle.rs
@@ -445,6 +445,7 @@ impl SessionAgent for RecordingTurnAgent {
         _prompt: meerkat_core::types::ContentInput,
         handling_mode: HandlingMode,
         render_metadata: Option<RenderMetadata>,
+        _typed_turn_appends: Vec<meerkat_core::lifecycle::run_primitive::ConversationAppend>,
         _execution_kind: Option<meerkat_core::lifecycle::RuntimeExecutionKind>,
         _event_tx: mpsc::Sender<AgentEvent>,
     ) -> Result<RunResult, meerkat_core::error::AgentError> {

--- a/meerkat/src/help_content/platform_skill.md
+++ b/meerkat/src/help_content/platform_skill.md
@@ -541,7 +541,7 @@ Real-time events include `text_delta`, tool lifecycle events, hook events, and t
 
 ### Background work and recovery
 
-Background shell jobs (shell tool with `&` or `background: true`), mob member terminals, and async external tool results all deliver back into the agent through a single completion stream. Each completion appears as a `[SYSTEM NOTICE][BG_JOB]` (or equivalent) message at the next LLM turn boundary, so the agent sees and reasons over it. Idle keep-alive sessions wake automatically when a completion lands.
+Background shell jobs (shell tool with `&` or `background: true`), mob member terminals, and async external tool results all deliver back into the agent through a single completion stream. Each completion is persisted as a typed `system_notice` block such as `background_job` at the next LLM turn boundary, then projected into provider-facing text for the model. Idle keep-alive sessions wake automatically when a completion lands.
 
 If the runtime is backed by persistent storage, completion state and cursors survive process restarts (bounded-loss; you may see one duplicate notice on the seam). Without persistence, conversation history resumes but pending background work doesn't.
 
@@ -600,13 +600,13 @@ Tool visibility can change during a session without restarting the agent. All ch
 - **Per-turn overlay** — `TurnToolOverlay` on `StartTurnRequest.flow_tool_overlay`. Ephemeral, used by mob flow steps to restrict tools per step.
 - **Configured MCP servers** — CLI `rkat mcp add/remove/list/get` edits `.rkat/mcp.toml` or `~/.rkat/mcp.toml`. New `rkat run` and `rkat run --resume` sessions load that config.
 - **Live MCP mutation** — JSON-RPC `mcp/add`, `mcp/remove`, `mcp/reload`, REST `POST /sessions/{id}/mcp/*`, MCP-server tools, and SDK helpers stage server changes on the `McpRouter`. Applied at next turn boundary. Removals drain in-flight calls before finalizing.
-- **Async MCP loading** — At startup, MCP servers connect in parallel in the background. The agent loop polls `poll_external_updates()` at each `CallingLlm` boundary. Tools appear as each server completes its handshake. A `[MCP_PENDING]` system notice is injected while servers are still connecting.
+- **Async MCP loading** — At startup, MCP servers connect in parallel in the background. The agent loop polls `poll_external_updates()` at each `CallingLlm` boundary. Tools appear as each server completes its handshake. A typed `mcp` system notice is recorded while servers are still connecting.
   - Per-server timeout: `connect_timeout_secs` in `.rkat/mcp.toml` (default: 10s)
   - CLI: `--wait-for-mcp` flag blocks before the first turn until all servers finish connecting
   - SDK: `McpRouterAdapter::wait_until_ready(timeout)` provides the same blocking behavior
   - `AgentBuildConfig.wait_for_mcp: bool` field for programmatic surface control
 - **Composition** — most-restrictive wins (allow-lists intersect, deny-lists union, deny beats allow).
-- **Agent awareness** — `ToolConfigChanged` event emitted + `[SYSTEM NOTICE]` injected into conversation on any change.
+- **Agent awareness** — `ToolConfigChanged` event emitted + typed `tool_config` system notice recorded on any change.
 
 Surface availability:
 

--- a/meerkat/src/service_factory.rs
+++ b/meerkat/src/service_factory.rs
@@ -88,6 +88,7 @@ impl SessionAgent for FactoryAgent {
         prompt: meerkat_core::types::ContentInput,
         handling_mode: HandlingMode,
         render_metadata: Option<RenderMetadata>,
+        typed_turn_appends: Vec<meerkat_core::lifecycle::run_primitive::ConversationAppend>,
         execution_kind: Option<meerkat_core::lifecycle::RuntimeExecutionKind>,
         event_tx: mpsc::Sender<AgentEvent>,
     ) -> Result<RunResult, meerkat_core::error::AgentError> {
@@ -107,7 +108,13 @@ impl SessionAgent for FactoryAgent {
             ));
         }
         self.agent.set_runtime_execution_kind(execution_kind);
-        self.agent.run_with_events(prompt, event_tx).await
+        if typed_turn_appends.is_empty() {
+            self.agent.run_with_events(prompt, event_tx).await
+        } else {
+            self.agent
+                .run_with_events_and_typed_turn_appends(prompt, typed_turn_appends, event_tx)
+                .await
+        }
     }
 
     async fn run_pending_with_events(
@@ -1372,6 +1379,7 @@ mod tests {
             "inspect".to_string().into(),
             HandlingMode::Queue,
             None,
+            Vec::new(),
             Some(meerkat_core::lifecycle::RuntimeExecutionKind::ContentTurn),
             run_tx,
         )
@@ -1440,6 +1448,7 @@ mod tests {
             "inspect".to_string().into(),
             HandlingMode::Queue,
             None,
+            Vec::new(),
             Some(meerkat_core::lifecycle::RuntimeExecutionKind::ContentTurn),
             run_tx,
         )

--- a/meerkat/src/session_runtime/live_orchestration.rs
+++ b/meerkat/src/session_runtime/live_orchestration.rs
@@ -94,21 +94,20 @@ pub fn apply_precheck_gates(
 /// `None`, the canonical session transcript's original first message is
 /// left in place — and that can legitimately be a `Message::SystemNotice`
 /// (e.g. an idle pre-prompt session whose only lead is a runtime-injected
-/// `[SYSTEM NOTICE][MCP_PENDING]` notice). Without honoring `SystemNotice`
+/// typed MCP-pending notice). Without honoring `SystemNotice`
 /// here, a `propagate_config_to_live_channels` refresh whose snapshot
 /// leads with one would silently emit empty instructions on
 /// `session.update` and wipe the realtime provider's session-level
-/// instructions. We use `SystemNoticeMessage::rendered_text()` (the
-/// prefix-tagged form, matching the projection the root-system helper
-/// itself emits) so the provider sees the same string the agent loop
-/// would.
+/// instructions. We use `SystemNoticeMessage::model_projection_text()` so
+/// the provider sees the internal projection without making prefix prose a
+/// transcript contract again.
 #[must_use]
 pub fn extract_system_prompt_from_seed_messages_runtime(
     seed_messages: &[Message],
 ) -> Option<String> {
     match seed_messages.first()? {
         Message::System(system) => Some(system.content.clone()),
-        Message::SystemNotice(notice) => Some(notice.rendered_text()),
+        Message::SystemNotice(notice) => Some(notice.model_projection_text()),
         _ => None,
     }
 }
@@ -271,7 +270,7 @@ pub fn realtime_projection_root_system_message(session: &Session) -> Option<Mess
                 .first()
                 .and_then(|message| match message {
                     Message::System(system) => Some(system.content.clone()),
-                    Message::SystemNotice(notice) => Some(notice.rendered_text()),
+                    Message::SystemNotice(notice) => Some(notice.model_projection_text()),
                     _ => None,
                 })
         })

--- a/meerkat/src/session_runtime/staged_promotion.rs
+++ b/meerkat/src/session_runtime/staged_promotion.rs
@@ -69,6 +69,14 @@ pub fn render_context_append_text(content: &CoreRenderable) -> String {
             Some(label) if !label.trim().is_empty() => format!("[Reference] {label} ({uri})"),
             _ => format!("[Reference] {uri}"),
         },
+        CoreRenderable::SystemNotice { kind, body, blocks } => {
+            meerkat_core::types::SystemNoticeMessage::with_blocks(
+                *kind,
+                body.clone(),
+                blocks.clone(),
+            )
+            .model_projection_text()
+        }
         _ => String::new(),
     }
 }

--- a/meerkat/src/surface/runtime_backed.rs
+++ b/meerkat/src/surface/runtime_backed.rs
@@ -536,6 +536,14 @@ fn pending_system_context_appends(
                     Some(label) => format!("{label}: {uri}"),
                     None => uri.clone(),
                 },
+                CoreRenderable::SystemNotice { kind, body, blocks } => {
+                    meerkat_core::types::SystemNoticeMessage::with_blocks(
+                        *kind,
+                        body.clone(),
+                        blocks.clone(),
+                    )
+                    .model_projection_text()
+                }
                 _ => String::new(),
             },
             source: Some(append.key.clone()),
@@ -569,7 +577,8 @@ fn start_turn_request_from_primitive(
             None,
             pre_turn_context_appends,
             metadata.cloned(),
-        ),
+        )
+        .with_typed_turn_appends(primitive.typed_turn_appends()),
     })
 }
 
@@ -751,6 +760,43 @@ fn ensure_materialized_session_id_matches(
     })
 }
 
+#[cfg(test)]
+mod typed_transcript_contract_tests {
+    use super::*;
+
+    #[test]
+    fn start_turn_request_carries_typed_turn_appends() {
+        let primitive = RunPrimitive::StagedInput(
+            meerkat_core::lifecycle::run_primitive::StagedRunInput {
+                boundary: meerkat_core::lifecycle::run_primitive::RunApplyBoundary::RunStart,
+                appends: vec![meerkat_core::lifecycle::run_primitive::ConversationAppend {
+                    role:
+                        meerkat_core::lifecycle::run_primitive::ConversationAppendRole::SystemNotice,
+                    content: CoreRenderable::SystemNotice {
+                        kind: meerkat_core::types::SystemNoticeKind::Comms,
+                        body: Some("typed notice".to_string()),
+                        blocks: Vec::new(),
+                    },
+                }],
+                context_appends: Vec::new(),
+                contributing_input_ids: vec![meerkat_core::lifecycle::InputId::new()],
+                turn_metadata: None,
+            },
+        );
+
+        let req = start_turn_request_from_primitive(&primitive).expect("request");
+
+        assert_eq!(
+            req.runtime.typed_turn_appends,
+            primitive.typed_turn_appends()
+        );
+        assert_eq!(
+            req.prompt,
+            meerkat_core::types::ContentInput::Text(String::new())
+        );
+    }
+}
+
 #[cfg(all(test, feature = "jsonl-store", not(target_arch = "wasm32")))]
 #[allow(clippy::expect_used, clippy::panic, clippy::unwrap_used)]
 mod tests {
@@ -856,6 +902,10 @@ mod tests {
         );
         assert_eq!(req.runtime.skill_references, None);
         assert_eq!(req.runtime.flow_tool_overlay, None);
+        assert_eq!(
+            req.runtime.typed_turn_appends,
+            primitive.typed_turn_appends()
+        );
         assert_eq!(req.runtime.turn_metadata, Some(metadata));
         assert_eq!(
             req.runtime

--- a/meerkat/src/surface/runtime_backed.rs
+++ b/meerkat/src/surface/runtime_backed.rs
@@ -1864,7 +1864,7 @@ mod tests {
                     context_appends: vec![ConversationContextAppend {
                         key: "peer_response_terminal:analyst-rt:req-123".to_string(),
                         content: CoreRenderable::Text {
-                            text: "[SYSTEM NOTICE][PEER_RESPONSE_TERMINAL] Correlated peer response from analyst-rt. Request ID: req-123. Status: completed. Result: {\"request_intent\":\"checksum_token\",\"request_subject\":\"alpha beta gamma\",\"token\":\"birch seventeen\"}.".to_string(),
+                            text: "Peer terminal response from analyst-rt\nRequest ID: req-123\nStatus: completed\nPayload: {\"request_intent\":\"checksum_token\",\"request_subject\":\"alpha beta gamma\",\"token\":\"birch seventeen\"}".to_string(),
                         },
                     }],
                     contributing_input_ids: vec![InputId::new()],
@@ -2112,7 +2112,7 @@ mod tests {
                     context_appends: vec![ConversationContextAppend {
                         key: "peer_response_terminal:analyst-rt:req-456".to_string(),
                         content: CoreRenderable::Text {
-                            text: "[SYSTEM NOTICE][PEER_RESPONSE_TERMINAL] done".to_string(),
+                            text: "Peer terminal response from analyst-rt\nRequest ID: req-456\nStatus: completed\ndone".to_string(),
                         },
                     }],
                     contributing_input_ids: vec![InputId::new()],
@@ -2153,7 +2153,7 @@ mod tests {
             "terminal peer response source must be applied before reaction turn: {system_context}"
         );
         assert!(
-            system_context.contains("[SYSTEM NOTICE][PEER_RESPONSE_TERMINAL] done"),
+            system_context.contains("Peer terminal response from analyst-rt"),
             "terminal peer response context must be applied before reaction turn: {system_context}"
         );
 
@@ -2203,7 +2203,7 @@ mod tests {
                     context_appends: vec![ConversationContextAppend {
                         key: "peer_response_terminal:analyst-rt:req-invalid".to_string(),
                         content: CoreRenderable::Text {
-                            text: "[SYSTEM NOTICE][PEER_RESPONSE_TERMINAL] invalid".to_string(),
+                            text: "Peer terminal response from analyst-rt\nRequest ID: req-invalid\nStatus: completed\ninvalid".to_string(),
                         },
                     }],
                     contributing_input_ids: vec![InputId::new()],

--- a/meerkat/tests/live_meerkat_regression.rs
+++ b/meerkat/tests/live_meerkat_regression.rs
@@ -467,6 +467,7 @@ mod image_generation_substrate {
             "make an image".to_string().into(),
             meerkat_core::types::HandlingMode::Queue,
             None,
+            Vec::new(),
             Some(RuntimeExecutionKind::ContentTurn),
             run_tx,
         )

--- a/meerkat/tests/session_runtime_live_orchestration.rs
+++ b/meerkat/tests/session_runtime_live_orchestration.rs
@@ -298,7 +298,7 @@ fn extract_system_prompt_returns_system_message_content() {
 #[test]
 fn extract_system_prompt_returns_rendered_notice_text() {
     let notice = SystemNoticeMessage::new(SystemNoticeKind::McpPending, "MCP servers connecting");
-    let rendered = notice.rendered_text();
+    let rendered = notice.model_projection_text();
     let msgs = vec![Message::SystemNotice(notice)];
     assert_eq!(
         extract_system_prompt_from_seed_messages_runtime(&msgs),

--- a/xtask/src/rmat_audit.rs
+++ b/xtask/src/rmat_audit.rs
@@ -1512,14 +1512,14 @@ fn runtime_external_event_projection_findings_for_sources(
         ));
     }
 
-    if !input_source
-        .contains("Input::ExternalEvent(e) if e.blocks.is_some() => CoreRenderable::Blocks")
+    if !input_source.contains("SystemNoticeBlock::ExternalEvent")
+        || !input_source.contains("content: event.blocks.clone().unwrap_or_default()")
     {
         findings.push(error_finding(
             "RuntimeExternalEventProjectionAlignment",
             input_path,
             "input_to_append",
-            "runtime loop must preserve ExternalEvent blocks as block renderables instead of flattening them to text"
+            "runtime loop must preserve ExternalEvent blocks inside typed system notices instead of flattening them to text"
                 .to_string(),
             false,
         ));
@@ -1856,11 +1856,24 @@ mod tests {
             }
         ";
         let loop_source = r"
+            fn external_event_notice_renderable(event: &ExternalEventInput) -> CoreRenderable {
+                CoreRenderable::SystemNotice {
+                    kind: SystemNoticeKind::ExternalEvent,
+                    body: Some(String::new()),
+                    blocks: vec![SystemNoticeBlock::ExternalEvent {
+                        source: String::new(),
+                        event_type: String::new(),
+                        summary: None,
+                        body: None,
+                        payload: Some(event.payload.clone()),
+                        content: event.blocks.clone().unwrap_or_default(),
+                    }],
+                }
+            }
+
             fn input_to_append(input: &Input) -> Option<ConversationAppend> {
                 let content = match input {
-                    Input::ExternalEvent(e) if e.blocks.is_some() => CoreRenderable::Blocks {
-                        blocks: e.blocks.clone().unwrap_or_default(),
-                    },
+                    Input::ExternalEvent(e) => external_event_notice_renderable(e),
                     _ => todo!(),
                 };
                 Some(todo!())


### PR DESCRIPTION
## Summary
- replace runtime-authored prefix text transcript semantics with typed system notice blocks
- keep user-role history operator-authored only and project typed notices to provider text only at model assembly boundaries
- add typed notice handling for comms, external events, tool/MCP/runtime metadata, CLI/REST/RPC/MCP context paths, and console-facing surfaces

## Validation
- ./scripts/repo-cargo test -p meerkat-core typed_transcript_contract --lib
- ./scripts/repo-cargo test -p meerkat-core system_notice_append --lib
- ./scripts/repo-cargo test -p meerkat-core typed_turn_appends_excludes --lib
- ./scripts/repo-cargo test -p meerkat-core future_system_notice_block --lib
- ./scripts/repo-cargo test -p meerkat-core system_notice_block_without_type --lib
- ./scripts/repo-cargo test -p meerkat-rpc context_system_notice_projects_only_via_notice_projection --tests
- ./scripts/repo-cargo test -p meerkat-rpc extract_system_prompt_returns_model_projection --tests
- ./scripts/repo-cargo test -p meerkat --features session-store start_turn_request_carries_typed_turn_appends --lib
- ./scripts/repo-cargo test -p rkat cli_context_system_notice_projects_via_typed_notice --bin rkat
- ./scripts/repo-cargo test -p meerkat-rest rest_context_system_notice_projects_via_typed_notice --lib
- ./scripts/repo-cargo test -p meerkat-mcp-server mcp_context_system_notice_projects_via_typed_notice --lib
- ./scripts/repo-cargo check -p meerkat-core --all-targets
- ./scripts/repo-cargo check -p meerkat-rpc --tests
- ./scripts/repo-cargo check -p meerkat --features integration-real-tests --test live_meerkat_regression
- ./scripts/repo-cargo check -p meerkat-mob --features integration-real-tests --test smoke_mob_generated_image_comms --test smoke_mob_pictionary
- ./scripts/repo-cargo clippy -p meerkat-core --lib --tests -- -D warnings
- ./scripts/repo-cargo clippy -p meerkat-runtime --lib -- -D warnings
- ./scripts/repo-cargo clippy -p meerkat-mob --lib --tests -- -D warnings
- git diff --check
- pre-push hook: fmt, clippy changed crates, deterministic workspace gate