### PR TITLE
[codex] Fix multimodal comms notice delivery

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -195,7 +195,7 @@ sh_test(
         "//meerkat-cli:rkat",
         "//meerkat-mcp-server:rkat_mcp_bin",
         "//meerkat-mob:smoke_mob_flow_runtime_test",
-        "//meerkat-mob:smoke_mob_pictionary_test",
+        "//meerkat-mob:smoke_mob_generated_image_comms_test",
         "//meerkat-mob:smoke_mob_resume_test",
         "//meerkat-rest:rkat_rest_bin",
         "//meerkat-rpc:live_smoke_rpc_test",

--- a/meerkat-anthropic/src/client.rs
+++ b/meerkat-anthropic/src/client.rs
@@ -11,7 +11,7 @@ use meerkat_core::lifecycle::run_primitive::{
 use meerkat_core::schema::{CompiledSchema, SchemaError};
 use meerkat_core::{
     AssistantBlock, BlockAssistantMessage, ContentBlock, ImageData, Message, OutputSchema,
-    Provider, StopReason, ToolResult, Usage,
+    Provider, StopReason, SystemNoticeBlock, SystemNoticeMessage, ToolResult, Usage,
 };
 use meerkat_llm_core::LlmError;
 use meerkat_llm_core::{LlmClient, LlmDoneOutcome, LlmEvent, LlmRequest, LlmStream};
@@ -402,6 +402,67 @@ impl AnthropicClient {
         self
     }
 
+    fn content_block_to_anthropic_part(block: &ContentBlock) -> Value {
+        match block {
+            ContentBlock::Text { text } => serde_json::json!({
+                "type": "text",
+                "text": text
+            }),
+            ContentBlock::Image { media_type, data } => match data {
+                ImageData::Inline { data } => serde_json::json!({
+                    "type": "image",
+                    "source": {
+                        "type": "base64",
+                        "media_type": media_type,
+                        "data": data
+                    }
+                }),
+                ImageData::Blob { .. } => serde_json::json!({
+                    "type": "text",
+                    "text": block.text_projection()
+                }),
+            },
+            _ => serde_json::json!({
+                "type": "text",
+                "text": block.text_projection()
+            }),
+        }
+    }
+
+    fn system_notice_anthropic_content(notice: &SystemNoticeMessage) -> Value {
+        let rendered = notice.model_projection_text();
+        let mut parts = Vec::new();
+        if !rendered.trim().is_empty() {
+            parts.push(serde_json::json!({
+                "type": "text",
+                "text": rendered
+            }));
+        }
+
+        for block in &notice.blocks {
+            match block {
+                SystemNoticeBlock::Comms { content, .. }
+                | SystemNoticeBlock::ExternalEvent { content, .. } => {
+                    for content_block in content {
+                        if !matches!(content_block, ContentBlock::Text { .. }) {
+                            parts.push(Self::content_block_to_anthropic_part(content_block));
+                        }
+                    }
+                }
+                _ => {}
+            }
+        }
+
+        match parts.as_slice() {
+            [] => Value::String(String::new()),
+            [only] if only.get("type").and_then(Value::as_str) == Some("text") => only
+                .get("text")
+                .cloned()
+                .unwrap_or_else(|| Value::String(String::new())),
+            _ => Value::Array(parts),
+        }
+    }
+
     /// Build request body for Anthropic API
     fn build_request_body(&self, request: &LlmRequest) -> Result<Value, LlmError> {
         let mut messages = Vec::new();
@@ -415,7 +476,7 @@ impl AnthropicClient {
                 Message::SystemNotice(notice) => {
                     messages.push(serde_json::json!({
                         "role": "user",
-                        "content": notice.model_projection_text()
+                        "content": Self::system_notice_anthropic_content(notice)
                     }));
                 }
                 Message::User(u) => {
@@ -423,30 +484,7 @@ impl AnthropicClient {
                         let content_array: Vec<Value> = u
                             .content
                             .iter()
-                            .map(|block| match block {
-                                ContentBlock::Text { text } => serde_json::json!({
-                                    "type": "text",
-                                    "text": text
-                                }),
-                                ContentBlock::Image { media_type, data } => match data {
-                                    ImageData::Inline { data } => serde_json::json!({
-                                        "type": "image",
-                                        "source": {
-                                            "type": "base64",
-                                            "media_type": media_type,
-                                            "data": data
-                                        }
-                                    }),
-                                    ImageData::Blob { .. } => serde_json::json!({
-                                        "type": "text",
-                                        "text": block.text_projection()
-                                    }),
-                                },
-                                _ => serde_json::json!({
-                                    "type": "text",
-                                    "text": block.text_projection()
-                                }),
-                            })
+                            .map(Self::content_block_to_anthropic_part)
                             .collect();
                         messages.push(serde_json::json!({
                             "role": "user",
@@ -3129,6 +3167,50 @@ mod tests {
                 .contains("source_path"),
             "source_path must never appear in provider payload"
         );
+        Ok(())
+    }
+
+    #[test]
+    fn anthropic_system_notice_with_image_emits_typed_image_part()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let client = AnthropicClient::new("test-key".to_string())?;
+        let request = LlmRequest::new(
+            "claude-sonnet-4-5",
+            vec![Message::SystemNotice(
+                meerkat_core::SystemNoticeMessage::with_block(
+                    meerkat_core::SystemNoticeKind::Comms,
+                    None,
+                    SystemNoticeBlock::Comms {
+                        kind: "message".to_string(),
+                        direction: meerkat_core::SystemNoticeDirection::Incoming,
+                        peer: Some(meerkat_core::SystemNoticePeer {
+                            id: "peer-1".to_string(),
+                            display_name: Some("operator".to_string()),
+                        }),
+                        request_id: None,
+                        intent: None,
+                        status: None,
+                        summary: None,
+                        payload: None,
+                        content: vec![ContentBlock::Image {
+                            media_type: "image/png".to_string(),
+                            data: ImageData::Inline {
+                                data: "iVBOR...".to_string(),
+                            },
+                        }],
+                    },
+                ),
+            )],
+        );
+
+        let body = client.build_request_body(&request)?;
+        let messages = body["messages"].as_array().unwrap();
+        let content = messages[0]["content"].as_array().unwrap();
+
+        assert_eq!(content[0]["type"], "text");
+        assert_eq!(content[1]["type"], "image");
+        assert_eq!(content[1]["source"]["media_type"], "image/png");
+        assert_eq!(content[1]["source"]["data"], "iVBOR...");
         Ok(())
     }
 

--- a/meerkat-core/src/image_content.rs
+++ b/meerkat-core/src/image_content.rs
@@ -2,7 +2,7 @@ use std::collections::BTreeSet;
 
 use crate::blob::{BlobId, BlobStore, BlobStoreError};
 use crate::session::SessionDeferredTurnState;
-use crate::types::{ContentBlock, ContentInput, ImageData, Message};
+use crate::types::{ContentBlock, ContentInput, ImageData, Message, SystemNoticeBlock};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum MissingBlobBehavior {
@@ -77,6 +77,9 @@ pub async fn externalize_messages_from(
                     externalize_content_blocks(blob_store, &mut result.content).await?;
                 }
             }
+            Message::SystemNotice(notice) => {
+                externalize_system_notice_blocks(blob_store, &mut notice.blocks).await?;
+            }
             _ => {}
         }
     }
@@ -98,6 +101,43 @@ pub async fn hydrate_messages_for_execution(
                     hydrate_content_blocks(blob_store, &mut result.content, missing_behavior)
                         .await?;
                 }
+            }
+            Message::SystemNotice(notice) => {
+                hydrate_system_notice_blocks(blob_store, &mut notice.blocks, missing_behavior)
+                    .await?;
+            }
+            _ => {}
+        }
+    }
+    Ok(())
+}
+
+async fn externalize_system_notice_blocks(
+    blob_store: &dyn BlobStore,
+    blocks: &mut [SystemNoticeBlock],
+) -> Result<(), BlobStoreError> {
+    for block in blocks {
+        match block {
+            SystemNoticeBlock::Comms { content, .. }
+            | SystemNoticeBlock::ExternalEvent { content, .. } => {
+                externalize_content_blocks(blob_store, content).await?;
+            }
+            _ => {}
+        }
+    }
+    Ok(())
+}
+
+async fn hydrate_system_notice_blocks(
+    blob_store: &dyn BlobStore,
+    blocks: &mut [SystemNoticeBlock],
+    missing_behavior: MissingBlobBehavior,
+) -> Result<(), BlobStoreError> {
+    for block in blocks {
+        match block {
+            SystemNoticeBlock::Comms { content, .. }
+            | SystemNoticeBlock::ExternalEvent { content, .. } => {
+                hydrate_content_blocks(blob_store, content, missing_behavior).await?;
             }
             _ => {}
         }
@@ -180,8 +220,149 @@ pub fn collect_blob_ids_from_messages(messages: &[Message]) -> BTreeSet<BlobId> 
                     ids.extend(collect_blob_ids_from_blocks(&result.content));
                 }
             }
+            Message::SystemNotice(notice) => {
+                for block in &notice.blocks {
+                    match block {
+                        SystemNoticeBlock::Comms { content, .. }
+                        | SystemNoticeBlock::ExternalEvent { content, .. } => {
+                            ids.extend(collect_blob_ids_from_blocks(content));
+                        }
+                        _ => {}
+                    }
+                }
+            }
             _ => {}
         }
     }
     ids
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::blob::{BlobPayload, BlobRef};
+    use crate::types::{
+        SystemNoticeDirection, SystemNoticeKind, SystemNoticeMessage, SystemNoticePeer,
+    };
+    use async_trait::async_trait;
+    use std::collections::HashMap;
+    use std::sync::Mutex;
+
+    #[derive(Default)]
+    struct TestBlobStore {
+        blobs: Mutex<HashMap<BlobId, BlobPayload>>,
+    }
+
+    impl TestBlobStore {
+        fn with_payload(payload: BlobPayload) -> Self {
+            Self {
+                blobs: Mutex::new(HashMap::from([(payload.blob_id.clone(), payload)])),
+            }
+        }
+    }
+
+    #[async_trait]
+    impl BlobStore for TestBlobStore {
+        async fn put_image(&self, media_type: &str, data: &str) -> Result<BlobRef, BlobStoreError> {
+            let blob_id = BlobId::new(format!("sha256:test-{}", data.len()));
+            let mut blobs = self.blobs.lock().map_err(|err| {
+                BlobStoreError::Internal(format!("test blob store mutex poisoned: {err}"))
+            })?;
+            blobs.insert(
+                blob_id.clone(),
+                BlobPayload {
+                    blob_id: blob_id.clone(),
+                    media_type: media_type.to_string(),
+                    data: data.to_string(),
+                },
+            );
+            Ok(BlobRef {
+                blob_id,
+                media_type: media_type.to_string(),
+            })
+        }
+
+        async fn get(&self, blob_id: &BlobId) -> Result<BlobPayload, BlobStoreError> {
+            self.blobs
+                .lock()
+                .map_err(|err| {
+                    BlobStoreError::Internal(format!("test blob store mutex poisoned: {err}"))
+                })?
+                .get(blob_id)
+                .cloned()
+                .ok_or_else(|| BlobStoreError::NotFound(blob_id.clone()))
+        }
+
+        async fn delete(&self, blob_id: &BlobId) -> Result<(), BlobStoreError> {
+            self.blobs
+                .lock()
+                .map_err(|err| {
+                    BlobStoreError::Internal(format!("test blob store mutex poisoned: {err}"))
+                })?
+                .remove(blob_id);
+            Ok(())
+        }
+
+        fn is_persistent(&self) -> bool {
+            false
+        }
+    }
+
+    #[tokio::test]
+    async fn hydrates_blob_refs_inside_system_notice_comms_content()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let blob_id = BlobId::new("sha256:poster");
+        let store = TestBlobStore::with_payload(BlobPayload {
+            blob_id: blob_id.clone(),
+            media_type: "image/png".to_string(),
+            data: "iVBORw0KGgo=".to_string(),
+        });
+        let mut messages = vec![Message::SystemNotice(SystemNoticeMessage::with_block(
+            SystemNoticeKind::Comms,
+            None,
+            SystemNoticeBlock::Comms {
+                kind: "message".to_string(),
+                direction: SystemNoticeDirection::Incoming,
+                peer: Some(SystemNoticePeer {
+                    id: "peer-1".to_string(),
+                    display_name: Some("operator".to_string()),
+                }),
+                request_id: None,
+                intent: None,
+                status: None,
+                summary: None,
+                payload: None,
+                content: vec![ContentBlock::Image {
+                    media_type: "image/png".to_string(),
+                    data: ImageData::Blob {
+                        blob_id: blob_id.clone(),
+                    },
+                }],
+            },
+        ))];
+
+        hydrate_messages_for_execution(
+            &store,
+            &mut messages,
+            MissingBlobBehavior::HistoricalPlaceholder,
+        )
+        .await?;
+
+        let Message::SystemNotice(notice) = &messages[0] else {
+            return Err(std::io::Error::other("expected system notice").into());
+        };
+        let SystemNoticeBlock::Comms { content, .. } = &notice.blocks[0] else {
+            return Err(std::io::Error::other("expected comms block").into());
+        };
+        assert_eq!(
+            content[0],
+            ContentBlock::Image {
+                media_type: "image/png".to_string(),
+                data: ImageData::Inline {
+                    data: "iVBORw0KGgo=".to_string(),
+                },
+            }
+        );
+        Ok(())
+    }
 }

--- a/meerkat-gemini/src/client.rs
+++ b/meerkat-gemini/src/client.rs
@@ -9,7 +9,8 @@ use meerkat_core::schema::{CompiledSchema, SchemaCompat, SchemaError, SchemaWarn
 use meerkat_core::{
     AssistantBlock, BlockAssistantMessage, ContentBlock, GeminiImageMetadata, ImageData,
     ImageGenerationIntent, ImageOperationTerminalClass, Message, OutputSchema, Provider,
-    ProviderImageMetadata, ProviderTextDisposition, StopReason, ToolResult, Usage, UserMessage,
+    ProviderImageMetadata, ProviderTextDisposition, StopReason, SystemNoticeBlock,
+    SystemNoticeMessage, ToolResult, Usage, UserMessage,
 };
 use meerkat_llm_core::LlmError;
 use meerkat_llm_core::{
@@ -327,6 +328,63 @@ impl GeminiClient {
         self
     }
 
+    fn content_block_to_gemini_part(block: &ContentBlock) -> Value {
+        match block {
+            ContentBlock::Text { text } => serde_json::json!({
+                "text": text
+            }),
+            ContentBlock::Image {
+                media_type,
+                data: ImageData::Inline { data },
+            } => serde_json::json!({
+                "inlineData": {
+                    "mimeType": media_type,
+                    "data": data
+                }
+            }),
+            ContentBlock::Video {
+                media_type,
+                duration_ms: _,
+                data: meerkat_core::VideoData::Inline { data },
+            } => serde_json::json!({
+                "inlineData": {
+                    "mimeType": media_type,
+                    "data": data
+                }
+            }),
+            _ => serde_json::json!({
+                "text": block.text_projection()
+            }),
+        }
+    }
+
+    fn system_notice_gemini_parts(notice: &SystemNoticeMessage) -> Vec<Value> {
+        let rendered = notice.model_projection_text();
+        let mut parts = Vec::new();
+        if !rendered.trim().is_empty() {
+            parts.push(serde_json::json!({ "text": rendered }));
+        }
+
+        for block in &notice.blocks {
+            match block {
+                SystemNoticeBlock::Comms { content, .. }
+                | SystemNoticeBlock::ExternalEvent { content, .. } => {
+                    for content_block in content {
+                        if !matches!(content_block, ContentBlock::Text { .. }) {
+                            parts.push(Self::content_block_to_gemini_part(content_block));
+                        }
+                    }
+                }
+                _ => {}
+            }
+        }
+
+        if parts.is_empty() {
+            parts.push(serde_json::json!({ "text": "" }));
+        }
+        parts
+    }
+
     /// Build request body for Gemini API
     fn build_request_body(&self, request: &LlmRequest) -> Result<Value, LlmError> {
         let mut contents = Vec::new();
@@ -344,7 +402,7 @@ impl GeminiClient {
                 Message::SystemNotice(notice) => {
                     contents.push(serde_json::json!({
                         "role": "user",
-                        "parts": [{"text": notice.model_projection_text()}]
+                        "parts": Self::system_notice_gemini_parts(notice)
                     }));
                 }
                 Message::User(u) => {
@@ -352,33 +410,7 @@ impl GeminiClient {
                         let parts: Vec<Value> = u
                             .content
                             .iter()
-                            .map(|block| match block {
-                                ContentBlock::Text { text } => serde_json::json!({
-                                    "text": text
-                                }),
-                                ContentBlock::Image {
-                                    media_type,
-                                    data: ImageData::Inline { data },
-                                } => serde_json::json!({
-                                    "inlineData": {
-                                        "mimeType": media_type,
-                                        "data": data
-                                    }
-                                }),
-                                ContentBlock::Video {
-                                    media_type,
-                                    duration_ms: _,
-                                    data: meerkat_core::VideoData::Inline { data },
-                                } => serde_json::json!({
-                                    "inlineData": {
-                                        "mimeType": media_type,
-                                        "data": data
-                                    }
-                                }),
-                                _ => serde_json::json!({
-                                    "text": block.text_projection()
-                                }),
-                            })
+                            .map(Self::content_block_to_gemini_part)
                             .collect();
                         contents.push(serde_json::json!({
                             "role": "user",
@@ -3876,6 +3908,47 @@ mod tests {
             !body_str.contains("/tmp/img.png"),
             "source_path value must never appear in provider payload"
         );
+        Ok(())
+    }
+
+    #[test]
+    fn gemini_system_notice_with_image_emits_inline_data_part()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let client = GeminiClient::new("test-key".to_string());
+        let request = LlmRequest::new(
+            "gemini-3.1-pro-preview",
+            vec![Message::SystemNotice(
+                meerkat_core::SystemNoticeMessage::with_block(
+                    meerkat_core::SystemNoticeKind::ExternalEvent,
+                    None,
+                    SystemNoticeBlock::ExternalEvent {
+                        source: "console".to_string(),
+                        event_type: "operator_message".to_string(),
+                        summary: None,
+                        body: Some("inspect this".to_string()),
+                        payload: None,
+                        content: vec![ContentBlock::Image {
+                            media_type: "image/png".to_string(),
+                            data: ImageData::Inline {
+                                data: "iVBOR...".to_string(),
+                            },
+                        }],
+                    },
+                ),
+            )],
+        );
+
+        let body = client.build_request_body(&request)?;
+        let contents = body["contents"].as_array().ok_or("missing contents")?;
+        let parts = contents[0]["parts"].as_array().ok_or("missing parts")?;
+
+        assert!(
+            parts[0]["text"]
+                .as_str()
+                .is_some_and(|text| text.contains("[image: image/png]"))
+        );
+        assert_eq!(parts[1]["inlineData"]["mimeType"], "image/png");
+        assert_eq!(parts[1]["inlineData"]["data"], "iVBOR...");
         Ok(())
     }
 

--- a/meerkat-mob/tests/smoke_mob_generated_image_comms.rs
+++ b/meerkat-mob/tests/smoke_mob_generated_image_comms.rs
@@ -2,7 +2,9 @@
 #![allow(clippy::expect_used, clippy::panic, clippy::unwrap_used)]
 
 use meerkat::{AgentFactory, Config, FactoryAgentBuilder};
-use meerkat_core::types::{AssistantBlock, ContentInput, HandlingMode, Message, text_content};
+use meerkat_core::types::{
+    AssistantBlock, ContentBlock, ContentInput, HandlingMode, Message, text_content,
+};
 use meerkat_core::{AssistantImageRef, BlobRef};
 use meerkat_mob::definition::{RoleWiringRule, WiringRules};
 use meerkat_mob::{
@@ -13,7 +15,7 @@ use meerkat_runtime::MeerkatMachine;
 use meerkat_session::PersistentSessionService;
 use meerkat_store::{JsonlStore, MemoryBlobStore, StoreAdapter};
 use serde_json::Value;
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::sync::Arc;
 use tempfile::TempDir;
 use tokio::time::{Duration, Instant, sleep};
@@ -26,8 +28,30 @@ fn gemini_api_key() -> Option<String> {
     first_env(&["RKAT_GEMINI_API_KEY", "GEMINI_API_KEY", "GOOGLE_API_KEY"])
 }
 
+fn openai_api_key() -> Option<String> {
+    first_env(&["RKAT_OPENAI_API_KEY", "OPENAI_API_KEY"])
+}
+
+fn anthropic_api_key() -> Option<String> {
+    first_env(&["RKAT_ANTHROPIC_API_KEY", "ANTHROPIC_API_KEY"])
+}
+
 fn image_comms_model() -> String {
     std::env::var("RKAT_MOB_IMAGE_COMMS_MODEL").unwrap_or_else(|_| "claude-sonnet-4-5".to_string())
+}
+
+fn image_relay_maker_model() -> String {
+    std::env::var("RKAT_MOB_IMAGE_RELAY_MAKER_MODEL").unwrap_or_else(|_| "gpt-5.5".to_string())
+}
+
+fn image_relay_relay_model() -> String {
+    std::env::var("RKAT_MOB_IMAGE_RELAY_RELAY_MODEL")
+        .unwrap_or_else(|_| "claude-sonnet-4-5".to_string())
+}
+
+fn image_relay_reader_model() -> String {
+    std::env::var("RKAT_MOB_IMAGE_RELAY_READER_MODEL")
+        .unwrap_or_else(|_| "gemini-3.1-pro-preview".to_string())
 }
 
 fn generated_image_comms_profile(
@@ -85,6 +109,75 @@ fn generated_image_comms_definition(model: &str) -> MobDefinition {
     definition
 }
 
+fn image_relay_profile(model: &str, peer_description: &str, image_generation: bool) -> Profile {
+    Profile {
+        model: model.to_string(),
+        skills: vec![],
+        tools: ToolConfig {
+            builtins: image_generation,
+            comms: true,
+            image_generation,
+            ..Default::default()
+        },
+        peer_description: peer_description.to_string(),
+        external_addressable: true,
+        backend: None,
+        runtime_mode: MobRuntimeMode::TurnDriven,
+        max_inline_peer_notifications: None,
+        output_schema: None,
+        provider_params: None,
+    }
+}
+
+fn image_relay_definition(
+    maker_model: &str,
+    relay_model: &str,
+    reader_model: &str,
+) -> MobDefinition {
+    let mut profiles = BTreeMap::new();
+    profiles.insert(
+        ProfileName::from("maker"),
+        ProfileBinding::Inline(image_relay_profile(
+            maker_model,
+            "maker - generates a text-bearing image and sends it to relay",
+            true,
+        )),
+    );
+    profiles.insert(
+        ProfileName::from("relay"),
+        ProfileBinding::Inline(image_relay_profile(
+            relay_model,
+            "relay - forwards maker images to reader and returns the readout",
+            false,
+        )),
+    );
+    profiles.insert(
+        ProfileName::from("reader"),
+        ProfileBinding::Inline(image_relay_profile(
+            reader_model,
+            "reader - reads text from relayed images",
+            false,
+        )),
+    );
+
+    let mut definition = MobDefinition::explicit(MobId::from("image-relay"));
+    definition.profiles = profiles;
+    definition.wiring = WiringRules {
+        auto_wire_orchestrator: false,
+        role_wiring: vec![
+            RoleWiringRule {
+                a: ProfileName::from("maker"),
+                b: ProfileName::from("relay"),
+            },
+            RoleWiringRule {
+                a: ProfileName::from("relay"),
+                b: ProfileName::from("reader"),
+            },
+        ],
+    };
+    definition
+}
+
 async fn setup_generated_image_comms_mob(
     api_key: String,
     model: &str,
@@ -123,6 +216,56 @@ async fn setup_generated_image_comms_mob(
     let mob_service: Arc<dyn MobSessionService> = session_service.clone();
     let handle = MobBuilder::new(
         generated_image_comms_definition(model),
+        MobStorage::in_memory(),
+    )
+    .with_session_service(mob_service.clone())
+    .with_runtime_adapter(runtime_adapter)
+    .create()
+    .await?;
+
+    Ok((handle, mob_service, temp_dir))
+}
+
+async fn setup_image_relay_mob(
+    openai_key: String,
+    maker_model: &str,
+    relay_model: &str,
+    reader_model: &str,
+) -> Result<(MobHandle, Arc<dyn MobSessionService>, TempDir), Box<dyn std::error::Error>> {
+    let temp_dir = TempDir::new()?;
+    let root = temp_dir.path();
+    let runtime_store = Arc::new(meerkat_runtime::InMemoryRuntimeStore::default());
+    let blob_store: Arc<dyn meerkat_core::BlobStore> = Arc::new(MemoryBlobStore::default());
+    let runtime_adapter = Arc::new(MeerkatMachine::persistent(
+        runtime_store.clone(),
+        blob_store.clone(),
+    ));
+
+    let factory = AgentFactory::new(root.join("factory-store"))
+        .user_config_root(root.join("user-config"))
+        .runtime_root(root.join("runtime-root"))
+        .project_root(root.join("project-root"))
+        .context_root(root.join("context-root"))
+        .builtins(true)
+        .comms(true)
+        .with_image_generation_machine(runtime_adapter.clone());
+    let mut builder = FactoryAgentBuilder::new(factory, Config::default());
+    builder.default_image_generation_executor =
+        Some(Arc::new(meerkat_client::OpenAiClient::new(openai_key)));
+    let store = Arc::new(JsonlStore::new(root.join("sessions-jsonl")));
+    builder.default_session_store = Some(Arc::new(StoreAdapter::new(store.clone())));
+
+    let store_dyn: Arc<dyn meerkat::SessionStore> = store;
+    let session_service = Arc::new(PersistentSessionService::new(
+        builder,
+        8,
+        store_dyn,
+        Some(runtime_store),
+        blob_store,
+    ));
+    let mob_service: Arc<dyn MobSessionService> = session_service.clone();
+    let handle = MobBuilder::new(
+        image_relay_definition(maker_model, relay_model, reader_model),
         MobStorage::in_memory(),
     )
     .with_session_service(mob_service.clone())
@@ -173,6 +316,67 @@ async fn spawn_generated_image_comms_members(
                      Do not answer with prose only. Do not send any peer message until maker sends you a request."
                         .to_string(),
                     "For checksum_token requests about image_receipt_check, the only successful terminal action is send_response with a blob-backed image_ref block."
+                        .to_string(),
+                ]),
+        )
+        .await?;
+    handle.wait_for_ready(Some(Duration::from_secs(60))).await?;
+    Ok(())
+}
+
+async fn spawn_image_relay_members(handle: &MobHandle) -> Result<(), Box<dyn std::error::Error>> {
+    handle
+        .spawn_spec(
+            SpawnMemberSpec::new("relay", AgentIdentity::from("relay"))
+                .with_initial_message(ContentInput::Text(
+                    "Stand by as relay for the image relay smoke. \
+                     For this spawn turn, do not call tools and do not contact peers. \
+                     Reply exactly RELAY-IMAGE-READOUT-READY."
+                        .to_string(),
+                ))
+                .with_additional_instructions(vec![
+                    "When maker sends an image relay task, do not read or describe the image yourself. \
+                     Extract the blob_id and media_type from maker's message. Then call send_message to \
+                     peer_id image-relay/reader/reader with handling_mode steer, a body asking reader to \
+                     read the visible text, and a blob-backed image_ref block using exactly that blob_id \
+                     and media_type. When reader replies, call send_message back to maker with body \
+                     READOUT: <reader's text>. Never invent the readout yourself."
+                        .to_string(),
+                ]),
+        )
+        .await?;
+    handle
+        .spawn_spec(
+            SpawnMemberSpec::new("reader", AgentIdentity::from("reader"))
+                .with_initial_message(ContentInput::Text(
+                    "Stand by as reader for the image relay smoke. \
+                     For this spawn turn, do not call tools and do not contact peers. \
+                     Reply exactly READER-IMAGE-READOUT-READY."
+                        .to_string(),
+                ))
+                .with_additional_instructions(vec![
+                    "When relay sends you an image, inspect the image pixels and read the visible text. \
+                     Reply to relay using send_message with handling_mode steer and body exactly \
+                     READOUT: <the text you see>. If you cannot see text, reply READOUT: NO_TEXT. \
+                     Do not use prior context or relay body text as the readout."
+                        .to_string(),
+                ]),
+        )
+        .await?;
+    handle
+        .spawn_spec(
+            SpawnMemberSpec::new("maker", AgentIdentity::from("maker"))
+                .with_initial_message(ContentInput::Text(
+                    "Stand by as maker for the image relay smoke. \
+                     For this spawn turn, do not call tools and do not contact peers. \
+                     Reply exactly MAKER-IMAGE-READOUT-READY."
+                        .to_string(),
+                ))
+                .with_additional_instructions(vec![
+                    "When asked to run the relay smoke, use tools rather than prose. Generate the image first. \
+                     After generate_image returns, send the generated image to relay with a blob-backed image_ref. \
+                     The send_message body may include the blob_id and media_type, but it must not reveal the \
+                     text that the image generation prompt asked the image to contain."
                         .to_string(),
                 ]),
         )
@@ -459,6 +663,310 @@ fn image_ref_matches_blob(message: &Message, tool_name: &str, expected: &BlobRef
     })
 }
 
+fn image_ref_matches_blob_to_peer(
+    message: &Message,
+    tool_name: &str,
+    peer_id: &str,
+    expected: &BlobRef,
+) -> bool {
+    tool_uses(message).into_iter().any(|(name, args)| {
+        name == tool_name
+            && args.get("peer_id").and_then(Value::as_str) == Some(peer_id)
+            && args
+                .get("blocks")
+                .and_then(Value::as_array)
+                .into_iter()
+                .flatten()
+                .any(|block| {
+                    block.get("type").and_then(Value::as_str) == Some("image_ref")
+                        && block.get("source").and_then(Value::as_str) == Some("blob")
+                        && block.get("blob_id").and_then(Value::as_str)
+                            == Some(expected.blob_id.as_str())
+                        && block.get("media_type").and_then(Value::as_str)
+                            == Some(expected.media_type.as_str())
+                })
+    })
+}
+
+fn image_ref_matches_blob_to_any_peer(
+    message: &Message,
+    tool_name: &str,
+    peer_ids: &[String],
+    expected: &BlobRef,
+) -> bool {
+    peer_ids
+        .iter()
+        .any(|peer_id| image_ref_matches_blob_to_peer(message, tool_name, peer_id, expected))
+}
+
+fn tool_use_leaks_readout_token(message: &Message, tool_name: &str) -> bool {
+    tool_uses(message).into_iter().any(|(name, args)| {
+        if name != tool_name {
+            return false;
+        }
+        let mut text = args
+            .get("body")
+            .and_then(Value::as_str)
+            .unwrap_or_default()
+            .to_string();
+        for block in args
+            .get("blocks")
+            .and_then(Value::as_array)
+            .into_iter()
+            .flatten()
+        {
+            if let Some(block_text) = block.get("text").and_then(Value::as_str) {
+                text.push('\n');
+                text.push_str(block_text);
+            }
+        }
+        readout_mentions_target(&text)
+    })
+}
+
+fn tool_use_to_any_peer_leaks_readout_token(
+    message: &Message,
+    tool_name: &str,
+    peer_ids: &[String],
+) -> bool {
+    tool_uses(message).into_iter().any(|(name, args)| {
+        if name != tool_name {
+            return false;
+        }
+        let Some(peer_id) = args.get("peer_id").and_then(Value::as_str) else {
+            return false;
+        };
+        if !peer_ids.iter().any(|expected| expected == peer_id) {
+            return false;
+        }
+        let mut text = args
+            .get("body")
+            .and_then(Value::as_str)
+            .unwrap_or_default()
+            .to_string();
+        for block in args
+            .get("blocks")
+            .and_then(Value::as_array)
+            .into_iter()
+            .flatten()
+        {
+            if let Some(block_text) = block.get("text").and_then(Value::as_str) {
+                text.push('\n');
+                text.push_str(block_text);
+            }
+        }
+        readout_mentions_target(&text)
+    })
+}
+
+fn value_mentions_reader(value: &Value) -> bool {
+    match value {
+        Value::String(text) => {
+            text.eq_ignore_ascii_case("reader")
+                || text.contains("image-relay/reader/reader")
+                || text.to_ascii_lowercase().contains(" reader")
+        }
+        Value::Array(values) => values.iter().any(value_mentions_reader),
+        Value::Object(map) => map.iter().any(|(key, value)| {
+            key.to_ascii_lowercase().contains("reader") || value_mentions_reader(value)
+        }),
+        _ => false,
+    }
+}
+
+fn collect_reader_peer_ids_from_value(value: &Value, ids: &mut BTreeSet<String>) {
+    match value {
+        Value::Array(values) => {
+            for value in values {
+                collect_reader_peer_ids_from_value(value, ids);
+            }
+        }
+        Value::Object(map) => {
+            let object_mentions_reader = map.iter().any(|(key, value)| {
+                key.to_ascii_lowercase().contains("reader") || value_mentions_reader(value)
+            });
+            if object_mentions_reader {
+                for key in ["id", "peer_id", "peerId", "name", "address", "endpoint"] {
+                    if let Some(peer_id) = map.get(key).and_then(Value::as_str) {
+                        ids.insert(peer_id.to_string());
+                    }
+                }
+            }
+            for (key, value) in map {
+                if key.to_ascii_lowercase().contains("reader")
+                    && let Some(peer_id) = value.as_str()
+                {
+                    ids.insert(peer_id.to_string());
+                }
+                collect_reader_peer_ids_from_value(value, ids);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn reader_peer_ids_from_history(messages: &[Message]) -> Vec<String> {
+    let mut ids = BTreeSet::from([
+        "image-relay/reader/reader".to_string(),
+        "reader".to_string(),
+    ]);
+    for message in messages {
+        let Message::ToolResults { results, .. } = message else {
+            continue;
+        };
+        for result in results {
+            let text = text_content(&result.content);
+            if let Ok(value) = serde_json::from_str::<Value>(&text) {
+                collect_reader_peer_ids_from_value(&value, &mut ids);
+            }
+        }
+    }
+    ids.into_iter().collect()
+}
+
+fn comms_content_from_peer<'a>(
+    message: &'a Message,
+    expected_peer_id: &str,
+) -> Option<&'a [ContentBlock]> {
+    let Message::SystemNotice(notice) = message else {
+        return None;
+    };
+    notice.blocks.iter().find_map(|block| {
+        let meerkat_core::SystemNoticeBlock::Comms { peer, content, .. } = block else {
+            return None;
+        };
+        let matches_peer = peer.as_ref().is_some_and(|peer| {
+            peer.id.as_str() == expected_peer_id
+                || peer.display_name.as_deref() == Some(expected_peer_id)
+        });
+        matches_peer.then_some(content.as_slice())
+    })
+}
+
+fn comms_text_from_peer(message: &Message, expected_peer_id: &str) -> Option<String> {
+    comms_content_from_peer(message, expected_peer_id)
+        .map(text_content)
+        .filter(|text| !text.trim().is_empty())
+}
+
+fn member_received_image_from(messages: &[Message], expected_peer_id: &str) -> bool {
+    messages.iter().any(|message| {
+        comms_content_from_peer(message, expected_peer_id).is_some_and(meerkat_core::has_images)
+    })
+}
+
+fn content_has_blob_ref(content: &[ContentBlock], expected: &BlobRef) -> bool {
+    content.iter().any(|block| {
+        block.image_blob_ref().is_some_and(|(media_type, blob_id)| {
+            media_type == expected.media_type && blob_id == &expected.blob_id
+        })
+    })
+}
+
+fn member_received_blob_from(
+    messages: &[Message],
+    expected_peer_id: &str,
+    expected: &BlobRef,
+) -> bool {
+    messages.iter().any(|message| {
+        comms_content_from_peer(message, expected_peer_id)
+            .is_some_and(|content| content_has_blob_ref(content, expected))
+    })
+}
+
+fn member_received_readout_from(messages: &[Message], expected_peer_id: &str) -> bool {
+    messages.iter().any(|message| {
+        comms_text_from_peer(message, expected_peer_id).is_some_and(|text| {
+            text.to_ascii_uppercase().contains("READOUT") && readout_mentions_target(&text)
+        })
+    })
+}
+
+fn readout_mentions_target(text: &str) -> bool {
+    let normalized = text.to_ascii_lowercase();
+    normalized.contains("rkat") && normalized.contains("7319")
+}
+
+fn relay_forwarded_blob_to_reader(
+    relay_messages: &[Message],
+    reader_messages: &[Message],
+    expected: &BlobRef,
+) -> bool {
+    let reader_peer_ids = reader_peer_ids_from_history(relay_messages);
+    let relay_targeted_reader = relay_messages.iter().any(|message| {
+        image_ref_matches_blob_to_any_peer(message, "send_message", &reader_peer_ids, expected)
+    });
+    let reader_received_same_blob =
+        member_received_blob_from(reader_messages, "image-relay/relay/relay", expected);
+    let relay_sent_same_blob = relay_messages
+        .iter()
+        .any(|message| image_ref_matches_blob(message, "send_message", expected));
+    relay_targeted_reader || (relay_sent_same_blob && reader_received_same_blob)
+}
+
+async fn wait_for_image_relay_readout_success(
+    handle: &MobHandle,
+    service: &dyn MobSessionService,
+    timeout: Duration,
+) -> Result<BlobRef, String> {
+    let deadline = Instant::now() + timeout;
+    loop {
+        let maker = member_messages(handle, service, "maker").await;
+        let relay = member_messages(handle, service, "relay").await;
+        let reader = member_messages(handle, service, "reader").await;
+
+        let maker_image = first_generated_image(&maker);
+        let maker_sent_blob_to_relay = maker_image.as_ref().is_some_and(|image| {
+            maker.iter().any(|message| {
+                image_ref_matches_blob_to_peer(
+                    message,
+                    "send_message",
+                    "image-relay/relay/relay",
+                    &image.blob_ref,
+                )
+            })
+        });
+        let relay_received_image = member_received_image_from(&relay, "image-relay/maker/maker");
+        let relay_sent_blob_to_reader = maker_image
+            .as_ref()
+            .is_some_and(|image| relay_forwarded_blob_to_reader(&relay, &reader, &image.blob_ref));
+        let reader_received_image = maker_image.as_ref().is_some_and(|image| {
+            member_received_blob_from(&reader, "image-relay/relay/relay", &image.blob_ref)
+        });
+        let relay_received_readout =
+            member_received_readout_from(&relay, "image-relay/reader/reader");
+        let maker_received_readout =
+            member_received_readout_from(&maker, "image-relay/relay/relay");
+
+        if let Some(image) = maker_image.as_ref()
+            && maker_sent_blob_to_relay
+            && relay_received_image
+            && relay_sent_blob_to_reader
+            && reader_received_image
+            && relay_received_readout
+            && maker_received_readout
+        {
+            return Ok(image.blob_ref.clone());
+        }
+
+        if Instant::now() >= deadline {
+            return Err(format!(
+                "timed out waiting for image relay readout: maker_generated={}, \
+                 maker_sent_blob_to_relay={maker_sent_blob_to_relay}, relay_received_image={relay_received_image}, \
+                 relay_sent_blob_to_reader={relay_sent_blob_to_reader}, reader_received_image={reader_received_image}, \
+                 relay_received_readout={relay_received_readout}, maker_received_readout={maker_received_readout}; \
+                 maker={}; relay={}; reader={}",
+                maker_image.is_some(),
+                history_summary(&maker),
+                history_summary(&relay),
+                history_summary(&reader)
+            ));
+        }
+
+        sleep(Duration::from_secs(3)).await;
+    }
+}
+
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 #[ignore = "lane:e2e-smoke"]
 async fn e2e_smoke_mob_generated_image_comms_blob_request_response() {
@@ -547,5 +1055,103 @@ async fn e2e_smoke_mob_generated_image_comms_blob_request_response() {
             &maker_image.blob_ref
         )),
         "maker should send the image generated in the previous turn as a blob image_ref"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+#[ignore = "lane:e2e-smoke"]
+async fn e2e_smoke_s86_mob_provider_image_relay_readout() {
+    let _ = tracing_subscriber::fmt()
+        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .with_test_writer()
+        .try_init();
+
+    let Some(openai_key) = openai_api_key() else {
+        eprintln!("Skipping image relay smoke: missing OPENAI_API_KEY");
+        return;
+    };
+    if anthropic_api_key().is_none() {
+        eprintln!("Skipping image relay smoke: missing ANTHROPIC_API_KEY");
+        return;
+    }
+    if gemini_api_key().is_none() {
+        eprintln!("Skipping image relay smoke: missing GEMINI_API_KEY");
+        return;
+    }
+
+    let maker_model = image_relay_maker_model();
+    let relay_model = image_relay_relay_model();
+    let reader_model = image_relay_reader_model();
+    let (handle, service, _tmp) =
+        setup_image_relay_mob(openai_key, &maker_model, &relay_model, &reader_model)
+            .await
+            .expect("image relay mob setup");
+    spawn_image_relay_members(&handle)
+        .await
+        .expect("spawn image relay members");
+    wait_for_member_histories_to_settle(
+        &handle,
+        service.as_ref(),
+        &["maker", "relay", "reader"],
+        Duration::from_secs(120),
+        Duration::from_secs(5),
+    )
+    .await
+    .expect("spawn turns should settle before relay smoke");
+
+    let maker = handle
+        .member(&AgentIdentity::from("maker"))
+        .await
+        .expect("maker member");
+    maker
+        .send(
+            ContentInput::Text(
+                "Run the provider image relay smoke now. Use exactly this tool sequence, in this order:\n\
+                 1. Call generate_image exactly once. The request must use provider openai, model gpt-image-2, \
+                 prompt \"Create a simple white poster with only the exact large black text RKAT 7319 centered. \
+                 No other letters, numbers, watermarks, captions, or symbols.\", size 1024x1024, quality low, \
+                 format png, count 1.\n\
+                 2. After generate_image returns, call send_message to peer_id \"image-relay/relay/relay\" with \
+                 handling_mode \"steer\". Attach the generated image as a blob-backed image_ref using the exact \
+                 blob_id and media_type returned by generate_image. The body must tell relay to forward that same \
+                 blob-backed image to reader, ask reader to read visible text, and then return reader's READOUT to you. \
+                 The body and any text block you send to relay MUST NOT contain the target text from the image prompt. \
+                 It may contain only the blob_id, media_type, routing instructions, and the word READOUT.\n\
+                 Do not answer with prose until the tools are done."
+                    .to_string(),
+            ),
+            HandlingMode::Queue,
+        )
+        .await
+        .expect("kick off image relay smoke");
+
+    let relayed_blob =
+        wait_for_image_relay_readout_success(&handle, service.as_ref(), Duration::from_secs(420))
+            .await
+            .expect("image relay readout should complete");
+
+    let maker_messages = member_messages(&handle, service.as_ref(), "maker").await;
+    let relay_messages = member_messages(&handle, service.as_ref(), "relay").await;
+    let reader_messages = member_messages(&handle, service.as_ref(), "reader").await;
+    let reader_peer_ids = reader_peer_ids_from_history(&relay_messages);
+    assert!(
+        !maker_messages
+            .iter()
+            .any(|message| tool_use_leaks_readout_token(message, "send_message")),
+        "maker must not reveal the target text in its relay message"
+    );
+    assert!(
+        !relay_messages
+            .iter()
+            .any(|message| tool_use_to_any_peer_leaks_readout_token(
+                message,
+                "send_message",
+                &reader_peer_ids
+            )),
+        "relay must not reveal the target text when asking reader to OCR the image"
+    );
+    assert!(
+        relay_forwarded_blob_to_reader(&relay_messages, &reader_messages, &relayed_blob),
+        "relay should forward maker's generated image blob to reader"
     );
 }

--- a/meerkat-mob/tests/smoke_mob_pictionary.rs
+++ b/meerkat-mob/tests/smoke_mob_pictionary.rs
@@ -1,7 +1,7 @@
 #![cfg(all(feature = "integration-real-tests", not(target_arch = "wasm32")))]
 #![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
 //!
-//! AI Pictionary — multimodal cross-model comms stress test.
+//! AI Pictionary — standalone multimodal cross-model comms correctness stress test.
 //!
 //! A mob of 4 agents (3 different LLM providers) plays Pictionary:
 //!
@@ -17,6 +17,9 @@
 //! - **Artist** (Claude Sonnet 4.5) validates the guess
 //!
 //! Three rounds: easy (lighthouse), medium (loneliness), hard (déjà vu)
+//!
+//! This is intentionally not part of `make e2e-smoke`: it is slow, creative,
+//! and strict about actual guess correctness rather than just transport.
 //!
 //! ## Run
 //! ```bash
@@ -677,10 +680,6 @@ async fn ensure_artist_image_delivery(
         Ok(receipt) => format!("initial artist turn {receipt:?}"),
         Err(err) => format!("artist turn error: {err}"),
     };
-    if let Err(err) = send_artist_image_directly_via_comms(handle, service, recipient, &image).await
-    {
-        last_outcome = format!("{last_outcome}; direct comms seed failed: {err}");
-    }
 
     loop {
         let missing = missing_guessers_for_artist_image(handle, service, &recipients).await;
@@ -733,49 +732,6 @@ async fn ensure_artist_image_delivery(
     }
 }
 
-async fn send_artist_image_directly_via_comms(
-    handle: &MobHandle,
-    service: &dyn MobSessionService,
-    recipient: &str,
-    image: &ArtistForwardImage<'_>,
-) -> Result<(), String> {
-    let artist_identity = AgentIdentity::from("artist");
-    let artist_session_id = handle
-        .resolve_bridge_session_id(&artist_identity)
-        .await
-        .ok_or_else(|| "artist bridge session missing".to_string())?;
-    let comms = service
-        .comms_runtime(&artist_session_id)
-        .await
-        .ok_or_else(|| "artist comms runtime missing".to_string())?;
-    let peer_name = format!("pictionary/{recipient}/{recipient}");
-    let peer = comms
-        .peers()
-        .await
-        .into_iter()
-        .find(|peer| peer.name.as_str() == peer_name)
-        .ok_or_else(|| format!("recipient peer {peer_name} missing from artist directory"))?;
-    let route = meerkat_core::comms::PeerRoute::with_display_name(peer.peer_id, peer.name);
-    comms
-        .send(meerkat_core::comms::CommsCommand::PeerMessage {
-            to: route,
-            body: artist_forward_body(image.label),
-            blocks: Some(vec![
-                ContentBlock::Text {
-                    text: artist_forward_text_block(image.label),
-                },
-                ContentBlock::Image {
-                    media_type: image.media_type.to_string(),
-                    data: image.data.to_string().into(),
-                },
-            ]),
-            handling_mode: HandlingMode::Steer,
-        })
-        .await
-        .map(|_| ())
-        .map_err(|err| err.to_string())
-}
-
 fn current_round_artist_received_guess(page: &meerkat_core::SessionHistoryPage) -> bool {
     page.messages.iter().any(|msg| {
         comms_content_from_peer(msg, "pictionary/guesser-a/guesser-a").is_some()
@@ -783,6 +739,49 @@ fn current_round_artist_received_guess(page: &meerkat_core::SessionHistoryPage) 
                 let text = text.to_lowercase();
                 text.contains("consensus guess") || text.contains("our consensus")
             })
+    })
+}
+
+fn normalized_words(text: &str) -> Vec<String> {
+    text.to_lowercase()
+        .replace('é', "e")
+        .replace('à', "a")
+        .chars()
+        .map(|ch| if ch.is_ascii_alphanumeric() { ch } else { ' ' })
+        .collect::<String>()
+        .split_whitespace()
+        .map(ToOwned::to_owned)
+        .collect()
+}
+
+fn guess_mentions_secret(text: &str, secret_word: &str) -> bool {
+    let words = normalized_words(text);
+    let joined = words.join(" ");
+    match secret_word {
+        "lighthouse" => words.iter().any(|word| word == "lighthouse"),
+        "loneliness" => {
+            words
+                .iter()
+                .any(|word| word == "loneliness" || word == "lonely")
+                || joined.contains("being alone")
+        }
+        "the feeling of déjà vu" => {
+            joined.contains("deja vu")
+                || joined.contains("already seen")
+                || joined.contains("seen this before")
+        }
+        other => joined.contains(&normalized_words(other).join(" ")),
+    }
+}
+
+fn current_round_artist_received_correct_guess(
+    page: &meerkat_core::SessionHistoryPage,
+    secret_word: &str,
+) -> bool {
+    page.messages.iter().any(|msg| {
+        comms_content_from_peer(msg, "pictionary/guesser-a/guesser-a").is_some_and(|content| {
+            guess_mentions_secret(&meerkat_core::types::text_content(content), secret_word)
+        }) || comms_text(msg).is_some_and(|text| guess_mentions_secret(&text, secret_word))
     })
 }
 
@@ -909,10 +908,11 @@ fn pictionary_history_page(texts: Vec<(&str, &str)>) -> meerkat_core::SessionHis
 
 /// Wait for a full round-trip: guesser-a discusses with both peers, then a guess
 /// is sent to the artist for the current round.
-async fn wait_for_artist_guess_after_discussion(
+async fn wait_for_correct_artist_guess_after_discussion(
     handle: &MobHandle,
     service: &dyn MobSessionService,
     label: &str,
+    secret_word: &str,
     timeout: Duration,
 ) -> bool {
     let deadline = Instant::now() + timeout;
@@ -930,7 +930,7 @@ async fn wait_for_artist_guess_after_discussion(
                 )
                 .await
         {
-            current_round_artist_received_guess(&page)
+            current_round_artist_received_correct_guess(&page, secret_word)
         } else {
             false
         };
@@ -1141,8 +1141,8 @@ async fn print_conversation(
 // ---------------------------------------------------------------------------
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
-#[ignore = "lane:e2e-smoke"]
-async fn e2e_pictionary_multimodal_comms_stress() {
+#[ignore = "standalone-live-pictionary"]
+async fn standalone_pictionary_multimodal_correctness_stress() {
     // Init tracing so RUST_LOG output is visible.
     let _ = tracing_subscriber::fmt()
         .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
@@ -1390,25 +1390,26 @@ async fn e2e_pictionary_multimodal_comms_stress() {
             }
         }
         // Success criteria: guesser-a hears from both peers and then sends a
-        // guess to the artist for the current round, regardless of correctness.
-        let guess_reached_artist = wait_for_artist_guess_after_discussion(
+        // correct guess to the artist for the current round.
+        let correct_guess_reached_artist = wait_for_correct_artist_guess_after_discussion(
             &handle,
             service.as_ref(),
             label,
+            secret_word,
             Duration::from_secs(300),
         )
         .await;
 
-        if guess_reached_artist {
+        if correct_guess_reached_artist {
             println!(
-                "  ✓ Discussion completed and a guess reached the artist [wait: {:.1}s, round: {:.1}s]",
+                "  ✓ Discussion completed and the correct guess reached the artist [wait: {:.1}s, round: {:.1}s]",
                 t.elapsed().as_secs_f64(),
                 round_start.elapsed().as_secs_f64()
             );
             passed += 1;
         } else {
             println!(
-                "  ✗ Timed out — no post-discussion guess reached the artist [wait: {:.1}s, round: {:.1}s]",
+                "  ✗ Timed out — no correct post-discussion guess reached the artist [wait: {:.1}s, round: {:.1}s]",
                 t.elapsed().as_secs_f64(),
                 round_start.elapsed().as_secs_f64()
             );
@@ -1424,16 +1425,21 @@ async fn e2e_pictionary_multimodal_comms_stress() {
 
         // Round 1 (easy) must pass to validate the pipeline works
         assert!(
-            round_idx != 0 || guess_reached_artist,
+            round_idx != 0 || correct_guess_reached_artist,
             "Round 1 (\"{secret_word}\") must pass — \
-             validates multimodal + comms pipeline"
+             validates multimodal + comms correctness"
         );
         println!();
     }
 
+    assert!(
+        passed >= 2,
+        "standalone pictionary should correctly solve at least 2/3 rounds"
+    );
+
     println!("============================================================");
     println!("  RESULTS: {passed}/3 rounds correct");
     println!("  Total time: {:.1}s", test_start.elapsed().as_secs_f64());
-    println!("  (Round 1 required; rounds 2-3 are stretch goals)");
+    println!("  (Round 1 required; at least 2/3 rounds must be correct)");
     println!("============================================================\n");
 }

--- a/meerkat-openai/src/client.rs
+++ b/meerkat-openai/src/client.rs
@@ -11,7 +11,8 @@ use meerkat_core::{
     AssistantBlock, BlockAssistantMessage, ContentBlock, ImageData, ImageGenerationIntent,
     ImageGenerationWarning, ImageOperationTerminalClass, Message, OpenAiImageMetadata,
     OutputSchema, ProviderImageMetadata, ProviderMeta, RevisedPromptDisposition,
-    RevisedPromptSource, StopReason, ToolResult, Usage, UserMessage,
+    RevisedPromptSource, StopReason, SystemNoticeBlock, SystemNoticeMessage, ToolResult, Usage,
+    UserMessage,
 };
 use meerkat_llm_core::BlockAssembler;
 use meerkat_llm_core::LlmError;
@@ -636,6 +637,63 @@ impl OpenAiClient {
         .map(|(input, _)| input)
     }
 
+    fn content_block_to_responses_part(block: &ContentBlock) -> Value {
+        match block {
+            ContentBlock::Text { text } => serde_json::json!({
+                "type": "input_text",
+                "text": text
+            }),
+            ContentBlock::Image { media_type, data } => match data {
+                ImageData::Inline { data } => serde_json::json!({
+                    "type": "input_image",
+                    "image_url": format!("data:{media_type};base64,{data}")
+                }),
+                ImageData::Blob { .. } => serde_json::json!({
+                    "type": "input_text",
+                    "text": block.text_projection()
+                }),
+            },
+            _ => serde_json::json!({
+                "type": "input_text",
+                "text": block.text_projection()
+            }),
+        }
+    }
+
+    fn system_notice_responses_content(notice: &SystemNoticeMessage) -> Value {
+        let rendered = notice.model_projection_text();
+        let mut parts = Vec::new();
+        if !rendered.trim().is_empty() {
+            parts.push(serde_json::json!({
+                "type": "input_text",
+                "text": rendered
+            }));
+        }
+
+        for block in &notice.blocks {
+            match block {
+                SystemNoticeBlock::Comms { content, .. }
+                | SystemNoticeBlock::ExternalEvent { content, .. } => {
+                    for content_block in content {
+                        if !matches!(content_block, ContentBlock::Text { .. }) {
+                            parts.push(Self::content_block_to_responses_part(content_block));
+                        }
+                    }
+                }
+                _ => {}
+            }
+        }
+
+        match parts.as_slice() {
+            [] => Value::String(String::new()),
+            [only] if only.get("type").and_then(Value::as_str) == Some("input_text") => only
+                .get("text")
+                .cloned()
+                .unwrap_or_else(|| Value::String(String::new())),
+            _ => Value::Array(parts),
+        }
+    }
+
     fn openai_reasoning_input_item(text: &str, meta: &ProviderMeta) -> Option<Value> {
         let ProviderMeta::OpenAi {
             id,
@@ -698,7 +756,7 @@ impl OpenAiClient {
                     items.push(serde_json::json!({
                         "type": "message",
                         "role": "user",
-                        "content": notice.model_projection_text()
+                        "content": Self::system_notice_responses_content(notice)
                     }));
                 }
                 Message::User(u) => {
@@ -706,26 +764,7 @@ impl OpenAiClient {
                         let content_array: Vec<Value> = u
                             .content
                             .iter()
-                            .map(|block| match block {
-                                ContentBlock::Text { text } => serde_json::json!({
-                                    "type": "input_text",
-                                    "text": text
-                                }),
-                                ContentBlock::Image { media_type, data } => match data {
-                                    ImageData::Inline { data } => serde_json::json!({
-                                        "type": "input_image",
-                                        "image_url": format!("data:{media_type};base64,{data}")
-                                    }),
-                                    ImageData::Blob { .. } => serde_json::json!({
-                                        "type": "input_text",
-                                        "text": block.text_projection()
-                                    }),
-                                },
-                                _ => serde_json::json!({
-                                    "type": "input_text",
-                                    "text": block.text_projection()
-                                }),
-                            })
+                            .map(Self::content_block_to_responses_part)
                             .collect();
                         items.push(serde_json::json!({
                             "type": "message",
@@ -5155,6 +5194,57 @@ mod tests {
             !body_str.contains("/tmp/img.png"),
             "source_path value must never appear in provider payload"
         );
+    }
+
+    #[test]
+    fn openai_system_notice_with_image_emits_typed_image_part() {
+        use meerkat_core::{
+            SystemNoticeDirection, SystemNoticeKind, SystemNoticeMessage, SystemNoticePeer,
+        };
+
+        let client = OpenAiClient::new("test-key".to_string());
+        let request = LlmRequest::new(
+            "gpt-5.4",
+            vec![Message::SystemNotice(SystemNoticeMessage::with_block(
+                SystemNoticeKind::Comms,
+                None,
+                SystemNoticeBlock::Comms {
+                    kind: "message".to_string(),
+                    direction: SystemNoticeDirection::Incoming,
+                    peer: Some(SystemNoticePeer {
+                        id: "peer-1".to_string(),
+                        display_name: Some("operator".to_string()),
+                    }),
+                    request_id: None,
+                    intent: None,
+                    status: None,
+                    summary: None,
+                    payload: None,
+                    content: vec![
+                        ContentBlock::Text {
+                            text: "describe this poster".to_string(),
+                        },
+                        ContentBlock::Image {
+                            media_type: "image/png".to_string(),
+                            data: ImageData::Inline {
+                                data: "iVBOR...".to_string(),
+                            },
+                        },
+                    ],
+                },
+            ))],
+        );
+
+        let body = client.build_request_body(&request).expect("build request");
+        let input = body["input"].as_array().expect("input array");
+        let notice_item = &input[0];
+
+        assert_eq!(notice_item["type"], "message");
+        assert_eq!(notice_item["role"], "user");
+        let content = notice_item["content"].as_array().expect("content array");
+        assert_eq!(content[0]["type"], "input_text");
+        assert_eq!(content[1]["type"], "input_image");
+        assert_eq!(content[1]["image_url"], "data:image/png;base64,iVBOR...");
     }
 
     #[test]

--- a/meerkat-openai/src/client_compatible.rs
+++ b/meerkat-openai/src/client_compatible.rs
@@ -4,7 +4,8 @@ use async_trait::async_trait;
 use futures::StreamExt;
 use meerkat_core::schema::{CompiledSchema, SchemaError};
 use meerkat_core::{
-    AssistantBlock, ContentBlock, ImageData, Message, OutputSchema, StopReason, Usage,
+    AssistantBlock, ContentBlock, ImageData, Message, OutputSchema, StopReason, SystemNoticeBlock,
+    SystemNoticeMessage, Usage,
 };
 use meerkat_llm_core::LlmError;
 use meerkat_llm_core::{
@@ -104,6 +105,65 @@ impl OpenAiCompatibleClient {
         false
     }
 
+    fn content_block_to_chat_part(block: &ContentBlock) -> Value {
+        match block {
+            ContentBlock::Text { text } => serde_json::json!({
+                "type": "text",
+                "text": text
+            }),
+            ContentBlock::Image { media_type, data } => match data {
+                ImageData::Inline { data } => serde_json::json!({
+                    "type": "image_url",
+                    "image_url": {
+                        "url": format!("data:{media_type};base64,{data}")
+                    }
+                }),
+                ImageData::Blob { .. } => serde_json::json!({
+                    "type": "text",
+                    "text": block.text_projection()
+                }),
+            },
+            _ => serde_json::json!({
+                "type": "text",
+                "text": block.text_projection()
+            }),
+        }
+    }
+
+    fn system_notice_chat_content(notice: &SystemNoticeMessage) -> Value {
+        let rendered = notice.model_projection_text();
+        let mut parts = Vec::new();
+        if !rendered.trim().is_empty() {
+            parts.push(serde_json::json!({
+                "type": "text",
+                "text": rendered
+            }));
+        }
+
+        for block in &notice.blocks {
+            match block {
+                SystemNoticeBlock::Comms { content, .. }
+                | SystemNoticeBlock::ExternalEvent { content, .. } => {
+                    for content_block in content {
+                        if !matches!(content_block, ContentBlock::Text { .. }) {
+                            parts.push(Self::content_block_to_chat_part(content_block));
+                        }
+                    }
+                }
+                _ => {}
+            }
+        }
+
+        match parts.as_slice() {
+            [] => Value::String(String::new()),
+            [only] if only.get("type").and_then(Value::as_str) == Some("text") => only
+                .get("text")
+                .cloned()
+                .unwrap_or_else(|| Value::String(String::new())),
+            _ => Value::Array(parts),
+        }
+    }
+
     fn build_chat_completions_body(&self, request: &LlmRequest) -> Result<Value, LlmError> {
         let mut body = serde_json::json!({
             "model": self.remote_model,
@@ -199,7 +259,7 @@ impl OpenAiCompatibleClient {
                 Message::SystemNotice(notice) => {
                     out.push(serde_json::json!({
                         "role": "user",
-                        "content": notice.model_projection_text()
+                        "content": Self::system_notice_chat_content(notice)
                     }));
                 }
                 Message::User(user) => {
@@ -207,28 +267,7 @@ impl OpenAiCompatibleClient {
                         let content: Vec<Value> = user
                             .content
                             .iter()
-                            .map(|block| match block {
-                                ContentBlock::Text { text } => serde_json::json!({
-                                    "type": "text",
-                                    "text": text
-                                }),
-                                ContentBlock::Image { media_type, data } => match data {
-                                    ImageData::Inline { data } => serde_json::json!({
-                                        "type": "image_url",
-                                        "image_url": {
-                                            "url": format!("data:{media_type};base64,{data}")
-                                        }
-                                    }),
-                                    ImageData::Blob { .. } => serde_json::json!({
-                                        "type": "text",
-                                        "text": block.text_projection()
-                                    }),
-                                },
-                                _ => serde_json::json!({
-                                    "type": "text",
-                                    "text": block.text_projection()
-                                }),
-                            })
+                            .map(Self::content_block_to_chat_part)
                             .collect();
                         out.push(serde_json::json!({
                             "role": "user",
@@ -765,6 +804,41 @@ mod tests {
             axum::serve(listener, app).await.expect("serve test server");
         });
         (format!("http://{addr}/v1"), auth_headers, handle)
+    }
+
+    #[test]
+    fn chat_completions_system_notice_with_image_emits_typed_image_part() {
+        use meerkat_core::{ContentBlock, ImageData, SystemNoticeKind, SystemNoticeMessage};
+
+        let messages = OpenAiCompatibleClient::convert_to_chat_messages(&[Message::SystemNotice(
+            SystemNoticeMessage::with_block(
+                SystemNoticeKind::ExternalEvent,
+                None,
+                SystemNoticeBlock::ExternalEvent {
+                    source: "console".to_string(),
+                    event_type: "operator_message".to_string(),
+                    summary: None,
+                    body: Some("inspect this".to_string()),
+                    payload: None,
+                    content: vec![ContentBlock::Image {
+                        media_type: "image/png".to_string(),
+                        data: ImageData::Inline {
+                            data: "iVBOR...".to_string(),
+                        },
+                    }],
+                },
+            ),
+        )])
+        .expect("convert chat messages");
+
+        assert_eq!(messages[0]["role"], "user");
+        let content = messages[0]["content"].as_array().expect("content array");
+        assert_eq!(content[0]["type"], "text");
+        assert_eq!(content[1]["type"], "image_url");
+        assert_eq!(
+            content[1]["image_url"]["url"],
+            "data:image/png;base64,iVBOR..."
+        );
     }
 
     #[tokio::test]

--- a/scripts/buildbuddy-bazel-poc
+++ b/scripts/buildbuddy-bazel-poc
@@ -313,7 +313,7 @@ case "${command}" in
   e2e-smoke-rbe)
     command="build"
     config="${BUILDBUDDY_BAZEL_CONFIG:-buildbuddy-macos-rbe}"
-    default_target="@wasm_pack_darwin_arm64//:wasm-pack //tests/integration:e2e_smoke_lane_test //tests/integration:e2e_artifacts_bin //meerkat-cli:rkat //meerkat-cli:cli_mobpack_live_smoke_test //meerkat-cli:live_smoke_cli_test //meerkat-mcp-server:rkat_mcp_bin //meerkat-mob:smoke_mob_flow_runtime_test //meerkat-mob:smoke_mob_pictionary_test //meerkat-mob:smoke_mob_resume_test //meerkat-rest:rkat_rest_bin //meerkat-rpc:rkat_rpc_bin //meerkat-rpc:live_smoke_rpc_test //tests/integration:smoke_shared_realm_test"
+    default_target="@wasm_pack_darwin_arm64//:wasm-pack //tests/integration:e2e_smoke_lane_test //tests/integration:e2e_artifacts_bin //meerkat-cli:rkat //meerkat-cli:cli_mobpack_live_smoke_test //meerkat-cli:live_smoke_cli_test //meerkat-mcp-server:rkat_mcp_bin //meerkat-mob:smoke_mob_flow_runtime_test //meerkat-mob:smoke_mob_generated_image_comms_test //meerkat-mob:smoke_mob_resume_test //meerkat-rest:rkat_rest_bin //meerkat-rpc:rkat_rpc_bin //meerkat-rpc:live_smoke_rpc_test //tests/integration:smoke_shared_realm_test"
     extra_args+=(
       --remote_download_outputs=toplevel
       --color=no

--- a/scripts/generate-bazel-rust-builds.mjs
+++ b/scripts/generate-bazel-rust-builds.mjs
@@ -854,7 +854,7 @@ function writeRootBuild(fastTestLabels, e2eSystemTestLabels, surfaceFeatureMatri
     `        "//meerkat-cli:rkat",`,
     `        "//meerkat-mcp-server:rkat_mcp_bin",`,
     `        "//meerkat-mob:smoke_mob_flow_runtime_test",`,
-    `        "//meerkat-mob:smoke_mob_pictionary_test",`,
+    `        "//meerkat-mob:smoke_mob_generated_image_comms_test",`,
     `        "//meerkat-mob:smoke_mob_resume_test",`,
     `        "//meerkat-rest:rkat_rest_bin",`,
     `        "//meerkat-rpc:live_smoke_rpc_test",`,

--- a/tests/integration/src/e2e_lanes.rs
+++ b/tests/integration/src/e2e_lanes.rs
@@ -201,13 +201,13 @@ macro_rules! e2e_smoke_lane_entries {
             scenario(e2e_smoke_s83_comms_multimodal_mcp_roundtrip, 83);
             scenario(e2e_smoke_s84_mob_generated_image_comms_roundtrip, 84);
             scenario(e2e_smoke_s85_workgraph_homecore_agent_spine, 85);
+            scenario(e2e_smoke_s86_mob_provider_image_relay_readout, 86);
             suite(e2e_smoke_rpc_dynamic_tool_pickup, "rpc-dynamic-tool-pickup");
             suite(e2e_smoke_rpc_deferred_catalog_session, "rpc-deferred-catalog-session");
             suite(e2e_smoke_cli_background_job_active_turn, "cli-background-job-active-turn");
             suite(e2e_smoke_cli_background_job_idle_keepalive, "cli-background-job-idle-keepalive");
             suite(e2e_smoke_mob_live_smoke, "mob-live-smoke");
             suite(e2e_smoke_mob_flow_runtime_suite, "mob-flow-runtime");
-            suite(e2e_smoke_mob_pictionary, "mob-pictionary");
         }
     };
 }
@@ -513,10 +513,7 @@ enum SmokeRuntimeClass {
 
 fn smoke_runtime_class(spec: &Spec) -> SmokeRuntimeClass {
     let label = run_label(spec).to_ascii_lowercase();
-    if label.contains("mob flow runtime")
-        || label.contains("pictionary")
-        || label.contains("partial resume collaborative joke")
-    {
+    if label.contains("mob flow runtime") || label.contains("partial resume collaborative joke") {
         return SmokeRuntimeClass::MobSuite;
     }
     if label.contains("image") || label.contains("audio") {
@@ -557,9 +554,6 @@ fn smoke_runtime_priority(spec: &Spec) -> u16 {
     }
 
     let label = run_label(spec).to_ascii_lowercase();
-    if label.contains("pictionary") {
-        return 1_000;
-    }
     if label.contains("mob flow runtime") {
         return 760;
     }
@@ -3991,6 +3985,29 @@ fn scenario_spec(id: u16) -> Option<&'static Spec> {
                 all_features: false,
             },
         }),
+        86 => Some(&Spec {
+            id: Some(86),
+            lane: Lane::Smoke,
+            title: "Mob provider image relay readout",
+            timeout_secs: 900,
+            required_env: &[
+                &["RKAT_OPENAI_API_KEY", "OPENAI_API_KEY"],
+                &["RKAT_ANTHROPIC_API_KEY", "ANTHROPIC_API_KEY"],
+                &["RKAT_GEMINI_API_KEY", "GEMINI_API_KEY", "GOOGLE_API_KEY"],
+            ],
+            required_bins: &["cargo"],
+            cwd: ".",
+            env: &[],
+            cargo_bin_env: &[],
+            pre_commands: &[],
+            command: CommandSpec::CargoTest {
+                package: "meerkat-mob",
+                test_target: "smoke_mob_generated_image_comms",
+                test_name: "e2e_smoke_s86_mob_provider_image_relay_readout",
+                features: &["integration-real-tests"],
+                all_features: false,
+            },
+        }),
         _ => None,
     }
 }
@@ -4853,29 +4870,6 @@ fn suite_spec(name: &str) -> Option<&'static Spec> {
                 output_policy: OutputPolicy::CargoTest,
             },
         }),
-        "mob-pictionary" => Some(&Spec {
-            id: None,
-            lane: Lane::Smoke,
-            title: "Mob pictionary multimodal smoke",
-            timeout_secs: 1800,
-            required_env: &[
-                &["RKAT_ANTHROPIC_API_KEY", "ANTHROPIC_API_KEY"],
-                &["RKAT_OPENAI_API_KEY", "OPENAI_API_KEY"],
-                &["RKAT_GEMINI_API_KEY", "GEMINI_API_KEY"],
-            ],
-            required_bins: &["cargo"],
-            cwd: ".",
-            env: &[],
-            cargo_bin_env: &[],
-            pre_commands: &[],
-            command: CommandSpec::CargoTest {
-                package: "meerkat-mob",
-                test_target: "smoke_mob_pictionary",
-                test_name: "e2e_pictionary_multimodal_comms_stress",
-                features: &["integration-real-tests"],
-                all_features: false,
-            },
-        }),
         _ => None,
     }
 }
@@ -5086,8 +5080,8 @@ mod tests {
                 suite: None,
             },
             super::SelectedSpec {
-                spec: suite_spec("mob-pictionary").unwrap(),
-                suite: Some("mob-pictionary".to_string()),
+                spec: scenario_spec(86).unwrap(),
+                suite: None,
             },
             super::SelectedSpec {
                 spec: scenario_spec(73).unwrap(),
@@ -5095,8 +5089,8 @@ mod tests {
             },
         ];
         order_smoke_specs_for_runtime(&mut selected);
-        assert_eq!(selected[0].suite.as_deref(), Some("mob-pictionary"));
-        assert_eq!(selected[1].spec.id, Some(73));
+        assert_eq!(selected[0].spec.id, Some(73));
+        assert_eq!(selected[1].spec.id, Some(86));
         assert_eq!(selected[2].spec.id, Some(16));
     }
 


### PR DESCRIPTION
## Summary

- Hydrate blob-backed media inside system-notice comms and external-event content before LLM execution.
- Preserve media-bearing system notices as typed multimodal provider inputs for OpenAI Responses, OpenAI-compatible chat completions, Anthropic, and Gemini.
- Add regression coverage for system-notice image hydration/provider projection.
- Move pictionary out of the smoke lane, make it correctness-oriented, and replace it with S86: a focused live-provider image relay/readout smoke test across OpenAI, Anthropic, and Gemini.

## Root Cause

Blob storage and UI upload were intact, but the runtime comms/external-event path delivered image blocks through `Message::SystemNotice`. Hydration and provider projection only handled normal user/tool content paths, while system notices fell back to text-only `model_projection_text()`, so providers could see placeholders such as `[image: image/png]` instead of typed image input.

## Validation

- `./scripts/repo-cargo fmt --all --check`
- `./scripts/repo-cargo test -p meerkat-core hydrates_blob_refs_inside_system_notice_comms_content --lib`
- `./scripts/repo-cargo test -p meerkat-openai system_notice_with_image --lib`
- `./scripts/repo-cargo test -p meerkat-anthropic system_notice_with_image --lib`
- `./scripts/repo-cargo test -p meerkat-gemini system_notice_with_image --lib`
- `./scripts/repo-cargo test -p meerkat-integration-tests e2e_lanes --lib`
- `./scripts/repo-cargo test -p meerkat-mob --test smoke_mob_generated_image_comms --features integration-real-tests e2e_smoke_s86_mob_provider_image_relay_readout -- --ignored --nocapture`
- `./scripts/repo-cargo test -p meerkat-mob --test smoke_mob_pictionary --features integration-real-tests standalone_pictionary_multimodal_correctness_stress -- --ignored --nocapture`
- Pre-push gate, including changed-crates clippy and workspace deterministic gate
