### PR TITLE
[codex] Fix WorkGraph machine authority doctrine

### DIFF
--- a/.claude/skills/meerkat-architecture/SKILL.md
+++ b/.claude/skills/meerkat-architecture/SKILL.md
@@ -115,15 +115,16 @@ lives in `meerkat-live`. For a deeper internal reference,
 `meerkat-contracts/src/wire/live.rs` are the authoritative surface;
 `docs/guides/realtime.mdx` is the user-facing Live Channels companion.
 
-## The 5-machine target
+## The 6-machine target
 
-Exactly five canonical machines, each with a DSL source in `meerkat-machine-schema/src/catalog/dsl/`:
+Exactly six canonical machines, each with a DSL source in `meerkat-machine-schema/src/catalog/dsl/`:
 
 - **MeerkatMachine** — session-scoped execution kernel. Owns session lifecycle, input admission, ops lifecycle, turn execution, tool surface state, drain lifecycle, peer comms classification.
 - **MobMachine** — mob-scoped orchestration. Owns mob lifecycle, member lifecycle, kickoff, wiring, roster, flow/frame/loop execution. (Per-member realtime intent and the realtime-binding plane were removed — live channels are caller-initiated via `live/*`, gated on each member's session-level `ModelCapabilities.realtime`.)
 - **ScheduleLifecycleMachine** — scheduler triggers and schedule lifecycle.
 - **OccurrenceLifecycleMachine** — occurrence dispatch and delivery.
 - **AuthMachine** — auth/session authorization state that must remain machine-owned.
+- **WorkGraphLifecycleMachine** — realm-scoped durable commitment graph authority. Owns work item lifecycle, revision/CAS legality, dependency readiness, claim leases, terminal state, topology legality, and evidence revision handling.
 
 Plus five composition protocols at the seams: `meerkat_mob_seam`, `schedule_bundle`, `schedule_runtime_bundle`, `schedule_mob_bundle`, `auth_lease_bundle`.
 
@@ -203,7 +204,7 @@ Load these as needed. SKILL.md alone is intentionally minimal — everything els
 
 For comprehensive file lists, see the matching reference. This is a minimal pointer index for the most common landmarks.
 
-- `meerkat-machine-schema/src/catalog/dsl/` — DSL sources (truth for all 5 canonical machines)
+- `meerkat-machine-schema/src/catalog/dsl/` — DSL sources (truth for all 6 canonical machines)
 - `meerkat-machine-schema/src/catalog/mod.rs` — `canonical_machine_schemas()` registry
 - `meerkat-machine-kernels/src/runtime.rs` — `GeneratedMachineKernel` interpreter
 - `meerkat-runtime/src/meerkat_machine/` — `MeerkatMachine`, session management, dispatch paths, DSL adapter

--- a/.claude/skills/meerkat-architecture/references/machine-system.md
+++ b/.claude/skills/meerkat-architecture/references/machine-system.md
@@ -2,19 +2,20 @@
 
 Load this reference when working on DSL definitions, schema catalog, generated kernels, TLC verification, production bridge modules, command classification, schema/alphabet parity, or authority cutover.
 
-## The 5-machine target
+## The 6-machine target
 
-The final system has exactly five canonical machines:
+The final system has exactly six canonical machines:
 
 - **MeerkatMachine** — session-scoped execution kernel (absorbs input lifecycle, runtime ingress, ops lifecycle, turn execution, comms drain, peer comms, external tool surface, session turn admission)
 - **MobMachine** — mob-scoped orchestration (absorbs mob lifecycle, member bootstrap, member lifecycle, wiring, roster, orchestrator, flow, loop iteration)
 - **ScheduleLifecycleMachine** — perimeter scheduler
 - **OccurrenceLifecycleMachine** — perimeter occurrence lifecycle
 - **AuthMachine** — auth/session authorization lifecycle
+- **WorkGraphLifecycleMachine** — realm-scoped durable work graph lifecycle, revision/CAS legality, dependency readiness, claim leases, terminal state, topology legality, and evidence revision handling
 
 Plus five canonical composition schemas at the seams: `meerkat_mob_seam`, `schedule_bundle`, `schedule_runtime_bundle`, `schedule_mob_bundle`, `auth_lease_bundle`.
 
-Catalog authoritative directory: `meerkat-machine-schema/src/catalog/dsl/` — contains exactly these five machine DSLs.
+Catalog authoritative directory: `meerkat-machine-schema/src/catalog/dsl/` — contains exactly these six machine DSLs.
 
 Previously-standalone machines absorbed into MeerkatMachine/MobMachine state become fields, inputs, and transitions inside the host machine. Post-absorption, remaining helper modules are projection/reducer support or shell mechanics; shell code routes semantic decisions through the host machine's DSL via handle traits or in-crate MobMachine authority access (see "Cross-crate DSL access" below).
 
@@ -24,12 +25,13 @@ The DSL is a single source that produces two artifacts:
 
 ```
 ┌────────────────────────────────────────────────────────────────────┐
-│  DSL SOURCE (single source of truth, 5 files)                      │
+│  DSL SOURCE (single source of truth, 6 files)                      │
 │  meerkat-machine-schema/src/catalog/dsl/meerkat_machine.rs         │
 │  meerkat-machine-schema/src/catalog/dsl/mob_machine.rs             │
 │  meerkat-machine-schema/src/catalog/dsl/schedule_lifecycle.rs      │
 │  meerkat-machine-schema/src/catalog/dsl/occurrence_lifecycle.rs    │
 │  meerkat-machine-schema/src/catalog/dsl/auth_machine.rs            │
+│  meerkat-machine-schema/src/catalog/dsl/workgraph_lifecycle.rs     │
 │                                                                    │
 │  machine_dsl! {                                                    │
 │    state { <fields> }                                              │
@@ -217,7 +219,7 @@ and archived historically at `docs-internal/archive/public-docs-removed-2026-05-
 
 ## What the workspace looks like in the target state
 
-- Exactly 5 canonical machine DSL files in `meerkat-machine-schema/src/catalog/dsl/` — one per machine. Shared catalog helpers in that directory are allowed; no production crate authors a competing machine body.
+- Exactly 6 canonical machine DSL files in `meerkat-machine-schema/src/catalog/dsl/` — one per machine. Shared catalog helpers in that directory are allowed; no production crate authors a competing machine body.
 - Exactly 5 canonical compositions in `meerkat-machine-schema/src/catalog/compositions.rs`, registered by `canonical_composition_schemas()`.
 - Zero `*_authority.rs` files containing handwritten match-table state machines. Files named `dsl_authority.rs` are runtime adapter plumbing (not state machines); other authority-named helpers must be projections, planners, or sealed mutators with no semantic transition table.
 - Runtime shell holds only: per-session `Arc<Mutex<MeerkatMachineAuthority>>` + `Arc<Mutex<MobMachineAuthority>>`, handle trait impls that route through the shared authorities, IO mechanics (channels, handles, wall-clock timestamps), and observability projections (history logs, diagnostic snapshots).

--- a/meerkat-machine-kernels/src/generated/work_graph_lifecycle.rs
+++ b/meerkat-machine-kernels/src/generated/work_graph_lifecycle.rs
@@ -12,6 +12,152 @@ pub fn schema() -> meerkat_machine_schema::MachineSchema {
     meerkat_machine_schema::catalog::dsl::dsl_work_graph_lifecycle_machine()
 }
 
+#[derive(
+    Debug,
+    Clone,
+    Default,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash,
+    serde::Serialize,
+    serde::Deserialize,
+)]
+pub struct WorkDependencyPathKey(pub String);
+impl From<String> for WorkDependencyPathKey {
+    fn from(value: String) -> Self {
+        Self(value)
+    }
+}
+impl From<&str> for WorkDependencyPathKey {
+    fn from(value: &str) -> Self {
+        Self(value.to_owned())
+    }
+}
+impl std::fmt::Display for WorkDependencyPathKey {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+#[derive(
+    Debug,
+    Clone,
+    Default,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash,
+    serde::Serialize,
+    serde::Deserialize,
+)]
+pub struct WorkEdgeKey(pub String);
+impl From<String> for WorkEdgeKey {
+    fn from(value: String) -> Self {
+        Self(value)
+    }
+}
+impl From<&str> for WorkEdgeKey {
+    fn from(value: &str) -> Self {
+        Self(value.to_owned())
+    }
+}
+impl std::fmt::Display for WorkEdgeKey {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+#[allow(non_camel_case_types)]
+#[derive(
+    Debug,
+    Clone,
+    Copy,
+    Default,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash,
+    serde::Serialize,
+    serde::Deserialize,
+)]
+pub enum WorkEdgeKind {
+    #[default]
+    #[serde(rename = "Blocks")]
+    Blocks,
+    #[serde(rename = "Parent")]
+    Parent,
+    #[serde(rename = "Related")]
+    Related,
+    #[serde(rename = "Supersedes")]
+    Supersedes,
+    #[serde(rename = "DerivedFrom")]
+    DerivedFrom,
+}
+impl WorkEdgeKind {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Blocks => "Blocks",
+            Self::Parent => "Parent",
+            Self::Related => "Related",
+            Self::Supersedes => "Supersedes",
+            Self::DerivedFrom => "DerivedFrom",
+        }
+    }
+}
+impl std::convert::TryFrom<&str> for WorkEdgeKind {
+    type Error = String;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        match value {
+            "Blocks" => Ok(Self::Blocks),
+            "Parent" => Ok(Self::Parent),
+            "Related" => Ok(Self::Related),
+            "Supersedes" => Ok(Self::Supersedes),
+            "DerivedFrom" => Ok(Self::DerivedFrom),
+            other => Err(format!("invalid WorkEdgeKind value `{other}`")),
+        }
+    }
+}
+impl std::convert::TryFrom<String> for WorkEdgeKind {
+    type Error = String;
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        Self::try_from(value.as_str())
+    }
+}
+impl std::fmt::Display for WorkEdgeKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+#[derive(
+    Debug,
+    Clone,
+    Default,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash,
+    serde::Serialize,
+    serde::Deserialize,
+)]
+pub struct WorkItemKey(pub String);
+impl From<String> for WorkItemKey {
+    fn from(value: String) -> Self {
+        Self(value)
+    }
+}
+impl From<&str> for WorkItemKey {
+    fn from(value: &str) -> Self {
+        Self(value.to_owned())
+    }
+}
+impl std::fmt::Display for WorkItemKey {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
 #[allow(non_camel_case_types)]
 #[derive(
     Debug,
@@ -82,34 +228,7 @@ impl std::fmt::Display for WorkLifecycleState {
         f.write_str(self.as_str())
     }
 }
-#[derive(
-    Debug,
-    Clone,
-    Default,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Hash,
-    serde::Serialize,
-    serde::Deserialize,
-)]
-pub struct WorkOwnerKey(pub String);
-impl From<String> for WorkOwnerKey {
-    fn from(value: String) -> Self {
-        Self(value)
-    }
-}
-impl From<&str> for WorkOwnerKey {
-    fn from(value: &str) -> Self {
-        Self(value.to_owned())
-    }
-}
-impl std::fmt::Display for WorkOwnerKey {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.write_str(&self.0)
-    }
-}
+pub type WorkOwnerKey = meerkat_machine_schema::catalog::dsl::workgraph_lifecycle::WorkOwnerKey;
 
 pub trait Context {}
 pub struct EmptyContext;
@@ -132,6 +251,10 @@ pub struct State {
     pub phase: Phase,
     pub revision: u64,
     pub unresolved_blocker_count: u64,
+    pub topology_item_keys: std::collections::BTreeSet<WorkItemKey>,
+    pub topology_edge_keys: std::collections::BTreeSet<WorkEdgeKey>,
+    pub blocks_reachability: std::collections::BTreeSet<WorkDependencyPathKey>,
+    pub parent_reachability: std::collections::BTreeSet<WorkDependencyPathKey>,
     pub claim_owner_key: Option<WorkOwnerKey>,
     pub claimed_at_utc_ms: Option<u64>,
     pub lease_expires_at_utc_ms: Option<u64>,
@@ -193,10 +316,11 @@ pub mod inputs {
     }
     #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
     pub struct ValidateLink {
-        pub endpoints_exist: bool,
-        pub self_edge: bool,
-        pub duplicate_edge: bool,
-        pub would_create_cycle: bool,
+        pub kind: WorkEdgeKind,
+        pub from_item_key: WorkItemKey,
+        pub to_item_key: WorkItemKey,
+        pub edge_key: WorkEdgeKey,
+        pub reverse_path_key: WorkDependencyPathKey,
     }
     #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
     pub struct CloseCompleted {
@@ -423,6 +547,10 @@ pub fn initial_state() -> State {
         phase: Phase::Absent,
         revision: 0,
         unresolved_blocker_count: 0,
+        topology_item_keys: Default::default(),
+        topology_edge_keys: Default::default(),
+        blocks_reachability: Default::default(),
+        parent_reachability: Default::default(),
         claim_owner_key: None,
         claimed_at_utc_ms: None,
         lease_expires_at_utc_ms: None,

--- a/meerkat-machine-schema/src/catalog/dsl/mod.rs
+++ b/meerkat-machine-schema/src/catalog/dsl/mod.rs
@@ -1098,7 +1098,25 @@ pub fn workgraph_lifecycle_schema_metadata() -> MachineSchemaMetadata {
                     "Failed",
                 ],
             ),
-            NamedTypeBinding::string("WorkOwnerKey"),
+            NamedTypeBinding::string("WorkItemKey"),
+            NamedTypeBinding::string("WorkEdgeKey"),
+            NamedTypeBinding::string("WorkDependencyPathKey"),
+            NamedTypeBinding::string_enum(
+                "WorkEdgeKind",
+                &["Blocks", "Parent", "Related", "Supersedes", "DerivedFrom"],
+            ),
+            NamedTypeBinding::string_enum(
+                "WorkOwnerKind",
+                &["Principal", "Agent", "Session", "Mob", "Label"],
+            ),
+            NamedTypeBinding::type_path_struct(
+                "WorkOwnerKey",
+                "crate::catalog::dsl::workgraph_lifecycle::WorkOwnerKey",
+                vec![
+                    TypePathStructField::named("kind", "WorkOwnerKind"),
+                    TypePathStructField::string("id"),
+                ],
+            ),
         ],
         vec![],
     )

--- a/meerkat-machine-schema/src/catalog/dsl/workgraph_lifecycle.rs
+++ b/meerkat-machine-schema/src/catalog/dsl/workgraph_lifecycle.rs
@@ -13,12 +13,115 @@ use meerkat_machine_dsl::machine;
     serde::Serialize,
     serde::Deserialize,
 )]
-pub struct WorkOwnerKey(pub String);
+pub struct WorkItemKey(pub String);
 
-impl<T: Into<String>> From<T> for WorkOwnerKey {
+impl<T: Into<String>> From<T> for WorkItemKey {
     fn from(value: T) -> Self {
         Self(value.into())
     }
+}
+
+#[derive(
+    Debug,
+    Clone,
+    Default,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash,
+    serde::Serialize,
+    serde::Deserialize,
+)]
+pub struct WorkEdgeKey(pub String);
+
+impl<T: Into<String>> From<T> for WorkEdgeKey {
+    fn from(value: T) -> Self {
+        Self(value.into())
+    }
+}
+
+#[derive(
+    Debug,
+    Clone,
+    Default,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash,
+    serde::Serialize,
+    serde::Deserialize,
+)]
+pub struct WorkDependencyPathKey(pub String);
+
+impl<T: Into<String>> From<T> for WorkDependencyPathKey {
+    fn from(value: T) -> Self {
+        Self(value.into())
+    }
+}
+
+#[derive(
+    Debug,
+    Clone,
+    Copy,
+    Default,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash,
+    serde::Serialize,
+    serde::Deserialize,
+)]
+#[serde(rename_all = "snake_case")]
+pub enum WorkOwnerKind {
+    Principal,
+    Agent,
+    Session,
+    Mob,
+    #[default]
+    Label,
+}
+
+#[derive(
+    Debug,
+    Clone,
+    Default,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash,
+    serde::Serialize,
+    serde::Deserialize,
+)]
+pub struct WorkOwnerKey {
+    pub kind: WorkOwnerKind,
+    pub id: String,
+}
+
+#[derive(
+    Debug,
+    Clone,
+    Copy,
+    Default,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash,
+    serde::Serialize,
+    serde::Deserialize,
+)]
+#[serde(rename_all = "snake_case")]
+pub enum WorkEdgeKind {
+    #[default]
+    Blocks,
+    Parent,
+    Related,
+    Supersedes,
+    DerivedFrom,
 }
 
 machine! {
@@ -30,6 +133,10 @@ machine! {
             lifecycle_phase: WorkLifecycleState,
             revision: u64,
             unresolved_blocker_count: u64,
+            topology_item_keys: Set<WorkItemKey>,
+            topology_edge_keys: Set<WorkEdgeKey>,
+            blocks_reachability: Set<WorkDependencyPathKey>,
+            parent_reachability: Set<WorkDependencyPathKey>,
             claim_owner_key: Option<WorkOwnerKey>,
             claimed_at_utc_ms: Option<u64>,
             lease_expires_at_utc_ms: Option<u64>,
@@ -43,6 +150,10 @@ machine! {
         init(Absent) {
             revision = 0,
             unresolved_blocker_count = 0,
+            topology_item_keys = EmptySet,
+            topology_edge_keys = EmptySet,
+            blocks_reachability = EmptySet,
+            parent_reachability = EmptySet,
             claim_owner_key = None,
             claimed_at_utc_ms = None,
             lease_expires_at_utc_ms = None,
@@ -95,10 +206,11 @@ machine! {
             Block { expected_revision: u64 },
             RefreshEligibility { unresolved_blocker_count: u64 },
             ValidateLink {
-                endpoints_exist: bool,
-                self_edge: bool,
-                duplicate_edge: bool,
-                would_create_cycle: bool,
+                kind: WorkEdgeKind,
+                from_item_key: WorkItemKey,
+                to_item_key: WorkItemKey,
+                edge_key: WorkEdgeKey,
+                reverse_path_key: WorkDependencyPathKey,
             },
             CloseCompleted { expected_revision: u64, at_utc_ms: u64 },
             CloseCancelled { expected_revision: u64, at_utc_ms: u64 },
@@ -123,6 +235,12 @@ machine! {
 
         invariant live_has_positive_revision {
             self.lifecycle_phase == Phase::Absent || self.revision > 0
+        }
+
+        invariant topology_snapshot_is_stateless {
+            self.topology_item_keys == EmptySet
+                || self.topology_edge_keys == EmptySet
+                || self.lifecycle_phase == Phase::Absent
         }
 
         invariant terminal_has_terminal_time {
@@ -339,12 +457,18 @@ machine! {
         }
 
         transition ValidateLink {
-            on input ValidateLink { endpoints_exist, self_edge, duplicate_edge, would_create_cycle }
+            on input ValidateLink { kind, from_item_key, to_item_key, edge_key, reverse_path_key }
             guard "stateless_checker" { self.lifecycle_phase == Phase::Absent }
-            guard "endpoints_exist" { endpoints_exist == true }
-            guard "not_self_edge" { self_edge == false }
-            guard "not_duplicate_edge" { duplicate_edge == false }
-            guard "acyclic" { would_create_cycle == false }
+            guard "from_endpoint_exists" { self.topology_item_keys.contains(from_item_key) }
+            guard "to_endpoint_exists" { self.topology_item_keys.contains(to_item_key) }
+            guard "not_self_edge" { from_item_key != to_item_key }
+            guard "not_duplicate_edge" { self.topology_edge_keys.contains(edge_key) == false }
+            guard "blocks_acyclic" {
+                kind != WorkEdgeKind::Blocks || self.blocks_reachability.contains(reverse_path_key) == false
+            }
+            guard "parent_acyclic" {
+                kind != WorkEdgeKind::Parent || self.parent_reachability.contains(reverse_path_key) == false
+            }
             to Absent
             emit LinkValidated
         }
@@ -540,5 +664,128 @@ machine! {
             to Failed
             emit EvidenceAdded
         }
+    }
+}
+
+impl serde::Serialize for WorkLifecycleState {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_str(match self {
+            Self::Absent => "absent",
+            Self::Open => "open",
+            Self::InProgress => "in_progress",
+            Self::Blocked => "blocked",
+            Self::Completed => "completed",
+            Self::Cancelled => "cancelled",
+            Self::Failed => "failed",
+        })
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for WorkLifecycleState {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let value = <String as serde::Deserialize>::deserialize(deserializer)?;
+        match value.as_str() {
+            "absent" | "Absent" => Ok(Self::Absent),
+            "open" | "Open" => Ok(Self::Open),
+            "in_progress" | "InProgress" => Ok(Self::InProgress),
+            "blocked" | "Blocked" => Ok(Self::Blocked),
+            "completed" | "Completed" => Ok(Self::Completed),
+            "cancelled" | "Cancelled" => Ok(Self::Cancelled),
+            "failed" | "Failed" => Ok(Self::Failed),
+            other => Err(serde::de::Error::custom(format!(
+                "invalid WorkLifecycleState `{other}`"
+            ))),
+        }
+    }
+}
+
+#[derive(serde::Serialize, serde::Deserialize)]
+struct WorkGraphLifecycleMachineStateWire {
+    lifecycle_phase: WorkLifecycleState,
+    revision: u64,
+    unresolved_blocker_count: u64,
+    #[serde(default)]
+    topology_item_keys: std::collections::BTreeSet<WorkItemKey>,
+    #[serde(default)]
+    topology_edge_keys: std::collections::BTreeSet<WorkEdgeKey>,
+    #[serde(default)]
+    blocks_reachability: std::collections::BTreeSet<WorkDependencyPathKey>,
+    #[serde(default)]
+    parent_reachability: std::collections::BTreeSet<WorkDependencyPathKey>,
+    claim_owner_key: Option<WorkOwnerKey>,
+    claimed_at_utc_ms: Option<u64>,
+    lease_expires_at_utc_ms: Option<u64>,
+    due_at_utc_ms: Option<u64>,
+    not_before_utc_ms: Option<u64>,
+    snoozed_until_utc_ms: Option<u64>,
+    terminal_at_utc_ms: Option<u64>,
+    evidence_count: u64,
+}
+
+impl From<&WorkGraphLifecycleMachineState> for WorkGraphLifecycleMachineStateWire {
+    fn from(state: &WorkGraphLifecycleMachineState) -> Self {
+        Self {
+            lifecycle_phase: state.lifecycle_phase,
+            revision: state.revision,
+            unresolved_blocker_count: state.unresolved_blocker_count,
+            topology_item_keys: state.topology_item_keys.clone(),
+            topology_edge_keys: state.topology_edge_keys.clone(),
+            blocks_reachability: state.blocks_reachability.clone(),
+            parent_reachability: state.parent_reachability.clone(),
+            claim_owner_key: state.claim_owner_key.clone(),
+            claimed_at_utc_ms: state.claimed_at_utc_ms,
+            lease_expires_at_utc_ms: state.lease_expires_at_utc_ms,
+            due_at_utc_ms: state.due_at_utc_ms,
+            not_before_utc_ms: state.not_before_utc_ms,
+            snoozed_until_utc_ms: state.snoozed_until_utc_ms,
+            terminal_at_utc_ms: state.terminal_at_utc_ms,
+            evidence_count: state.evidence_count,
+        }
+    }
+}
+
+impl From<WorkGraphLifecycleMachineStateWire> for WorkGraphLifecycleMachineState {
+    fn from(wire: WorkGraphLifecycleMachineStateWire) -> Self {
+        Self {
+            lifecycle_phase: wire.lifecycle_phase,
+            revision: wire.revision,
+            unresolved_blocker_count: wire.unresolved_blocker_count,
+            topology_item_keys: wire.topology_item_keys,
+            topology_edge_keys: wire.topology_edge_keys,
+            blocks_reachability: wire.blocks_reachability,
+            parent_reachability: wire.parent_reachability,
+            claim_owner_key: wire.claim_owner_key,
+            claimed_at_utc_ms: wire.claimed_at_utc_ms,
+            lease_expires_at_utc_ms: wire.lease_expires_at_utc_ms,
+            due_at_utc_ms: wire.due_at_utc_ms,
+            not_before_utc_ms: wire.not_before_utc_ms,
+            snoozed_until_utc_ms: wire.snoozed_until_utc_ms,
+            terminal_at_utc_ms: wire.terminal_at_utc_ms,
+            evidence_count: wire.evidence_count,
+        }
+    }
+}
+
+impl serde::Serialize for WorkGraphLifecycleMachineState {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        WorkGraphLifecycleMachineStateWire::from(self).serialize(serializer)
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for WorkGraphLifecycleMachineState {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        WorkGraphLifecycleMachineStateWire::deserialize(deserializer).map(Self::from)
     }
 }

--- a/meerkat-workgraph/src/lib.rs
+++ b/meerkat-workgraph/src/lib.rs
@@ -38,8 +38,9 @@ pub use types::{
     AddEvidenceRequest, ClaimWorkItemRequest, CloseWorkItemRequest, CreateWorkItemRequest,
     ExternalWorkRef, LinkWorkItemsRequest, ReadyWorkFilter, ReleaseWorkItemRequest,
     UpdateWorkItemRequest, WorkClaim, WorkEdge, WorkEdgeKind, WorkEvidenceRef, WorkGraphEvent,
-    WorkGraphEventKind, WorkGraphSnapshot, WorkGraphSnapshotFilter, WorkItem, WorkItemFilter,
-    WorkItemId, WorkNamespace, WorkOwner, WorkPriority, WorkStatus,
+    WorkGraphEventKind, WorkGraphMachineState, WorkGraphSnapshot, WorkGraphSnapshotFilter,
+    WorkItem, WorkItemFilter, WorkItemId, WorkNamespace, WorkOwner, WorkOwnerKey, WorkOwnerKind,
+    WorkPriority, WorkStatus,
 };
 
 #[doc(hidden)]

--- a/meerkat-workgraph/src/machine.rs
+++ b/meerkat-workgraph/src/machine.rs
@@ -8,13 +8,18 @@ use crate::machines::workgraph_lifecycle as wg_dsl;
 use crate::types::{
     AddEvidenceRequest, ClaimWorkItemRequest, CloseWorkItemRequest, CreateWorkItemRequest,
     ReleaseWorkItemRequest, UpdateWorkItemRequest, WorkClaim, WorkEdge, WorkEdgeKind,
-    WorkGraphEvent, WorkGraphEventKind, WorkItem, WorkItemId, WorkNamespace, WorkStatus,
+    WorkGraphEvent, WorkGraphEventKind, WorkGraphMachineState, WorkItem, WorkItemId, WorkNamespace,
+    WorkStatus,
 };
 
 #[derive(Debug, Default, Clone, Copy)]
 pub struct WorkGraphMachine;
 
 impl WorkGraphMachine {
+    pub fn validate_item_projection(item: &WorkItem) -> Result<(), WorkGraphError> {
+        validate_item_machine_projection(item)
+    }
+
     pub fn create_item(
         request: CreateWorkItemRequest,
         realm_id: String,
@@ -53,7 +58,7 @@ impl WorkGraphMachine {
             | WorkStatus::Failed => unreachable!("invalid create status rejected above"),
         };
         let dsl_state = apply_new_item_dsl(input)?;
-        let item = WorkItem {
+        let mut item = WorkItem {
             id: WorkItemId::generated(),
             realm_id,
             namespace,
@@ -64,6 +69,7 @@ impl WorkGraphMachine {
             labels: normalize_labels(request.labels)?,
             owner: None,
             claim: None,
+            machine_state: dsl_state.clone(),
             revision: dsl_state.revision,
             due_at: dsl_state.due_at_utc_ms.and_then(millis_to_datetime),
             not_before: dsl_state.not_before_utc_ms.and_then(millis_to_datetime),
@@ -74,6 +80,7 @@ impl WorkGraphMachine {
             external_refs: request.external_refs,
             evidence_refs: request.evidence_refs,
         };
+        sync_item_from_machine_state(&mut item)?;
         let event = item_event(&item, WorkGraphEventKind::Created, now)?;
         Ok((item, event))
     }
@@ -88,13 +95,13 @@ impl WorkGraphMachine {
         let snoozed_until = request.snoozed_until.or(item.snoozed_until);
         let dsl_state = apply_item_dsl(
             &item,
-            0,
+            item.machine_state.unresolved_blocker_count,
             wg_dsl::WorkGraphLifecycleInput::Update {
                 expected_revision: request.expected_revision,
                 due_at_utc_ms: due_at.map(datetime_to_millis),
                 not_before_utc_ms: not_before.map(datetime_to_millis),
                 snoozed_until_utc_ms: snoozed_until.map(datetime_to_millis),
-                unresolved_blocker_count: 0,
+                unresolved_blocker_count: item.machine_state.unresolved_blocker_count,
             },
             Some(request.expected_revision),
         )?;
@@ -111,11 +118,8 @@ impl WorkGraphMachine {
         if let Some(labels) = request.labels {
             item.labels = normalize_labels(labels)?;
         }
-        item.status = work_status_from_dsl(dsl_state.lifecycle_phase)?;
-        item.revision = dsl_state.revision;
-        item.due_at = dsl_state.due_at_utc_ms.and_then(millis_to_datetime);
-        item.not_before = dsl_state.not_before_utc_ms.and_then(millis_to_datetime);
-        item.snoozed_until = dsl_state.snoozed_until_utc_ms.and_then(millis_to_datetime);
+        item.machine_state = dsl_state;
+        sync_item_from_machine_state(&mut item)?;
         if !request.external_refs.is_empty() {
             item.external_refs = request.external_refs;
         }
@@ -129,22 +133,43 @@ impl WorkGraphMachine {
         request: ClaimWorkItemRequest,
         now: DateTime<Utc>,
     ) -> Result<(WorkItem, WorkGraphEvent), WorkGraphError> {
-        Self::claim_item_with_unresolved_blockers(item, 0, request, now)
+        Self::claim_ready_item(item, request, now)
     }
 
     pub fn claim_ready_item(
         item: WorkItem,
-        all_items: &BTreeMap<WorkItemId, WorkItem>,
-        edges: &[WorkEdge],
         request: ClaimWorkItemRequest,
         now: DateTime<Utc>,
     ) -> Result<(WorkItem, WorkGraphEvent), WorkGraphError> {
         Self::claim_item_with_unresolved_blockers(
             item.clone(),
-            unresolved_blocker_count(&item, all_items, edges),
+            item.machine_state.unresolved_blocker_count,
             request,
             now,
         )
+    }
+
+    pub fn refresh_eligibility(
+        mut item: WorkItem,
+        unresolved_blocker_count: u64,
+        now: DateTime<Utc>,
+    ) -> Result<Option<(WorkItem, WorkGraphEvent)>, WorkGraphError> {
+        if item.machine_state.unresolved_blocker_count == unresolved_blocker_count {
+            return Ok(None);
+        }
+        let dsl_state = apply_item_dsl(
+            &item,
+            unresolved_blocker_count,
+            wg_dsl::WorkGraphLifecycleInput::RefreshEligibility {
+                unresolved_blocker_count,
+            },
+            None,
+        )?;
+        item.machine_state = dsl_state;
+        sync_item_from_machine_state(&mut item)?;
+        item.updated_at = now;
+        let event = item_event(&item, WorkGraphEventKind::Updated, now)?;
+        Ok(Some((item, event)))
     }
 
     fn claim_item_with_unresolved_blockers(
@@ -176,8 +201,8 @@ impl WorkGraphMachine {
             claimed_at: now,
             lease_expires_at,
         });
-        item.status = work_status_from_dsl(dsl_state.lifecycle_phase)?;
-        item.revision = dsl_state.revision;
+        item.machine_state = dsl_state;
+        sync_item_from_machine_state(&mut item)?;
         item.updated_at = now;
         let event = item_event(&item, WorkGraphEventKind::Claimed, now)?;
         Ok((item, event))
@@ -190,7 +215,7 @@ impl WorkGraphMachine {
     ) -> Result<(WorkItem, WorkGraphEvent), WorkGraphError> {
         let dsl_state = apply_item_dsl(
             &item,
-            0,
+            item.machine_state.unresolved_blocker_count,
             wg_dsl::WorkGraphLifecycleInput::Release {
                 expected_revision: request.expected_revision,
             },
@@ -198,8 +223,8 @@ impl WorkGraphMachine {
         )?;
         item.claim = None;
         item.owner = None;
-        item.status = work_status_from_dsl(dsl_state.lifecycle_phase)?;
-        item.revision = dsl_state.revision;
+        item.machine_state = dsl_state;
+        sync_item_from_machine_state(&mut item)?;
         item.updated_at = now;
         let event = item_event(&item, WorkGraphEventKind::Released, now)?;
         Ok((item, event))
@@ -212,15 +237,14 @@ impl WorkGraphMachine {
     ) -> Result<(WorkItem, WorkGraphEvent), WorkGraphError> {
         let dsl_state = apply_item_dsl(
             &item,
-            0,
+            item.machine_state.unresolved_blocker_count,
             wg_dsl::WorkGraphLifecycleInput::Block { expected_revision },
             Some(expected_revision),
         )?;
-        item.status = WorkStatus::Blocked;
         item.claim = None;
         item.owner = None;
-        item.status = work_status_from_dsl(dsl_state.lifecycle_phase)?;
-        item.revision = dsl_state.revision;
+        item.machine_state = dsl_state;
+        sync_item_from_machine_state(&mut item)?;
         item.updated_at = now;
         let event = item_event(&item, WorkGraphEventKind::Blocked, now)?;
         Ok((item, event))
@@ -250,12 +274,16 @@ impl WorkGraphMachine {
                 ));
             }
         };
-        let dsl_state = apply_item_dsl(&item, 0, dsl_input, Some(request.expected_revision))?;
-        item.status = work_status_from_dsl(dsl_state.lifecycle_phase)?;
+        let dsl_state = apply_item_dsl(
+            &item,
+            item.machine_state.unresolved_blocker_count,
+            dsl_input,
+            Some(request.expected_revision),
+        )?;
         item.claim = None;
         item.owner = None;
-        item.terminal_at = dsl_state.terminal_at_utc_ms.and_then(millis_to_datetime);
-        item.revision = dsl_state.revision;
+        item.machine_state = dsl_state;
+        sync_item_from_machine_state(&mut item)?;
         item.updated_at = now;
         let event = item_event(&item, WorkGraphEventKind::Closed, now)?;
         Ok((item, event))
@@ -268,30 +296,28 @@ impl WorkGraphMachine {
     ) -> Result<(WorkItem, WorkGraphEvent), WorkGraphError> {
         let dsl_state = apply_item_dsl(
             &item,
-            0,
+            item.machine_state.unresolved_blocker_count,
             wg_dsl::WorkGraphLifecycleInput::AddEvidence {
                 expected_revision: request.expected_revision,
             },
             Some(request.expected_revision),
         )?;
         item.evidence_refs.push(request.evidence);
-        item.status = work_status_from_dsl(dsl_state.lifecycle_phase)?;
-        item.revision = dsl_state.revision;
+        item.machine_state = dsl_state;
+        sync_item_from_machine_state(&mut item)?;
         item.updated_at = now;
         let event = item_event(&item, WorkGraphEventKind::EvidenceAdded, now)?;
         Ok((item, event))
     }
 
-    pub fn is_ready(
-        item: &WorkItem,
-        all_items: &BTreeMap<WorkItemId, WorkItem>,
-        edges: &[WorkEdge],
-        now: DateTime<Utc>,
-    ) -> bool {
-        let owner_key = wg_dsl::WorkOwnerKey("__ready_probe__".to_string());
+    pub fn is_ready(item: &WorkItem, now: DateTime<Utc>) -> bool {
+        let owner_key = wg_dsl::WorkOwnerKey {
+            kind: wg_dsl::WorkOwnerKind::Label,
+            id: "__ready_probe__".to_string(),
+        };
         apply_item_dsl(
             item,
-            unresolved_blocker_count(item, all_items, edges),
+            item.machine_state.unresolved_blocker_count,
             wg_dsl::WorkGraphLifecycleInput::Claim {
                 expected_revision: item.revision,
                 owner_key,
@@ -303,41 +329,29 @@ impl WorkGraphMachine {
         .is_ok()
     }
 
-    pub fn ready_items(
-        items: Vec<WorkItem>,
-        edges: &[WorkEdge],
-        now: DateTime<Utc>,
-    ) -> Vec<WorkItem> {
-        let all_items = items
-            .iter()
-            .cloned()
-            .map(|item| (item.id.clone(), item))
-            .collect::<BTreeMap<_, _>>();
+    pub fn ready_items(items: Vec<WorkItem>, now: DateTime<Utc>) -> Vec<WorkItem> {
         items
             .into_iter()
-            .filter(|item| Self::is_ready(item, &all_items, edges, now))
+            .filter(|item| Self::is_ready(item, now))
             .collect()
     }
 
     pub fn validate_link(
         edge: &WorkEdge,
+        existing_items: &[WorkItem],
         existing_edges: &[WorkEdge],
-        endpoints_exist: bool,
     ) -> Result<(), WorkGraphError> {
-        let self_edge = edge.from_id == edge.to_id;
-        let duplicate_edge = existing_edges.iter().any(|existing| {
-            existing.kind == edge.kind
-                && existing.from_id == edge.from_id
-                && existing.to_id == edge.to_id
-        });
-        let would_create_cycle = matches!(edge.kind, WorkEdgeKind::Blocks | WorkEdgeKind::Parent)
-            && has_path(existing_edges, edge.kind, &edge.to_id, &edge.from_id);
-        apply_link_validation_dsl(wg_dsl::WorkGraphLifecycleInput::ValidateLink {
-            endpoints_exist,
-            self_edge,
-            duplicate_edge,
-            would_create_cycle,
-        })?;
+        let topology_state = topology_state(existing_items, existing_edges);
+        apply_link_validation_dsl(
+            topology_state,
+            wg_dsl::WorkGraphLifecycleInput::ValidateLink {
+                kind: dsl_edge_kind(edge.kind),
+                from_item_key: work_item_key(&edge.from_id),
+                to_item_key: work_item_key(&edge.to_id),
+                edge_key: work_edge_key(edge.kind, &edge.from_id, &edge.to_id),
+                reverse_path_key: dependency_path_key(edge.kind, &edge.to_id, &edge.from_id),
+            },
+        )?;
         Ok(())
     }
 }
@@ -375,8 +389,11 @@ fn apply_new_item_dsl(
     Ok(dsl_auth.state)
 }
 
-fn apply_link_validation_dsl(input: wg_dsl::WorkGraphLifecycleInput) -> Result<(), WorkGraphError> {
-    let mut dsl_auth = wg_dsl::WorkGraphLifecycleMachineAuthority::new();
+fn apply_link_validation_dsl(
+    state: WorkGraphMachineState,
+    input: wg_dsl::WorkGraphLifecycleInput,
+) -> Result<(), WorkGraphError> {
+    let mut dsl_auth = wg_dsl::WorkGraphLifecycleMachineAuthority::from_state(state);
     wg_dsl::WorkGraphLifecycleMachineMutator::apply(&mut dsl_auth, input)
         .map_err(|error| WorkGraphError::InvalidTransition(format!("{error:?}")))?;
     Ok(())
@@ -387,11 +404,11 @@ fn apply_item_dsl(
     unresolved_blocker_count: u64,
     input: wg_dsl::WorkGraphLifecycleInput,
     expected_revision: Option<u64>,
-) -> Result<wg_dsl::WorkGraphLifecycleMachineState, WorkGraphError> {
-    let mut dsl_auth = wg_dsl::WorkGraphLifecycleMachineAuthority::from_state(project_item(
-        item,
-        unresolved_blocker_count,
-    )?);
+) -> Result<WorkGraphMachineState, WorkGraphError> {
+    validate_item_machine_projection(item)?;
+    let mut state = item.machine_state.clone();
+    state.unresolved_blocker_count = unresolved_blocker_count;
+    let mut dsl_auth = wg_dsl::WorkGraphLifecycleMachineAuthority::from_state(state);
     wg_dsl::WorkGraphLifecycleMachineMutator::apply(&mut dsl_auth, input).map_err(|error| {
         if let Some(expected) = expected_revision
             && item.revision != expected
@@ -405,46 +422,6 @@ fn apply_item_dsl(
         WorkGraphError::InvalidTransition(format!("{error:?}"))
     })?;
     Ok(dsl_auth.state)
-}
-
-fn project_item(
-    item: &WorkItem,
-    unresolved_blocker_count: u64,
-) -> Result<wg_dsl::WorkGraphLifecycleMachineState, WorkGraphError> {
-    Ok(wg_dsl::WorkGraphLifecycleMachineState {
-        lifecycle_phase: dsl_state_from_work_status(item.status),
-        revision: item.revision,
-        unresolved_blocker_count,
-        claim_owner_key: item
-            .claim
-            .as_ref()
-            .map(|claim| work_owner_key(&claim.owner))
-            .transpose()?,
-        claimed_at_utc_ms: item
-            .claim
-            .as_ref()
-            .map(|claim| datetime_to_millis(claim.claimed_at)),
-        lease_expires_at_utc_ms: item
-            .claim
-            .as_ref()
-            .and_then(|claim| claim.lease_expires_at.map(datetime_to_millis)),
-        due_at_utc_ms: item.due_at.map(datetime_to_millis),
-        not_before_utc_ms: item.not_before.map(datetime_to_millis),
-        snoozed_until_utc_ms: item.snoozed_until.map(datetime_to_millis),
-        terminal_at_utc_ms: item.terminal_at.map(datetime_to_millis),
-        evidence_count: u64::try_from(item.evidence_refs.len()).unwrap_or(u64::MAX),
-    })
-}
-
-fn dsl_state_from_work_status(status: WorkStatus) -> wg_dsl::WorkLifecycleState {
-    match status {
-        WorkStatus::Open => wg_dsl::WorkLifecycleState::Open,
-        WorkStatus::InProgress => wg_dsl::WorkLifecycleState::InProgress,
-        WorkStatus::Blocked => wg_dsl::WorkLifecycleState::Blocked,
-        WorkStatus::Completed => wg_dsl::WorkLifecycleState::Completed,
-        WorkStatus::Cancelled => wg_dsl::WorkLifecycleState::Cancelled,
-        WorkStatus::Failed => wg_dsl::WorkLifecycleState::Failed,
-    }
 }
 
 fn work_status_from_dsl(status: wg_dsl::WorkLifecycleState) -> Result<WorkStatus, WorkGraphError> {
@@ -461,28 +438,214 @@ fn work_status_from_dsl(status: wg_dsl::WorkLifecycleState) -> Result<WorkStatus
     }
 }
 
-fn unresolved_blocker_count(
-    item: &WorkItem,
-    all_items: &BTreeMap<WorkItemId, WorkItem>,
-    edges: &[WorkEdge],
-) -> u64 {
-    edges
-        .iter()
-        .filter(|edge| edge.kind == WorkEdgeKind::Blocks && edge.to_id == item.id)
-        .filter(|edge| {
-            all_items
-                .get(&edge.from_id)
-                .is_none_or(|blocker| !blocker.status.is_terminal_success())
-        })
-        .count()
-        .try_into()
-        .unwrap_or(u64::MAX)
+fn sync_item_from_machine_state(item: &mut WorkItem) -> Result<(), WorkGraphError> {
+    item.status = work_status_from_dsl(item.machine_state.lifecycle_phase)?;
+    item.revision = item.machine_state.revision;
+    item.due_at = item
+        .machine_state
+        .due_at_utc_ms
+        .and_then(millis_to_datetime);
+    item.not_before = item
+        .machine_state
+        .not_before_utc_ms
+        .and_then(millis_to_datetime);
+    item.snoozed_until = item
+        .machine_state
+        .snoozed_until_utc_ms
+        .and_then(millis_to_datetime);
+    item.terminal_at = item
+        .machine_state
+        .terminal_at_utc_ms
+        .and_then(millis_to_datetime);
+    Ok(())
+}
+
+fn validate_item_machine_projection(item: &WorkItem) -> Result<(), WorkGraphError> {
+    let status = work_status_from_dsl(item.machine_state.lifecycle_phase)?;
+    if item.status != status {
+        return Err(WorkGraphError::Store(format!(
+            "work item {} status projection {:?} does not match machine state {:?}",
+            item.id, item.status, status
+        )));
+    }
+    if item.revision != item.machine_state.revision {
+        return Err(WorkGraphError::Store(format!(
+            "work item {} revision projection {} does not match machine state {}",
+            item.id, item.revision, item.machine_state.revision
+        )));
+    }
+    if item.due_at.map(datetime_to_millis) != item.machine_state.due_at_utc_ms {
+        return Err(WorkGraphError::Store(format!(
+            "work item {} due_at projection does not match machine state",
+            item.id
+        )));
+    }
+    if item.not_before.map(datetime_to_millis) != item.machine_state.not_before_utc_ms {
+        return Err(WorkGraphError::Store(format!(
+            "work item {} not_before projection does not match machine state",
+            item.id
+        )));
+    }
+    if item.snoozed_until.map(datetime_to_millis) != item.machine_state.snoozed_until_utc_ms {
+        return Err(WorkGraphError::Store(format!(
+            "work item {} snoozed_until projection does not match machine state",
+            item.id
+        )));
+    }
+    if item.terminal_at.map(datetime_to_millis) != item.machine_state.terminal_at_utc_ms {
+        return Err(WorkGraphError::Store(format!(
+            "work item {} terminal_at projection does not match machine state",
+            item.id
+        )));
+    }
+    if let Some(claim) = &item.claim {
+        let claim_owner_key = work_owner_key(&claim.owner)?;
+        if item.machine_state.claim_owner_key.as_ref() != Some(&claim_owner_key) {
+            return Err(WorkGraphError::Store(format!(
+                "work item {} claim owner projection does not match machine state",
+                item.id
+            )));
+        }
+        if item.machine_state.claimed_at_utc_ms != Some(datetime_to_millis(claim.claimed_at)) {
+            return Err(WorkGraphError::Store(format!(
+                "work item {} claim time projection does not match machine state",
+                item.id
+            )));
+        }
+        if item.machine_state.lease_expires_at_utc_ms
+            != claim.lease_expires_at.map(datetime_to_millis)
+        {
+            return Err(WorkGraphError::Store(format!(
+                "work item {} claim lease projection does not match machine state",
+                item.id
+            )));
+        }
+    } else if item.machine_state.claim_owner_key.is_some()
+        || item.machine_state.claimed_at_utc_ms.is_some()
+        || item.machine_state.lease_expires_at_utc_ms.is_some()
+    {
+        return Err(WorkGraphError::Store(format!(
+            "work item {} machine state has a claim without a claim projection",
+            item.id
+        )));
+    }
+    Ok(())
 }
 
 fn work_owner_key(owner: &crate::types::WorkOwner) -> Result<wg_dsl::WorkOwnerKey, WorkGraphError> {
-    serde_json::to_string(owner)
-        .map(wg_dsl::WorkOwnerKey)
-        .map_err(|error| WorkGraphError::InvalidInput(error.to_string()))
+    let kind = match owner.key.kind {
+        crate::types::WorkOwnerKind::Principal => wg_dsl::WorkOwnerKind::Principal,
+        crate::types::WorkOwnerKind::Agent => wg_dsl::WorkOwnerKind::Agent,
+        crate::types::WorkOwnerKind::Session => wg_dsl::WorkOwnerKind::Session,
+        crate::types::WorkOwnerKind::Mob => wg_dsl::WorkOwnerKind::Mob,
+        crate::types::WorkOwnerKind::Label => wg_dsl::WorkOwnerKind::Label,
+    };
+    Ok(wg_dsl::WorkOwnerKey {
+        kind,
+        id: owner.key.id.clone(),
+    })
+}
+
+fn topology_state(
+    existing_items: &[WorkItem],
+    existing_edges: &[WorkEdge],
+) -> WorkGraphMachineState {
+    WorkGraphMachineState {
+        topology_item_keys: existing_items
+            .iter()
+            .map(|item| work_item_key(&item.id))
+            .collect(),
+        topology_edge_keys: existing_edges
+            .iter()
+            .map(|edge| work_edge_key(edge.kind, &edge.from_id, &edge.to_id))
+            .collect(),
+        blocks_reachability: dependency_reachability(existing_edges, WorkEdgeKind::Blocks),
+        parent_reachability: dependency_reachability(existing_edges, WorkEdgeKind::Parent),
+        ..Default::default()
+    }
+}
+
+fn dependency_reachability(
+    edges: &[WorkEdge],
+    kind: WorkEdgeKind,
+) -> BTreeSet<wg_dsl::WorkDependencyPathKey> {
+    let mut adjacency = BTreeMap::<WorkItemId, BTreeSet<WorkItemId>>::new();
+    for edge in edges.iter().filter(|edge| edge.kind == kind) {
+        adjacency
+            .entry(edge.from_id.clone())
+            .or_default()
+            .insert(edge.to_id.clone());
+    }
+
+    let mut reachability = BTreeSet::new();
+    for start in adjacency.keys() {
+        let mut stack = adjacency
+            .get(start)
+            .into_iter()
+            .flat_map(|targets| targets.iter().cloned())
+            .collect::<Vec<_>>();
+        let mut seen = BTreeSet::new();
+        while let Some(current) = stack.pop() {
+            if !seen.insert(current.clone()) {
+                continue;
+            }
+            reachability.insert(dependency_path_key(kind, start, &current));
+            if let Some(targets) = adjacency.get(&current) {
+                stack.extend(targets.iter().cloned());
+            }
+        }
+    }
+    reachability
+}
+
+fn work_item_key(id: &WorkItemId) -> wg_dsl::WorkItemKey {
+    wg_dsl::WorkItemKey(id.as_str().to_string())
+}
+
+fn work_edge_key(
+    kind: WorkEdgeKind,
+    from_id: &WorkItemId,
+    to_id: &WorkItemId,
+) -> wg_dsl::WorkEdgeKey {
+    wg_dsl::WorkEdgeKey(format!(
+        "{}:{}:{}",
+        edge_kind_key(kind),
+        from_id.as_str(),
+        to_id.as_str()
+    ))
+}
+
+fn dependency_path_key(
+    kind: WorkEdgeKind,
+    from_id: &WorkItemId,
+    to_id: &WorkItemId,
+) -> wg_dsl::WorkDependencyPathKey {
+    wg_dsl::WorkDependencyPathKey(format!(
+        "{}:{}:{}",
+        edge_kind_key(kind),
+        from_id.as_str(),
+        to_id.as_str()
+    ))
+}
+
+fn dsl_edge_kind(kind: WorkEdgeKind) -> wg_dsl::WorkEdgeKind {
+    match kind {
+        WorkEdgeKind::Blocks => wg_dsl::WorkEdgeKind::Blocks,
+        WorkEdgeKind::Parent => wg_dsl::WorkEdgeKind::Parent,
+        WorkEdgeKind::Related => wg_dsl::WorkEdgeKind::Related,
+        WorkEdgeKind::Supersedes => wg_dsl::WorkEdgeKind::Supersedes,
+        WorkEdgeKind::DerivedFrom => wg_dsl::WorkEdgeKind::DerivedFrom,
+    }
+}
+
+fn edge_kind_key(kind: WorkEdgeKind) -> &'static str {
+    match kind {
+        WorkEdgeKind::Blocks => "blocks",
+        WorkEdgeKind::Parent => "parent",
+        WorkEdgeKind::Related => "related",
+        WorkEdgeKind::Supersedes => "supersedes",
+        WorkEdgeKind::DerivedFrom => "derived_from",
+    }
 }
 
 fn datetime_to_millis(dt: DateTime<Utc>) -> u64 {
@@ -513,36 +676,13 @@ fn seconds_to_duration(seconds: u64) -> Duration {
     Duration::seconds(seconds)
 }
 
-fn has_path(
-    edges: &[WorkEdge],
-    kind: WorkEdgeKind,
-    start: &WorkItemId,
-    target: &WorkItemId,
-) -> bool {
-    let mut stack = vec![start.clone()];
-    let mut seen = BTreeSet::new();
-    while let Some(current) = stack.pop() {
-        if !seen.insert(current.clone()) {
-            continue;
-        }
-        if &current == target {
-            return true;
-        }
-        stack.extend(
-            edges
-                .iter()
-                .filter(|edge| edge.kind == kind && edge.from_id == current)
-                .map(|edge| edge.to_id.clone()),
-        );
-    }
-    false
-}
-
 #[cfg(test)]
 #[allow(clippy::expect_used, clippy::unwrap_used)]
 mod tests {
     use super::*;
-    use crate::types::{ClaimWorkItemRequest, CloseWorkItemRequest, WorkOwner};
+    use crate::types::{
+        ClaimWorkItemRequest, CloseWorkItemRequest, UpdateWorkItemRequest, WorkOwner, WorkOwnerKey,
+    };
 
     fn create(title: &str, now: DateTime<Utc>) -> WorkItem {
         WorkGraphMachine::create_item(
@@ -568,21 +708,43 @@ mod tests {
         .0
     }
 
+    fn owner(id: &str) -> WorkOwner {
+        WorkOwner::new(WorkOwnerKey::label(id).expect("owner key"))
+    }
+
     #[test]
     fn blocked_items_are_never_ready() {
         let now = Utc::now();
-        let mut item = create("blocked", now);
-        item.status = WorkStatus::Blocked;
-        assert!(WorkGraphMachine::ready_items(vec![item], &[], now).is_empty());
+        let item = create("blocked", now);
+        let (item, _) = WorkGraphMachine::block_item(item, 1, now).expect("block");
+        assert!(WorkGraphMachine::ready_items(vec![item], now).is_empty());
     }
 
     #[test]
     fn future_due_items_are_not_ready() {
         let now = Utc::now();
-        let mut item = create("future", now);
-        item.due_at = Some(now + Duration::hours(1));
+        let item = create("future", now);
+        let (item, _) = WorkGraphMachine::update_item(
+            item,
+            UpdateWorkItemRequest {
+                id: WorkItemId::generated(),
+                realm_id: None,
+                namespace: None,
+                expected_revision: 1,
+                title: None,
+                description: None,
+                priority: None,
+                labels: None,
+                due_at: Some(now + Duration::hours(1)),
+                not_before: None,
+                snoozed_until: None,
+                external_refs: Vec::new(),
+            },
+            now,
+        )
+        .expect("update due");
 
-        assert!(WorkGraphMachine::ready_items(vec![item], &[], now).is_empty());
+        assert!(WorkGraphMachine::ready_items(vec![item], now).is_empty());
     }
 
     #[test]
@@ -608,7 +770,7 @@ mod tests {
                 realm_id: None,
                 namespace: None,
                 expected_revision: 2,
-                owner: WorkOwner::default(),
+                owner: owner("worker"),
                 lease_seconds: None,
                 lease_expires_at: None,
             },
@@ -638,7 +800,7 @@ mod tests {
                 realm_id: None,
                 namespace: None,
                 expected_revision: 1,
-                owner: WorkOwner::default(),
+                owner: owner("worker"),
                 lease_seconds: Some(60),
                 lease_expires_at: None,
             },
@@ -652,7 +814,7 @@ mod tests {
                 realm_id: None,
                 namespace: None,
                 expected_revision: 2,
-                owner: WorkOwner::default(),
+                owner: owner("worker-2"),
                 lease_seconds: Some(60),
                 lease_expires_at: None,
             },

--- a/meerkat-workgraph/src/service.rs
+++ b/meerkat-workgraph/src/service.rs
@@ -9,8 +9,8 @@ use crate::store::{WorkGraphEventFilter, WorkGraphStore};
 use crate::types::{
     AddEvidenceRequest, ClaimWorkItemRequest, CloseWorkItemRequest, CreateWorkItemRequest,
     LinkWorkItemsRequest, ReadyWorkFilter, ReleaseWorkItemRequest, UpdateWorkItemRequest, WorkEdge,
-    WorkGraphEvent, WorkGraphEventKind, WorkGraphSnapshot, WorkGraphSnapshotFilter, WorkItem,
-    WorkItemFilter, WorkItemId, WorkNamespace,
+    WorkEdgeKind, WorkGraphEvent, WorkGraphEventKind, WorkGraphSnapshot, WorkGraphSnapshotFilter,
+    WorkItem, WorkItemFilter, WorkItemId, WorkNamespace,
 };
 
 #[derive(Clone)]
@@ -93,7 +93,6 @@ impl WorkGraphService {
                 .into_iter()
                 .filter(|item| labels.iter().all(|label| item.labels.contains(label)))
                 .collect(),
-            &self.store.list_edges(&realm_id, &namespace).await?,
             now,
         );
         if let Some(limit) = filter.limit {
@@ -178,22 +177,8 @@ impl WorkGraphService {
             .ok_or_else(|| {
                 WorkGraphError::not_found(realm_id.clone(), namespace.clone(), request.id.clone())
             })?;
-        let all_items = self
-            .store
-            .list_items(WorkItemFilter {
-                realm_id: Some(realm_id.clone()),
-                namespace: Some(namespace.clone()),
-                include_terminal: true,
-                ..WorkItemFilter::default()
-            })
-            .await?
-            .into_iter()
-            .map(|item| (item.id.clone(), item))
-            .collect::<BTreeMap<_, _>>();
-        let edges = self.store.list_edges(&realm_id, &namespace).await?;
         let expected_previous_revision = item.revision;
-        let (item, event) =
-            WorkGraphMachine::claim_ready_item(item, &all_items, &edges, request, now)?;
+        let (item, event) = WorkGraphMachine::claim_ready_item(item, request, now)?;
         self.store
             .update_item_cas(item, expected_previous_revision, event)
             .await
@@ -261,24 +246,18 @@ impl WorkGraphService {
             .await?;
         let expected_previous_revision = item.revision;
         let (item, event) = WorkGraphMachine::close_item(item, request, now)?;
-        self.store
+        let closed = self
+            .store
             .update_item_cas(item, expected_previous_revision, event)
-            .await
+            .await?;
+        self.refresh_dependents_after_blocker_change(&closed, now)
+            .await?;
+        Ok(closed)
     }
 
     pub async fn link(&self, request: LinkWorkItemsRequest) -> Result<WorkEdge, WorkGraphError> {
         let now = self.store.get_store_time_utc().await?;
         let (realm_id, namespace) = self.scope(request.realm_id.clone(), request.namespace.clone());
-        let endpoints_exist = self
-            .store
-            .get_item(&realm_id, &namespace, &request.from_id)
-            .await?
-            .is_some()
-            && self
-                .store
-                .get_item(&realm_id, &namespace, &request.to_id)
-                .await?
-                .is_some();
         let edge = WorkEdge {
             realm_id,
             namespace,
@@ -291,7 +270,16 @@ impl WorkGraphService {
             .store
             .list_edges(&edge.realm_id, &edge.namespace)
             .await?;
-        WorkGraphMachine::validate_link(&edge, &existing_edges, endpoints_exist)?;
+        let existing_items = self
+            .store
+            .list_items(WorkItemFilter {
+                realm_id: Some(edge.realm_id.clone()),
+                namespace: Some(edge.namespace.clone()),
+                include_terminal: true,
+                ..WorkItemFilter::default()
+            })
+            .await?;
+        WorkGraphMachine::validate_link(&edge, &existing_items, &existing_edges)?;
         let event = WorkGraphEvent::graph(
             edge.realm_id.clone(),
             edge.namespace.clone(),
@@ -299,7 +287,17 @@ impl WorkGraphService {
             now,
             json!({ "edge": edge }),
         );
-        self.store.insert_edge(edge, event).await
+        let inserted = self.store.insert_edge(edge, event).await?;
+        if inserted.kind == WorkEdgeKind::Blocks {
+            self.refresh_item_eligibility(
+                &inserted.realm_id,
+                &inserted.namespace,
+                &inserted.to_id,
+                now,
+            )
+            .await?;
+        }
+        Ok(inserted)
     }
 
     pub async fn add_evidence(
@@ -426,13 +424,84 @@ impl WorkGraphService {
                     .into_iter()
                     .filter(|item| labels.iter().all(|label| item.labels.contains(label)))
                     .collect(),
-                &self.store.list_edges(realm_id, namespace).await?,
                 now,
             );
             ready_ids.extend(ready_items.into_iter().map(|item| item.id));
         }
         Ok(ready_ids)
     }
+
+    async fn refresh_dependents_after_blocker_change(
+        &self,
+        blocker: &WorkItem,
+        now: chrono::DateTime<chrono::Utc>,
+    ) -> Result<(), WorkGraphError> {
+        let edges = self
+            .store
+            .list_edges(&blocker.realm_id, &blocker.namespace)
+            .await?;
+        for edge in edges
+            .iter()
+            .filter(|edge| edge.kind == WorkEdgeKind::Blocks && edge.from_id == blocker.id)
+        {
+            self.refresh_item_eligibility(&blocker.realm_id, &blocker.namespace, &edge.to_id, now)
+                .await?;
+        }
+        Ok(())
+    }
+
+    async fn refresh_item_eligibility(
+        &self,
+        realm_id: &str,
+        namespace: &WorkNamespace,
+        id: &WorkItemId,
+        now: chrono::DateTime<chrono::Utc>,
+    ) -> Result<(), WorkGraphError> {
+        let Some(item) = self.store.get_item(realm_id, namespace, id).await? else {
+            return Ok(());
+        };
+        let all_items = self
+            .store
+            .list_items(WorkItemFilter {
+                realm_id: Some(realm_id.to_string()),
+                namespace: Some(namespace.clone()),
+                include_terminal: true,
+                ..WorkItemFilter::default()
+            })
+            .await?
+            .into_iter()
+            .map(|item| (item.id.clone(), item))
+            .collect::<BTreeMap<_, _>>();
+        let edges = self.store.list_edges(realm_id, namespace).await?;
+        let unresolved_blockers = unresolved_blocker_count(&item, &all_items, &edges);
+        if let Some((item, event)) =
+            WorkGraphMachine::refresh_eligibility(item, unresolved_blockers, now)?
+        {
+            let expected_previous_revision = item.revision;
+            self.store
+                .update_item_cas(item, expected_previous_revision, event)
+                .await?;
+        }
+        Ok(())
+    }
+}
+
+fn unresolved_blocker_count(
+    item: &WorkItem,
+    all_items: &BTreeMap<WorkItemId, WorkItem>,
+    edges: &[WorkEdge],
+) -> u64 {
+    edges
+        .iter()
+        .filter(|edge| edge.kind == WorkEdgeKind::Blocks && edge.to_id == item.id)
+        .filter(|edge| {
+            all_items
+                .get(&edge.from_id)
+                .is_none_or(|blocker| !blocker.status.is_terminal_success())
+        })
+        .count()
+        .try_into()
+        .unwrap_or(u64::MAX)
 }
 
 #[cfg(test)]
@@ -442,8 +511,13 @@ mod tests {
     use std::sync::Arc;
 
     use crate::store::WorkGraphEventFilter;
-    use crate::types::{ClaimWorkItemRequest, LinkWorkItemsRequest, WorkEdgeKind, WorkOwner};
-    use crate::{CreateWorkItemRequest, MemoryWorkGraphStore, WorkGraphService, WorkNamespace};
+    use crate::types::{
+        ClaimWorkItemRequest, LinkWorkItemsRequest, WorkEdgeKind, WorkOwner, WorkOwnerKey,
+    };
+    use crate::{
+        CreateWorkItemRequest, MemoryWorkGraphStore, UpdateWorkItemRequest, WorkGraphService,
+        WorkNamespace,
+    };
 
     fn create_req(title: &str) -> CreateWorkItemRequest {
         CreateWorkItemRequest {
@@ -506,6 +580,58 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn blocked_dependency_stays_unready_after_item_update() {
+        let service = WorkGraphService::with_scope(
+            Arc::new(MemoryWorkGraphStore::new()),
+            "realm",
+            WorkNamespace::default(),
+        );
+        let blocker = service
+            .create(create_req("blocker"))
+            .await
+            .expect("blocker");
+        let blocked = service
+            .create(create_req("blocked"))
+            .await
+            .expect("blocked");
+        service
+            .link(LinkWorkItemsRequest {
+                realm_id: None,
+                namespace: None,
+                kind: WorkEdgeKind::Blocks,
+                from_id: blocker.id,
+                to_id: blocked.id.clone(),
+            })
+            .await
+            .expect("link");
+        let blocked = service
+            .get(None, None, blocked.id.clone())
+            .await
+            .expect("blocked after link");
+
+        service
+            .update(UpdateWorkItemRequest {
+                id: blocked.id.clone(),
+                realm_id: None,
+                namespace: None,
+                expected_revision: blocked.revision,
+                title: Some("blocked, updated".to_string()),
+                description: None,
+                priority: None,
+                labels: None,
+                due_at: None,
+                not_before: None,
+                snoozed_until: None,
+                external_refs: Vec::new(),
+            })
+            .await
+            .expect("update blocked item");
+
+        let ready = service.ready(Default::default()).await.expect("ready");
+        assert!(!ready.iter().any(|item| item.id == blocked.id));
+    }
+
+    #[tokio::test]
     async fn concurrent_claim_attempts_have_one_winner() {
         let service = WorkGraphService::with_scope(
             Arc::new(MemoryWorkGraphStore::new()),
@@ -518,10 +644,7 @@ mod tests {
             realm_id: None,
             namespace: None,
             expected_revision: item.revision,
-            owner: WorkOwner {
-                label: Some("worker".to_string()),
-                ..WorkOwner::default()
-            },
+            owner: WorkOwner::new(WorkOwnerKey::label("worker").expect("owner key")),
             lease_seconds: Some(60),
             lease_expires_at: None,
         };

--- a/meerkat-workgraph/src/store.rs
+++ b/meerkat-workgraph/src/store.rs
@@ -9,6 +9,7 @@ use chrono::{DateTime, Utc};
 use rusqlite::{Connection, ErrorCode, OptionalExtension, Transaction, params};
 
 use crate::WorkGraphError;
+use crate::WorkGraphMachine;
 use crate::types::{
     WorkEdge, WorkGraphEvent, WorkGraphEventKind, WorkItem, WorkItemFilter, WorkItemId,
     WorkNamespace,
@@ -208,6 +209,7 @@ impl WorkGraphStore for MemoryWorkGraphStore {
         item: WorkItem,
         event: WorkGraphEvent,
     ) -> Result<WorkItem, WorkGraphError> {
+        WorkGraphMachine::validate_item_projection(&item)?;
         let mut guard = self.inner.write().await;
         let key = item_key(&item.realm_id, &item.namespace, &item.id);
         if guard.items.contains_key(&key) {
@@ -227,6 +229,7 @@ impl WorkGraphStore for MemoryWorkGraphStore {
         expected_previous_revision: u64,
         event: WorkGraphEvent,
     ) -> Result<WorkItem, WorkGraphError> {
+        WorkGraphMachine::validate_item_projection(&item)?;
         let mut guard = self.inner.write().await;
         let key = item_key(&item.realm_id, &item.namespace, &item.id);
         let Some(current) = guard.items.get(&key) else {
@@ -468,6 +471,7 @@ impl WorkGraphStore for SqliteWorkGraphStore {
         item: WorkItem,
         event: WorkGraphEvent,
     ) -> Result<WorkItem, WorkGraphError> {
+        WorkGraphMachine::validate_item_projection(&item)?;
         self.with_connection(|conn| {
             let tx = conn
                 .transaction()
@@ -486,6 +490,7 @@ impl WorkGraphStore for SqliteWorkGraphStore {
         expected_previous_revision: u64,
         event: WorkGraphEvent,
     ) -> Result<WorkItem, WorkGraphError> {
+        WorkGraphMachine::validate_item_projection(&item)?;
         self.with_connection(|conn| {
             let tx = conn
                 .transaction()

--- a/meerkat-workgraph/src/tools.rs
+++ b/meerkat-workgraph/src/tools.rs
@@ -29,70 +29,109 @@ impl WorkGraphToolError {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum WorkGraphToolContract {
+    Create,
+    Get,
+    List,
+    Ready,
+    Snapshot,
+    Events,
+    Claim,
+    Release,
+    Update,
+    Block,
+    Close,
+    Link,
+    AddEvidence,
+}
+
+impl WorkGraphToolContract {
+    const ALL: &'static [Self] = &[
+        Self::Create,
+        Self::Get,
+        Self::List,
+        Self::Ready,
+        Self::Snapshot,
+        Self::Events,
+        Self::Claim,
+        Self::Release,
+        Self::Update,
+        Self::Block,
+        Self::Close,
+        Self::Link,
+        Self::AddEvidence,
+    ];
+
+    const fn name(self) -> &'static str {
+        match self {
+            Self::Create => "workgraph_create",
+            Self::Get => "workgraph_get",
+            Self::List => "workgraph_list",
+            Self::Ready => "workgraph_ready",
+            Self::Snapshot => "workgraph_snapshot",
+            Self::Events => "workgraph_events",
+            Self::Claim => "workgraph_claim",
+            Self::Release => "workgraph_release",
+            Self::Update => "workgraph_update",
+            Self::Block => "workgraph_block",
+            Self::Close => "workgraph_close",
+            Self::Link => "workgraph_link",
+            Self::AddEvidence => "workgraph_add_evidence",
+        }
+    }
+
+    const fn description(self) -> &'static str {
+        match self {
+            Self::Create => "Create a durable WorkGraph item.",
+            Self::Get => "Read one WorkGraph item.",
+            Self::List => "List WorkGraph items.",
+            Self::Ready => "List ready, claimable WorkGraph items.",
+            Self::Snapshot => "Read a WorkGraph observability snapshot.",
+            Self::Events => "Read WorkGraph event history.",
+            Self::Claim => "Claim a ready WorkGraph item with CAS revision checking.",
+            Self::Release => "Release a claimed WorkGraph item.",
+            Self::Update => "Update non-terminal WorkGraph item fields.",
+            Self::Block => "Mark a WorkGraph item blocked.",
+            Self::Close => "Close a WorkGraph item with a terminal status.",
+            Self::Link => "Create a dependency or relationship edge.",
+            Self::AddEvidence => "Attach a typed evidence reference to a WorkGraph item.",
+        }
+    }
+
+    fn schema(self) -> Value {
+        match self {
+            Self::Create => create_schema(),
+            Self::Get => id_schema(false),
+            Self::List => list_schema(),
+            Self::Ready => ready_schema(),
+            Self::Snapshot => snapshot_schema(),
+            Self::Events => events_schema(),
+            Self::Claim => claim_schema(),
+            Self::Release | Self::Block => revision_id_schema(),
+            Self::Update => update_schema(),
+            Self::Close => close_schema(),
+            Self::Link => link_schema(),
+            Self::AddEvidence => evidence_schema(),
+        }
+    }
+
+    fn parse(name: &str) -> Result<Self, WorkGraphToolError> {
+        Self::ALL
+            .iter()
+            .copied()
+            .find(|contract| contract.name() == name)
+            .ok_or_else(|| {
+                WorkGraphToolError::new(NOT_FOUND, format!("unknown WorkGraph tool '{name}'"))
+            })
+    }
+}
+
 pub fn workgraph_tools_list() -> Vec<Value> {
-    vec![
-        tool(
-            "workgraph_create",
-            "Create a durable WorkGraph item.",
-            create_schema(),
-        ),
-        tool(
-            "workgraph_get",
-            "Read one WorkGraph item.",
-            id_schema(false),
-        ),
-        tool("workgraph_list", "List WorkGraph items.", list_schema()),
-        tool(
-            "workgraph_ready",
-            "List ready, claimable WorkGraph items.",
-            ready_schema(),
-        ),
-        tool(
-            "workgraph_snapshot",
-            "Read a WorkGraph observability snapshot.",
-            snapshot_schema(),
-        ),
-        tool(
-            "workgraph_events",
-            "Read WorkGraph event history.",
-            events_schema(),
-        ),
-        tool(
-            "workgraph_claim",
-            "Claim a ready WorkGraph item with CAS revision checking.",
-            claim_schema(),
-        ),
-        tool(
-            "workgraph_release",
-            "Release a claimed WorkGraph item.",
-            revision_id_schema(),
-        ),
-        tool(
-            "workgraph_update",
-            "Update non-terminal WorkGraph item fields.",
-            update_schema(),
-        ),
-        tool(
-            "workgraph_block",
-            "Mark a WorkGraph item blocked.",
-            revision_id_schema(),
-        ),
-        tool(
-            "workgraph_close",
-            "Close a WorkGraph item with a terminal status.",
-            close_schema(),
-        ),
-        tool(
-            "workgraph_link",
-            "Create a dependency or relationship edge.",
-            link_schema(),
-        ),
-        tool(
-            "workgraph_add_evidence",
-            "Attach a typed evidence reference to a WorkGraph item.",
-            evidence_schema(),
-        ),
-    ]
+    WorkGraphToolContract::ALL
+        .iter()
+        .map(|contract| tool(contract.name(), contract.description(), contract.schema()))
+        .collect()
 }
 
 pub async fn handle_workgraph_tools_call(
@@ -100,8 +139,8 @@ pub async fn handle_workgraph_tools_call(
     name: &str,
     arguments: &Value,
 ) -> Result<Value, WorkGraphToolError> {
-    match name {
-        "workgraph_create" => {
+    match WorkGraphToolContract::parse(name)? {
+        WorkGraphToolContract::Create => {
             let request: CreateWorkItemRequest = parse(arguments)?;
             service
                 .create(request)
@@ -109,7 +148,7 @@ pub async fn handle_workgraph_tools_call(
                 .map(|item| json!({ "item": item }))
                 .map_err(map_error)
         }
-        "workgraph_get" => {
+        WorkGraphToolContract::Get => {
             let request: IdParams = parse(arguments)?;
             service
                 .get(request.realm_id, request.namespace, request.id)
@@ -117,7 +156,7 @@ pub async fn handle_workgraph_tools_call(
                 .map(|item| json!({ "item": item }))
                 .map_err(map_error)
         }
-        "workgraph_list" => {
+        WorkGraphToolContract::List => {
             let filter: WorkItemFilter = parse(arguments)?;
             service
                 .list(filter)
@@ -125,7 +164,7 @@ pub async fn handle_workgraph_tools_call(
                 .map(|items| json!({ "items": items }))
                 .map_err(map_error)
         }
-        "workgraph_ready" => {
+        WorkGraphToolContract::Ready => {
             let filter: ReadyWorkFilter = parse(arguments)?;
             service
                 .ready(filter)
@@ -133,7 +172,7 @@ pub async fn handle_workgraph_tools_call(
                 .map(|items| json!({ "items": items }))
                 .map_err(map_error)
         }
-        "workgraph_snapshot" => {
+        WorkGraphToolContract::Snapshot => {
             let filter: WorkGraphSnapshotFilter = parse(arguments)?;
             service
                 .snapshot(filter)
@@ -141,7 +180,7 @@ pub async fn handle_workgraph_tools_call(
                 .map(|snapshot| json!({ "snapshot": snapshot }))
                 .map_err(map_error)
         }
-        "workgraph_claim" => {
+        WorkGraphToolContract::Claim => {
             let request: ClaimWorkItemRequest = parse(arguments)?;
             service
                 .claim(request)
@@ -149,7 +188,7 @@ pub async fn handle_workgraph_tools_call(
                 .map(|item| json!({ "item": item }))
                 .map_err(map_error)
         }
-        "workgraph_release" => {
+        WorkGraphToolContract::Release => {
             let request: ReleaseWorkItemRequest = parse(arguments)?;
             service
                 .release(request)
@@ -157,7 +196,7 @@ pub async fn handle_workgraph_tools_call(
                 .map(|item| json!({ "item": item }))
                 .map_err(map_error)
         }
-        "workgraph_update" => {
+        WorkGraphToolContract::Update => {
             let request: UpdateWorkItemRequest = parse(arguments)?;
             service
                 .update(request)
@@ -165,7 +204,7 @@ pub async fn handle_workgraph_tools_call(
                 .map(|item| json!({ "item": item }))
                 .map_err(map_error)
         }
-        "workgraph_block" => {
+        WorkGraphToolContract::Block => {
             let request: RevisionIdParams = parse(arguments)?;
             service
                 .block(
@@ -178,7 +217,7 @@ pub async fn handle_workgraph_tools_call(
                 .map(|item| json!({ "item": item }))
                 .map_err(map_error)
         }
-        "workgraph_close" => {
+        WorkGraphToolContract::Close => {
             let request: CloseWorkItemRequest = parse(arguments)?;
             service
                 .close(request)
@@ -186,7 +225,7 @@ pub async fn handle_workgraph_tools_call(
                 .map(|item| json!({ "item": item }))
                 .map_err(map_error)
         }
-        "workgraph_link" => {
+        WorkGraphToolContract::Link => {
             let request: LinkWorkItemsRequest = parse(arguments)?;
             service
                 .link(request)
@@ -194,7 +233,7 @@ pub async fn handle_workgraph_tools_call(
                 .map(|edge| json!({ "edge": edge }))
                 .map_err(map_error)
         }
-        "workgraph_add_evidence" => {
+        WorkGraphToolContract::AddEvidence => {
             let request: AddEvidenceRequest = parse(arguments)?;
             service
                 .add_evidence(request)
@@ -202,7 +241,7 @@ pub async fn handle_workgraph_tools_call(
                 .map(|item| json!({ "item": item }))
                 .map_err(map_error)
         }
-        "workgraph_events" => {
+        WorkGraphToolContract::Events => {
             let filter: WorkGraphEventFilterParams = parse(arguments)?;
             service
                 .events(filter.into())
@@ -210,10 +249,6 @@ pub async fn handle_workgraph_tools_call(
                 .map(|events| json!({ "events": events }))
                 .map_err(map_error)
         }
-        _ => Err(WorkGraphToolError::new(
-            NOT_FOUND,
-            format!("unknown WorkGraph tool '{name}'"),
-        )),
     }
 }
 
@@ -424,7 +459,29 @@ fn claim_schema() -> Value {
             "expected_revision".to_string(),
             json!({ "type": "integer", "minimum": 0 }),
         ),
-        ("owner".to_string(), json!({ "type": "object" })),
+        (
+            "owner".to_string(),
+            json!({
+                "type": "object",
+                "properties": {
+                    "key": {
+                        "type": "object",
+                        "properties": {
+                            "kind": {
+                                "type": "string",
+                                "enum": ["principal", "agent", "session", "mob", "label"]
+                            },
+                            "id": { "type": "string" }
+                        },
+                        "required": ["kind", "id"],
+                        "additionalProperties": false
+                    },
+                    "display_name": { "type": "string" }
+                },
+                "required": ["key"],
+                "additionalProperties": false
+            }),
+        ),
         (
             "lease_seconds".to_string(),
             json!({ "type": "integer", "minimum": 1 }),
@@ -434,7 +491,7 @@ fn claim_schema() -> Value {
             json!({ "type": "string", "format": "date-time" }),
         ),
     ]);
-    object(properties, &["id", "expected_revision"])
+    object(properties, &["id", "expected_revision", "owner"])
 }
 
 fn update_schema() -> Value {

--- a/meerkat-workgraph/src/types.rs
+++ b/meerkat-workgraph/src/types.rs
@@ -8,6 +8,7 @@ use serde_json::Value;
 use uuid::Uuid;
 
 use crate::WorkGraphError;
+pub use crate::machines::workgraph_lifecycle::WorkGraphLifecycleMachineState as WorkGraphMachineState;
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 #[serde(transparent)]
@@ -135,18 +136,81 @@ pub enum WorkEdgeKind {
     DerivedFrom,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum WorkOwnerKind {
+    Principal,
+    Agent,
+    Session,
+    Mob,
+    Label,
+}
+
+impl WorkOwnerKind {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Principal => "principal",
+            Self::Agent => "agent",
+            Self::Session => "session",
+            Self::Mob => "mob",
+            Self::Label => "label",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+pub struct WorkOwnerKey {
+    pub kind: WorkOwnerKind,
+    pub id: String,
+}
+
+impl WorkOwnerKey {
+    pub fn new(kind: WorkOwnerKind, id: impl Into<String>) -> Result<Self, WorkGraphError> {
+        Ok(Self {
+            kind,
+            id: validate_token("work owner id", id.into())?,
+        })
+    }
+
+    pub fn principal(id: impl Into<String>) -> Result<Self, WorkGraphError> {
+        Self::new(WorkOwnerKind::Principal, id)
+    }
+
+    pub fn agent(id: impl Into<String>) -> Result<Self, WorkGraphError> {
+        Self::new(WorkOwnerKind::Agent, id)
+    }
+
+    pub fn session(id: impl Into<String>) -> Result<Self, WorkGraphError> {
+        Self::new(WorkOwnerKind::Session, id)
+    }
+
+    pub fn mob(id: impl Into<String>) -> Result<Self, WorkGraphError> {
+        Self::new(WorkOwnerKind::Mob, id)
+    }
+
+    pub fn label(id: impl Into<String>) -> Result<Self, WorkGraphError> {
+        Self::new(WorkOwnerKind::Label, id)
+    }
+
+    pub fn canonical(&self) -> String {
+        format!("{}:{}", self.kind.as_str(), self.id)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct WorkOwner {
+    pub key: WorkOwnerKey,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub principal: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub agent: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub session_id: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub mob_id: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub label: Option<String>,
+    pub display_name: Option<String>,
+}
+
+impl WorkOwner {
+    pub fn new(key: WorkOwnerKey) -> Self {
+        Self {
+            key,
+            display_name: None,
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -198,6 +262,8 @@ pub struct WorkItem {
     pub owner: Option<WorkOwner>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub claim: Option<WorkClaim>,
+    #[serde(default = "default_workgraph_machine_state")]
+    pub machine_state: WorkGraphMachineState,
     pub revision: u64,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub due_at: Option<DateTime<Utc>>,
@@ -213,6 +279,10 @@ pub struct WorkItem {
     pub external_refs: Vec<ExternalWorkRef>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub evidence_refs: Vec<WorkEvidenceRef>,
+}
+
+fn default_workgraph_machine_state() -> WorkGraphMachineState {
+    WorkGraphMachineState::default()
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
@@ -352,7 +422,6 @@ pub struct ClaimWorkItemRequest {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub namespace: Option<WorkNamespace>,
     pub expected_revision: u64,
-    #[serde(default)]
     pub owner: WorkOwner,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub lease_seconds: Option<u64>,

--- a/meerkat/src/lib.rs
+++ b/meerkat/src/lib.rs
@@ -197,7 +197,8 @@ pub use meerkat_workgraph::{
     WorkGraphEvent, WorkGraphEventFilter, WorkGraphEventKind, WorkGraphMachine, WorkGraphService,
     WorkGraphSnapshot, WorkGraphSnapshotFilter, WorkGraphStore, WorkGraphStoreKind,
     WorkGraphToolError, WorkGraphToolSurface, WorkItem, WorkItemFilter, WorkItemId, WorkNamespace,
-    WorkOwner, WorkPriority, WorkStatus, handle_workgraph_tools_call, workgraph_tools_list,
+    WorkOwner, WorkOwnerKey, WorkOwnerKind, WorkPriority, WorkStatus, handle_workgraph_tools_call,
+    workgraph_tools_list,
 };
 
 // AgentFactory and build_agent types

--- a/sdks/python/meerkat/__init__.py
+++ b/sdks/python/meerkat/__init__.py
@@ -194,6 +194,8 @@ from .types import (
     WorkGraphEventKind,
     WorkGraphItemFilter,
     WorkGraphOwner,
+    WorkGraphOwnerKey,
+    WorkGraphOwnerKind,
     WorkGraphPriority,
     WorkGraphReadyFilter,
     WorkGraphSnapshot,

--- a/sdks/python/meerkat/types.py
+++ b/sdks/python/meerkat/types.py
@@ -448,20 +448,23 @@ WorkGraphEventKind = Literal[
     "linked",
     "evidence_added",
 ]
+WorkGraphOwnerKind = Literal["principal", "agent", "session", "mob", "label"]
 
 
-class WorkGraphOwner(TypedDict, total=False):
-    principal: str
-    agent: str
-    session_id: str
-    mob_id: str
-    label: str
+class WorkGraphOwnerKey(TypedDict):
+    kind: WorkGraphOwnerKind
+    id: str
 
 
-class WorkGraphClaim(TypedDict, total=False):
+class WorkGraphOwner(TypedDict):
+    key: WorkGraphOwnerKey
+    display_name: NotRequired[str]
+
+
+class WorkGraphClaim(TypedDict):
     owner: WorkGraphOwner
     claimed_at: str
-    lease_expires_at: str
+    lease_expires_at: NotRequired[str]
 
 
 class ExternalWorkRef(TypedDict, total=False):
@@ -526,12 +529,12 @@ class WorkGraphEventsResult(TypedDict):
     events: list[WorkGraphEvent]
 
 
-class WorkGraphSnapshot(TypedDict, total=False):
+class WorkGraphSnapshot(TypedDict):
     realm_id: str
-    namespace: str
+    namespace: NotRequired[str]
     all_namespaces: bool
     captured_at: str
-    event_high_water_mark: int
+    event_high_water_mark: NotRequired[int]
     items: list[WorkItem]
     edges: list[WorkGraphEdge]
     ready_item_ids: list[str]

--- a/sdks/typescript/src/client.ts
+++ b/sdks/typescript/src/client.ts
@@ -147,6 +147,7 @@ import type {
   WorkGraphItemFilter,
   WorkGraphItemLookupOptions,
   WorkGraphOwner,
+  WorkGraphOwnerKind,
   WorkGraphPriority,
   WorkGraphReadyFilter,
   WorkGraphSnapshot,
@@ -3259,125 +3260,227 @@ export class MeerkatClient {
     return params;
   }
 
-  private static parseStringArray(value: unknown): string[] {
-    return Array.isArray(value) ? value.map((item) => String(item)) : [];
+  private static parseStringArray(value: unknown, context: string): string[] {
+    if (value == null) {
+      return [];
+    }
+    return MeerkatClient.requireStringArray(value, context);
   }
 
-  private static parseRecordArray(value: unknown): Array<Record<string, unknown>> {
-    return Array.isArray(value)
-      ? value.filter(
-          (item): item is Record<string, unknown> =>
-            typeof item === "object" && item !== null && !Array.isArray(item),
-        )
-      : [];
+  private static requireStringArray(value: unknown, context: string): string[] {
+    if (!Array.isArray(value)) {
+      throw new MeerkatError("INVALID_RESPONSE", `${context}: expected array`);
+    }
+    return value.map((item, index) => {
+      if (typeof item !== "string" || item.length === 0) {
+        throw new MeerkatError(
+          "INVALID_RESPONSE",
+          `${context}: entry ${index} must be string`,
+        );
+      }
+      return item;
+    });
   }
 
-  private static parseWorkGraphOwner(raw: unknown): WorkGraphOwner | undefined {
-    if (typeof raw !== "object" || raw === null || Array.isArray(raw)) {
+  private static parseRecordArray(
+    value: unknown,
+    context: string,
+  ): Array<Record<string, unknown>> {
+    if (value == null) {
+      return [];
+    }
+    return MeerkatClient.requireRecordArray(value, context);
+  }
+
+  private static requireRecordArray(
+    value: unknown,
+    context: string,
+  ): Array<Record<string, unknown>> {
+    if (!Array.isArray(value)) {
+      throw new MeerkatError("INVALID_RESPONSE", `${context}: expected array`);
+    }
+    return value.map((item, index) =>
+      MeerkatClient.requireRecord(item, `entry ${index}`, context),
+    );
+  }
+
+  private static parseWorkGraphOwner(raw: unknown, context: string): WorkGraphOwner | undefined {
+    if (raw == null) {
       return undefined;
     }
-    const data = raw as Record<string, unknown>;
+    const data = MeerkatClient.requireRecord(raw, "owner", context);
+    const key = MeerkatClient.requireRecord(data.key, "key", context);
+    const kind = MeerkatClient.requireStringField(key, "kind", context);
+    if (!["principal", "agent", "session", "mob", "label"].includes(kind)) {
+      throw new MeerkatError("INVALID_RESPONSE", `${context}: invalid owner key kind`);
+    }
     return {
-      principal: MeerkatClient.parseOptionalString(data.principal),
-      agent: MeerkatClient.parseOptionalString(data.agent),
-      sessionId: MeerkatClient.parseOptionalString(data.session_id),
-      mobId: MeerkatClient.parseOptionalString(data.mob_id),
-      label: MeerkatClient.parseOptionalString(data.label),
+      key: {
+        kind: kind as WorkGraphOwnerKind,
+        id: MeerkatClient.requireStringField(key, "id", context),
+      },
+      displayName: MeerkatClient.parseOptionalString(data.display_name),
     };
   }
 
   private static parseWorkGraphClaim(raw: unknown): WorkGraphClaim | undefined {
-    if (typeof raw !== "object" || raw === null || Array.isArray(raw)) {
+    if (raw == null) {
       return undefined;
     }
-    const data = raw as Record<string, unknown>;
+    const data = MeerkatClient.requireRecord(raw, "claim", "Invalid workgraph item");
+    const owner = MeerkatClient.parseWorkGraphOwner(
+      data.owner,
+      "Invalid workgraph item claim",
+    );
+    if (!owner) {
+      throw new MeerkatError("INVALID_RESPONSE", "Invalid workgraph item claim: missing owner");
+    }
     return {
-      owner: MeerkatClient.parseWorkGraphOwner(data.owner) ?? {},
-      claimedAt: String(data.claimed_at ?? ""),
+      owner,
+      claimedAt: MeerkatClient.requireStringField(
+        data,
+        "claimed_at",
+        "Invalid workgraph item claim",
+      ),
       leaseExpiresAt: MeerkatClient.parseOptionalString(data.lease_expires_at),
     };
   }
 
   static parseWorkItem(data: Record<string, unknown>): WorkItem {
+    const status = MeerkatClient.requireStringField(data, "status", "Invalid workgraph item");
+    if (!["open", "in_progress", "blocked", "completed", "cancelled", "failed"].includes(status)) {
+      throw new MeerkatError("INVALID_RESPONSE", "Invalid workgraph item: invalid status");
+    }
+    const priority = MeerkatClient.requireStringField(
+      data,
+      "priority",
+      "Invalid workgraph item",
+    );
+    if (!["low", "medium", "high"].includes(priority)) {
+      throw new MeerkatError("INVALID_RESPONSE", "Invalid workgraph item: invalid priority");
+    }
     return {
-      id: String(data.id ?? ""),
-      realmId: String(data.realm_id ?? ""),
-      namespace: String(data.namespace ?? ""),
-      title: String(data.title ?? ""),
+      id: MeerkatClient.requireStringField(data, "id", "Invalid workgraph item"),
+      realmId: MeerkatClient.requireStringField(data, "realm_id", "Invalid workgraph item"),
+      namespace: MeerkatClient.requireStringField(data, "namespace", "Invalid workgraph item"),
+      title: MeerkatClient.requireStringField(data, "title", "Invalid workgraph item"),
       description: MeerkatClient.parseOptionalString(data.description),
-      status: String(data.status ?? "open") as WorkGraphStatus,
-      priority: String(data.priority ?? "medium") as WorkGraphPriority,
-      labels: MeerkatClient.parseStringArray(data.labels),
-      owner: MeerkatClient.parseWorkGraphOwner(data.owner),
+      status: status as WorkGraphStatus,
+      priority: priority as WorkGraphPriority,
+      labels: MeerkatClient.parseStringArray(data.labels, "Invalid workgraph item labels"),
+      owner: MeerkatClient.parseWorkGraphOwner(data.owner, "Invalid workgraph item"),
       claim: MeerkatClient.parseWorkGraphClaim(data.claim),
-      revision: Number(data.revision ?? 0),
+      revision: MeerkatClient.requireNumberField(data, "revision", "Invalid workgraph item"),
       dueAt: MeerkatClient.parseOptionalString(data.due_at),
       notBefore: MeerkatClient.parseOptionalString(data.not_before),
       snoozedUntil: MeerkatClient.parseOptionalString(data.snoozed_until),
-      createdAt: String(data.created_at ?? ""),
-      updatedAt: String(data.updated_at ?? ""),
+      createdAt: MeerkatClient.requireStringField(data, "created_at", "Invalid workgraph item"),
+      updatedAt: MeerkatClient.requireStringField(data, "updated_at", "Invalid workgraph item"),
       terminalAt: MeerkatClient.parseOptionalString(data.terminal_at),
-      externalRefs: MeerkatClient.parseRecordArray(data.external_refs).map((ref) => ({
-        kind: String(ref.kind ?? ""),
-        id: String(ref.id ?? ""),
+      externalRefs: MeerkatClient.parseRecordArray(
+        data.external_refs,
+        "Invalid workgraph external refs",
+      ).map((ref) => ({
+        kind: MeerkatClient.requireStringField(ref, "kind", "Invalid workgraph external ref"),
+        id: MeerkatClient.requireStringField(ref, "id", "Invalid workgraph external ref"),
         url: MeerkatClient.parseOptionalString(ref.url),
       })),
-      evidenceRefs: MeerkatClient.parseRecordArray(data.evidence_refs).map((ref) => ({
-        kind: String(ref.kind ?? ""),
-        id: String(ref.id ?? ""),
+      evidenceRefs: MeerkatClient.parseRecordArray(
+        data.evidence_refs,
+        "Invalid workgraph evidence refs",
+      ).map((ref) => ({
+        kind: MeerkatClient.requireStringField(ref, "kind", "Invalid workgraph evidence ref"),
+        id: MeerkatClient.requireStringField(ref, "id", "Invalid workgraph evidence ref"),
         label: MeerkatClient.parseOptionalString(ref.label),
         summary: MeerkatClient.parseOptionalString(ref.summary),
       })),
     };
   }
 
-  private static parseWorkItemArray(value: unknown): WorkItem[] {
-    return MeerkatClient.parseRecordArray(value).map((item) =>
+  private static parseWorkItemArray(
+    value: unknown,
+    context = "Invalid workgraph item list",
+  ): WorkItem[] {
+    return MeerkatClient.requireRecordArray(value, context).map((item) =>
       MeerkatClient.parseWorkItem(item),
     );
   }
 
   private static parseWorkGraphEdge(data: Record<string, unknown>): WorkGraphEdge {
+    const kind = MeerkatClient.requireStringField(data, "kind", "Invalid workgraph edge");
+    if (!["blocks", "parent", "related", "supersedes", "derived_from"].includes(kind)) {
+      throw new MeerkatError("INVALID_RESPONSE", "Invalid workgraph edge: invalid kind");
+    }
     return {
-      realmId: String(data.realm_id ?? ""),
-      namespace: String(data.namespace ?? ""),
-      kind: String(data.kind ?? "related") as WorkGraphEdgeKind,
-      fromId: String(data.from_id ?? ""),
-      toId: String(data.to_id ?? ""),
-      createdAt: String(data.created_at ?? ""),
+      realmId: MeerkatClient.requireStringField(data, "realm_id", "Invalid workgraph edge"),
+      namespace: MeerkatClient.requireStringField(data, "namespace", "Invalid workgraph edge"),
+      kind: kind as WorkGraphEdgeKind,
+      fromId: MeerkatClient.requireStringField(data, "from_id", "Invalid workgraph edge"),
+      toId: MeerkatClient.requireStringField(data, "to_id", "Invalid workgraph edge"),
+      createdAt: MeerkatClient.requireStringField(data, "created_at", "Invalid workgraph edge"),
     };
   }
 
   private static parseWorkGraphEvent(data: Record<string, unknown>): WorkGraphEvent {
+    const kind = MeerkatClient.requireStringField(data, "kind", "Invalid workgraph event");
+    if (
+      ![
+        "created",
+        "updated",
+        "claimed",
+        "released",
+        "blocked",
+        "closed",
+        "linked",
+        "evidence_added",
+      ].includes(kind)
+    ) {
+      throw new MeerkatError("INVALID_RESPONSE", "Invalid workgraph event: invalid kind");
+    }
     return {
       seq: MeerkatClient.parseOptionalNumber(data.seq),
-      realmId: String(data.realm_id ?? ""),
-      namespace: String(data.namespace ?? ""),
+      realmId: MeerkatClient.requireStringField(data, "realm_id", "Invalid workgraph event"),
+      namespace: MeerkatClient.requireStringField(data, "namespace", "Invalid workgraph event"),
       itemId: MeerkatClient.parseOptionalString(data.item_id),
-      kind: String(data.kind ?? "updated") as WorkGraphEventKind,
-      at: String(data.at ?? ""),
+      kind: kind as WorkGraphEventKind,
+      at: MeerkatClient.requireStringField(data, "at", "Invalid workgraph event"),
       payload: data.payload,
     };
   }
 
   private static parseWorkGraphEventArray(value: unknown): WorkGraphEvent[] {
-    return MeerkatClient.parseRecordArray(value).map((event) =>
+    return MeerkatClient.requireRecordArray(value, "Invalid workgraph event list").map((event) =>
       MeerkatClient.parseWorkGraphEvent(event),
     );
   }
 
   static parseWorkGraphSnapshot(data: Record<string, unknown>): WorkGraphSnapshot {
     return {
-      realmId: String(data.realm_id ?? ""),
+      realmId: MeerkatClient.requireStringField(data, "realm_id", "Invalid workgraph snapshot"),
       namespace: MeerkatClient.parseOptionalString(data.namespace),
-      allNamespaces: Boolean(data.all_namespaces),
-      capturedAt: String(data.captured_at ?? ""),
-      eventHighWaterMark: MeerkatClient.parseOptionalNumber(data.event_high_water_mark),
-      items: MeerkatClient.parseWorkItemArray(data.items),
-      edges: MeerkatClient.parseRecordArray(data.edges).map((edge) =>
-        MeerkatClient.parseWorkGraphEdge(edge),
+      allNamespaces: MeerkatClient.requireBooleanField(
+        data,
+        "all_namespaces",
+        "Invalid workgraph snapshot",
       ),
-      readyItemIds: MeerkatClient.parseStringArray(data.ready_item_ids),
+      capturedAt: MeerkatClient.requireStringField(
+        data,
+        "captured_at",
+        "Invalid workgraph snapshot",
+      ),
+      eventHighWaterMark: MeerkatClient.parseOptionalNumber(data.event_high_water_mark),
+      items: MeerkatClient.parseWorkItemArray(
+        data.items,
+        "Invalid workgraph snapshot items",
+      ),
+      edges: MeerkatClient.requireRecordArray(
+        data.edges,
+        "Invalid workgraph snapshot edges",
+      ).map((edge) => MeerkatClient.parseWorkGraphEdge(edge)),
+      readyItemIds: MeerkatClient.requireStringArray(
+        data.ready_item_ids,
+        "Invalid workgraph snapshot ready item ids",
+      ),
     };
   }
 

--- a/sdks/typescript/src/index.ts
+++ b/sdks/typescript/src/index.ts
@@ -154,6 +154,8 @@ export type {
   WorkGraphItemFilter,
   WorkGraphItemLookupOptions,
   WorkGraphOwner,
+  WorkGraphOwnerKey,
+  WorkGraphOwnerKind,
   WorkGraphPriority,
   WorkGraphReadyFilter,
   WorkGraphSnapshot,

--- a/sdks/typescript/src/types.ts
+++ b/sdks/typescript/src/types.ts
@@ -877,12 +877,16 @@ export type WorkGraphEventKind =
   | "linked"
   | "evidence_added";
 
+export type WorkGraphOwnerKind = "principal" | "agent" | "session" | "mob" | "label";
+
+export interface WorkGraphOwnerKey {
+  readonly kind: WorkGraphOwnerKind;
+  readonly id: string;
+}
+
 export interface WorkGraphOwner {
-  readonly principal?: string;
-  readonly agent?: string;
-  readonly sessionId?: string;
-  readonly mobId?: string;
-  readonly label?: string;
+  readonly key: WorkGraphOwnerKey;
+  readonly displayName?: string;
 }
 
 export interface WorkGraphClaim {

--- a/sdks/typescript/tests/types.test.js
+++ b/sdks/typescript/tests/types.test.js
@@ -1128,6 +1128,110 @@ describe("Typed Events", () => {
   });
 });
 
+describe("WorkGraph parsers", () => {
+  const timestamp = "2026-05-12T12:00:00Z";
+  const claimedItem = {
+    id: "prep-dentist-ride",
+    realm_id: "homecore",
+    namespace: "family/appointments",
+    title: "Prep A for non-preferred dentist car",
+    status: "in_progress",
+    priority: "high",
+    labels: ["autism-support", "dentist"],
+    owner: {
+      key: { kind: "agent", id: "homecore-kapellmeister" },
+      display_name: "Homecore Kapellmeister",
+    },
+    claim: {
+      owner: { key: { kind: "agent", id: "homecore-kapellmeister" } },
+      claimed_at: timestamp,
+    },
+    revision: 4,
+    created_at: timestamp,
+    updated_at: timestamp,
+    external_refs: [{ kind: "calendar_event", id: "dentist-visit" }],
+    evidence_refs: [{ kind: "message_draft", id: "draft-1" }],
+  };
+
+  it("parses typed owners, claims, and read-only snapshots", () => {
+    const snapshot = MeerkatClient.parseWorkGraphSnapshot({
+      realm_id: "homecore",
+      namespace: "family/appointments",
+      all_namespaces: false,
+      captured_at: timestamp,
+      event_high_water_mark: 42,
+      items: [claimedItem],
+      edges: [
+        {
+          realm_id: "homecore",
+          namespace: "family/appointments",
+          kind: "blocks",
+          from_id: "notice-car-change",
+          to_id: "prep-dentist-ride",
+          created_at: timestamp,
+        },
+      ],
+      ready_item_ids: ["prep-dentist-ride"],
+    });
+
+    assert.equal(snapshot.realmId, "homecore");
+    assert.equal(snapshot.items[0].owner?.key.kind, "agent");
+    assert.equal(snapshot.items[0].claim?.owner.key.id, "homecore-kapellmeister");
+    assert.equal(snapshot.edges[0].kind, "blocks");
+    assert.deepEqual(snapshot.readyItemIds, ["prep-dentist-ride"]);
+  });
+
+  it("rejects malformed WorkGraph lifecycle truth", () => {
+    assert.throws(
+      () =>
+        MeerkatClient.parseWorkGraphSnapshot({
+          realm_id: "homecore",
+          namespace: "family/appointments",
+          all_namespaces: false,
+          captured_at: timestamp,
+          items: [{ ...claimedItem, status: undefined }],
+          edges: [],
+          ready_item_ids: [],
+        }),
+      (error) =>
+        error instanceof MeerkatError &&
+        error.code === "INVALID_RESPONSE" &&
+        String(error.message).includes("Invalid workgraph item"),
+    );
+  });
+
+  it("requires typed WorkGraph claim owners", () => {
+    assert.throws(
+      () =>
+        MeerkatClient.parseWorkItem({
+          ...claimedItem,
+          claim: { claimed_at: timestamp },
+        }),
+      (error) =>
+        error instanceof MeerkatError &&
+        error.code === "INVALID_RESPONSE" &&
+        String(error.message).includes("missing owner"),
+    );
+  });
+
+  it("requires WorkGraph snapshot arrays instead of fabricating empty projections", () => {
+    assert.throws(
+      () =>
+        MeerkatClient.parseWorkGraphSnapshot({
+          realm_id: "homecore",
+          all_namespaces: false,
+          captured_at: timestamp,
+          items: [claimedItem],
+          edges: [],
+        }),
+      (error) =>
+        error instanceof MeerkatError &&
+        error.code === "INVALID_RESPONSE" &&
+        String(error.message).includes("ready item ids"),
+    );
+  });
+});
+
 describe("Session wrappers", () => {
   it("createSession returns a runtime-backed Session wrapper", async () => {
     const client = new MeerkatClient();

--- a/specs/machines/work_graph_lifecycle/ci.cfg
+++ b/specs/machines/work_graph_lifecycle/ci.cfg
@@ -1,11 +1,18 @@
 SPECIFICATION Spec
 CONSTANTS
-  BooleanValues = {TRUE, FALSE}
   NatValues = {1}
-  WorkOwnerKeyValues = {"workownerkey_1"}
+  SetOfWorkDependencyPathKeyValues = {{}, {"workdependencypathkey_1"}}
+  SetOfWorkEdgeKeyValues = {{}, {"workedgekey_1"}}
+  SetOfWorkItemKeyValues = {{}, {"workitemkey_1"}}
+  WorkDependencyPathKeyValues = {"workdependencypathkey_1"}
+  WorkEdgeKeyValues = {"workedgekey_1"}
+  WorkEdgeKindValues = {"Blocks", "Parent", "Related", "Supersedes", "DerivedFrom"}
+  WorkItemKeyValues = {"workitemkey_1"}
+  WorkOwnerKeyValues <- WorkOwnerKeyValuesCi
 INVARIANTS
   absent_has_zero_revision
   live_has_positive_revision
+  topology_snapshot_is_stateless
   terminal_has_terminal_time
   claim_only_in_progress
   blocked_has_no_claim

--- a/specs/machines/work_graph_lifecycle/contract.md
+++ b/specs/machines/work_graph_lifecycle/contract.md
@@ -9,6 +9,10 @@ _Generated from the Rust machine catalog. Do not edit by hand._
 - Phase enum: `Absent | Open | InProgress | Blocked | Completed | Cancelled | Failed`
 - `revision`: `u64`
 - `unresolved_blocker_count`: `u64`
+- `topology_item_keys`: `Set<WorkItemKey>`
+- `topology_edge_keys`: `Set<WorkEdgeKey>`
+- `blocks_reachability`: `Set<WorkDependencyPathKey>`
+- `parent_reachability`: `Set<WorkDependencyPathKey>`
 - `claim_owner_key`: `Option<WorkOwnerKey>`
 - `claimed_at_utc_ms`: `Option<u64>`
 - `lease_expires_at_utc_ms`: `Option<u64>`
@@ -26,7 +30,7 @@ _Generated from the Rust machine catalog. Do not edit by hand._
 - `Release`(expected_revision: u64)
 - `Block`(expected_revision: u64)
 - `RefreshEligibility`(unresolved_blocker_count: u64)
-- `ValidateLink`(endpoints_exist: Bool, self_edge: Bool, duplicate_edge: Bool, would_create_cycle: Bool)
+- `ValidateLink`(kind: WorkEdgeKind, from_item_key: WorkItemKey, to_item_key: WorkItemKey, edge_key: WorkEdgeKey, reverse_path_key: WorkDependencyPathKey)
 - `CloseCompleted`(expected_revision: u64, at_utc_ms: u64)
 - `CloseCancelled`(expected_revision: u64, at_utc_ms: u64)
 - `CloseFailed`(expected_revision: u64, at_utc_ms: u64)
@@ -47,6 +51,7 @@ _Generated from the Rust machine catalog. Do not edit by hand._
 ## Invariants
 - `absent_has_zero_revision`
 - `live_has_positive_revision`
+- `topology_snapshot_is_stateless`
 - `terminal_has_terminal_time`
 - `claim_only_in_progress`
 - `blocked_has_no_claim`
@@ -165,12 +170,14 @@ _Generated from the Rust machine catalog. Do not edit by hand._
 
 ### `ValidateLink`
 - From: `Absent`
-- On: `ValidateLink`(endpoints_exist, self_edge, duplicate_edge, would_create_cycle)
+- On: `ValidateLink`(kind, from_item_key, to_item_key, edge_key, reverse_path_key)
 - Guards:
-  - `endpoints_exist`
+  - `from_endpoint_exists`
+  - `to_endpoint_exists`
   - `not_self_edge`
   - `not_duplicate_edge`
-  - `acyclic`
+  - `blocks_acyclic`
+  - `parent_acyclic`
 - Emits: `LinkValidated`
 - To: `Absent`
 

--- a/specs/machines/work_graph_lifecycle/deep.cfg
+++ b/specs/machines/work_graph_lifecycle/deep.cfg
@@ -1,11 +1,18 @@
 SPECIFICATION Spec
 CONSTANTS
-  BooleanValues = {TRUE, FALSE}
   NatValues = {0, 1, 2}
-  WorkOwnerKeyValues = {"workownerkey_1", "workownerkey_2"}
+  SetOfWorkDependencyPathKeyValues = {{}, {"workdependencypathkey_1"}, {"workdependencypathkey_1", "workdependencypathkey_2"}}
+  SetOfWorkEdgeKeyValues = {{}, {"workedgekey_1"}, {"workedgekey_1", "workedgekey_2"}}
+  SetOfWorkItemKeyValues = {{}, {"workitemkey_1"}, {"workitemkey_1", "workitemkey_2"}}
+  WorkDependencyPathKeyValues = {"workdependencypathkey_1", "workdependencypathkey_2"}
+  WorkEdgeKeyValues = {"workedgekey_1", "workedgekey_2"}
+  WorkEdgeKindValues = {"Blocks", "Parent", "Related", "Supersedes", "DerivedFrom"}
+  WorkItemKeyValues = {"workitemkey_1", "workitemkey_2"}
+  WorkOwnerKeyValues <- WorkOwnerKeyValuesDeep
 INVARIANTS
   absent_has_zero_revision
   live_has_positive_revision
+  topology_snapshot_is_stateless
   terminal_has_terminal_time
   claim_only_in_progress
   blocked_has_no_claim

--- a/specs/machines/work_graph_lifecycle/mapping.md
+++ b/specs/machines/work_graph_lifecycle/mapping.md
@@ -141,6 +141,9 @@ This section is generated from the Rust machine catalog. Do not edit it by hand.
 - `live_has_positive_revision`
   - anchors: `workgraph_lifecycle`
   - scenarios: `workgraph_block_close_evidence`
+- `topology_snapshot_is_stateless`
+  - anchors: `workgraph_lifecycle`
+  - scenarios: `workgraph_topology_legality`
 - `terminal_has_terminal_time`
   - anchors: `workgraph_lifecycle`
   - scenarios: `workgraph_block_close_evidence`

--- a/specs/machines/work_graph_lifecycle/model.tla
+++ b/specs/machines/work_graph_lifecycle/model.tla
@@ -3,7 +3,11 @@ EXTENDS TLC, Naturals, Sequences, FiniteSets
 
 \* Generated semantic machine model for WorkGraphLifecycleMachine.
 
-CONSTANTS BooleanValues, NatValues, WorkOwnerKeyValues
+CONSTANTS NatValues, SetOfWorkDependencyPathKeyValues, SetOfWorkEdgeKeyValues, SetOfWorkItemKeyValues, WorkDependencyPathKeyValues, WorkEdgeKeyValues, WorkEdgeKindValues, WorkItemKeyValues, WorkOwnerKeyValues
+
+WorkOwnerKeyValuesCi == {}
+
+WorkOwnerKeyValuesDeep == {[kind |-> "Principal", id |-> "alpha"], [kind |-> "Agent", id |-> "beta"]}
 
 None == [tag |-> "none", value |-> "none"]
 Some(v) == [tag |-> "some", value |-> v]
@@ -23,15 +27,19 @@ SeqRemove(seq, value) == IF Len(seq) = 0 THEN <<>> ELSE IF Head(seq) = value THE
 RECURSIVE SeqRemoveAll(_, _)
 SeqRemoveAll(seq, values) == IF Len(values) = 0 THEN seq ELSE SeqRemoveAll(SeqRemove(seq, Head(values)), Tail(values))
 
-VARIABLES phase, model_step_count, revision, unresolved_blocker_count, claim_owner_key, claimed_at_utc_ms, lease_expires_at_utc_ms, due_at_utc_ms, not_before_utc_ms, snoozed_until_utc_ms, terminal_at_utc_ms, evidence_count
+VARIABLES phase, model_step_count, revision, unresolved_blocker_count, topology_item_keys, topology_edge_keys, blocks_reachability, parent_reachability, claim_owner_key, claimed_at_utc_ms, lease_expires_at_utc_ms, due_at_utc_ms, not_before_utc_ms, snoozed_until_utc_ms, terminal_at_utc_ms, evidence_count
 
-vars == << phase, model_step_count, revision, unresolved_blocker_count, claim_owner_key, claimed_at_utc_ms, lease_expires_at_utc_ms, due_at_utc_ms, not_before_utc_ms, snoozed_until_utc_ms, terminal_at_utc_ms, evidence_count >>
+vars == << phase, model_step_count, revision, unresolved_blocker_count, topology_item_keys, topology_edge_keys, blocks_reachability, parent_reachability, claim_owner_key, claimed_at_utc_ms, lease_expires_at_utc_ms, due_at_utc_ms, not_before_utc_ms, snoozed_until_utc_ms, terminal_at_utc_ms, evidence_count >>
 
 Init ==
     /\ phase = "Absent"
     /\ model_step_count = 0
     /\ revision = 0
     /\ unresolved_blocker_count = 0
+    /\ topology_item_keys = {}
+    /\ topology_edge_keys = {}
+    /\ blocks_reachability = {}
+    /\ parent_reachability = {}
     /\ claim_owner_key = None
     /\ claimed_at_utc_ms = None
     /\ lease_expires_at_utc_ms = None
@@ -54,7 +62,7 @@ CreateOpen(arg_due_at_utc_ms, arg_not_before_utc_ms, arg_snoozed_until_utc_ms, a
     /\ due_at_utc_ms' = arg_due_at_utc_ms
     /\ not_before_utc_ms' = arg_not_before_utc_ms
     /\ snoozed_until_utc_ms' = arg_snoozed_until_utc_ms
-    /\ UNCHANGED << claim_owner_key, claimed_at_utc_ms, lease_expires_at_utc_ms, terminal_at_utc_ms, evidence_count >>
+    /\ UNCHANGED << topology_item_keys, topology_edge_keys, blocks_reachability, parent_reachability, claim_owner_key, claimed_at_utc_ms, lease_expires_at_utc_ms, terminal_at_utc_ms, evidence_count >>
 
 
 CreateBlocked(arg_due_at_utc_ms, arg_not_before_utc_ms, arg_snoozed_until_utc_ms, arg_unresolved_blocker_count) ==
@@ -66,7 +74,7 @@ CreateBlocked(arg_due_at_utc_ms, arg_not_before_utc_ms, arg_snoozed_until_utc_ms
     /\ due_at_utc_ms' = arg_due_at_utc_ms
     /\ not_before_utc_ms' = arg_not_before_utc_ms
     /\ snoozed_until_utc_ms' = arg_snoozed_until_utc_ms
-    /\ UNCHANGED << claim_owner_key, claimed_at_utc_ms, lease_expires_at_utc_ms, terminal_at_utc_ms, evidence_count >>
+    /\ UNCHANGED << topology_item_keys, topology_edge_keys, blocks_reachability, parent_reachability, claim_owner_key, claimed_at_utc_ms, lease_expires_at_utc_ms, terminal_at_utc_ms, evidence_count >>
 
 
 UpdateOpen(expected_revision, arg_due_at_utc_ms, arg_not_before_utc_ms, arg_snoozed_until_utc_ms, arg_unresolved_blocker_count) ==
@@ -79,7 +87,7 @@ UpdateOpen(expected_revision, arg_due_at_utc_ms, arg_not_before_utc_ms, arg_snoo
     /\ due_at_utc_ms' = arg_due_at_utc_ms
     /\ not_before_utc_ms' = arg_not_before_utc_ms
     /\ snoozed_until_utc_ms' = arg_snoozed_until_utc_ms
-    /\ UNCHANGED << claim_owner_key, claimed_at_utc_ms, lease_expires_at_utc_ms, terminal_at_utc_ms, evidence_count >>
+    /\ UNCHANGED << topology_item_keys, topology_edge_keys, blocks_reachability, parent_reachability, claim_owner_key, claimed_at_utc_ms, lease_expires_at_utc_ms, terminal_at_utc_ms, evidence_count >>
 
 
 UpdateInProgress(expected_revision, arg_due_at_utc_ms, arg_not_before_utc_ms, arg_snoozed_until_utc_ms, arg_unresolved_blocker_count) ==
@@ -92,7 +100,7 @@ UpdateInProgress(expected_revision, arg_due_at_utc_ms, arg_not_before_utc_ms, ar
     /\ due_at_utc_ms' = arg_due_at_utc_ms
     /\ not_before_utc_ms' = arg_not_before_utc_ms
     /\ snoozed_until_utc_ms' = arg_snoozed_until_utc_ms
-    /\ UNCHANGED << claim_owner_key, claimed_at_utc_ms, lease_expires_at_utc_ms, terminal_at_utc_ms, evidence_count >>
+    /\ UNCHANGED << topology_item_keys, topology_edge_keys, blocks_reachability, parent_reachability, claim_owner_key, claimed_at_utc_ms, lease_expires_at_utc_ms, terminal_at_utc_ms, evidence_count >>
 
 
 UpdateBlocked(expected_revision, arg_due_at_utc_ms, arg_not_before_utc_ms, arg_snoozed_until_utc_ms, arg_unresolved_blocker_count) ==
@@ -105,7 +113,7 @@ UpdateBlocked(expected_revision, arg_due_at_utc_ms, arg_not_before_utc_ms, arg_s
     /\ due_at_utc_ms' = arg_due_at_utc_ms
     /\ not_before_utc_ms' = arg_not_before_utc_ms
     /\ snoozed_until_utc_ms' = arg_snoozed_until_utc_ms
-    /\ UNCHANGED << claim_owner_key, claimed_at_utc_ms, lease_expires_at_utc_ms, terminal_at_utc_ms, evidence_count >>
+    /\ UNCHANGED << topology_item_keys, topology_edge_keys, blocks_reachability, parent_reachability, claim_owner_key, claimed_at_utc_ms, lease_expires_at_utc_ms, terminal_at_utc_ms, evidence_count >>
 
 
 ClaimOpen(expected_revision, owner_key, now_utc_ms, arg_lease_expires_at_utc_ms) ==
@@ -121,7 +129,7 @@ ClaimOpen(expected_revision, owner_key, now_utc_ms, arg_lease_expires_at_utc_ms)
     /\ claim_owner_key' = Some(owner_key)
     /\ claimed_at_utc_ms' = Some(now_utc_ms)
     /\ lease_expires_at_utc_ms' = arg_lease_expires_at_utc_ms
-    /\ UNCHANGED << unresolved_blocker_count, due_at_utc_ms, not_before_utc_ms, snoozed_until_utc_ms, terminal_at_utc_ms, evidence_count >>
+    /\ UNCHANGED << unresolved_blocker_count, topology_item_keys, topology_edge_keys, blocks_reachability, parent_reachability, due_at_utc_ms, not_before_utc_ms, snoozed_until_utc_ms, terminal_at_utc_ms, evidence_count >>
 
 
 ClaimExpiredInProgress(expected_revision, owner_key, now_utc_ms, arg_lease_expires_at_utc_ms) ==
@@ -140,7 +148,7 @@ ClaimExpiredInProgress(expected_revision, owner_key, now_utc_ms, arg_lease_expir
     /\ claim_owner_key' = Some(owner_key)
     /\ claimed_at_utc_ms' = Some(now_utc_ms)
     /\ lease_expires_at_utc_ms' = arg_lease_expires_at_utc_ms
-    /\ UNCHANGED << unresolved_blocker_count, due_at_utc_ms, not_before_utc_ms, snoozed_until_utc_ms, terminal_at_utc_ms, evidence_count >>
+    /\ UNCHANGED << unresolved_blocker_count, topology_item_keys, topology_edge_keys, blocks_reachability, parent_reachability, due_at_utc_ms, not_before_utc_ms, snoozed_until_utc_ms, terminal_at_utc_ms, evidence_count >>
 
 
 ReleaseInProgress(expected_revision) ==
@@ -152,7 +160,7 @@ ReleaseInProgress(expected_revision) ==
     /\ claim_owner_key' = None
     /\ claimed_at_utc_ms' = None
     /\ lease_expires_at_utc_ms' = None
-    /\ UNCHANGED << unresolved_blocker_count, due_at_utc_ms, not_before_utc_ms, snoozed_until_utc_ms, terminal_at_utc_ms, evidence_count >>
+    /\ UNCHANGED << unresolved_blocker_count, topology_item_keys, topology_edge_keys, blocks_reachability, parent_reachability, due_at_utc_ms, not_before_utc_ms, snoozed_until_utc_ms, terminal_at_utc_ms, evidence_count >>
 
 
 BlockOpen(expected_revision) ==
@@ -164,7 +172,7 @@ BlockOpen(expected_revision) ==
     /\ claim_owner_key' = None
     /\ claimed_at_utc_ms' = None
     /\ lease_expires_at_utc_ms' = None
-    /\ UNCHANGED << unresolved_blocker_count, due_at_utc_ms, not_before_utc_ms, snoozed_until_utc_ms, terminal_at_utc_ms, evidence_count >>
+    /\ UNCHANGED << unresolved_blocker_count, topology_item_keys, topology_edge_keys, blocks_reachability, parent_reachability, due_at_utc_ms, not_before_utc_ms, snoozed_until_utc_ms, terminal_at_utc_ms, evidence_count >>
 
 
 BlockInProgress(expected_revision) ==
@@ -176,7 +184,7 @@ BlockInProgress(expected_revision) ==
     /\ claim_owner_key' = None
     /\ claimed_at_utc_ms' = None
     /\ lease_expires_at_utc_ms' = None
-    /\ UNCHANGED << unresolved_blocker_count, due_at_utc_ms, not_before_utc_ms, snoozed_until_utc_ms, terminal_at_utc_ms, evidence_count >>
+    /\ UNCHANGED << unresolved_blocker_count, topology_item_keys, topology_edge_keys, blocks_reachability, parent_reachability, due_at_utc_ms, not_before_utc_ms, snoozed_until_utc_ms, terminal_at_utc_ms, evidence_count >>
 
 
 BlockBlocked(expected_revision) ==
@@ -188,7 +196,7 @@ BlockBlocked(expected_revision) ==
     /\ claim_owner_key' = None
     /\ claimed_at_utc_ms' = None
     /\ lease_expires_at_utc_ms' = None
-    /\ UNCHANGED << unresolved_blocker_count, due_at_utc_ms, not_before_utc_ms, snoozed_until_utc_ms, terminal_at_utc_ms, evidence_count >>
+    /\ UNCHANGED << unresolved_blocker_count, topology_item_keys, topology_edge_keys, blocks_reachability, parent_reachability, due_at_utc_ms, not_before_utc_ms, snoozed_until_utc_ms, terminal_at_utc_ms, evidence_count >>
 
 
 RefreshEligibilityOpen(arg_unresolved_blocker_count) ==
@@ -196,7 +204,7 @@ RefreshEligibilityOpen(arg_unresolved_blocker_count) ==
     /\ phase' = "Open"
     /\ model_step_count' = model_step_count + 1
     /\ unresolved_blocker_count' = arg_unresolved_blocker_count
-    /\ UNCHANGED << revision, claim_owner_key, claimed_at_utc_ms, lease_expires_at_utc_ms, due_at_utc_ms, not_before_utc_ms, snoozed_until_utc_ms, terminal_at_utc_ms, evidence_count >>
+    /\ UNCHANGED << revision, topology_item_keys, topology_edge_keys, blocks_reachability, parent_reachability, claim_owner_key, claimed_at_utc_ms, lease_expires_at_utc_ms, due_at_utc_ms, not_before_utc_ms, snoozed_until_utc_ms, terminal_at_utc_ms, evidence_count >>
 
 
 RefreshEligibilityInProgress(arg_unresolved_blocker_count) ==
@@ -204,7 +212,7 @@ RefreshEligibilityInProgress(arg_unresolved_blocker_count) ==
     /\ phase' = "InProgress"
     /\ model_step_count' = model_step_count + 1
     /\ unresolved_blocker_count' = arg_unresolved_blocker_count
-    /\ UNCHANGED << revision, claim_owner_key, claimed_at_utc_ms, lease_expires_at_utc_ms, due_at_utc_ms, not_before_utc_ms, snoozed_until_utc_ms, terminal_at_utc_ms, evidence_count >>
+    /\ UNCHANGED << revision, topology_item_keys, topology_edge_keys, blocks_reachability, parent_reachability, claim_owner_key, claimed_at_utc_ms, lease_expires_at_utc_ms, due_at_utc_ms, not_before_utc_ms, snoozed_until_utc_ms, terminal_at_utc_ms, evidence_count >>
 
 
 RefreshEligibilityBlocked(arg_unresolved_blocker_count) ==
@@ -212,18 +220,20 @@ RefreshEligibilityBlocked(arg_unresolved_blocker_count) ==
     /\ phase' = "Blocked"
     /\ model_step_count' = model_step_count + 1
     /\ unresolved_blocker_count' = arg_unresolved_blocker_count
-    /\ UNCHANGED << revision, claim_owner_key, claimed_at_utc_ms, lease_expires_at_utc_ms, due_at_utc_ms, not_before_utc_ms, snoozed_until_utc_ms, terminal_at_utc_ms, evidence_count >>
+    /\ UNCHANGED << revision, topology_item_keys, topology_edge_keys, blocks_reachability, parent_reachability, claim_owner_key, claimed_at_utc_ms, lease_expires_at_utc_ms, due_at_utc_ms, not_before_utc_ms, snoozed_until_utc_ms, terminal_at_utc_ms, evidence_count >>
 
 
-ValidateLink(endpoints_exist, self_edge, duplicate_edge, would_create_cycle) ==
+ValidateLink(kind, from_item_key, to_item_key, edge_key, reverse_path_key) ==
     /\ phase = "Absent"
-    /\ (endpoints_exist = TRUE)
-    /\ (self_edge = FALSE)
-    /\ (duplicate_edge = FALSE)
-    /\ (would_create_cycle = FALSE)
+    /\ (from_item_key \in topology_item_keys)
+    /\ (to_item_key \in topology_item_keys)
+    /\ (from_item_key # to_item_key)
+    /\ ((edge_key \in topology_edge_keys) = FALSE)
+    /\ ((kind # "Blocks") \/ ((reverse_path_key \in blocks_reachability) = FALSE))
+    /\ ((kind # "Parent") \/ ((reverse_path_key \in parent_reachability) = FALSE))
     /\ phase' = "Absent"
     /\ model_step_count' = model_step_count + 1
-    /\ UNCHANGED << revision, unresolved_blocker_count, claim_owner_key, claimed_at_utc_ms, lease_expires_at_utc_ms, due_at_utc_ms, not_before_utc_ms, snoozed_until_utc_ms, terminal_at_utc_ms, evidence_count >>
+    /\ UNCHANGED << revision, unresolved_blocker_count, topology_item_keys, topology_edge_keys, blocks_reachability, parent_reachability, claim_owner_key, claimed_at_utc_ms, lease_expires_at_utc_ms, due_at_utc_ms, not_before_utc_ms, snoozed_until_utc_ms, terminal_at_utc_ms, evidence_count >>
 
 
 CloseOpenCompleted(expected_revision, at_utc_ms) ==
@@ -236,7 +246,7 @@ CloseOpenCompleted(expected_revision, at_utc_ms) ==
     /\ claimed_at_utc_ms' = None
     /\ lease_expires_at_utc_ms' = None
     /\ terminal_at_utc_ms' = Some(at_utc_ms)
-    /\ UNCHANGED << unresolved_blocker_count, due_at_utc_ms, not_before_utc_ms, snoozed_until_utc_ms, evidence_count >>
+    /\ UNCHANGED << unresolved_blocker_count, topology_item_keys, topology_edge_keys, blocks_reachability, parent_reachability, due_at_utc_ms, not_before_utc_ms, snoozed_until_utc_ms, evidence_count >>
 
 
 CloseInProgressCompleted(expected_revision, at_utc_ms) ==
@@ -249,7 +259,7 @@ CloseInProgressCompleted(expected_revision, at_utc_ms) ==
     /\ claimed_at_utc_ms' = None
     /\ lease_expires_at_utc_ms' = None
     /\ terminal_at_utc_ms' = Some(at_utc_ms)
-    /\ UNCHANGED << unresolved_blocker_count, due_at_utc_ms, not_before_utc_ms, snoozed_until_utc_ms, evidence_count >>
+    /\ UNCHANGED << unresolved_blocker_count, topology_item_keys, topology_edge_keys, blocks_reachability, parent_reachability, due_at_utc_ms, not_before_utc_ms, snoozed_until_utc_ms, evidence_count >>
 
 
 CloseBlockedCompleted(expected_revision, at_utc_ms) ==
@@ -262,7 +272,7 @@ CloseBlockedCompleted(expected_revision, at_utc_ms) ==
     /\ claimed_at_utc_ms' = None
     /\ lease_expires_at_utc_ms' = None
     /\ terminal_at_utc_ms' = Some(at_utc_ms)
-    /\ UNCHANGED << unresolved_blocker_count, due_at_utc_ms, not_before_utc_ms, snoozed_until_utc_ms, evidence_count >>
+    /\ UNCHANGED << unresolved_blocker_count, topology_item_keys, topology_edge_keys, blocks_reachability, parent_reachability, due_at_utc_ms, not_before_utc_ms, snoozed_until_utc_ms, evidence_count >>
 
 
 CloseOpenCancelled(expected_revision, at_utc_ms) ==
@@ -275,7 +285,7 @@ CloseOpenCancelled(expected_revision, at_utc_ms) ==
     /\ claimed_at_utc_ms' = None
     /\ lease_expires_at_utc_ms' = None
     /\ terminal_at_utc_ms' = Some(at_utc_ms)
-    /\ UNCHANGED << unresolved_blocker_count, due_at_utc_ms, not_before_utc_ms, snoozed_until_utc_ms, evidence_count >>
+    /\ UNCHANGED << unresolved_blocker_count, topology_item_keys, topology_edge_keys, blocks_reachability, parent_reachability, due_at_utc_ms, not_before_utc_ms, snoozed_until_utc_ms, evidence_count >>
 
 
 CloseInProgressCancelled(expected_revision, at_utc_ms) ==
@@ -288,7 +298,7 @@ CloseInProgressCancelled(expected_revision, at_utc_ms) ==
     /\ claimed_at_utc_ms' = None
     /\ lease_expires_at_utc_ms' = None
     /\ terminal_at_utc_ms' = Some(at_utc_ms)
-    /\ UNCHANGED << unresolved_blocker_count, due_at_utc_ms, not_before_utc_ms, snoozed_until_utc_ms, evidence_count >>
+    /\ UNCHANGED << unresolved_blocker_count, topology_item_keys, topology_edge_keys, blocks_reachability, parent_reachability, due_at_utc_ms, not_before_utc_ms, snoozed_until_utc_ms, evidence_count >>
 
 
 CloseBlockedCancelled(expected_revision, at_utc_ms) ==
@@ -301,7 +311,7 @@ CloseBlockedCancelled(expected_revision, at_utc_ms) ==
     /\ claimed_at_utc_ms' = None
     /\ lease_expires_at_utc_ms' = None
     /\ terminal_at_utc_ms' = Some(at_utc_ms)
-    /\ UNCHANGED << unresolved_blocker_count, due_at_utc_ms, not_before_utc_ms, snoozed_until_utc_ms, evidence_count >>
+    /\ UNCHANGED << unresolved_blocker_count, topology_item_keys, topology_edge_keys, blocks_reachability, parent_reachability, due_at_utc_ms, not_before_utc_ms, snoozed_until_utc_ms, evidence_count >>
 
 
 CloseOpenFailed(expected_revision, at_utc_ms) ==
@@ -314,7 +324,7 @@ CloseOpenFailed(expected_revision, at_utc_ms) ==
     /\ claimed_at_utc_ms' = None
     /\ lease_expires_at_utc_ms' = None
     /\ terminal_at_utc_ms' = Some(at_utc_ms)
-    /\ UNCHANGED << unresolved_blocker_count, due_at_utc_ms, not_before_utc_ms, snoozed_until_utc_ms, evidence_count >>
+    /\ UNCHANGED << unresolved_blocker_count, topology_item_keys, topology_edge_keys, blocks_reachability, parent_reachability, due_at_utc_ms, not_before_utc_ms, snoozed_until_utc_ms, evidence_count >>
 
 
 CloseInProgressFailed(expected_revision, at_utc_ms) ==
@@ -327,7 +337,7 @@ CloseInProgressFailed(expected_revision, at_utc_ms) ==
     /\ claimed_at_utc_ms' = None
     /\ lease_expires_at_utc_ms' = None
     /\ terminal_at_utc_ms' = Some(at_utc_ms)
-    /\ UNCHANGED << unresolved_blocker_count, due_at_utc_ms, not_before_utc_ms, snoozed_until_utc_ms, evidence_count >>
+    /\ UNCHANGED << unresolved_blocker_count, topology_item_keys, topology_edge_keys, blocks_reachability, parent_reachability, due_at_utc_ms, not_before_utc_ms, snoozed_until_utc_ms, evidence_count >>
 
 
 CloseBlockedFailed(expected_revision, at_utc_ms) ==
@@ -340,7 +350,7 @@ CloseBlockedFailed(expected_revision, at_utc_ms) ==
     /\ claimed_at_utc_ms' = None
     /\ lease_expires_at_utc_ms' = None
     /\ terminal_at_utc_ms' = Some(at_utc_ms)
-    /\ UNCHANGED << unresolved_blocker_count, due_at_utc_ms, not_before_utc_ms, snoozed_until_utc_ms, evidence_count >>
+    /\ UNCHANGED << unresolved_blocker_count, topology_item_keys, topology_edge_keys, blocks_reachability, parent_reachability, due_at_utc_ms, not_before_utc_ms, snoozed_until_utc_ms, evidence_count >>
 
 
 AddEvidenceOpen(expected_revision) ==
@@ -350,7 +360,7 @@ AddEvidenceOpen(expected_revision) ==
     /\ model_step_count' = model_step_count + 1
     /\ revision' = (revision) + 1
     /\ evidence_count' = (evidence_count) + 1
-    /\ UNCHANGED << unresolved_blocker_count, claim_owner_key, claimed_at_utc_ms, lease_expires_at_utc_ms, due_at_utc_ms, not_before_utc_ms, snoozed_until_utc_ms, terminal_at_utc_ms >>
+    /\ UNCHANGED << unresolved_blocker_count, topology_item_keys, topology_edge_keys, blocks_reachability, parent_reachability, claim_owner_key, claimed_at_utc_ms, lease_expires_at_utc_ms, due_at_utc_ms, not_before_utc_ms, snoozed_until_utc_ms, terminal_at_utc_ms >>
 
 
 AddEvidenceInProgress(expected_revision) ==
@@ -360,7 +370,7 @@ AddEvidenceInProgress(expected_revision) ==
     /\ model_step_count' = model_step_count + 1
     /\ revision' = (revision) + 1
     /\ evidence_count' = (evidence_count) + 1
-    /\ UNCHANGED << unresolved_blocker_count, claim_owner_key, claimed_at_utc_ms, lease_expires_at_utc_ms, due_at_utc_ms, not_before_utc_ms, snoozed_until_utc_ms, terminal_at_utc_ms >>
+    /\ UNCHANGED << unresolved_blocker_count, topology_item_keys, topology_edge_keys, blocks_reachability, parent_reachability, claim_owner_key, claimed_at_utc_ms, lease_expires_at_utc_ms, due_at_utc_ms, not_before_utc_ms, snoozed_until_utc_ms, terminal_at_utc_ms >>
 
 
 AddEvidenceBlocked(expected_revision) ==
@@ -370,7 +380,7 @@ AddEvidenceBlocked(expected_revision) ==
     /\ model_step_count' = model_step_count + 1
     /\ revision' = (revision) + 1
     /\ evidence_count' = (evidence_count) + 1
-    /\ UNCHANGED << unresolved_blocker_count, claim_owner_key, claimed_at_utc_ms, lease_expires_at_utc_ms, due_at_utc_ms, not_before_utc_ms, snoozed_until_utc_ms, terminal_at_utc_ms >>
+    /\ UNCHANGED << unresolved_blocker_count, topology_item_keys, topology_edge_keys, blocks_reachability, parent_reachability, claim_owner_key, claimed_at_utc_ms, lease_expires_at_utc_ms, due_at_utc_ms, not_before_utc_ms, snoozed_until_utc_ms, terminal_at_utc_ms >>
 
 
 AddEvidenceCompleted(expected_revision) ==
@@ -380,7 +390,7 @@ AddEvidenceCompleted(expected_revision) ==
     /\ model_step_count' = model_step_count + 1
     /\ revision' = (revision) + 1
     /\ evidence_count' = (evidence_count) + 1
-    /\ UNCHANGED << unresolved_blocker_count, claim_owner_key, claimed_at_utc_ms, lease_expires_at_utc_ms, due_at_utc_ms, not_before_utc_ms, snoozed_until_utc_ms, terminal_at_utc_ms >>
+    /\ UNCHANGED << unresolved_blocker_count, topology_item_keys, topology_edge_keys, blocks_reachability, parent_reachability, claim_owner_key, claimed_at_utc_ms, lease_expires_at_utc_ms, due_at_utc_ms, not_before_utc_ms, snoozed_until_utc_ms, terminal_at_utc_ms >>
 
 
 AddEvidenceCancelled(expected_revision) ==
@@ -390,7 +400,7 @@ AddEvidenceCancelled(expected_revision) ==
     /\ model_step_count' = model_step_count + 1
     /\ revision' = (revision) + 1
     /\ evidence_count' = (evidence_count) + 1
-    /\ UNCHANGED << unresolved_blocker_count, claim_owner_key, claimed_at_utc_ms, lease_expires_at_utc_ms, due_at_utc_ms, not_before_utc_ms, snoozed_until_utc_ms, terminal_at_utc_ms >>
+    /\ UNCHANGED << unresolved_blocker_count, topology_item_keys, topology_edge_keys, blocks_reachability, parent_reachability, claim_owner_key, claimed_at_utc_ms, lease_expires_at_utc_ms, due_at_utc_ms, not_before_utc_ms, snoozed_until_utc_ms, terminal_at_utc_ms >>
 
 
 AddEvidenceFailed(expected_revision) ==
@@ -400,7 +410,7 @@ AddEvidenceFailed(expected_revision) ==
     /\ model_step_count' = model_step_count + 1
     /\ revision' = (revision) + 1
     /\ evidence_count' = (evidence_count) + 1
-    /\ UNCHANGED << unresolved_blocker_count, claim_owner_key, claimed_at_utc_ms, lease_expires_at_utc_ms, due_at_utc_ms, not_before_utc_ms, snoozed_until_utc_ms, terminal_at_utc_ms >>
+    /\ UNCHANGED << unresolved_blocker_count, topology_item_keys, topology_edge_keys, blocks_reachability, parent_reachability, claim_owner_key, claimed_at_utc_ms, lease_expires_at_utc_ms, due_at_utc_ms, not_before_utc_ms, snoozed_until_utc_ms, terminal_at_utc_ms >>
 
 
 Next ==
@@ -418,7 +428,7 @@ Next ==
     \/ \E arg_unresolved_blocker_count \in 0..2 : RefreshEligibilityOpen(arg_unresolved_blocker_count)
     \/ \E arg_unresolved_blocker_count \in 0..2 : RefreshEligibilityInProgress(arg_unresolved_blocker_count)
     \/ \E arg_unresolved_blocker_count \in 0..2 : RefreshEligibilityBlocked(arg_unresolved_blocker_count)
-    \/ \E endpoints_exist \in BOOLEAN : \E self_edge \in BOOLEAN : \E duplicate_edge \in BOOLEAN : \E would_create_cycle \in BOOLEAN : ValidateLink(endpoints_exist, self_edge, duplicate_edge, would_create_cycle)
+    \/ \E kind \in WorkEdgeKindValues : \E from_item_key \in WorkItemKeyValues : \E to_item_key \in WorkItemKeyValues : \E edge_key \in WorkEdgeKeyValues : \E reverse_path_key \in WorkDependencyPathKeyValues : ValidateLink(kind, from_item_key, to_item_key, edge_key, reverse_path_key)
     \/ \E expected_revision \in 0..2 : \E at_utc_ms \in 0..2 : CloseOpenCompleted(expected_revision, at_utc_ms)
     \/ \E expected_revision \in 0..2 : \E at_utc_ms \in 0..2 : CloseInProgressCompleted(expected_revision, at_utc_ms)
     \/ \E expected_revision \in 0..2 : \E at_utc_ms \in 0..2 : CloseBlockedCompleted(expected_revision, at_utc_ms)
@@ -438,18 +448,20 @@ Next ==
 
 absent_has_zero_revision == ((phase # "Absent") \/ (revision = 0))
 live_has_positive_revision == ((phase = "Absent") \/ (revision > 0))
+topology_snapshot_is_stateless == ((topology_item_keys = {}) \/ (topology_edge_keys = {}) \/ (phase = "Absent"))
 terminal_has_terminal_time == (((phase # "Completed") /\ (phase # "Cancelled") /\ (phase # "Failed")) \/ (terminal_at_utc_ms # None))
 claim_only_in_progress == ((claim_owner_key = None) \/ (phase = "InProgress"))
 blocked_has_no_claim == ((phase # "Blocked") \/ (claim_owner_key = None))
 terminal_has_no_claim == (((phase # "Completed") /\ (phase # "Cancelled") /\ (phase # "Failed")) \/ (claim_owner_key = None))
 
-CiStateConstraint == /\ model_step_count <= 6
-DeepStateConstraint == /\ model_step_count <= 8
+CiStateConstraint == /\ model_step_count <= 6 /\ Cardinality(topology_item_keys) <= 1 /\ Cardinality(topology_edge_keys) <= 1 /\ Cardinality(blocks_reachability) <= 1 /\ Cardinality(parent_reachability) <= 1
+DeepStateConstraint == /\ model_step_count <= 8 /\ Cardinality(topology_item_keys) <= 2 /\ Cardinality(topology_edge_keys) <= 2 /\ Cardinality(blocks_reachability) <= 2 /\ Cardinality(parent_reachability) <= 2
 
 Spec == Init /\ [][Next]_vars
 
 THEOREM Spec => []absent_has_zero_revision
 THEOREM Spec => []live_has_positive_revision
+THEOREM Spec => []topology_snapshot_is_stateless
 THEOREM Spec => []terminal_has_terminal_time
 THEOREM Spec => []claim_only_in_progress
 THEOREM Spec => []blocked_has_no_claim

--- a/tests/integration/tests/system_shared_realm.rs
+++ b/tests/integration/tests/system_shared_realm.rs
@@ -264,10 +264,9 @@ async fn seed_workgraph_commitments(
             realm_id: None,
             namespace: None,
             expected_revision: blocker.revision,
-            owner: meerkat::WorkOwner {
-                principal: Some("system-workgraph-e2e".to_string()),
-                ..meerkat::WorkOwner::default()
-            },
+            owner: meerkat::WorkOwner::new(meerkat::WorkOwnerKey::principal(
+                "system-workgraph-e2e",
+            )?),
             lease_seconds: Some(300),
             lease_expires_at: None,
         })


### PR DESCRIPTION
## Summary

- keep WorkGraph as the sixth canonical machine in internal doctrine and generated machine authority artifacts
- persist WorkGraph lifecycle machine state on items and route lifecycle/readiness/claim transitions through the generated DSL state instead of rebuilding truth from projections
- move owner identity to typed owner keys, make topology validation machine-owned with typed topology sets, and fail-close WorkGraph SDK parsers
- keep host surfaces read-only while preserving agent tools, and add/verify shared-realm observability coverage

## Validation

- make machine-codegen
- make machine-check-drift
- make machine-verify
- ./scripts/repo-cargo test -p meerkat-workgraph --lib -- --nocapture
- ./scripts/repo-cargo test -p meerkat-machine-schema --tests -- --nocapture
- ./scripts/repo-cargo test -p meerkat-machine-codegen --tests -- --nocapture
- npm test (sdks/typescript; 140 tests, including live/provider smoke, 136 passed / 4 expected skips)
- make test-sdk-python (185 passed)
- ./scripts/repo-cargo test -p meerkat-integration-tests --test e2e_system_lane e2e_system_workgraph_shared_realm_observability -- --ignored --nocapture
- make fmt-check
- make check
- make agent-gate AGENT_GATE_ARGS=--committed (573 fast tests passed)
- pre-push hooks, including changed-crate clippy, machine codegen+verify, generated-header audit, bridge guard, Bazel freshness, and deterministic workspace gate
