### PR TITLE
Fix turn-driven spawn initial message dispatch

### DIFF
--- a/meerkat-mob/src/runtime/actor.rs
+++ b/meerkat-mob/src/runtime/actor.rs
@@ -273,6 +273,7 @@ pub(super) struct PendingSpawn {
     pub(super) agent_identity: MeerkatId,
     pub(super) admitted_bridge_session_id: SessionId,
     pub(super) prompt: ContentInput,
+    pub(super) initial_turn_prompt: Option<ContentInput>,
     pub(super) runtime_mode: crate::MobRuntimeMode,
     pub(super) labels: std::collections::BTreeMap<String, String>,
     pub(super) owner_bridge_session_id: Option<SessionId>,
@@ -4159,12 +4160,14 @@ impl MobActor {
                     let prompt = initial_message.clone().unwrap_or_else(|| {
                         ContentInput::from(self.fallback_spawn_prompt(&profile_name, &agent_identity))
                     });
+                    let initial_turn_prompt = initial_message.as_ref().map(|_| prompt.clone());
                     let resolved_labels = labels.unwrap_or_default();
 
                     return Ok((
                         profile_name,
                         agent_identity,
                         prompt,
+                        initial_turn_prompt,
                         selected_runtime_mode,
                         profile_external_addressable,
                         resolved_labels,
@@ -4219,6 +4222,7 @@ impl MobActor {
                     let prompt = initial_message.clone().unwrap_or_else(|| {
                         ContentInput::from(self.fallback_spawn_prompt(&profile_name, &agent_identity))
                     });
+                    let initial_turn_prompt = initial_message.as_ref().map(|_| prompt.clone());
                     let req = build::to_create_session_request(&config, prompt.clone());
                     let selected_binding = resolve_binding(
                         binding.clone(),
@@ -4242,6 +4246,7 @@ impl MobActor {
                         profile_name,
                         agent_identity,
                         prompt,
+                        initial_turn_prompt,
                         selected_runtime_mode,
                         profile_external_addressable,
                         resolved_labels,
@@ -4359,6 +4364,7 @@ impl MobActor {
             } else {
                 base_prompt
             };
+            let initial_turn_prompt = initial_message.as_ref().map(|_| prompt.clone());
             let req = build::to_create_session_request(&config, prompt.clone());
             let selected_binding = resolve_binding(
                 binding,
@@ -4382,6 +4388,7 @@ impl MobActor {
                 profile_name,
                 agent_identity,
                 prompt,
+                initial_turn_prompt,
                 selected_runtime_mode,
                 profile_external_addressable,
                 resolved_labels,
@@ -4398,6 +4405,7 @@ impl MobActor {
             profile_name,
             agent_identity,
             prompt,
+            initial_turn_prompt,
             selected_runtime_mode,
             external_addressable,
             resolved_labels,
@@ -4468,6 +4476,7 @@ impl MobActor {
                     fence,
                     selected_runtime_mode,
                     prompt,
+                    initial_turn_prompt,
                     resolved_labels,
                     provision,
                     operation_id,
@@ -4520,6 +4529,7 @@ impl MobActor {
             agent_identity,
             admitted_bridge_session_id,
             prompt,
+            initial_turn_prompt,
             runtime_mode: selected_runtime_mode,
             labels: resolved_labels,
             owner_bridge_session_id: spawn_owner_bridge_session_id,
@@ -4669,6 +4679,7 @@ impl MobActor {
                 agent_identity,
                 admitted_bridge_session_id: _,
                 prompt,
+                initial_turn_prompt,
                 runtime_mode,
                 labels,
                 owner_bridge_session_id,
@@ -4702,6 +4713,7 @@ impl MobActor {
                             fence,
                             runtime_mode,
                             prompt,
+                            initial_turn_prompt,
                             labels,
                             provision,
                             spawn_receipt.operation_id,
@@ -4819,6 +4831,7 @@ impl MobActor {
             agent_identity: agent_identity.clone(),
             admitted_bridge_session_id,
             prompt: prompt.clone(),
+            initial_turn_prompt: None,
             runtime_mode,
             labels: labels.clone(),
             owner_bridge_session_id: None,
@@ -4890,6 +4903,7 @@ impl MobActor {
                 fence,
                 runtime_mode,
                 prompt,
+                None,
                 labels,
                 provision,
                 spawn_receipt.operation_id,
@@ -4935,6 +4949,7 @@ impl MobActor {
         fence_token: crate::ids::FenceToken,
         runtime_mode: crate::MobRuntimeMode,
         prompt: ContentInput,
+        initial_turn_prompt: Option<ContentInput>,
         labels: std::collections::BTreeMap<String, String>,
         provision: PendingProvision,
         operation_id: meerkat_core::ops::OperationId,
@@ -5321,7 +5336,9 @@ impl MobActor {
                 }
                 return Err(start_error);
             }
-        } else {
+        }
+
+        if runtime_mode == crate::MobRuntimeMode::TurnDriven {
             // Turn-driven mob members still need a persistent comms drain:
             // async peer requests/responses arrive between user turns (think
             // realtime audio operators calling `send_request` and waiting for
@@ -5356,6 +5373,34 @@ impl MobActor {
                     let _ = adapter
                         .maybe_spawn_mob_comms_drain(bridge_session_id, comms_runtime, mob_id)
                         .await;
+                }
+            }
+
+            if let Some(initial_turn_prompt) = initial_turn_prompt {
+                if let Err(start_error) = self
+                    .dispatch_turn_driven_spawn_initial_turn(
+                        agent_identity,
+                        &agent_runtime_id,
+                        fence_token,
+                        initial_turn_prompt,
+                    )
+                    .await
+                {
+                    if let Err(rollback_error) = self
+                        .rollback_failed_spawn(
+                            agent_identity,
+                            profile_name,
+                            &member_ref,
+                            &wired_spawn_targets,
+                            &planned_wiring_targets,
+                        )
+                        .await
+                    {
+                        return Err(MobError::Internal(format!(
+                            "turn-driven spawn initial turn failed for '{agent_identity}': {start_error}; rollback failed: {rollback_error}"
+                        )));
+                    }
+                    return Err(start_error);
                 }
             }
         }
@@ -7605,9 +7650,18 @@ impl MobActor {
         }
 
         // 3. Rebuild the replacement spawn preserving identity, profile, labels, mode, and peer intent.
-        let prompt = initial_message.unwrap_or_else(|| {
-            ContentInput::from(self.fallback_spawn_prompt(&snapshot.profile_name, &agent_identity))
-        });
+        let (prompt, initial_turn_prompt) = match initial_message {
+            Some(message) => {
+                let prompt = message;
+                (prompt.clone(), Some(prompt))
+            }
+            None => (
+                ContentInput::from(
+                    self.fallback_spawn_prompt(&snapshot.profile_name, &agent_identity),
+                ),
+                None,
+            ),
+        };
         // Prefer roster's effective_profile_override on respawn for lifecycle safety.
         let profile = if let Some(p) = snapshot.effective_profile_override.clone() {
             p
@@ -7664,6 +7718,7 @@ impl MobActor {
             agent_identity: agent_identity.clone(),
             admitted_bridge_session_id,
             prompt: prompt.clone(),
+            initial_turn_prompt: initial_turn_prompt.clone(),
             runtime_mode: snapshot.runtime_mode,
             labels: snapshot.labels.clone(),
             owner_bridge_session_id: None,
@@ -7768,24 +7823,25 @@ impl MobActor {
             let respawn_fence = self.issue_fence_token();
             let finalized = self
                 .finalize_spawn_from_pending(
-                &snapshot.profile_name,
-                &agent_identity,
-                replacement_generation,
-                respawn_fence,
-                snapshot.runtime_mode,
-                prompt,
-                snapshot.labels.clone(),
-                provision,
-                spawn_receipt.operation_id,
-                None,
-                false,
-                (!snapshot.restore_wiring.local_peers.is_empty()
-                    || !snapshot.restore_wiring.external_peers.is_empty())
-                .then_some(snapshot.restore_wiring.clone()),
-                snapshot.effective_profile_override.clone(),
-            )
-            .await
-            .map_err(|error| MobRespawnError::SpawnAfterRetire {
+                    &snapshot.profile_name,
+                    &agent_identity,
+                    replacement_generation,
+                    respawn_fence,
+                    snapshot.runtime_mode,
+                    prompt,
+                    initial_turn_prompt,
+                    snapshot.labels.clone(),
+                    provision,
+                    spawn_receipt.operation_id,
+                    None,
+                    false,
+                    (!snapshot.restore_wiring.local_peers.is_empty()
+                        || !snapshot.restore_wiring.external_peers.is_empty())
+                    .then_some(snapshot.restore_wiring.clone()),
+                    snapshot.effective_profile_override.clone(),
+                )
+                .await
+                .map_err(|error| MobRespawnError::SpawnAfterRetire {
                 identity: AgentIdentity::from(agent_identity.as_str()),
                 reason: error.to_string(),
             })?;
@@ -10117,8 +10173,88 @@ impl MobActor {
             ));
         }
 
-        self.dispatch_member_turn(&entry, content, handling_mode, render_metadata, ack_mode)
-            .await
+        self.dispatch_member_turn_after_machine_admission(
+            &entry,
+            content,
+            handling_mode,
+            render_metadata,
+            ack_mode,
+        )
+        .await
+    }
+
+    async fn dispatch_turn_driven_spawn_initial_turn(
+        &mut self,
+        agent_identity: &MeerkatId,
+        agent_runtime_id: &AgentRuntimeId,
+        fence_token: FenceToken,
+        content: ContentInput,
+    ) -> Result<(), MobError> {
+        let entry = {
+            let roster = self.roster.read().await;
+            roster.get(agent_identity).cloned()
+        }
+        .ok_or_else(|| MobError::MemberNotFound(agent_identity.clone()))?;
+        if entry.fence_token != fence_token {
+            return Err(MobError::StaleFenceToken {
+                runtime_id: agent_runtime_id.clone(),
+                expected: entry.fence_token,
+                actual: fence_token,
+            });
+        }
+
+        let work_ref = WorkRef::new();
+        let origin = WorkOrigin::Internal;
+        let dsl_runtime_id = mob_dsl::AgentRuntimeId::from_domain(agent_runtime_id);
+        let dsl_fence_token = mob_dsl::FenceToken::from_domain(fence_token);
+        let dsl_work_id = mob_dsl::WorkId::from_work_ref(&work_ref);
+        let dsl_origin = mob_dsl::WorkOrigin::from(origin);
+        let transition = match mob_dsl::MobMachineMutator::apply(
+            &mut self.dsl_authority,
+            mob_dsl::MobMachineInput::SubmitWork {
+                agent_runtime_id: dsl_runtime_id.clone(),
+                fence_token: dsl_fence_token,
+                work_id: dsl_work_id,
+                origin: dsl_origin,
+            },
+        ) {
+            Ok(transition) => transition,
+            Err(_) => {
+                return Err(self.submit_work_rejection_for_machine_state(
+                    &self.dsl_authority.state,
+                    &dsl_runtime_id,
+                    origin,
+                    agent_identity,
+                ));
+            }
+        };
+        if transition.from_phase != transition.to_phase {
+            self.dsl_authority.state.lifecycle_phase = transition.to_phase;
+            let _ = self.phase_watch_tx.send(self.state());
+        }
+        self.publish_machine_state_projection();
+        let ingress_admitted = transition.effects.iter().any(|effect| {
+            matches!(
+                effect,
+                mob_dsl::MobMachineEffect::RequestRuntimeIngress { .. }
+            )
+        });
+        drop(transition);
+        if !ingress_admitted {
+            return Err(MobError::Internal(
+                "MobMachine accepted spawn initial SubmitWork but emitted no RequestRuntimeIngress effect"
+                    .into(),
+            ));
+        }
+
+        self.dispatch_member_turn_after_machine_admission(
+            &entry,
+            content,
+            meerkat_core::types::HandlingMode::Queue,
+            None,
+            crate::mob_machine::SubmitWorkAckMode::IngressAccepted,
+        )
+        .await
     }
 
     /// Unified work-lane cancel entry.
@@ -10199,6 +10335,24 @@ impl MobActor {
         ack_mode: crate::mob_machine::SubmitWorkAckMode,
     ) -> Result<(), MobError> {
         self.ensure_pending_spawn_alignment("dispatch_member_turn preflight")?;
+        self.dispatch_member_turn_after_machine_admission(
+            entry,
+            content,
+            handling_mode,
+            render_metadata,
+            ack_mode,
+        )
+        .await
+    }
+
+    async fn dispatch_member_turn_after_machine_admission(
+        &self,
+        entry: &RosterEntry,
+        content: ContentInput,
+        handling_mode: meerkat_core::types::HandlingMode,
+        render_metadata: Option<meerkat_core::types::RenderMetadata>,
+        ack_mode: crate::mob_machine::SubmitWorkAckMode,
+    ) -> Result<(), MobError> {
         match entry.runtime_mode {
             crate::MobRuntimeMode::AutonomousHost => {
                 let bridge_session_id = entry.member_ref.bridge_session_id().ok_or_else(|| {

--- a/meerkat-mob/src/runtime/tests.rs
+++ b/meerkat-mob/src/runtime/tests.rs
@@ -603,6 +603,7 @@ struct MockSessionService {
     start_turn_calls: AtomicU64,
     keep_alive_start_turn_calls: AtomicU64,
     keep_alive_turns_complete_immediately: std::sync::atomic::AtomicBool,
+    start_turn_prompts: RwLock<Vec<(SessionId, String)>>,
     keep_alive_prompts: RwLock<Vec<(SessionId, String)>>,
     interrupt_calls: AtomicU64,
     cancel_after_boundary_supported: AtomicBool,
@@ -658,6 +659,7 @@ impl MockSessionService {
             start_turn_calls: AtomicU64::new(0),
             keep_alive_start_turn_calls: AtomicU64::new(0),
             keep_alive_turns_complete_immediately: std::sync::atomic::AtomicBool::new(false),
+            start_turn_prompts: RwLock::new(Vec::new()),
             keep_alive_prompts: RwLock::new(Vec::new()),
             interrupt_calls: AtomicU64::new(0),
             cancel_after_boundary_supported: AtomicBool::new(true),
@@ -739,6 +741,10 @@ impl MockSessionService {
 
     async fn recorded_create_requests(&self) -> Vec<CreateSessionRecord> {
         self.create_requests.read().await.clone()
+    }
+
+    async fn recorded_start_turn_prompts(&self) -> Vec<(SessionId, String)> {
+        self.start_turn_prompts.read().await.clone()
     }
 
     async fn recorded_external_tools_flags(&self) -> Vec<bool> {
@@ -1243,6 +1249,10 @@ impl SessionService for MockSessionService {
             .await
             .push((id.clone(), req.runtime.flow_tool_overlay.clone()));
         self.start_turn_calls.fetch_add(1, Ordering::Relaxed);
+        self.start_turn_prompts
+            .write()
+            .await
+            .push((id.clone(), req.prompt.text_content()));
         // Determine keep-alive by checking if a notifier was registered for this session
         // (created in create_session when build.keep_alive is true).
         let is_keep_alive = self.keep_alive_notifiers.read().await.contains_key(id);
@@ -22573,6 +22583,165 @@ async fn test_turn_driven_without_adapter_accepted_at_build_time() {
     }
     let result = try_create_test_mob_without_adapter(def).await;
     assert!(result.is_ok(), "TurnDriven without adapter must succeed");
+}
+
+async fn wait_for_start_turn_call_count(
+    service: &MockSessionService,
+    expected: u64,
+    context: &str,
+) {
+    let deadline = Instant::now() + Duration::from_secs(2);
+    while service.start_turn_call_count() < expected {
+        assert!(Instant::now() < deadline, "{context}");
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+}
+
+#[tokio::test]
+async fn test_turn_driven_spawn_with_initial_message_starts_initial_turn() {
+    let (handle, service) = create_test_mob(sample_definition()).await;
+    let initial_message = "Run the requested review task exactly once.";
+
+    handle
+        .spawn_with_options(
+            ProfileName::from("worker"),
+            MeerkatId::from("w-turn-initial"),
+            Some(initial_message.to_string().into()),
+            Some(crate::MobRuntimeMode::TurnDriven),
+            None,
+        )
+        .await
+        .expect("spawn turn-driven worker with initial message");
+
+    assert_eq!(
+        service.keep_alive_start_turn_call_count(),
+        0,
+        "turn-driven initial prompt must not start an autonomous host loop"
+    );
+    wait_for_start_turn_call_count(
+        &service,
+        1,
+        "turn-driven initial prompt should reach the runtime executor",
+    )
+    .await;
+    assert_eq!(
+        service.start_turn_call_count(),
+        1,
+        "turn-driven spawn with initial_message must execute exactly one initial turn"
+    );
+    let prompts = service.recorded_start_turn_prompts().await;
+    assert_eq!(
+        prompts,
+        vec![(
+            service.recorded_prompts().await[0].0.clone(),
+            initial_message.to_string()
+        )],
+        "turn-driven spawn must deliver the caller's initial_message to start_turn"
+    );
+}
+
+#[tokio::test]
+async fn test_turn_driven_spawn_without_initial_message_does_not_synthesize_turn() {
+    let (handle, service) = create_test_mob(sample_definition()).await;
+
+    handle
+        .spawn_with_options(
+            ProfileName::from("worker"),
+            MeerkatId::from("w-turn-idle"),
+            None,
+            Some(crate::MobRuntimeMode::TurnDriven),
+            None,
+        )
+        .await
+        .expect("spawn turn-driven worker without initial message");
+
+    assert_eq!(
+        service.start_turn_call_count(),
+        0,
+        "turn-driven spawn without initial_message should remain idle until an explicit turn"
+    );
+}
+
+#[tokio::test]
+async fn test_turn_driven_respawn_with_initial_message_starts_initial_turn() {
+    let (handle, service) = create_test_mob(sample_definition()).await;
+    let member_id = MeerkatId::from("w-turn-respawn");
+    let initial_message = "Resume the queued review after replacement.";
+
+    handle
+        .spawn_with_options(
+            ProfileName::from("worker"),
+            member_id.clone(),
+            None,
+            Some(crate::MobRuntimeMode::TurnDriven),
+            None,
+        )
+        .await
+        .expect("spawn original turn-driven worker");
+    assert_eq!(
+        service.start_turn_call_count(),
+        0,
+        "test setup should begin with an idle turn-driven member"
+    );
+
+    let receipt = handle
+        .respawn(
+            AgentIdentity::from(member_id.as_str()),
+            Some(initial_message.into()),
+        )
+        .await
+        .expect("respawn turn-driven worker with initial message");
+
+    wait_for_start_turn_call_count(
+        &service,
+        1,
+        "turn-driven respawn initial prompt should reach the runtime executor",
+    )
+    .await;
+    assert_eq!(
+        service.start_turn_call_count(),
+        1,
+        "turn-driven respawn with initial_message must execute exactly one initial turn"
+    );
+    let snapshot = handle
+        .member_status(&receipt.identity)
+        .await
+        .expect("respawned member snapshot");
+    let bridge_session_id = snapshot
+        .current_bridge_session_id
+        .expect("respawned turn-driven member should have a bridge session");
+    assert_eq!(
+        service.recorded_start_turn_prompts().await,
+        vec![(bridge_session_id, initial_message.to_string())],
+        "turn-driven respawn must deliver the caller's initial_message to the replacement session"
+    );
+}
+
+#[tokio::test]
+async fn test_turn_driven_respawn_without_initial_message_does_not_synthesize_turn() {
+    let (handle, service) = create_test_mob(sample_definition()).await;
+    let member_id = MeerkatId::from("w-turn-respawn-idle");
+
+    handle
+        .spawn_with_options(
+            ProfileName::from("worker"),
+            member_id.clone(),
+            None,
+            Some(crate::MobRuntimeMode::TurnDriven),
+            None,
+        )
+        .await
+        .expect("spawn original turn-driven worker");
+    handle
+        .respawn(AgentIdentity::from(member_id.as_str()), None)
+        .await
+        .expect("respawn turn-driven worker without initial message");
+
+    assert_eq!(
+        service.start_turn_call_count(),
+        0,
+        "turn-driven respawn without initial_message should remain idle until an explicit turn"
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

- Preserves explicit `initial_message` intent separately from fallback spawn prompts.
- Dispatches turn-driven spawn/respawn initial prompts through MobMachine `SubmitWork` after the member is live.
- Adds regressions for spawn and respawn with and without explicit initial messages.

## Root Cause

`spawn_member` carried `initial_message` into pending spawn finalization, but the turn-driven branch only started the persistent comms drain and never submitted the prompt as work. Because create-session uses deferred/discarded initial-turn policy, the prompt had no later owner and was silently dropped.

## Validation

- `./scripts/repo-cargo fmt --check`
- `git diff --check`
- `./scripts/repo-cargo test -p meerkat-mob turn_driven`
- `./scripts/repo-cargo test -p meerkat-mob --lib`
- `./scripts/repo-cargo clippy -p meerkat-mob --tests -- -D warnings`
- pre-push gate, including changed-crate clippy, machine codegen/verify, generated-header audit, Bazel freshness, and workspace deterministic gate
