### PR TITLE
[codex] Use catalog defaults for auth bindings

### DIFF
--- a/meerkat-cli/src/main.rs
+++ b/meerkat-cli/src/main.rs
@@ -3548,10 +3548,15 @@ impl LoginProvider {
     }
 
     fn sample_model(self) -> &'static str {
+        meerkat_core::model_profile::catalog::default_model(self.config_provider())
+            .expect("login provider must have a catalog default model")
+    }
+
+    fn legacy_sample_models(self) -> &'static [&'static str] {
         match self {
-            Self::Anthropic => "claude-sonnet-4-6",
-            Self::OpenAi => "gpt-5.4",
-            Self::Google => "gemini-2.5-flash",
+            Self::Anthropic => &["claude-sonnet-4-6", "claude-opus-4-6"],
+            Self::OpenAi => &["gpt-5.4"],
+            Self::Google => &["gemini-3.1-flash-lite"],
         }
     }
 }
@@ -3761,11 +3766,13 @@ fn ensure_cli_interactive_oauth_config(provider: LoginProvider, config: &mut Con
             },
         );
         changed = true;
-    } else if provider == LoginProvider::Google
-        && let Some(binding) = section.binding.get_mut(binding_id)
+    } else if let Some(binding) = section.binding.get_mut(binding_id)
         && binding.backend_profile == backend_profile_id
         && binding.auth_profile == auth_profile_id
-        && binding.default_model.as_deref() == Some("gemini-3.1-flash-lite")
+        && binding
+            .default_model
+            .as_deref()
+            .is_some_and(|model| provider.legacy_sample_models().contains(&model))
     {
         binding.default_model = Some(provider.sample_model().to_string());
         changed = true;
@@ -11617,6 +11624,89 @@ mod tests {
         assert_eq!(target.auth_binding.realm.as_str(), "dev");
         assert_eq!(target.auth_binding.binding.as_str(), "openai_oauth");
         assert_eq!(target.auth_profile.auth_method, "managed_chatgpt_oauth");
+    }
+
+    #[cfg(all(feature = "anthropic", feature = "openai", feature = "gemini"))]
+    #[test]
+    fn test_cli_interactive_oauth_config_uses_current_provider_default_models() {
+        let mut config = Config::default();
+
+        assert!(ensure_cli_interactive_oauth_config(
+            LoginProvider::Anthropic,
+            &mut config
+        ));
+        assert!(ensure_cli_interactive_oauth_config(
+            LoginProvider::OpenAi,
+            &mut config
+        ));
+
+        let realm = config.realm.get("dev").expect("dev realm");
+        assert_eq!(
+            realm
+                .binding
+                .get("anthropic_oauth")
+                .and_then(|binding| binding.default_model.as_deref()),
+            meerkat_core::model_profile::catalog::default_model("anthropic")
+        );
+        assert_eq!(
+            realm
+                .binding
+                .get("openai_oauth")
+                .and_then(|binding| binding.default_model.as_deref()),
+            meerkat_core::model_profile::catalog::default_model("openai")
+        );
+    }
+
+    #[cfg(all(feature = "anthropic", feature = "openai", feature = "gemini"))]
+    #[test]
+    fn test_cli_interactive_oauth_config_heals_legacy_provider_default_models() {
+        let mut config = Config::default();
+
+        assert!(ensure_cli_interactive_oauth_config(
+            LoginProvider::Anthropic,
+            &mut config
+        ));
+        assert!(ensure_cli_interactive_oauth_config(
+            LoginProvider::OpenAi,
+            &mut config
+        ));
+
+        let realm = config.realm.get_mut("dev").expect("dev realm");
+        realm
+            .binding
+            .get_mut("anthropic_oauth")
+            .expect("anthropic oauth binding")
+            .default_model = Some("claude-sonnet-4-6".to_string());
+        realm
+            .binding
+            .get_mut("openai_oauth")
+            .expect("openai oauth binding")
+            .default_model = Some("gpt-5.4".to_string());
+
+        assert!(ensure_cli_interactive_oauth_config(
+            LoginProvider::Anthropic,
+            &mut config
+        ));
+        assert!(ensure_cli_interactive_oauth_config(
+            LoginProvider::OpenAi,
+            &mut config
+        ));
+
+        let realm = config.realm.get("dev").expect("dev realm");
+        assert_eq!(
+            realm
+                .binding
+                .get("anthropic_oauth")
+                .and_then(|binding| binding.default_model.as_deref()),
+            meerkat_core::model_profile::catalog::default_model("anthropic")
+        );
+        assert_eq!(
+            realm
+                .binding
+                .get("openai_oauth")
+                .and_then(|binding| binding.default_model.as_deref()),
+            meerkat_core::model_profile::catalog::default_model("openai")
+        );
     }
 
     #[cfg(all(feature = "anthropic", feature = "openai", feature = "gemini"))]

--- a/meerkat-core/src/config.rs
+++ b/meerkat-core/src/config.rs
@@ -1999,6 +1999,16 @@ mod tests {
     }
 
     #[test]
+    fn config_template_agent_model_tracks_anthropic_catalog_default() {
+        let config = Config::template().expect("template parses");
+        assert_eq!(
+            config.agent.model.as_str(),
+            crate::model_profile::catalog::default_model("anthropic")
+                .expect("anthropic catalog default")
+        );
+    }
+
+    #[test]
     fn test_limits_max_sessions_configures_runtime_capacity() {
         let mut config = Config::default();
         config

--- a/meerkat-core/src/config_store.rs
+++ b/meerkat-core/src/config_store.rs
@@ -272,7 +272,7 @@ mod tests {
             crate::ProviderBindingConfig {
                 backend_profile: "openai_chatgpt".to_string(),
                 auth_profile: "openai_oauth".to_string(),
-                default_model: Some("gpt-5.4".to_string()),
+                default_model: Some("gpt-5.5".to_string()),
                 policy: Default::default(),
             },
         );

--- a/meerkat-core/src/connection.rs
+++ b/meerkat-core/src/connection.rs
@@ -1302,7 +1302,7 @@ source = { kind = "managed_store" }
 [dev.binding.openai_oauth]
 backend_profile = "openai_chatgpt"
 auth_profile = "openai_oauth"
-default_model = "gpt-5.4"
+default_model = "gpt-5.5"
 "#,
         );
         let preferred_realm = RealmId::parse("dev").unwrap();

--- a/meerkat/src/factory.rs
+++ b/meerkat/src/factory.rs
@@ -5579,7 +5579,7 @@ mod tests {
             ProviderBindingConfig {
                 backend_profile: "openai_api".to_string(),
                 auth_profile: "openai_key".to_string(),
-                default_model: Some("gpt-5.4".to_string()),
+                default_model: Some("gpt-5.5".to_string()),
                 policy: Default::default(),
             },
         );
@@ -5643,7 +5643,7 @@ mod tests {
             ProviderBindingConfig {
                 backend_profile: "openai_api".to_string(),
                 auth_profile: "openai_key".to_string(),
-                default_model: Some("gpt-5.4".to_string()),
+                default_model: Some("gpt-5.5".to_string()),
                 policy: Default::default(),
             },
         );
@@ -5784,7 +5784,7 @@ mod tests {
             ProviderBindingConfig {
                 backend_profile: "anthropic_api".to_string(),
                 auth_profile: "anthropic_key".to_string(),
-                default_model: Some("claude-sonnet-4-6".to_string()),
+                default_model: Some("claude-opus-4-7".to_string()),
                 policy: Default::default(),
             },
         );


### PR DESCRIPTION
## What changed

- Make `rkat auth login` bootstrap OpenAI and Anthropic binding defaults from the model catalog instead of duplicating current model IDs in the CLI.
- Heal legacy synthesized OAuth binding defaults from `gpt-5.4`, `claude-sonnet-4-6`, and `claude-opus-4-6` to the current catalog defaults.
- Refresh stale default-model fixtures and add a template/catalog guard for the default Anthropic model.

## Why

The catalog is the source of truth for provider defaults. The CLI bootstrap path had drifted and was still creating `dev:openai_oauth` as `gpt-5.4` and `dev:anthropic_oauth` as `claude-sonnet-4-6`.

## Validation

- `./scripts/repo-cargo fmt --check`
- `./scripts/repo-cargo test -p rkat test_cli_interactive_oauth_config`
- `./scripts/repo-cargo test -p meerkat build_agent_without_auth_binding`
- `./scripts/repo-cargo test -p meerkat-core auth_binding_candidates_prefer_provider_binding_in_preferred_realm`
- `./scripts/repo-cargo test -p meerkat-core file_config_store_set_skips_null_backend_options`
- `./scripts/repo-cargo test -p meerkat-core config_template_agent_model_tracks_anthropic_catalog_default`
- pre-push hook: changed-crate clippy, machine codegen verify, generated header audit, bridge invariant, Bazel freshness, workspace deterministic gate
