### PR TITLE
[codex] Add Azure OpenAI backend support

### DIFF
--- a/artifacts/schemas/auth-connection-contracts.json
+++ b/artifacts/schemas/auth-connection-contracts.json
@@ -1,6 +1,7 @@
 {
   "auth_methods": [
     "api_key",
+    "azure_api_key",
     "static_bearer",
     "managed_chatgpt_oauth",
     "external_chatgpt_tokens",
@@ -30,6 +31,7 @@
   "backend_kinds": [
     "openai_api",
     "chatgpt_backend",
+    "azure_openai",
     "anthropic_api",
     "bedrock",
     "vertex",
@@ -81,6 +83,7 @@
     ],
     "openai": [
       "api_key",
+      "azure_api_key",
       "static_bearer",
       "managed_chatgpt_oauth",
       "external_chatgpt_tokens",
@@ -106,7 +109,8 @@
     ],
     "openai": [
       "openai_api",
-      "chatgpt_backend"
+      "chatgpt_backend",
+      "azure_openai"
     ],
     "self_hosted": [
       "self_hosted",

--- a/docs/api/rest.mdx
+++ b/docs/api/rest.mdx
@@ -937,7 +937,7 @@ configured outside this endpoint.
 </ParamField>
 
 <ParamField body="auth_method" type="string" required>
-  Stored-secret method: `"api_key"` or `"static_bearer"`.
+  Stored-secret method: `"api_key"`, `"azure_api_key"`, or `"static_bearer"`.
 </ParamField>
 
 <ParamField body="secret" type="string" required>

--- a/docs/cli/configuration.mdx
+++ b/docs/cli/configuration.mdx
@@ -42,6 +42,7 @@ Required API keys (at least one):
 |----------|----------|
 | `ANTHROPIC_API_KEY` | Anthropic Claude |
 | `OPENAI_API_KEY` | OpenAI GPT |
+| `AZURE_OPENAI_API_KEY` plus `AZURE_OPENAI_ENDPOINT` | Azure OpenAI |
 | `GOOGLE_API_KEY` / `GEMINI_API_KEY` | Google Gemini |
 
 See [providers](/concepts/providers) for full key precedence (`RKAT_*` variants included).

--- a/docs/concepts/providers.mdx
+++ b/docs/concepts/providers.mdx
@@ -101,6 +101,7 @@ This page is the concept layer for provider abstraction. Use [Auth](/guides/auth
 |----------|----------|----------|
 | `RKAT_ANTHROPIC_API_KEY` | `ANTHROPIC_API_KEY` | Anthropic Claude |
 | `RKAT_OPENAI_API_KEY` | `OPENAI_API_KEY` | OpenAI GPT |
+| `RKAT_AZURE_OPENAI_API_KEY` plus `RKAT_AZURE_OPENAI_ENDPOINT` | `AZURE_OPENAI_API_KEY` plus `AZURE_OPENAI_ENDPOINT` | Azure OpenAI |
 | `RKAT_GEMINI_API_KEY` | `GEMINI_API_KEY`, `GOOGLE_API_KEY` | Google Gemini |
 
 <Note>

--- a/docs/guides/auth.mdx
+++ b/docs/guides/auth.mdx
@@ -4,8 +4,9 @@ description: "Realm-scoped credential resolution: from the env-var happy path to
 icon: "key"
 ---
 
-Meerkat's auth story has two layers. The **fast path** is an env var
-(`ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `GEMINI_API_KEY`) — set it and
+Meerkat's auth story has two layers. The **fast path** is env vars
+(`ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `GEMINI_API_KEY`, or
+`AZURE_OPENAI_API_KEY` plus `AZURE_OPENAI_ENDPOINT`) — set them and
 `rkat run` works. The **powerful path** is realm-scoped bindings:
 declare a realm in your config, register credentials via `rkat auth
 login` or the REST/RPC surfaces, and pass `--auth-binding
@@ -43,11 +44,17 @@ That's it. If the env var is set, Meerkat synthesizes a default realm
 env vars (e.g., `RKAT_ANTHROPIC_API_KEY`) take precedence over the
 provider-native names.
 
-| Provider  | Primary env var       | Fallback         |
-|-----------|-----------------------|------------------|
-| Anthropic | `ANTHROPIC_API_KEY`   | —                |
-| OpenAI    | `OPENAI_API_KEY`      | —                |
-| Gemini    | `GEMINI_API_KEY`      | `GOOGLE_API_KEY` |
+| Provider | Primary env var | Fallback |
+|----------|-----------------|----------|
+| Anthropic | `ANTHROPIC_API_KEY` | — |
+| OpenAI | `OPENAI_API_KEY` | — |
+| OpenAI on Azure | `AZURE_OPENAI_API_KEY` plus `AZURE_OPENAI_ENDPOINT` | Optional `AZURE_OPENAI_IMAGE_GENERATION_DEPLOYMENT`, `AZURE_OPENAI_IMAGE_GENERATION_API_VERSION` |
+| Gemini | `GEMINI_API_KEY` | `GOOGLE_API_KEY` |
+
+If both public OpenAI and unprefixed Azure OpenAI env vars are present, the
+public OpenAI env default wins. Use `RKAT_AZURE_OPENAI_API_KEY` plus
+`RKAT_AZURE_OPENAI_ENDPOINT`, or an explicit realm binding, to make Azure
+OpenAI the env default in that case.
 
 ## The powerful path: realms + bindings
 
@@ -92,6 +99,27 @@ backend_profile = "openai_primary"
 auth_profile    = "openai_apikey"
 ```
 
+Azure OpenAI uses the same provider id (`openai`) with an Azure-specific
+backend/auth pair:
+
+```toml
+[realm.prod.backend.azure_openai]
+provider = "openai"
+backend_kind = "azure_openai"
+base_url = "https://my-resource.cognitiveservices.azure.com"
+options = { image_generation_deployment = "gpt-image-2", image_generation_api_version = "preview" }
+
+[realm.prod.auth.azure_openai_key]
+provider = "openai"
+auth_method = "azure_api_key"
+source = { kind = "managed_store" }
+
+[realm.prod.binding.azure_openai]
+backend_profile = "azure_openai"
+auth_profile    = "azure_openai_key"
+default_model   = "gpt-5.5" # Azure deployment name
+```
+
 ### Log in
 
 ```bash
@@ -131,7 +159,7 @@ rkat run --auth-binding prod:openai   "hello"
     rkat auth refresh --realm prod <profile_id>   # force-refresh OAuth tokens
     ```
 
-    `rkat auth refresh` is a no-op for `api_key` / `static_bearer`
+    `rkat auth refresh` is a no-op for `api_key` / `azure_api_key` / `static_bearer`
     auth methods (nothing to refresh). For OAuth-backed methods it
     exchanges the persisted refresh token for a fresh access token and
     writes the new bundle back to the TokenStore.
@@ -180,6 +208,7 @@ auth_method)` pairs. The table below summarizes what's wired today.
 | Anthropic | `vertex`            | `vertex_google_auth`    | GoogleAuth / Vertex AI |
 | Anthropic | `foundry`           | `foundry_api_key`, `foundry_azure_ad` | Azure AI Foundry |
 | OpenAI    | `openai_api`        | `api_key`, `static_bearer`, `external_authorizer` | Direct to api.openai.com or host-resolved auth |
+| OpenAI    | `azure_openai`      | `azure_api_key`       | Azure OpenAI Responses API; `base_url` required; session model is the Azure deployment name |
 | OpenAI    | `chatgpt_backend`   | `managed_chatgpt_oauth` | ChatGPT Plus/Pro OAuth |
 | OpenAI    | `chatgpt_backend`   | `external_chatgpt_tokens` | Host-supplied tokens |
 | Google    | `google_genai`      | `api_key`, `bearer_api_key`, `external_authorizer` | Direct to Google GenAI or host-resolved auth |

--- a/docs/guides/image-generation.mdx
+++ b/docs/guides/image-generation.mdx
@@ -11,7 +11,7 @@ This is not a standalone `image/generate` RPC. Use it by running a session with 
 ## Requirements
 
 - A runtime-backed session surface with builtins enabled. The CLI default `--tools safe` enables builtins; `--tools none` hides `generate_image`.
-- At least one configured image provider. OpenAI uses `RKAT_OPENAI_API_KEY` or `OPENAI_API_KEY`; Gemini uses `RKAT_GEMINI_API_KEY`, `GEMINI_API_KEY`, or `GOOGLE_API_KEY`.
+- At least one configured image provider. OpenAI uses `RKAT_OPENAI_API_KEY` or `OPENAI_API_KEY`; Azure OpenAI uses `AZURE_OPENAI_API_KEY`, `AZURE_OPENAI_ENDPOINT`, and `AZURE_OPENAI_IMAGE_GENERATION_DEPLOYMENT`; Gemini uses `RKAT_GEMINI_API_KEY`, `GEMINI_API_KEY`, or `GOOGLE_API_KEY`.
 - A blob store. CLI, REST, RPC, MCP, and persistent SDK-backed sessions wire this automatically through the runtime-backed surface.
 - `count` must be `1`. Multiple image output is rejected today with `unsupported_count`; run multiple operations if you need several variants.
 
@@ -178,6 +178,7 @@ Meerkat fields and OpenAI lowering:
 Model behavior:
 
 - `gpt-image-2` uses the hosted Responses image tool internally, but callers still pass Meerkat's `generate_image` request shape.
+- On the `azure_openai` backend, hosted image generation requires backend option `image_generation_deployment` (for example `gpt-image-2`). The session model remains the Azure text deployment name, and Meerkat selects the image deployment with Azure's Responses image-generation header.
 - `gpt-image-2` accepts flexible `WIDTHxHEIGHT` sizes when they satisfy OpenAI's constraints: both edges are multiples of 16 px, max edge is 3840 px, aspect ratio is at most 3:1, and total pixels are between 655,360 and 8,294,400. Common values include `1024x1024`, `1536x1024`, `1024x1536`, `2048x2048`, `2048x1152`, `3840x2160`, and `2160x3840`.
 - Do not copy raw Responses API JSON into `provider_params`. Use Meerkat's universal `size`, `quality`, `format`, and `intent` fields, and reserve `provider_params` for the advanced OpenAI overrides above.
 - For fresh/current image-only requests, prefer passing `provider_params.web_search` to `generate_image` over doing a separate search turn first.

--- a/docs/guides/realtime.mdx
+++ b/docs/guides/realtime.mdx
@@ -191,7 +191,7 @@ Open a live channel against the member's session after the member is spawned.
 
 ## Limitations and known gaps
 
-- **OpenAI Realtime API only.** The shipped provider integration is OpenAI's Realtime API (`gpt-realtime-2`). Other providers are not yet wired into the live transport layer.
+- **OpenAI Realtime API only.** The shipped provider integration is OpenAI's Realtime API (`gpt-realtime-2`). Azure OpenAI (`azure_openai`) and other providers are not yet wired into the live transport layer.
 - **One live channel per session.** A session has at most one live channel at a time. For per-member live channels in mobs, open channels against individual member sessions.
 - **Idle sessions cannot host a channel.** Start a turn or spawn the member first.
 - **Identity swaps require close/reopen.** `live/refresh` applies config-only changes (instructions, tools, audio format); model or provider swaps require `live/close` + `live/open`.

--- a/meerkat-auth-core/src/auth_store/mod.rs
+++ b/meerkat-auth-core/src/auth_store/mod.rs
@@ -36,7 +36,9 @@ pub use meerkat_core::auth::token_store::{
 
 pub fn persisted_auth_mode_for_auth_method(auth_method: &str) -> Option<PersistedAuthMode> {
     match auth_method {
-        "api_key" | "api_key_express" | "foundry_api_key" => Some(PersistedAuthMode::ApiKey),
+        "api_key" | "api_key_express" | "foundry_api_key" | "azure_api_key" => {
+            Some(PersistedAuthMode::ApiKey)
+        }
         "static_bearer" | "bearer_api_key" | "bedrock_bearer" => {
             Some(PersistedAuthMode::StaticBearer)
         }
@@ -120,6 +122,14 @@ impl TokenStoreBackend {
 #[allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn azure_openai_api_key_uses_api_key_token_store_mode() {
+        assert_eq!(
+            persisted_auth_mode_for_auth_method("azure_api_key"),
+            Some(PersistedAuthMode::ApiKey)
+        );
+    }
 
     #[test]
     fn persisted_tokens_round_trip_serde() {

--- a/meerkat-cli/src/main.rs
+++ b/meerkat-cli/src/main.rs
@@ -5531,24 +5531,7 @@ async fn handle_doctor(scope: &RuntimeScope) -> anyhow::Result<()> {
             ],
         ),
     ];
-    let openai_env_present = ["RKAT_OPENAI_API_KEY", "OPENAI_API_KEY"]
-        .iter()
-        .any(|env_key| env_var_present(env_key));
-    let azure_openai_env_present = ["RKAT_AZURE_OPENAI_API_KEY", "AZURE_OPENAI_API_KEY"]
-        .iter()
-        .any(|env_key| env_var_present(env_key))
-        && ["RKAT_AZURE_OPENAI_ENDPOINT", "AZURE_OPENAI_ENDPOINT"]
-            .iter()
-            .any(|env_key| env_var_present(env_key));
-    if openai_env_present {
-        println!("ok\tprovider\topenai via OPENAI_API_KEY");
-    } else if azure_openai_env_present {
-        println!("ok\tprovider\topenai via AZURE_OPENAI_API_KEY + AZURE_OPENAI_ENDPOINT");
-    } else {
-        println!(
-            "warn\tprovider\topenai missing RKAT_OPENAI_API_KEY/OPENAI_API_KEY or AZURE_OPENAI_API_KEY + AZURE_OPENAI_ENDPOINT"
-        );
-    }
+    println!("{}", doctor_openai_env_default_message(env_var_present));
     for (provider, env_keys) in provider_keys {
         if let Some(env_key) = env_keys.iter().find(|env_key| env_var_present(env_key)) {
             println!("ok\tprovider\t{provider} via {env_key}");
@@ -5687,6 +5670,32 @@ fn env_var_present(env_key: &str) -> bool {
         .ok()
         .filter(|value| !value.is_empty())
         .is_some()
+}
+
+fn doctor_openai_env_default_message<F>(mut env_present: F) -> &'static str
+where
+    F: FnMut(&str) -> bool,
+{
+    let public_openai_env_present = ["RKAT_OPENAI_API_KEY", "OPENAI_API_KEY"]
+        .iter()
+        .any(|env_key| env_present(env_key));
+    let azure_key_present = ["RKAT_AZURE_OPENAI_API_KEY", "AZURE_OPENAI_API_KEY"]
+        .iter()
+        .any(|env_key| env_present(env_key));
+    let azure_endpoint_present = ["RKAT_AZURE_OPENAI_ENDPOINT", "AZURE_OPENAI_ENDPOINT"]
+        .iter()
+        .any(|env_key| env_present(env_key));
+    let azure_explicit =
+        env_present("RKAT_AZURE_OPENAI_API_KEY") || env_present("RKAT_AZURE_OPENAI_ENDPOINT");
+
+    if azure_key_present && azure_endpoint_present && (azure_explicit || !public_openai_env_present)
+    {
+        "ok\tprovider\topenai via AZURE_OPENAI_API_KEY + AZURE_OPENAI_ENDPOINT"
+    } else if public_openai_env_present {
+        "ok\tprovider\topenai via OPENAI_API_KEY"
+    } else {
+        "warn\tprovider\topenai missing RKAT_OPENAI_API_KEY/OPENAI_API_KEY or AZURE_OPENAI_API_KEY + AZURE_OPENAI_ENDPOINT"
+    }
 }
 
 async fn handle_realm_command(command: RealmCommands, scope: &RuntimeScope) -> anyhow::Result<()> {
@@ -12873,6 +12882,35 @@ mod tests {
             auth_header
         });
         (base_url, handle)
+    }
+
+    fn doctor_openai_message_for_env(keys: &[&str]) -> &'static str {
+        doctor_openai_env_default_message(|key| keys.contains(&key))
+    }
+
+    #[test]
+    fn doctor_openai_env_default_reports_rkat_azure_override_before_public_openai() {
+        let message = doctor_openai_message_for_env(&[
+            "OPENAI_API_KEY",
+            "RKAT_AZURE_OPENAI_API_KEY",
+            "RKAT_AZURE_OPENAI_ENDPOINT",
+        ]);
+
+        assert_eq!(
+            message,
+            "ok\tprovider\topenai via AZURE_OPENAI_API_KEY + AZURE_OPENAI_ENDPOINT"
+        );
+    }
+
+    #[test]
+    fn doctor_openai_env_default_keeps_public_openai_before_plain_azure_env() {
+        let message = doctor_openai_message_for_env(&[
+            "OPENAI_API_KEY",
+            "AZURE_OPENAI_API_KEY",
+            "AZURE_OPENAI_ENDPOINT",
+        ]);
+
+        assert_eq!(message, "ok\tprovider\topenai via OPENAI_API_KEY");
     }
 
     #[tokio::test]

--- a/meerkat-cli/src/main.rs
+++ b/meerkat-cli/src/main.rs
@@ -1549,8 +1549,9 @@ enum Commands {
     /// `login` runs the interactive OAuth flow by default, or writes an
     /// inline api_key when `--non-interactive --secret <S>` is passed.
     /// Env-var auth (`RKAT_*` provider keys, ANTHROPIC_API_KEY,
-    /// OPENAI_API_KEY, GEMINI_API_KEY / GOOGLE_API_KEY) continues to work
-    /// as a fallback for callers that haven't migrated.
+    /// OPENAI_API_KEY, AZURE_OPENAI_API_KEY + AZURE_OPENAI_ENDPOINT,
+    /// GEMINI_API_KEY / GOOGLE_API_KEY) continues to work as a fallback for
+    /// callers that haven't migrated.
     Auth {
         #[command(subcommand)]
         command: AuthCommands,
@@ -1614,9 +1615,9 @@ enum AuthCommands {
         #[arg(long)]
         backend: Option<String>,
 
-        /// Auth method (e.g. `api_key`, `managed_chatgpt_oauth`,
-        /// `claude_ai_oauth`, `google_oauth`). Defaults to the primary
-        /// interactive flow for the provider.
+        /// Auth method (e.g. `api_key`, `azure_api_key`,
+        /// `managed_chatgpt_oauth`, `claude_ai_oauth`, `google_oauth`).
+        /// Defaults to the primary interactive flow for the provider.
         #[arg(long)]
         method: Option<String>,
 
@@ -4707,9 +4708,9 @@ async fn noninteractive_login(
     }
 
     let method = method_hint.unwrap_or("api_key");
-    if method != "api_key" && method != "static_bearer" {
+    if method != "api_key" && method != "azure_api_key" && method != "static_bearer" {
         anyhow::bail!(
-            "--non-interactive login supports only --method api_key|static_bearer; \
+            "--non-interactive login supports only --method api_key|azure_api_key|static_bearer; \
              OAuth-backed methods (managed_chatgpt_oauth, claude_ai_oauth, google_oauth, \
              oauth_to_api_key) require the interactive browser flow"
         );
@@ -5515,12 +5516,11 @@ async fn handle_doctor(scope: &RuntimeScope) -> anyhow::Result<()> {
         println!("warn\tconfig\tmissing config at {}", config_path.display());
     }
 
-    let provider_keys: [(&str, &[&str]); 3] = [
+    let provider_keys: [(&str, &[&str]); 2] = [
         (
             "anthropic",
             &["RKAT_ANTHROPIC_API_KEY", "ANTHROPIC_API_KEY"],
         ),
-        ("openai", &["RKAT_OPENAI_API_KEY", "OPENAI_API_KEY"]),
         (
             "gemini",
             &[
@@ -5531,13 +5531,26 @@ async fn handle_doctor(scope: &RuntimeScope) -> anyhow::Result<()> {
             ],
         ),
     ];
+    let openai_env_present = ["RKAT_OPENAI_API_KEY", "OPENAI_API_KEY"]
+        .iter()
+        .any(|env_key| env_var_present(env_key));
+    let azure_openai_env_present = ["RKAT_AZURE_OPENAI_API_KEY", "AZURE_OPENAI_API_KEY"]
+        .iter()
+        .any(|env_key| env_var_present(env_key))
+        && ["RKAT_AZURE_OPENAI_ENDPOINT", "AZURE_OPENAI_ENDPOINT"]
+            .iter()
+            .any(|env_key| env_var_present(env_key));
+    if openai_env_present {
+        println!("ok\tprovider\topenai via OPENAI_API_KEY");
+    } else if azure_openai_env_present {
+        println!("ok\tprovider\topenai via AZURE_OPENAI_API_KEY + AZURE_OPENAI_ENDPOINT");
+    } else {
+        println!(
+            "warn\tprovider\topenai missing RKAT_OPENAI_API_KEY/OPENAI_API_KEY or AZURE_OPENAI_API_KEY + AZURE_OPENAI_ENDPOINT"
+        );
+    }
     for (provider, env_keys) in provider_keys {
-        if let Some(env_key) = env_keys.iter().find(|env_key| {
-            std::env::var(env_key)
-                .ok()
-                .filter(|v| !v.is_empty())
-                .is_some()
-        }) {
+        if let Some(env_key) = env_keys.iter().find(|env_key| env_var_present(env_key)) {
             println!("ok\tprovider\t{provider} via {env_key}");
         } else {
             println!("warn\tprovider\t{provider} missing {}", env_keys.join("/"));
@@ -5667,6 +5680,13 @@ async fn handle_doctor(scope: &RuntimeScope) -> anyhow::Result<()> {
             "doctor found issues; review the warnings above"
         ))
     }
+}
+
+fn env_var_present(env_key: &str) -> bool {
+    std::env::var(env_key)
+        .ok()
+        .filter(|value| !value.is_empty())
+        .is_some()
 }
 
 async fn handle_realm_command(command: RealmCommands, scope: &RuntimeScope) -> anyhow::Result<()> {

--- a/meerkat-contracts/src/emit.rs
+++ b/meerkat-contracts/src/emit.rs
@@ -1434,7 +1434,14 @@ mod tests {
         );
         assert_eq!(
             contracts["provider_backend_kinds"]["openai"],
-            serde_json::json!(["openai_api", "chatgpt_backend"])
+            serde_json::json!(["openai_api", "chatgpt_backend", "azure_openai"])
+        );
+        assert!(
+            contracts["provider_auth_methods"]["openai"]
+                .as_array()
+                .expect("openai auth methods")
+                .contains(&serde_json::json!("azure_api_key")),
+            "provider auth relation map must include Azure OpenAI api-key auth"
         );
         assert!(
             contracts["provider_auth_methods"]["openai"]

--- a/meerkat-core/src/connection.rs
+++ b/meerkat-core/src/connection.rs
@@ -21,6 +21,24 @@ use crate::provider_matrix::{
     AnthropicBackendKind, GoogleBackendKind, OpenAiBackendKind, SelfHostedBackendKind,
 };
 
+const AZURE_OPENAI_API_KEY_ENV: &str = "AZURE_OPENAI_API_KEY";
+const AZURE_OPENAI_ENDPOINT_ENV: &str = "AZURE_OPENAI_ENDPOINT";
+const AZURE_OPENAI_IMAGE_GENERATION_DEPLOYMENT_ENV: &str =
+    "AZURE_OPENAI_IMAGE_GENERATION_DEPLOYMENT";
+const AZURE_OPENAI_IMAGE_DEPLOYMENT_ENV: &str = "AZURE_OPENAI_IMAGE_DEPLOYMENT";
+const AZURE_OPENAI_IMAGE_GENERATION_API_VERSION_ENV: &str =
+    "AZURE_OPENAI_IMAGE_GENERATION_API_VERSION";
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct EnvDefaultSpec {
+    backend_kind: &'static str,
+    auth_method: &'static str,
+    env_var: &'static str,
+    fallback: Vec<String>,
+    base_url: Option<String>,
+    options: serde_json::Value,
+}
+
 // ---------------------------------------------------------------------
 // Runtime shapes (what providers/surfaces consume at runtime)
 // ---------------------------------------------------------------------
@@ -741,78 +759,77 @@ impl RealmConnectionSet {
     /// sourcing credentials from a well-known env var. Used by surface
     /// factories when no explicit realm config exists but the user has
     /// set `ANTHROPIC_API_KEY` / `OPENAI_API_KEY` / `GEMINI_API_KEY` in
-    /// the environment — the synthesized realm is consumed by the same
-    /// `ProviderRuntimeRegistry` path as explicit realms, so env-var auth
-    /// and realm-config auth share one resolution pipeline.
+    /// the environment. OpenAI also supports an Azure env envelope:
+    /// `AZURE_OPENAI_API_KEY` plus `AZURE_OPENAI_ENDPOINT` synthesizes the
+    /// `azure_openai` backend instead of public OpenAI when no public OpenAI
+    /// key is present. The synthesized realm is consumed by the same
+    /// `ProviderRuntimeRegistry` path as explicit realms, so env-var auth and
+    /// realm-config auth share one resolution pipeline.
     ///
     /// Returns a realm with id `"env_default"` containing one binding
     /// `"default"` pointing at:
     /// - BackendProfile `"default"` with the provider's default
     ///   backend_kind and base_url=None (provider client uses its default).
-    /// - AuthProfile `"default"` with `source = Env { env: <ENV_VAR> }`,
-    ///   `auth_method = "api_key"`.
+    /// - AuthProfile `"default"` with `source = Env { env: <ENV_VAR> }` and
+    ///   the provider-specific env auth method.
     ///
     /// The ENV_VAR name is per-provider:
     /// - Anthropic: `ANTHROPIC_API_KEY`
     /// - OpenAI:   `OPENAI_API_KEY`
+    /// - Azure OpenAI: `AZURE_OPENAI_API_KEY` + `AZURE_OPENAI_ENDPOINT`
     /// - Google:   `GEMINI_API_KEY`
     ///
     /// Callers should also honor `RKAT_*`-prefixed overrides via
     /// `ResolverEnvironment::with_process_env()`; that lookup is applied
     /// inside the registry's resolve path when it reads the env source.
     pub fn synthesize_env_default(provider: Provider) -> Self {
-        Self::synthesize_default(provider, None)
+        Self::synthesize_env_default_from_lookup(provider, |key| std::env::var(key).ok())
+    }
+
+    /// Testable variant of [`Self::synthesize_env_default`] that lets callers
+    /// inject the env lookup used to select the OpenAI public-vs-Azure default.
+    pub fn synthesize_env_default_from_lookup<F>(provider: Provider, env_lookup: F) -> Self
+    where
+        F: Fn(&str) -> Option<String>,
+    {
+        let spec = env_default_spec(provider, env_lookup);
+        Self::synthesize_default_from_spec(provider, None, spec)
     }
 
     /// Synthesize a default realm with an inline secret instead of an env
     /// lookup. Used when callers have already read the api key from a
     /// config file (legacy credential-map path).
     pub fn synthesize_inline_default(provider: Provider, secret: String) -> Self {
-        Self::synthesize_default(provider, Some(secret))
+        Self::synthesize_default_from_spec(
+            provider,
+            Some(secret),
+            env_default_spec(provider, |_| None),
+        )
     }
 
-    fn synthesize_default(provider: Provider, inline_secret: Option<String>) -> Self {
-        let (backend_kind, env_var, fallback) = match provider {
-            Provider::Anthropic => (
-                AnthropicBackendKind::AnthropicApi.as_str(),
-                "ANTHROPIC_API_KEY",
-                vec![],
-            ),
-            Provider::OpenAI => (
-                OpenAiBackendKind::OpenAiApi.as_str(),
-                "OPENAI_API_KEY",
-                vec![],
-            ),
-            Provider::Gemini => (
-                GoogleBackendKind::GoogleGenAi.as_str(),
-                "GEMINI_API_KEY",
-                vec!["GOOGLE_API_KEY".to_string()],
-            ),
-            Provider::SelfHosted => (
-                SelfHostedBackendKind::SelfHosted.as_str(),
-                "RKAT_SELF_HOSTED_API_KEY",
-                vec![],
-            ),
-            Provider::Other => ("other_api", "RKAT_OTHER_API_KEY", vec![]),
-        };
+    fn synthesize_default_from_spec(
+        provider: Provider,
+        inline_secret: Option<String>,
+        spec: EnvDefaultSpec,
+    ) -> Self {
         let backend = BackendProfile {
             id: "default".to_string(),
             provider,
-            backend_kind: backend_kind.to_string(),
-            base_url: None,
-            options: serde_json::Value::Null,
+            backend_kind: spec.backend_kind.to_string(),
+            base_url: spec.base_url,
+            options: spec.options,
         };
         let source = match inline_secret {
             Some(secret) => CredentialSourceSpec::InlineSecret { secret },
             None => CredentialSourceSpec::Env {
-                env: env_var.to_string(),
-                fallback,
+                env: spec.env_var.to_string(),
+                fallback: spec.fallback,
             },
         };
         let auth = AuthProfile {
             id: "default".to_string(),
             provider,
-            auth_method: "api_key".to_string(),
+            auth_method: spec.auth_method.to_string(),
             source,
             constraints: AuthConstraints::default(),
             metadata_defaults: AuthMetadataDefaults::default(),
@@ -1015,6 +1032,123 @@ impl RealmConfigSection {
     }
 }
 
+fn env_default_spec<F>(provider: Provider, env_lookup: F) -> EnvDefaultSpec
+where
+    F: Fn(&str) -> Option<String>,
+{
+    match provider {
+        Provider::Anthropic => EnvDefaultSpec {
+            backend_kind: AnthropicBackendKind::AnthropicApi.as_str(),
+            auth_method: "api_key",
+            env_var: "ANTHROPIC_API_KEY",
+            fallback: vec![],
+            base_url: None,
+            options: serde_json::Value::Null,
+        },
+        Provider::OpenAI => openai_env_default_spec(env_lookup),
+        Provider::Gemini => EnvDefaultSpec {
+            backend_kind: GoogleBackendKind::GoogleGenAi.as_str(),
+            auth_method: "api_key",
+            env_var: "GEMINI_API_KEY",
+            fallback: vec!["GOOGLE_API_KEY".to_string()],
+            base_url: None,
+            options: serde_json::Value::Null,
+        },
+        Provider::SelfHosted => EnvDefaultSpec {
+            backend_kind: SelfHostedBackendKind::SelfHosted.as_str(),
+            auth_method: "api_key",
+            env_var: "RKAT_SELF_HOSTED_API_KEY",
+            fallback: vec![],
+            base_url: None,
+            options: serde_json::Value::Null,
+        },
+        Provider::Other => EnvDefaultSpec {
+            backend_kind: "other_api",
+            auth_method: "api_key",
+            env_var: "RKAT_OTHER_API_KEY",
+            fallback: vec![],
+            base_url: None,
+            options: serde_json::Value::Null,
+        },
+    }
+}
+
+fn openai_env_default_spec<F>(env_lookup: F) -> EnvDefaultSpec
+where
+    F: Fn(&str) -> Option<String>,
+{
+    let public_openai_key = env_value_with_rkat(&env_lookup, "OPENAI_API_KEY");
+    let azure_key = env_value_with_rkat(&env_lookup, AZURE_OPENAI_API_KEY_ENV);
+    let azure_endpoint = env_value_with_rkat(&env_lookup, AZURE_OPENAI_ENDPOINT_ENV);
+    let azure_explicit = direct_env_value(&env_lookup, &format!("RKAT_{AZURE_OPENAI_API_KEY_ENV}"))
+        .is_some()
+        || direct_env_value(&env_lookup, &format!("RKAT_{AZURE_OPENAI_ENDPOINT_ENV}")).is_some();
+    if azure_key.is_some()
+        && let Some(endpoint) = azure_endpoint
+        && (azure_explicit || public_openai_key.is_none())
+    {
+        let mut options = serde_json::Map::new();
+        if let Some(deployment) =
+            env_value_with_rkat(&env_lookup, AZURE_OPENAI_IMAGE_GENERATION_DEPLOYMENT_ENV)
+                .or_else(|| env_value_with_rkat(&env_lookup, AZURE_OPENAI_IMAGE_DEPLOYMENT_ENV))
+        {
+            options.insert(
+                "image_generation_deployment".to_string(),
+                serde_json::Value::String(deployment),
+            );
+        }
+        if let Some(api_version) =
+            env_value_with_rkat(&env_lookup, AZURE_OPENAI_IMAGE_GENERATION_API_VERSION_ENV)
+        {
+            options.insert(
+                "image_generation_api_version".to_string(),
+                serde_json::Value::String(api_version),
+            );
+        }
+        return EnvDefaultSpec {
+            backend_kind: OpenAiBackendKind::AzureOpenAi.as_str(),
+            auth_method: "azure_api_key",
+            env_var: AZURE_OPENAI_API_KEY_ENV,
+            fallback: vec![],
+            base_url: Some(endpoint),
+            options: if options.is_empty() {
+                serde_json::Value::Null
+            } else {
+                serde_json::Value::Object(options)
+            },
+        };
+    }
+    EnvDefaultSpec {
+        backend_kind: OpenAiBackendKind::OpenAiApi.as_str(),
+        auth_method: "api_key",
+        env_var: "OPENAI_API_KEY",
+        fallback: vec![],
+        base_url: None,
+        options: serde_json::Value::Null,
+    }
+}
+
+fn env_value_with_rkat<F>(env_lookup: &F, candidate: &str) -> Option<String>
+where
+    F: Fn(&str) -> Option<String>,
+{
+    let rkat_override = if candidate.starts_with("RKAT_") {
+        None
+    } else {
+        direct_env_value(env_lookup, &format!("RKAT_{candidate}"))
+    };
+    rkat_override.or_else(|| direct_env_value(env_lookup, candidate))
+}
+
+fn direct_env_value<F>(env_lookup: &F, key: &str) -> Option<String>
+where
+    F: Fn(&str) -> Option<String>,
+{
+    env_lookup(key)
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+}
+
 /// Serialized backend profile (pre-normalization).
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
@@ -1088,6 +1222,16 @@ backend_profile = "openai_default"
 auth_profile = "openai_oauth"
 "#,
         )
+    }
+
+    fn lookup_from_pairs(
+        pairs: &'static [(&'static str, &'static str)],
+    ) -> impl Fn(&str) -> Option<String> {
+        move |key| {
+            pairs
+                .iter()
+                .find_map(|(candidate, value)| (*candidate == key).then(|| (*value).to_string()))
+        }
     }
 
     #[test]
@@ -1193,6 +1337,101 @@ auth_profile = "default_profile"
             err.to_string().contains("nonexistent") || err.to_string().contains("unknown variant"),
             "serde error should mention unknown variant: {err}",
         );
+    }
+
+    #[test]
+    fn env_default_openai_uses_public_openai_without_azure_envelope() {
+        let realm = RealmConnectionSet::synthesize_env_default_from_lookup(
+            Provider::OpenAI,
+            lookup_from_pairs(&[]),
+        );
+        let backend = realm.backends.get("default").unwrap();
+        let auth = realm.auth_profiles.get("default").unwrap();
+
+        assert_eq!(backend.backend_kind, "openai_api");
+        assert_eq!(backend.base_url, None);
+        assert_eq!(auth.auth_method, "api_key");
+        assert_eq!(
+            auth.source,
+            CredentialSourceSpec::Env {
+                env: "OPENAI_API_KEY".to_string(),
+                fallback: Vec::new(),
+            }
+        );
+    }
+
+    #[test]
+    fn env_default_openai_uses_azure_when_key_and_endpoint_are_present() {
+        let realm = RealmConnectionSet::synthesize_env_default_from_lookup(
+            Provider::OpenAI,
+            lookup_from_pairs(&[
+                ("AZURE_OPENAI_API_KEY", "azure-key"),
+                ("AZURE_OPENAI_ENDPOINT", "https://example.openai.azure.com/"),
+                ("AZURE_OPENAI_IMAGE_GENERATION_DEPLOYMENT", "gpt-image-2"),
+                ("AZURE_OPENAI_IMAGE_GENERATION_API_VERSION", "preview"),
+            ]),
+        );
+        let backend = realm.backends.get("default").unwrap();
+        let auth = realm.auth_profiles.get("default").unwrap();
+
+        assert_eq!(backend.backend_kind, "azure_openai");
+        assert_eq!(
+            backend.base_url.as_deref(),
+            Some("https://example.openai.azure.com/")
+        );
+        assert_eq!(
+            backend.options["image_generation_deployment"],
+            "gpt-image-2"
+        );
+        assert_eq!(backend.options["image_generation_api_version"], "preview");
+        assert_eq!(auth.auth_method, "azure_api_key");
+        assert_eq!(
+            auth.source,
+            CredentialSourceSpec::Env {
+                env: "AZURE_OPENAI_API_KEY".to_string(),
+                fallback: Vec::new(),
+            }
+        );
+    }
+
+    #[test]
+    fn env_default_openai_keeps_public_key_when_plain_azure_and_public_keys_are_both_set() {
+        let realm = RealmConnectionSet::synthesize_env_default_from_lookup(
+            Provider::OpenAI,
+            lookup_from_pairs(&[
+                ("OPENAI_API_KEY", "public-key"),
+                ("AZURE_OPENAI_API_KEY", "azure-key"),
+                ("AZURE_OPENAI_ENDPOINT", "https://example.openai.azure.com"),
+            ]),
+        );
+        let backend = realm.backends.get("default").unwrap();
+
+        assert_eq!(backend.backend_kind, "openai_api");
+        assert_eq!(backend.base_url, None);
+    }
+
+    #[test]
+    fn env_default_openai_rkat_azure_envelope_overrides_public_openai_key() {
+        let realm = RealmConnectionSet::synthesize_env_default_from_lookup(
+            Provider::OpenAI,
+            lookup_from_pairs(&[
+                ("OPENAI_API_KEY", "public-key"),
+                ("RKAT_AZURE_OPENAI_API_KEY", "azure-key"),
+                (
+                    "RKAT_AZURE_OPENAI_ENDPOINT",
+                    "https://example.openai.azure.com",
+                ),
+            ]),
+        );
+        let backend = realm.backends.get("default").unwrap();
+        let auth = realm.auth_profiles.get("default").unwrap();
+
+        assert_eq!(backend.backend_kind, "azure_openai");
+        assert_eq!(
+            backend.base_url.as_deref(),
+            Some("https://example.openai.azure.com")
+        );
+        assert_eq!(auth.auth_method, "azure_api_key");
     }
 
     #[test]

--- a/meerkat-core/src/provider_matrix/openai_auth.rs
+++ b/meerkat-core/src/provider_matrix/openai_auth.rs
@@ -14,6 +14,7 @@ pub const FEDRAMP_HEADER: &str = "X-OpenAI-Fedramp";
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum OpenAiAuthMethod {
     ApiKey,
+    AzureApiKey,
     StaticBearer,
     ManagedChatGptOauth,
     ExternalChatGptTokens,
@@ -23,6 +24,7 @@ pub enum OpenAiAuthMethod {
 impl OpenAiAuthMethod {
     pub const ALL: &'static [Self] = &[
         Self::ApiKey,
+        Self::AzureApiKey,
         Self::StaticBearer,
         Self::ManagedChatGptOauth,
         Self::ExternalChatGptTokens,
@@ -32,6 +34,7 @@ impl OpenAiAuthMethod {
     pub fn parse(raw: &str) -> Option<Self> {
         match raw {
             "api_key" => Some(Self::ApiKey),
+            "azure_api_key" => Some(Self::AzureApiKey),
             "static_bearer" => Some(Self::StaticBearer),
             "managed_chatgpt_oauth" => Some(Self::ManagedChatGptOauth),
             "external_chatgpt_tokens" => Some(Self::ExternalChatGptTokens),
@@ -43,6 +46,7 @@ impl OpenAiAuthMethod {
     pub fn as_str(self) -> &'static str {
         match self {
             Self::ApiKey => "api_key",
+            Self::AzureApiKey => "azure_api_key",
             Self::StaticBearer => "static_bearer",
             Self::ManagedChatGptOauth => "managed_chatgpt_oauth",
             Self::ExternalChatGptTokens => "external_chatgpt_tokens",

--- a/meerkat-core/src/provider_matrix/openai_backend.rs
+++ b/meerkat-core/src/provider_matrix/openai_backend.rs
@@ -4,17 +4,19 @@
 pub enum OpenAiBackendKind {
     OpenAiApi,
     ChatGptBackend,
+    AzureOpenAi,
 }
 
 pub const CHATGPT_CODEX_DEFAULT_BASE_URL: &str = "https://chatgpt.com/backend-api/codex";
 
 impl OpenAiBackendKind {
-    pub const ALL: &'static [Self] = &[Self::OpenAiApi, Self::ChatGptBackend];
+    pub const ALL: &'static [Self] = &[Self::OpenAiApi, Self::ChatGptBackend, Self::AzureOpenAi];
 
     pub fn parse(raw: &str) -> Option<Self> {
         match raw {
             "openai_api" => Some(Self::OpenAiApi),
             "chatgpt_backend" => Some(Self::ChatGptBackend),
+            "azure_openai" => Some(Self::AzureOpenAi),
             _ => None,
         }
     }
@@ -23,6 +25,7 @@ impl OpenAiBackendKind {
         match self {
             Self::OpenAiApi => "openai_api",
             Self::ChatGptBackend => "chatgpt_backend",
+            Self::AzureOpenAi => "azure_openai",
         }
     }
 
@@ -30,6 +33,7 @@ impl OpenAiBackendKind {
         match self {
             Self::OpenAiApi => "https://api.openai.com",
             Self::ChatGptBackend => CHATGPT_CODEX_DEFAULT_BASE_URL,
+            Self::AzureOpenAi => "",
         }
     }
 }
@@ -63,5 +67,6 @@ mod tests {
             OpenAiBackendKind::ChatGptBackend.default_base_url(),
             "https://chatgpt.com/backend-api/codex",
         );
+        assert_eq!(OpenAiBackendKind::AzureOpenAi.default_base_url(), "");
     }
 }

--- a/meerkat-llm-core/src/provider_runtime/catalog.rs
+++ b/meerkat-llm-core/src/provider_runtime/catalog.rs
@@ -207,6 +207,9 @@ impl ProviderRuntimeCatalog {
                         | OpenAiAuthMethod::ExternalAuthorizer,
                 ),
             ) | (
+                NormalizedBackendKind::OpenAi(OpenAiBackendKind::AzureOpenAi),
+                NormalizedAuthMethod::OpenAi(OpenAiAuthMethod::AzureApiKey),
+            ) | (
                 NormalizedBackendKind::OpenAi(OpenAiBackendKind::ChatGptBackend),
                 NormalizedAuthMethod::OpenAi(
                     OpenAiAuthMethod::ManagedChatGptOauth | OpenAiAuthMethod::ExternalChatGptTokens,
@@ -332,6 +335,25 @@ mod tests {
     }
 
     #[test]
+    fn validate_accepts_azure_openai_api_key_combination() {
+        let binding = ProviderRuntimeCatalog::validate_binding(
+            &auth_binding(),
+            &backend(Provider::OpenAI, "azure_openai"),
+            &auth(Provider::OpenAI, "azure_api_key"),
+            &BindingPolicy::default(),
+        )
+        .unwrap();
+        assert_eq!(
+            binding.backend(),
+            NormalizedBackendKind::OpenAi(OpenAiBackendKind::AzureOpenAi)
+        );
+        assert_eq!(
+            binding.auth(),
+            NormalizedAuthMethod::OpenAi(OpenAiAuthMethod::AzureApiKey)
+        );
+    }
+
+    #[test]
     fn validate_rejects_unknown_backend_kind() {
         let err = ProviderRuntimeCatalog::validate_binding(
             &auth_binding(),
@@ -371,6 +393,21 @@ mod tests {
     }
 
     #[test]
+    fn validate_rejects_azure_openai_with_public_openai_api_key() {
+        let err = ProviderRuntimeCatalog::validate_binding(
+            &auth_binding(),
+            &backend(Provider::OpenAI, "azure_openai"),
+            &auth(Provider::OpenAI, "api_key"),
+            &BindingPolicy::default(),
+        )
+        .unwrap_err();
+        assert!(matches!(
+            err,
+            ProviderBindingError::UnsupportedCombination { .. }
+        ));
+    }
+
+    #[test]
     fn validate_rejects_profile_provider_mismatch() {
         let err = ProviderRuntimeCatalog::validate_binding(
             &auth_binding(),
@@ -387,6 +424,10 @@ mod tests {
         assert!(ProviderRuntimeCatalog::supports(
             NormalizedBackendKind::OpenAi(OpenAiBackendKind::ChatGptBackend),
             NormalizedAuthMethod::OpenAi(OpenAiAuthMethod::ManagedChatGptOauth),
+        ));
+        assert!(ProviderRuntimeCatalog::supports(
+            NormalizedBackendKind::OpenAi(OpenAiBackendKind::AzureOpenAi),
+            NormalizedAuthMethod::OpenAi(OpenAiAuthMethod::AzureApiKey),
         ));
         assert!(ProviderRuntimeCatalog::supports(
             NormalizedBackendKind::Anthropic(AnthropicBackendKind::Bedrock),

--- a/meerkat-openai/src/client.rs
+++ b/meerkat-openai/src/client.rs
@@ -45,7 +45,7 @@ pub struct OpenAiClient {
     api_key: Option<String>,
     base_url: String,
     responses_path: String,
-    chatgpt_backend_wire: bool,
+    backend_wire: OpenAiBackendWire,
     http: reqwest::Client,
     /// Extra headers emitted on every request (e.g. `ChatGPT-Account-ID`,
     /// `X-OpenAI-Fedramp`). Populated by provider runtimes when the
@@ -57,6 +57,28 @@ pub struct OpenAiClient {
     /// invocation. Used for ExternalAuthorizer flows that produce a
     /// DynamicAuthorizer envelope (host-managed OAuth refresh, etc.).
     authorizer: Option<std::sync::Arc<dyn meerkat_core::HttpAuthorizer>>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AzureOpenAiWireConfig {
+    pub image_generation_deployment: Option<String>,
+    pub image_generation_api_version: String,
+}
+
+impl Default for AzureOpenAiWireConfig {
+    fn default() -> Self {
+        Self {
+            image_generation_deployment: None,
+            image_generation_api_version: "preview".to_string(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum OpenAiBackendWire {
+    PublicOpenAi,
+    ChatGptBackend,
+    AzureOpenAi(AzureOpenAiWireConfig),
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -359,7 +381,7 @@ impl OpenAiClient {
             api_key,
             base_url,
             responses_path: "v1/responses".to_string(),
-            chatgpt_backend_wire: false,
+            backend_wire: OpenAiBackendWire::PublicOpenAi,
             http,
             extra_headers: Vec::new(),
             authorizer: None,
@@ -386,8 +408,13 @@ impl OpenAiClient {
 
     pub fn with_chatgpt_backend_wire(self) -> Self {
         let mut client = self.with_responses_path("responses");
-        client.chatgpt_backend_wire = true;
+        client.backend_wire = OpenAiBackendWire::ChatGptBackend;
         client
+    }
+
+    pub fn with_azure_openai_wire(mut self, config: AzureOpenAiWireConfig) -> Self {
+        self.backend_wire = OpenAiBackendWire::AzureOpenAi(config);
+        self
     }
 
     /// Attach a dynamic authorizer. When set, overrides the
@@ -404,6 +431,55 @@ impl OpenAiClient {
 
     pub fn extra_headers(&self) -> &[(String, String)] {
         &self.extra_headers
+    }
+
+    fn is_chatgpt_backend_wire(&self) -> bool {
+        matches!(self.backend_wire, OpenAiBackendWire::ChatGptBackend)
+    }
+
+    fn azure_openai_wire_config(&self) -> Option<&AzureOpenAiWireConfig> {
+        match &self.backend_wire {
+            OpenAiBackendWire::AzureOpenAi(config) => Some(config),
+            OpenAiBackendWire::PublicOpenAi | OpenAiBackendWire::ChatGptBackend => None,
+        }
+    }
+
+    async fn apply_request_headers(
+        &self,
+        mut request_builder: reqwest::RequestBuilder,
+        endpoint: &str,
+        request_extra_headers: &[(String, String)],
+    ) -> Result<reqwest::RequestBuilder, LlmError> {
+        if let Some(authorizer) = &self.authorizer {
+            let mut extra: Vec<(String, String)> = Vec::new();
+            let mut auth_req = meerkat_core::HttpAuthorizationRequest {
+                method: "POST",
+                url: endpoint,
+                headers: &mut extra,
+            };
+            authorizer.authorize(&mut auth_req).await.map_err(|e| {
+                LlmError::AuthenticationFailed {
+                    message: format!("openai authorizer failed: {e}"),
+                }
+            })?;
+            for (name, value) in extra {
+                request_builder = request_builder.header(name, value);
+            }
+        } else if let Some(api_key) = &self.api_key {
+            if self.azure_openai_wire_config().is_some() {
+                request_builder = request_builder.header("api-key", api_key);
+            } else {
+                request_builder =
+                    request_builder.header("Authorization", format!("Bearer {api_key}"));
+            }
+        }
+        for (name, value) in &self.extra_headers {
+            request_builder = request_builder.header(name, value);
+        }
+        for (name, value) in request_extra_headers {
+            request_builder = request_builder.header(name, value);
+        }
+        Ok(request_builder)
     }
 
     fn responses_endpoint(&self) -> String {
@@ -425,7 +501,7 @@ impl OpenAiClient {
 
     /// Build request body for OpenAI Responses API
     fn build_request_body(&self, request: &LlmRequest) -> Result<Value, LlmError> {
-        let (input, instructions) = if self.chatgpt_backend_wire {
+        let (input, instructions) = if self.is_chatgpt_backend_wire() {
             Self::convert_to_responses_input_with_system_mode(
                 &request.messages,
                 SystemMessageMode::ExtractToInstructions,
@@ -453,7 +529,7 @@ impl OpenAiClient {
             });
         }
 
-        if self.chatgpt_backend_wire {
+        if self.is_chatgpt_backend_wire() {
             body["instructions"] = Value::String(
                 instructions.unwrap_or_else(|| "You are a helpful assistant.".to_string()),
             );
@@ -893,31 +969,23 @@ impl OpenAiClient {
         endpoint: &str,
         body: &Value,
     ) -> Result<reqwest::Response, LlmError> {
+        self.post_json_to_openai_with_headers(endpoint, body, &[])
+            .await
+    }
+
+    async fn post_json_to_openai_with_headers(
+        &self,
+        endpoint: &str,
+        body: &Value,
+        request_extra_headers: &[(String, String)],
+    ) -> Result<reqwest::Response, LlmError> {
         let mut request_builder = self
             .http
             .post(endpoint)
             .header("Content-Type", "application/json");
-        if let Some(authorizer) = &self.authorizer {
-            let mut extra: Vec<(String, String)> = Vec::new();
-            let mut auth_req = meerkat_core::HttpAuthorizationRequest {
-                method: "POST",
-                url: endpoint,
-                headers: &mut extra,
-            };
-            authorizer.authorize(&mut auth_req).await.map_err(|e| {
-                LlmError::AuthenticationFailed {
-                    message: format!("openai authorizer failed: {e}"),
-                }
-            })?;
-            for (name, value) in extra {
-                request_builder = request_builder.header(name, value);
-            }
-        } else if let Some(api_key) = &self.api_key {
-            request_builder = request_builder.header("Authorization", format!("Bearer {api_key}"));
-        }
-        for (name, value) in &self.extra_headers {
-            request_builder = request_builder.header(name, value);
-        }
+        request_builder = self
+            .apply_request_headers(request_builder, endpoint, request_extra_headers)
+            .await?;
         request_builder.json(body).send().await.map_err(|e| {
             if e.is_timeout() {
                 LlmError::NetworkTimeout { duration_ms: 30000 }
@@ -952,10 +1020,12 @@ impl OpenAiClient {
             "type".to_string(),
             serde_json::Value::String(plan.tool_name),
         );
-        tool.insert(
-            "model".to_string(),
-            serde_json::Value::String(plan.model.to_string()),
-        );
+        if self.azure_openai_wire_config().is_none() {
+            tool.insert(
+                "model".to_string(),
+                serde_json::Value::String(plan.model.to_string()),
+            );
+        }
         Self::apply_image_output_options(&mut tool, &plan.output);
         Self::apply_openai_image_provider_params(&mut tool, &plan.provider_params, true);
         let mut tools = Vec::new();
@@ -963,7 +1033,7 @@ impl OpenAiClient {
             tools.push(web_search_tool);
         }
         tools.push(serde_json::Value::Object(tool));
-        let stream = self.chatgpt_backend_wire;
+        let stream = self.is_chatgpt_backend_wire();
         let body = serde_json::json!({
             "model": request.model,
             "input": input,
@@ -977,8 +1047,32 @@ impl OpenAiClient {
         if let Some(effort) = plan.provider_params.reasoning_effort {
             body["reasoning"] = serde_json::json!({ "effort": effort.as_legacy_str() });
         }
+        let mut extra_headers = Vec::new();
+        if let Some(config) = self.azure_openai_wire_config() {
+            let deployment = config
+                .image_generation_deployment
+                .as_deref()
+                .map(str::trim)
+                .filter(|value| !value.is_empty())
+                .ok_or_else(|| LlmError::InvalidConfig {
+                    message: "azure_openai image generation requires backend option `image_generation_deployment`".to_string(),
+                })?;
+            extra_headers.push((
+                "x-ms-oai-image-generation-deployment".to_string(),
+                deployment.to_string(),
+            ));
+            let api_version = config.image_generation_api_version.trim();
+            if api_version.is_empty() {
+                return Err(LlmError::InvalidConfig {
+                    message: "azure_openai image generation requires a non-empty `image_generation_api_version`".to_string(),
+                });
+            }
+            extra_headers.push(("api_version".to_string(), api_version.to_string()));
+        }
         let endpoint = self.responses_endpoint();
-        let response = self.post_json_to_openai(&endpoint, &body).await?;
+        let response = self
+            .post_json_to_openai_with_headers(&endpoint, &body, &extra_headers)
+            .await?;
         if stream {
             let status_code = response.status().as_u16();
             if (200..=299).contains(&status_code) {
@@ -1419,29 +1513,7 @@ impl LlmClient for OpenAiClient {
                 .http
                 .post(&endpoint)
                 .header("Content-Type", "application/json");
-            // Auth path: authorizer overrides Bearer<api_key>.
-            if let Some(authorizer) = &self.authorizer {
-                let mut extra: Vec<(String, String)> = Vec::new();
-                let mut auth_req = meerkat_core::HttpAuthorizationRequest {
-                    method: "POST",
-                    url: &endpoint,
-                    headers: &mut extra,
-                };
-                authorizer.authorize(&mut auth_req).await.map_err(|e| {
-                    LlmError::AuthenticationFailed {
-                        message: format!("openai authorizer failed: {e}"),
-                    }
-                })?;
-                for (name, value) in extra {
-                    request_builder = request_builder.header(name, value);
-                }
-            } else if let Some(api_key) = &self.api_key {
-                request_builder =
-                    request_builder.header("Authorization", format!("Bearer {api_key}"));
-            }
-            for (name, value) in &self.extra_headers {
-                request_builder = request_builder.header(name, value);
-            }
+            request_builder = self.apply_request_headers(request_builder, &endpoint, &[]).await?;
             let response = request_builder
                 .json(&body)
                 .send()
@@ -2112,7 +2184,9 @@ fn parse_tool_call_arguments(
 #[allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
 mod tests {
     use super::*;
-    use axum::{Json, Router, extract::State, response::IntoResponse, routing::post};
+    use axum::{
+        Json, Router, extract::State, http::HeaderMap, response::IntoResponse, routing::post,
+    };
     use meerkat_core::{
         AssistantImageId, BlobId, BlobRef, BlockAssistantMessage, MediaType, ProviderImageMetadata,
         RevisedPromptDisposition, ToolResult, UserMessage, VideoData,
@@ -2446,16 +2520,44 @@ mod tests {
     }
 
     #[derive(Clone)]
+    struct HeaderStreamStubState {
+        payload: String,
+        seen: Arc<Mutex<Vec<Value>>>,
+        seen_headers: Arc<Mutex<Vec<HeaderMap>>>,
+    }
+
+    async fn responses_sse_with_body_and_headers(
+        State(state): State<HeaderStreamStubState>,
+        headers: HeaderMap,
+        Json(body): Json<Value>,
+    ) -> impl IntoResponse {
+        state.seen.lock().expect("seen mutex").push(body);
+        state
+            .seen_headers
+            .lock()
+            .expect("seen headers mutex")
+            .push(headers);
+        ([("content-type", "text/event-stream")], state.payload)
+    }
+
+    #[derive(Clone)]
     struct ImageStubState {
         response: Value,
         seen: Arc<Mutex<Vec<Value>>>,
+        seen_headers: Arc<Mutex<Vec<HeaderMap>>>,
     }
 
     async fn openai_image_stub(
         State(state): State<ImageStubState>,
+        headers: HeaderMap,
         Json(body): Json<Value>,
     ) -> impl IntoResponse {
         state.seen.lock().expect("seen mutex").push(body);
+        state
+            .seen_headers
+            .lock()
+            .expect("seen headers mutex")
+            .push(headers);
         Json(state.response)
     }
 
@@ -2490,15 +2592,54 @@ mod tests {
         (format!("http://{addr}"), handle)
     }
 
+    async fn spawn_azure_responses_stub_server(
+        payload: String,
+        seen: Arc<Mutex<Vec<Value>>>,
+        seen_headers: Arc<Mutex<Vec<HeaderMap>>>,
+    ) -> (String, tokio::task::JoinHandle<()>) {
+        let app = Router::new()
+            .route(
+                "/openai/v1/responses",
+                post(responses_sse_with_body_and_headers),
+            )
+            .with_state(HeaderStreamStubState {
+                payload,
+                seen,
+                seen_headers,
+            });
+        let listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind test server");
+        let addr = listener.local_addr().expect("local addr");
+        let handle = tokio::spawn(async move {
+            axum::serve(listener, app).await.expect("serve test server");
+        });
+        (format!("http://{addr}"), handle)
+    }
+
     async fn spawn_openai_image_stub(
         response: Value,
         seen: Arc<Mutex<Vec<Value>>>,
     ) -> (String, tokio::task::JoinHandle<()>) {
+        let seen_headers = Arc::new(Mutex::new(Vec::new()));
+        spawn_openai_image_stub_with_headers(response, seen, seen_headers).await
+    }
+
+    async fn spawn_openai_image_stub_with_headers(
+        response: Value,
+        seen: Arc<Mutex<Vec<Value>>>,
+        seen_headers: Arc<Mutex<Vec<HeaderMap>>>,
+    ) -> (String, tokio::task::JoinHandle<()>) {
         let app = Router::new()
             .route("/v1/responses", post(openai_image_stub))
+            .route("/openai/v1/responses", post(openai_image_stub))
             .route("/responses", post(openai_image_stub))
             .route("/v1/images/generations", post(openai_image_stub))
-            .with_state(ImageStubState { response, seen });
+            .with_state(ImageStubState {
+                response,
+                seen,
+                seen_headers,
+            });
         let listener = TcpListener::bind("127.0.0.1:0")
             .await
             .expect("bind test server");
@@ -2728,6 +2869,97 @@ mod tests {
         assert!(body.get("stream").and_then(Value::as_bool) == Some(false));
 
         handle.abort();
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn azure_openai_hosted_image_uses_deployment_header_and_omits_tool_model()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let seen = Arc::new(Mutex::new(Vec::new()));
+        let seen_headers = Arc::new(Mutex::new(Vec::new()));
+        let response = serde_json::json!({
+            "id": "resp_img_azure",
+            "output": [{
+                "type": "image_generation_call",
+                "id": "ig_azure",
+                "result": "data:image/png;base64,aGVsbG8="
+            }]
+        });
+        let (base_url, handle) =
+            spawn_openai_image_stub_with_headers(response, seen.clone(), seen_headers.clone())
+                .await;
+        let client =
+            OpenAiClient::new_with_base_url("azure-key".to_string(), format!("{base_url}/openai"))
+                .with_azure_openai_wire(AzureOpenAiWireConfig {
+                    image_generation_deployment: Some("gpt-image-2".to_string()),
+                    image_generation_api_version: "preview".to_string(),
+                });
+        let mut request = image_executor_request_json(hosted_openai_plan_json());
+        request.model = "gpt-5.5".to_string();
+
+        let output = client.execute_image_generation(request).await?;
+
+        assert!(matches!(
+            output.terminal,
+            ImageOperationTerminalClass::Generated
+        ));
+        let headers = seen_headers.lock().expect("seen headers mutex");
+        let headers = headers.first().expect("captured Azure image headers");
+        assert_eq!(
+            headers.get("api-key").and_then(|v| v.to_str().ok()),
+            Some("azure-key")
+        );
+        assert!(headers.get("authorization").is_none());
+        assert_eq!(
+            headers
+                .get("x-ms-oai-image-generation-deployment")
+                .and_then(|v| v.to_str().ok()),
+            Some("gpt-image-2")
+        );
+        assert_eq!(
+            headers.get("api_version").and_then(|v| v.to_str().ok()),
+            Some("preview")
+        );
+        let bodies = seen.lock().expect("seen mutex");
+        let body = bodies.first().expect("captured Azure image request");
+        assert_eq!(body["model"], "gpt-5.5");
+        assert_eq!(body["tools"][0]["type"], "image_generation");
+        assert!(
+            !body["tools"][0]
+                .as_object()
+                .expect("tool object")
+                .contains_key("model"),
+            "Azure Responses image generation selects the image deployment via header"
+        );
+        assert_eq!(body["stream"], false);
+        assert_eq!(body["store"], false);
+
+        handle.abort();
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn azure_openai_hosted_image_requires_image_generation_deployment()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let client = OpenAiClient::new_with_base_url(
+            "azure-key".to_string(),
+            "http://127.0.0.1:1/openai".to_string(),
+        )
+        .with_azure_openai_wire(AzureOpenAiWireConfig::default());
+
+        let err = match client
+            .execute_image_generation(image_executor_request_json(hosted_openai_plan_json()))
+            .await
+        {
+            Ok(_) => panic!("missing Azure image deployment should fail before HTTP"),
+            Err(err) => err,
+        };
+
+        assert!(matches!(
+            err,
+            LlmError::InvalidConfig { message }
+                if message.contains("image_generation_deployment")
+        ));
         Ok(())
     }
 
@@ -3057,6 +3289,56 @@ mod tests {
                 .all(|item| item.get("role").and_then(Value::as_str) != Some("system")),
             "ChatGPT Codex backend rejects system messages in input; they must be lifted to instructions"
         );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn azure_openai_wire_uses_api_key_header_and_openai_responses_path()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let payload = [
+            r#"data: {"type":"response.output_text.delta","delta":"Hello from Azure"}"#,
+            r#"data: {"type":"response.completed","response":{"status":"completed","usage":{"input_tokens":4,"output_tokens":3}}}"#,
+            "data: [DONE]",
+            "",
+        ]
+        .join("\n");
+        let seen = Arc::new(Mutex::new(Vec::new()));
+        let seen_headers = Arc::new(Mutex::new(Vec::new()));
+        let (base_url, server) =
+            spawn_azure_responses_stub_server(payload, seen.clone(), seen_headers.clone()).await;
+        let client =
+            OpenAiClient::new_with_base_url("azure-key".to_string(), format!("{base_url}/openai"))
+                .with_azure_openai_wire(AzureOpenAiWireConfig::default());
+        let request = LlmRequest::new(
+            "gpt-5.5",
+            vec![Message::User(UserMessage::text("hello".to_string()))],
+        );
+
+        let mut stream = client.stream(&request);
+        let mut deltas = Vec::new();
+        while let Some(event) = stream.next().await {
+            match event? {
+                LlmEvent::TextDelta { delta, .. } => deltas.push(delta),
+                LlmEvent::Done { .. } => break,
+                _ => {}
+            }
+        }
+        server.abort();
+
+        assert_eq!(deltas, vec!["Hello from Azure"]);
+        let headers = seen_headers.lock().expect("seen headers mutex");
+        let headers = headers.first().expect("captured Azure headers");
+        assert_eq!(
+            headers.get("api-key").and_then(|v| v.to_str().ok()),
+            Some("azure-key")
+        );
+        assert!(headers.get("authorization").is_none());
+        let bodies = seen.lock().expect("seen mutex");
+        let body = bodies.first().expect("captured Azure request body");
+        assert_eq!(body["model"], "gpt-5.5");
+        assert_eq!(body["stream"], true);
+        assert_eq!(body["store"], false);
+        assert!(body.get("max_output_tokens").is_some());
         Ok(())
     }
 

--- a/meerkat-openai/src/lib.rs
+++ b/meerkat-openai/src/lib.rs
@@ -20,7 +20,7 @@ pub mod runtime;
 pub mod text_adapter;
 pub mod web_search;
 
-pub use client::OpenAiClient;
+pub use client::{AzureOpenAiWireConfig, OpenAiClient};
 pub use client_compatible::OpenAiCompatibleClient;
 pub use image_generation::{
     OpenAiImageGenerationProfile, OpenAiImageOutputOptions, OpenAiImageProviderParams,

--- a/meerkat-openai/src/runtime/mod.rs
+++ b/meerkat-openai/src/runtime/mod.rs
@@ -97,7 +97,9 @@ fn azure_openai_base_url(configured: Option<&str>) -> Result<String, ProviderCli
         ));
     };
     let trimmed = raw.trim_end_matches('/');
-    if trimmed.ends_with("/openai") {
+    if let Some(base) = trimmed.strip_suffix("/openai/v1") {
+        Ok(format!("{base}/openai"))
+    } else if trimmed.ends_with("/openai") {
         Ok(trimmed.to_string())
     } else {
         Ok(format!("{trimmed}/openai"))
@@ -472,6 +474,13 @@ impl ProviderRuntime for OpenAiProviderRuntime {
                  — registry dispatch invariant violated"
             ),
         };
+        if matches!(backend_kind, OpenAiBackendKind::AzureOpenAi)
+            && azure_openai_wire_config(&connection)
+                .image_generation_deployment
+                .is_none()
+        {
+            return Ok(None);
+        }
         #[cfg(not(target_arch = "wasm32"))]
         if let Some(authorizer) = connection.resolved_authorizer() {
             let base_url = match backend_kind {
@@ -624,6 +633,23 @@ mod tests {
                 metadata,
                 None,
                 "openai:test",
+            )),
+        }
+    }
+
+    fn resolved_azure_connection(options: serde_json::Value) -> ResolvedConnection {
+        let mut backend = backend("azure_openai");
+        backend.base_url = Some("https://example.openai.azure.com".to_string());
+        backend.options = options;
+        ResolvedConnection {
+            provider: Provider::OpenAI,
+            backend: NormalizedBackendKind::OpenAi(OpenAiBackendKind::AzureOpenAi),
+            backend_profile: Arc::new(backend),
+            auth_lease: Arc::new(StaticLease::inline_secret(
+                "azure-api-key".into(),
+                AuthMetadata::default(),
+                None,
+                "openai:azure",
             )),
         }
     }
@@ -783,6 +809,10 @@ mod tests {
             azure_openai_base_url(Some("https://example.openai.azure.com/openai")).unwrap(),
             "https://example.openai.azure.com/openai"
         );
+        assert_eq!(
+            azure_openai_base_url(Some("https://example.openai.azure.com/openai/v1/")).unwrap(),
+            "https://example.openai.azure.com/openai"
+        );
     }
 
     #[test]
@@ -824,6 +854,32 @@ mod tests {
         )
         .expect("allowed combination");
         assert_eq!(vb.policy(), &policy);
+    }
+
+    #[test]
+    fn azure_openai_without_image_deployment_does_not_claim_image_executor() {
+        let executor = OpenAiProviderRuntime
+            .build_image_generation_executor(resolved_azure_connection(serde_json::Value::Null))
+            .expect("Azure text connection should build cleanly");
+
+        assert!(
+            executor.is_none(),
+            "Azure OpenAI should not shadow another OpenAI image binding unless image deployment is configured"
+        );
+    }
+
+    #[test]
+    fn azure_openai_with_image_deployment_claims_image_executor() {
+        let executor = OpenAiProviderRuntime
+            .build_image_generation_executor(resolved_azure_connection(serde_json::json!({
+                "image_generation_deployment": "gpt-image-2"
+            })))
+            .expect("Azure image-capable connection should build cleanly");
+
+        assert!(
+            executor.is_some(),
+            "Azure OpenAI image executor should remain available when image deployment is configured"
+        );
     }
 
     #[test]

--- a/meerkat-openai/src/runtime/mod.rs
+++ b/meerkat-openai/src/runtime/mod.rs
@@ -37,6 +37,8 @@ use meerkat_llm_core::provider_runtime::registry::ResolverEnvironment;
 use meerkat_llm_core::provider_runtime::runtime::ProviderRuntime;
 use meerkat_llm_core::{ImageGenerationExecutor, LlmClient};
 
+use crate::client::AzureOpenAiWireConfig;
+
 pub use meerkat_core::provider_matrix::openai::{OpenAiAuthMethod, OpenAiBackendKind};
 
 #[cfg(all(not(target_arch = "wasm32"), feature = "oauth"))]
@@ -85,6 +87,45 @@ fn chatgpt_backend_base_url(configured: Option<&str>) -> String {
         OpenAiBackendKind::ChatGptBackend.default_base_url().into()
     } else {
         trimmed.to_string()
+    }
+}
+
+fn azure_openai_base_url(configured: Option<&str>) -> Result<String, ProviderClientError> {
+    let Some(raw) = configured.map(str::trim).filter(|url| !url.is_empty()) else {
+        return Err(ProviderClientError::InvalidBaseUrl(
+            "azure_openai requires backend base_url".to_string(),
+        ));
+    };
+    let trimmed = raw.trim_end_matches('/');
+    if trimmed.ends_with("/openai") {
+        Ok(trimmed.to_string())
+    } else {
+        Ok(format!("{trimmed}/openai"))
+    }
+}
+
+fn backend_option_string(connection: &ResolvedConnection, key: &str) -> Option<String> {
+    connection
+        .backend_profile
+        .options
+        .get(key)
+        .and_then(serde_json::Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_string)
+}
+
+fn azure_openai_wire_config(connection: &ResolvedConnection) -> AzureOpenAiWireConfig {
+    AzureOpenAiWireConfig {
+        image_generation_deployment: backend_option_string(
+            connection,
+            "image_generation_deployment",
+        ),
+        image_generation_api_version: backend_option_string(
+            connection,
+            "image_generation_api_version",
+        )
+        .unwrap_or_else(|| "preview".to_string()),
     }
 }
 
@@ -153,7 +194,9 @@ impl ProviderRuntime for OpenAiProviderRuntime {
 
         let source_label = format!("openai:{}", binding.auth_profile().id);
         let lease: Arc<dyn AuthLease> = match auth_method {
-            OpenAiAuthMethod::ApiKey | OpenAiAuthMethod::StaticBearer => {
+            OpenAiAuthMethod::ApiKey
+            | OpenAiAuthMethod::AzureApiKey
+            | OpenAiAuthMethod::StaticBearer => {
                 let secret =
                     resolve_simple_secret(&binding.auth_profile().source, env, binding).await?;
                 let metadata = finalize_auth_metadata(binding, AuthMetadata::default())?;
@@ -356,6 +399,9 @@ impl ProviderRuntime for OpenAiProviderRuntime {
                 OpenAiBackendKind::ChatGptBackend => {
                     chatgpt_backend_base_url(connection.backend_profile.base_url.as_deref())
                 }
+                OpenAiBackendKind::AzureOpenAi => {
+                    azure_openai_base_url(connection.backend_profile.base_url.as_deref())?
+                }
                 OpenAiBackendKind::OpenAiApi => connection
                     .backend_profile
                     .base_url
@@ -367,6 +413,8 @@ impl ProviderRuntime for OpenAiProviderRuntime {
                     .with_authorizer(authorizer);
             if matches!(backend_kind, OpenAiBackendKind::ChatGptBackend) {
                 client = client.with_chatgpt_backend_wire();
+            } else if matches!(backend_kind, OpenAiBackendKind::AzureOpenAi) {
+                client = client.with_azure_openai_wire(azure_openai_wire_config(&connection));
             }
             return Ok(Arc::new(client));
         }
@@ -403,6 +451,13 @@ impl ProviderRuntime for OpenAiProviderRuntime {
                     .with_chatgpt_backend_wire();
                 Ok(Arc::new(client))
             }
+            OpenAiBackendKind::AzureOpenAi => {
+                let base_url =
+                    azure_openai_base_url(connection.backend_profile.base_url.as_deref())?;
+                let client = crate::OpenAiClient::new_with_base_url(secret, base_url)
+                    .with_azure_openai_wire(azure_openai_wire_config(&connection));
+                Ok(Arc::new(client))
+            }
         }
     }
 
@@ -423,6 +478,9 @@ impl ProviderRuntime for OpenAiProviderRuntime {
                 OpenAiBackendKind::ChatGptBackend => {
                     chatgpt_backend_base_url(connection.backend_profile.base_url.as_deref())
                 }
+                OpenAiBackendKind::AzureOpenAi => {
+                    azure_openai_base_url(connection.backend_profile.base_url.as_deref())?
+                }
                 OpenAiBackendKind::OpenAiApi => connection
                     .backend_profile
                     .base_url
@@ -434,6 +492,8 @@ impl ProviderRuntime for OpenAiProviderRuntime {
                     .with_authorizer(authorizer);
             if matches!(backend_kind, OpenAiBackendKind::ChatGptBackend) {
                 client = client.with_chatgpt_backend_wire();
+            } else if matches!(backend_kind, OpenAiBackendKind::AzureOpenAi) {
+                client = client.with_azure_openai_wire(azure_openai_wire_config(&connection));
             }
             return Ok(Some(Arc::new(client)));
         }
@@ -458,6 +518,12 @@ impl ProviderRuntime for OpenAiProviderRuntime {
                 crate::OpenAiClient::new_with_base_url(secret, base_url)
                     .with_extra_headers(chatgpt_backend_extra_headers(&connection))
                     .with_chatgpt_backend_wire()
+            }
+            OpenAiBackendKind::AzureOpenAi => {
+                let base_url =
+                    azure_openai_base_url(connection.backend_profile.base_url.as_deref())?;
+                crate::OpenAiClient::new_with_base_url(secret, base_url)
+                    .with_azure_openai_wire(azure_openai_wire_config(&connection))
             }
         };
         Ok(Some(Arc::new(client)))
@@ -496,6 +562,14 @@ mod tests {
         assert!(ProviderRuntimeCatalog::supports(
             NormalizedBackendKind::OpenAi(OpenAiBackendKind::ChatGptBackend),
             NormalizedAuthMethod::OpenAi(OpenAiAuthMethod::ManagedChatGptOauth),
+        ));
+        assert!(ProviderRuntimeCatalog::supports(
+            NormalizedBackendKind::OpenAi(OpenAiBackendKind::AzureOpenAi),
+            NormalizedAuthMethod::OpenAi(OpenAiAuthMethod::AzureApiKey),
+        ));
+        assert!(!ProviderRuntimeCatalog::supports(
+            NormalizedBackendKind::OpenAi(OpenAiBackendKind::AzureOpenAi),
+            NormalizedAuthMethod::OpenAi(OpenAiAuthMethod::ApiKey),
         ));
     }
 
@@ -656,6 +730,22 @@ mod tests {
     }
 
     #[test]
+    fn typed_catalog_validate_accepts_azure_openai_combination() {
+        let vb = ProviderRuntimeCatalog::validate_binding(
+            &auth_binding(),
+            &backend("azure_openai"),
+            &auth("azure_api_key"),
+            &BindingPolicy::default(),
+        )
+        .expect("allowed Azure OpenAI combination");
+        assert_eq!(vb.provider(), Provider::OpenAI);
+        assert_eq!(
+            vb.backend(),
+            NormalizedBackendKind::OpenAi(OpenAiBackendKind::AzureOpenAi)
+        );
+    }
+
+    #[test]
     fn typed_catalog_validate_rejects_unknown_backend_kind() {
         let err = ProviderRuntimeCatalog::validate_binding(
             &auth_binding(),
@@ -681,6 +771,26 @@ mod tests {
             err,
             ProviderBindingError::UnsupportedCombination { .. }
         ));
+    }
+
+    #[test]
+    fn azure_openai_base_url_normalizes_resource_endpoint() {
+        assert_eq!(
+            azure_openai_base_url(Some("https://example.openai.azure.com/")).unwrap(),
+            "https://example.openai.azure.com/openai"
+        );
+        assert_eq!(
+            azure_openai_base_url(Some("https://example.openai.azure.com/openai")).unwrap(),
+            "https://example.openai.azure.com/openai"
+        );
+    }
+
+    #[test]
+    fn azure_openai_base_url_rejects_missing_value() {
+        let err = azure_openai_base_url(None).unwrap_err();
+        assert!(matches!(err, ProviderClientError::InvalidBaseUrl(_)));
+        let err = azure_openai_base_url(Some("   ")).unwrap_err();
+        assert!(matches!(err, ProviderClientError::InvalidBaseUrl(_)));
     }
 
     #[test]

--- a/meerkat/src/factory.rs
+++ b/meerkat/src/factory.rs
@@ -92,7 +92,7 @@ use crate::compose_tools_with_comms;
 #[cfg(not(target_arch = "wasm32"))]
 use crate::{create_default_hook_engine, resolve_layered_hooks_config};
 
-#[cfg(feature = "openai")]
+#[cfg(all(feature = "openai", feature = "openai-realtime"))]
 fn is_azure_openai_connection(connection: &meerkat_providers::ResolvedConnection) -> bool {
     matches!(
         connection.backend,

--- a/meerkat/src/factory.rs
+++ b/meerkat/src/factory.rs
@@ -92,6 +92,16 @@ use crate::compose_tools_with_comms;
 #[cfg(not(target_arch = "wasm32"))]
 use crate::{create_default_hook_engine, resolve_layered_hooks_config};
 
+#[cfg(feature = "openai")]
+fn is_azure_openai_connection(connection: &meerkat_providers::ResolvedConnection) -> bool {
+    matches!(
+        connection.backend,
+        meerkat_providers::NormalizedBackendKind::OpenAi(
+            meerkat_core::provider_matrix::OpenAiBackendKind::AzureOpenAi
+        )
+    )
+}
+
 /// Ephemeral in-process store used when no storage backend feature is enabled.
 #[cfg(not(feature = "memory-store"))]
 #[derive(Default)]
@@ -1677,6 +1687,12 @@ impl AgentFactory {
             .resolve(&realm, &auth_binding, &env)
             .await
             .map_err(|e| BuildAgentError::ConnectionResolution(e.to_string()))?;
+        if is_azure_openai_connection(&connection) {
+            return Err(BuildAgentError::ConnectionResolution(
+                "azure_openai does not support the OpenAI realtime sideband in Meerkat v1"
+                    .to_string(),
+            ));
+        }
         let secret = connection.resolved_secret().ok_or_else(|| {
             BuildAgentError::ConnectionResolution(
                 "OpenAI realtime sideband requires resolved inline credential material".to_string(),
@@ -3427,6 +3443,14 @@ impl AgentFactory {
                         }
                         #[cfg(feature = "openai-realtime")]
                         if realtime_route {
+                            if is_azure_openai_connection(&connection) {
+                                return Err(BuildAgentError::ConnectionResolution(format!(
+                                    "model '{}' advertises ModelCapabilities.realtime=true, \
+                                     but azure_openai does not support the OpenAI realtime \
+                                     text adapter in Meerkat v1",
+                                    build_config.model
+                                )));
+                            }
                             let secret = connection.resolved_secret().ok_or_else(|| {
                                 BuildAgentError::ConnectionResolution(
                                     "openai realtime text adapter requires an inline API key (\

--- a/sdks/web/src/generated/auth.ts
+++ b/sdks/web/src/generated/auth.ts
@@ -13,6 +13,7 @@ export type WireAuthProvider = typeof WIRE_AUTH_PROVIDERS[number];
 export const WIRE_BACKEND_KINDS = [
   "openai_api",
   "chatgpt_backend",
+  "azure_openai",
   "anthropic_api",
   "bedrock",
   "vertex",
@@ -28,6 +29,7 @@ export type WireBackendKind = typeof WIRE_BACKEND_KINDS[number];
 
 export const WIRE_AUTH_METHODS = [
   "api_key",
+  "azure_api_key",
   "static_bearer",
   "managed_chatgpt_oauth",
   "external_chatgpt_tokens",
@@ -59,6 +61,7 @@ export const WIRE_PROVIDER_BACKEND_KINDS = {
   openai: [
     "openai_api",
     "chatgpt_backend",
+    "azure_openai",
   ],
   gemini: [
     "google_genai",
@@ -86,6 +89,7 @@ export const WIRE_PROVIDER_AUTH_METHODS = {
   ],
   openai: [
     "api_key",
+    "azure_api_key",
     "static_bearer",
     "managed_chatgpt_oauth",
     "external_chatgpt_tokens",


### PR DESCRIPTION
## Summary
- Add `azure_openai` backend and `azure_api_key` auth under the OpenAI provider matrix.
- Wire Azure Responses auth/path behavior, hosted image-generation deployment headers, and explicit realtime rejection.
- Add Azure env-default support via `AZURE_OPENAI_API_KEY` + `AZURE_OPENAI_ENDPOINT`, plus docs, schema, and generated web auth updates.

## Validation
- `make check`
- `make fmt-check`
- `make docs-check`
- `make regen-schemas`
- `./scripts/repo-cargo test -p meerkat-core provider_matrix::openai --lib`
- `./scripts/repo-cargo test -p meerkat-core env_default_openai --lib`
- `./scripts/repo-cargo test -p meerkat-llm-core provider_runtime::catalog --lib`
- `./scripts/repo-cargo test -p meerkat-openai azure_openai --lib`
- `./scripts/repo-cargo test -p meerkat-openai runtime::tests::typed_catalog --lib`
- `./scripts/repo-cargo test -p meerkat-openai chatgpt_backend --lib`
- `./scripts/repo-cargo test -p meerkat-openai openai_hosted_image --lib`
- `./scripts/repo-cargo test -p meerkat-auth-core azure_openai_api_key_uses_api_key_token_store_mode --lib`
- `./scripts/repo-cargo check -p rkat`
- `./scripts/repo-cargo check -p meerkat --features openai-realtime`
- `git diff --check`

## Notes
- Azure AD auth remains out of scope for this V1.
- Azure realtime is intentionally rejected with a clear error.
