### PR TITLE
Fix Claude AI OAuth, default model, and CLI realm roots

### DIFF
--- a/.claude/skills/meerkat-platform/SKILL.md
+++ b/.claude/skills/meerkat-platform/SKILL.md
@@ -29,8 +29,16 @@ Default persistent backend:
 
 Default realm behavior:
 
-- CLI (`run`, `run --resume`, `session`): workspace-derived stable realm.
+- CLI (`run`, `run --resume`, `session`): workspace-derived stable realm from the context root, defaulting to the current directory.
 - RPC/REST/MCP/SDK: new opaque realm unless explicitly provided.
+
+CLI filesystem defaults:
+
+- `context_root` controls workspace identity and project files (`.rkat/mcp.toml`, `.rkat/skills`, AGENTS/CLAUDE discovery, etc.).
+- `state_root` is the parent directory containing realm directories.
+- Without overrides, CLI uses `context_root = CWD` and `state_root = <context_root>/.rkat/realms`, creating it on first use.
+- `--context-root` changes the derived `ws-...` realm id and, unless `--state-root` is supplied, the project-local realm state root.
+- `--state-root` changes storage location only; it does not change the realm id.
 
 Use explicit realm to share:
 

--- a/.claude/skills/meerkat-platform/references/api_reference.md
+++ b/.claude/skills/meerkat-platform/references/api_reference.md
@@ -43,8 +43,8 @@ Global flags (available on all commands):
 --isolated                # start in isolated mode (new generated realm)
 --instance <id>           # optional instance ID inside a realm
 --realm-backend <sqlite|jsonl>
---state-root <path>       # override state root directory
---context-root <path>     # convention context root for skills/hooks/AGENTS/MCP config
+--state-root <path>       # override realm state root; default <context-root>/.rkat/realms
+--context-root <path>     # realm identity + project files root; default CWD
 --user-config-root <path> # optional user-global convention root
 ```
 

--- a/docs/cli/commands.mdx
+++ b/docs/cli/commands.mdx
@@ -37,6 +37,12 @@ rkat [--realm <id>] [--isolated] [--instance <id>] \
   <command>
 ```
 
+By default, CLI commands use the current directory as the context root, derive a
+stable workspace realm id from that path, and store realm state under
+`<context-root>/.rkat/realms/<realm>/`. `--context-root` changes both the
+derived workspace identity and the default project-local state root.
+`--state-root` changes only where realm directories are stored.
+
 ## Common commands
 
 | Command | Purpose |

--- a/docs/cli/configuration.mdx
+++ b/docs/cli/configuration.mdx
@@ -9,8 +9,11 @@ icon: "sliders"
 All CLI commands accept realm scope flags:
 
 - `--realm <id>`
+- `--isolated`
 - `--instance <id>`
 - `--realm-backend <sqlite|jsonl>` (creation hint only)
+- `--state-root <path>`
+- `--context-root <path>`
 
 These flags decide which realm config/session state is used.
 
@@ -23,6 +26,13 @@ These flags decide which realm config/session state is used.
 | `rkat-rpc` | New opaque realm (`realm-...`) |
 
 If you want CLI + RPC to share the same state, pass the same explicit `--realm` to both.
+
+For CLI commands, the default context root is the current directory. The default
+state root is `<context-root>/.rkat/realms`.
+
+Use `--verbose` on `rkat run` to print the active realm, context root, and
+physical realm root. See the [realm guide](/guides/realms) for the full
+identity-vs-storage model.
 
 ## Environment variables
 
@@ -38,7 +48,8 @@ See [providers](/concepts/providers) for full key precedence (`RKAT_*` variants 
 
 ## Config files
 
-Canonical runtime config for CLI commands is realm-scoped (`<realm>/config.toml` under platform data dir).
+Canonical runtime config for CLI commands is realm-scoped
+(`<context-root>/.rkat/realms/<realm>/config.toml` by default).
 
 Compatibility files still exist:
 
@@ -102,11 +113,14 @@ Use `bearer_token_env` instead of `bearer_token` whenever possible.
 
 ## Session storage layout
 
-Realm storage lives under platform data dir:
+CLI realm storage lives under the active state root. By default, that is
+project-local:
 
-- macOS: `~/Library/Application Support/meerkat/realms/<realm>/`
-- Linux: `~/.local/share/meerkat/realms/<realm>/`
-- Windows: `%APPDATA%\meerkat\realms\<realm>\`
+```text
+<context-root>/.rkat/realms/<realm>/
+```
+
+Pass `--state-root <path>` to use a different parent directory.
 
 Important files:
 

--- a/docs/concepts/configuration.mdx
+++ b/docs/concepts/configuration.mdx
@@ -14,7 +14,15 @@ Every realm has its own config file and runtime state:
 - `config_state.json` (generation counter for CAS)
 - `realm_manifest.json` (pinned backend + metadata)
 
-The canonical location is under the platform data directory:
+The canonical location is under the active realm state root. For CLI commands,
+the default is project-local:
+
+```text
+<context-root>/.rkat/realms/<realm>/
+```
+
+For daemon/API surfaces that do not receive a `--state-root`, the default state
+root is the platform data directory:
 
 - macOS: `~/Library/Application Support/meerkat/realms/<realm>/`
 - Linux: `~/.local/share/meerkat/realms/<realm>/`
@@ -77,7 +85,8 @@ rkat --realm team-alpha config get --format json --with-generation
 rkat --realm team-alpha config patch --json '{"agent":{"model":"gpt-5.5"}}' --expected-generation 4
 ```
 
-Without `--realm`, CLI uses the workspace-derived default realm (`ws-...`).
+Without `--realm`, CLI derives a stable workspace realm (`ws-...`) from the
+current directory, or from `--context-root` when supplied.
 
 ## What about `~/.rkat/config.toml` and `.rkat/config.toml`?
 

--- a/docs/concepts/providers.mdx
+++ b/docs/concepts/providers.mdx
@@ -58,13 +58,13 @@ This page is the concept layer for provider abstraction. Use [Auth](/guides/auth
 
     | Model | Context | Best for |
     |-------|---------|----------|
-    | `gemini-3-flash-preview` | 1M | Default Gemini recommendation |
-    | `gemini-3.1-pro-preview` | 1M | Advanced reasoning, complex tasks |
+    | `gemini-3.1-pro-preview` | 1M | Default Gemini recommendation, advanced reasoning |
+    | `gemini-3-flash-preview` | 1M | Fast general-purpose tasks |
     | `gemini-3.1-flash-lite-preview` | 1M | Lightweight fast-path tasks |
 
     ```toml config.toml (active realm)
     [agent]
-    model = "gemini-3-flash-preview"
+    model = "gemini-3.1-pro-preview"
     max_tokens_per_turn = 8192
     ```
   </Tab>

--- a/docs/concepts/realms.mdx
+++ b/docs/concepts/realms.mdx
@@ -6,6 +6,9 @@ icon: "earth-americas"
 
 Meerkat is realm-first. A `realm_id` is the only identity key for sharing or isolating state across surfaces.
 
+For task-oriented CLI behavior, filesystem layout, and troubleshooting, see the
+[realm guide](/guides/realms).
+
 ## Core rules
 
 1. Same `realm_id` means shared sessions, config, and runtime metadata.
@@ -26,6 +29,11 @@ Realm IDs must be 1-64 characters, start with an ASCII alphanumeric character, a
 | Python/TypeScript SDK | Whatever the spawned `rkat-rpc` process picks (new opaque realm unless `realm_id` is passed) |
 
 This means CLI is workspace-friendly by default, while non-CLI surfaces are isolated by default.
+
+The CLI workspace default uses the current directory as `context_root`, derives
+identity from that path, and stores realm runtime state under
+`<context-root>/.rkat/realms/` unless `--context-root` or `--state-root` is
+provided.
 
 ## Explicit sharing
 

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -57,6 +57,7 @@
           {
             "group": "Guides: Runtime Behavior",
             "pages": [
+              "guides/realms",
               "guides/structured-output",
               "guides/memory",
               "guides/hooks",

--- a/docs/guides/realms.mdx
+++ b/docs/guides/realms.mdx
@@ -1,0 +1,180 @@
+---
+title: "Realm guide"
+description: "How rkat chooses a realm, where realm state lives, and how to share or isolate state deliberately."
+icon: "earth-americas"
+---
+
+Realms are Meerkat's state boundary. A realm owns sessions, runtime config,
+auth bindings, schedules, blobs, mob state, and the pinned persistence backend.
+
+There are two separate choices:
+
+1. **Realm identity**: which logical realm id is active.
+2. **Realm state root**: where realm directories are stored on disk.
+
+The CLI's default is workspace-friendly identity with project-local storage:
+
+```bash
+rkat "summarize this repo"
+```
+
+That derives a stable `ws-...` realm id from the workspace/context root, then
+stores the realm under `<context-root>/.rkat/realms/`.
+
+## See The Active Realm
+
+Use verbose mode when behavior is surprising:
+
+```bash
+rkat "hello" --verbose
+```
+
+The startup log includes:
+
+```text
+Using realm: ws-..., context root: /path/to/workspace, realm root: /path/to/workspace/.rkat/realms/ws-...
+```
+
+- `realm` is the logical sharing key.
+- `context root` is the path used to derive a workspace realm when `--realm` is omitted.
+- `realm root` is the physical realm directory that contains `config.toml`,
+  `realm_manifest.json`, sessions, blobs, and other realm state.
+
+## Default CLI Behavior
+
+When `--realm` is omitted, CLI run/session commands use a stable workspace
+realm:
+
+```bash
+rkat run "fix the failing test"
+rkat session list
+```
+
+By default, the context root is the current directory. The CLI derives the
+workspace realm id from that path and creates `.rkat/realms/<realm>/` there on
+first use.
+
+This means a subdirectory is a different default realm from its parent. Pass
+`--context-root <parent>` or `--realm <id>` when you want a subdirectory command
+to share the parent project's state.
+
+## Where State Lives
+
+By default, CLI realm state is project-local:
+
+```text
+<context-root>/.rkat/realms/
+```
+
+Each realm gets a subdirectory:
+
+```text
+<state-root>/<realm-id>/
+  config.toml
+  realm_manifest.json
+  sessions.sqlite3
+  sessions_jsonl/
+```
+
+Project-local `.rkat/` also contains project-scoped files such as
+`.rkat/mcp.toml`, `.rkat/skills/`, and compatibility configuration workflows.
+
+## Choose An Explicit Shared Realm
+
+Use `--realm` when multiple surfaces or folders should intentionally share
+state:
+
+```bash
+rkat --realm team-alpha run "draft release notes"
+rkat --realm team-alpha session list
+rkat-rpc --realm team-alpha
+rkat-rest --realm team-alpha
+rkat-mcp --realm team-alpha
+```
+
+The same explicit realm id means the same sessions, config, auth bindings,
+schedules, blobs, and mob state.
+
+## Isolate A Run
+
+Use `--isolated` when a command should not reuse workspace state:
+
+```bash
+rkat --isolated run "try this without touching my project realm"
+```
+
+This creates a fresh opaque `realm-...` id.
+
+## Change The Workspace Root
+
+Use `--context-root` when you want workspace-derived identity, but from a
+specific path:
+
+```bash
+rkat --context-root "$PWD" run "use this folder as the workspace identity"
+```
+
+This changes both the derived `ws-...` realm id and, unless `--state-root` is
+also supplied, the default project-local state root.
+
+## Override The State Root
+
+Use `--state-root` when you want realm files somewhere other than
+`<context-root>/.rkat/realms`:
+
+```bash
+rkat --state-root "$HOME/.local/share/meerkat/realms" run "store this realm globally"
+```
+
+`--state-root` changes the parent directory that contains realm directories. It
+does not change the realm id. Combine it with `--context-root` or `--realm` when
+you need both custom storage and predictable identity:
+
+```bash
+rkat \
+  --context-root "$PWD" \
+  --state-root "$HOME/.local/share/meerkat/realms" \
+  run "use project identity and global storage"
+```
+
+## Backend Pinning
+
+The first open of a realm writes `realm_manifest.json` and pins the backend.
+
+```bash
+rkat --realm audit --realm-backend sqlite run "start audit"
+```
+
+After the manifest exists, `--realm-backend` is ignored for that realm. The
+stored manifest wins so every surface opens the same backend.
+
+## Common Surprises
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| A subdirectory does not see parent sessions | CLI defaults `context_root` to the current directory | Pass `--context-root <parent>` or an explicit shared `--realm` |
+| A command creates a new `.rkat/realms` directory | No state root was supplied, so CLI used `<context-root>/.rkat/realms` | Pass `--state-root <path>` |
+| CLI and RPC do not share state | RPC defaults to an isolated opaque realm | Pass the same `--realm` to both |
+| `--realm-backend` does not switch an existing realm | Backend is pinned in `realm_manifest.json` | Create a new realm or migrate state intentionally |
+
+## Recommended Defaults
+
+For normal local development, use the CLI defaults and inspect with
+`--verbose` when needed.
+
+For team or daemon workflows, use explicit names:
+
+```bash
+rkat --realm prod run "check deploy readiness"
+rkat-rpc --realm prod
+```
+
+For a fully explicit project-local setup, set both axes:
+
+```bash
+rkat \
+  --context-root "$PWD" \
+  --state-root "$PWD/.rkat/realms" \
+  --realm project \
+  run "work only in this project-local realm"
+```

--- a/meerkat-anthropic/src/client.rs
+++ b/meerkat-anthropic/src/client.rs
@@ -29,6 +29,9 @@ const DEFAULT_REQUEST_TIMEOUT: Duration = Duration::from_secs(300);
 const DEFAULT_POOL_IDLE_TIMEOUT: Duration = Duration::from_secs(90);
 /// SSE buffer capacity to reduce reallocations
 const SSE_BUFFER_CAPACITY: usize = 4096;
+const CLAUDE_AI_OAUTH_SYSTEM_MARKER: &str =
+    "You are a Claude agent, built on Anthropic's Claude Agent SDK.";
+const CLAUDE_AI_OAUTH_AUTHORIZER_LABEL: &str = "claude-ai-oauth";
 
 /// Client for Anthropic API
 #[cfg_attr(target_arch = "wasm32", allow(dead_code))]
@@ -41,8 +44,8 @@ pub struct AnthropicClient {
     pool_idle_timeout: Duration,
     /// Dynamic authorizer — when set, replaces the `x-api-key` header
     /// path with `HttpAuthorizer::authorize` invocation (used for
-    /// Vertex and Foundry backends where the Bearer token is acquired
-    /// at request time from Google Auth / Azure AD).
+    /// OAuth and cloud backends where the Bearer token is acquired at
+    /// request time).
     authorizer: Option<std::sync::Arc<dyn meerkat_core::HttpAuthorizer>>,
 }
 
@@ -781,6 +784,57 @@ impl AnthropicClient {
         Ok(body)
     }
 
+    fn ensure_claude_ai_oauth_system_marker(body: &mut Value) {
+        match body.get_mut("system") {
+            Some(Value::String(system)) => {
+                if system.contains(CLAUDE_AI_OAUTH_SYSTEM_MARKER) {
+                    return;
+                }
+                if system.is_empty() {
+                    *system = CLAUDE_AI_OAUTH_SYSTEM_MARKER.to_string();
+                } else {
+                    let existing = std::mem::take(system);
+                    body["system"] = Value::Array(vec![
+                        serde_json::json!({
+                            "type": "text",
+                            "text": CLAUDE_AI_OAUTH_SYSTEM_MARKER,
+                        }),
+                        serde_json::json!({
+                            "type": "text",
+                            "text": existing,
+                        }),
+                    ]);
+                }
+            }
+            Some(Value::Array(blocks)) => {
+                let already_present = blocks.iter().any(|block| {
+                    block
+                        .get("text")
+                        .and_then(Value::as_str)
+                        .is_some_and(|text| text.contains(CLAUDE_AI_OAUTH_SYSTEM_MARKER))
+                });
+                if !already_present {
+                    blocks.insert(
+                        0,
+                        serde_json::json!({
+                            "type": "text",
+                            "text": CLAUDE_AI_OAUTH_SYSTEM_MARKER,
+                        }),
+                    );
+                }
+            }
+            _ => {
+                body["system"] = Value::String(CLAUDE_AI_OAUTH_SYSTEM_MARKER.to_string());
+            }
+        }
+    }
+
+    fn authorizer_needs_claude_ai_oauth_system_marker(&self) -> bool {
+        self.authorizer
+            .as_ref()
+            .is_some_and(|authorizer| authorizer.label() == CLAUDE_AI_OAUTH_AUTHORIZER_LABEL)
+    }
+
     /// Parse an SSE event from the response
     fn parse_sse_line(line: &str) -> Option<AnthropicEvent> {
         if let Some(data) = Self::strip_data_prefix(line) {
@@ -870,7 +924,10 @@ impl LlmClient for AnthropicClient {
             let mut projected_request = request.clone();
             projected_request.messages = self.project_replay_messages(&request.messages)?;
             let request = &projected_request;
-            let body = self.build_request_body(request)?;
+            let mut body = self.build_request_body(request)?;
+            if self.authorizer_needs_claude_ai_oauth_system_marker() {
+                Self::ensure_claude_ai_oauth_system_marker(&mut body);
+            }
 
             // Collect beta headers based on request features.
             // Uses String (not &str) because authorizer-injected betas
@@ -1433,7 +1490,7 @@ mod tests {
     use meerkat_core::{
         AssistantBlock, AssistantImageId, BlobId, BlobRef, BlockAssistantMessage, ContentBlock,
         ImageData, MediaType, ProviderImageMetadata, ProviderMeta, RevisedPromptDisposition,
-        ToolResult, UserMessage,
+        SystemMessage, ToolResult, UserMessage,
     };
 
     fn assistant_image_block() -> AssistantBlock {
@@ -1449,6 +1506,42 @@ mod tests {
             revised_prompt: RevisedPromptDisposition::NotRequested,
             meta: ProviderImageMetadata::NotEmitted,
         }
+    }
+
+    #[test]
+    fn claude_ai_oauth_marker_is_prepended_to_existing_system() {
+        let client = AnthropicClient::new("test-key".to_string()).unwrap();
+        let request = LlmRequest::new(
+            "claude-sonnet-4-6",
+            vec![
+                Message::System(SystemMessage::new("Project system prompt.")),
+                Message::User(UserMessage::text("hello".to_string())),
+            ],
+        );
+        let mut body = client.build_request_body(&request).unwrap();
+
+        AnthropicClient::ensure_claude_ai_oauth_system_marker(&mut body);
+        AnthropicClient::ensure_claude_ai_oauth_system_marker(&mut body);
+
+        let system = body["system"].as_array().expect("system should be blocks");
+        assert_eq!(system.len(), 2);
+        assert_eq!(system[0]["type"], "text");
+        assert_eq!(system[0]["text"], CLAUDE_AI_OAUTH_SYSTEM_MARKER);
+        assert_eq!(system[1]["type"], "text");
+        assert_eq!(system[1]["text"], "Project system prompt.");
+    }
+
+    #[test]
+    fn build_request_body_does_not_add_claude_ai_oauth_marker_for_api_key_path() {
+        let client = AnthropicClient::new("test-key".to_string()).unwrap();
+        let request = LlmRequest::new(
+            "claude-sonnet-4-6",
+            vec![Message::User(UserMessage::text("hello".to_string()))],
+        );
+
+        let body = client.build_request_body(&request).unwrap();
+
+        assert!(body.get("system").is_none());
     }
 
     // =========================================================================

--- a/meerkat-cli/src/main.rs
+++ b/meerkat-cli/src/main.rs
@@ -88,10 +88,10 @@ const EXIT_BUDGET_EXHAUSTED: u8 = 2;
 
 const CLI_ABOUT: &str = "Run agent tasks and manage local Meerkat surfaces from the terminal";
 
-const ROOT_AFTER_HELP: &str = "Command groups:\n  Runtime:      run, help\n  Realm config: init, config, realm\n  Utility:      session, blob, models, capabilities, doctor\n\nAdditional commands appear when their supporting capabilities are compiled in.\n\nExamples:\n  rkat \"summarize this repository\"\n  rkat help \"How do I add an mcp server?\"\n  cat story.txt | rkat \"summarize the story\"\n  git diff | rkat run \"review these changes\"\n  tail -f app.log | rkat run --stdin lines \"watch for incidents\"\n  rkat run -t workspace \"fix the failing test\"\n\nUse `<binary> <command> -h` for the basic view and `<binary> <command> --help` for all options.";
+const ROOT_AFTER_HELP: &str = "Command groups:\n  Runtime:      run, help\n  Realm config: init, config, realm\n  Utility:      session, blob, models, capabilities, doctor\n\nAdditional commands appear when their supporting capabilities are compiled in.\n\nRealm defaults:\n  - context root: current directory, unless --context-root is supplied\n  - state root: <context-root>/.rkat/realms, unless --state-root is supplied\n  - realm id: workspace-derived ws-... unless --realm or --isolated is supplied\n\nExamples:\n  rkat \"summarize this repository\"\n  rkat help \"How do I add an mcp server?\"\n  cat story.txt | rkat \"summarize the story\"\n  git diff | rkat run \"review these changes\"\n  tail -f app.log | rkat run --stdin lines \"watch for incidents\"\n  rkat run -t workspace \"fix the failing test\"\n\nUse `<binary> <command> -h` for the basic view and `<binary> <command> --help` for all options.";
 const HELP_AFTER_HELP: &str = "Examples:\n  rkat help \"How do I add an mcp server and schedule to remove it in 30 minutes\"\n  rkat help \"Use gemini with my vertex auth, load ~/codex/skills\" --prompt \"Write a match-3 game in Erlang\"";
 
-const RUN_AFTER_HELP: &str = "Examples:\n  rkat run \"summarize this repository\"\n  cat story.txt | rkat run \"summarize the story\"\n  git diff | rkat run --json \"review these changes\"\n  rkat run --html \"make a visual explainer\"\n  rkat run --browser \"create an implementation plan\"\n  rkat run --resume \"keep going\"\n  rkat run --resume ~2 \"pick this thread back up\"\n  tail -f app.log | rkat run --stdin lines \"watch for incidents\"\n  rkat run -t workspace \"fix the failing test\"\n\nDefaults:\n  - `--tools safe`\n  - provider-native web search on for supporting models; use `--no-web-search` to disable\n  - stream on in a TTY, off in pipes/scripts\n  - piped stdin is read as blob context unless `--stdin lines` is set";
+const RUN_AFTER_HELP: &str = "Examples:\n  rkat run \"summarize this repository\"\n  cat story.txt | rkat run \"summarize the story\"\n  git diff | rkat run --json \"review these changes\"\n  rkat run --html \"make a visual explainer\"\n  rkat run --browser \"create an implementation plan\"\n  rkat run --resume \"keep going\"\n  rkat run --resume ~2 \"pick this thread back up\"\n  tail -f app.log | rkat run --stdin lines \"watch for incidents\"\n  rkat run -t workspace \"fix the failing test\"\n\nDefaults:\n  - realm state under <context-root>/.rkat/realms; use --verbose to print the active realm root\n  - `--tools safe`\n  - provider-native web search on for supporting models; use `--no-web-search` to disable\n  - stream on in a TTY, off in pipes/scripts\n  - piped stdin is read as blob context unless `--stdin lines` is set";
 
 const DEFAULT_TRACE_FILTER: &str = "off";
 const VERBOSE_TRACE_FILTER: &str = "info";
@@ -882,7 +882,7 @@ struct Cli {
         help_heading = "Realm options"
     )]
     realm_backend: Option<RealmBackendArg>,
-    /// Override state root (directory that contains realms).
+    /// Override realm state root. Defaults to <context-root>/.rkat/realms.
     #[arg(
         long,
         global = true,
@@ -890,7 +890,7 @@ struct Cli {
         help_heading = "Realm options"
     )]
     state_root: Option<PathBuf>,
-    /// Convention context root for skills/hooks/AGENTS/MCP config.
+    /// Context root for realm identity and project files. Defaults to CWD.
     #[arg(
         long,
         global = true,
@@ -3136,12 +3136,12 @@ fn resolve_runtime_scope_with_realm(
     cli: &Cli,
     realm_override: Option<String>,
 ) -> anyhow::Result<RuntimeScope> {
-    let default_selection = {
-        let root = cli.context_root.clone().unwrap_or_else(|| {
-            let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
-            find_project_root(&cwd).unwrap_or(cwd)
-        });
-        RealmSelection::WorkspaceDerived { root }
+    let context_root = cli
+        .context_root
+        .clone()
+        .unwrap_or_else(|| std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".")));
+    let default_selection = RealmSelection::WorkspaceDerived {
+        root: context_root.clone(),
     };
     let selection =
         RealmConfig::selection_from_inputs(realm_override, cli.isolated, default_selection)?;
@@ -3150,6 +3150,10 @@ fn resolve_runtime_scope_with_realm(
         RealmSelection::Isolated => RealmOrigin::Generated,
         RealmSelection::WorkspaceDerived { .. } => RealmOrigin::Workspace,
     };
+    let state_root = cli
+        .state_root
+        .clone()
+        .unwrap_or_else(|| default_cli_state_root(&context_root));
     let realm_cfg = RealmConfig {
         selection,
         instance_id: cli.instance.clone(),
@@ -3157,16 +3161,9 @@ fn resolve_runtime_scope_with_realm(
             .realm_backend
             .map(Into::into)
             .map(|b: RealmBackend| b.as_str().to_string()),
-        state_root: cli.state_root.clone(),
+        state_root: Some(state_root),
     };
     let locator = realm_cfg.resolve_locator()?;
-    let context_root = Some(match cli.context_root.clone() {
-        Some(root) => root,
-        None => {
-            let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
-            find_project_root(&cwd).unwrap_or(cwd)
-        }
-    });
     let user_config_root = cli.user_config_root.clone().or_else(dirs::home_dir);
     #[cfg(all(feature = "anthropic", feature = "openai", feature = "gemini"))]
     let (auth_lease, oauth_flow_authority) = new_cli_auth_handles();
@@ -3179,12 +3176,16 @@ fn resolve_runtime_scope_with_realm(
         // Existing realms are always opened using their pinned manifest backend.
         backend_hint: cli.realm_backend.map(Into::into),
         origin_hint,
-        context_root,
+        context_root: Some(context_root),
         user_config_root,
         auth_lease,
         #[cfg(all(feature = "anthropic", feature = "openai", feature = "gemini"))]
         oauth_flow_authority,
     })
+}
+
+fn default_cli_state_root(context_root: &Path) -> PathBuf {
+    context_root.join(".rkat").join("realms")
 }
 
 async fn resolve_config_store(
@@ -7456,7 +7457,7 @@ async fn run_agent(
             .as_deref()
             .map_or_else(|| "(none)".to_string(), |path| path.display().to_string());
         tracing::info!(
-            "Using realm: {}, context root: {}, config root: {}",
+            "Using realm: {}, context root: {}, realm root: {}",
             scope.locator.realm.as_str(),
             context_root,
             config_base_dir.display()
@@ -17213,6 +17214,56 @@ capabilities = ["definitely_missing_capability"]
         let from_json = parse_hook_run_overrides(None, Some(fixture))
             .expect("fixture hook override must parse from inline json");
         assert_eq!(from_json, from_file);
+    }
+
+    #[test]
+    fn test_default_cli_state_root_is_project_local_rkat_realms() {
+        let root = PathBuf::from("/tmp/example-project");
+
+        assert_eq!(
+            default_cli_state_root(&root),
+            PathBuf::from("/tmp/example-project/.rkat/realms")
+        );
+    }
+
+    #[test]
+    fn test_resolve_runtime_scope_uses_context_local_state_root_by_default() {
+        let cli = Cli::try_parse_from([
+            "rkat",
+            "--context-root",
+            "/tmp/example-project",
+            "run",
+            "hello",
+        ])
+        .expect("cli should parse");
+        let scope =
+            resolve_runtime_scope_with_realm(&cli, cli.realm.clone()).expect("scope resolves");
+
+        assert_eq!(
+            scope.locator.state_root,
+            PathBuf::from("/tmp/example-project/.rkat/realms")
+        );
+    }
+
+    #[test]
+    fn test_resolve_runtime_scope_respects_explicit_state_root() {
+        let cli = Cli::try_parse_from([
+            "rkat",
+            "--context-root",
+            "/tmp/example-project",
+            "--state-root",
+            "/tmp/custom-realms",
+            "run",
+            "hello",
+        ])
+        .expect("cli should parse");
+        let scope =
+            resolve_runtime_scope_with_realm(&cli, cli.realm.clone()).expect("scope resolves");
+
+        assert_eq!(
+            scope.locator.state_root,
+            PathBuf::from("/tmp/custom-realms")
+        );
     }
 
     #[test]

--- a/meerkat-cli/src/main.rs
+++ b/meerkat-cli/src/main.rs
@@ -2658,7 +2658,7 @@ async fn handle_run_command(
         auth_binding_selection
             .as_ref()
             .and_then(|selection| selection.default_model.clone())
-            .unwrap_or_else(|| config.agent.model.clone())
+            .unwrap_or_else(|| resolve_cli_default_agent_model(&config))
     });
     let max_tokens = max_tokens.unwrap_or(config.agent.max_tokens_per_turn);
     let resolved_provider = resolve_cli_provider_with_auth_binding(
@@ -3216,6 +3216,16 @@ async fn load_config(scope: &RuntimeScope) -> anyhow::Result<(Config, PathBuf)> 
         .validate()
         .map_err(|e| anyhow::anyhow!("Invalid runtime config: {e}"))?;
     Ok((config, base_dir))
+}
+
+const LEGACY_AGENT_MODEL_DEFAULTS: &[&str] = &["claude-opus-4-7"];
+
+fn resolve_cli_default_agent_model(config: &Config) -> String {
+    if LEGACY_AGENT_MODEL_DEFAULTS.contains(&config.agent.model.as_str()) {
+        return config.models.openai.clone();
+    }
+
+    config.agent.model.clone()
 }
 
 async fn handle_config_get(
@@ -7319,7 +7329,7 @@ async fn run_agent(
     labels: Vec<(String, String)>,
     instructions: Vec<String>,
     app_context: Option<String>,
-    _config_base_dir: PathBuf,
+    config_base_dir: PathBuf,
     hooks_override: HookRunOverrides,
     auth_binding: Option<AuthBindingRef>,
     scope: &RuntimeScope,
@@ -7359,7 +7369,7 @@ async fn run_agent(
             labels,
             instructions,
             app_context,
-            _config_base_dir,
+            config_base_dir,
             hooks_override,
             auth_binding,
             scope,
@@ -7441,6 +7451,16 @@ async fn run_agent(
         #[cfg(feature = "comms")]
         let factory = factory.comms(!comms_overrides.disabled);
 
+        let context_root = scope
+            .context_root
+            .as_deref()
+            .map_or_else(|| "(none)".to_string(), |path| path.display().to_string());
+        tracing::info!(
+            "Using realm: {}, context root: {}, config root: {}",
+            scope.locator.realm.as_str(),
+            context_root,
+            config_base_dir.display()
+        );
         tracing::info!("Using provider: {:?}, model: {}", provider, model);
 
         // Apply --comms-listen-tcp override to the config
@@ -17193,6 +17213,26 @@ capabilities = ["definitely_missing_capability"]
         let from_json = parse_hook_run_overrides(None, Some(fixture))
             .expect("fixture hook override must parse from inline json");
         assert_eq!(from_json, from_file);
+    }
+
+    #[test]
+    fn test_resolve_cli_default_agent_model_heals_legacy_builtin_default() {
+        let mut config = Config::default();
+        config.agent.model = "claude-opus-4-7".to_string();
+        config.models.openai = "gpt-5.5-custom".to_string();
+
+        assert_eq!(resolve_cli_default_agent_model(&config), "gpt-5.5-custom");
+    }
+
+    #[test]
+    fn test_resolve_cli_default_agent_model_preserves_custom_model() {
+        let mut config = Config::default();
+        config.agent.model = "claude-sonnet-4-6".to_string();
+
+        assert_eq!(
+            resolve_cli_default_agent_model(&config),
+            "claude-sonnet-4-6"
+        );
     }
 
     #[test]

--- a/meerkat-cli/src/main.rs
+++ b/meerkat-cli/src/main.rs
@@ -2654,12 +2654,8 @@ async fn handle_run_command(
         .as_ref()
         .map(|binding| resolve_cli_auth_binding_selection(&config, binding))
         .transpose()?;
-    let model = model.unwrap_or_else(|| {
-        auth_binding_selection
-            .as_ref()
-            .and_then(|selection| selection.default_model.clone())
-            .unwrap_or_else(|| resolve_cli_default_agent_model(&config))
-    });
+    let model =
+        resolve_cli_effective_model(&config, model, provider, auth_binding_selection.as_ref());
     let max_tokens = max_tokens.unwrap_or(config.agent.max_tokens_per_turn);
     let resolved_provider = resolve_cli_provider_with_auth_binding(
         &config,
@@ -3221,12 +3217,70 @@ async fn load_config(scope: &RuntimeScope) -> anyhow::Result<(Config, PathBuf)> 
 
 const LEGACY_AGENT_MODEL_DEFAULTS: &[&str] = &["claude-opus-4-7"];
 
+fn model_provider(config: &Config, model: &str) -> Option<Provider> {
+    config
+        .model_registry()
+        .ok()
+        .and_then(|registry| registry.entry(model).map(|entry| entry.provider))
+        .and_then(Provider::from_core)
+}
+
+fn provider_default_model(config: &Config, provider: Provider) -> Option<String> {
+    let model = match provider {
+        Provider::Anthropic => &config.models.anthropic,
+        Provider::Openai => &config.models.openai,
+        Provider::Gemini => &config.models.gemini,
+        Provider::SelfHosted => return None,
+    };
+    (!model.is_empty()).then(|| model.clone())
+}
+
+fn best_available_default_model(config: &Config) -> String {
+    [Provider::Openai, Provider::Anthropic, Provider::Gemini]
+        .into_iter()
+        .find_map(|provider| provider_default_model(config, provider))
+        .unwrap_or_else(|| config.agent.model.clone())
+}
+
 fn resolve_cli_default_agent_model(config: &Config) -> String {
     if LEGACY_AGENT_MODEL_DEFAULTS.contains(&config.agent.model.as_str()) {
-        return config.models.openai.clone();
+        return best_available_default_model(config);
     }
 
     config.agent.model.clone()
+}
+
+fn resolve_provider_constrained_default_model(config: &Config, provider: Provider) -> String {
+    match model_provider(config, &config.agent.model) {
+        Some(model_provider) if model_provider == provider => config.agent.model.clone(),
+        Some(_) => {
+            provider_default_model(config, provider).unwrap_or_else(|| config.agent.model.clone())
+        }
+        None => config.agent.model.clone(),
+    }
+}
+
+fn resolve_cli_effective_model(
+    config: &Config,
+    explicit_model: Option<String>,
+    explicit_provider: Option<Provider>,
+    auth_binding: Option<&CliAuthBindingSelection>,
+) -> String {
+    if let Some(model) = explicit_model {
+        return model;
+    }
+
+    if let Some(model) = auth_binding.and_then(|selection| selection.default_model.clone()) {
+        return model;
+    }
+
+    if let Some(provider) =
+        explicit_provider.or_else(|| auth_binding.map(|selection| selection.provider))
+    {
+        return resolve_provider_constrained_default_model(config, provider);
+    }
+
+    resolve_cli_default_agent_model(config)
 }
 
 async fn handle_config_get(
@@ -17276,6 +17330,24 @@ capabilities = ["definitely_missing_capability"]
     }
 
     #[test]
+    fn test_resolve_cli_default_agent_model_falls_back_by_best_available_priority() {
+        let mut config = Config::default();
+        config.agent.model = "claude-opus-4-7".to_string();
+        config.models.openai.clear();
+
+        assert_eq!(
+            resolve_cli_default_agent_model(&config),
+            config.models.anthropic
+        );
+
+        config.models.anthropic.clear();
+        assert_eq!(
+            resolve_cli_default_agent_model(&config),
+            config.models.gemini
+        );
+    }
+
+    #[test]
     fn test_resolve_cli_default_agent_model_preserves_custom_model() {
         let mut config = Config::default();
         config.agent.model = "claude-sonnet-4-6".to_string();
@@ -17283,6 +17355,71 @@ capabilities = ["definitely_missing_capability"]
         assert_eq!(
             resolve_cli_default_agent_model(&config),
             "claude-sonnet-4-6"
+        );
+    }
+
+    #[test]
+    fn test_resolve_cli_effective_model_keeps_legacy_default_when_provider_matches() {
+        let mut config = Config::default();
+        config.agent.model = "claude-opus-4-7".to_string();
+
+        assert_eq!(
+            resolve_cli_effective_model(&config, None, Some(Provider::Anthropic), None),
+            "claude-opus-4-7"
+        );
+    }
+
+    #[test]
+    fn test_resolve_cli_effective_model_uses_constrained_provider_default_on_mismatch() {
+        let config = Config::default();
+
+        assert_eq!(
+            resolve_cli_effective_model(&config, None, Some(Provider::Anthropic), None),
+            config.models.anthropic
+        );
+    }
+
+    #[test]
+    fn test_resolve_cli_effective_model_uses_auth_binding_provider_without_binding_default() {
+        let mut config = Config::default();
+        config.agent.model = "claude-opus-4-7".to_string();
+        let selection = CliAuthBindingSelection {
+            provider: Provider::Anthropic,
+            default_model: None,
+        };
+
+        assert_eq!(
+            resolve_cli_effective_model(&config, None, None, Some(&selection)),
+            "claude-opus-4-7"
+        );
+    }
+
+    #[test]
+    fn test_resolve_cli_effective_model_uses_binding_default_before_provider_default() {
+        let config = Config::default();
+        let selection = CliAuthBindingSelection {
+            provider: Provider::Anthropic,
+            default_model: Some("claude-sonnet-4-6".to_string()),
+        };
+
+        assert_eq!(
+            resolve_cli_effective_model(&config, None, None, Some(&selection)),
+            "claude-sonnet-4-6"
+        );
+    }
+
+    #[test]
+    fn test_resolve_cli_effective_model_uses_gemini_default_for_gemini_binding_mismatch() {
+        let mut config = Config::default();
+        config.agent.model = "claude-opus-4-7".to_string();
+        let selection = CliAuthBindingSelection {
+            provider: Provider::Gemini,
+            default_model: None,
+        };
+
+        assert_eq!(
+            resolve_cli_effective_model(&config, None, None, Some(&selection)),
+            config.models.gemini
         );
     }
 

--- a/meerkat-core/src/config.rs
+++ b/meerkat-core/src/config.rs
@@ -2038,19 +2038,18 @@ mod tests {
     #[test]
     fn test_config_default() {
         let config = Config::default();
-        assert_eq!(config.agent.model, "claude-opus-4-7");
+        assert_eq!(config.agent.model, "gpt-5.5");
         assert_eq!(config.agent.max_tokens_per_turn, 16384);
         assert_eq!(config.retry.max_retries, 3);
         assert_eq!(config.max_sessions(), DEFAULT_MAX_SESSIONS);
     }
 
     #[test]
-    fn config_template_agent_model_tracks_anthropic_catalog_default() {
+    fn config_template_agent_model_tracks_openai_catalog_default() {
         let config = Config::template().expect("template parses");
         assert_eq!(
             config.agent.model.as_str(),
-            crate::model_profile::catalog::default_model("anthropic")
-                .expect("anthropic catalog default")
+            crate::model_profile::catalog::default_model("openai").expect("openai catalog default")
         );
     }
 
@@ -2072,7 +2071,7 @@ max_sessions = 7
     fn test_config_layering() {
         // 1. Test defaults
         let config = Config::default();
-        assert_eq!(config.agent.model, "claude-opus-4-7");
+        assert_eq!(config.agent.model, "gpt-5.5");
         assert_eq!(config.budget.max_tokens, None);
 
         // 2. Test env override (secrets only)

--- a/meerkat-core/src/config_template.toml
+++ b/meerkat-core/src/config_template.toml
@@ -2,7 +2,7 @@
 # This file is used to bootstrap ~/.rkat/config.toml when missing.
 
 [agent]
-model = "claude-opus-4-7"
+model = "gpt-5.5"
 max_tokens_per_turn = 16384
 budget_warning_threshold = 0.8
 

--- a/meerkat-core/src/lib.rs
+++ b/meerkat-core/src/lib.rs
@@ -261,10 +261,11 @@ pub use session::{
     SESSION_DEFERRED_TURN_STATE_KEY, SESSION_METADATA_SCHEMA_VERSION,
     SESSION_SYSTEM_CONTEXT_STATE_KEY, SESSION_TOOL_VISIBILITY_STATE_KEY, SESSION_VERSION,
     SYSTEM_CONTEXT_SEPARATOR, SeenSystemContextKey, SeenSystemContextState, Session,
-    SessionBuildState, SessionDeferredTurnState, SessionLlmIdentity, SessionLlmRequestPolicy,
-    SessionMeta, SessionMetadata, SessionSystemContextState, SessionToolVisibilityState,
-    SessionTooling, SystemContextStageError, ToolCategoryOverride, ToolVisibilityWitness,
-    VIEW_IMAGE_TOOL_NAME, WitnessedToolFilter, capability_base_filter_for_image_tool_results,
+    SessionBuildState, SessionDeferredTurnState, SessionLlmIdentity, SessionLlmIdentityOverride,
+    SessionLlmIdentityOverrideError, SessionLlmRequestPolicy, SessionMeta, SessionMetadata,
+    SessionSystemContextState, SessionToolVisibilityState, SessionTooling, SystemContextStageError,
+    ToolCategoryOverride, ToolVisibilityWitness, VIEW_IMAGE_TOOL_NAME, WitnessedToolFilter,
+    capability_base_filter_for_image_tool_results, resolve_session_llm_identity_override,
 };
 pub use session_recovery::{
     BUILD_ONLY_RECOVERY_OVERRIDE_ERROR, RecoveredSessionBuild, SurfaceSessionRecoveryContext,

--- a/meerkat-core/src/model_profile/catalog.rs
+++ b/meerkat-core/src/model_profile/catalog.rs
@@ -127,7 +127,7 @@ const PROVIDER_NAMES: &[&str] = &["anthropic", "gemini", "openai"];
 /// Default model ID per provider. First recommended model wins.
 const DEFAULT_ANTHROPIC: &str = "claude-opus-4-7";
 const DEFAULT_OPENAI: &str = "gpt-5.5";
-const DEFAULT_GEMINI: &str = "gemini-3-flash-preview";
+const DEFAULT_GEMINI: &str = "gemini-3.1-pro-preview";
 
 /// Image-generation default model ID per provider.
 const IMAGE_DEFAULT_OPENAI: &str = "gpt-image-2";

--- a/meerkat-core/src/session.rs
+++ b/meerkat-core/src/session.rs
@@ -2070,6 +2070,125 @@ pub struct SessionLlmIdentity {
     pub auth_binding: Option<crate::AuthBindingRef>,
 }
 
+/// Typed per-turn override request for a session LLM identity.
+pub struct SessionLlmIdentityOverride<'a> {
+    pub model: Option<&'a str>,
+    pub provider: Option<Provider>,
+    pub provider_params: Option<&'a serde_json::Value>,
+    pub clear_provider_params: bool,
+    pub auth_binding: Option<&'a crate::AuthBindingRef>,
+    pub clear_auth_binding: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum SessionLlmIdentityOverrideError {
+    #[error("provider override requires model on an existing session")]
+    ProviderRequiresModel,
+    #[error("clear_provider_params cannot be combined with provider_params")]
+    SetAndClearProviderParams,
+    #[error("clear_auth_binding cannot be combined with auth_binding")]
+    SetAndClearAuthBinding,
+    #[error("{0}")]
+    ProviderModelMismatch(String),
+    #[error("self-hosted provider requires a registered model alias; '{model}' is not configured")]
+    MissingSelfHostedAlias { model: String },
+}
+
+/// Resolve a turn-time model/provider/auth override against the current
+/// durable session identity.
+///
+/// The model registry is the authority for catalog ownership. A model-only
+/// override follows catalog ownership when the target model is registered;
+/// uncatalogued models keep the current provider so custom aliases remain
+/// possible.
+pub fn resolve_session_llm_identity_override(
+    current: &SessionLlmIdentity,
+    registry: &crate::ModelRegistry,
+    overrides: SessionLlmIdentityOverride<'_>,
+) -> Result<SessionLlmIdentity, SessionLlmIdentityOverrideError> {
+    if overrides.provider.is_some() && overrides.model.is_none() {
+        return Err(SessionLlmIdentityOverrideError::ProviderRequiresModel);
+    }
+    if overrides.clear_provider_params && overrides.provider_params.is_some() {
+        return Err(SessionLlmIdentityOverrideError::SetAndClearProviderParams);
+    }
+    if overrides.clear_auth_binding && overrides.auth_binding.is_some() {
+        return Err(SessionLlmIdentityOverrideError::SetAndClearAuthBinding);
+    }
+
+    let model = overrides
+        .model
+        .map(str::to_string)
+        .unwrap_or_else(|| current.model.clone());
+    let provider = if let Some(provider) = overrides.provider {
+        provider
+    } else if overrides.model.is_some() {
+        registry
+            .entry(&model)
+            .map_or(current.provider, |entry| entry.provider)
+    } else {
+        current.provider
+    };
+
+    if (overrides.model.is_some() || overrides.provider.is_some())
+        && let Some(reason) = registry.provider_override_mismatch_reason(provider, &model)
+    {
+        return Err(SessionLlmIdentityOverrideError::ProviderModelMismatch(
+            reason,
+        ));
+    }
+
+    let provider_params = if overrides.clear_provider_params {
+        None
+    } else {
+        overrides
+            .provider_params
+            .cloned()
+            .or_else(|| current.provider_params.clone())
+    };
+    let self_hosted_server_id = if provider == Provider::SelfHosted {
+        if overrides.model.is_none() {
+            current.self_hosted_server_id.clone().or_else(|| {
+                registry
+                    .entry_for_provider(Provider::SelfHosted, &model)
+                    .and_then(|entry| entry.self_hosted.as_ref())
+                    .map(|server| server.server_id.clone())
+            })
+        } else {
+            let entry = registry
+                .entry_for_provider(Provider::SelfHosted, &model)
+                .ok_or_else(|| SessionLlmIdentityOverrideError::MissingSelfHostedAlias {
+                    model: model.clone(),
+                })?;
+            entry
+                .self_hosted
+                .as_ref()
+                .map(|server| server.server_id.clone())
+        }
+    } else {
+        None
+    };
+
+    let auth_binding = if overrides.clear_auth_binding
+        || (provider != current.provider && overrides.auth_binding.is_none())
+    {
+        None
+    } else {
+        overrides
+            .auth_binding
+            .cloned()
+            .or_else(|| current.auth_binding.clone())
+    };
+
+    Ok(SessionLlmIdentity {
+        model,
+        provider,
+        self_hosted_server_id,
+        provider_params,
+        auth_binding,
+    })
+}
+
 /// Live request policy paired with a session LLM identity hot-swap.
 ///
 /// `SessionLlmIdentity` is the durable semantic identity. This projection is
@@ -2615,6 +2734,72 @@ mod tests {
         assert_eq!(session.version(), SESSION_VERSION);
         assert!(session.messages().is_empty());
         assert!(session.created_at() <= session.updated_at());
+    }
+
+    #[test]
+    fn llm_identity_model_override_switches_to_catalog_provider() {
+        let registry = crate::Config::default().model_registry().unwrap();
+        let current = SessionLlmIdentity {
+            model: "claude-sonnet-4-5".to_string(),
+            provider: Provider::Anthropic,
+            self_hosted_server_id: None,
+            provider_params: None,
+            auth_binding: Some(crate::AuthBindingRef {
+                realm: crate::RealmId::parse("tenant_a").unwrap(),
+                binding: crate::BindingId::parse("anthropic_default").unwrap(),
+                profile: None,
+            }),
+        };
+
+        let resolved = resolve_session_llm_identity_override(
+            &current,
+            &registry,
+            SessionLlmIdentityOverride {
+                model: Some("gpt-5.5"),
+                provider: None,
+                provider_params: None,
+                clear_provider_params: false,
+                auth_binding: None,
+                clear_auth_binding: false,
+            },
+        )
+        .unwrap();
+
+        assert_eq!(resolved.model, "gpt-5.5");
+        assert_eq!(resolved.provider, Provider::OpenAI);
+        assert!(
+            resolved.auth_binding.is_none(),
+            "provider switches must not inherit a binding from the previous provider"
+        );
+    }
+
+    #[test]
+    fn llm_identity_model_override_keeps_uncatalogued_model_on_current_provider() {
+        let registry = crate::Config::default().model_registry().unwrap();
+        let current = SessionLlmIdentity {
+            model: "custom-model".to_string(),
+            provider: Provider::Anthropic,
+            self_hosted_server_id: None,
+            provider_params: None,
+            auth_binding: None,
+        };
+
+        let resolved = resolve_session_llm_identity_override(
+            &current,
+            &registry,
+            SessionLlmIdentityOverride {
+                model: Some("uncatalogued-custom-model"),
+                provider: None,
+                provider_params: None,
+                clear_provider_params: false,
+                auth_binding: None,
+                clear_auth_binding: false,
+            },
+        )
+        .unwrap();
+
+        assert_eq!(resolved.model, "uncatalogued-custom-model");
+        assert_eq!(resolved.provider, Provider::Anthropic);
     }
 
     #[test]

--- a/meerkat-core/tests/rct_contracts.rs
+++ b/meerkat-core/tests/rct_contracts.rs
@@ -241,7 +241,7 @@ fn test_config_patch_semantics() {
 #[test]
 fn test_inv_001_default_model_from_config() {
     let config = Config::default();
-    assert_eq!(config.agent.model, config.models.anthropic);
+    assert_eq!(config.agent.model, config.models.openai);
 }
 
 #[test]

--- a/meerkat-rpc/src/session_runtime.rs
+++ b/meerkat-rpc/src/session_runtime.rs
@@ -54,8 +54,9 @@ use meerkat_core::types::{Message, RunResult, SessionId};
 use meerkat_core::{
     AgentExecutionSnapshot, Config, ConfigStore, ContentInput, ExternalToolSurfaceSnapshot,
     PeerIngressRuntimeSnapshot, PendingSystemContextAppend, Session, SessionLlmIdentity,
-    SessionSystemContextState, SurfaceSessionRecoveryContext, SurfaceSessionRecoveryError,
-    SurfaceSessionRecoveryOverrides, SystemMessage, ToolScopeSnapshot, build_recovered_session,
+    SessionLlmIdentityOverride, SessionSystemContextState, SurfaceSessionRecoveryContext,
+    SurfaceSessionRecoveryError, SurfaceSessionRecoveryOverrides, SystemMessage, ToolScopeSnapshot,
+    build_recovered_session,
 };
 use meerkat_core::{EventEnvelope, EventStream, InputId, RunId, StreamError};
 use meerkat_runtime::{
@@ -1466,6 +1467,12 @@ impl SessionRuntime {
                 ov.auth_binding.clone().map(TurnMetadataOverride::Set)
             }
         });
+        let provider = overrides.and_then(|ov| {
+            ov.provider
+                .as_deref()
+                .or_else(|| ov.model.as_ref().and(provider_hint))
+                .and_then(|provider| parse_provider_override(provider).ok())
+        });
         let metadata = meerkat_core::lifecycle::run_primitive::RuntimeTurnMetadata {
             handling_mode: None,
             keep_alive: overrides.and_then(|ov| Self::turn_keep_alive_policy(ov.keep_alive)),
@@ -1475,9 +1482,7 @@ impl SessionRuntime {
             model: overrides
                 .and_then(|ov| ov.model.clone())
                 .map(meerkat_core::lifecycle::run_primitive::ModelId::new),
-            provider: overrides
-                .and_then(|ov| ov.provider.as_ref())
-                .and_then(|provider| parse_provider_override(provider).ok()),
+            provider,
             provider_params,
             render_metadata: None,
             auth_binding,
@@ -3227,100 +3232,34 @@ impl SessionRuntime {
         current: &SessionLlmIdentity,
         ov: &crate::handlers::turn::TurnOverrides,
     ) -> Result<SessionLlmIdentity, RpcError> {
-        if ov.provider.is_some() && ov.model.is_none() {
-            return Err(RpcError {
-                code: error::INVALID_PARAMS,
-                message: "provider override requires model on an existing session".to_string(),
-                data: None,
-            });
-        }
-        if ov.clear_provider_params && ov.provider_params.is_some() {
-            return Err(RpcError {
-                code: error::INVALID_PARAMS,
-                message: "clear_provider_params cannot be combined with provider_params"
-                    .to_string(),
-                data: None,
-            });
-        }
-        if ov.clear_auth_binding && ov.auth_binding.is_some() {
-            return Err(RpcError {
-                code: error::INVALID_PARAMS,
-                message: "clear_auth_binding cannot be combined with auth_binding".to_string(),
-                data: None,
-            });
-        }
-
         let registry = self.model_registry().await?;
-        let model = ov.model.clone().unwrap_or_else(|| current.model.clone());
-        let provider = if let Some(provider_name) = ov.provider.as_ref() {
-            parse_provider_override(provider_name).map_err(|message| RpcError {
+        let provider = ov
+            .provider
+            .as_deref()
+            .map(parse_provider_override)
+            .transpose()
+            .map_err(|message| RpcError {
                 code: error::INVALID_PARAMS,
                 message,
                 data: None,
-            })?
-        } else {
-            current.provider
-        };
-        if (ov.model.is_some() || ov.provider.is_some())
-            && let Some(reason) =
-                registered_model_provider_mismatch_reason(&registry, provider, &model)
-        {
-            return Err(RpcError {
-                code: error::INVALID_PARAMS,
-                message: reason,
-                data: None,
-            });
-        }
-        let provider_params = if ov.clear_provider_params {
-            None
-        } else {
-            ov.provider_params
-                .clone()
-                .or_else(|| current.provider_params.clone())
-        };
-        let self_hosted_server_id = if provider == meerkat_core::Provider::SelfHosted {
-            if ov.model.is_none() {
-                current.self_hosted_server_id.clone().or_else(|| {
-                    registry
-                        .entry_for_provider(meerkat_core::Provider::SelfHosted, &model)
-                        .and_then(|entry| entry.self_hosted.as_ref())
-                        .map(|server| server.server_id.clone())
-                })
-            } else {
-                match registry.entry_for_provider(meerkat_core::Provider::SelfHosted, &model) {
-                    Some(entry) => entry
-                        .self_hosted
-                        .as_ref()
-                        .map(|server| server.server_id.clone()),
-                    None => {
-                        return Err(RpcError {
-                            code: error::INVALID_PARAMS,
-                            message: format!(
-                                "self-hosted provider requires a registered model alias; '{model}' is not configured"
-                            ),
-                            data: None,
-                        });
-                    }
-                }
-            }
-        } else {
-            None
-        };
+            })?;
 
-        let auth_binding = if ov.clear_auth_binding {
-            None
-        } else {
-            ov.auth_binding
-                .clone()
-                .or_else(|| current.auth_binding.clone())
-        };
-
-        Ok(SessionLlmIdentity {
-            model,
-            provider,
-            self_hosted_server_id,
-            provider_params,
-            auth_binding,
+        meerkat_core::resolve_session_llm_identity_override(
+            current,
+            &registry,
+            SessionLlmIdentityOverride {
+                model: ov.model.as_deref(),
+                provider,
+                provider_params: ov.provider_params.as_ref(),
+                clear_provider_params: ov.clear_provider_params,
+                auth_binding: ov.auth_binding.as_ref(),
+                clear_auth_binding: ov.clear_auth_binding,
+            },
+        )
+        .map_err(|err| RpcError {
+            code: error::INVALID_PARAMS,
+            message: err.to_string(),
+            data: None,
         })
     }
 
@@ -5369,8 +5308,8 @@ impl SessionRuntime {
     ///
     /// `overrides` may contain per-turn overrides. For pending (deferred)
     /// sessions, all overrides are applied to the staged `AgentBuildConfig`.
-    /// For materialized sessions, only `keep_alive` is allowed; all other
-    /// overrides are rejected with an error.
+    /// For materialized sessions, build-only fields are rejected; turn-scoped
+    /// identity and policy overrides are applied through runtime metadata.
     #[allow(clippy::too_many_arguments)]
     #[cfg(test)]
     pub async fn start_turn(
@@ -5604,6 +5543,12 @@ impl SessionRuntime {
             }
         }
 
+        let effective_identity = self
+            .effective_llm_identity_for_turn(session_id, overrides.as_ref())
+            .await?;
+        self.validate_prompt_video_input(&turn_prompt, &effective_identity)
+            .await?;
+
         let keep_alive = match overrides.as_ref().and_then(|ov| ov.keep_alive) {
             Some(keep_alive) => keep_alive,
             None => self
@@ -5617,7 +5562,7 @@ impl SessionRuntime {
             flow_tool_overlay.clone(),
             additional_instructions.clone(),
             overrides.as_ref(),
-            overrides.as_ref().and_then(|ov| ov.provider.as_deref()),
+            Some(effective_identity.provider.as_str()),
         ));
 
         if self.live_session_is_stale(session_id).await? {
@@ -7853,6 +7798,29 @@ mod tests {
             metadata.execution_kind,
             Some(meerkat_core::lifecycle::RuntimeExecutionKind::ContentTurn)
         );
+    }
+
+    #[test]
+    fn runtime_turn_metadata_model_override_uses_resolved_provider_hint() {
+        let overrides = crate::handlers::turn::TurnOverrides {
+            model: Some("claude-sonnet-4-5".to_string()),
+            ..Default::default()
+        };
+
+        let metadata = SessionRuntime::turn_metadata_from_overrides(
+            None,
+            None,
+            None,
+            Some(&overrides),
+            Some("anthropic"),
+        )
+        .expect("model override should produce turn metadata");
+
+        assert_eq!(
+            metadata.model.as_ref().map(|m| m.as_str()),
+            Some("claude-sonnet-4-5")
+        );
+        assert_eq!(metadata.provider, Some(meerkat_core::Provider::Anthropic));
     }
 
     /// B19 helper sanity: realtime capability lookup must round-trip the
@@ -11647,13 +11615,13 @@ mod tests {
         assert_eq!(
             resolved.provider,
             meerkat_core::Provider::Anthropic,
-            "model-only turn overrides must not infer a new provider from model id alone"
+            "model-only turn overrides should keep the provider when the target model is owned by it"
         );
         assert_eq!(resolved.model, "claude-opus-4-6");
     }
 
     #[tokio::test]
-    async fn turn_model_override_without_provider_rejects_other_provider_catalog_model() {
+    async fn turn_model_override_without_provider_switches_to_catalog_provider() {
         let temp = tempfile::tempdir().unwrap();
         let runtime = make_runtime(temp_factory(&temp), 10);
         let current = SessionLlmIdentity {
@@ -11661,25 +11629,28 @@ mod tests {
             provider: meerkat_core::Provider::Anthropic,
             self_hosted_server_id: None,
             provider_params: None,
-            auth_binding: None,
+            auth_binding: Some(meerkat_core::AuthBindingRef {
+                realm: meerkat_core::RealmId::parse("tenant_a").expect("valid realm"),
+                binding: meerkat_core::BindingId::parse("anthropic_default")
+                    .expect("valid binding"),
+                profile: None,
+            }),
         };
         let overrides = crate::handlers::turn::TurnOverrides {
-            model: Some("gpt-5.4".to_string()),
+            model: Some("gpt-5.5".to_string()),
             ..Default::default()
         };
 
-        let err = runtime
+        let resolved = runtime
             .resolve_target_llm_identity(&current, &overrides)
             .await
-            .expect_err("model owned by another provider must fail closed");
+            .expect("model-only override should infer the catalog provider");
 
-        assert_eq!(err.code, error::INVALID_PARAMS);
+        assert_eq!(resolved.provider, meerkat_core::Provider::OpenAI);
+        assert_eq!(resolved.model, "gpt-5.5");
         assert!(
-            err.message.contains("openai")
-                && err.message.contains("anthropic")
-                && err.message.contains("gpt-5.4"),
-            "error should identify the rejected provider/model pair: {}",
-            err.message
+            resolved.auth_binding.is_none(),
+            "provider switches must not inherit a binding from the previous provider"
         );
     }
 

--- a/meerkat-rpc/tests/integration_server.rs
+++ b/meerkat-rpc/tests/integration_server.rs
@@ -1190,13 +1190,15 @@ async fn in_session_model_switch_via_turn_start() {
         first_text.contains("Hello from mock"),
         "First turn should produce mock text, got: {first_text}"
     );
-    // Default model is claude-opus-4-7; verify it
+    // Default model is the best available global default; verify it.
     assert!(
-        first_text.contains("model=claude-opus-4-7"),
-        "First turn should use default model (claude-opus-4-7), got: {first_text}"
+        first_text.contains("model=gpt-5.5"),
+        "First turn should use default model (gpt-5.5), got: {first_text}"
     );
 
-    // 2. turn/start with model override on the materialized session
+    // 2. turn/start with model override on the materialized session.
+    // Model-only overrides may switch providers between turns when the
+    // target model has catalog ownership.
     let turn_req = serde_json::json!({
         "jsonrpc": "2.0",
         "id": 2,


### PR DESCRIPTION
## Summary
- Add the Claude Agent SDK system marker only for Claude.ai OAuth requests so subscription OAuth tokens are accepted outside Claude Code.
- Keep API-key Anthropic requests unchanged.
- Switch the generated/default CLI model to OpenAI gpt-5.5 and treat the old generated Anthropic default as legacy for no-model runs.
- Make CLI realm state project-local by default: context root defaults to CWD and state root defaults to `<context-root>/.rkat/realms`.
- Log the active realm, context root, and realm root in verbose CLI startup output.
- Add a realm guide and update CLI docs/help plus Meerkat platform skill docs for context-root vs state-root.

## Validation
- ./scripts/repo-cargo fmt --all --check
- ./scripts/repo-cargo test -p rkat test_resolve_cli_default_agent_model -- --nocapture
- ./scripts/repo-cargo test -p rkat resolve_runtime_scope_ -- --nocapture
- ./scripts/repo-cargo test -p rkat default_cli_state_root -- --nocapture
- ./scripts/repo-cargo test -p meerkat-core test_config_default -- --nocapture
- ./scripts/repo-cargo test -p meerkat-core config_template_agent_model_tracks_openai_catalog_default -- --nocapture
- ./scripts/repo-cargo test -p meerkat-anthropic claude_ai_oauth_marker -- --nocapture
- ./scripts/repo-cargo run -p rkat -- --help
- ./scripts/repo-cargo run -p rkat -- run --help
- ./scripts/repo-cargo run -p rkat -- "Hello. Which model are you?" --verbose --tools none --max-duration 5s
