### PR TITLE
[codex] Harden WorkGraph refresh and legacy state

### DIFF
--- a/meerkat-workgraph/src/service.rs
+++ b/meerkat-workgraph/src/service.rs
@@ -13,6 +13,8 @@ use crate::types::{
     WorkItem, WorkItemFilter, WorkItemId, WorkNamespace,
 };
 
+const BEST_EFFORT_REFRESH_ATTEMPTS: usize = 3;
+
 #[derive(Clone)]
 pub struct WorkGraphService {
     store: Arc<dyn WorkGraphStore>,
@@ -250,8 +252,8 @@ impl WorkGraphService {
             .store
             .update_item_cas(item, expected_previous_revision, event)
             .await?;
-        self.refresh_dependents_after_blocker_change(&closed, now)
-            .await?;
+        self.best_effort_refresh_dependents_after_blocker_change(&closed, now)
+            .await;
         Ok(closed)
     }
 
@@ -289,13 +291,13 @@ impl WorkGraphService {
         );
         let inserted = self.store.insert_edge(edge, event).await?;
         if inserted.kind == WorkEdgeKind::Blocks {
-            self.refresh_item_eligibility(
+            self.best_effort_refresh_item_eligibility(
                 &inserted.realm_id,
                 &inserted.namespace,
                 &inserted.to_id,
                 now,
             )
-            .await?;
+            .await;
         }
         Ok(inserted)
     }
@@ -450,6 +452,42 @@ impl WorkGraphService {
         Ok(())
     }
 
+    async fn best_effort_refresh_dependents_after_blocker_change(
+        &self,
+        blocker: &WorkItem,
+        now: chrono::DateTime<chrono::Utc>,
+    ) {
+        for _ in 0..BEST_EFFORT_REFRESH_ATTEMPTS {
+            match self
+                .refresh_dependents_after_blocker_change(blocker, now)
+                .await
+            {
+                Ok(()) => return,
+                Err(WorkGraphError::StaleRevision { .. }) => continue,
+                Err(_) => return,
+            }
+        }
+    }
+
+    async fn best_effort_refresh_item_eligibility(
+        &self,
+        realm_id: &str,
+        namespace: &WorkNamespace,
+        id: &WorkItemId,
+        now: chrono::DateTime<chrono::Utc>,
+    ) {
+        for _ in 0..BEST_EFFORT_REFRESH_ATTEMPTS {
+            match self
+                .refresh_item_eligibility(realm_id, namespace, id, now)
+                .await
+            {
+                Ok(()) => return,
+                Err(WorkGraphError::StaleRevision { .. }) => continue,
+                Err(_) => return,
+            }
+        }
+    }
+
     async fn refresh_item_eligibility(
         &self,
         realm_id: &str,
@@ -509,14 +547,19 @@ fn unresolved_blocker_count(
 mod tests {
     use std::collections::BTreeSet;
     use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    use async_trait::async_trait;
+    use chrono::{DateTime, Utc};
 
     use crate::store::WorkGraphEventFilter;
     use crate::types::{
-        ClaimWorkItemRequest, LinkWorkItemsRequest, WorkEdgeKind, WorkOwner, WorkOwnerKey,
+        ClaimWorkItemRequest, LinkWorkItemsRequest, WorkEdge, WorkEdgeKind, WorkGraphEvent,
+        WorkGraphEventKind, WorkItem, WorkItemFilter, WorkOwner, WorkOwnerKey,
     };
     use crate::{
         CreateWorkItemRequest, MemoryWorkGraphStore, UpdateWorkItemRequest, WorkGraphService,
-        WorkNamespace,
+        WorkGraphStore, WorkGraphStoreKind, WorkItemId, WorkNamespace,
     };
 
     fn create_req(title: &str) -> CreateWorkItemRequest {
@@ -533,6 +576,107 @@ mod tests {
             external_refs: Vec::new(),
             evidence_refs: Vec::new(),
             status: None,
+        }
+    }
+
+    struct RefreshConflictStore {
+        inner: MemoryWorkGraphStore,
+        fail_updated_events: AtomicUsize,
+    }
+
+    impl RefreshConflictStore {
+        fn new() -> Self {
+            Self {
+                inner: MemoryWorkGraphStore::new(),
+                fail_updated_events: AtomicUsize::new(0),
+            }
+        }
+
+        fn fail_next_refresh_update(&self) {
+            self.fail_updated_events.fetch_add(1, Ordering::SeqCst);
+        }
+    }
+
+    #[async_trait]
+    impl WorkGraphStore for RefreshConflictStore {
+        fn kind(&self) -> WorkGraphStoreKind {
+            WorkGraphStoreKind::Custom
+        }
+
+        async fn get_store_time_utc(&self) -> Result<DateTime<Utc>, crate::WorkGraphError> {
+            self.inner.get_store_time_utc().await
+        }
+
+        async fn insert_item(
+            &self,
+            item: WorkItem,
+            event: WorkGraphEvent,
+        ) -> Result<WorkItem, crate::WorkGraphError> {
+            self.inner.insert_item(item, event).await
+        }
+
+        async fn update_item_cas(
+            &self,
+            item: WorkItem,
+            expected_previous_revision: u64,
+            event: WorkGraphEvent,
+        ) -> Result<WorkItem, crate::WorkGraphError> {
+            if event.kind == WorkGraphEventKind::Updated
+                && self
+                    .fail_updated_events
+                    .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |remaining| {
+                        remaining.checked_sub(1)
+                    })
+                    .is_ok()
+            {
+                return Err(crate::WorkGraphError::StaleRevision {
+                    id: item.id,
+                    expected: expected_previous_revision,
+                    actual: expected_previous_revision.saturating_add(1),
+                });
+            }
+            self.inner
+                .update_item_cas(item, expected_previous_revision, event)
+                .await
+        }
+
+        async fn get_item(
+            &self,
+            realm_id: &str,
+            namespace: &WorkNamespace,
+            id: &WorkItemId,
+        ) -> Result<Option<WorkItem>, crate::WorkGraphError> {
+            self.inner.get_item(realm_id, namespace, id).await
+        }
+
+        async fn list_items(
+            &self,
+            filter: WorkItemFilter,
+        ) -> Result<Vec<WorkItem>, crate::WorkGraphError> {
+            self.inner.list_items(filter).await
+        }
+
+        async fn insert_edge(
+            &self,
+            edge: WorkEdge,
+            event: WorkGraphEvent,
+        ) -> Result<WorkEdge, crate::WorkGraphError> {
+            self.inner.insert_edge(edge, event).await
+        }
+
+        async fn list_edges(
+            &self,
+            realm_id: &str,
+            namespace: &WorkNamespace,
+        ) -> Result<Vec<WorkEdge>, crate::WorkGraphError> {
+            self.inner.list_edges(realm_id, namespace).await
+        }
+
+        async fn list_events(
+            &self,
+            filter: WorkGraphEventFilter,
+        ) -> Result<Vec<WorkGraphEvent>, crate::WorkGraphError> {
+            self.inner.list_events(filter).await
         }
     }
 
@@ -575,6 +719,90 @@ mod tests {
             })
             .await
             .expect("close blocker");
+        let ready = service.ready(Default::default()).await.expect("ready");
+        assert!(ready.iter().any(|item| item.id == blocked.id));
+    }
+
+    #[tokio::test]
+    async fn link_reports_success_when_post_insert_refresh_conflicts() {
+        let store = Arc::new(RefreshConflictStore::new());
+        let service =
+            WorkGraphService::with_scope(store.clone(), "realm", WorkNamespace::default());
+        let blocker = service
+            .create(create_req("blocker"))
+            .await
+            .expect("blocker");
+        let blocked = service
+            .create(create_req("blocked"))
+            .await
+            .expect("blocked");
+
+        store.fail_next_refresh_update();
+        let edge = service
+            .link(LinkWorkItemsRequest {
+                realm_id: None,
+                namespace: None,
+                kind: WorkEdgeKind::Blocks,
+                from_id: blocker.id.clone(),
+                to_id: blocked.id.clone(),
+            })
+            .await
+            .expect("link should report inserted edge despite refresh conflict");
+
+        assert_eq!(edge.from_id, blocker.id);
+        assert_eq!(edge.to_id, blocked.id);
+        let edges = store
+            .list_edges("realm", &WorkNamespace::default())
+            .await
+            .expect("edges");
+        assert_eq!(edges.len(), 1);
+        let ready = service.ready(Default::default()).await.expect("ready");
+        assert!(!ready.iter().any(|item| item.id == blocked.id));
+    }
+
+    #[tokio::test]
+    async fn close_reports_success_when_dependent_refresh_conflicts() {
+        let store = Arc::new(RefreshConflictStore::new());
+        let service =
+            WorkGraphService::with_scope(store.clone(), "realm", WorkNamespace::default());
+        let blocker = service
+            .create(create_req("blocker"))
+            .await
+            .expect("blocker");
+        let blocked = service
+            .create(create_req("blocked"))
+            .await
+            .expect("blocked");
+        service
+            .link(LinkWorkItemsRequest {
+                realm_id: None,
+                namespace: None,
+                kind: WorkEdgeKind::Blocks,
+                from_id: blocker.id.clone(),
+                to_id: blocked.id.clone(),
+            })
+            .await
+            .expect("link");
+
+        store.fail_next_refresh_update();
+        let closed = service
+            .close(crate::CloseWorkItemRequest {
+                id: blocker.id.clone(),
+                realm_id: None,
+                namespace: None,
+                expected_revision: blocker.revision,
+                status: crate::WorkStatus::Completed,
+            })
+            .await
+            .expect("close should report committed terminal item despite refresh conflict");
+
+        assert_eq!(closed.id, blocker.id);
+        assert_eq!(closed.status, crate::WorkStatus::Completed);
+        let fetched = service
+            .get(None, None, closed.id)
+            .await
+            .expect("closed item should be stored");
+        assert_eq!(fetched.status, crate::WorkStatus::Completed);
         let ready = service.ready(Default::default()).await.expect("ready");
         assert!(ready.iter().any(|item| item.id == blocked.id));
     }

--- a/meerkat-workgraph/src/store.rs
+++ b/meerkat-workgraph/src/store.rs
@@ -898,9 +898,10 @@ mod tests {
 
     use crate::types::WorkEdge;
     use crate::{
-        CreateWorkItemRequest, LinkWorkItemsRequest, MemoryWorkGraphStore, WorkEdgeKind,
-        WorkGraphError, WorkGraphEvent, WorkGraphEventFilter, WorkGraphEventKind, WorkGraphService,
-        WorkGraphStore, WorkItemFilter, WorkItemId, WorkNamespace,
+        ClaimWorkItemRequest, CreateWorkItemRequest, LinkWorkItemsRequest, MemoryWorkGraphStore,
+        WorkEdgeKind, WorkGraphError, WorkGraphEvent, WorkGraphEventFilter, WorkGraphEventKind,
+        WorkGraphService, WorkGraphStore, WorkItemFilter, WorkItemId, WorkNamespace, WorkOwner,
+        WorkOwnerKey, WorkStatus,
     };
 
     fn test_edge() -> WorkEdge {
@@ -1038,6 +1039,93 @@ mod tests {
         let service = WorkGraphService::with_scope(reopened, "realm", WorkNamespace::default());
         let fetched = service.get(None, None, item.id.clone()).await.expect("get");
         assert_eq!(fetched.title, "persist me");
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    #[tokio::test]
+    async fn sqlite_legacy_item_without_machine_state_backfills_on_write() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("workgraph.sqlite3");
+        let store = std::sync::Arc::new(crate::SqliteWorkGraphStore::open(&path).expect("open"));
+        let service =
+            WorkGraphService::with_scope(store.clone(), "realm", WorkNamespace::default());
+        let item = service
+            .create(CreateWorkItemRequest {
+                realm_id: None,
+                namespace: None,
+                title: "legacy item".to_string(),
+                description: None,
+                priority: Default::default(),
+                labels: BTreeSet::new(),
+                due_at: None,
+                not_before: None,
+                snoozed_until: None,
+                external_refs: Vec::new(),
+                evidence_refs: Vec::new(),
+                status: None,
+            })
+            .await
+            .expect("create");
+
+        store
+            .with_connection(|conn| {
+                let json: String = conn
+                    .query_row(
+                        "SELECT item_json FROM workgraph_items
+                         WHERE realm_id = ?1 AND namespace = ?2 AND item_id = ?3",
+                        rusqlite::params![
+                            &item.realm_id,
+                            item.namespace.as_str(),
+                            item.id.as_str()
+                        ],
+                        |row| row.get(0),
+                    )
+                    .map_err(|err| WorkGraphError::Store(err.to_string()))?;
+                let mut value = serde_json::from_str::<serde_json::Value>(&json)
+                    .map_err(|err| WorkGraphError::Store(err.to_string()))?;
+                value
+                    .as_object_mut()
+                    .expect("item json object")
+                    .remove("machine_state");
+                conn.execute(
+                    "UPDATE workgraph_items
+                        SET item_json = ?4
+                      WHERE realm_id = ?1 AND namespace = ?2 AND item_id = ?3",
+                    rusqlite::params![
+                        &item.realm_id,
+                        item.namespace.as_str(),
+                        item.id.as_str(),
+                        serde_json::to_string(&value)
+                            .map_err(|err| WorkGraphError::Store(err.to_string()))?
+                    ],
+                )
+                .map_err(|err| WorkGraphError::Store(err.to_string()))?;
+                Ok(())
+            })
+            .expect("strip machine state");
+
+        let reopened = std::sync::Arc::new(crate::SqliteWorkGraphStore::open(&path).expect("open"));
+        let service = WorkGraphService::with_scope(reopened, "realm", WorkNamespace::default());
+        let legacy = service.get(None, None, item.id).await.expect("get legacy");
+        assert_eq!(legacy.machine_state.revision, legacy.revision);
+        assert!(matches!(
+            legacy.machine_state.lifecycle_phase,
+            crate::machines::workgraph_lifecycle::WorkLifecycleState::Open
+        ));
+
+        let claimed = service
+            .claim(ClaimWorkItemRequest {
+                id: legacy.id,
+                realm_id: None,
+                namespace: None,
+                expected_revision: legacy.revision,
+                owner: WorkOwner::new(WorkOwnerKey::label("worker").expect("owner")),
+                lease_seconds: Some(60),
+                lease_expires_at: None,
+            })
+            .await
+            .expect("claim legacy");
+        assert_eq!(claimed.status, WorkStatus::InProgress);
     }
 
     #[cfg(not(target_arch = "wasm32"))]

--- a/meerkat-workgraph/src/types.rs
+++ b/meerkat-workgraph/src/types.rs
@@ -8,6 +8,7 @@ use serde_json::Value;
 use uuid::Uuid;
 
 use crate::WorkGraphError;
+use crate::machines::workgraph_lifecycle as wg_dsl;
 pub use crate::machines::workgraph_lifecycle::WorkGraphLifecycleMachineState as WorkGraphMachineState;
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
@@ -246,7 +247,7 @@ pub struct WorkEvidenceRef {
     pub summary: Option<String>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct WorkItem {
     pub id: WorkItemId,
     pub realm_id: String,
@@ -283,6 +284,124 @@ pub struct WorkItem {
 
 fn default_workgraph_machine_state() -> WorkGraphMachineState {
     WorkGraphMachineState::default()
+}
+
+#[derive(Deserialize)]
+struct WorkItemWire {
+    id: WorkItemId,
+    realm_id: String,
+    namespace: WorkNamespace,
+    title: String,
+    #[serde(default)]
+    description: Option<String>,
+    status: WorkStatus,
+    priority: WorkPriority,
+    #[serde(default)]
+    labels: BTreeSet<String>,
+    #[serde(default)]
+    owner: Option<WorkOwner>,
+    #[serde(default)]
+    claim: Option<WorkClaim>,
+    #[serde(default)]
+    machine_state: Option<WorkGraphMachineState>,
+    revision: u64,
+    #[serde(default)]
+    due_at: Option<DateTime<Utc>>,
+    #[serde(default)]
+    not_before: Option<DateTime<Utc>>,
+    #[serde(default)]
+    snoozed_until: Option<DateTime<Utc>>,
+    created_at: DateTime<Utc>,
+    updated_at: DateTime<Utc>,
+    #[serde(default)]
+    terminal_at: Option<DateTime<Utc>>,
+    #[serde(default)]
+    external_refs: Vec<ExternalWorkRef>,
+    #[serde(default)]
+    evidence_refs: Vec<WorkEvidenceRef>,
+}
+
+impl<'de> Deserialize<'de> for WorkItem {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let mut wire = WorkItemWire::deserialize(deserializer)?;
+        let machine_state = wire
+            .machine_state
+            .take()
+            .unwrap_or_else(|| legacy_workgraph_machine_state(&wire));
+        Ok(Self {
+            id: wire.id,
+            realm_id: wire.realm_id,
+            namespace: wire.namespace,
+            title: wire.title,
+            description: wire.description,
+            status: wire.status,
+            priority: wire.priority,
+            labels: wire.labels,
+            owner: wire.owner,
+            claim: wire.claim,
+            machine_state,
+            revision: wire.revision,
+            due_at: wire.due_at,
+            not_before: wire.not_before,
+            snoozed_until: wire.snoozed_until,
+            created_at: wire.created_at,
+            updated_at: wire.updated_at,
+            terminal_at: wire.terminal_at,
+            external_refs: wire.external_refs,
+            evidence_refs: wire.evidence_refs,
+        })
+    }
+}
+
+fn legacy_workgraph_machine_state(wire: &WorkItemWire) -> WorkGraphMachineState {
+    let mut machine_state = WorkGraphMachineState {
+        lifecycle_phase: work_lifecycle_state_from_status(wire.status),
+        revision: wire.revision,
+        due_at_utc_ms: wire.due_at.map(datetime_to_millis),
+        not_before_utc_ms: wire.not_before.map(datetime_to_millis),
+        snoozed_until_utc_ms: wire.snoozed_until.map(datetime_to_millis),
+        terminal_at_utc_ms: wire.terminal_at.map(datetime_to_millis),
+        evidence_count: wire.evidence_refs.len().try_into().unwrap_or(u64::MAX),
+        ..default_workgraph_machine_state()
+    };
+    if let Some(claim) = &wire.claim {
+        machine_state.claim_owner_key = Some(work_owner_key_to_machine(&claim.owner.key));
+        machine_state.claimed_at_utc_ms = Some(datetime_to_millis(claim.claimed_at));
+        machine_state.lease_expires_at_utc_ms = claim.lease_expires_at.map(datetime_to_millis);
+    }
+    machine_state
+}
+
+fn work_lifecycle_state_from_status(status: WorkStatus) -> wg_dsl::WorkLifecycleState {
+    match status {
+        WorkStatus::Open => wg_dsl::WorkLifecycleState::Open,
+        WorkStatus::InProgress => wg_dsl::WorkLifecycleState::InProgress,
+        WorkStatus::Blocked => wg_dsl::WorkLifecycleState::Blocked,
+        WorkStatus::Completed => wg_dsl::WorkLifecycleState::Completed,
+        WorkStatus::Cancelled => wg_dsl::WorkLifecycleState::Cancelled,
+        WorkStatus::Failed => wg_dsl::WorkLifecycleState::Failed,
+    }
+}
+
+fn work_owner_key_to_machine(owner: &WorkOwnerKey) -> wg_dsl::WorkOwnerKey {
+    let kind = match owner.kind {
+        WorkOwnerKind::Principal => wg_dsl::WorkOwnerKind::Principal,
+        WorkOwnerKind::Agent => wg_dsl::WorkOwnerKind::Agent,
+        WorkOwnerKind::Session => wg_dsl::WorkOwnerKind::Session,
+        WorkOwnerKind::Mob => wg_dsl::WorkOwnerKind::Mob,
+        WorkOwnerKind::Label => wg_dsl::WorkOwnerKind::Label,
+    };
+    wg_dsl::WorkOwnerKey {
+        kind,
+        id: owner.id.clone(),
+    }
+}
+
+fn datetime_to_millis(dt: DateTime<Utc>) -> u64 {
+    u64::try_from(dt.timestamp_millis()).unwrap_or(0)
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]


### PR DESCRIPTION
## Summary

Fixes the three post-merge WorkGraph follow-ups:

- make post-commit eligibility refresh after `close` and `link` best-effort, with bounded retry for transient stale-revision races;
- preserve successful committed mutations instead of reporting follow-up refresh failures to callers;
- backfill missing legacy `WorkItem.machine_state` from projected item fields during deserialization so upgraded persisted items can still pass machine projection validation on later writes.

## Validation

- `make fmt`
- `./scripts/repo-cargo test -p meerkat-workgraph --lib -- --nocapture`
- `make fmt-check`
- `make check`
- `make agent-gate AGENT_GATE_ARGS=--working-tree`
- pre-push hooks: secret/format checks, changed-crate clippy, machine codegen + verify, generated-header audit, response-status guard, Bazel freshness, workspace deterministic gate