### PR TITLE
[codex] Fix WorkGraph and delegate runtime gaps

### DIFF
--- a/meerkat-cli/src/main.rs
+++ b/meerkat-cli/src/main.rs
@@ -6981,6 +6981,55 @@ impl meerkat_mob::MobSessionService for RunMobSessionService {
         .await
     }
 
+    async fn execution_snapshot(
+        &self,
+        session_id: &SessionId,
+    ) -> Result<Option<meerkat_core::AgentExecutionSnapshot>, meerkat_core::service::SessionError>
+    {
+        <EphemeralSessionService<FactoryAgentBuilder> as meerkat_mob::MobSessionService>::execution_snapshot(
+            &self.inner,
+            session_id,
+        )
+        .await
+    }
+
+    async fn tool_scope_snapshot(
+        &self,
+        session_id: &SessionId,
+    ) -> Result<Option<meerkat_core::ToolScopeSnapshot>, meerkat_core::service::SessionError> {
+        <EphemeralSessionService<FactoryAgentBuilder> as meerkat_mob::MobSessionService>::tool_scope_snapshot(
+            &self.inner,
+            session_id,
+        )
+        .await
+    }
+
+    async fn external_tool_surface_snapshot(
+        &self,
+        session_id: &SessionId,
+    ) -> Result<
+        Option<meerkat_core::ExternalToolSurfaceSnapshot>,
+        meerkat_core::service::SessionError,
+    > {
+        <EphemeralSessionService<FactoryAgentBuilder> as meerkat_mob::MobSessionService>::external_tool_surface_snapshot(
+            &self.inner,
+            session_id,
+        )
+        .await
+    }
+
+    async fn peer_ingress_runtime_snapshot(
+        &self,
+        session_id: &SessionId,
+    ) -> Result<Option<meerkat_core::PeerIngressRuntimeSnapshot>, meerkat_core::service::SessionError>
+    {
+        <EphemeralSessionService<FactoryAgentBuilder> as meerkat_mob::MobSessionService>::peer_ingress_runtime_snapshot(
+            &self.inner,
+            session_id,
+        )
+        .await
+    }
+
     async fn apply_runtime_turn(
         &self,
         session_id: &SessionId,
@@ -6999,6 +7048,72 @@ impl meerkat_mob::MobSessionService for RunMobSessionService {
             req,
             boundary,
             contributing_input_ids,
+        )
+        .await
+    }
+
+    async fn apply_runtime_context_appends(
+        &self,
+        session_id: &SessionId,
+        run_id: meerkat_core::RunId,
+        appends: Vec<meerkat_core::PendingSystemContextAppend>,
+        contributing_input_ids: Vec<meerkat_core::InputId>,
+    ) -> Result<
+        meerkat_core::lifecycle::core_executor::CoreApplyOutput,
+        meerkat_core::service::SessionError,
+    > {
+        <EphemeralSessionService<FactoryAgentBuilder> as meerkat_mob::MobSessionService>::apply_runtime_context_appends(
+            &self.inner,
+            session_id,
+            run_id,
+            appends,
+            contributing_input_ids,
+        )
+        .await
+    }
+
+    async fn apply_runtime_context_appends_with_boundary(
+        &self,
+        session_id: &SessionId,
+        run_id: meerkat_core::RunId,
+        appends: Vec<meerkat_core::PendingSystemContextAppend>,
+        boundary: meerkat_core::lifecycle::run_primitive::RunApplyBoundary,
+        contributing_input_ids: Vec<meerkat_core::InputId>,
+    ) -> Result<
+        meerkat_core::lifecycle::core_executor::CoreApplyOutput,
+        meerkat_core::service::SessionError,
+    > {
+        <EphemeralSessionService<FactoryAgentBuilder> as meerkat_mob::MobSessionService>::apply_runtime_context_appends_with_boundary(
+            &self.inner,
+            session_id,
+            run_id,
+            appends,
+            boundary,
+            contributing_input_ids,
+        )
+        .await
+    }
+
+    async fn apply_runtime_system_context_for_turn(
+        &self,
+        session_id: &SessionId,
+        appends: Vec<meerkat_core::PendingSystemContextAppend>,
+    ) -> Result<(), meerkat_core::service::SessionError> {
+        <EphemeralSessionService<FactoryAgentBuilder> as meerkat_mob::MobSessionService>::apply_runtime_system_context_for_turn(
+            &self.inner,
+            session_id,
+            appends,
+        )
+        .await
+    }
+
+    async fn discard_live_session(
+        &self,
+        session_id: &SessionId,
+    ) -> Result<(), meerkat_core::service::SessionError> {
+        <EphemeralSessionService<FactoryAgentBuilder> as meerkat_mob::MobSessionService>::discard_live_session(
+            &self.inner,
+            session_id,
         )
         .await
     }
@@ -9368,6 +9483,66 @@ impl meerkat_mob::MobSessionService for MobCliSessionService {
         .await
     }
 
+    async fn load_persisted_session(
+        &self,
+        session_id: &SessionId,
+    ) -> Result<Option<Session>, meerkat_core::service::SessionError> {
+        <meerkat::PersistentSessionService<FactoryAgentBuilder> as meerkat_mob::MobSessionService>::load_persisted_session(
+            &self.inner,
+            session_id,
+        )
+        .await
+    }
+
+    async fn execution_snapshot(
+        &self,
+        session_id: &SessionId,
+    ) -> Result<Option<meerkat_core::AgentExecutionSnapshot>, meerkat_core::service::SessionError>
+    {
+        <meerkat::PersistentSessionService<FactoryAgentBuilder> as meerkat_mob::MobSessionService>::execution_snapshot(
+            &self.inner,
+            session_id,
+        )
+        .await
+    }
+
+    async fn tool_scope_snapshot(
+        &self,
+        session_id: &SessionId,
+    ) -> Result<Option<meerkat_core::ToolScopeSnapshot>, meerkat_core::service::SessionError> {
+        <meerkat::PersistentSessionService<FactoryAgentBuilder> as meerkat_mob::MobSessionService>::tool_scope_snapshot(
+            &self.inner,
+            session_id,
+        )
+        .await
+    }
+
+    async fn external_tool_surface_snapshot(
+        &self,
+        session_id: &SessionId,
+    ) -> Result<
+        Option<meerkat_core::ExternalToolSurfaceSnapshot>,
+        meerkat_core::service::SessionError,
+    > {
+        <meerkat::PersistentSessionService<FactoryAgentBuilder> as meerkat_mob::MobSessionService>::external_tool_surface_snapshot(
+            &self.inner,
+            session_id,
+        )
+        .await
+    }
+
+    async fn peer_ingress_runtime_snapshot(
+        &self,
+        session_id: &SessionId,
+    ) -> Result<Option<meerkat_core::PeerIngressRuntimeSnapshot>, meerkat_core::service::SessionError>
+    {
+        <meerkat::PersistentSessionService<FactoryAgentBuilder> as meerkat_mob::MobSessionService>::peer_ingress_runtime_snapshot(
+            &self.inner,
+            session_id,
+        )
+        .await
+    }
+
     async fn apply_runtime_turn(
         &self,
         session_id: &SessionId,
@@ -9386,6 +9561,72 @@ impl meerkat_mob::MobSessionService for MobCliSessionService {
             req,
             boundary,
             contributing_input_ids,
+        )
+        .await
+    }
+
+    async fn apply_runtime_context_appends(
+        &self,
+        session_id: &SessionId,
+        run_id: meerkat_core::RunId,
+        appends: Vec<meerkat_core::PendingSystemContextAppend>,
+        contributing_input_ids: Vec<meerkat_core::InputId>,
+    ) -> Result<
+        meerkat_core::lifecycle::core_executor::CoreApplyOutput,
+        meerkat_core::service::SessionError,
+    > {
+        <meerkat::PersistentSessionService<FactoryAgentBuilder> as meerkat_mob::MobSessionService>::apply_runtime_context_appends(
+            &self.inner,
+            session_id,
+            run_id,
+            appends,
+            contributing_input_ids,
+        )
+        .await
+    }
+
+    async fn apply_runtime_context_appends_with_boundary(
+        &self,
+        session_id: &SessionId,
+        run_id: meerkat_core::RunId,
+        appends: Vec<meerkat_core::PendingSystemContextAppend>,
+        boundary: meerkat_core::lifecycle::run_primitive::RunApplyBoundary,
+        contributing_input_ids: Vec<meerkat_core::InputId>,
+    ) -> Result<
+        meerkat_core::lifecycle::core_executor::CoreApplyOutput,
+        meerkat_core::service::SessionError,
+    > {
+        <meerkat::PersistentSessionService<FactoryAgentBuilder> as meerkat_mob::MobSessionService>::apply_runtime_context_appends_with_boundary(
+            &self.inner,
+            session_id,
+            run_id,
+            appends,
+            boundary,
+            contributing_input_ids,
+        )
+        .await
+    }
+
+    async fn apply_runtime_system_context_for_turn(
+        &self,
+        session_id: &SessionId,
+        appends: Vec<meerkat_core::PendingSystemContextAppend>,
+    ) -> Result<(), meerkat_core::service::SessionError> {
+        <meerkat::PersistentSessionService<FactoryAgentBuilder> as meerkat_mob::MobSessionService>::apply_runtime_system_context_for_turn(
+            &self.inner,
+            session_id,
+            appends,
+        )
+        .await
+    }
+
+    async fn discard_live_session(
+        &self,
+        session_id: &SessionId,
+    ) -> Result<(), meerkat_core::service::SessionError> {
+        <meerkat::PersistentSessionService<FactoryAgentBuilder> as meerkat_mob::MobSessionService>::discard_live_session(
+            &self.inner,
+            session_id,
         )
         .await
     }
@@ -16636,6 +16877,32 @@ capabilities = ["definitely_missing_capability"]
             .await
             .expect("deferred run mob session should be created");
 
+        let expected_tool_scope = service
+            .tool_scope_snapshot(&created.session_id)
+            .await
+            .expect("inner service should read tool scope");
+        let wrapper_tool_scope =
+            <RunMobSessionService as meerkat_mob::MobSessionService>::tool_scope_snapshot(
+                &wrapper,
+                &created.session_id,
+            )
+            .await
+            .expect("run mob wrapper should forward tool scope snapshots");
+        assert_eq!(wrapper_tool_scope.is_some(), expected_tool_scope.is_some());
+
+        let expected_execution = service
+            .execution_snapshot(&created.session_id)
+            .await
+            .expect("inner service should read execution snapshot");
+        let wrapper_execution =
+            <RunMobSessionService as meerkat_mob::MobSessionService>::execution_snapshot(
+                &wrapper,
+                &created.session_id,
+            )
+            .await
+            .expect("run mob wrapper should forward execution snapshots");
+        assert_eq!(wrapper_execution.is_some(), expected_execution.is_some());
+
         let output = <RunMobSessionService as meerkat_mob::MobSessionService>::apply_runtime_turn(
             &wrapper,
             &created.session_id,
@@ -16729,6 +16996,32 @@ capabilities = ["definitely_missing_capability"]
             })
             .await
             .expect("deferred persistent mob session should be created");
+
+        let expected_tool_scope = service
+            .tool_scope_snapshot(&created.session_id)
+            .await
+            .expect("inner service should read tool scope");
+        let wrapper_tool_scope =
+            <MobCliSessionService as meerkat_mob::MobSessionService>::tool_scope_snapshot(
+                &wrapper,
+                &created.session_id,
+            )
+            .await
+            .expect("persistent mob wrapper should forward tool scope snapshots");
+        assert_eq!(wrapper_tool_scope.is_some(), expected_tool_scope.is_some());
+
+        let expected_execution = service
+            .execution_snapshot(&created.session_id)
+            .await
+            .expect("inner service should read execution snapshot");
+        let wrapper_execution =
+            <MobCliSessionService as meerkat_mob::MobSessionService>::execution_snapshot(
+                &wrapper,
+                &created.session_id,
+            )
+            .await
+            .expect("persistent mob wrapper should forward execution snapshots");
+        assert_eq!(wrapper_execution.is_some(), expected_execution.is_some());
 
         let output = <MobCliSessionService as meerkat_mob::MobSessionService>::apply_runtime_turn(
             &wrapper,

--- a/meerkat-mob/src/mob_machine.rs
+++ b/meerkat-mob/src/mob_machine.rs
@@ -151,6 +151,18 @@ pub(crate) enum MobMachineCommand {
     },
 }
 
+/// Runtime-shell acknowledgement policy for an admitted SubmitWork command.
+///
+/// This does not decide whether the mob machine accepts the transition. It only
+/// selects how long the runtime actor waits while realizing the admitted effect.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum SubmitWorkAckMode {
+    /// Return once the turn has been accepted by the runtime/session ingress.
+    IngressAccepted,
+    /// Return after the member turn completes.
+    TurnCompleted,
+}
+
 /// Payload for [`MobMachineCommand::SubmitWork`].
 pub(crate) struct SubmitWorkCommand {
     pub runtime_id: AgentRuntimeId,
@@ -159,6 +171,7 @@ pub(crate) struct SubmitWorkCommand {
     pub spec: WorkSpec,
     pub handling_mode: meerkat_core::types::HandlingMode,
     pub render_metadata: Option<meerkat_core::types::RenderMetadata>,
+    pub ack_mode: SubmitWorkAckMode,
 }
 
 #[allow(clippy::large_enum_variant)]

--- a/meerkat-mob/src/runtime/actor.rs
+++ b/meerkat-mob/src/runtime/actor.rs
@@ -44,6 +44,29 @@ impl InitialTurnHandle {
 const MAX_PARALLEL_REMOTE_MEMBER_TEARDOWNS: usize = 64;
 const MAX_LIFECYCLE_NOTIFICATION_TASKS: usize = 16;
 
+fn observed_runtime_id(signal: &mob_dsl::MobMachineSignal) -> Option<&mob_dsl::AgentRuntimeId> {
+    match signal {
+        mob_dsl::MobMachineSignal::ObserveRuntimeReady {
+            agent_runtime_id, ..
+        }
+        | mob_dsl::MobMachineSignal::ObserveRuntimeRetired {
+            agent_runtime_id, ..
+        }
+        | mob_dsl::MobMachineSignal::ObserveRuntimeDestroyed {
+            agent_runtime_id, ..
+        } => Some(agent_runtime_id),
+        _ => None,
+    }
+}
+
+fn foreign_runtime_observation<'a>(
+    state: &mob_dsl::MobMachineState,
+    signal: &'a mob_dsl::MobMachineSignal,
+) -> Option<&'a mob_dsl::AgentRuntimeId> {
+    let agent_runtime_id = observed_runtime_id(signal)?;
+    (!state.live_runtime_ids.contains(agent_runtime_id)).then_some(agent_runtime_id)
+}
+
 #[derive(Clone)]
 enum WiringEndpoint {
     Local {
@@ -3287,11 +3310,21 @@ impl MobActor {
                     let _ = reply_tx.send(self.dsl_authority.state.clone());
                 }
                 MobCommand::ProjectMachineSignal { signal } => {
+                    let foreign_runtime_id =
+                        foreign_runtime_observation(&self.dsl_authority.state, &signal).cloned();
                     if let Err(error) = self.apply_dsl_signal(signal, "project_machine_signal") {
-                        tracing::error!(
-                            error = %error,
-                            "typed composition signal projection failed"
-                        );
+                        if let Some(agent_runtime_id) = foreign_runtime_id {
+                            tracing::debug!(
+                                ?agent_runtime_id,
+                                error = %error,
+                                "ignored foreign runtime lifecycle observation"
+                            );
+                        } else {
+                            tracing::error!(
+                                error = %error,
+                                "typed composition signal projection failed"
+                            );
+                        }
                     }
                 }
                 MobCommand::FlowFinished { run_id } => {
@@ -11774,6 +11807,36 @@ impl MobActor {
             sender_comms,
         )
         .await
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used)]
+mod runtime_observation_tests {
+    use super::{foreign_runtime_observation, mob_dsl};
+
+    #[test]
+    fn foreign_runtime_observations_are_identified_for_log_downgrade() {
+        let state = mob_dsl::MobMachineState::default();
+        let signal = mob_dsl::MobMachineSignal::ObserveRuntimeReady {
+            agent_runtime_id: mob_dsl::AgentRuntimeId("rt:session:parent".to_string()),
+            fence_token: mob_dsl::FenceToken(0),
+        };
+
+        assert!(foreign_runtime_observation(&state, &signal).is_some());
+    }
+
+    #[test]
+    fn live_member_runtime_observations_remain_machine_owned() {
+        let runtime_id = mob_dsl::AgentRuntimeId("member:0".to_string());
+        let mut state = mob_dsl::MobMachineState::default();
+        state.live_runtime_ids.insert(runtime_id.clone());
+        let signal = mob_dsl::MobMachineSignal::ObserveRuntimeReady {
+            agent_runtime_id: runtime_id,
+            fence_token: mob_dsl::FenceToken(1),
+        };
+
+        assert!(foreign_runtime_observation(&state, &signal).is_none());
     }
 }
 

--- a/meerkat-mob/src/runtime/actor.rs
+++ b/meerkat-mob/src/runtime/actor.rs
@@ -9967,6 +9967,7 @@ impl MobActor {
             origin,
             handling_mode,
             render_metadata,
+            ack_mode,
         } = *payload;
         self.ensure_pending_spawn_alignment("handle_submit_work preflight")?;
 
@@ -10116,7 +10117,7 @@ impl MobActor {
             ));
         }
 
-        self.dispatch_member_turn(&entry, content, handling_mode, render_metadata)
+        self.dispatch_member_turn(&entry, content, handling_mode, render_metadata, ack_mode)
             .await
     }
 
@@ -10195,6 +10196,7 @@ impl MobActor {
         content: ContentInput,
         handling_mode: meerkat_core::types::HandlingMode,
         render_metadata: Option<meerkat_core::types::RenderMetadata>,
+        ack_mode: crate::mob_machine::SubmitWorkAckMode,
     ) -> Result<(), MobError> {
         self.ensure_pending_spawn_alignment("dispatch_member_turn preflight")?;
         match entry.runtime_mode {
@@ -10245,7 +10247,14 @@ impl MobActor {
                         None,
                     ),
                 };
-                self.provisioner.start_turn(&entry.member_ref, req).await?;
+                match ack_mode {
+                    crate::mob_machine::SubmitWorkAckMode::IngressAccepted => {
+                        self.provisioner.admit_turn(&entry.member_ref, req).await?;
+                    }
+                    crate::mob_machine::SubmitWorkAckMode::TurnCompleted => {
+                        self.provisioner.start_turn(&entry.member_ref, req).await?;
+                    }
+                }
                 Ok(())
             }
         }

--- a/meerkat-mob/src/runtime/handle.rs
+++ b/meerkat-mob/src/runtime/handle.rs
@@ -1366,6 +1366,7 @@ impl MobHandle {
                     spec,
                     handling_mode,
                     render_metadata,
+                    ack_mode,
                 } = *cmd;
                 let receipt_work_ref = work_ref.clone();
                 let payload = Box::new(super::state::SubmitWorkPayload {
@@ -1376,6 +1377,7 @@ impl MobHandle {
                     origin: spec.origin,
                     handling_mode,
                     render_metadata,
+                    ack_mode,
                 });
                 self.send_actor_command(|reply_tx| MobCommand::SubmitWork { payload, reply_tx })
                     .await??;
@@ -2771,6 +2773,7 @@ impl MobHandle {
             spec: WorkSpec::new(message, WorkOrigin::External),
             handling_mode,
             render_metadata,
+            ack_mode: crate::mob_machine::SubmitWorkAckMode::IngressAccepted,
         });
         self.execute_machine_command(MobMachineCommand::SubmitWork(cmd))
             .await?;
@@ -2805,6 +2808,7 @@ impl MobHandle {
             spec: WorkSpec::new(message, WorkOrigin::Internal),
             handling_mode: HandlingMode::Queue,
             render_metadata: None,
+            ack_mode: crate::mob_machine::SubmitWorkAckMode::TurnCompleted,
         });
         self.execute_machine_command(MobMachineCommand::SubmitWork(cmd))
             .await?;
@@ -2835,6 +2839,7 @@ impl MobHandle {
             spec,
             handling_mode: HandlingMode::Queue,
             render_metadata: None,
+            ack_mode: crate::mob_machine::SubmitWorkAckMode::IngressAccepted,
         });
         match self
             .execute_machine_command(MobMachineCommand::SubmitWork(cmd))

--- a/meerkat-mob/src/runtime/provision_guard.rs
+++ b/meerkat-mob/src/runtime/provision_guard.rs
@@ -184,6 +184,14 @@ mod tests {
             Ok(())
         }
 
+        async fn admit_turn(
+            &self,
+            _member_ref: &MemberRef,
+            _req: StartTurnRequest,
+        ) -> Result<(), MobError> {
+            Ok(())
+        }
+
         async fn interaction_event_injector(
             &self,
             _session_id: &SessionId,

--- a/meerkat-mob/src/runtime/provisioner.rs
+++ b/meerkat-mob/src/runtime/provisioner.rs
@@ -146,6 +146,11 @@ pub trait MobProvisioner: Send + Sync {
         member_ref: &MemberRef,
         req: StartTurnRequest,
     ) -> Result<(), MobError>;
+    async fn admit_turn(
+        &self,
+        member_ref: &MemberRef,
+        req: StartTurnRequest,
+    ) -> Result<(), MobError>;
     async fn start_flow_step(
         &self,
         member_ref: &MemberRef,
@@ -462,6 +467,38 @@ impl SessionBackend {
         }
 
         runtime_completion_to_mob_result(session_id, completion)
+    }
+
+    fn runtime_input_from_turn_request(req: &StartTurnRequest) -> Input {
+        let turn_metadata = meerkat_core::lifecycle::run_primitive::RuntimeTurnMetadata {
+            handling_mode: Some(req.runtime.handling_mode),
+            keep_alive: None,
+            skill_references: req.runtime.skill_references.clone(),
+            flow_tool_overlay: req.runtime.flow_tool_overlay.clone(),
+            render_metadata: req.runtime.render_metadata.clone(),
+            ..Default::default()
+        };
+        let prompt = req.prompt.clone();
+        Input::Prompt(PromptInput {
+            header: InputHeader {
+                id: meerkat_core::InputId::new(),
+                timestamp: chrono::Utc::now(),
+                source: InputOrigin::Operator,
+                durability: InputDurability::Durable,
+                visibility: InputVisibility::default(),
+                idempotency_key: None,
+                supersession_key: None,
+                correlation_id: None,
+            },
+            text: prompt.text_content(),
+            blocks: if prompt.has_images() {
+                Some(prompt.into_blocks())
+            } else {
+                None
+            },
+            typed_turn_appends: req.runtime.typed_turn_appends.clone(),
+            turn_metadata: Some(turn_metadata),
+        })
     }
 
     async fn admit_runtime_input(
@@ -1463,35 +1500,7 @@ impl MobProvisioner for SessionBackend {
             self.ops_adapter
                 .report_member_progress(member_ref, "turn dispatched")
                 .await?;
-            let turn_metadata = meerkat_core::lifecycle::run_primitive::RuntimeTurnMetadata {
-                handling_mode: Some(req.runtime.handling_mode),
-                keep_alive: None,
-                skill_references: req.runtime.skill_references.clone(),
-                flow_tool_overlay: req.runtime.flow_tool_overlay.clone(),
-                render_metadata: req.runtime.render_metadata.clone(),
-                ..Default::default()
-            };
-            let prompt = req.prompt.clone();
-            let input = Input::Prompt(PromptInput {
-                header: InputHeader {
-                    id: meerkat_core::InputId::new(),
-                    timestamp: chrono::Utc::now(),
-                    source: InputOrigin::Operator,
-                    durability: InputDurability::Durable,
-                    visibility: InputVisibility::default(),
-                    idempotency_key: None,
-                    supersession_key: None,
-                    correlation_id: None,
-                },
-                text: prompt.text_content(),
-                blocks: if prompt.has_images() {
-                    Some(prompt.into_blocks())
-                } else {
-                    None
-                },
-                typed_turn_appends: req.runtime.typed_turn_appends.clone(),
-                turn_metadata: Some(turn_metadata),
-            });
+            let input = Self::runtime_input_from_turn_request(&req);
             return self
                 .execute_runtime_input(&session_id, input, req.event_tx)
                 .await;
@@ -1502,6 +1511,42 @@ impl MobProvisioner for SessionBackend {
             .await
             .map(|_| ())
             .map_err(|error| session_turn_error_to_mob_error(&session_id, error))
+    }
+
+    async fn admit_turn(
+        &self,
+        member_ref: &MemberRef,
+        req: StartTurnRequest,
+    ) -> Result<(), MobError> {
+        let session_id = Self::require_session(member_ref, "admit turn")?;
+        if self.runtime_adapter.is_some() {
+            self.ops_adapter
+                .report_member_progress(member_ref, "turn dispatched")
+                .await?;
+            let input = Self::runtime_input_from_turn_request(&req);
+            return self
+                .admit_runtime_input(&session_id, input, req.event_tx)
+                .await;
+        }
+
+        let session_service = self.session_service.clone();
+        let task_session_id = session_id.clone();
+        let mut task = tokio::spawn(async move {
+            session_service
+                .start_turn(&task_session_id, req)
+                .await
+                .map(|_| ())
+                .map_err(|error| session_turn_error_to_mob_error(&task_session_id, error))
+        });
+
+        tokio::select! {
+            result = &mut task => {
+                result.map_err(|error| {
+                    MobError::Internal(format!("turn admission task failed: {error}"))
+                })?
+            }
+            () = tokio::task::yield_now() => Ok(()),
+        }
     }
 
     async fn start_flow_step(
@@ -2341,6 +2386,19 @@ impl MobProvisioner for MultiBackendProvisioner {
                 Ok(())
             }
             _ => self.session.start_turn(member_ref, req).await,
+        }
+    }
+
+    async fn admit_turn(
+        &self,
+        member_ref: &MemberRef,
+        req: StartTurnRequest,
+    ) -> Result<(), MobError> {
+        match member_ref {
+            MemberRef::BackendPeer {
+                session_id: None, ..
+            } => self.start_turn(member_ref, req).await,
+            _ => self.session.admit_turn(member_ref, req).await,
         }
     }
 

--- a/meerkat-mob/src/runtime/state.rs
+++ b/meerkat-mob/src/runtime/state.rs
@@ -155,6 +155,7 @@ pub(super) struct SubmitWorkPayload {
     pub origin: WorkOrigin,
     pub handling_mode: meerkat_core::types::HandlingMode,
     pub render_metadata: Option<meerkat_core::types::RenderMetadata>,
+    pub ack_mode: crate::mob_machine::SubmitWorkAckMode,
 }
 
 // ---------------------------------------------------------------------------

--- a/meerkat-mob/src/runtime/tests.rs
+++ b/meerkat-mob/src/runtime/tests.rs
@@ -17651,7 +17651,7 @@ async fn test_external_turn_turn_driven_mode_uses_start_turn_dispatch() {
 }
 
 #[tokio::test]
-async fn test_runtime_backed_turn_driven_dispatch_surfaces_start_turn_failure() {
+async fn test_runtime_backed_turn_driven_dispatch_returns_after_ingress_admission() {
     let (handle, service) = create_test_mob_with_runtime_adapter(sample_definition()).await;
     handle
         .spawn_with_options(
@@ -17675,14 +17675,17 @@ async fn test_runtime_backed_turn_driven_dispatch_surfaces_start_turn_failure() 
     let debug = format!("{result:?}");
 
     assert!(
-        matches!(&result, Err(MobError::Internal(message)) if message.contains("mock start_turn failure")),
-        "runtime-backed turn dispatch must surface the underlying turn failure, got: {debug}"
+        result.is_ok(),
+        "runtime-backed turn dispatch should return after ingress admission, got: {debug}"
     );
-    assert_eq!(
-        service.start_turn_call_count(),
-        baseline_start_turn_calls + 1,
-        "runtime-backed dispatch should still attempt exactly one turn"
-    );
+    let deadline = Instant::now() + Duration::from_secs(2);
+    while service.start_turn_call_count() < baseline_start_turn_calls + 1 {
+        assert!(
+            Instant::now() < deadline,
+            "runtime-backed dispatch should still attempt exactly one turn"
+        );
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
 }
 
 #[cfg(feature = "runtime-adapter")]
@@ -28789,6 +28792,85 @@ async fn test_submit_work_external_origin_succeeds() {
         .await
         .expect("submit_work external should succeed for externally addressable member");
     assert_eq!(receipt.runtime_id, entry.agent_runtime_id);
+}
+
+#[tokio::test]
+async fn test_wire_external_peer_not_blocked_by_delayed_turn_driven_submit_work() {
+    let (handle, service) = create_test_mob(sample_definition()).await;
+    let member_id = MeerkatId::from("l-busy-turn-driven");
+    handle
+        .spawn_with_options(
+            ProfileName::from("lead"),
+            member_id.clone(),
+            None,
+            Some(crate::MobRuntimeMode::TurnDriven),
+            None,
+        )
+        .await
+        .expect("spawn turn-driven lead");
+
+    let entry = handle
+        .get_member(&AgentIdentity::from(member_id.as_str()))
+        .await
+        .expect("member exists");
+    service.set_start_turn_delay_ms(600_000);
+
+    let submit_handle = handle.clone();
+    let submit_runtime_id = entry.agent_runtime_id.clone();
+    let submit_fence = entry.fence_token;
+    let submit = tokio::spawn(async move {
+        submit_handle
+            .submit_work(
+                submit_runtime_id,
+                submit_fence,
+                WorkRef::new(),
+                WorkSpec::new("long running work".to_string(), WorkOrigin::External),
+            )
+            .await
+    });
+
+    let deadline = Instant::now() + Duration::from_secs(2);
+    while service.start_turn_call_count() == 0 {
+        assert!(
+            Instant::now() < deadline,
+            "delayed turn-driven work should reach the runtime executor"
+        );
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+
+    let external = test_trusted_peer_descriptor(
+        "remote-mob/worker/busy-peer",
+        "inproc://remote-mob/worker/busy-peer",
+    );
+
+    tokio::time::timeout(
+        Duration::from_millis(100),
+        handle.wire(
+            AgentIdentity::from(member_id.as_str()),
+            PeerTarget::External(external.clone()),
+        ),
+    )
+    .await
+    .expect("wire must not wait behind turn completion")
+    .expect("wire external peer");
+
+    let trusted = entry
+        .member_ref
+        .bridge_session_id()
+        .map(|session_id| service.trusted_peer_names(session_id));
+    if let Some(trusted) = trusted {
+        let trusted = trusted.await;
+        assert!(
+            trusted.iter().any(|name| name == external.name.as_str()),
+            "external peer trust should be installed after wire"
+        );
+    }
+
+    tokio::time::timeout(Duration::from_millis(100), submit)
+        .await
+        .expect("submit_work should return after ingress admission")
+        .expect("submit task should not panic")
+        .expect("submit_work should be accepted");
 }
 
 #[tokio::test]

--- a/meerkat-workgraph/src/machine.rs
+++ b/meerkat-workgraph/src/machine.rs
@@ -172,7 +172,7 @@ impl WorkGraphMachine {
         Ok(Some((item, event)))
     }
 
-    fn claim_item_with_unresolved_blockers(
+    pub(crate) fn claim_item_with_unresolved_blockers(
         mut item: WorkItem,
         unresolved_blocker_count: u64,
         request: ClaimWorkItemRequest,

--- a/meerkat-workgraph/src/service.rs
+++ b/meerkat-workgraph/src/service.rs
@@ -180,7 +180,15 @@ impl WorkGraphService {
                 WorkGraphError::not_found(realm_id.clone(), namespace.clone(), request.id.clone())
             })?;
         let expected_previous_revision = item.revision;
-        let (item, event) = WorkGraphMachine::claim_ready_item(item, request, now)?;
+        let unresolved_blockers = self
+            .unresolved_blocker_count_for_item(&realm_id, &namespace, &item)
+            .await?;
+        let (item, event) = WorkGraphMachine::claim_item_with_unresolved_blockers(
+            item,
+            unresolved_blockers,
+            request,
+            now,
+        )?;
         self.store
             .update_item_cas(item, expected_previous_revision, event)
             .await
@@ -522,6 +530,28 @@ impl WorkGraphService {
         }
         Ok(())
     }
+
+    async fn unresolved_blocker_count_for_item(
+        &self,
+        realm_id: &str,
+        namespace: &WorkNamespace,
+        item: &WorkItem,
+    ) -> Result<u64, WorkGraphError> {
+        let all_items = self
+            .store
+            .list_items(WorkItemFilter {
+                realm_id: Some(realm_id.to_string()),
+                namespace: Some(namespace.clone()),
+                include_terminal: true,
+                ..WorkItemFilter::default()
+            })
+            .await?
+            .into_iter()
+            .map(|item| (item.id.clone(), item))
+            .collect::<BTreeMap<_, _>>();
+        let edges = self.store.list_edges(realm_id, namespace).await?;
+        Ok(unresolved_blocker_count(item, &all_items, &edges))
+    }
 }
 
 fn unresolved_blocker_count(
@@ -551,6 +581,7 @@ mod tests {
 
     use async_trait::async_trait;
     use chrono::{DateTime, Utc};
+    use serde_json::json;
 
     use crate::store::WorkGraphEventFilter;
     use crate::types::{
@@ -879,6 +910,100 @@ mod tests {
         let first = service.claim(request.clone()).await;
         let second = service.claim(request).await;
         assert!(first.is_ok() ^ second.is_ok());
+    }
+
+    #[tokio::test]
+    async fn blocker_item_remains_claimable_after_linking_dependents() {
+        let service = WorkGraphService::with_scope(
+            Arc::new(MemoryWorkGraphStore::new()),
+            "realm",
+            WorkNamespace::default(),
+        );
+        let blocker = service
+            .create(create_req("blocker"))
+            .await
+            .expect("blocker");
+        let dependent = service
+            .create(create_req("dependent"))
+            .await
+            .expect("dependent");
+        service
+            .link(LinkWorkItemsRequest {
+                realm_id: None,
+                namespace: None,
+                kind: WorkEdgeKind::Blocks,
+                from_id: blocker.id.clone(),
+                to_id: dependent.id.clone(),
+            })
+            .await
+            .expect("link");
+
+        let claimed = service
+            .claim(ClaimWorkItemRequest {
+                id: blocker.id.clone(),
+                realm_id: None,
+                namespace: None,
+                expected_revision: blocker.revision,
+                owner: WorkOwner::new(WorkOwnerKey::label("worker").expect("owner key")),
+                lease_seconds: Some(60),
+                lease_expires_at: None,
+            })
+            .await
+            .expect("blocker with outgoing dependencies should remain claimable");
+
+        assert_eq!(claimed.id, blocker.id);
+        assert_eq!(claimed.status, crate::WorkStatus::InProgress);
+    }
+
+    #[tokio::test]
+    async fn claim_recomputes_dependency_projection_before_admission() {
+        let store = Arc::new(MemoryWorkGraphStore::new());
+        let service =
+            WorkGraphService::with_scope(store.clone(), "realm", WorkNamespace::default());
+        let blocker = service
+            .create(create_req("blocker"))
+            .await
+            .expect("blocker");
+        let dependent = service
+            .create(create_req("dependent"))
+            .await
+            .expect("dependent");
+        let now = store.get_store_time_utc().await.expect("time");
+        store
+            .insert_edge(
+                WorkEdge {
+                    realm_id: "realm".to_string(),
+                    namespace: WorkNamespace::default(),
+                    kind: WorkEdgeKind::Blocks,
+                    from_id: blocker.id,
+                    to_id: dependent.id.clone(),
+                    created_at: now,
+                },
+                WorkGraphEvent::graph(
+                    "realm".to_string(),
+                    WorkNamespace::default(),
+                    WorkGraphEventKind::Linked,
+                    now,
+                    json!({ "test": "stale-projection" }),
+                ),
+            )
+            .await
+            .expect("raw edge insert");
+
+        let error = service
+            .claim(ClaimWorkItemRequest {
+                id: dependent.id,
+                realm_id: None,
+                namespace: None,
+                expected_revision: dependent.revision,
+                owner: WorkOwner::new(WorkOwnerKey::label("worker").expect("owner key")),
+                lease_seconds: Some(60),
+                lease_expires_at: None,
+            })
+            .await
+            .expect_err("fresh graph blockers should reject stale ready projection");
+
+        assert!(matches!(error, crate::WorkGraphError::InvalidTransition(_)));
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
- Recompute WorkGraph blocker projection during claim admission so stale item projections cannot make blocked work claimable, while blockers with outgoing dependents remain claimable.
- Forward CLI mob wrapper snapshots and runtime context paths so `delegate` default `InheritParent` can see the parent tool surface in both run and persistent CLI paths.
- Downgrade foreign runtime lifecycle observations to debug logging after MobMachine rejection, avoiding noisy `typed composition signal projection failed` errors for parent/runtime ids outside the mob.
- Keep `MobHandle::wire(... PeerTarget::External(...))` responsive while a turn-driven member is busy by making external submit/send paths acknowledge after runtime ingress admission instead of waiting for full turn completion.

## Root Cause
The CLI mob wrappers were thinner for runtime apply than for parent execution/tool snapshots, so delegate inheritance could lose the parent tool surface. Separately, WorkGraph claim admission trusted item-local blocker projection instead of recomputing from the graph at claim time. The mob actor also logged expected foreign runtime lifecycle observations as projection failures even though the MobMachine correctly rejected ids outside `live_runtime_ids`.

The new MobHandle wiring issue was an actor/provisioner coupling bug: turn-driven `SubmitWork` could await full member turn completion while the mob actor command loop was still handling the command. That let long or backed-up turns starve unrelated control-plane commands such as external peer wiring. The fix keeps machine admission authority unchanged and moves the caller-facing acknowledgement choice into a typed runtime-shell policy: external work returns after ingress acceptance, while internal supervisor turns still wait for completion.

## Dogma / Semantics Note
This is not a MobMachine semantic-authority change. The machine still decides whether `SubmitWork` and `Wire` transitions are accepted. `SubmitWorkAckMode` only controls how long the runtime actor waits while realizing an already-admitted effect, so control-plane wiring is not blocked behind data-plane/model turn execution.

## Validation
- TDD red: `./scripts/repo-cargo test -p meerkat-mob test_wire_external_peer_not_blocked_by_delayed_turn_driven_submit_work -- --nocapture` reproduced `wire must not wait behind turn completion` before the MobHandle/provisioner fix.
- TDD green: `./scripts/repo-cargo test -p meerkat-mob test_wire_external_peer_not_blocked_by_delayed_turn_driven_submit_work -- --nocapture`
- `./scripts/repo-cargo test -p meerkat-mob turn_driven_dispatch -- --nocapture`
- `./scripts/repo-cargo test -p meerkat-mob submit_work -- --nocapture`
- `./scripts/repo-cargo test -p meerkat-mob wire_external -- --nocapture`
- `./scripts/repo-cargo test -p meerkat-mob test_supervisor_escalation_times_out_when_turn_hangs -- --nocapture`
- `./scripts/repo-cargo test -p meerkat-mob` (`852 passed; 0 failed; 4 ignored`)
- `./scripts/repo-cargo fmt --all`
- `git diff --check`
- `./scripts/repo-cargo test -p meerkat-workgraph blocker_item_remains_claimable_after_linking_dependents -- --nocapture`
- `./scripts/repo-cargo test -p meerkat-workgraph claim_recomputes_dependency_projection_before_admission -- --nocapture`
- `./scripts/repo-cargo test -p meerkat-mob foreign_runtime_observations_are_identified_for_log_downgrade -- --nocapture`
- `./scripts/repo-cargo test -p meerkat-mob live_member_runtime_observations -- --nocapture`
- `./scripts/repo-cargo test -p rkat test_run_mob_session_service_forwards_runtime_apply -- --nocapture`
- `./scripts/repo-cargo test -p rkat test_mob_cli_session_service_forwards_runtime_apply -- --nocapture`
- `./scripts/repo-cargo check -p rkat -p meerkat-mob -p meerkat-workgraph`
- push hooks: cargo fmt check, clippy changed crates, machine codegen verify, generated header audit, bridge status audit, Bazel freshness, deterministic gate
