### PR TITLE
[codex] Wire delegate helpers from parent comms

### DIFF
--- a/meerkat-comms/src/runtime/comms_runtime.rs
+++ b/meerkat-comms/src/runtime/comms_runtime.rs
@@ -321,6 +321,10 @@ impl CoreCommsRuntime for CommsRuntime {
         Some(*self.public_key.as_bytes())
     }
 
+    fn comms_name(&self) -> Option<String> {
+        Some(self.participant_name().to_string())
+    }
+
     fn advertised_address(&self) -> Option<String> {
         #[cfg(not(target_arch = "wasm32"))]
         {

--- a/meerkat-core/src/agent.rs
+++ b/meerkat-core/src/agent.rs
@@ -729,6 +729,15 @@ pub trait CommsRuntime: Send + Sync {
         None
     }
 
+    /// Runtime-local canonical comms routing name, if available.
+    ///
+    /// This is the peer name used in trusted-peer descriptors and peer
+    /// directories. It is separate from the advertised transport address so
+    /// callers do not recover identity by parsing transport strings.
+    fn comms_name(&self) -> Option<String> {
+        None
+    }
+
     /// Runtime-local advertised comms address, if available.
     ///
     /// This is the canonical address the runtime expects peers to use when

--- a/meerkat-mob-mcp/src/agent_tools.rs
+++ b/meerkat-mob-mcp/src/agent_tools.rs
@@ -2404,6 +2404,14 @@ mod tests {
             Some(self.public_key_bytes)
         }
 
+        fn comms_name(&self) -> Option<String> {
+            Some(self.name.clone())
+        }
+
+        fn advertised_address(&self) -> Option<String> {
+            Some(format!("inproc://{}", self.name))
+        }
+
         async fn add_trusted_peer(&self, peer: TrustedPeerDescriptor) -> Result<(), SendError> {
             TrustedPeerDescriptor::validate_pubkey_for_peer_id(peer.peer_id, &peer.pubkey)
                 .map_err(SendError::Validation)?;
@@ -3544,6 +3552,97 @@ mod tests {
         assert_eq!(audit_events[0].0, "mob_spawn_member");
         assert_eq!(audit_events[0].1.as_str(), "scope-principal");
         assert_eq!(audit_events[0].2.as_deref(), Some("audit-scope"));
+    }
+
+    #[tokio::test]
+    async fn test_delegate_dispatch_auto_wires_parent_and_helper_peers() {
+        struct TestSnapshotProvider;
+        impl VisibleToolSnapshotProvider for TestSnapshotProvider {
+            fn snapshot_visible_tools(&self) -> Vec<Arc<ToolDef>> {
+                vec![Arc::new(ToolDef {
+                    name: "read_file".into(),
+                    description: "read_file tool".to_string(),
+                    input_schema: json!({"type": "object"}),
+                    provenance: Some(ToolProvenance {
+                        kind: ToolSourceKind::Builtin,
+                        source_id: "test-read-file".into(),
+                    }),
+                })]
+            }
+        }
+
+        let service = Arc::new(RealCommsSessionSvc::new());
+        let state = Arc::new(MobMcpState::new(service.clone()));
+        let parent_name = "parent/lead/l-1".to_string();
+        let parent_comms = service.register_external_comms(&parent_name).await;
+        let parent_peer_id = parent_comms.peer_id().expect("parent peer id");
+        let provider: Arc<dyn VisibleToolSnapshotProvider> = Arc::new(TestSnapshotProvider);
+        let session_id = SessionId::new();
+        let surface = AgentMobToolSurface::new_with_effective_authority(
+            Arc::clone(&state),
+            None,
+            Arc::new(std::sync::RwLock::new(create_only_authority())),
+            "claude-sonnet-4-5".to_string(),
+            session_id,
+            Some(parent_name.clone()),
+            Some(parent_peer_id),
+            Some(parent_comms.clone() as Arc<dyn CoreCommsRuntime>),
+            MobToolSnapshotContext::ParentOwned(provider),
+        );
+
+        let delegate_args = serde_json::value::RawValue::from_string(
+            json!({
+                "member_id": "helper-dispatch-1",
+                "task": "report back"
+            })
+            .to_string(),
+        )
+        .unwrap();
+        let result = surface
+            .dispatch(ToolCallView {
+                id: "delegate-wired",
+                name: "delegate",
+                args: &delegate_args,
+            })
+            .await
+            .expect("delegate should spawn and wire helper");
+        let parsed: serde_json::Value =
+            serde_json::from_str(&result.result.text_content()).expect("delegate JSON");
+        assert_eq!(
+            parsed["wired"].as_bool(),
+            Some(true),
+            "delegate() must report wired=true when parent comms are available"
+        );
+
+        let mob_id = parsed["mob_id"].as_str().expect("mob id");
+        let helper_name = format!("{mob_id}/delegate/helper-dispatch-1");
+        let parent_peers = CoreCommsRuntime::peers(&*parent_comms).await;
+        assert!(
+            parent_peers
+                .iter()
+                .any(|entry| entry.name.as_str() == helper_name),
+            "delegate() should add the helper to the parent peer directory"
+        );
+
+        let handle = state
+            .handle_for(&MobId::from(mob_id))
+            .await
+            .expect("mob handle");
+        let helper_bridge_session_id = handle
+            .resolve_bridge_session_id(&AgentIdentity::from("helper-dispatch-1"))
+            .await
+            .expect("helper bridge session id");
+        let helper_comms = service
+            .real_comms(&helper_bridge_session_id)
+            .await
+            .expect("helper comms");
+        let helper_peers = CoreCommsRuntime::peers(&*helper_comms).await;
+        assert!(
+            helper_peers
+                .iter()
+                .any(|entry| entry.name.as_str() == parent_name),
+            "delegate() should add the parent to the helper peer directory"
+        );
     }
 
     #[tokio::test]

--- a/meerkat/src/factory.rs
+++ b/meerkat/src/factory.rs
@@ -3757,6 +3757,19 @@ impl AgentFactory {
             }
         }
 
+        #[cfg(feature = "comms")]
+        {
+            let mob_operator_tools_available = build_config.mob_tool_authority_context.is_some()
+                && (build_config.mob_tools.is_some() || self.mob_tools.is_some());
+            if mob_operator_tools_available
+                && self.enable_comms
+                && self.comms_runtime.is_none()
+                && build_config.comms_name.is_none()
+            {
+                build_config.comms_name = Some(format!("mob-owner/{}", session.id()));
+            }
+        }
+
         // 6b. Create comms runtime before tool wiring.
         // If the factory has a pre-built runtime (surface with stable identity),
         // use it directly. Otherwise create a per-session runtime from config.
@@ -4167,6 +4180,13 @@ impl AgentFactory {
                 .map(|r| Arc::clone(r) as Arc<dyn meerkat_core::agent::CommsRuntime>);
             #[cfg(not(feature = "comms"))]
             let mob_comms: Option<Arc<dyn meerkat_core::agent::CommsRuntime>> = None;
+            #[cfg(feature = "comms")]
+            let mob_comms_name = build_config
+                .comms_name
+                .clone()
+                .or_else(|| mob_comms.as_ref().and_then(|runtime| runtime.comms_name()));
+            #[cfg(not(feature = "comms"))]
+            let mob_comms_name = build_config.comms_name.clone();
 
             // Create the shared effective-authority handle. The agent owns the
             // write side (via apply_session_effects); mob tools get a read view.
@@ -4189,7 +4209,7 @@ impl AgentFactory {
                 model: model.clone(),
                 authority_context: build_config.mob_tool_authority_context.clone(),
                 effective_authority: mob_authority_handle.clone(),
-                comms_name: build_config.comms_name.clone(),
+                comms_name: mob_comms_name,
                 comms_runtime: mob_comms,
                 snapshot_context: meerkat_core::service::MobToolSnapshotContext::ParentOwned(
                     snapshot_provider,

--- a/meerkat/tests/factory_build_agent.rs
+++ b/meerkat/tests/factory_build_agent.rs
@@ -304,6 +304,36 @@ impl meerkat_core::service::MobToolsFactory for RecordingMobToolsFactory {
     }
 }
 
+#[cfg(feature = "comms")]
+#[derive(Debug, Default)]
+struct RecordedMobToolCommsArgs {
+    comms_name: Option<String>,
+    comms_runtime_present: bool,
+}
+
+#[cfg(feature = "comms")]
+struct RecordingMobCommsFactory {
+    observed: Arc<std::sync::Mutex<Vec<RecordedMobToolCommsArgs>>>,
+}
+
+#[cfg(feature = "comms")]
+#[async_trait]
+impl meerkat_core::service::MobToolsFactory for RecordingMobCommsFactory {
+    async fn build_mob_tools(
+        &self,
+        args: meerkat_core::service::MobToolsBuildArgs,
+    ) -> Result<Arc<dyn AgentToolDispatcher>, Box<dyn std::error::Error + Send + Sync>> {
+        self.observed
+            .lock()
+            .expect("recording mutex")
+            .push(RecordedMobToolCommsArgs {
+                comms_name: args.comms_name,
+                comms_runtime_present: args.comms_runtime.is_some(),
+            });
+        Ok(Arc::new(EmptyDispatcher))
+    }
+}
+
 #[cfg_attr(not(feature = "comms"), allow(dead_code))]
 struct StaticMobToolsFactory {
     dispatcher: Arc<dyn AgentToolDispatcher>,
@@ -2116,6 +2146,71 @@ async fn explicit_mob_override_generates_create_only_operator_capabilities() {
     let observed = observed.lock().expect("recording mutex");
     assert_eq!(observed.len(), 1);
     assert_generated_create_only_authority(observed[0].as_ref());
+}
+
+#[cfg(feature = "comms")]
+#[tokio::test]
+async fn explicit_mob_override_builds_parent_comms_identity_for_delegate_wiring() {
+    let temp = tempfile::tempdir().unwrap();
+    let observed = Arc::new(std::sync::Mutex::new(Vec::new()));
+    let mob_factory = Arc::new(RecordingMobCommsFactory {
+        observed: Arc::clone(&observed),
+    });
+    let factory = temp_factory(&temp)
+        .comms(true)
+        .mob(false)
+        .mob_tools_factory(mob_factory);
+    let config = Config::default();
+
+    let build_config = AgentBuildConfig {
+        override_mob: ToolCategoryOverride::Enable,
+        llm_client_override: Some(Arc::new(MockLlmClient)),
+        ..AgentBuildConfig::new("claude-sonnet-4-5")
+    };
+
+    let _agent = factory.build_agent(build_config, &config).await.unwrap();
+    let observed = observed.lock().expect("recording mutex");
+    assert_eq!(observed.len(), 1);
+    assert!(
+        observed[0].comms_name.is_some(),
+        "mob-enabled parent sessions must get a canonical comms_name so delegate() can wire helpers"
+    );
+    assert!(
+        observed[0].comms_runtime_present,
+        "mob-enabled parent sessions must get a comms runtime so delegate() can install parent<->child trust"
+    );
+}
+
+#[cfg(feature = "comms")]
+#[tokio::test]
+async fn ambient_mob_enable_without_authority_does_not_create_parent_comms_identity() {
+    let temp = tempfile::tempdir().unwrap();
+    let observed = Arc::new(std::sync::Mutex::new(Vec::new()));
+    let mob_factory = Arc::new(RecordingMobCommsFactory {
+        observed: Arc::clone(&observed),
+    });
+    let factory = temp_factory(&temp)
+        .comms(true)
+        .mob(true)
+        .mob_tools_factory(mob_factory);
+    let config = Config::default();
+
+    let build_config = AgentBuildConfig {
+        llm_client_override: Some(Arc::new(MockLlmClient)),
+        ..AgentBuildConfig::new("claude-sonnet-4-5")
+    };
+
+    let _agent = factory.build_agent(build_config, &config).await.unwrap();
+    let observed = observed.lock().expect("recording mutex");
+    assert_eq!(observed.len(), 1);
+    assert_eq!(
+        observed[0].comms_name, None,
+        "ambient mob availability without operator authority must not synthesize a parent comms_name"
+    );
+    assert!(
+        !observed[0].comms_runtime_present,
+        "ambient mob availability without operator authority must not create delegate wiring comms"
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary
- Ensure mob-enabled parent sessions with operator authority get a comms identity when delegate tooling is available, so `delegate()` can wire parent <-> child by default.
- Avoid creating synthetic parent comms identity for ambient mob availability when no mob operator authority exists.
- Add typed `CommsRuntime::comms_name()` as the canonical runtime-owned peer-name seam instead of recovering peer identity from transport addresses.
- Add regressions for the factory handoff, the ambient-no-authority case, and full `delegate()` dispatch returning `wired: true` with reciprocal parent/helper peer-directory entries.

## Root Cause
`delegate()` already had a helper wiring path, but the product factory path could build mob tools without a parent `comms_name` and `comms_runtime`. In that state, `wire_delegate_helper_to_creator` correctly failed closed and `delegate()` returned `wired: false`, forcing callers to poll helper status instead of receiving push messages.

The first fix was too broad: it treated ambient mob capability as sufficient to synthesize parent comms identity. The final predicate uses mob operator authority as the gate, so explicit/generated or persisted mob authority gets comms for delegate wiring, while ambient mob availability without usable operator tools stays side-effect free.

## Dogma / Semantics
The fix keeps identity and trust ownership in the runtime/comms seams:
- `CommsRuntime::comms_name()` exposes canonical peer name as typed runtime fact.
- `AgentFactory` provisions parent comms identity only when mob operator tooling is actually available.
- `delegate()` consumes typed comms facts and installs trust; it does not invent parent identity or parse `inproc://...` transport strings.

## Validation
- Red: `./scripts/repo-cargo test -p meerkat --features comms explicit_mob_override_builds_parent_comms_identity_for_delegate_wiring -- --nocapture` failed before the fix because parent `comms_name` was missing.
- `./scripts/repo-cargo test -p meerkat --features comms explicit_mob_override_builds_parent_comms_identity_for_delegate_wiring -- --nocapture`
- `./scripts/repo-cargo test -p meerkat --features comms --test factory_build_agent -- --nocapture`
- `./scripts/repo-cargo test -p meerkat-mob-mcp --lib agent_tools::tests::test_delegate -- --nocapture`
- `./scripts/repo-cargo check -p meerkat --features comms -p meerkat-mob-mcp -p meerkat-comms`
- `./scripts/repo-cargo check -p meerkat`
- `./scripts/repo-cargo fmt --all`
- `git diff --check`
- push hooks: cargo fmt check, clippy changed crates, machine codegen verify, generated header audit, bridge status audit, Bazel freshness, deterministic gate
