### PR TITLE
[codex] Fix OpenAI OAuth image generation

### DIFF
--- a/meerkat-openai/src/client.rs
+++ b/meerkat-openai/src/client.rs
@@ -440,6 +440,7 @@ impl OpenAiClient {
             "input": input,
             "max_output_tokens": request.max_tokens,
             "stream": true,
+            "store": false,
         });
 
         if reasoning_enabled {
@@ -456,7 +457,6 @@ impl OpenAiClient {
             body["instructions"] = Value::String(
                 instructions.unwrap_or_else(|| "You are a helpful assistant.".to_string()),
             );
-            body["store"] = Value::Bool(false);
             body["tools"] = Value::Array(Vec::new());
             body["tool_choice"] = Value::String("auto".to_string());
             body["parallel_tool_calls"] = Value::Bool(false);
@@ -900,13 +900,15 @@ impl OpenAiClient {
             tools.push(web_search_tool);
         }
         tools.push(serde_json::Value::Object(tool));
+        let stream = self.chatgpt_backend_wire;
         let body = serde_json::json!({
             "model": request.model,
             "input": input,
             "instructions": "You are an image-generation agent. The user's input is always a request to produce one or more images. Call the image_generation tool to produce each image. Never reply in text instead of calling the tool. If the request cannot be fulfilled, refuse briefly and explicitly so the caller can see the reason.",
             "tools": tools,
             "tool_choice": "required",
-            "stream": false,
+            "stream": stream,
+            "store": false,
         });
         let mut body = body;
         if let Some(effort) = plan.provider_params.reasoning_effort {
@@ -914,6 +916,12 @@ impl OpenAiClient {
         }
         let endpoint = self.responses_endpoint();
         let response = self.post_json_to_openai(&endpoint, &body).await?;
+        if stream {
+            let status_code = response.status().as_u16();
+            if (200..=299).contains(&status_code) {
+                return self.normalize_openai_image_stream(request, response).await;
+            }
+        }
         self.normalize_openai_image_response(request, response, true)
             .await
     }
@@ -1018,33 +1026,12 @@ impl OpenAiClient {
         }
     }
 
-    async fn normalize_openai_image_response(
+    fn normalize_openai_image_response_value(
         &self,
         request: ProviderImageGenerationRequest,
-        response: reqwest::Response,
+        value: Value,
         hosted_responses: bool,
     ) -> Result<ProviderImageGenerationOutput, LlmError> {
-        let status_code = response.status().as_u16();
-        let text = response.text().await.unwrap_or_default();
-        if !(200..=299).contains(&status_code) {
-            return Ok(ProviderImageGenerationOutput {
-                operation_id: request.operation_id,
-                terminal: Self::openai_error_terminal(status_code, &text),
-                images: Vec::new(),
-                provider_text: None,
-                revised_prompt: RevisedPromptDisposition::NotRequested,
-                native_metadata: ProviderImageMetadata::OpenAi(OpenAiImageMetadata {
-                    target_model: request.model,
-                    response_id: None,
-                    image_generation_call_id: None,
-                }),
-                warnings: Vec::new(),
-            });
-        }
-
-        let value: Value = serde_json::from_str(&text).map_err(|e| LlmError::StreamParseError {
-            message: format!("invalid OpenAI image response JSON: {e}"),
-        })?;
         let (width, height) = dimensions_from_size_preference(&request.generate_request.size);
         let media_type = media_type_from_format_preference(request.generate_request.format);
         let mut images = Vec::new();
@@ -1055,17 +1042,17 @@ impl OpenAiClient {
         if hosted_responses {
             if let Some(output) = value.get("output").and_then(Value::as_array) {
                 for item in output {
-                    match item.get("type").and_then(|v| v.as_str()) {
+                    match item.get("type").and_then(Value::as_str) {
                         Some("image_generation_call") => {
                             if image_generation_call_id.is_none() {
                                 image_generation_call_id =
-                                    item.get("id").and_then(|v| v.as_str()).map(str::to_string);
+                                    item.get("id").and_then(Value::as_str).map(str::to_string);
                             }
                             if let Some(data) = item
                                 .get("result")
                                 .or_else(|| item.get("b64_json"))
                                 .or_else(|| item.get("image_data"))
-                                .and_then(|v| v.as_str())
+                                .and_then(Value::as_str)
                             {
                                 images.push(ProviderGeneratedImage {
                                     media_type: media_type.clone(),
@@ -1074,7 +1061,7 @@ impl OpenAiClient {
                                     height,
                                 });
                             }
-                            if let Some(text) = item.get("revised_prompt").and_then(|v| v.as_str())
+                            if let Some(text) = item.get("revised_prompt").and_then(Value::as_str)
                                 && let Ok(prompt) = meerkat_core::PromptText::new(text.to_string())
                             {
                                 revised_prompt = RevisedPromptDisposition::Revised {
@@ -1084,9 +1071,9 @@ impl OpenAiClient {
                             }
                         }
                         Some("message") => {
-                            if let Some(parts) = item.get("content").and_then(|v| v.as_array()) {
+                            if let Some(parts) = item.get("content").and_then(Value::as_array) {
                                 for part in parts {
-                                    if let Some(text) = part.get("text").and_then(|v| v.as_str()) {
+                                    if let Some(text) = part.get("text").and_then(Value::as_str) {
                                         provider_text.push(text.to_string());
                                     }
                                 }
@@ -1096,9 +1083,9 @@ impl OpenAiClient {
                     }
                 }
             }
-        } else if let Some(data) = value.get("data").and_then(|v| v.as_array()) {
+        } else if let Some(data) = value.get("data").and_then(Value::as_array) {
             for item in data {
-                if let Some(data) = item.get("b64_json").and_then(|v| v.as_str()) {
+                if let Some(data) = item.get("b64_json").and_then(Value::as_str) {
                     images.push(ProviderGeneratedImage {
                         media_type: media_type.clone(),
                         base64_data: normalize_base64_image_data(data),
@@ -1106,7 +1093,7 @@ impl OpenAiClient {
                         height,
                     });
                 }
-                if let Some(text) = item.get("revised_prompt").and_then(|v| v.as_str())
+                if let Some(text) = item.get("revised_prompt").and_then(Value::as_str)
                     && let Ok(prompt) = meerkat_core::PromptText::new(text.to_string())
                 {
                     revised_prompt = RevisedPromptDisposition::Revised {
@@ -1141,11 +1128,149 @@ impl OpenAiClient {
             revised_prompt,
             native_metadata: ProviderImageMetadata::OpenAi(OpenAiImageMetadata {
                 target_model: request.model,
-                response_id: value.get("id").and_then(|v| v.as_str()).map(str::to_string),
+                response_id: value.get("id").and_then(Value::as_str).map(str::to_string),
                 image_generation_call_id,
             }),
             warnings,
         })
+    }
+
+    async fn normalize_openai_image_stream(
+        &self,
+        request: ProviderImageGenerationRequest,
+        response: reqwest::Response,
+    ) -> Result<ProviderImageGenerationOutput, LlmError> {
+        let mut stream = Box::pin(response.bytes_stream());
+        let mut buffer = String::with_capacity(512);
+        let mut streamed_output_items: Vec<Value> = Vec::new();
+        while let Some(chunk) = stream.next().await {
+            let chunk = chunk.map_err(|_| LlmError::ConnectionReset)?;
+            buffer.push_str(&String::from_utf8_lossy(&chunk));
+
+            while let Some(newline_pos) = buffer.find('\n') {
+                let line = buffer[..newline_pos].trim();
+                let should_process = !line.is_empty() && !line.starts_with(':');
+                let parsed_event = if should_process {
+                    Self::parse_responses_sse_line(line)
+                } else {
+                    None
+                };
+                buffer.drain(..=newline_pos);
+
+                let Some(event) = parsed_event else {
+                    continue;
+                };
+                if matches!(
+                    event.event_type.as_str(),
+                    "response.output_item.added" | "response.output_item.done"
+                ) && let Some(item) = event.item.as_ref()
+                    && item
+                        .get("type")
+                        .and_then(Value::as_str)
+                        .is_some_and(|kind| kind == "image_generation_call")
+                {
+                    if let Some(id) = item.get("id").and_then(Value::as_str) {
+                        if let Some(existing) = streamed_output_items
+                            .iter_mut()
+                            .find(|existing| existing.get("id").and_then(Value::as_str) == Some(id))
+                        {
+                            *existing = item.clone();
+                        } else {
+                            streamed_output_items.push(item.clone());
+                        }
+                    } else {
+                        streamed_output_items.push(item.clone());
+                    }
+                }
+                if event.event_type == "response.failed" {
+                    let value = event.response.unwrap_or_else(|| serde_json::json!({}));
+                    return Ok(ProviderImageGenerationOutput {
+                        operation_id: request.operation_id,
+                        terminal: Self::openai_structured_error_terminal(&value)
+                            .unwrap_or(ImageOperationTerminalClass::Failed),
+                        images: Vec::new(),
+                        provider_text: None,
+                        revised_prompt: RevisedPromptDisposition::NotRequested,
+                        native_metadata: ProviderImageMetadata::OpenAi(OpenAiImageMetadata {
+                            target_model: request.model,
+                            response_id: value
+                                .get("id")
+                                .and_then(Value::as_str)
+                                .map(str::to_string),
+                            image_generation_call_id: None,
+                        }),
+                        warnings: vec![ImageGenerationWarning::ProviderExecutionFailed {
+                            message: format!("OpenAI streamed image response failed: {value}"),
+                        }],
+                    });
+                }
+                if event.event_type == "response.completed" {
+                    let mut value = event.response.ok_or_else(|| LlmError::StreamParseError {
+                        message: "OpenAI streamed image response.completed missing response"
+                            .to_string(),
+                    })?;
+                    if !streamed_output_items.is_empty()
+                        && !value
+                            .get("output")
+                            .and_then(Value::as_array)
+                            .is_some_and(|items| {
+                                items.iter().any(|item| {
+                                    item.get("type").and_then(Value::as_str)
+                                        == Some("image_generation_call")
+                                })
+                            })
+                        && let Some(obj) = value.as_object_mut()
+                    {
+                        obj.insert(
+                            "output".to_string(),
+                            Value::Array(streamed_output_items.clone()),
+                        );
+                    }
+                    return self.normalize_openai_image_response_value(request, value, true);
+                }
+            }
+        }
+
+        Err(LlmError::IncompleteResponse {
+            message: "OpenAI streamed image response ended before response.completed".to_string(),
+        })
+    }
+
+    async fn normalize_openai_image_response(
+        &self,
+        request: ProviderImageGenerationRequest,
+        response: reqwest::Response,
+        hosted_responses: bool,
+    ) -> Result<ProviderImageGenerationOutput, LlmError> {
+        let status_code = response.status().as_u16();
+        let text = response.text().await.unwrap_or_default();
+        if !(200..=299).contains(&status_code) {
+            let warning_text = if text.trim().is_empty() {
+                format!("OpenAI image request failed with HTTP {status_code}")
+            } else {
+                format!("OpenAI image request failed with HTTP {status_code}: {text}")
+            };
+            return Ok(ProviderImageGenerationOutput {
+                operation_id: request.operation_id,
+                terminal: Self::openai_error_terminal(status_code, &text),
+                images: Vec::new(),
+                provider_text: None,
+                revised_prompt: RevisedPromptDisposition::NotRequested,
+                native_metadata: ProviderImageMetadata::OpenAi(OpenAiImageMetadata {
+                    target_model: request.model,
+                    response_id: None,
+                    image_generation_call_id: None,
+                }),
+                warnings: vec![ImageGenerationWarning::ProviderExecutionFailed {
+                    message: warning_text,
+                }],
+            });
+        }
+
+        let value: Value = serde_json::from_str(&text).map_err(|e| LlmError::StreamParseError {
+            message: format!("invalid OpenAI image response JSON: {e}"),
+        })?;
+        self.normalize_openai_image_response_value(request, value, hosted_responses)
     }
 }
 
@@ -2269,6 +2394,7 @@ mod tests {
     ) -> (String, tokio::task::JoinHandle<()>) {
         let app = Router::new()
             .route("/v1/responses", post(openai_image_stub))
+            .route("/responses", post(openai_image_stub))
             .route("/v1/images/generations", post(openai_image_stub))
             .with_state(ImageStubState { response, seen });
         let listener = TcpListener::bind("127.0.0.1:0")
@@ -2504,6 +2630,40 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn chatgpt_backend_hosted_image_executor_sets_store_false()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let seen = Arc::new(Mutex::new(Vec::new()));
+        let payload = [
+            r#"data: {"type":"response.output_item.added","item":{"id":"ig_1","type":"image_generation_call","status":"in_progress"}}"#,
+            r#"data: {"type":"response.output_item.done","item":{"id":"ig_1","type":"image_generation_call","status":"completed","result":"data:image/png;base64,aGVsbG8="}}"#,
+            r#"data: {"type":"response.completed","response":{"id":"resp_image","output":[]}}"#,
+            "data: [DONE]",
+            "",
+        ]
+        .join("\n");
+        let (base_url, handle) = spawn_chatgpt_stub_server(payload, seen.clone()).await;
+        let client = OpenAiClient::new_with_base_url("test-key".to_string(), base_url)
+            .with_chatgpt_backend_wire();
+
+        let output = client
+            .execute_image_generation(image_executor_request_json(hosted_openai_plan_json()))
+            .await?;
+
+        assert!(matches!(
+            output.terminal,
+            ImageOperationTerminalClass::Generated
+        ));
+        let bodies = seen.lock().expect("seen mutex");
+        let body = bodies.first().expect("captured ChatGPT image request");
+        assert_eq!(body["store"], false);
+        assert_eq!(body["stream"], true);
+        assert_eq!(body["tool_choice"], "required");
+
+        handle.abort();
+        Ok(())
+    }
+
+    #[tokio::test]
     async fn openai_images_api_executor_sends_output_options()
     -> Result<(), Box<dyn std::error::Error>> {
         let seen = Arc::new(Mutex::new(Vec::new()));
@@ -2668,6 +2828,11 @@ mod tests {
         assert!(
             body.get("messages").is_none(),
             "should NOT have 'messages' field"
+        );
+        assert_eq!(
+            body.get("store").and_then(Value::as_bool),
+            Some(false),
+            "Responses requests should not store provider-side copies by default"
         );
 
         // Should include reasoning.encrypted_content

--- a/meerkat-openai/src/runtime/mod.rs
+++ b/meerkat-openai/src/runtime/mod.rs
@@ -88,6 +88,33 @@ fn chatgpt_backend_base_url(configured: Option<&str>) -> String {
     }
 }
 
+fn chatgpt_backend_extra_headers(connection: &ResolvedConnection) -> Vec<(String, String)> {
+    // Pull account identity + fedramp from the resolved lease's AuthMetadata
+    // so the ChatGPT backend can emit the wire headers Codex's
+    // bearer_auth_provider.rs:23-38 requires.
+    let (account_id, is_fedramp) = match connection.auth_lease.metadata().provider_metadata {
+        Some(meerkat_core::ProviderAuthMetadata::OpenAi(ref metadata)) => {
+            (metadata.account_id.clone(), metadata.is_fedramp)
+        }
+        _ => (connection.auth_lease.metadata().account_id.clone(), None),
+    };
+
+    let mut headers = Vec::new();
+    if let Some(account_id) = account_id {
+        headers.push((
+            meerkat_core::provider_matrix::openai_auth::CHATGPT_ACCOUNT_HEADER.to_string(),
+            account_id,
+        ));
+    }
+    if matches!(is_fedramp, Some(true)) {
+        headers.push((
+            meerkat_core::provider_matrix::openai_auth::FEDRAMP_HEADER.to_string(),
+            "true".to_string(),
+        ));
+    }
+    headers
+}
+
 pub struct OpenAiProviderRuntime;
 
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
@@ -357,16 +384,6 @@ impl ProviderRuntime for OpenAiProviderRuntime {
         let secret = connection
             .resolved_secret()
             .ok_or(ProviderClientError::NoCredentialMaterial)?;
-        // Pull account identity + fedramp from the resolved lease's
-        // AuthMetadata so the ChatGPT backend can emit the wire
-        // headers Codex's bearer_auth_provider.rs:23-38 requires.
-        let (account_id, is_fedramp) = match connection.auth_lease.metadata().provider_metadata {
-            Some(meerkat_core::ProviderAuthMetadata::OpenAi(ref m)) => {
-                (m.account_id.clone(), m.is_fedramp)
-            }
-            _ => (connection.auth_lease.metadata().account_id.clone(), None),
-        };
-
         match backend_kind {
             OpenAiBackendKind::OpenAiApi => {
                 // S1-verified: OpenAiClient::new returns Self (infallible).
@@ -381,22 +398,8 @@ impl ProviderRuntime for OpenAiProviderRuntime {
                 // headers per Codex bearer_auth_provider.rs:23-38.
                 let base_url =
                     chatgpt_backend_base_url(connection.backend_profile.base_url.as_deref());
-                let mut extra_headers: Vec<(String, String)> = Vec::new();
-                if let Some(acct) = account_id {
-                    extra_headers.push((
-                        meerkat_core::provider_matrix::openai_auth::CHATGPT_ACCOUNT_HEADER
-                            .to_string(),
-                        acct,
-                    ));
-                }
-                if matches!(is_fedramp, Some(true)) {
-                    extra_headers.push((
-                        meerkat_core::provider_matrix::openai_auth::FEDRAMP_HEADER.to_string(),
-                        "true".to_string(),
-                    ));
-                }
                 let client = crate::OpenAiClient::new_with_base_url(secret, base_url)
-                    .with_extra_headers(extra_headers)
+                    .with_extra_headers(chatgpt_backend_extra_headers(&connection))
                     .with_chatgpt_backend_wire();
                 Ok(Arc::new(client))
             }
@@ -452,7 +455,9 @@ impl ProviderRuntime for OpenAiProviderRuntime {
             OpenAiBackendKind::ChatGptBackend => {
                 let base_url =
                     chatgpt_backend_base_url(connection.backend_profile.base_url.as_deref());
-                crate::OpenAiClient::new_with_base_url(secret, base_url).with_chatgpt_backend_wire()
+                crate::OpenAiClient::new_with_base_url(secret, base_url)
+                    .with_extra_headers(chatgpt_backend_extra_headers(&connection))
+                    .with_chatgpt_backend_wire()
             }
         };
         Ok(Some(Arc::new(client)))
@@ -469,8 +474,18 @@ impl ProviderRuntime for OpenAiProviderRuntime {
 #[allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
 mod tests {
     use super::*;
-    use meerkat_core::{AuthProfile, BackendProfile, BindingPolicy};
-    use meerkat_llm_core::provider_runtime::ProviderRuntimeCatalog;
+    use axum::{
+        Json, Router, extract::State, http::HeaderMap, response::IntoResponse, routing::post,
+    };
+    use meerkat_core::{
+        AuthMetadata, AuthProfile, BackendProfile, BindingPolicy, ImageOperationTerminalClass,
+        OpenAiAuthMetadata, ProviderAuthMetadata,
+    };
+    use meerkat_llm_core::{
+        ProviderImageGenerationRequest, provider_runtime::ProviderRuntimeCatalog,
+    };
+    use std::sync::Mutex;
+    use tokio::net::TcpListener;
 
     #[test]
     fn typed_catalog_contains_expected_combinations() {
@@ -518,6 +533,114 @@ mod tests {
             binding: meerkat_core::connection::BindingId::parse("default").unwrap(),
             profile: None,
         }
+    }
+
+    fn resolved_chatgpt_connection(
+        metadata: AuthMetadata,
+        base_url: Option<String>,
+    ) -> ResolvedConnection {
+        let mut backend = backend("chatgpt_backend");
+        backend.base_url = base_url;
+        ResolvedConnection {
+            provider: Provider::OpenAI,
+            backend: NormalizedBackendKind::OpenAi(OpenAiBackendKind::ChatGptBackend),
+            backend_profile: Arc::new(backend),
+            auth_lease: Arc::new(StaticLease::inline_secret(
+                "oauth-access-token".into(),
+                metadata,
+                None,
+                "openai:test",
+            )),
+        }
+    }
+
+    #[derive(Clone)]
+    struct ImageHeaderState {
+        seen: Arc<Mutex<Vec<HeaderMap>>>,
+    }
+
+    async fn image_header_stub(
+        State(state): State<ImageHeaderState>,
+        headers: HeaderMap,
+        Json(_body): Json<serde_json::Value>,
+    ) -> impl IntoResponse {
+        state.seen.lock().expect("seen headers").push(headers);
+        let payload = [
+            r#"data: {"type":"response.output_item.done","item":{"id":"ig_test","type":"image_generation_call","status":"completed","result":"data:image/png;base64,aGVsbG8="}}"#,
+            r#"data: {"type":"response.completed","response":{"id":"resp_test","output":[]}}"#,
+            "data: [DONE]",
+            "",
+        ]
+        .join("\n");
+        ([("content-type", "text/event-stream")], payload)
+    }
+
+    async fn spawn_image_header_stub() -> (
+        String,
+        Arc<Mutex<Vec<HeaderMap>>>,
+        tokio::task::JoinHandle<()>,
+    ) {
+        let seen = Arc::new(Mutex::new(Vec::new()));
+        let app = Router::new()
+            .route("/responses", post(image_header_stub))
+            .with_state(ImageHeaderState {
+                seen: Arc::clone(&seen),
+            });
+        let listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind test server");
+        let addr = listener.local_addr().expect("local addr");
+        let handle = tokio::spawn(async move {
+            axum::serve(listener, app).await.expect("serve test server");
+        });
+        (format!("http://{addr}"), seen, handle)
+    }
+
+    fn hosted_image_request() -> ProviderImageGenerationRequest {
+        serde_json::from_value(serde_json::json!({
+            "operation_id": "00000000-0000-0000-0000-000000000101",
+            "model": "gpt-5.4",
+            "generate_request": {
+                "intent": {
+                    "intent": "generate",
+                    "prompt": {"content": "draw a small red square"},
+                    "prompt_source": {
+                        "source": "user_provided",
+                        "message_id": "00000000-0000-0000-0000-000000000102"
+                    },
+                    "reference_images": []
+                },
+                "target": {"target": "auto"},
+                "size": {"size": "square1024"},
+                "quality": "low",
+                "format": "png",
+                "count": 1
+            },
+            "execution_plan": {
+                "provider": "openai",
+                "backend": "hosted_tool",
+                "max_count": 1,
+                "capabilities": {
+                    "hosted_image_generation_tool": true,
+                    "native_image_output": false,
+                    "custom_tools": true,
+                    "image_search_grounding": false,
+                    "image_continuity_tokens": "unsupported"
+                },
+                "requires_scoped_override": false,
+                "provider_plan": {
+                    "tool_name": "image_generation",
+                    "model": "gpt-image-2",
+                    "output": {
+                        "size": "square1024",
+                        "quality": "low",
+                        "output_format": "png"
+                    }
+                }
+            },
+            "projected_messages": []
+        }))
+        .expect("hosted image request")
     }
 
     #[test]
@@ -591,5 +714,98 @@ mod tests {
         )
         .expect("allowed combination");
         assert_eq!(vb.policy(), &policy);
+    }
+
+    #[test]
+    fn chatgpt_backend_headers_use_openai_oauth_metadata() {
+        let connection = resolved_chatgpt_connection(
+            AuthMetadata {
+                provider_metadata: Some(ProviderAuthMetadata::OpenAi(OpenAiAuthMetadata {
+                    account_id: Some("acct_123".into()),
+                    is_fedramp: Some(true),
+                    ..Default::default()
+                })),
+                ..Default::default()
+            },
+            None,
+        );
+
+        let headers = chatgpt_backend_extra_headers(&connection);
+
+        assert!(headers.contains(&(
+            meerkat_core::provider_matrix::openai_auth::CHATGPT_ACCOUNT_HEADER.to_string(),
+            "acct_123".to_string(),
+        )));
+        assert!(headers.contains(&(
+            meerkat_core::provider_matrix::openai_auth::FEDRAMP_HEADER.to_string(),
+            "true".to_string(),
+        )));
+    }
+
+    #[test]
+    fn chatgpt_backend_headers_fall_back_to_generic_account_metadata() {
+        let connection = resolved_chatgpt_connection(
+            AuthMetadata {
+                account_id: Some("acct_generic".into()),
+                ..Default::default()
+            },
+            None,
+        );
+
+        let headers = chatgpt_backend_extra_headers(&connection);
+
+        assert_eq!(
+            headers,
+            vec![(
+                meerkat_core::provider_matrix::openai_auth::CHATGPT_ACCOUNT_HEADER.to_string(),
+                "acct_generic".to_string(),
+            )]
+        );
+    }
+
+    #[tokio::test]
+    async fn chatgpt_backend_image_executor_sends_oauth_account_headers()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let (base_url, seen, handle) = spawn_image_header_stub().await;
+        let connection = resolved_chatgpt_connection(
+            AuthMetadata {
+                provider_metadata: Some(ProviderAuthMetadata::OpenAi(OpenAiAuthMetadata {
+                    account_id: Some("acct_image".into()),
+                    is_fedramp: Some(true),
+                    ..Default::default()
+                })),
+                ..Default::default()
+            },
+            Some(base_url),
+        );
+
+        let executor = OpenAiProviderRuntime
+            .build_image_generation_executor(connection)?
+            .expect("chatgpt backend should provide image executor");
+        let output = executor
+            .execute_image_generation(hosted_image_request())
+            .await?;
+
+        assert!(matches!(
+            output.terminal,
+            ImageOperationTerminalClass::Generated
+        ));
+        let headers = seen.lock().expect("seen headers");
+        let first = headers.first().expect("captured image request headers");
+        assert_eq!(
+            first
+                .get(meerkat_core::provider_matrix::openai_auth::CHATGPT_ACCOUNT_HEADER)
+                .and_then(|value| value.to_str().ok()),
+            Some("acct_image")
+        );
+        assert_eq!(
+            first
+                .get(meerkat_core::provider_matrix::openai_auth::FEDRAMP_HEADER)
+                .and_then(|value| value.to_str().ok()),
+            Some("true")
+        );
+
+        handle.abort();
+        Ok(())
     }
 }

--- a/meerkat/src/factory.rs
+++ b/meerkat/src/factory.rs
@@ -944,6 +944,112 @@ impl meerkat_llm_core::ImageGenerationExecutor for RoutingImageGenerationExecuto
     }
 }
 
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod image_generation_executor_routing_tests {
+    use super::RoutingImageGenerationExecutor;
+    use async_trait::async_trait;
+    use meerkat_llm_core::{
+        ImageGenerationExecutor, LlmError, ProviderImageGenerationOutput,
+        ProviderImageGenerationRequest,
+    };
+    use std::collections::BTreeMap;
+    use std::sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    };
+
+    struct CountingImageExecutor {
+        calls: Arc<AtomicUsize>,
+    }
+
+    #[async_trait]
+    impl ImageGenerationExecutor for CountingImageExecutor {
+        async fn execute_image_generation(
+            &self,
+            _request: ProviderImageGenerationRequest,
+        ) -> Result<ProviderImageGenerationOutput, LlmError> {
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            Err(LlmError::InvalidRequest {
+                message: "executor should not be called for another provider".to_string(),
+            })
+        }
+    }
+
+    fn hosted_openai_request() -> ProviderImageGenerationRequest {
+        serde_json::from_value(serde_json::json!({
+            "operation_id": "00000000-0000-0000-0000-000000000101",
+            "model": "gpt-5.4",
+            "generate_request": {
+                "intent": {
+                    "intent": "generate",
+                    "prompt": {"content": "draw a square"},
+                    "prompt_source": {
+                        "source": "user_provided",
+                        "message_id": "00000000-0000-0000-0000-000000000102"
+                    },
+                    "reference_images": []
+                },
+                "target": {"target": "auto"},
+                "size": {"size": "square1024"},
+                "quality": "low",
+                "format": "png",
+                "count": 1
+            },
+            "execution_plan": {
+                "provider": "openai",
+                "backend": "hosted_tool",
+                "max_count": 1,
+                "capabilities": {
+                    "hosted_image_generation_tool": true,
+                    "native_image_output": false,
+                    "custom_tools": false,
+                    "image_search_grounding": false,
+                    "image_continuity_tokens": "unsupported"
+                },
+                "requires_scoped_override": false,
+                "provider_plan": {
+                    "tool_name": "image_generation",
+                    "model": "gpt-image-2",
+                    "output": {
+                        "size": "square1024",
+                        "quality": "low",
+                        "output_format": "png"
+                    },
+                    "provider_params": {}
+                }
+            },
+            "projected_messages": []
+        }))
+        .expect("hosted OpenAI image request")
+    }
+
+    #[tokio::test]
+    async fn single_provider_router_does_not_dispatch_openai_plan_to_gemini_executor() {
+        let calls = Arc::new(AtomicUsize::new(0));
+        let mut executors: BTreeMap<String, Arc<dyn ImageGenerationExecutor>> = BTreeMap::new();
+        executors.insert(
+            "gemini".to_string(),
+            Arc::new(CountingImageExecutor {
+                calls: Arc::clone(&calls),
+            }),
+        );
+        let router = RoutingImageGenerationExecutor::new(executors);
+
+        let err = router
+            .execute_image_generation(hosted_openai_request())
+            .await
+            .expect_err("OpenAI plan should not dispatch to a Gemini-only executor");
+
+        assert_eq!(calls.load(Ordering::SeqCst), 0);
+        assert!(
+            err.to_string()
+                .contains("no image generation executor configured for provider openai"),
+            "unexpected error: {err}"
+        );
+    }
+}
+
 #[cfg(not(target_arch = "wasm32"))]
 struct CompositeImageGenerationPlanner {
     profiles: Vec<Arc<dyn meerkat_core::ImageGenerationProviderProfile>>,
@@ -3252,24 +3358,11 @@ impl AgentFactory {
 
                         #[cfg(not(target_arch = "wasm32"))]
                         {
-                            let selected_realm = build_config.realm_id.as_deref();
-                            let connection_is_in_selected_realm = selected_realm
-                                .map(|realm| resolved_auth_binding.realm.as_str() == realm)
-                                .unwrap_or(true);
-                            if connection_is_in_selected_realm {
-                                auto_image_generation_executor = provider_registry
-                                    .build_image_generation_executor(connection.clone())
-                                    .map_err(|e| {
-                                        BuildAgentError::ConnectionResolution(e.to_string())
-                                    })?;
-                            } else {
-                                tracing::debug!(
-                                    provider = provider.as_str(),
-                                    ?selected_realm,
-                                    resolved_realm = resolved_auth_binding.realm.as_str(),
-                                    "skipping image executor reuse for LLM connection outside selected realm"
-                                );
-                            }
+                            auto_image_generation_executor = provider_registry
+                                .build_image_generation_executor(connection.clone())
+                                .map_err(|e| {
+                                    BuildAgentError::ConnectionResolution(e.to_string())
+                                })?;
                         }
 
                         if lease_auth_binding.is_some() {
@@ -3387,7 +3480,6 @@ impl AgentFactory {
             }
             auto_image_generation_executor = match executors.len() {
                 0 => None,
-                1 => executors.into_values().next(),
                 _ => Some(Arc::new(RoutingImageGenerationExecutor::new(executors))
                     as Arc<dyn meerkat_llm_core::ImageGenerationExecutor>),
             };
@@ -7249,7 +7341,7 @@ mod tests {
 
     #[cfg(not(target_arch = "wasm32"))]
     #[tokio::test]
-    async fn selected_realm_skips_env_default_same_provider_image_executor() {
+    async fn selected_realm_reuses_active_same_provider_image_executor() {
         use meerkat_llm_core::provider_runtime::{
             ProviderAuthError, ProviderClientError, ProviderRuntime, ProviderRuntimeRegistry,
             ResolvedConnection, ResolverEnvironment, StaticLease, ValidatedBinding,
@@ -7341,8 +7433,8 @@ mod tests {
 
         assert_eq!(
             image_executor_builds.load(std::sync::atomic::Ordering::SeqCst),
-            0,
-            "selected-realm image setup must not reuse the env_default LLM connection"
+            1,
+            "same-provider image setup should reuse the already-authorized active LLM connection"
         );
     }
 


### PR DESCRIPTION
## Summary
- Fix OpenAI ChatGPT OAuth image generation so hosted `gpt-image-2` uses the OpenAI executor instead of falling through to another provider.
- Add ChatGPT-backend hosted image streaming support (`stream:true`) and parse streamed `image_generation_call` output items.
- Default OpenAI Responses requests to `store:false`, including hosted image requests.
- Reuse the active same-provider OAuth connection for image executor setup and carry ChatGPT account/FedRAMP headers into image executors.

## Root Cause
With API-key env vars unset, the OpenAI text path resolved through ChatGPT OAuth, but image executor setup skipped that active connection because its resolved realm differed from the selected workspace realm. If only another provider image executor was discovered, the single-executor optimization let an OpenAI image plan dispatch to the wrong executor. After fixing that routing, the ChatGPT backend required `store:false` and `stream:true`, and streamed image bytes through `response.output_item.done` rather than only final `response.completed.output`.

## Verification
- `./scripts/repo-cargo test -p meerkat-openai`
- `./scripts/repo-cargo test -p meerkat`
- `./scripts/repo-cargo test -p meerkat-client`
- `CARGO_TARGET_DIR=target ./scripts/repo-cargo build -p rkat`
- Live OAuth smoke with `OPENAI_API_KEY`, `RKAT_OPENAI_API_KEY`, `OPENAI_KEY`, and `RKAT_OPENAI_KEY` unset generated a PNG via `provider:"open_ai"` with `terminal:"generated"` and an `image_generation_call_id`.
