### PR TITLE
Allow reasoning-only LLM completions

### DIFF
--- a/meerkat-core/src/agent/state.rs
+++ b/meerkat-core/src/agent/state.rs
@@ -6050,11 +6050,19 @@ mod tests {
         ) -> Result<super::LlmStreamResult, AgentError> {
             Ok(super::LlmStreamResult::new(
                 vec![AssistantBlock::Reasoning {
-                    text: "I should call a tool".to_string(),
-                    meta: None,
+                    text: String::new(),
+                    meta: Some(Box::new(crate::types::ProviderMeta::OpenAi {
+                        id: "rs_reasoning_only".to_string(),
+                        encrypted_content: Some("encrypted-reasoning".to_string()),
+                        phase: None,
+                    })),
                 }],
                 StopReason::EndTurn,
-                Usage::default(),
+                Usage {
+                    input_tokens: 11,
+                    output_tokens: 7,
+                    ..Usage::default()
+                },
             ))
         }
 
@@ -6068,46 +6076,30 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn reasoning_only_llm_response_does_not_complete_turn() {
+    async fn reasoning_only_llm_response_completes_silent_turn() {
         let mut agent = build_agent(Arc::new(ReasoningOnlyLlmClient)).await;
         agent.config.max_turns = Some(1);
 
-        let err = agent
+        let result = agent
             .run("Use a tool".to_string().into())
             .await
-            .expect_err("reasoning-only LLM response should terminalize as a failure");
+            .expect("reasoning-only LLM response should commit as a silent completion");
 
-        match err {
-            AgentError::Llm {
-                reason, message, ..
-            } => {
-                assert!(
-                    message.contains("user-visible text"),
-                    "unexpected message: {message}"
-                );
-                assert!(matches!(
-                    reason,
-                    crate::error::LlmFailureReason::ProviderError(crate::error::LlmProviderError {
-                        kind: crate::error::LlmProviderErrorKind::IncompleteResponse,
-                        ..
-                    })
-                ));
-            }
-            other => panic!("expected LLM incomplete-response failure, got {other:?}"),
-        }
+        assert_eq!(
+            result.text, "",
+            "reasoning-only completions have no user-visible assistant text"
+        );
+        assert_eq!(result.usage.output_tokens, 7);
 
         let snapshot = agent
             .execution_snapshot()
             .expect("test turn-state handle should expose a snapshot");
-        assert_eq!(snapshot.turn_phase, crate::TurnPhase::Failed);
+        assert_eq!(snapshot.turn_phase, crate::TurnPhase::Completed);
         assert_eq!(
             snapshot.terminal_outcome,
-            crate::TurnTerminalOutcome::Failed
+            crate::TurnTerminalOutcome::Completed
         );
-        assert_eq!(
-            snapshot.terminal_cause_kind,
-            Some(crate::TurnTerminalCauseKind::LlmFailure)
-        );
+        assert_eq!(snapshot.terminal_cause_kind, None);
     }
 
     #[tokio::test]

--- a/meerkat-core/src/types.rs
+++ b/meerkat-core/src/types.rs
@@ -566,7 +566,8 @@ pub fn assistant_blocks_have_visible_or_actionable_output(blocks: &[AssistantBlo
             !text.trim().is_empty()
         }
         AssistantBlock::ToolUse { .. } | AssistantBlock::Image { .. } => true,
-        AssistantBlock::Reasoning { .. } | AssistantBlock::ServerToolContent { .. } => false,
+        AssistantBlock::Reasoning { text, meta } => !text.trim().is_empty() || meta.is_some(),
+        AssistantBlock::ServerToolContent { .. } => false,
     })
 }
 

--- a/meerkat-core/src/types/tests.rs
+++ b/meerkat-core/src/types/tests.rs
@@ -872,6 +872,36 @@ mod ordered_transcript_types {
     }
 
     #[test]
+    fn reasoning_with_provider_metadata_counts_as_actionable_output() {
+        let blocks = vec![AssistantBlock::Reasoning {
+            text: String::new(),
+            meta: Some(Box::new(ProviderMeta::OpenAi {
+                id: "reasoning_123".to_string(),
+                encrypted_content: Some("encrypted".to_string()),
+                phase: None,
+            })),
+        }];
+
+        assert!(
+            crate::assistant_blocks_have_visible_or_actionable_output(&blocks),
+            "reasoning-only completions with provider continuity metadata are valid output"
+        );
+    }
+
+    #[test]
+    fn empty_reasoning_without_metadata_is_not_actionable_output() {
+        let blocks = vec![AssistantBlock::Reasoning {
+            text: String::new(),
+            meta: None,
+        }];
+
+        assert!(
+            !crate::assistant_blocks_have_visible_or_actionable_output(&blocks),
+            "empty reasoning without continuity metadata is still an empty completion"
+        );
+    }
+
+    #[test]
     fn test_assistant_block_tool_use_roundtrip() {
         let args = RawValue::from_string(r#"{"path":"/tmp/test.txt"}"#.to_string()).unwrap();
         let block = AssistantBlock::ToolUse {

--- a/meerkat-llm-core/src/adapter.rs
+++ b/meerkat-llm-core/src/adapter.rs
@@ -355,6 +355,23 @@ impl AgentLlmClient for LlmClientAdapter {
                 }
             }
         }
+        if reasoning_started {
+            let reasoning_text = assembler.current_reasoning_text();
+            assembler.on_reasoning_complete(None);
+            meerkat_core::tap_try_send(
+                &self.event_tap,
+                &AgentEvent::ReasoningComplete {
+                    content: reasoning_text.clone(),
+                },
+            );
+            if let Some(ref tx) = self.event_tx {
+                let _ = tx
+                    .send(AgentEvent::ReasoningComplete {
+                        content: reasoning_text,
+                    })
+                    .await;
+            }
+        }
         Ok(LlmStreamResult::new(
             assembler.finalize(),
             stop_reason,
@@ -388,6 +405,10 @@ mod tests {
 
     struct ProjectionClient {
         seen: Arc<Mutex<Option<Vec<Message>>>>,
+    }
+
+    struct ScriptedClient {
+        events: Vec<Result<LlmEvent, LlmError>>,
     }
 
     #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
@@ -442,6 +463,26 @@ mod tests {
         }
     }
 
+    #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
+    #[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+    impl LlmClient for ScriptedClient {
+        fn project_replay_messages(&self, messages: &[Message]) -> Result<Vec<Message>, LlmError> {
+            Ok(messages.to_vec())
+        }
+
+        fn stream<'a>(&'a self, _request: &'a LlmRequest) -> LlmStream<'a> {
+            Box::pin(stream::iter(self.events.clone()))
+        }
+
+        fn provider(&self) -> &'static str {
+            "scripted-test"
+        }
+
+        async fn health_check(&self) -> Result<(), LlmError> {
+            Ok(())
+        }
+    }
+
     fn assistant_image_block() -> AssistantBlock {
         AssistantBlock::Image {
             image_id: AssistantImageId::new(meerkat_core::time_compat::new_uuid_v7()),
@@ -485,6 +526,58 @@ mod tests {
             .ok_or_else(|| "request was not captured".to_string())?;
         assert_eq!(projected.len(), 1);
         assert!(matches!(projected[0], Message::User(_)));
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn adapter_commits_reasoning_delta_when_done_lacks_reasoning_complete()
+    -> Result<(), String> {
+        let adapter = LlmClientAdapter::new(
+            Arc::new(ScriptedClient {
+                events: vec![
+                    Ok(LlmEvent::ReasoningDelta {
+                        delta: "thinking before silence".to_string(),
+                    }),
+                    Ok(LlmEvent::UsageUpdate {
+                        usage: Usage {
+                            input_tokens: 3,
+                            output_tokens: 5,
+                            ..Usage::default()
+                        },
+                    }),
+                    Ok(LlmEvent::Done {
+                        outcome: LlmDoneOutcome::Success {
+                            stop_reason: StopReason::EndTurn,
+                        },
+                    }),
+                ],
+            }),
+            "scripted-model".to_string(),
+        );
+
+        let result = adapter
+            .stream_response(
+                &[Message::User(UserMessage::text("ack silently"))],
+                &[],
+                1024,
+                None,
+                None,
+            )
+            .await
+            .map_err(|err| {
+                format!("pending reasoning should be finalized on successful done: {err}")
+            })?;
+
+        assert_eq!(result.usage().output_tokens, 5);
+        assert!(matches!(
+            result.blocks(),
+            [AssistantBlock::Reasoning { text, meta }]
+                if text == "thinking before silence" && meta.is_none()
+        ));
+        assert!(
+            meerkat_core::assistant_blocks_have_visible_or_actionable_output(result.blocks()),
+            "non-empty reasoning delta should survive to the core commit predicate"
+        );
         Ok(())
     }
 }

--- a/meerkat-openai/src/client.rs
+++ b/meerkat-openai/src/client.rs
@@ -2230,7 +2230,7 @@ mod tests {
         AssistantImageId, BlobId, BlobRef, BlockAssistantMessage, MediaType, ProviderImageMetadata,
         RevisedPromptDisposition, ToolResult, UserMessage, VideoData,
     };
-    use meerkat_llm_core::ImageGenerationExecutor;
+    use meerkat_llm_core::{ImageGenerationExecutor, LlmClientAdapter};
     use std::sync::{Arc, Mutex};
     use tokio::net::TcpListener;
 
@@ -5058,6 +5058,88 @@ mod tests {
 
         // Should only get one ReasoningComplete, not duplicated from response.completed
         assert_eq!(reasoning_completes, 1);
+    }
+
+    #[tokio::test]
+    async fn test_agent_adapter_accepts_reasoning_only_completed_response() {
+        let payload = [
+            r#"data: {"type":"response.completed","response":{"status":"completed","output":[{"type":"reasoning","id":"rs_silent","summary":[],"encrypted_content":"enc_silent"}],"usage":{"input_tokens":10,"output_tokens":409770}}}"#,
+            "data: [DONE]",
+            "",
+        ]
+        .join("\n");
+        let (base_url, server) = spawn_openai_stub_server(payload).await;
+        let client = Arc::new(OpenAiClient::new_with_base_url(
+            "test-key".to_string(),
+            base_url,
+        ));
+        let adapter = LlmClientAdapter::new(client, "gpt-5.5".to_string());
+
+        let result = meerkat_core::AgentLlmClient::stream_response(
+            &adapter,
+            &[Message::User(UserMessage::text("ack silently".to_string()))],
+            &[],
+            1024,
+            None,
+            None,
+        )
+        .await
+        .expect("reasoning-only OpenAI response should assemble successfully");
+        server.abort();
+
+        assert_eq!(result.usage().output_tokens, 409770);
+        assert!(matches!(
+            result.blocks(),
+            [AssistantBlock::Reasoning { text, meta }]
+                if text.is_empty() && meta.is_some()
+        ));
+        assert!(
+            result
+                .blocks()
+                .iter()
+                .any(|block| matches!(block, AssistantBlock::Reasoning { .. })),
+            "adapter should preserve the reasoning item for the core commit boundary"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_agent_adapter_preserves_reasoning_delta_when_completed_omits_reasoning_item() {
+        let payload = [
+            r#"data: {"type":"response.reasoning_summary_text.delta","delta":"thinking then silent"}"#,
+            r#"data: {"type":"response.completed","response":{"status":"completed","output":[],"usage":{"input_tokens":10,"output_tokens":409770}}}"#,
+            "data: [DONE]",
+            "",
+        ]
+        .join("\n");
+        let (base_url, server) = spawn_openai_stub_server(payload).await;
+        let client = Arc::new(OpenAiClient::new_with_base_url(
+            "test-key".to_string(),
+            base_url,
+        ));
+        let adapter = LlmClientAdapter::new(client, "gpt-5.5".to_string());
+
+        let result = meerkat_core::AgentLlmClient::stream_response(
+            &adapter,
+            &[Message::User(UserMessage::text("ack silently".to_string()))],
+            &[],
+            1024,
+            None,
+            None,
+        )
+        .await
+        .expect("terminal OpenAI stream should preserve pending reasoning deltas");
+        server.abort();
+
+        assert_eq!(result.usage().output_tokens, 409770);
+        assert!(matches!(
+            result.blocks(),
+            [AssistantBlock::Reasoning { text, meta }]
+                if text == "thinking then silent" && meta.is_none()
+        ));
+        assert!(
+            meerkat_core::assistant_blocks_have_visible_or_actionable_output(result.blocks()),
+            "pending reasoning summary text should satisfy the core commit predicate"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
- allow reasoning-only assistant blocks with text or provider continuity metadata to satisfy core commit output validation
- finalize pending reasoning deltas on successful LLM stream completion so reasoning summaries are not dropped
- add OpenAI and shared-adapter regressions for GPT-5.5 silent reasoning completions with high token usage

## Tests
- ./scripts/repo-cargo fmt --check
- git diff --check
- ./scripts/repo-cargo test -p meerkat-llm-core -p meerkat-core -p meerkat-openai
- ./scripts/repo-cargo test -p meerkat-llm-core adapter_commits_reasoning_delta_when_done_lacks_reasoning_complete
- ./scripts/repo-cargo clippy -p meerkat-llm-core --tests -- -D warnings
- pre-push hook suite
