### PR TITLE
Fix mob delegate authority inheritance

### DIFF
--- a/meerkat-core/src/service/mod.rs
+++ b/meerkat-core/src/service/mod.rs
@@ -431,6 +431,8 @@ pub struct MobToolAuthorityContext {
     can_mutate_profiles: bool,
     #[serde(default, skip_serializing_if = "BTreeSet::is_empty")]
     managed_mob_scope: BTreeSet<String>,
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    spawn_profile_scope: BTreeMap<String, BTreeSet<String>>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     caller_provenance: Option<MobToolCallerProvenance>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -444,6 +446,7 @@ impl MobToolAuthorityContext {
             can_create_mobs,
             can_mutate_profiles: can_create_mobs,
             managed_mob_scope: BTreeSet::new(),
+            spawn_profile_scope: BTreeMap::new(),
             caller_provenance: None,
             audit_invocation_id: None,
         }
@@ -486,8 +489,52 @@ impl MobToolAuthorityContext {
         self.managed_mob_scope.contains(mob_id)
     }
 
+    pub fn can_spawn_profile_in_mob(&self, mob_id: &str, profile: &str) -> bool {
+        self.can_manage_mob(mob_id)
+            || self
+                .spawn_profile_scope
+                .get(mob_id)
+                .is_some_and(|profiles| profiles.contains(profile))
+    }
+
+    pub fn can_spawn_any_profile_in_mob(&self, mob_id: &str) -> bool {
+        self.can_manage_mob(mob_id)
+            || self
+                .spawn_profile_scope
+                .get(mob_id)
+                .is_some_and(|profiles| !profiles.is_empty())
+    }
+
     pub fn grant_manage_mob(mut self, mob_id: impl Into<String>) -> Self {
         self.managed_mob_scope.insert(mob_id.into());
+        self
+    }
+
+    pub fn grant_spawn_profile_in_mob(
+        mut self,
+        mob_id: impl Into<String>,
+        profile: impl Into<String>,
+    ) -> Self {
+        self.spawn_profile_scope
+            .entry(mob_id.into())
+            .or_default()
+            .insert(profile.into());
+        self
+    }
+
+    pub fn grant_spawn_profiles_in_mob<I, S>(
+        mut self,
+        mob_id: impl Into<String>,
+        profiles: I,
+    ) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        self.spawn_profile_scope
+            .entry(mob_id.into())
+            .or_default()
+            .extend(profiles.into_iter().map(Into::into));
         self
     }
 
@@ -1455,6 +1502,17 @@ mod tests {
         assert!(ctx.managed_mob_scope.contains("mob-1"));
         assert!(ctx.managed_mob_scope.contains("mob-2"));
         assert_eq!(ctx.managed_mob_scope.len(), 2);
+    }
+
+    #[test]
+    fn spawn_profile_scope_allows_only_granted_profile_without_manage_scope() {
+        let ctx = MobToolAuthorityContext::create_only_generated()
+            .grant_spawn_profile_in_mob("mob-1", "investigator");
+
+        assert!(ctx.can_spawn_any_profile_in_mob("mob-1"));
+        assert!(ctx.can_spawn_profile_in_mob("mob-1", "investigator"));
+        assert!(!ctx.can_spawn_profile_in_mob("mob-1", "writer"));
+        assert!(!ctx.can_manage_mob("mob-1"));
     }
 
     struct MockSnapshotProvider {

--- a/meerkat-mob-mcp/src/agent_tools.rs
+++ b/meerkat-mob-mcp/src/agent_tools.rs
@@ -4159,6 +4159,34 @@ mod tests {
         )
     }
 
+    struct UnprovenancedParentToolProvider;
+    impl VisibleToolSnapshotProvider for UnprovenancedParentToolProvider {
+        fn snapshot_visible_tools(&self) -> Vec<Arc<ToolDef>> {
+            vec![Arc::new(ToolDef {
+                name: "external_ob3_tool".into(),
+                description: "external Ob3 tool".to_string(),
+                input_schema: json!({"type": "object"}),
+                provenance: None,
+            })]
+        }
+    }
+
+    fn surface_with_unprovenanced_parent_tool() -> AgentMobToolSurface {
+        let provider: Arc<dyn VisibleToolSnapshotProvider> =
+            Arc::new(UnprovenancedParentToolProvider);
+        AgentMobToolSurface::new_with_effective_authority(
+            MobMcpState::new_in_memory(),
+            None,
+            Arc::new(std::sync::RwLock::new(create_only_authority())),
+            "claude-sonnet-4-5".to_string(),
+            SessionId::new(),
+            None,
+            None,
+            None,
+            MobToolSnapshotContext::ParentOwned(provider),
+        )
+    }
+
     fn surface_standalone() -> AgentMobToolSurface {
         AgentMobToolSurface::new(
             MobMcpState::new_in_memory(),
@@ -4205,6 +4233,33 @@ mod tests {
         assert!(names.contains("send"));
         assert!(names.contains("read_file"));
         assert!(names.contains("bash"));
+    }
+
+    #[tokio::test]
+    async fn test_resolve_spawn_tooling_inherit_parent_synthesizes_missing_witnesses() {
+        let surface = surface_with_unprovenanced_parent_tool();
+        let tooling = meerkat_mob::SpawnTooling::InheritParent {
+            allow_overlay: None,
+            deny_overlay: None,
+        };
+        let resolved = surface.resolve_spawn_tooling(&tooling).await.unwrap();
+        let authority = resolved
+            .inherited_tool_filter
+            .expect("expected inherited tool filter authority");
+        let witness = authority
+            .witnesses
+            .get("external_ob3_tool")
+            .expect("unprovenanced parent tool should still get a witness");
+
+        assert!(
+            witness.has_provenance_identity_witness(),
+            "delegate inheritance should be valid for visible external tools without provenance"
+        );
+        meerkat_core::tool_scope::validate_witnessed_filter_authority(
+            &authority.filter,
+            &authority.witnesses,
+        )
+        .expect("delegate inherited filter should validate with synthesized witness");
     }
 
     #[tokio::test]

--- a/meerkat-mob/src/runtime/tests.rs
+++ b/meerkat-mob/src/runtime/tests.rs
@@ -9734,12 +9734,12 @@ async fn test_spawn_fails_when_tool_bundle_not_registered() {
 }
 
 #[tokio::test]
-async fn test_mob_management_tools_visible_with_default_authority_but_scope_restricted() {
+async fn test_mob_management_tools_visible_with_default_authority_but_management_restricted() {
     // profile.tools.mob = true is the policy declaration. The canonical
     // resolver synthesizes a generated create-only authority on spawn, so the
     // operator dispatcher mounts and the tools are visible in the catalog.
-    // Without `managed_mob_scope`, dispatch on the current mob is denied with
-    // AccessDenied — capability scope is the gate, not visibility.
+    // Without `managed_mob_scope`, management dispatch on the current mob is
+    // denied with AccessDenied — capability scope is the gate, not visibility.
     let (handle, service) = create_test_mob(sample_definition_with_mob_tools()).await;
     let sid_1 = handle
         .spawn(ProfileName::from("worker"), MeerkatId::from("w-1"), None)
@@ -9764,24 +9764,63 @@ async fn test_mob_management_tools_visible_with_default_authority_but_scope_rest
         );
     }
 
-    let spawn_err = service
+    let list_err = service
+        .dispatch_external_tool_outcome(&sid_1, "list_members", serde_json::json!({}))
+        .await
+        .expect_err("list_members should be denied without managed_mob_scope");
+    assert!(
+        matches!(list_err, ToolError::AccessDenied { .. }),
+        "expected AccessDenied (scope gate), got: {list_err:?}"
+    );
+}
+
+#[tokio::test]
+async fn test_default_mob_authority_can_spawn_definition_profiles_only() {
+    let (handle, service) = create_test_mob(sample_definition_with_mob_tools()).await;
+    let sid_1 = handle
+        .spawn(ProfileName::from("worker"), MeerkatId::from("w-1"), None)
+        .await
+        .expect("spawn w-1")
+        .bridge_session_id()
+        .expect("session-backed")
+        .clone();
+
+    let spawn_result = service
         .dispatch_external_tool_outcome(
             &sid_1,
             "spawn_member",
             serde_json::json!({"profile": "worker", "member_id": "w-2"}),
         )
         .await
-        .expect_err("spawn_member should be denied without managed_mob_scope");
+        .expect("default mob authority should spawn profiles declared by this mob definition");
+    let spawn_payload: serde_json::Value =
+        serde_json::from_str(&spawn_result.result.text_content()).expect("spawn payload");
+    assert_eq!(spawn_payload["agent_identity"], "w-2");
     assert!(
-        matches!(spawn_err, ToolError::AccessDenied { .. }),
-        "expected AccessDenied (scope gate), got: {spawn_err:?}"
+        spawn_payload["member_ref"]
+            .as_str()
+            .is_some_and(|value| !value.is_empty()),
+        "definition-profile spawn should return a canonical member ref"
+    );
+
+    let unknown_profile_err = service
+        .dispatch_external_tool_outcome(
+            &sid_1,
+            "spawn_member",
+            serde_json::json!({"profile": "not-in-definition", "member_id": "blocked"}),
+        )
+        .await
+        .expect_err("default mob authority must not spawn profiles outside the mob definition");
+    assert!(
+        matches!(unknown_profile_err, ToolError::AccessDenied { .. }),
+        "expected AccessDenied for profile outside spawn scope, got: {unknown_profile_err:?}"
     );
     assert!(
         handle
-            .get_member(&AgentIdentity::from("w-2"))
+            .get_member(&AgentIdentity::from("blocked"))
             .await
             .is_none(),
-        "scope-denied operator tools must not mutate roster state"
+        "scope-denied profile spawn must not mutate roster state"
     );
 }
 
@@ -27260,17 +27299,13 @@ async fn test_external_tools_name_collision_profile_wins() {
         "non-colliding callback tool should be present"
     );
 
-    // Dispatch spawn_member — reaches the mob-owned dispatcher, denied on scope.
+    // Dispatch spawn_member — reaches the mob-owned dispatcher, not the
+    // colliding callback tool.
     let raw_args = serde_json::json!({"profile": "worker", "member_id": "w-test"});
-    let err = service
+    service
         .dispatch_external_tool_outcome(&session_id, "spawn_member", raw_args)
         .await
-        .expect_err("mob-owned spawn_member should win and deny on missing scope");
-    assert!(
-        matches!(err, ToolError::AccessDenied { .. }),
-        "expected scope-denied AccessDenied (profile-declared tool wins, callback shadowed); \
-         got: {err:?}"
-    );
+        .expect("mob-owned spawn_member should win and use generated definition-profile scope");
 }
 
 #[tokio::test]

--- a/meerkat-mob/src/runtime/tools.rs
+++ b/meerkat-mob/src/runtime/tools.rs
@@ -214,11 +214,23 @@ pub(super) fn compose_external_tools_for_profile(
 
     // Mount mob operator tools iff the canonical resolver yields an authority.
     // The resolver is the single source of truth shared with build_agent_config.
+    let should_grant_default_spawn_profiles =
+        profile.tools.mob && persisted_mob_tool_authority_context.is_none();
     let (_, effective_authority) = crate::build::resolve_profile_mob_operator_access(
         profile,
         persisted_mob_tool_authority_context,
     );
-    if let Some(authority_context) = effective_authority {
+    if let Some(mut authority_context) = effective_authority {
+        if should_grant_default_spawn_profiles {
+            let mob_id = mob_handle.definition().id.to_string();
+            let profiles = mob_handle
+                .definition()
+                .profiles
+                .keys()
+                .map(|profile| profile.as_str().to_string())
+                .collect::<Vec<_>>();
+            authority_context = authority_context.grant_spawn_profiles_in_mob(mob_id, profiles);
+        }
         dispatchers.push(Arc::new(MobOperatorToolDispatcher::new(
             mob_handle,
             profile.tools.mob,
@@ -498,6 +510,45 @@ impl MobOperatorToolDispatcher {
         Err(ToolError::access_denied(tool_name))
     }
 
+    fn can_manage_current_mob(&self) -> bool {
+        let mob_id = self.handle.definition().id.as_str();
+        self.authority_context.can_manage_mob(mob_id)
+    }
+
+    fn ensure_spawn_member_scope(
+        &self,
+        tool_name: &str,
+        args: &SpawnMemberArgs,
+    ) -> Result<(), ToolError> {
+        if self.can_manage_current_mob() {
+            return Ok(());
+        }
+        if args.resume_bridge_session_id.is_some()
+            || args.resume_session_id.is_some()
+            || args.backend.is_some()
+            || args.runtime_mode.is_some()
+            || args.launch_mode.is_some()
+            || args.tool_access_policy.is_some()
+            || args.budget_split_policy.is_some()
+            || args.auto_wire_parent.is_some()
+        {
+            return Err(ToolError::access_denied(tool_name));
+        }
+        let mob_id = self.handle.definition().id.as_str();
+        if self
+            .authority_context
+            .can_spawn_profile_in_mob(mob_id, &args.profile)
+        {
+            return Ok(());
+        }
+        Err(ToolError::access_denied(tool_name))
+    }
+
+    fn can_spawn_any_profile_in_current_mob(&self) -> bool {
+        let mob_id = self.handle.definition().id.as_str();
+        self.authority_context.can_spawn_any_profile_in_mob(mob_id)
+    }
+
     fn map_mob_error(call: ToolCallView<'_>, error: MobError) -> ToolError {
         ToolError::execution_failed(format!("tool '{}' failed: {error}", call.name))
     }
@@ -728,14 +779,21 @@ impl AgentToolDispatcher for MobOperatorToolDispatcher {
         &self,
         call: ToolCallView<'_>,
     ) -> Result<meerkat_core::ToolDispatchOutcome, ToolError> {
-        if self.tools.iter().any(|tool| tool.name == call.name) {
+        if self.tools.iter().any(|tool| tool.name == call.name)
+            && !matches!(call.name, TOOL_SPAWN_MEMBER | TOOL_SPAWN_MANY_MEMBERS)
+        {
             self.ensure_current_mob_scope(call.name)?;
+        } else if matches!(call.name, TOOL_SPAWN_MEMBER | TOOL_SPAWN_MANY_MEMBERS)
+            && !self.can_spawn_any_profile_in_current_mob()
+        {
+            return Err(ToolError::access_denied(call.name));
         }
         match call.name {
             TOOL_SPAWN_MEMBER => {
                 let args: SpawnMemberArgs = call
                     .parse_args()
                     .map_err(|error| ToolError::invalid_arguments(call.name, error.to_string()))?;
+                self.ensure_spawn_member_scope(call.name, &args)?;
                 let agent_identity = AgentIdentity::from(args.member_id.as_str());
                 let mut spec = SpawnMemberSpec::from_wire(
                     args.profile,
@@ -800,6 +858,9 @@ impl AgentToolDispatcher for MobOperatorToolDispatcher {
                 let args: SpawnManyMembersArgs = call
                     .parse_args()
                     .map_err(|error| ToolError::invalid_arguments(call.name, error.to_string()))?;
+                for spec in &args.specs {
+                    self.ensure_spawn_member_scope(call.name, spec)?;
+                }
                 let identities = args
                     .specs
                     .iter()

--- a/meerkat-mob/src/snapshot.rs
+++ b/meerkat-mob/src/snapshot.rs
@@ -2,9 +2,9 @@
 
 use meerkat_core::WitnessedToolFilter;
 use meerkat_core::tool_scope::ToolFilter;
-use meerkat_core::types::ToolDef;
+use meerkat_core::types::{ToolDef, ToolProvenance, ToolSourceId, ToolSourceKind};
 use serde::{Deserialize, Serialize};
-use std::collections::HashSet;
+use std::collections::{BTreeMap, HashSet};
 use std::sync::Arc;
 
 /// Snapshot of a parent agent's visible tools at child spawn time.
@@ -67,7 +67,8 @@ impl ParentToolScopeSnapshot {
     }
 
     fn witnessed_filter_for(&self, filter: ToolFilter) -> WitnessedToolFilter {
-        meerkat_core::tool_scope::witnessed_tool_filter_for_defs(filter, &self.visible_tool_defs)
+        let witnesses = inherited_filter_witnesses_for_defs(&filter, &self.visible_tool_defs);
+        WitnessedToolFilter::new(filter, witnesses)
     }
 
     /// Create a snapshot from a set of visible tool definitions.
@@ -77,6 +78,43 @@ impl ParentToolScopeSnapshot {
             visible_tool_defs: tools.iter().map(|t| (**t).clone()).collect(),
             captured_at: chrono::Utc::now(),
         }
+    }
+}
+
+fn inherited_filter_witnesses_for_defs(
+    filter: &ToolFilter,
+    tool_defs: &[ToolDef],
+) -> BTreeMap<String, meerkat_core::ToolVisibilityWitness> {
+    let filter_names = match filter {
+        ToolFilter::All => return BTreeMap::new(),
+        ToolFilter::Allow(names) | ToolFilter::Deny(names) => names,
+    };
+
+    filter_names
+        .iter()
+        .filter_map(|name| {
+            let tool = tool_defs.iter().find(|tool| tool.name == name.as_str())?;
+            let provenance = tool
+                .provenance
+                .clone()
+                .unwrap_or_else(|| synthetic_parent_tool_provenance(name));
+            Some((
+                name.as_str().to_string(),
+                meerkat_core::ToolVisibilityWitness {
+                    stable_owner_key: Some(
+                        meerkat_core::tool_catalog::stable_owner_key_from_provenance(&provenance),
+                    ),
+                    last_seen_provenance: Some(provenance),
+                },
+            ))
+        })
+        .collect()
+}
+
+fn synthetic_parent_tool_provenance(tool_name: &str) -> ToolProvenance {
+    ToolProvenance {
+        kind: ToolSourceKind::Callback,
+        source_id: ToolSourceId::new(format!("parent_snapshot:{tool_name}")),
     }
 }
 
@@ -190,5 +228,33 @@ mod tests {
         assert_eq!(snapshot.visible_tool_defs.len(), 2);
         assert!(snapshot.visible_tool_names.contains("x"));
         assert!(snapshot.visible_tool_names.contains("y"));
+    }
+
+    #[test]
+    fn unprovenanced_parent_tools_get_inherited_filter_witnesses() {
+        let tools = vec![make_tool("external_tool")];
+        let snapshot = ParentToolScopeSnapshot::from_tools(&tools);
+        let authority = snapshot.to_witnessed_tool_filter();
+        let witness = authority
+            .witnesses
+            .get("external_tool")
+            .expect("external tool should have synthesized witness");
+
+        assert!(
+            witness.has_provenance_identity_witness(),
+            "inherited filters need provenance-backed witnesses"
+        );
+        assert_eq!(
+            witness
+                .last_seen_provenance
+                .as_ref()
+                .map(|provenance| provenance.source_id.as_str()),
+            Some("parent_snapshot:external_tool")
+        );
+        meerkat_core::tool_scope::validate_witnessed_filter_authority(
+            &authority.filter,
+            &authority.witnesses,
+        )
+        .expect("synthesized witness should satisfy inherited visibility validation");
     }
 }


### PR DESCRIPTION
## Summary
- synthesize visibility witnesses for unprovenanced parent-visible tools during delegate inheritance
- add profile-scoped spawn authority for default mob tools so agents can spawn definition profiles without full mob management
- keep broader management and advanced spawn overrides gated behind managed mob scope

## Tests
- ./scripts/repo-cargo fmt --check
- git diff --check
- ./scripts/repo-cargo test -p meerkat-core service::tests
- ./scripts/repo-cargo test -p meerkat-mob-mcp
- ./scripts/repo-cargo test -p meerkat-mob
- pre-push hook suite, including changed-crates clippy and machine codegen + verify
