### PR TITLE
Use hosted Windows fallback for release assets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,7 +61,6 @@ env:
 #   PYPI_API_TOKEN        - PyPI API token (scoped to meerkat-sdk package)
 #   NPM_TOKEN             - npm access token (scoped to @meerkat org or publish)
 #   BUILDBUDDY_API_KEY    - optional owner-only BuildBuddy binary recovery path
-#   BUILDBUDDY_ENDPOINT   - optional owner-only Windows BB endpoint override
 
 jobs:
   require_ci_green:
@@ -332,33 +331,11 @@ jobs:
         needs.release_validate_gate.result == 'skipped')) &&
       (startsWith(github.ref, 'refs/tags/v') ||
        (github.event_name == 'workflow_dispatch' &&
-        github.event.inputs.publish_release_assets_only == 'true')) &&
-      !(github.actor == 'lukacf' &&
-        ((github.event_name == 'workflow_dispatch' &&
-          github.event.inputs.release_backend == 'buildbuddy') ||
-         (github.event_name != 'workflow_dispatch' &&
-          (vars.MEERKAT_RELEASE_BUILDBUDDY == 'true' ||
-           vars.MEERKAT_RELEASE_BUILDBUDDY == '1'))))
+        github.event.inputs.publish_release_assets_only == 'true'))
     runs-on: ${{ matrix.runs-on }}
     strategy:
       fail-fast: false
-      matrix:
-        include:
-          - runs-on: ubuntu-latest
-            target: x86_64-unknown-linux-gnu
-            archive_ext: tar.gz
-          - runs-on: ubuntu-24.04-arm
-            target: aarch64-unknown-linux-gnu
-            archive_ext: tar.gz
-          - runs-on: macos-15
-            target: aarch64-apple-darwin
-            archive_ext: tar.gz
-          - runs-on: macos-15-large
-            target: x86_64-apple-darwin
-            archive_ext: tar.gz
-          - runs-on: windows-latest
-            target: x86_64-pc-windows-msvc
-            archive_ext: zip
+      matrix: ${{ fromJSON((github.actor == 'lukacf' && ((github.event_name == 'workflow_dispatch' && github.event.inputs.release_backend == 'buildbuddy') || (github.event_name != 'workflow_dispatch' && (vars.MEERKAT_RELEASE_BUILDBUDDY == 'true' || vars.MEERKAT_RELEASE_BUILDBUDDY == '1')))) && '{"include":[{"runs-on":"windows-latest","target":"x86_64-pc-windows-msvc","archive_ext":"zip"}]}' || '{"include":[{"runs-on":"ubuntu-latest","target":"x86_64-unknown-linux-gnu","archive_ext":"tar.gz"},{"runs-on":"ubuntu-24.04-arm","target":"aarch64-unknown-linux-gnu","archive_ext":"tar.gz"},{"runs-on":"macos-15","target":"aarch64-apple-darwin","archive_ext":"tar.gz"},{"runs-on":"macos-15-large","target":"x86_64-apple-darwin","archive_ext":"tar.gz"},{"runs-on":"windows-latest","target":"x86_64-pc-windows-msvc","archive_ext":"zip"}]}') }}
 
     steps:
       - name: Checkout
@@ -487,9 +464,6 @@ jobs:
           - bb_command: release-build-macos-x86
             target: x86_64-apple-darwin
             archive_ext: tar.gz
-          - bb_command: release-build-windows-x86
-            target: x86_64-pc-windows-msvc
-            archive_ext: zip
 
     steps:
       - name: Checkout
@@ -505,7 +479,6 @@ jobs:
         shell: bash
         env:
           BUILDBUDDY_BAZEL_COMMAND: ${{ matrix.bb_command }}
-          BUILDBUDDY_ENDPOINT: ${{ matrix.bb_command == 'release-build-windows-x86' && secrets.BUILDBUDDY_ENDPOINT || '' }}
           BUILDBUDDY_OUTPUT_LANE: release-build-${{ matrix.target }}
           BUILDBUDDY_OUTPUT_BASE: ${{ runner.temp }}/bb-release-${{ matrix.target }}
           MEERKAT_BUILDBUDDY_OUTPUT_ROOT: ${{ runner.temp }}/bb-release
@@ -722,8 +695,8 @@ jobs:
 
           if [[ "${bb_selected}" == "true" ]]; then
             echo "BuildBuddy release binary build selected: ${buildbuddy_result}"
-            echo "GitHub-hosted release binary build skipped: ${github_result}"
-            [[ "${buildbuddy_result}" == "success" && "${github_result}" == "skipped" ]]
+            echo "GitHub-hosted Windows release binary fallback: ${github_result}"
+            [[ "${buildbuddy_result}" == "success" && "${github_result}" == "success" ]]
             exit $?
           fi
 

--- a/scripts/release-doctor
+++ b/scripts/release-doctor
@@ -118,6 +118,19 @@ else
   bad "Release workflow does not publish @rkat/web from a prebuilt package artifact"
 fi
 
+if ! grep -Fq 'BUILDBUDDY_ENDPOINT' .github/workflows/release.yml &&
+  ! awk '
+    /^  build_binaries_buildbuddy:/ { in_job = 1; next }
+    in_job && /^  [[:alnum:]_-]+:/ { in_job = 0 }
+    in_job && /release-build-windows-x86/ { found = 1 }
+    END { exit found ? 0 : 1 }
+  ' .github/workflows/release.yml &&
+  grep -Fq 'GitHub-hosted Windows release binary fallback' .github/workflows/release.yml; then
+  pass "Release workflow keeps Windows off BuildBuddy and uses the GitHub-hosted fallback"
+else
+  bad "Release workflow should build Linux/macOS on BuildBuddy and Windows via GitHub-hosted fallback"
+fi
+
 web_build_timeout="$(
   awk '
     /^  build_web_sdk_package:/ { in_job = 1; next }

--- a/scripts/release-workflow-dispatch
+++ b/scripts/release-workflow-dispatch
@@ -8,10 +8,12 @@ usage: release-workflow-dispatch [--mode full|assets|packages|web-sdk|web-sdk-pu
 Dispatches the release workflow through the same public/default vs owner-only
 BuildBuddy backend split used by CI.
 
-Backend note: release_backend=buildbuddy covers release validation and binary
-asset builds. @rkat/web is built once as a release artifact before npm
-publishing. Credentialed registry publish jobs still run on GitHub-hosted
-runners; use the narrow recovery modes for retries.
+Backend note: release_backend=buildbuddy covers release validation and the
+Linux/macOS binary assets. Windows release binaries use the GitHub-hosted
+fallback because Windows is not currently a reliable BuildBuddy target. @rkat/web
+is built once as a release artifact before npm publishing. Credentialed registry
+publish jobs still run on GitHub-hosted runners; use the narrow recovery modes
+for retries.
 
 Environment equivalents:
   VERSION or RELEASE_TAG     Release tag, for example v0.6.1.
@@ -205,7 +207,7 @@ printf 'release workflow mode: %s\n' "${mode}"
 printf 'release workflow ref: %s\n' "${workflow_ref}"
 printf 'release workflow tag: %s\n' "${version}"
 if [[ "${backend}" == "buildbuddy" ]]; then
-  printf 'release workflow acceleration: BuildBuddy validation + binary asset builds\n'
+  printf 'release workflow acceleration: BuildBuddy validation + Linux/macOS binary builds; GitHub-hosted Windows fallback\n'
 else
   printf 'release workflow acceleration: GitHub-hosted validation + binary asset builds\n'
 fi


### PR DESCRIPTION
## Summary
- keep Windows release binaries off the BuildBuddy release matrix
- run only the Windows binary build on GitHub-hosted runners when BuildBuddy is selected
- remove the stale Windows BUILDBUDDY_ENDPOINT override and teach release-doctor to guard the new split

## Verification
- go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/release.yml
- bash -n scripts/release-doctor scripts/release-workflow-dispatch
- git diff --check
- make release-doctor VERSION=v0.6.15
- scripts/release-workflow-dispatch --mode assets --version v0.6.15 --backend github-hosted --dry-run
- scripts/release-workflow-dispatch --mode assets --version v0.6.15 --backend buildbuddy --dry-run