### PR TITLE
[codex] Backpressure committed lifecycle delivery

### DIFF
--- a/meerkat-mob/src/runtime/composition.rs
+++ b/meerkat-mob/src/runtime/composition.rs
@@ -379,8 +379,9 @@ impl SignalConsumerSurface for MobSignalConsumerSurface {
     ) -> Result<(), String> {
         let signal = build_mob_signal(&variant, &projected_fields)?;
         self.command_tx
-            .try_send(super::state::MobCommand::ProjectMachineSignal { signal })
-            .map_err(|error| format!("mob actor refused signal enqueue: {error}"))
+            .send(super::state::MobCommand::ProjectMachineSignal { signal })
+            .await
+            .map_err(|error| format!("mob actor signal queue closed: {error}"))
     }
 }
 
@@ -657,5 +658,76 @@ mod tests {
             outcome.is_none(),
             "standalone dispatcher performs no routing"
         );
+    }
+
+    #[cfg(feature = "runtime-adapter")]
+    #[tokio::test]
+    async fn mob_signal_consumer_backpressures_when_actor_queue_is_full() {
+        use super::super::state::MobCommand;
+        use std::time::Duration;
+
+        let (command_tx, mut command_rx) = mpsc::channel(1);
+        let first_signal = mob_dsl::MobMachineSignal::ObserveRuntimeReady {
+            agent_runtime_id: mob_dsl::AgentRuntimeId::from("rt-first"),
+            fence_token: mob_dsl::FenceToken(1),
+        };
+        command_tx
+            .try_send(MobCommand::ProjectMachineSignal {
+                signal: first_signal,
+            })
+            .expect("test precondition: bounded actor queue is full");
+
+        let consumer = MobSignalConsumerSurface::new(command_tx);
+        let mut receive = tokio::spawn(async move {
+            consumer
+                .receive_signal(
+                    seam_facts::signals::observe_runtime_ready(),
+                    vec![
+                        (
+                            seam_facts::fields::agent_runtime_id(),
+                            OwnedFieldValue::Str("rt-backpressured".to_string()),
+                        ),
+                        (seam_facts::fields::fence_token(), OwnedFieldValue::U64(7)),
+                    ],
+                )
+                .await
+        });
+
+        let premature = tokio::time::timeout(Duration::from_millis(50), &mut receive).await;
+        assert!(
+            premature.is_err(),
+            "full actor queue must backpressure routed lifecycle signals instead of failing fast"
+        );
+
+        match command_rx.recv().await.expect("first queued command") {
+            MobCommand::ProjectMachineSignal { signal } => assert!(matches!(
+                signal,
+                mob_dsl::MobMachineSignal::ObserveRuntimeReady {
+                    agent_runtime_id,
+                    fence_token: mob_dsl::FenceToken(1),
+                } if agent_runtime_id.0 == "rt-first"
+            )),
+            _ => panic!("unexpected command in test queue"),
+        }
+
+        receive
+            .await
+            .expect("signal receive task should not panic")
+            .expect("backpressured signal enqueue should complete once capacity opens");
+
+        match command_rx
+            .recv()
+            .await
+            .expect("backpressured signal command")
+        {
+            MobCommand::ProjectMachineSignal { signal } => assert!(matches!(
+                signal,
+                mob_dsl::MobMachineSignal::ObserveRuntimeReady {
+                    agent_runtime_id,
+                    fence_token: mob_dsl::FenceToken(7),
+                } if agent_runtime_id.0 == "rt-backpressured"
+            )),
+            _ => panic!("unexpected command in test queue"),
+        }
     }
 }

--- a/meerkat-mob/src/runtime/transaction.rs
+++ b/meerkat-mob/src/runtime/transaction.rs
@@ -53,6 +53,15 @@ impl<'a> LifecycleRollback<'a> {
         let mut rollback_errors = Vec::new();
         while let Some((label, action)) = self.actions.pop() {
             if let Err(error) = action().await {
+                if Self::is_benign_compensation_absence(&error) {
+                    tracing::debug!(
+                        context = self.context,
+                        compensation = %label,
+                        %error,
+                        "rollback compensation target was already absent"
+                    );
+                    continue;
+                }
                 rollback_errors.push(format!("{label}: {error}"));
             }
         }
@@ -66,5 +75,55 @@ impl<'a> LifecycleRollback<'a> {
             self.context,
             rollback_errors.join("; ")
         ))
+    }
+
+    fn is_benign_compensation_absence(error: &MobError) -> bool {
+        matches!(
+            error,
+            MobError::CommsError(meerkat_core::comms::SendError::PeerNotFound(_))
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn fail_suppresses_already_absent_peer_compensation() {
+        let mut rollback = LifecycleRollback::new("test rollback");
+        rollback.defer("compensating peer notice", || async {
+            Err(MobError::CommsError(
+                meerkat_core::comms::SendError::PeerNotFound("peer-1".to_string()),
+            ))
+        });
+
+        let error = rollback
+            .fail(MobError::Internal("primary failure".to_string()))
+            .await;
+
+        assert!(
+            matches!(error, MobError::Internal(message) if message == "primary failure"),
+            "already-absent peer compensation should not obscure the primary failure"
+        );
+    }
+
+    #[tokio::test]
+    async fn fail_preserves_non_absence_compensation_failure() {
+        let mut rollback = LifecycleRollback::new("test rollback");
+        rollback.defer("compensating peer notice", || async {
+            Err(MobError::CommsError(
+                meerkat_core::comms::SendError::PeerOffline,
+            ))
+        });
+
+        let error = rollback
+            .fail(MobError::Internal("primary failure".to_string()))
+            .await;
+
+        assert!(
+            matches!(error, MobError::Internal(message) if message.contains("rollback failures") && message.contains("peer offline")),
+            "non-benign compensation failures should still be reported"
+        );
     }
 }

--- a/meerkat-runtime/src/meerkat_machine/mod.rs
+++ b/meerkat-runtime/src/meerkat_machine/mod.rs
@@ -753,12 +753,9 @@ impl MeerkatMachine {
                 })?;
         }
 
-        match effect_tx.try_send(projected_effect.into_effect()) {
+        match effect_tx.send(projected_effect.into_effect()).await {
             Ok(()) => Ok(()),
-            Err(mpsc::error::TrySendError::Full(_)) => Err(RuntimeDriverError::Internal(format!(
-                "{context}: runtime effect channel full after accepted boundary cancel"
-            ))),
-            Err(mpsc::error::TrySendError::Closed(_)) => {
+            Err(_) => {
                 self.clear_dead_runtime_attachment(session_id).await;
                 Err(RuntimeDriverError::NotReady {
                     state: RuntimeState::Idle,

--- a/meerkat-runtime/src/meerkat_machine_tests.rs
+++ b/meerkat-runtime/src/meerkat_machine_tests.rs
@@ -5136,7 +5136,7 @@ async fn cancel_after_boundary_on_attached_runtime_calls_live_handle_and_queues_
 }
 
 #[tokio::test]
-async fn cancel_after_boundary_full_effect_channel_fails_closed_after_live_wake() {
+async fn cancel_after_boundary_full_effect_channel_backpressures_after_live_wake() {
     struct BlockingExecutor {
         live_boundary_cancel_calls: Arc<AtomicUsize>,
         queued_boundary_cancel_calls: Arc<AtomicUsize>,
@@ -5261,24 +5261,37 @@ async fn cancel_after_boundary_full_effect_channel_fails_closed_after_live_wake(
         "runtime loop is still blocked inside apply, so queued effects have not drained"
     );
 
-    let err = tokio::time::timeout(
-        Duration::from_millis(500),
-        adapter.cancel_after_boundary(&session_id),
-    )
+    let mut saturated_cancel = tokio::spawn({
+        let adapter = Arc::clone(&adapter);
+        let session_id = session_id.clone();
+        async move { adapter.cancel_after_boundary(&session_id).await }
+    });
+    tokio::time::timeout(Duration::from_secs(1), async {
+        loop {
+            if live_boundary_cancel_calls.load(Ordering::SeqCst) == 17 {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+    })
     .await
-    .expect("live boundary cancel must not wait for capacity in the bounded effect channel")
-    .expect_err("full effect channel must fail closed instead of dropping the queued effect");
+    .expect("saturated boundary cancel should still apply the live cooperative wake");
+    let premature = tokio::time::timeout(Duration::from_millis(100), &mut saturated_cancel).await;
     assert!(
-        err.to_string().contains("runtime effect channel full"),
-        "unexpected cancel error: {err}"
+        premature.is_err(),
+        "full effect channel must backpressure committed runtime effects instead of failing fast"
     );
     assert_eq!(
         live_boundary_cancel_calls.load(Ordering::SeqCst),
         17,
-        "saturated effect channel reports failure after attempting the live cooperative wake"
+        "saturated effect channel backpressures after attempting the live cooperative wake"
     );
 
     allow_finish.notify_waiters();
+    saturated_cancel
+        .await
+        .expect("saturated cancel task should not panic")
+        .expect("saturated cancel should complete once runtime effect capacity opens");
     match completion_handle.wait().await {
         CompletionOutcome::CompletedWithoutResult => {}
         other => panic!("expected attached queued prompt to complete normally, got {other:?}"),


### PR DESCRIPTION
## Summary

Fixes committed lifecycle/effect delivery under burst load by replacing fail-fast bounded queue sends with backpressured sends on the Mob and runtime committed-effect paths.

## Root Cause

`MobSignalConsumerSurface::receive_signal` routed `ObserveRuntimeReady` / `ObserveRuntimeRetired` / `ObserveRuntimeDestroyed` into the mob actor with `try_send`. Under high fan-out, for example launching 140 agents at once, the bounded actor queue could fill and turn committed lifecycle facts into immediate failures. That violates the Meerkat dogma rule that semantic lifecycle/effect delivery must not be a dropped observation or capacity accident.

## Changes

- Backpressure MobMachine lifecycle signal projection into the mob actor with async `send`.
- Backpressure the analogous committed runtime effect channel in `MeerkatMachine`.
- Treat typed `SendError::PeerNotFound` during rollback compensation as benign already-absent cleanup fallout, while preserving other rollback failures.
- Add regression coverage for capacity-1 backpressure on the mob signal consumer and the runtime effect channel.

## Validation

- `make fmt`
- `make fmt-check`
- `./scripts/repo-cargo test -p meerkat-mob mob_signal_consumer_backpressures_when_actor_queue_is_full`
- `./scripts/repo-cargo test -p meerkat-mob fail_`
- `./scripts/repo-cargo test -p meerkat-runtime cancel_after_boundary_full_effect_channel_backpressures_after_live_wake`
- `make check`
- pre-push hook: secrets, formatting, changed-crates clippy, machine verify, generated-header audit, Bazel freshness, deterministic gate
