### PR TITLE
Prebuild Web SDK package during release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -604,6 +604,74 @@ jobs:
           path: dist/*
           if-no-files-found: error
 
+  build_web_sdk_package:
+    name: Build Web SDK package
+    needs: [require_ci_green, release_validate_gate]
+    if: >-
+      always() &&
+      needs.require_ci_green.result == 'success' &&
+      (needs.release_validate_gate.result == 'success' ||
+       (github.event_name == 'workflow_dispatch' &&
+        github.event.inputs.publish_web_sdk_only == 'true' &&
+        needs.release_validate_gate.result == 'skipped')) &&
+      (startsWith(github.ref, 'refs/tags/v') ||
+       (github.event_name == 'workflow_dispatch' &&
+        github.event.inputs.publish_release_packages == 'true'))
+    runs-on: ${{ fromJSON(vars.MEERKAT_CI_RUNNER || '"ubuntu-latest"') }}
+    timeout-minutes: 180
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.release_tag != '' && github.event.inputs.release_tag || github.ref }}
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo registry
+        uses: Swatinem/rust-cache@v2
+
+      - name: Install Python + Node tooling
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.14"
+
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: "22"
+
+      - name: Install wasm-pack
+        shell: bash
+        run: |
+          set -euo pipefail
+          version="0.13.1"
+          archive="wasm-pack-v${version}-x86_64-unknown-linux-musl.tar.gz"
+          curl --fail --location --retry 5 --retry-delay 2 \
+            "https://github.com/wasm-bindgen/wasm-pack/releases/download/v${version}/${archive}" \
+            --output "/tmp/${archive}"
+          tar -xzf "/tmp/${archive}" -C /tmp
+          install -m 0755 "/tmp/wasm-pack-v${version}-x86_64-unknown-linux-musl/wasm-pack" "$HOME/.cargo/bin/wasm-pack"
+          wasm-pack --version
+
+      - name: Add wasm32 target
+        run: rustup target add wasm32-unknown-unknown
+
+      - name: Build and pack Web SDK
+        env:
+          VERSION: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.release_tag || github.ref_name }}
+          CARGO_BUILD_JOBS: "1"
+          CARGO_INCREMENTAL: "0"
+          RUSTFLAGS: '--cfg getrandom_backend="wasm_js"'
+        run: scripts/release-build-web-sdk-package.sh "${GITHUB_WORKSPACE}/web-sdk-package"
+
+      - name: Upload Web SDK package
+        uses: actions/upload-artifact@v4
+        with:
+          name: rkat-web-package
+          path: web-sdk-package/rkat-web-*.tgz
+          if-no-files-found: error
+
   build_binaries_gate:
     name: Release binary build gate
     if: >-
@@ -835,7 +903,7 @@ jobs:
   #
   # Use registry_dry_run=true to validate without uploading.
   publish_registries:
-    name: Publish crates + SDK packages
+    name: Publish crates + Python/TypeScript SDK packages
     if: >-
       always() &&
       needs.require_ci_green.result == 'success' &&
@@ -935,127 +1003,39 @@ jobs:
             npm publish --access public
           fi
 
-      - name: Install wasm-pack
-        shell: bash
-        run: |
-          set -euo pipefail
-          version="0.13.1"
-          archive="wasm-pack-v${version}-x86_64-unknown-linux-musl.tar.gz"
-          curl --fail --location --retry 5 --retry-delay 2 \
-            "https://github.com/wasm-bindgen/wasm-pack/releases/download/v${version}/${archive}" \
-            --output "/tmp/${archive}"
-          tar -xzf "/tmp/${archive}" -C /tmp
-          install -m 0755 "/tmp/wasm-pack-v${version}-x86_64-unknown-linux-musl/wasm-pack" "$HOME/.cargo/bin/wasm-pack"
-          wasm-pack --version
-
-      - name: Add wasm32 target
-        run: rustup target add wasm32-unknown-unknown
-
-      - name: Publish Web SDK
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-          CARGO_BUILD_JOBS: "1"
-          CARGO_INCREMENTAL: "0"
-          RUSTFLAGS: '--cfg getrandom_backend="wasm_js"'
-        working-directory: sdks/web
-        run: |
-          set -euo pipefail
-          DRY_RUN="${{ github.event_name == 'workflow_dispatch' && github.event.inputs.registry_dry_run == 'true' }}"
-          PACKAGE_VERSION="$(node -p "const p = require('./package.json'); p.name + '@' + p.version")"
-          if [[ "$DRY_RUN" != "true" ]] && npm view "$PACKAGE_VERSION" version >/dev/null 2>&1; then
-            echo "$PACKAGE_VERSION already published, skipping"
-            exit 0
-          fi
-          npm install --ignore-scripts
-          npm config set //registry.npmjs.org/:_authToken ${NODE_AUTH_TOKEN}
-          npm run build &
-          build_pid=$!
-          while kill -0 "$build_pid" 2>/dev/null; do
-            echo "Web SDK build still running..."
-            sleep 60
-          done
-          wait "$build_pid"
-          if [[ "$DRY_RUN" == "true" ]]; then
-            npm publish --access public --dry-run --ignore-scripts
-          else
-            npm publish --access public --ignore-scripts
-          fi
-
-  publish_web_sdk_recovery:
-    name: Publish Web SDK recovery
+  publish_web_sdk:
+    name: Publish Web SDK package
     if: >-
       always() &&
       needs.require_ci_green.result == 'success' &&
-      github.event_name == 'workflow_dispatch' &&
-      github.event.inputs.publish_release_packages == 'true' &&
-      github.event.inputs.publish_web_sdk_only == 'true'
-    needs: [require_ci_green]
+      needs.build_web_sdk_package.result == 'success' &&
+      (startsWith(github.ref, 'refs/tags/v') ||
+       (github.event_name == 'workflow_dispatch' &&
+        github.event.inputs.publish_release_packages == 'true'))
+    needs: [require_ci_green, build_web_sdk_package]
     runs-on: ubuntu-latest
-    timeout-minutes: 180
+    timeout-minutes: 15
     steps:
       - name: Checkout
         uses: actions/checkout@v6
         with:
           ref: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.release_tag != '' && github.event.inputs.release_tag || github.ref }}
 
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
-
-      - name: Cache cargo registry
-        uses: Swatinem/rust-cache@v2
-
-      - name: Install Python + Node tooling
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.14"
       - name: Setup Node
         uses: actions/setup-node@v6
         with:
           node-version: "22"
 
-
-      - name: Install wasm-pack
-        shell: bash
-        run: |
-          set -euo pipefail
-          version="0.13.1"
-          archive="wasm-pack-v${version}-x86_64-unknown-linux-musl.tar.gz"
-          curl --fail --location --retry 5 --retry-delay 2 \
-            "https://github.com/wasm-bindgen/wasm-pack/releases/download/v${version}/${archive}" \
-            --output "/tmp/${archive}"
-          tar -xzf "/tmp/${archive}" -C /tmp
-          install -m 0755 "/tmp/wasm-pack-v${version}-x86_64-unknown-linux-musl/wasm-pack" "$HOME/.cargo/bin/wasm-pack"
-          wasm-pack --version
-
-      - name: Add wasm32 target
-        run: rustup target add wasm32-unknown-unknown
+      - name: Download Web SDK package
+        uses: actions/download-artifact@v4
+        with:
+          name: rkat-web-package
+          path: web-sdk-package
 
       - name: Publish Web SDK
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-          CARGO_BUILD_JOBS: "1"
-          CARGO_INCREMENTAL: "0"
-          RUSTFLAGS: '--cfg getrandom_backend="wasm_js"'
-        working-directory: sdks/web
+          MEERKAT_REGISTRY_DRY_RUN: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.registry_dry_run == 'true' }}
         run: |
           set -euo pipefail
-          DRY_RUN="${{ github.event_name == 'workflow_dispatch' && github.event.inputs.registry_dry_run == 'true' }}"
-          PACKAGE_VERSION="$(node -p "const p = require('./package.json'); p.name + '@' + p.version")"
-          if [[ "$DRY_RUN" != "true" ]] && npm view "$PACKAGE_VERSION" version >/dev/null 2>&1; then
-            echo "$PACKAGE_VERSION already published, skipping"
-            exit 0
-          fi
-          npm install --ignore-scripts
-          npm config set //registry.npmjs.org/:_authToken ${NODE_AUTH_TOKEN}
-          npm run build &
-          build_pid=$!
-          while kill -0 "$build_pid" 2>/dev/null; do
-            echo "Web SDK build still running..."
-            sleep 60
-          done
-          wait "$build_pid"
-          if [[ "$DRY_RUN" == "true" ]]; then
-            npm publish --access public --dry-run --ignore-scripts
-          else
-            npm publish --access public --ignore-scripts
-          fi
+          scripts/release-publish-web-sdk-package.sh web-sdk-package/rkat-web-*.tgz

--- a/scripts/release-build-web-sdk-package.sh
+++ b/scripts/release-build-web-sdk-package.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+root="$(git rev-parse --show-toplevel)"
+out_dir="${1:-${root}/dist/web-sdk-package}"
+version="${VERSION:-${RELEASE_TAG:-}}"
+
+if [[ -n "${version}" ]]; then
+  case "${version}" in
+    v*) version="${version#v}" ;;
+  esac
+fi
+
+cd "${root}/sdks/web"
+
+package_name="$(node -p "const p = require('./package.json'); p.name")"
+package_version="$(node -p "const p = require('./package.json'); p.version")"
+package_spec="${package_name}@${package_version}"
+
+if [[ -n "${version}" && "${package_version}" != "${version}" ]]; then
+  echo "Web SDK package version ${package_version} does not match release version ${version}" >&2
+  exit 1
+fi
+
+npm install --ignore-scripts
+
+npm run build &
+build_pid=$!
+elapsed=0
+while kill -0 "${build_pid}" 2>/dev/null; do
+  sleep 5
+  elapsed=$((elapsed + 5))
+  if ((elapsed % 60 == 0)) && kill -0 "${build_pid}" 2>/dev/null; then
+    echo "Web SDK package build still running..."
+  fi
+done
+wait "${build_pid}"
+
+rm -rf "${out_dir}"
+mkdir -p "${out_dir}"
+
+packfile="$(npm pack --ignore-scripts | tail -n 1)"
+tarball="${out_dir}/${packfile}"
+mv "${packfile}" "${tarball}"
+
+tar -tzf "${tarball}" | grep -Fxq "package/wasm/meerkat_web_runtime_bg.wasm"
+tar -tzf "${tarball}" | grep -Fxq "package/dist/index.js"
+tar -tzf "${tarball}" | grep -Fxq "package/proxy/cli.mjs"
+
+smoke_dir="$(mktemp -d)"
+trap 'rm -rf "${smoke_dir}"' EXIT
+(
+  cd "${smoke_dir}"
+  npm init -y >/dev/null 2>&1
+  npm install "${tarball}" >/dev/null 2>&1
+  node --input-type=module -e "const web = await import('@rkat/web'); if (!web.MeerkatRuntime || !web.Session) throw new Error('missing @rkat/web exports');"
+)
+
+echo "Built ${package_spec} package at ${tarball}"

--- a/scripts/release-doctor
+++ b/scripts/release-doctor
@@ -109,9 +109,18 @@ else
   bad "Release workflow does not use the maintained wasm-bindgen wasm-pack release URL"
 fi
 
-web_timeout="$(
+if grep -Fq 'build_web_sdk_package:' .github/workflows/release.yml &&
+  grep -Fq 'scripts/release-build-web-sdk-package.sh' .github/workflows/release.yml &&
+  grep -Fq 'name: rkat-web-package' .github/workflows/release.yml &&
+  grep -Fq 'scripts/release-publish-web-sdk-package.sh' .github/workflows/release.yml; then
+  pass "Release workflow builds @rkat/web once as an artifact before npm publishing"
+else
+  bad "Release workflow does not publish @rkat/web from a prebuilt package artifact"
+fi
+
+web_build_timeout="$(
   awk '
-    /^  publish_web_sdk_recovery:/ { in_job = 1; next }
+    /^  build_web_sdk_package:/ { in_job = 1; next }
     in_job && /^  [[:alnum:]_-]+:/ { in_job = 0 }
     in_job && /timeout-minutes:/ {
       gsub(/[^0-9]/, "", $0)
@@ -120,10 +129,27 @@ web_timeout="$(
     }
   ' .github/workflows/release.yml
 )"
-if [[ "${web_timeout:-0}" =~ ^[0-9]+$ ]] && ((web_timeout >= 120)); then
-  pass "Web SDK recovery job has a long timeout (${web_timeout} minutes)"
+if [[ "${web_build_timeout:-0}" =~ ^[0-9]+$ ]] && ((web_build_timeout >= 120)); then
+  pass "Web SDK package build job has a long timeout (${web_build_timeout} minutes)"
 else
-  bad "Web SDK recovery job timeout is '${web_timeout:-missing}'; expected at least 120 minutes"
+  bad "Web SDK package build job timeout is '${web_build_timeout:-missing}'; expected at least 120 minutes"
+fi
+
+web_publish_timeout="$(
+  awk '
+    /^  publish_web_sdk:/ { in_job = 1; next }
+    in_job && /^  [[:alnum:]_-]+:/ { in_job = 0 }
+    in_job && /timeout-minutes:/ {
+      gsub(/[^0-9]/, "", $0)
+      print $0
+      exit
+    }
+  ' .github/workflows/release.yml
+)"
+if [[ "${web_publish_timeout:-0}" =~ ^[0-9]+$ ]] && ((web_publish_timeout <= 30)); then
+  pass "Web SDK publish job is artifact-only (${web_publish_timeout} minute timeout)"
+else
+  bad "Web SDK publish job timeout is '${web_publish_timeout:-missing}'; expected at most 30 minutes for artifact-only publish"
 fi
 
 if grep -Fq 'Too Many Requests' scripts/release-publish-rust-crates.sh &&

--- a/scripts/release-publish-web-sdk-package.sh
+++ b/scripts/release-publish-web-sdk-package.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+root="$(git rev-parse --show-toplevel)"
+tarball="${1:-}"
+
+if [[ -z "${tarball}" ]]; then
+  tarball="$(find "${root}/web-sdk-package" "${root}/dist/web-sdk-package" -maxdepth 1 -name 'rkat-web-*.tgz' -print -quit 2>/dev/null || true)"
+fi
+
+if [[ -z "${tarball}" || ! -f "${tarball}" ]]; then
+  echo "Usage: $0 /path/to/rkat-web-<version>.tgz" >&2
+  exit 2
+fi
+
+cd "${root}"
+
+dry_run="${MEERKAT_REGISTRY_DRY_RUN:-${REGISTRY_DRY_RUN:-false}}"
+package_spec="$(node -p "const p = require('./sdks/web/package.json'); p.name + '@' + p.version")"
+
+if [[ "${dry_run}" != "true" ]] && npm view "${package_spec}" version >/dev/null 2>&1; then
+  echo "${package_spec} already published, skipping"
+  exit 0
+fi
+
+if [[ -n "${NODE_AUTH_TOKEN:-}" ]]; then
+  npm config set //registry.npmjs.org/:_authToken "${NODE_AUTH_TOKEN}"
+fi
+
+if [[ "${dry_run}" == "true" ]]; then
+  npm publish "${tarball}" --access public --dry-run --ignore-scripts
+else
+  npm publish "${tarball}" --access public --ignore-scripts
+fi

--- a/scripts/release-workflow-dispatch
+++ b/scripts/release-workflow-dispatch
@@ -9,8 +9,9 @@ Dispatches the release workflow through the same public/default vs owner-only
 BuildBuddy backend split used by CI.
 
 Backend note: release_backend=buildbuddy covers release validation and binary
-asset builds. Registry package publish jobs, including @rkat/web, run on
-GitHub-hosted runners today; use the narrow recovery modes for retries.
+asset builds. @rkat/web is built once as a release artifact before npm
+publishing. Credentialed registry publish jobs still run on GitHub-hosted
+runners; use the narrow recovery modes for retries.
 
 Environment equivalents:
   VERSION or RELEASE_TAG     Release tag, for example v0.6.1.
@@ -192,7 +193,7 @@ else
 fi
 case "${mode}" in
   full|packages|web-sdk)
-    printf 'release workflow registry publishing: GitHub-hosted runners (use web-sdk/packages recovery for retries)\n'
+    printf 'release workflow registry publishing: prebuilt Web SDK artifact + GitHub-hosted credentialed publish (use web-sdk/packages recovery for retries)\n'
     ;;
 esac
 

--- a/sdks/web/package.json
+++ b/sdks/web/package.json
@@ -6,7 +6,7 @@
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "bin": {
-    "rkat-web-proxy": "./proxy/cli.mjs"
+    "rkat-web-proxy": "proxy/cli.mjs"
   },
   "exports": {
     ".": {


### PR DESCRIPTION
## Summary
- build @rkat/web once as a release artifact before credentialed npm publishing
- split Web SDK publishing from Rust/Python/TypeScript registry publishing so non-Web packages are not blocked on the WASM build
- add reusable build/publish scripts and release-doctor coverage for the artifact path
- normalize the @rkat/web bin path to avoid npm publish auto-correction

## Verification
- bash -n scripts/release-build-web-sdk-package.sh scripts/release-publish-web-sdk-package.sh scripts/release-doctor scripts/release-workflow-dispatch
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release.yml"); puts "yaml ok"'\n- VERSION=v0.6.8 make release-doctor\n- VERSION=v0.6.8 RELEASE_WORKFLOW_DRY_RUN=true scripts/release-workflow-dispatch --mode web-sdk --backend buildbuddy --ref main\n- VERSION=v0.6.7 scripts/release-build-web-sdk-package.sh /tmp/meerkat-web-sdk-package-test-2\n- REGISTRY_DRY_RUN=true scripts/release-publish-web-sdk-package.sh /tmp/meerkat-web-sdk-package-test-2/rkat-web-0.6.7.tgz