### PR TITLE
[codex] Fix mob retire active-turn teardown race

### DIFF
--- a/meerkat-mob/src/runtime/actor.rs
+++ b/meerkat-mob/src/runtime/actor.rs
@@ -2764,15 +2764,6 @@ impl MobActor {
         Ok(())
     }
 
-    async fn teardown_autonomous_runtime(&self, member_ref: &MemberRef) {
-        #[cfg(feature = "runtime-adapter")]
-        if let (Some(adapter), Some(bridge_session_id)) =
-            (&self.runtime_adapter, member_ref.bridge_session_id())
-        {
-            adapter.unregister_session(bridge_session_id).await;
-        }
-    }
-
     async fn teardown_session_runtime_bindings_from_roster(&self) {
         #[cfg(feature = "runtime-adapter")]
         if let Some(adapter) = &self.runtime_adapter {
@@ -8011,16 +8002,12 @@ impl MobActor {
         }
     }
 
-    /// Stop the autonomous member and unregister session (disposal only).
+    /// Stop the autonomous member host loop. Session unregister is owned by
+    /// the archive step after runtime retire/drain quiesces.
     async fn dispose_stop_host_loop(&mut self, ctx: &DisposalContext) -> Result<(), MobError> {
         if ctx.entry.runtime_mode == crate::MobRuntimeMode::AutonomousHost {
             self.stop_autonomous_member(&ctx.agent_identity, &ctx.entry.member_ref)
                 .await?;
-            // Full teardown: unregister from MeerkatMachine.
-            // stop_autonomous_member only aborts the drain; disposal also
-            // needs to release the session registration.
-            self.teardown_autonomous_runtime(&ctx.entry.member_ref)
-                .await;
         }
         Ok(())
     }

--- a/meerkat-mob/src/runtime/provisioner.rs
+++ b/meerkat-mob/src/runtime/provisioner.rs
@@ -40,7 +40,7 @@ use serde::de::DeserializeOwned;
 #[cfg(feature = "runtime-adapter")]
 use std::collections::HashMap;
 #[cfg(feature = "runtime-adapter")]
-use std::time::Duration;
+use std::time::{Duration, Instant};
 #[cfg(feature = "runtime-adapter")]
 use tokio::sync::{Mutex, RwLock, mpsc, oneshot};
 
@@ -340,10 +340,165 @@ impl SessionBackend {
         }
     }
 
+    #[cfg(feature = "runtime-adapter")]
+    fn runtime_archive_error(message: impl Into<String>) -> SessionError {
+        SessionError::Agent(meerkat_core::error::AgentError::InternalError(
+            message.into(),
+        ))
+    }
+
+    #[cfg(feature = "runtime-adapter")]
+    async fn retire_runtime_before_archive(
+        &self,
+        session_id: &SessionId,
+    ) -> Result<(), SessionError> {
+        let Some(adapter) = &self.runtime_adapter else {
+            return Ok(());
+        };
+        if !adapter.contains_session(session_id).await {
+            return Ok(());
+        }
+
+        self.cancel_active_runtime_turn_before_retire(session_id)
+            .await?;
+
+        let runtime_id = meerkat_runtime::LogicalRuntimeId::for_session(session_id);
+        match meerkat_runtime::RuntimeControlPlane::retire(adapter.as_ref(), &runtime_id).await {
+            Ok(_) => {}
+            Err(meerkat_runtime::RuntimeControlPlaneError::NotFound(_)) => return Ok(()),
+            Err(error) => {
+                return Err(Self::runtime_archive_error(format!(
+                    "runtime retire before mob archive failed for {session_id}: {error}"
+                )));
+            }
+        }
+
+        self.wait_for_runtime_retire_drain(session_id).await
+    }
+
+    #[cfg(not(feature = "runtime-adapter"))]
+    async fn retire_runtime_before_archive(
+        &self,
+        _session_id: &SessionId,
+    ) -> Result<(), SessionError> {
+        Ok(())
+    }
+
+    #[cfg(feature = "runtime-adapter")]
+    fn runtime_run_bound(snapshot: &meerkat_runtime::MeerkatMachineSpineSnapshot) -> bool {
+        snapshot.control.current_run_id.is_some() || snapshot.inputs.current_run_id.is_some()
+    }
+
+    #[cfg(feature = "runtime-adapter")]
+    fn runtime_turn_cancellable(snapshot: &meerkat_runtime::MeerkatMachineSpineSnapshot) -> bool {
+        snapshot.control.phase == meerkat_runtime::RuntimeState::Running
+            && Self::runtime_run_bound(snapshot)
+    }
+
+    #[cfg(feature = "runtime-adapter")]
+    async fn cancel_active_runtime_turn_before_retire(
+        &self,
+        session_id: &SessionId,
+    ) -> Result<(), SessionError> {
+        let Some(adapter) = &self.runtime_adapter else {
+            return Ok(());
+        };
+        let deadline = Instant::now() + Duration::from_secs(30);
+        let mut cancel_requested = false;
+
+        loop {
+            if !adapter.contains_session(session_id).await {
+                return Ok(());
+            }
+            let Some(snapshot) = adapter.meerkat_machine_spine_snapshot(session_id).await else {
+                return Ok(());
+            };
+            if snapshot.control.phase != meerkat_runtime::RuntimeState::Running
+                || !Self::runtime_run_bound(&snapshot)
+            {
+                return Ok(());
+            }
+
+            if !cancel_requested {
+                if let Err(error) = adapter.cancel_after_boundary(session_id).await {
+                    let still_active = adapter
+                        .meerkat_machine_spine_snapshot(session_id)
+                        .await
+                        .is_some_and(|snapshot| Self::runtime_turn_cancellable(&snapshot));
+                    if still_active {
+                        return Err(Self::runtime_archive_error(format!(
+                            "runtime cancel-before-retire failed for {session_id}: {error}"
+                        )));
+                    }
+                    continue;
+                }
+                cancel_requested = true;
+            }
+
+            if Instant::now() >= deadline {
+                return Err(Self::runtime_archive_error(format!(
+                    "timed out waiting for active runtime turn before mob archive for {session_id}: phase={:?}, control_run={:?}, ingress_run={:?}, queue_len={}, steer_queue_len={}",
+                    snapshot.control.phase,
+                    snapshot.control.current_run_id,
+                    snapshot.inputs.current_run_id,
+                    snapshot.inputs.queue.len(),
+                    snapshot.inputs.steer_queue.len(),
+                )));
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+    }
+
+    #[cfg(feature = "runtime-adapter")]
+    async fn wait_for_runtime_retire_drain(
+        &self,
+        session_id: &SessionId,
+    ) -> Result<(), SessionError> {
+        let Some(adapter) = &self.runtime_adapter else {
+            return Ok(());
+        };
+        let deadline = Instant::now() + Duration::from_secs(30);
+
+        loop {
+            if !adapter.contains_session(session_id).await {
+                return Ok(());
+            }
+            let Some(snapshot) = adapter.meerkat_machine_spine_snapshot(session_id).await else {
+                return Ok(());
+            };
+            let ingress_quiescent =
+                snapshot.inputs.queue.is_empty() && snapshot.inputs.steer_queue.is_empty();
+            // Retired is machine-owned terminal lifecycle truth for archive
+            // purposes. The spine may preserve diagnostic run ids after retire,
+            // so unregister must not wait on those ids once ingress is empty.
+            let lifecycle_retired = matches!(
+                snapshot.control.phase,
+                meerkat_runtime::RuntimeState::Retired | meerkat_runtime::RuntimeState::Stopped
+            );
+            let no_run_bound = snapshot.control.current_run_id.is_none()
+                && snapshot.inputs.current_run_id.is_none();
+            if ingress_quiescent && (lifecycle_retired || no_run_bound) {
+                return Ok(());
+            }
+            if Instant::now() >= deadline {
+                return Err(Self::runtime_archive_error(format!(
+                    "timed out waiting for runtime retire drain before mob archive for {session_id}: phase={:?}, control_run={:?}, ingress_run={:?}, queue_len={}, steer_queue_len={}",
+                    snapshot.control.phase,
+                    snapshot.control.current_run_id,
+                    snapshot.inputs.current_run_id,
+                    snapshot.inputs.queue.len(),
+                    snapshot.inputs.steer_queue.len(),
+                )));
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+    }
+
     async fn archive_with_authority_then_unregister(
         &self,
         session_id: &SessionId,
     ) -> Result<(), SessionError> {
+        self.retire_runtime_before_archive(session_id).await?;
         match self
             .session_service
             .archive_with_mob_lifecycle_authority(session_id)
@@ -1408,15 +1563,6 @@ impl MobProvisioner for SessionBackend {
 
     async fn retire_member(&self, member_ref: &MemberRef) -> Result<(), MobError> {
         let session_id = Self::require_session(member_ref, "retire")?;
-        if let Some(adapter) = &self.runtime_adapter {
-            if adapter.contains_session(&session_id).await {
-                LocalMobRuntimeBridge::new(adapter.clone(), session_id.clone())
-                    .retire_member()
-                    .await
-                    .map(|_| ())
-                    .map_err(|err| MobError::Internal(err.to_string()))?;
-            }
-        }
         self.archive_with_authority_then_unregister(&session_id)
             .await?;
         self.ops_adapter.mark_member_retired(member_ref).await?;

--- a/meerkat-mob/src/runtime/tests.rs
+++ b/meerkat-mob/src/runtime/tests.rs
@@ -17891,6 +17891,155 @@ async fn test_abort_member_provision_archive_failure_keeps_runtime_binding_for_r
     );
 }
 
+#[cfg(feature = "runtime-adapter")]
+#[tokio::test]
+async fn test_retire_member_waits_for_active_runtime_turn_before_unregister() {
+    struct BlockingExecutor {
+        apply_started: Arc<tokio::sync::Notify>,
+        allow_finish: Arc<tokio::sync::Notify>,
+    }
+
+    #[async_trait::async_trait]
+    impl meerkat_core::lifecycle::core_executor::CoreExecutor for BlockingExecutor {
+        async fn apply(
+            &mut self,
+            run_id: meerkat_core::RunId,
+            primitive: meerkat_core::lifecycle::run_primitive::RunPrimitive,
+        ) -> Result<
+            meerkat_core::lifecycle::core_executor::CoreApplyOutput,
+            meerkat_core::lifecycle::core_executor::CoreExecutorError,
+        > {
+            self.apply_started.notify_waiters();
+            self.allow_finish.notified().await;
+
+            Ok(meerkat_core::lifecycle::core_executor::CoreApplyOutput {
+                receipt: meerkat_core::lifecycle::run_receipt::RunBoundaryReceipt {
+                    run_id,
+                    boundary: meerkat_core::lifecycle::run_primitive::RunApplyBoundary::RunStart,
+                    contributing_input_ids: primitive.contributing_input_ids().to_vec(),
+                    conversation_digest: None,
+                    message_count: 0,
+                    sequence: 0,
+                },
+                session_snapshot: None,
+                terminal: None,
+            })
+        }
+
+        async fn cancel_after_boundary(
+            &mut self,
+            _reason: String,
+        ) -> Result<(), meerkat_core::lifecycle::core_executor::CoreExecutorError> {
+            Ok(())
+        }
+
+        async fn stop_runtime_executor(
+            &mut self,
+            _reason: String,
+        ) -> Result<(), meerkat_core::lifecycle::core_executor::CoreExecutorError> {
+            Ok(())
+        }
+    }
+
+    let service = Arc::new(MockSessionService::new());
+    let adapter = Arc::new(meerkat_runtime::MeerkatMachine::ephemeral());
+    service.set_runtime_adapter(adapter.clone());
+    let provisioner =
+        super::provisioner::SessionBackend::new(service.clone(), Some(adapter.clone()));
+    let session = Session::new();
+    let session_id = session.id().clone();
+    let apply_started = Arc::new(tokio::sync::Notify::new());
+    let allow_finish = Arc::new(tokio::sync::Notify::new());
+
+    service
+        .create_session(CreateSessionRequest {
+            model: "claude-sonnet-4-5".to_string(),
+            prompt: "retire active runtime turn".to_string().into(),
+            render_metadata: None,
+            system_prompt: None,
+            max_tokens: None,
+            event_tx: None,
+            build: Some(meerkat_core::service::SessionBuildOptions {
+                resume_session: Some(session),
+                comms_name: Some("test-mob/worker/retire-active-turn".to_string()),
+                keep_alive: true,
+                ..Default::default()
+            }),
+            skill_references: None,
+            initial_turn: meerkat_core::service::InitialTurnPolicy::Defer,
+            deferred_prompt_policy: meerkat_core::service::DeferredPromptPolicy::Discard,
+            labels: None,
+        })
+        .await
+        .expect("create runtime-backed active-turn session");
+    adapter
+        .ensure_session_with_executor(
+            session_id.clone(),
+            Box::new(BlockingExecutor {
+                apply_started: Arc::clone(&apply_started),
+                allow_finish: Arc::clone(&allow_finish),
+            }),
+        )
+        .await;
+
+    let input = meerkat_runtime::Input::Prompt(meerkat_runtime::PromptInput::new(
+        "active turn before retire",
+        Some(
+            meerkat_core::lifecycle::run_primitive::RuntimeTurnMetadata {
+                handling_mode: Some(HandlingMode::Steer),
+                ..Default::default()
+            },
+        ),
+    ));
+    let (outcome, completion) = adapter
+        .accept_input_with_completion(&session_id, input)
+        .await
+        .expect("active steered prompt should be accepted");
+    assert!(outcome.is_accepted());
+    let completion = completion.expect("active prompt should register a completion waiter");
+
+    tokio::time::timeout(Duration::from_secs(1), apply_started.notified())
+        .await
+        .expect("runtime executor should enter active apply before retire");
+
+    let member_ref = MemberRef::from_bridge_session_id(session_id.clone());
+    let retire_task = tokio::spawn(async move { provisioner.retire_member(&member_ref).await });
+
+    tokio::time::sleep(Duration::from_millis(50)).await;
+    assert!(
+        !retire_task.is_finished(),
+        "retire_member must not archive/unregister while the runtime authority still has an active turn"
+    );
+    assert!(
+        adapter.contains_session(&session_id).await,
+        "runtime session must remain registered while the active turn can still emit turn-state transitions"
+    );
+
+    allow_finish.notify_waiters();
+    match completion.wait().await {
+        meerkat_runtime::CompletionOutcome::CompletedWithoutResult => {}
+        other => {
+            panic!("expected active runtime turn to complete before retire cleanup: {other:?}")
+        }
+    }
+    retire_task
+        .await
+        .expect("retire task should not panic")
+        .expect("retire_member should finish after active turn drains");
+
+    assert!(
+        !adapter.contains_session(&session_id).await,
+        "retire_member should unregister after the active turn drains and archive succeeds"
+    );
+    assert!(
+        !service
+            .has_live_session(&session_id)
+            .await
+            .expect("read live service state"),
+        "retire_member should archive the session after runtime drain"
+    );
+}
+
 #[tokio::test]
 async fn test_builder_rejects_runtime_adapter_with_mismatched_persistence_authority() {
     let service = Arc::new(MockSessionService::new());


### PR DESCRIPTION
## Summary
- Move mob runtime retirement into the archive/unregister path so runtime teardown waits for machine-observed quiescence.
- Stop direct autonomous runtime unregister during disposal.
- Add a regression that blocks an active runtime turn and verifies `retire_member` does not unregister until the turn drains.

## Root cause
`SessionBackend::retire_member` retired through `LocalMobRuntimeBridge` before archive/unregister coordination. That allowed the runtime to become `Retired` while an executor still held an active turn and could emit turn-state transitions such as `RegisterPendingOps`.

## Validation
- `./scripts/repo-cargo fmt --check`
- `./scripts/repo-cargo test -p meerkat-mob test_retire_member_waits_for_active_runtime_turn_before_unregister -- --nocapture`
- `./scripts/repo-cargo test -p meerkat-mob test_abort_member_provision_retires_runtime_before_absent_cleanup_unregister -- --nocapture`
- `./scripts/repo-cargo test -p meerkat-mob test_abort_member_provision_archive_failure_keeps_runtime_binding_for_retry -- --nocapture`
- `./scripts/repo-cargo clippy -p meerkat-mob --tests -- -D warnings`
- push hook: cargo fmt, changed-crate clippy, machine codegen/verify, generated-header audit, response-status bridge guard, Bazel freshness, workspace deterministic gate
