### PR TITLE
ci: keep BuildBuddy runs queued

### DIFF
--- a/.github/workflows/buildbuddy.yml
+++ b/.github/workflows/buildbuddy.yml
@@ -54,6 +54,9 @@ permissions:
 
 concurrency:
   group: buildbuddy-gcp-executors
+  # Keep all pending BuildBuddy runs queued behind the shared GCP executor pool.
+  # GitHub's default single pending slot cancels older PR CI before any steps run.
+  queue: max
   cancel-in-progress: false
 
 env:

--- a/scripts/buildbuddy-doctor
+++ b/scripts/buildbuddy-doctor
@@ -366,6 +366,7 @@ fi
 
 if grep -Fq 'MEERKAT_GCP_BUILDBUDDY_CI_MAX_SECONDS' .github/workflows/buildbuddy.yml &&
   grep -Fq 'buildbuddy-gcp-executors' .github/workflows/buildbuddy.yml &&
+  grep -Fq 'queue: max' .github/workflows/buildbuddy.yml &&
   grep -Fq 'MEERKAT_GCP_BUILDBUDDY_WAIT_ON_DOWN' .github/workflows/buildbuddy.yml &&
   grep -Fq 'scripts/gcp-buildbuddy-executor-pool down' .github/workflows/buildbuddy.yml &&
   grep -Fq 'MEERKAT_GCP_BUILDBUDDY_DOWN_MODE' .github/workflows/buildbuddy.yml &&


### PR DESCRIPTION
## Summary
- enable a real GitHub Actions queue for the shared GCP BuildBuddy executor lock
- teach buildbuddy-doctor to assert the non-lossy queue setting stays wired

## Validation
- git diff --check
- Ruby YAML parse for .github/workflows/buildbuddy.yml
- make buildbuddy-doctor