### PR TITLE
[codex] Add batch mob topology materialization

### DIFF
--- a/meerkat-comms/src/inbox.rs
+++ b/meerkat-comms/src/inbox.rs
@@ -133,6 +133,7 @@ struct ClassifiedInboxQueue {
     trusted_peers: Arc<RwLock<TrustedPeers>>,
     phase: PeerIngressState,
     dropped_count: Arc<AtomicU64>,
+    capacity_notify: Arc<Notify>,
 }
 
 impl ClassifiedInboxQueue {
@@ -145,11 +146,16 @@ impl ClassifiedInboxQueue {
             trusted_peers,
             phase: PeerIngressState::Absent,
             dropped_count: Arc::new(AtomicU64::new(0)),
+            capacity_notify: Arc::new(Notify::new()),
         }
     }
 
     fn dropped_counter(&self) -> Arc<AtomicU64> {
         self.dropped_count.clone()
+    }
+
+    fn capacity_notifier(&self) -> Arc<Notify> {
+        self.capacity_notify.clone()
     }
 
     /// Admit a prepared item into the peer-ingress lifecycle.
@@ -258,6 +264,9 @@ impl ClassifiedInboxQueue {
         for entry in &drained {
             self.note_peer_dequeue(entry);
         }
+        if !drained.is_empty() {
+            self.capacity_notify.notify_waiters();
+        }
         drained
     }
 
@@ -265,6 +274,7 @@ impl ClassifiedInboxQueue {
         let entry = self.entries.pop_front();
         if let Some(entry_ref) = entry.as_ref() {
             self.note_peer_dequeue(entry_ref);
+            self.capacity_notify.notify_one();
         }
         entry
     }
@@ -779,6 +789,112 @@ impl InboxSender {
                 );
                 self.record_drop(DropReason::InboxFull)
             }
+        }
+    }
+
+    /// Send an item through the same admission path as [`Self::send`], but
+    /// await queue capacity instead of reporting `InboxFull`.
+    ///
+    /// This is used by runtime-originated peer sends where backpressure is
+    /// preferable to semantic loss. Policy and closed-queue failures remain
+    /// typed `Dropped` outcomes; only capacity waits.
+    pub async fn send_wait(&self, item: InboxItem) -> AdmissionOutcome {
+        if self.classification_context.is_some() {
+            return self.send_classified_wait(item).await;
+        }
+        match self.tx.send(item).await {
+            Ok(()) => {
+                self.notify.notify_waiters();
+                AdmissionOutcome::Admitted
+            }
+            Err(_) => {
+                tracing::warn!(
+                    reason = ?DropReason::SessionClosed,
+                    "raw inbox dropped item while waiting: queue closed"
+                );
+                self.record_drop(DropReason::SessionClosed)
+            }
+        }
+    }
+
+    async fn send_classified_wait(&self, item: InboxItem) -> AdmissionOutcome {
+        let (Some(ctx), Some(classified_queue)) =
+            (&self.classification_context, &self.classified_queue)
+        else {
+            return self.send_wait_raw_fallback(item).await;
+        };
+
+        let result = match ctx.prepare(item) {
+            Some(r) => r,
+            None => {
+                tracing::warn!(
+                    reason = ?DropReason::ClassificationRejected,
+                    "classified inbox dropped item at classification stage"
+                );
+                return self.record_drop(DropReason::ClassificationRejected);
+            }
+        };
+        let kind = result.kind;
+        let is_actionable = result.class.is_actionable();
+        let mut prepared = Some(result);
+
+        loop {
+            let capacity_notify = {
+                let mut queue = classified_queue.lock();
+                if queue.closed {
+                    tracing::warn!(
+                        kind = ?kind,
+                        reason = ?DropReason::SessionClosed,
+                        "classified inbox dropped item while waiting: queue closed"
+                    );
+                    return self.record_drop(DropReason::SessionClosed);
+                }
+                if queue.entries.len() < queue.capacity {
+                    let Some(result) = prepared.take() else {
+                        tracing::error!(
+                            kind = ?kind,
+                            reason = ?DropReason::SessionClosed,
+                            "classified inbox send_wait reached admission after item was already consumed"
+                        );
+                        return self.record_drop(DropReason::SessionClosed);
+                    };
+                    let decision = queue.admit_peer_receive(&result);
+                    if let AdmissionOutcome::Dropped { reason } = decision.outcome {
+                        return self.record_drop(reason);
+                    }
+                    queue.entries.push_back(ClassifiedInboxEntry {
+                        raw_item_id: result.raw_item_id,
+                        item: result.item,
+                        class: result.class,
+                        auth: result.auth,
+                        kind,
+                        from_peer: result.from_peer,
+                        ingress_fact: result.ingress_fact,
+                        lifecycle_peer: result.lifecycle_peer,
+                        request_id: result.request_id,
+                        admission_diagnostic: decision.admission_diagnostic,
+                        response_terminality: result.response_terminality,
+                        text_projection: result.text_projection,
+                    });
+                    if is_actionable && let Some(ref actionable) = self.actionable_notify {
+                        actionable.notify_waiters();
+                    }
+                    self.notify.notify_waiters();
+                    return AdmissionOutcome::Admitted;
+                }
+                queue.capacity_notifier()
+            };
+            capacity_notify.notified().await;
+        }
+    }
+
+    async fn send_wait_raw_fallback(&self, item: InboxItem) -> AdmissionOutcome {
+        match self.tx.send(item).await {
+            Ok(()) => {
+                self.notify.notify_waiters();
+                AdmissionOutcome::Admitted
+            }
+            Err(_) => self.record_drop(DropReason::SessionClosed),
         }
     }
 
@@ -1742,6 +1858,191 @@ mod tests {
             }
         );
         assert_eq!(counter.load(Ordering::Relaxed), 1);
+    }
+
+    #[tokio::test]
+    async fn test_classified_send_wait_backpressures_until_capacity_opens() {
+        let sender_pubkey = PubKey::new([1u8; 32]);
+        let ctx = make_classification_context(make_trusted("peer", &sender_pubkey), false);
+        let actionable_notify = Arc::new(Notify::new());
+        let notify = Arc::new(Notify::new());
+        let queue = ClassifiedInboxQueue::new(1, ctx.require_peer_auth, ctx.trusted_peers.clone());
+        let counter = queue.dropped_counter();
+        let classified_queue = Arc::new(Mutex::new(queue));
+        let (tx, _rx) = mpsc::channel::<InboxItem>(1);
+        let sender = InboxSender {
+            tx,
+            notify,
+            classification_context: Some(ctx),
+            classified_queue: Some(classified_queue.clone()),
+            actionable_notify: Some(actionable_notify),
+            dropped_count: Some(counter.clone()),
+        };
+
+        assert_eq!(
+            sender.send_classified(InboxItem::External {
+                envelope: make_test_envelope(),
+            }),
+            AdmissionOutcome::Admitted
+        );
+
+        let waiting_sender = sender.clone();
+        let waiting = tokio::spawn(async move {
+            waiting_sender
+                .send_wait(InboxItem::External {
+                    envelope: make_test_envelope(),
+                })
+                .await
+        });
+        tokio::task::yield_now().await;
+        assert!(
+            !waiting.is_finished(),
+            "send_wait must wait instead of dropping when the classified queue is full"
+        );
+
+        assert!(classified_queue.lock().pop_front().is_some());
+        assert_eq!(
+            waiting.await.expect("send_wait task should complete"),
+            AdmissionOutcome::Admitted
+        );
+        assert_eq!(
+            counter.load(Ordering::Relaxed),
+            0,
+            "backpressured send should not increment the drop counter"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_classified_send_wait_rechecks_trust_after_capacity_opens() {
+        let sender_pubkey = PubKey::new([1u8; 32]);
+        let ctx = make_classification_context(make_trusted("peer", &sender_pubkey), true);
+        let actionable_notify = Arc::new(Notify::new());
+        let notify = Arc::new(Notify::new());
+        let queue = ClassifiedInboxQueue::new(1, ctx.require_peer_auth, ctx.trusted_peers.clone());
+        let counter = queue.dropped_counter();
+        let classified_queue = Arc::new(Mutex::new(queue));
+        let (tx, _rx) = mpsc::channel::<InboxItem>(1);
+        let sender = InboxSender {
+            tx,
+            notify,
+            classification_context: Some(ctx.clone()),
+            classified_queue: Some(classified_queue.clone()),
+            actionable_notify: Some(actionable_notify),
+            dropped_count: Some(counter.clone()),
+        };
+
+        assert_eq!(
+            sender.send_classified(InboxItem::External {
+                envelope: make_test_envelope(),
+            }),
+            AdmissionOutcome::Admitted
+        );
+
+        let waiting_sender = sender.clone();
+        let waiting = tokio::spawn(async move {
+            waiting_sender
+                .send_wait(InboxItem::External {
+                    envelope: make_test_envelope(),
+                })
+                .await
+        });
+        tokio::task::yield_now().await;
+        assert!(
+            !waiting.is_finished(),
+            "send_wait should be parked on capacity before the revoke"
+        );
+
+        *ctx.trusted_peers.write() = TrustedPeers::new();
+        assert!(classified_queue.lock().pop_front().is_some());
+
+        assert_eq!(
+            waiting.await.expect("send_wait task should complete"),
+            AdmissionOutcome::Dropped {
+                reason: DropReason::UntrustedSender
+            },
+            "capacity wait must not carry stale classification-time trust into admission"
+        );
+        assert_eq!(counter.load(Ordering::Relaxed), 1);
+        assert_eq!(
+            classified_queue.lock().entries.len(),
+            0,
+            "revoked ingress must not be queued after capacity opens"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn test_classified_send_wait_stress_backpressures_burst_without_drops() {
+        const CAPACITY: usize = 8;
+        const WAITERS: usize = 256;
+
+        let sender_pubkey = PubKey::new([1u8; 32]);
+        let ctx = make_classification_context(make_trusted("peer", &sender_pubkey), true);
+        let actionable_notify = Arc::new(Notify::new());
+        let notify = Arc::new(Notify::new());
+        let queue =
+            ClassifiedInboxQueue::new(CAPACITY, ctx.require_peer_auth, ctx.trusted_peers.clone());
+        let counter = queue.dropped_counter();
+        let classified_queue = Arc::new(Mutex::new(queue));
+        let (tx, _rx) = mpsc::channel::<InboxItem>(CAPACITY);
+        let sender = InboxSender {
+            tx,
+            notify,
+            classification_context: Some(ctx),
+            classified_queue: Some(classified_queue.clone()),
+            actionable_notify: Some(actionable_notify),
+            dropped_count: Some(counter.clone()),
+        };
+
+        for _ in 0..CAPACITY {
+            assert_eq!(
+                sender.send_classified(InboxItem::External {
+                    envelope: make_test_envelope(),
+                }),
+                AdmissionOutcome::Admitted
+            );
+        }
+
+        let mut waiters = Vec::with_capacity(WAITERS);
+        for _ in 0..WAITERS {
+            let waiting_sender = sender.clone();
+            waiters.push(tokio::spawn(async move {
+                waiting_sender
+                    .send_wait(InboxItem::External {
+                        envelope: make_test_envelope(),
+                    })
+                    .await
+            }));
+        }
+        tokio::task::yield_now().await;
+        assert!(
+            waiters.iter().any(|waiter| !waiter.is_finished()),
+            "burst should saturate the tiny classified queue and park send_wait tasks"
+        );
+
+        for _ in 0..(CAPACITY + WAITERS) {
+            loop {
+                if classified_queue.lock().pop_front().is_some() {
+                    break;
+                }
+                tokio::task::yield_now().await;
+            }
+            tokio::task::yield_now().await;
+        }
+
+        for waiter in waiters {
+            assert_eq!(
+                tokio::time::timeout(std::time::Duration::from_secs(2), waiter)
+                    .await
+                    .expect("send_wait task should complete without stalling")
+                    .expect("send_wait task should join"),
+                AdmissionOutcome::Admitted
+            );
+        }
+        assert_eq!(
+            counter.load(Ordering::Relaxed),
+            0,
+            "backpressured burst must not record capacity drops"
+        );
     }
 
     #[test]

--- a/meerkat-comms/src/inproc.rs
+++ b/meerkat-comms/src/inproc.rs
@@ -471,6 +471,7 @@ impl InprocRegistry {
     ///
     /// Router call sites already resolved the destination from canonical trust
     /// state, so delivery must use that identity rather than a display name.
+    #[cfg(test)]
     pub(crate) fn send_to_pubkey_any_namespace_with_id(
         &self,
         from_keypair: &Keypair,
@@ -491,6 +492,33 @@ impl InprocRegistry {
             kind,
             sign_envelope,
         )
+    }
+
+    /// Backpressured variant of [`Self::send_to_pubkey_any_namespace_with_id`].
+    ///
+    /// Runtime-originated peer sends should await receiver capacity instead of
+    /// turning a transient full inbox into semantic message loss.
+    pub(crate) async fn send_to_pubkey_any_namespace_with_id_wait(
+        &self,
+        from_keypair: &Keypair,
+        to_pubkey: &PubKey,
+        envelope_id: Uuid,
+        kind: MessageKind,
+        sign_envelope: bool,
+    ) -> Result<uuid::Uuid, InprocSendError> {
+        let sender = self
+            .get_by_pubkey_any_namespace(to_pubkey)
+            .ok_or_else(|| InprocSendError::PeerNotFound(to_pubkey.to_peer_id().to_string()))?;
+
+        Self::deliver_to_sender_wait(
+            from_keypair,
+            *to_pubkey,
+            sender,
+            envelope_id,
+            kind,
+            sign_envelope,
+        )
+        .await
     }
 
     /// Send a message directly to an inproc peer within a namespace.
@@ -587,6 +615,42 @@ impl InprocRegistry {
         // Deliver directly to inbox
         let envelope_id = envelope.id;
         match sender.send_classified(InboxItem::External { envelope }) {
+            AdmissionOutcome::Admitted => {}
+            AdmissionOutcome::Dropped {
+                reason: DropReason::SessionClosed,
+            } => return Err(InprocSendError::InboxClosed),
+            AdmissionOutcome::Dropped {
+                reason: DropReason::InboxFull,
+            } => return Err(InprocSendError::InboxFull),
+            AdmissionOutcome::Dropped { reason } => {
+                return Err(InprocSendError::IngressDropped(reason));
+            }
+        }
+
+        Ok(envelope_id)
+    }
+
+    async fn deliver_to_sender_wait(
+        from_keypair: &Keypair,
+        to_pubkey: PubKey,
+        sender: InboxSender,
+        envelope_id: Uuid,
+        kind: MessageKind,
+        sign_envelope: bool,
+    ) -> Result<uuid::Uuid, InprocSendError> {
+        let mut envelope = Envelope {
+            id: envelope_id,
+            from: from_keypair.public_key(),
+            to: to_pubkey,
+            kind,
+            sig: Signature::new([0u8; 64]),
+        };
+        if sign_envelope {
+            envelope.sign(from_keypair);
+        }
+
+        let envelope_id = envelope.id;
+        match sender.send_wait(InboxItem::External { envelope }).await {
             AdmissionOutcome::Admitted => {}
             AdmissionOutcome::Dropped {
                 reason: DropReason::SessionClosed,

--- a/meerkat-comms/src/router.rs
+++ b/meerkat-comms/src/router.rs
@@ -437,13 +437,14 @@ impl Router {
                     // typed target namespace. Require the canonical pubkey to
                     // have exactly one live inproc owner before delivery.
                     registry
-                        .send_to_pubkey_any_namespace_with_id(
+                        .send_to_pubkey_any_namespace_with_id_wait(
                             &self.keypair,
                             &peer.pubkey,
                             envelope.id,
                             envelope.kind,
                             self.require_peer_auth,
                         )
+                        .await
                         .map_err(|err| map_inproc_send_error(err, dest))
                 }
             }
@@ -458,13 +459,14 @@ impl Router {
                 PeerAddr::Inproc(_) => {
                     let registry = InprocRegistry::global();
                     registry
-                        .send_to_pubkey_any_namespace_with_id(
+                        .send_to_pubkey_any_namespace_with_id_wait(
                             &self.keypair,
                             &peer.pubkey,
                             envelope.id,
                             envelope.kind,
                             self.require_peer_auth,
                         )
+                        .await
                         .map_err(|err| map_inproc_send_error(err, dest))
                 }
             }

--- a/meerkat-mob/src/event.rs
+++ b/meerkat-mob/src/event.rs
@@ -329,6 +329,15 @@ pub enum MobEventKind {
         /// Second member of the edge.
         b: AgentIdentity,
     },
+    /// Multiple bidirectional wiring edges were established between local members.
+    ///
+    /// This is the compact projection event for batch topology materialization.
+    /// MobMachine still owns the canonical `wiring_edges` graph; the event is
+    /// replay data for roster/read-model consumers.
+    MembersWiredBatch {
+        /// Normalized `(a, b)` member edges admitted by the MobMachine authority.
+        edges: Vec<MemberWireEdge>,
+    },
     /// Bidirectional wiring edge removed between two local members.
     ///
     /// DSL-emit-driven observability counterpart of [`Self::MembersWired`].
@@ -449,6 +458,15 @@ pub enum MobEventKind {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         audit_invocation_id: Option<String>,
     },
+}
+
+/// Normalized local-member wiring edge carried by compact topology events.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct MemberWireEdge {
+    /// First member of the edge (lexicographically smaller identity).
+    pub a: AgentIdentity,
+    /// Second member of the edge.
+    pub b: AgentIdentity,
 }
 
 /// An agent event attributed to a specific mob member.
@@ -775,6 +793,22 @@ mod tests {
         roundtrip(&MobEventKind::MembersWired {
             a: AgentIdentity::from("l-1"),
             b: AgentIdentity::from("w-2"),
+        });
+    }
+
+    #[test]
+    fn test_members_wired_batch_roundtrip() {
+        roundtrip(&MobEventKind::MembersWiredBatch {
+            edges: vec![
+                MemberWireEdge {
+                    a: AgentIdentity::from("l-1"),
+                    b: AgentIdentity::from("w-2"),
+                },
+                MemberWireEdge {
+                    a: AgentIdentity::from("l-1"),
+                    b: AgentIdentity::from("w-3"),
+                },
+            ],
         });
     }
 

--- a/meerkat-mob/src/lib.rs
+++ b/meerkat-mob/src/lib.rs
@@ -77,7 +77,7 @@ pub use coordination::{
 };
 pub use definition::MobDefinition;
 pub use error::MobError;
-pub use event::{AttributedEvent, MobEvent, MobEventKind, NewMobEvent};
+pub use event::{AttributedEvent, MemberWireEdge, MobEvent, MobEventKind, NewMobEvent};
 pub use ids::{
     AgentIdentity, AgentRuntimeId, BranchId, FenceToken, FlowId, FlowNodeId, FrameId, Generation,
     LoopId, LoopInstanceId, MobId, ProfileName, RunId, StepId, WorkOrigin, WorkRef, WorkSpec,
@@ -127,9 +127,9 @@ pub use runtime::{
     MemberRespawnReceipt, MobBuilder, MobDestroyError, MobDestroyReport, MobEventRouterConfig,
     MobEventRouterHandle, MobEventsSubscription, MobEventsSubscriptionConfig, MobHandle,
     MobMemberSnapshot, MobMemberStatus, MobPeerConnectivitySnapshot, MobRespawnError,
-    MobSessionService, MobState, MobUnreachablePeer, PeerTarget, PreviousMemberCleanupReport,
-    SpawnMemberSpec, SpawnPolicy, SpawnResult, SpawnSpec, SupervisorRotationReport,
-    WorkDeliveryReceipt,
+    MobSessionService, MobState, MobUnreachablePeer, MobWireMembersBatchReport, PeerTarget,
+    PreviousMemberCleanupReport, SpawnMemberSpec, SpawnPolicy, SpawnResult, SpawnSpec,
+    SupervisorRotationReport, WorkDeliveryReceipt,
 };
 pub use runtime::{FlowFrameKernel, FlowFrameMutator};
 pub use runtime::{FlowTurnExecutor, FlowTurnOutcome, FlowTurnTicket, TimeoutDisposition};

--- a/meerkat-mob/src/mob_machine.rs
+++ b/meerkat-mob/src/mob_machine.rs
@@ -127,6 +127,11 @@ pub(crate) enum MobMachineCommand {
     #[cfg(test)]
     LifecycleSnapshot,
     #[cfg(test)]
+    LifecycleNotificationBurst {
+        count: usize,
+        message: String,
+    },
+    #[cfg(test)]
     DslT2Snapshot,
     SetSpawnPolicy {
         policy: Option<Arc<dyn crate::runtime::SpawnPolicy>>,
@@ -143,6 +148,15 @@ pub(crate) enum MobMachineCommand {
     Wire {
         local: MeerkatId,
         target: crate::runtime::PeerTarget,
+    },
+    /// Materialize many local-member wiring edges through one actor command.
+    ///
+    /// This is shell batching for dense topology reconciliation. Each edge
+    /// still lowers into the MobMachine-owned `WireMembers` input; the command
+    /// only coalesces validation, actor queuing, comms side effects, and
+    /// projection/event fanout.
+    WireMembersBatch {
+        edges: Vec<(AgentIdentity, AgentIdentity)>,
     },
     /// Unwire a local member from a peer target. Mirror of `Wire`.
     Unwire {
@@ -177,6 +191,7 @@ pub(crate) struct SubmitWorkCommand {
 #[allow(clippy::large_enum_variant)]
 pub(crate) enum MobMachineCommandResult {
     Unit,
+    WireMembersBatchReport(crate::runtime::MobWireMembersBatchReport),
     RunId(RunId),
     WorkReceipt {
         work_ref: WorkRef,
@@ -209,6 +224,8 @@ pub(crate) enum MobMachineCommandResult {
     OrchestratorSnapshot(MobOrchestratorSnapshot),
     #[cfg(test)]
     LifecycleSnapshot(MobLifecycleSnapshot),
+    #[cfg(test)]
+    LifecycleNotificationBurst,
     #[cfg(test)]
     DslT2Snapshot(crate::runtime::MobDslT2Snapshot),
 }
@@ -549,12 +566,14 @@ impl MobMachineCommandVariant {
             Self::FlowTrackerCounts
             | Self::OrchestratorSnapshot
             | Self::LifecycleSnapshot
+            | Self::LifecycleNotificationBurst
             | Self::DslT2Snapshot
             | Self::ListMembersMatching
             | Self::Wire
+            | Self::WireMembersBatch
             | Self::Unwire => None,
             #[cfg(not(test))]
-            Self::ListMembersMatching | Self::Wire | Self::Unwire => None,
+            Self::ListMembersMatching | Self::Wire | Self::WireMembersBatch | Self::Unwire => None,
             Self::RunFlow => Some(MobMachineCatalogInput::RunFlow),
             Self::CancelFlow => Some(MobMachineCatalogInput::CancelFlow),
             Self::FlowStatus => Some(MobMachineCatalogInput::FlowStatus),
@@ -744,6 +763,7 @@ const fn mob_machine_command_classification(
         MobMachineCommandVariant::FlowTrackerCounts
         | MobMachineCommandVariant::OrchestratorSnapshot
         | MobMachineCommandVariant::LifecycleSnapshot
+        | MobMachineCommandVariant::LifecycleNotificationBurst
         | MobMachineCommandVariant::DslT2Snapshot => {
             MobMachineCommandClassification::ShellMechanic(
                 MobMachineShellMechanicReason::TestInspection,
@@ -758,6 +778,9 @@ const fn mob_machine_command_classification(
             MobMachineCatalogInput::WireMembers,
             MobMachineCatalogInput::WireExternalPeer,
         ]),
+        MobMachineCommandVariant::WireMembersBatch => {
+            MobMachineCommandClassification::CatalogInput(MobMachineCatalogInput::WireMembers)
+        }
         MobMachineCommandVariant::Unwire => MobMachineCommandClassification::CatalogInputs(&[
             MobMachineCatalogInput::UnwireMembers,
             MobMachineCatalogInput::UnwireExternalPeer,

--- a/meerkat-mob/src/roster.rs
+++ b/meerkat-mob/src/roster.rs
@@ -11,7 +11,7 @@
 //!   consistency checks.
 //! - `wire`/`unwire`/`remove` are projection mutations only.
 
-use crate::event::{MemberRef, MobEvent, MobEventKind};
+use crate::event::{MemberRef, MemberWireEdge, MobEvent, MobEventKind};
 use crate::ids::{AgentIdentity, AgentRuntimeId, FenceToken, Generation, ProfileName};
 use crate::runtime_mode::MobRuntimeMode;
 use meerkat_core::comms::{PeerId, TrustedPeerDescriptor};
@@ -219,6 +219,16 @@ impl Roster {
                 }
                 if let Some(entry) = self.entries.get_mut(b) {
                     entry.wired_to.insert(a.clone());
+                }
+            }
+            MobEventKind::MembersWiredBatch { edges } => {
+                for edge in edges {
+                    if let Some(entry) = self.entries.get_mut(&edge.a) {
+                        entry.wired_to.insert(edge.b.clone());
+                    }
+                    if let Some(entry) = self.entries.get_mut(&edge.b) {
+                        entry.wired_to.insert(edge.a.clone());
+                    }
                 }
             }
             MobEventKind::MembersUnwired { a, b } => {
@@ -859,6 +869,71 @@ mod tests {
             roster1.get(&MeerkatId::from("a")).unwrap().role,
             roster2.get(&MeerkatId::from("a")).unwrap().role,
         );
+    }
+
+    #[test]
+    fn test_members_wired_batch_projects_bidirectional_edges() {
+        let a = AgentIdentity::from("a");
+        let b = AgentIdentity::from("b");
+        let c = AgentIdentity::from("c");
+        let events = vec![
+            make_event(
+                1,
+                spawned_kind(
+                    a.as_str(),
+                    "worker",
+                    MobRuntimeMode::AutonomousHost,
+                    MemberRef::from_bridge_session_id(session_id()),
+                    BTreeMap::new(),
+                ),
+            ),
+            make_event(
+                2,
+                spawned_kind(
+                    b.as_str(),
+                    "worker",
+                    MobRuntimeMode::AutonomousHost,
+                    MemberRef::from_bridge_session_id(session_id()),
+                    BTreeMap::new(),
+                ),
+            ),
+            make_event(
+                3,
+                spawned_kind(
+                    c.as_str(),
+                    "worker",
+                    MobRuntimeMode::AutonomousHost,
+                    MemberRef::from_bridge_session_id(session_id()),
+                    BTreeMap::new(),
+                ),
+            ),
+            make_event(
+                4,
+                MobEventKind::MembersWiredBatch {
+                    edges: vec![
+                        MemberWireEdge {
+                            a: a.clone(),
+                            b: b.clone(),
+                        },
+                        MemberWireEdge {
+                            a: a.clone(),
+                            b: c.clone(),
+                        },
+                    ],
+                },
+            ),
+        ];
+
+        let roster = Roster::project(&events);
+        let a_entry = roster.get_by_identity(&a).expect("a projected");
+        let b_entry = roster.get_by_identity(&b).expect("b projected");
+        let c_entry = roster.get_by_identity(&c).expect("c projected");
+
+        assert!(a_entry.wired_to.contains(&b));
+        assert!(a_entry.wired_to.contains(&c));
+        assert_eq!(a_entry.wired_to.len(), 2);
+        assert!(b_entry.wired_to.contains(&a));
+        assert!(c_entry.wired_to.contains(&a));
     }
 
     #[test]

--- a/meerkat-mob/src/runtime/actor.rs
+++ b/meerkat-mob/src/runtime/actor.rs
@@ -43,6 +43,7 @@ impl InitialTurnHandle {
 #[cfg(not(target_arch = "wasm32"))]
 const MAX_PARALLEL_REMOTE_MEMBER_TEARDOWNS: usize = 64;
 const MAX_LIFECYCLE_NOTIFICATION_TASKS: usize = 16;
+const MAX_PARALLEL_PEER_RETIRE_NOTIFICATIONS: usize = 64;
 
 fn observed_runtime_id(signal: &mob_dsl::MobMachineSignal) -> Option<&mob_dsl::AgentRuntimeId> {
     match signal {
@@ -79,6 +80,13 @@ enum WiringEndpoint {
         spec: TrustedPeerDescriptor,
         binding: crate::RuntimeBinding,
     },
+}
+
+#[derive(Clone)]
+struct LocalBatchWiringEndpoint {
+    comms: Arc<dyn CoreCommsRuntime>,
+    spec: TrustedPeerDescriptor,
+    removal_key: String,
 }
 
 struct SupervisorPrivateTrustInstall {
@@ -2112,14 +2120,14 @@ impl MobActor {
             return;
         };
 
-        // Backpressure: drop notification if at capacity.
-        if self.lifecycle_tasks.len() >= MAX_LIFECYCLE_NOTIFICATION_TASKS {
-            tracing::warn!(
-                mob_id = %self.definition.id,
-                pending = self.lifecycle_tasks.len(),
-                "lifecycle notification dropped: task limit reached"
-            );
-            return;
+        while self.lifecycle_tasks.len() >= MAX_LIFECYCLE_NOTIFICATION_TASKS {
+            match self.lifecycle_tasks.join_next().await {
+                Some(Ok(())) => {}
+                Some(Err(error)) => {
+                    tracing::debug!(error = %error, "lifecycle notification task failed");
+                }
+                None => break,
+            }
         }
 
         let provisioner = self.provisioner.clone();
@@ -3361,6 +3369,18 @@ impl MobActor {
                     });
                 }
                 #[cfg(test)]
+                MobCommand::LifecycleNotificationBurst {
+                    count,
+                    message,
+                    reply_tx,
+                } => {
+                    for index in 0..count {
+                        self.notify_orchestrator_lifecycle(format!("{message} #{index}"))
+                            .await;
+                    }
+                    let _ = reply_tx.send(Ok(()));
+                }
+                #[cfg(test)]
                 MobCommand::DslT2Snapshot { reply_tx } => {
                     let dsl = &self.dsl_authority.state;
                     let _ = reply_tx.send(super::state::MobDslT2Snapshot {
@@ -3707,6 +3727,10 @@ impl MobActor {
                     reply_tx,
                 } => {
                     let result = self.handle_wire(local, target).await;
+                    let _ = reply_tx.send(result);
+                }
+                MobCommand::WireMembersBatch { edges, reply_tx } => {
+                    let result = self.handle_wire_members_batch(edges).await;
                     let _ = reply_tx.send(result);
                 }
                 MobCommand::Unwire {
@@ -6093,6 +6117,248 @@ impl MobActor {
         Ok(())
     }
 
+    /// Dense local-member topology materialization path.
+    ///
+    /// Dogma shape:
+    /// - MobMachine remains the single owner of `wiring_edges`; each new edge
+    ///   is lowered into `WireMembers` and committed through one prepared
+    ///   authority update.
+    /// - The actor owns only shell mechanics: roster snapshot validation,
+    ///   comms trust installation, rollback, and compact projection event.
+    /// - External peers stay on the interactive single-edge path because
+    ///   descriptor exchange and rollback are per-peer semantics.
+    async fn handle_wire_members_batch(
+        &mut self,
+        requested_edges: Vec<(AgentIdentity, AgentIdentity)>,
+    ) -> Result<super::handle::MobWireMembersBatchReport, MobError> {
+        let requested = requested_edges.len();
+        let mut normalized_edges = BTreeSet::new();
+        let mut endpoint_ids = BTreeSet::new();
+        for (left, right) in requested_edges {
+            if left == right {
+                return Err(MobError::WiringError(format!(
+                    "wire_members_batch requires distinct members (got '{left}')"
+                )));
+            }
+            let (a, b) = if left <= right {
+                (left, right)
+            } else {
+                (right, left)
+            };
+            endpoint_ids.insert(a.clone());
+            endpoint_ids.insert(b.clone());
+            normalized_edges.insert((a, b));
+        }
+
+        if normalized_edges.is_empty() {
+            return Ok(super::handle::MobWireMembersBatchReport {
+                requested,
+                already_wired: Vec::new(),
+                wired: Vec::new(),
+            });
+        }
+
+        let broken_members = self
+            .dsl_authority
+            .state
+            .member_restore_failures
+            .keys()
+            .map(|identity| AgentIdentity::from(identity.0.as_str()))
+            .collect::<BTreeSet<_>>();
+        for identity in &endpoint_ids {
+            if broken_members.contains(identity) {
+                return Err(MobError::WiringError(format!(
+                    "wire_members_batch cannot wire broken member '{identity}'"
+                )));
+            }
+        }
+
+        let entries = {
+            let roster = self.roster.read().await;
+            let mut entries = BTreeMap::new();
+            for identity in &endpoint_ids {
+                let entry = roster
+                    .get(identity)
+                    .cloned()
+                    .ok_or_else(|| MobError::MemberNotFound(identity.clone()))?;
+                entries.insert(identity.clone(), entry);
+            }
+            entries
+        };
+
+        let mut endpoints = BTreeMap::new();
+        for (identity, entry) in entries {
+            match self
+                .resolve_wiring_endpoint(&entry, "wire_members_batch")
+                .await?
+            {
+                WiringEndpoint::Local { comms, spec, .. } => {
+                    let removal_key = Self::trusted_peer_removal_key(&spec);
+                    endpoints.insert(
+                        identity,
+                        LocalBatchWiringEndpoint {
+                            comms,
+                            spec,
+                            removal_key,
+                        },
+                    );
+                }
+                WiringEndpoint::PeerOnly { .. } => {
+                    return Err(MobError::WiringError(format!(
+                        "wire_members_batch only supports local session-backed members (got '{identity}')"
+                    )));
+                }
+            }
+        }
+
+        let mut already_wired = Vec::new();
+        let mut to_add = Vec::new();
+        for (a, b) in normalized_edges {
+            let event_edge = crate::event::MemberWireEdge {
+                a: a.clone(),
+                b: b.clone(),
+            };
+            let dsl_edge = mob_dsl::WiringEdge::new(
+                mob_dsl::AgentIdentity::from_domain(&a),
+                mob_dsl::AgentIdentity::from_domain(&b),
+            );
+            if self
+                .dsl_authority
+                .state
+                .wiring_edges
+                .iter()
+                .any(|existing| existing == &dsl_edge)
+            {
+                already_wired.push(event_edge);
+            } else {
+                to_add.push((event_edge, dsl_edge));
+            }
+        }
+
+        if to_add.is_empty() {
+            return Ok(super::handle::MobWireMembersBatchReport {
+                requested,
+                already_wired,
+                wired: Vec::new(),
+            });
+        }
+
+        let wire_inputs = to_add
+            .iter()
+            .map(|(_, edge)| mob_dsl::MobMachineInput::WireMembers { edge: edge.clone() })
+            .collect::<Vec<_>>();
+        let prepared = self.prepare_dsl_inputs(&wire_inputs, "wire_members_batch")?;
+        let wired = prepared
+            .effects
+            .iter()
+            .filter_map(|effect| match effect {
+                mob_dsl::MobMachineEffect::EmitWiringLifecycleNotice {
+                    kind: mob_dsl::WiringLifecycleKind::Wired,
+                    edge,
+                } => Some(crate::event::MemberWireEdge {
+                    a: AgentIdentity::from(edge.a.0.as_str()),
+                    b: AgentIdentity::from(edge.b.0.as_str()),
+                }),
+                _ => None,
+            })
+            .collect::<Vec<_>>();
+        self.commit_prepared_dsl_input(prepared);
+
+        let mut installed_trust: Vec<(Arc<dyn CoreCommsRuntime>, String)> = Vec::new();
+        for (event_edge, _) in &to_add {
+            let left = endpoints.get(&event_edge.a).ok_or_else(|| {
+                MobError::WiringError(format!(
+                    "wire_members_batch missing endpoint '{}'",
+                    event_edge.a
+                ))
+            })?;
+            let right = endpoints.get(&event_edge.b).ok_or_else(|| {
+                MobError::WiringError(format!(
+                    "wire_members_batch missing endpoint '{}'",
+                    event_edge.b
+                ))
+            })?;
+
+            if let Err(error) = left.comms.add_trusted_peer(right.spec.clone()).await {
+                self.rollback_wire_members_batch(&to_add, installed_trust)
+                    .await;
+                return Err(MobError::from(error));
+            }
+            installed_trust.push((left.comms.clone(), right.removal_key.clone()));
+
+            if let Err(error) = right.comms.add_trusted_peer(left.spec.clone()).await {
+                self.rollback_wire_members_batch(&to_add, installed_trust)
+                    .await;
+                return Err(MobError::from(error));
+            }
+            installed_trust.push((right.comms.clone(), left.removal_key.clone()));
+        }
+
+        let event = NewMobEvent {
+            mob_id: self.definition.id.clone(),
+            timestamp: None,
+            kind: MobEventKind::MembersWiredBatch {
+                edges: wired.clone(),
+            },
+        };
+        let stored = match self.events.append(event).await {
+            Ok(stored) => stored,
+            Err(error) => {
+                self.rollback_wire_members_batch(&to_add, installed_trust)
+                    .await;
+                return Err(MobError::from(error));
+            }
+        };
+        self.roster.write().await.apply_event(&stored);
+
+        tracing::info!(
+            mob_id = %self.definition.id,
+            requested,
+            wired = wired.len(),
+            already_wired = already_wired.len(),
+            participants = endpoints.len(),
+            "wire_members_batch materialized local topology"
+        );
+
+        Ok(super::handle::MobWireMembersBatchReport {
+            requested,
+            already_wired,
+            wired,
+        })
+    }
+
+    async fn rollback_wire_members_batch(
+        &mut self,
+        added_edges: &[(crate::event::MemberWireEdge, mob_dsl::WiringEdge)],
+        installed_trust: Vec<(Arc<dyn CoreCommsRuntime>, String)>,
+    ) {
+        for (comms, removal_key) in installed_trust.into_iter().rev() {
+            if let Err(error) = comms.remove_trusted_peer(&removal_key).await {
+                tracing::warn!(
+                    mob_id = %self.definition.id,
+                    %error,
+                    "wire_members_batch rollback: failed to remove trusted peer"
+                );
+            }
+        }
+
+        let rollback_inputs = added_edges
+            .iter()
+            .rev()
+            .map(|(_, edge)| mob_dsl::MobMachineInput::UnwireMembers { edge: edge.clone() })
+            .collect::<Vec<_>>();
+        match self.prepare_dsl_inputs(&rollback_inputs, "wire_members_batch_rollback") {
+            Ok(prepared) => self.commit_prepared_dsl_input(prepared),
+            Err(error) => {
+                tracing::warn!(
+                    mob_id = %self.definition.id,
+                    %error,
+                    "wire_members_batch rollback: failed to revert MobMachine wiring graph"
+                );
+            }
+        }
+    }
+
     fn apply_wire_members_idempotent(
         &mut self,
         edge: &mob_dsl::WiringEdge,
@@ -8047,72 +8313,84 @@ impl MobActor {
         {
             WiringEndpoint::Local { spec, .. } | WiringEndpoint::PeerOnly { spec, .. } => spec,
         };
-        let mut first_error: Option<MobError> = None;
-        for peer_identity in &ctx.entry.wired_to {
-            // Resolve identity to bridge MeerkatId; skip absent peers (already retired).
-            let peer_entry = {
-                let roster = self.roster.read().await;
-                roster.get_by_identity(peer_identity).cloned()
-            };
-            let Some(peer_entry) = peer_entry else {
-                tracing::debug!(
-                    mob_id = %self.definition.id,
-                    agent_identity = %ctx.agent_identity,
-                    peer_id = %peer_identity,
-                    "dispose_notify_peers: skipping absent peer"
-                );
-                continue;
-            };
-            let (recipient_spec, recipient_comms, recipient_binding) = match self
-                .resolve_wiring_endpoint(&peer_entry, "dispose_notify_peers")
-                .await?
-            {
-                WiringEndpoint::Local { comms, spec, .. } => (spec, Some(comms), None),
-                WiringEndpoint::PeerOnly { spec, binding } => (spec, None, Some(binding)),
-            };
+        let peer_identities = ctx.entry.wired_to.iter().cloned().collect::<Vec<_>>();
+        let errors = futures::stream::iter(peer_identities)
+            .map(|peer_identity| {
+                let retiring_comms = retiring_comms.clone();
+                let retiring_spec = retiring_spec.clone();
+                async move {
+                    // Resolve identity to bridge MeerkatId; skip absent peers (already retired).
+                    let peer_entry = {
+                        let roster = self.roster.read().await;
+                        roster.get_by_identity(&peer_identity).cloned()
+                    };
+                    let Some(peer_entry) = peer_entry else {
+                        tracing::debug!(
+                            mob_id = %self.definition.id,
+                            agent_identity = %ctx.agent_identity,
+                            peer_id = %peer_identity,
+                            "dispose_notify_peers: skipping absent peer"
+                        );
+                        return None;
+                    };
+                    let (recipient_spec, recipient_comms, recipient_binding) = match self
+                        .resolve_wiring_endpoint(&peer_entry, "dispose_notify_peers")
+                        .await
+                    {
+                        Ok(WiringEndpoint::Local { comms, spec, .. }) => (spec, Some(comms), None),
+                        Ok(WiringEndpoint::PeerOnly { spec, binding }) => {
+                            (spec, None, Some(binding))
+                        }
+                        Err(error) => return Some(error),
+                    };
 
-            if let Err(error) = self
-                .notify_peer_retired(
-                    &recipient_spec,
-                    &ctx.agent_identity,
-                    &ctx.entry,
-                    &retiring_comms,
-                )
-                .await
-            {
-                if Self::is_peer_destroying_admission_rejection(&error) {
-                    tracing::debug!(
-                        mob_id = %self.definition.id,
-                        agent_identity = %ctx.agent_identity,
-                        peer_id = %peer_identity,
-                        "dispose_notify_peers: peer rejected lifecycle notice (already retiring)"
-                    );
-                } else if first_error.is_none() {
-                    first_error = Some(error);
+                    if let Err(error) = self
+                        .notify_peer_retired(
+                            &recipient_spec,
+                            &ctx.agent_identity,
+                            &ctx.entry,
+                            &retiring_comms,
+                        )
+                        .await
+                    {
+                        if Self::is_peer_destroying_admission_rejection(&error) {
+                            tracing::debug!(
+                                mob_id = %self.definition.id,
+                                agent_identity = %ctx.agent_identity,
+                                peer_id = %peer_identity,
+                                "dispose_notify_peers: peer rejected lifecycle notice (already retiring)"
+                            );
+                        } else {
+                            return Some(error);
+                        }
+                    }
+                    if let Some(recipient_comms) = recipient_comms {
+                        if let Err(error) = recipient_comms
+                            .remove_trusted_peer(&Self::trusted_peer_removal_key(&retiring_spec))
+                            .await
+                        {
+                            return Some(MobError::from(error));
+                        }
+                    } else if let Some(recipient_binding) = recipient_binding
+                        && let Err(error) = self
+                            .unwire_peer_only_recipient(
+                                &recipient_spec,
+                                Some(&recipient_binding),
+                                &retiring_spec,
+                                std::time::Duration::from_secs(10),
+                            )
+                            .await
+                    {
+                        return Some(error);
+                    }
+                    None
                 }
-            }
-            if let Some(recipient_comms) = recipient_comms {
-                if let Err(error) = recipient_comms
-                    .remove_trusted_peer(&Self::trusted_peer_removal_key(&retiring_spec))
-                    .await
-                    && first_error.is_none()
-                {
-                    first_error = Some(MobError::from(error));
-                }
-            } else if let Some(recipient_binding) = recipient_binding
-                && let Err(error) = self
-                    .unwire_peer_only_recipient(
-                        &recipient_spec,
-                        Some(&recipient_binding),
-                        &retiring_spec,
-                        std::time::Duration::from_secs(10),
-                    )
-                    .await
-                && first_error.is_none()
-            {
-                first_error = Some(error);
-            }
-        }
+            })
+            .buffer_unordered(MAX_PARALLEL_PEER_RETIRE_NOTIFICATIONS)
+            .filter_map(|error| async move { error })
+            .collect::<Vec<_>>()
+            .await;
+        let first_error = errors.into_iter().next();
         match first_error {
             Some(error) => Err(error),
             None => Ok(()),

--- a/meerkat-mob/src/runtime/builder.rs
+++ b/meerkat-mob/src/runtime/builder.rs
@@ -5,6 +5,8 @@ use std::collections::HashMap;
 #[cfg(feature = "runtime-adapter")]
 use std::collections::HashSet;
 
+const MOB_COMMAND_CHANNEL_CAPACITY: usize = 4096;
+
 // ---------------------------------------------------------------------------
 // MobBuilder
 // ---------------------------------------------------------------------------
@@ -937,7 +939,7 @@ impl MobBuilder {
         // Prepare shared runtime components early so resume reconciliation can
         // wire tool dispatchers for recreated sessions to the final actor channel.
         let roster_state = Arc::new(RwLock::new(RosterAuthority::new()));
-        let (command_tx, command_rx) = mpsc::channel(64);
+        let (command_tx, command_rx) = mpsc::channel(MOB_COMMAND_CHANNEL_CAPACITY);
         let restore_diagnostics = Arc::new(RwLock::new(seeded_restore_diagnostics));
         let initial_dsl_authority = Box::new(seed_mob_authority(dsl_seed_state));
         let (machine_state_watch_tx, machine_state_watch_rx) =
@@ -1614,7 +1616,7 @@ impl MobBuilder {
         let (machine_state_watch_tx, _machine_state_watch_rx) =
             tokio::sync::watch::channel(dsl_authority.state.clone());
         let roster = Arc::new(RwLock::new(RosterAuthority::from_roster(initial_roster)));
-        let (command_tx, command_rx) = mpsc::channel(64);
+        let (command_tx, command_rx) = mpsc::channel(MOB_COMMAND_CHANNEL_CAPACITY);
         let restore_diagnostics = Arc::new(RwLock::new(HashMap::new()));
         let wiring = RuntimeWiring {
             roster,

--- a/meerkat-mob/src/runtime/handle.rs
+++ b/meerkat-mob/src/runtime/handle.rs
@@ -649,6 +649,17 @@ pub enum PeerTarget {
     External(TrustedPeerDescriptor),
 }
 
+/// Summary for one dense local-member topology materialization pass.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct MobWireMembersBatchReport {
+    /// Number of edges requested before normalization/deduplication.
+    pub requested: usize,
+    /// Normalized unique edges already present in the MobMachine graph.
+    pub already_wired: Vec<crate::event::MemberWireEdge>,
+    /// Normalized unique edges newly admitted by the MobMachine graph.
+    pub wired: Vec<crate::event::MemberWireEdge>,
+}
+
 /// Typed request to bind a local member to an external peer.
 ///
 /// App-facing surfaces provide this shape instead of comms-owned `peer_id` /
@@ -1563,6 +1574,16 @@ impl MobHandle {
                 Ok(MobMachineCommandResult::LifecycleSnapshot(snapshot))
             }
             #[cfg(test)]
+            MobMachineCommand::LifecycleNotificationBurst { count, message } => {
+                self.send_actor_command(|reply_tx| MobCommand::LifecycleNotificationBurst {
+                    count,
+                    message,
+                    reply_tx,
+                })
+                .await??;
+                Ok(MobMachineCommandResult::LifecycleNotificationBurst)
+            }
+            #[cfg(test)]
             MobMachineCommand::DslT2Snapshot => {
                 let snapshot = self
                     .send_actor_command(|reply_tx| MobCommand::DslT2Snapshot { reply_tx })
@@ -1595,6 +1616,12 @@ impl MobHandle {
                 })
                 .await??;
                 Ok(MobMachineCommandResult::Unit)
+            }
+            MobMachineCommand::WireMembersBatch { edges } => {
+                let report = self
+                    .send_actor_command(|reply_tx| MobCommand::WireMembersBatch { edges, reply_tx })
+                    .await??;
+                Ok(MobMachineCommandResult::WireMembersBatchReport(report))
             }
             MobMachineCommand::Unwire { local, target } => {
                 self.send_actor_command(|reply_tx| MobCommand::Unwire {
@@ -2702,6 +2729,36 @@ impl MobHandle {
         }
     }
 
+    /// Materialize many local-member wiring edges in one actor command.
+    ///
+    /// This is intended for initial topology reconciliation, where callers
+    /// already have a graph snapshot. It only accepts local mob-member
+    /// identities; external peer wiring stays on the single-edge path because
+    /// those mutations carry descriptor/rollback semantics per peer.
+    pub async fn wire_members_batch<I, A, B>(
+        &self,
+        edges: I,
+    ) -> Result<MobWireMembersBatchReport, MobError>
+    where
+        I: IntoIterator<Item = (A, B)>,
+        A: Into<AgentIdentity>,
+        B: Into<AgentIdentity>,
+    {
+        let edges = edges
+            .into_iter()
+            .map(|(a, b)| (a.into(), b.into()))
+            .collect();
+        match self
+            .execute_machine_command(MobMachineCommand::WireMembersBatch { edges })
+            .await?
+        {
+            MobMachineCommandResult::WireMembersBatchReport(report) => Ok(report),
+            _ => Err(MobError::Internal(
+                "unexpected command result variant".into(),
+            )),
+        }
+    }
+
     /// Unwire a local member from either another local member or an external peer.
     pub async fn unwire<T>(&self, local: AgentIdentity, target: T) -> Result<(), MobError>
     where
@@ -3039,6 +3096,26 @@ impl MobHandle {
             .await?
         {
             MobMachineCommandResult::LifecycleSnapshot(snapshot) => Ok(snapshot),
+            _ => Err(MobError::Internal(
+                "unexpected command result variant".into(),
+            )),
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) async fn debug_lifecycle_notification_burst(
+        &self,
+        count: usize,
+        message: impl Into<String>,
+    ) -> Result<(), MobError> {
+        match self
+            .execute_machine_command(MobMachineCommand::LifecycleNotificationBurst {
+                count,
+                message: message.into(),
+            })
+            .await?
+        {
+            MobMachineCommandResult::LifecycleNotificationBurst => Ok(()),
             _ => Err(MobError::Internal(
                 "unexpected command result variant".into(),
             )),

--- a/meerkat-mob/src/runtime/mod.rs
+++ b/meerkat-mob/src/runtime/mod.rs
@@ -127,8 +127,9 @@ pub use handle::{
     HelperResult, MemberDeliveryReceipt, MemberHandle, MemberRespawnReceipt, MobDestroyError,
     MobDestroyReport, MobEventsSubscription, MobEventsSubscriptionConfig, MobEventsView, MobHandle,
     MobMemberListEntry, MobMemberSnapshot, MobMemberStatus, MobPeerConnectivitySnapshot,
-    MobRespawnError, MobUnreachablePeer, PeerTarget, PreviousMemberCleanupReport, SpawnMemberSpec,
-    SpawnResult, SupervisorRotationReport, WorkDeliveryReceipt,
+    MobRespawnError, MobUnreachablePeer, MobWireMembersBatchReport, PeerTarget,
+    PreviousMemberCleanupReport, SpawnMemberSpec, SpawnResult, SupervisorRotationReport,
+    WorkDeliveryReceipt,
 };
 use pending_spawn_lineage::{PendingSpawnInsertImpact, PendingSpawnLineage};
 pub use reconcile::{

--- a/meerkat-mob/src/runtime/provisioner.rs
+++ b/meerkat-mob/src/runtime/provisioner.rs
@@ -47,6 +47,9 @@ use tokio::sync::{Mutex, RwLock, mpsc, oneshot};
 type TurnEventTx = tokio::sync::mpsc::Sender<meerkat_core::EventEnvelope<meerkat_core::AgentEvent>>;
 
 #[cfg(feature = "runtime-adapter")]
+const DEFERRED_TURN_EVENT_CHANNEL_CAPACITY: usize = 1024;
+
+#[cfg(feature = "runtime-adapter")]
 struct DeferredTurnEventDelivery {
     release_tx: oneshot::Sender<()>,
 }
@@ -67,7 +70,7 @@ fn defer_turn_events_until_machine_completion(
         return (None, None);
     };
 
-    let (deferred_tx, mut deferred_rx) = mpsc::channel(64);
+    let (deferred_tx, mut deferred_rx) = mpsc::channel(DEFERRED_TURN_EVENT_CHANNEL_CAPACITY);
     let (release_tx, release_rx) = oneshot::channel();
     let session_id = session_id.clone();
     tokio::spawn(async move {

--- a/meerkat-mob/src/runtime/state.rs
+++ b/meerkat-mob/src/runtime/state.rs
@@ -281,6 +281,12 @@ pub(super) enum MobCommand {
     LifecycleSnapshot {
         reply_tx: oneshot::Sender<MobLifecycleSnapshot>,
     },
+    #[cfg(test)]
+    LifecycleNotificationBurst {
+        count: usize,
+        message: String,
+        reply_tx: oneshot::Sender<Result<(), MobError>>,
+    },
     /// Snapshot the T2 DSL field projections (member state markers, wiring
     /// edges, identity→runtime map, tasks + task id sets) directly from the
     /// DSL authority. Test-only read seam used by the runtime-parity
@@ -360,6 +366,11 @@ pub(super) enum MobCommand {
         local: MeerkatId,
         target: super::handle::PeerTarget,
         reply_tx: oneshot::Sender<Result<(), MobError>>,
+    },
+    /// Materialize many local-member wiring edges through one actor turn.
+    WireMembersBatch {
+        edges: Vec<(AgentIdentity, AgentIdentity)>,
+        reply_tx: oneshot::Sender<Result<super::handle::MobWireMembersBatchReport, MobError>>,
     },
     /// Unwire a local mob member from a peer target. Mirror of `Wire`:
     /// local member targets forward to `UnwireMembers`, while raw external

--- a/meerkat-mob/src/runtime/tests.rs
+++ b/meerkat-mob/src/runtime/tests.rs
@@ -188,6 +188,7 @@ struct MockCommsBehavior {
     fail_send_peer_added: bool,
     fail_send_peer_retired: bool,
     fail_send_peer_unwired: bool,
+    peer_lifecycle_delay_ms: u64,
 }
 
 struct MockCommsRuntime {
@@ -428,6 +429,10 @@ impl CoreCommsRuntime for MockCommsRuntime {
                     .behavior
                     .read()
                     .expect("poisoned behavior lock in mock runtime");
+                if behavior.peer_lifecycle_delay_ms > 0 {
+                    tokio::time::sleep(Duration::from_millis(behavior.peer_lifecycle_delay_ms))
+                        .await;
+                }
                 match kind {
                     meerkat_core::comms::PeerLifecycleKind::PeerAdded
                         if behavior.fail_send_peer_added =>
@@ -615,6 +620,7 @@ struct MockSessionService {
     create_session_max_in_flight: AtomicU64,
     archive_delay_ms: AtomicU64,
     start_turn_delay_ms: AtomicU64,
+    inject_delay_ms: AtomicU64,
     flow_turn_delay_ms: AtomicU64,
     flow_turn_never_terminal: std::sync::atomic::AtomicBool,
     flow_turn_fail: std::sync::atomic::AtomicBool,
@@ -672,6 +678,7 @@ impl MockSessionService {
             create_session_max_in_flight: AtomicU64::new(0),
             archive_delay_ms: AtomicU64::new(0),
             start_turn_delay_ms: AtomicU64::new(0),
+            inject_delay_ms: AtomicU64::new(0),
             flow_turn_delay_ms: AtomicU64::new(0),
             flow_turn_never_terminal: std::sync::atomic::AtomicBool::new(false),
             flow_turn_fail: std::sync::atomic::AtomicBool::new(false),
@@ -943,6 +950,11 @@ impl MockSessionService {
 
     fn set_start_turn_delay_ms(&self, delay_ms: u64) {
         self.start_turn_delay_ms
+            .store(delay_ms, std::sync::atomic::Ordering::Relaxed);
+    }
+
+    fn set_inject_delay_ms(&self, delay_ms: u64) {
+        self.inject_delay_ms
             .store(delay_ms, std::sync::atomic::Ordering::Relaxed);
     }
 
@@ -1527,6 +1539,7 @@ async fn retire_test_runtime_archive(
 
 struct CountingInjector {
     calls: Arc<AtomicU64>,
+    inject_delay_ms: u64,
     delay_ms: u64,
     never_terminal: bool,
     fail: bool,
@@ -1544,6 +1557,9 @@ impl EventInjector for CountingInjector {
     ) -> Result<(), EventInjectorError> {
         if self.fail_inject {
             return Err(EventInjectorError::Closed);
+        }
+        if self.inject_delay_ms > 0 {
+            std::thread::sleep(std::time::Duration::from_millis(self.inject_delay_ms));
         }
         self.calls.fetch_add(1, Ordering::Relaxed);
         Ok(())
@@ -1617,6 +1633,7 @@ impl SessionServiceCommsExt for MockSessionService {
             return None;
         }
         let delay_ms = self.flow_turn_delay_ms.load(Ordering::Relaxed);
+        let inject_delay_ms = self.inject_delay_ms.load(Ordering::Relaxed);
         let never_terminal = self
             .flow_turn_never_terminal
             .load(std::sync::atomic::Ordering::Relaxed);
@@ -1632,6 +1649,7 @@ impl SessionServiceCommsExt for MockSessionService {
         let fail_inject = self.fail_inject.load(std::sync::atomic::Ordering::Relaxed);
         Some(Arc::new(CountingInjector {
             calls: self.inject_calls.clone(),
+            inject_delay_ms,
             delay_ms,
             never_terminal,
             fail,
@@ -1654,6 +1672,7 @@ impl SessionServiceCommsExt for MockSessionService {
             return None;
         }
         let delay_ms = self.flow_turn_delay_ms.load(Ordering::Relaxed);
+        let inject_delay_ms = self.inject_delay_ms.load(Ordering::Relaxed);
         let never_terminal = self
             .flow_turn_never_terminal
             .load(std::sync::atomic::Ordering::Relaxed);
@@ -1669,6 +1688,7 @@ impl SessionServiceCommsExt for MockSessionService {
         let fail_inject = self.fail_inject.load(std::sync::atomic::Ordering::Relaxed);
         Some(Arc::new(CountingInjector {
             calls: self.inject_calls.clone(),
+            inject_delay_ms,
             delay_ms,
             never_terminal,
             fail,
@@ -1886,6 +1906,7 @@ impl FaultInjectedMobEventStore {
             MobEventKind::MemberReset { .. } => "MemberReset",
             MobEventKind::MemberKickoffUpdated { .. } => "MemberKickoffUpdated",
             MobEventKind::MembersWired { .. } => "MembersWired",
+            MobEventKind::MembersWiredBatch { .. } => "MembersWiredBatch",
             MobEventKind::MembersUnwired { .. } => "MembersUnwired",
             MobEventKind::ExternalPeerWired { .. } => "ExternalPeerWired",
             MobEventKind::ExternalPeerUnwired { .. } => "ExternalPeerUnwired",
@@ -15600,6 +15621,283 @@ async fn test_wire_emits_peers_wired_event() {
 }
 
 #[tokio::test]
+async fn test_wire_members_batch_materializes_dense_topology_once() {
+    let (handle, service) = create_test_mob(sample_definition()).await;
+    let sid_l = handle
+        .spawn(ProfileName::from("lead"), MeerkatId::from("l-1"), None)
+        .await
+        .expect("spawn lead")
+        .bridge_session_id()
+        .expect("session-backed")
+        .clone();
+    let sid_w1 = handle
+        .spawn(ProfileName::from("worker"), MeerkatId::from("w-1"), None)
+        .await
+        .expect("spawn worker one")
+        .bridge_session_id()
+        .expect("session-backed")
+        .clone();
+    handle
+        .spawn(ProfileName::from("worker"), MeerkatId::from("w-2"), None)
+        .await
+        .expect("spawn worker two");
+
+    let report = handle
+        .wire_members_batch([
+            (AgentIdentity::from("l-1"), AgentIdentity::from("w-1")),
+            (AgentIdentity::from("w-2"), AgentIdentity::from("l-1")),
+            (AgentIdentity::from("l-1"), AgentIdentity::from("w-1")),
+        ])
+        .await
+        .expect("batch wire");
+    assert_eq!(report.requested, 3);
+    assert_eq!(report.wired.len(), 2);
+    assert!(report.already_wired.is_empty());
+
+    let lead = handle
+        .get_member(&AgentIdentity::from("l-1"))
+        .await
+        .expect("lead projected");
+    assert_eq!(lead.wired_to.len(), 2);
+    assert!(lead.wired_to.contains(&AgentIdentity::from("w-1")));
+    assert!(lead.wired_to.contains(&AgentIdentity::from("w-2")));
+    let worker = handle
+        .get_member(&AgentIdentity::from("w-1"))
+        .await
+        .expect("worker projected");
+    assert!(worker.wired_to.contains(&AgentIdentity::from("l-1")));
+
+    let trusted_by_lead = service.trusted_peer_names(&sid_l).await;
+    assert!(
+        trusted_by_lead
+            .iter()
+            .any(|name| name.as_str() == test_comms_name("worker", "w-1"))
+    );
+    assert!(
+        trusted_by_lead
+            .iter()
+            .any(|name| name.as_str() == test_comms_name("worker", "w-2"))
+    );
+    let trusted_by_worker = service.trusted_peer_names(&sid_w1).await;
+    assert!(
+        trusted_by_worker
+            .iter()
+            .any(|name| name.as_str() == test_comms_name("lead", "l-1"))
+    );
+
+    let events = handle.events().replay_all().await.expect("replay");
+    assert_eq!(
+        events
+            .iter()
+            .filter(|event| matches!(event.kind, MobEventKind::MembersWiredBatch { .. }))
+            .count(),
+        1,
+        "batch topology materialization should emit one compact event"
+    );
+    assert_eq!(
+        events
+            .iter()
+            .filter(|event| matches!(event.kind, MobEventKind::MembersWired { .. }))
+            .count(),
+        0,
+        "batch topology materialization must not fan out per-edge events"
+    );
+
+    let second = handle
+        .wire_members_batch([
+            (AgentIdentity::from("l-1"), AgentIdentity::from("w-1")),
+            (AgentIdentity::from("l-1"), AgentIdentity::from("w-2")),
+        ])
+        .await
+        .expect("idempotent batch wire");
+    assert_eq!(second.requested, 2);
+    assert_eq!(second.already_wired.len(), 2);
+    assert!(second.wired.is_empty());
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn test_wire_members_batch_materializes_300_by_150_dense_topology_in_seconds() {
+    const AGENTS: usize = 300;
+    const PEERS_PER_AGENT: usize = 150;
+    const EDGE_OFFSETS: usize = PEERS_PER_AGENT / 2;
+    const EXPECTED_EDGES: usize = AGENTS * PEERS_PER_AGENT / 2;
+
+    let (handle, _service) = create_test_mob(sample_definition()).await;
+    let identities = (0..AGENTS)
+        .map(|index| AgentIdentity::from(format!("agent-{index:03}")))
+        .collect::<Vec<_>>();
+    let specs = identities
+        .iter()
+        .map(|identity| SpawnMemberSpec::new("worker", identity.as_str()))
+        .collect::<Vec<_>>();
+
+    let spawn_started = std::time::Instant::now();
+    let spawned = handle.spawn_many(specs).await;
+    let spawn_elapsed = spawn_started.elapsed();
+    assert_eq!(spawned.len(), AGENTS);
+    for result in spawned {
+        result.expect("spawn_many dense topology member");
+    }
+
+    let mut edges = Vec::with_capacity(EXPECTED_EDGES);
+    for index in 0..AGENTS {
+        for offset in 1..=EDGE_OFFSETS {
+            edges.push((
+                identities[index].clone(),
+                identities[(index + offset) % AGENTS].clone(),
+            ));
+        }
+    }
+    assert_eq!(edges.len(), EXPECTED_EDGES);
+
+    let wire_started = std::time::Instant::now();
+    let report = handle
+        .wire_members_batch(edges)
+        .await
+        .expect("batch wire dense topology");
+    let wire_elapsed = wire_started.elapsed();
+
+    assert_eq!(report.requested, EXPECTED_EDGES);
+    assert_eq!(report.wired.len(), EXPECTED_EDGES);
+    assert!(report.already_wired.is_empty());
+
+    for identity in &identities {
+        let member = handle
+            .get_member(identity)
+            .await
+            .expect("dense topology member projected");
+        assert_eq!(
+            member.wired_to.len(),
+            PEERS_PER_AGENT,
+            "{identity} should have exactly {PEERS_PER_AGENT} peers"
+        );
+    }
+
+    let events = handle.events().replay_all().await.expect("replay");
+    let batch_events = events
+        .iter()
+        .filter(|event| matches!(event.kind, MobEventKind::MembersWiredBatch { .. }))
+        .count();
+    let single_edge_events = events
+        .iter()
+        .filter(|event| matches!(event.kind, MobEventKind::MembersWired { .. }))
+        .count();
+    assert_eq!(batch_events, 1);
+    assert_eq!(
+        single_edge_events, 0,
+        "dense topology materialization must not emit per-edge wire events"
+    );
+    assert!(
+        wire_elapsed < std::time::Duration::from_secs(30),
+        "300x150 topology materialization should be seconds, not minutes (spawn={spawn_elapsed:?}, wire={wire_elapsed:?})"
+    );
+    eprintln!(
+        "dense topology stress: agents={AGENTS}, edges={EXPECTED_EDGES}, spawn={spawn_elapsed:?}, wire={wire_elapsed:?}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn test_retire_fanout_notifies_150_peers_with_bounded_parallelism() {
+    const PEERS: usize = 150;
+    const PER_NOTIFICATION_DELAY_MS: u64 = 20;
+
+    let (handle, service) = create_test_mob(sample_definition()).await;
+    let retiring = AgentIdentity::from("retiring");
+    let retiring_sid = handle
+        .spawn(
+            ProfileName::from("worker"),
+            MeerkatId::from("retiring"),
+            None,
+        )
+        .await
+        .expect("spawn retiring member")
+        .bridge_session_id()
+        .expect("session-backed retiring member")
+        .clone();
+
+    let peer_identities = (0..PEERS)
+        .map(|index| AgentIdentity::from(format!("peer-{index:03}")))
+        .collect::<Vec<_>>();
+    let specs = peer_identities
+        .iter()
+        .map(|identity| SpawnMemberSpec::new("worker", identity.as_str()))
+        .collect::<Vec<_>>();
+    let spawned = handle.spawn_many(specs).await;
+    for result in spawned {
+        result.expect("spawn peer");
+    }
+
+    let mut peer_session_ids = Vec::with_capacity(PEERS);
+    for identity in &peer_identities {
+        peer_session_ids.push(
+            handle
+                .resolve_bridge_session_id(identity)
+                .await
+                .expect("peer bridge session id"),
+        );
+    }
+
+    handle
+        .wire_members_batch(
+            peer_identities
+                .iter()
+                .map(|peer| (retiring.clone(), peer.clone())),
+        )
+        .await
+        .expect("wire retiring member to peers");
+    service
+        .set_comms_behavior(
+            &test_comms_name("worker", "retiring"),
+            MockCommsBehavior {
+                peer_lifecycle_delay_ms: PER_NOTIFICATION_DELAY_MS,
+                ..MockCommsBehavior::default()
+            },
+        )
+        .await;
+
+    let started = Instant::now();
+    handle
+        .retire(retiring.clone())
+        .await
+        .expect("retire high-degree member");
+    let elapsed = started.elapsed();
+
+    assert!(
+        elapsed < Duration::from_secs(2),
+        "150 peer-retired notifications with {PER_NOTIFICATION_DELAY_MS}ms send delay should fan out with bounded parallelism, not run sequentially (elapsed={elapsed:?})"
+    );
+    eprintln!(
+        "retire fanout stress: peers={PEERS}, per_notification_delay_ms={PER_NOTIFICATION_DELAY_MS}, retire={elapsed:?}"
+    );
+    let retiring_intents = service.sent_intents(&retiring_sid).await;
+    assert_eq!(
+        retiring_intents
+            .iter()
+            .filter(|intent| intent.as_str() == "mob.peer_retired")
+            .count(),
+        PEERS,
+        "retiring member must send one peer-retired notice per wired peer"
+    );
+    for (identity, session_id) in peer_identities.iter().zip(peer_session_ids.iter()) {
+        let member = handle
+            .get_member(identity)
+            .await
+            .expect("peer should remain active");
+        assert!(
+            !member.wired_to.contains(&retiring),
+            "{identity} should no longer project the retired peer"
+        );
+        let trusted = service.trusted_peer_names(session_id).await;
+        assert!(
+            !trusted
+                .iter()
+                .any(|name| name == &test_comms_name("worker", "retiring")),
+            "{identity} should remove trust for the retired peer"
+        );
+    }
+}
+
+#[tokio::test]
 async fn test_wire_is_idempotent_and_emits_single_pair_event() {
     let (handle, service) = create_test_mob(sample_definition()).await;
     let sid_l = handle
@@ -26639,6 +26937,60 @@ async fn test_shutdown_does_not_stall_on_stuck_lifecycle_notification() {
         "shutdown must not stall on stuck lifecycle notification tasks"
     );
     shutdown_result.unwrap().expect("shutdown should succeed");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn test_lifecycle_notification_burst_backpressures_without_dropping() {
+    const NOTIFICATIONS: usize = 48;
+    const INJECT_DELAY_MS: u64 = 20;
+
+    let def = sample_definition();
+    let service = Arc::new(MockSessionService::new());
+    let _ = service.enable_runtime_adapter();
+    let handle = MobBuilder::new(def, MobStorage::in_memory())
+        .with_session_service(service.clone())
+        .create()
+        .await
+        .expect("create mob");
+    handle
+        .spawn(ProfileName::from("lead"), MeerkatId::from("lead-1"), None)
+        .await
+        .expect("spawn autonomous orchestrator");
+    service.set_inject_delay_ms(INJECT_DELAY_MS);
+
+    let baseline = service.inject_call_count();
+    let started = Instant::now();
+    handle
+        .debug_lifecycle_notification_burst(NOTIFICATIONS, "burst lifecycle")
+        .await
+        .expect("lifecycle burst");
+    let command_elapsed = started.elapsed();
+    let deadline = Instant::now() + Duration::from_secs(2);
+    while service.inject_call_count() < baseline + NOTIFICATIONS as u64 {
+        assert!(
+            Instant::now() < deadline,
+            "lifecycle burst must inject every notification instead of dropping at the task cap"
+        );
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+    let total_elapsed = started.elapsed();
+
+    assert_eq!(
+        service.inject_call_count(),
+        baseline + NOTIFICATIONS as u64,
+        "lifecycle burst must inject every notification instead of dropping at the task cap"
+    );
+    assert!(
+        command_elapsed >= Duration::from_millis(INJECT_DELAY_MS),
+        "burst should apply backpressure once the lifecycle task set saturates"
+    );
+    assert!(
+        total_elapsed < Duration::from_secs(3),
+        "backpressured lifecycle burst should complete in bounded waves, not stall indefinitely (elapsed={total_elapsed:?})"
+    );
+    eprintln!(
+        "lifecycle notification stress: notifications={NOTIFICATIONS}, inject_delay_ms={INJECT_DELAY_MS}, command={command_elapsed:?}, total={total_elapsed:?}"
+    );
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Add a Meerkat-side batch local-member topology API for dense reconciliation, exposed as `MobHandle::wire_members_batch(...)`.
- Lower each batch edge through the MobMachine-owned `WireMembers` input while coalescing actor work, roster projection, and event replay into one compact `MembersWiredBatch` event.
- Add backpressured inproc peer delivery for runtime-originated sends so full inboxes do not become semantic message loss.
- Improve burst behavior around lifecycle notifications, peer retire fanout, mob command capacity, and deferred turn-event buffering without introducing new semantic owners.

## Dogma Shape

MobMachine remains the owner of peer wiring truth. The new batch path is shell batching around roster snapshot validation, comms trust installation, rollback, and projection/event fanout. Existing single-edge wire/unwire semantics remain intact for interactive mutations and external-peer cases.

## Stress Results

Added and ran `test_wire_members_batch_materializes_300_by_150_dense_topology_in_seconds`, which spawns 300 mocked session-backed mob members and batch-wires a 22,500-edge regular graph where every member has 150 peers.

Fresh local timing from `--nocapture` run:

- spawn 300 members: `442.161833ms`
- materialize 22,500 batch edges: `2.953465167s`

The topology stress asserts every member projects exactly 150 peers, exactly one `MembersWiredBatch` event is emitted, zero per-edge `MembersWired` events are emitted, and materialization stays below a 30s guard.

Additional burst-path stress coverage now included:

- `test_classified_send_wait_stress_backpressures_burst_without_drops`: fills a capacity-8 classified inbox, parks 256 `send_wait` senders behind it, drains capacity, and asserts every waiter is admitted with zero capacity drops.
- `test_lifecycle_notification_burst_backpressures_without_dropping`: sends 48 delayed lifecycle notifications through the production autonomous notification branch; local timing was command `260.664458ms`, total `332.040375ms`.
- `test_retire_fanout_notifies_150_peers_with_bounded_parallelism`: retires a member wired to 150 peers with an artificial 20ms per-notification comms delay; local retire timing was `542.882ms`, with all 150 `mob.peer_retired` intents observed and peer projections/trust cleaned up.

## Validation

- `./scripts/repo-cargo test -p meerkat-mob test_wire_members_batch_materializes_300_by_150_dense_topology_in_seconds -- --nocapture`
- `./scripts/repo-cargo test -p meerkat-comms test_classified_send_wait_stress_backpressures_burst_without_drops -- --nocapture`
- `./scripts/repo-cargo test -p meerkat-mob test_lifecycle_notification_burst_backpressures_without_dropping -- --nocapture`
- `./scripts/repo-cargo test -p meerkat-mob test_retire_fanout_notifies_150_peers_with_bounded_parallelism -- --nocapture`
- `./scripts/repo-cargo test -p meerkat-comms`
- `./scripts/repo-cargo test -p meerkat-mob`
- `make check`
- `make lint`
- `git diff --check`
- pre-push hooks: secrets, whitespace, fmt, changed-crate clippy, machine codegen/verify, generated-header audit, bridge response-status audit, Bazel freshness, deterministic workspace gate
