### PR TITLE
Fix e2e smoke mob lifecycle and image comms

### DIFF
--- a/meerkat-anthropic/src/client.rs
+++ b/meerkat-anthropic/src/client.rs
@@ -17,7 +17,7 @@ use meerkat_llm_core::LlmError;
 use meerkat_llm_core::{LlmClient, LlmDoneOutcome, LlmEvent, LlmRequest, LlmStream};
 use meerkat_llm_core::{http, streaming};
 use serde::Deserialize;
-use serde_json::Value;
+use serde_json::{Map, Value};
 use std::collections::HashSet;
 use std::time::Duration;
 
@@ -715,14 +715,15 @@ impl AnthropicClient {
             let tools: Vec<Value> = request
                 .tools
                 .iter()
-                .map(|t| {
-                    serde_json::json!({
+                .map(|t| -> Result<Value, LlmError> {
+                    let input_schema = normalize_anthropic_tool_input_schema(&t.input_schema)?;
+                    Ok(serde_json::json!({
                         "name": t.name,
                         "description": t.description,
-                        "input_schema": t.input_schema
-                    })
+                        "input_schema": input_schema
+                    }))
                 })
-                .collect();
+                .collect::<Result<Vec<_>, _>>()?;
             body["tools"] = Value::Array(tools);
         }
 
@@ -1449,6 +1450,145 @@ impl LlmClient for AnthropicClient {
             schema,
             warnings: Vec::new(),
         })
+    }
+}
+
+fn normalize_anthropic_tool_input_schema(schema: &Value) -> Result<Value, LlmError> {
+    let mut unresolved_refs = Vec::new();
+    let mut normalized =
+        inline_local_schema_refs(schema, schema, &mut Vec::new(), 0, &mut unresolved_refs);
+    if !unresolved_refs.is_empty() {
+        unresolved_refs.sort();
+        unresolved_refs.dedup();
+        return Err(LlmError::InvalidRequest {
+            message: format!(
+                "Anthropic tool input schema contains unresolved $ref values: {}. \
+                 Only local refs (for example '#/$defs/...') are supported for inlining.",
+                unresolved_refs.join(", ")
+            ),
+        });
+    }
+    strip_anthropic_tool_schema_definition_keywords(&mut normalized);
+    Ok(normalized)
+}
+
+fn inline_local_schema_refs(
+    node: &Value,
+    root: &Value,
+    active_refs: &mut Vec<String>,
+    depth: usize,
+    unresolved_refs: &mut Vec<String>,
+) -> Value {
+    const MAX_REF_DEPTH: usize = 64;
+    if depth > MAX_REF_DEPTH {
+        return node.clone();
+    }
+
+    match node {
+        Value::Object(obj) => {
+            if let Some(reference) = obj.get("$ref").and_then(Value::as_str)
+                && let Some(resolved) = resolve_local_schema_ref(root, reference)
+                && !active_refs.iter().any(|r| r == reference)
+            {
+                active_refs.push(reference.to_string());
+                let mut inlined = inline_local_schema_refs(
+                    resolved,
+                    root,
+                    active_refs,
+                    depth + 1,
+                    unresolved_refs,
+                );
+                active_refs.pop();
+
+                if let Value::Object(ref mut inlined_obj) = inlined {
+                    for (key, value) in obj {
+                        if key == "$ref" {
+                            continue;
+                        }
+                        inlined_obj.insert(
+                            key.clone(),
+                            inline_local_schema_refs(
+                                value,
+                                root,
+                                active_refs,
+                                depth + 1,
+                                unresolved_refs,
+                            ),
+                        );
+                    }
+                    return inlined;
+                }
+
+                return inlined;
+            }
+            if let Some(reference) = obj.get("$ref").and_then(Value::as_str) {
+                unresolved_refs.push(reference.to_string());
+            }
+
+            let mut mapped = Map::new();
+            for (key, value) in obj {
+                mapped.insert(
+                    key.clone(),
+                    inline_local_schema_refs(value, root, active_refs, depth + 1, unresolved_refs),
+                );
+            }
+            Value::Object(mapped)
+        }
+        Value::Array(items) => Value::Array(
+            items
+                .iter()
+                .map(|item| {
+                    inline_local_schema_refs(item, root, active_refs, depth + 1, unresolved_refs)
+                })
+                .collect(),
+        ),
+        _ => node.clone(),
+    }
+}
+
+fn resolve_local_schema_ref<'a>(root: &'a Value, reference: &str) -> Option<&'a Value> {
+    if !reference.starts_with("#/") {
+        return None;
+    }
+
+    let mut cursor = root;
+    for segment in reference.trim_start_matches("#/").split('/') {
+        let key = segment.replace("~1", "/").replace("~0", "~");
+        cursor = cursor.get(&key)?;
+    }
+
+    Some(cursor)
+}
+
+fn strip_anthropic_tool_schema_definition_keywords(value: &mut Value) {
+    match value {
+        Value::Object(obj) => {
+            obj.remove("$schema");
+            obj.remove("$defs");
+            obj.remove("defs");
+            obj.remove("definitions");
+            obj.remove("$ref");
+            obj.remove("$id");
+            obj.remove("$anchor");
+
+            for (key, child) in obj.iter_mut() {
+                if key == "properties" {
+                    if let Value::Object(props) = child {
+                        for prop_schema in props.values_mut() {
+                            strip_anthropic_tool_schema_definition_keywords(prop_schema);
+                        }
+                    }
+                } else {
+                    strip_anthropic_tool_schema_definition_keywords(child);
+                }
+            }
+        }
+        Value::Array(items) => {
+            for item in items {
+                strip_anthropic_tool_schema_definition_keywords(item);
+            }
+        }
+        _ => {}
     }
 }
 

--- a/meerkat-comms/src/mcp/tools.rs
+++ b/meerkat-comms/src/mcp/tools.rs
@@ -98,7 +98,13 @@ pub struct SendRequestInput {
     pub intent: CommsPeerRequestIntent,
     /// "steer" for immediate processing (normal), "queue" for next turn boundary
     pub handling_mode: HandlingMode,
-    /// Request parameters
+    /// Request parameters. Shape is validated against the selected intent at
+    /// the typed dispatch boundary; model-facing schema stays compact so
+    /// internal bridge wire variants do not dominate ordinary comms turns.
+    #[schemars(
+        with = "Value",
+        description = "Request parameters for the selected intent. For checksum_token use {\"subject\":\"image_receipt_check\"}. For supervisor.bridge use the bridge command payload described in the tool text."
+    )]
     pub params: CommsPeerRequestParams,
     /// Optional multimodal blocks. Use image_ref entries such as
     /// {"type":"image_ref","source":"current_turn","index":0} to forward
@@ -155,8 +161,13 @@ pub struct SendResponseInput {
     pub in_reply_to: String,
     /// Response status: "accepted", "completed", or "failed"
     pub status: ResponseStatus,
-    /// Response result data (optional)
+    /// Response result data (optional). Shape is validated against the
+    /// original request contract at the typed dispatch boundary.
     #[serde(default)]
+    #[schemars(
+        with = "Option<Value>",
+        description = "Typed response payload. For checksum_token use {\"request_intent\":\"checksum_token\",\"request_subject\":\"image_receipt_check\",\"token\":\"generated-image-response-ok\"}. For supervisor.bridge use simple bridge reply objects such as {\"result\":\"ack\",\"ok\":true}."
+    )]
     pub result: Option<CommsPeerResponseResult>,
     /// Optional multimodal blocks. Use image_ref entries such as
     /// {"type":"image_ref","source":"current_turn","index":0} to forward

--- a/meerkat-core/src/agent/state.rs
+++ b/meerkat-core/src/agent/state.rs
@@ -57,6 +57,7 @@ struct LlmRetryRequest<'a> {
     max_tokens: u32,
     temperature: Option<f32>,
     provider_params: Option<&'a ProviderParamsOverride>,
+    allow_empty_success: bool,
 }
 
 fn turn_input_run_id(input: &TurnExecutionInput) -> Option<RunId> {
@@ -147,6 +148,17 @@ fn assistant_image_events_from_effects(
         }
     }
     images
+}
+
+fn assistant_blocks_have_user_visible_output(blocks: &[crate::types::AssistantBlock]) -> bool {
+    blocks.iter().any(|block| match block {
+        crate::types::AssistantBlock::Text { text, .. }
+        | crate::types::AssistantBlock::Transcript { text, .. }
+        | crate::types::AssistantBlock::Reasoning { text, .. } => !text.trim().is_empty(),
+        crate::types::AssistantBlock::Image { .. } => true,
+        crate::types::AssistantBlock::ToolUse { .. }
+        | crate::types::AssistantBlock::ServerToolContent { .. } => false,
+    })
 }
 
 fn validate_turn_input_failure_reason(input: &TurnExecutionInput) -> Result<(), AgentError> {
@@ -425,6 +437,7 @@ where
             max_tokens,
             temperature,
             provider_params,
+            allow_empty_success,
         } = request;
 
         let hydrated_messages = if let Some(blob_store) = self.blob_store.as_ref() {
@@ -539,7 +552,61 @@ where
 
             // 5. Handle call result
             match call_result {
-                Ok(result) => return Ok(result),
+                Ok(result) => {
+                    if !crate::types::assistant_blocks_have_visible_or_actionable_output(
+                        result.blocks(),
+                    ) {
+                        if allow_empty_success {
+                            return Ok(result);
+                        }
+                        let error = AgentError::llm_empty_response(self.client.provider());
+                        if let Some(retry_schedule) = self.retry_policy.schedule_retry(
+                            &error,
+                            attempt,
+                            self.budget.remaining_duration(),
+                        ) {
+                            tracing::warn!(
+                                "LLM completed without visible/actionable output (attempt {}), retrying in {}ms",
+                                retry_schedule.plan.attempt,
+                                retry_schedule.plan.selected_delay_ms,
+                            );
+                            let recover =
+                                self.apply_turn_input(TurnExecutionInput::RecoverableFailure {
+                                    run_id: run_id.clone(),
+                                    retry: retry_schedule.clone(),
+                                })?;
+                            self.execute_turn_effects(&recover, turn_count, event_tx)
+                                .await;
+                            let _ = crate::event_tap::tap_emit(
+                                &self.event_tap,
+                                event_tx.as_ref(),
+                                AgentEvent::Retrying {
+                                    attempt: retry_schedule.plan.attempt,
+                                    max_attempts: retry_schedule.plan.max_retries,
+                                    error: error.to_string(),
+                                    delay_ms: retry_schedule.plan.selected_delay_ms,
+                                    retry: Some(retry_schedule.clone()),
+                                },
+                            )
+                            .await;
+                            attempt += 1;
+                            tokio::time::sleep(retry_schedule.plan.selected_delay()).await;
+                            if let Some(exceeded) = self.budget.observe().exceeded() {
+                                return Err(exceeded.to_agent_error());
+                            }
+                            let retry =
+                                self.apply_turn_input(TurnExecutionInput::RetryRequested {
+                                    run_id: run_id.clone(),
+                                    retry_attempt: retry_schedule.plan.attempt,
+                                })?;
+                            self.execute_turn_effects(&retry, turn_count, event_tx)
+                                .await;
+                            continue;
+                        }
+                        return Err(error);
+                    }
+                    return Ok(result);
+                }
                 Err(e) => {
                     if let Some(retry_schedule) = self.retry_policy.schedule_retry(
                         &e,
@@ -1163,6 +1230,7 @@ where
         let max_turns = self.config.max_turns.unwrap_or(100);
         let mut tool_call_count = 0u32;
         let mut event_stream_open = true;
+        let mut run_has_visible_or_actionable_output = false;
         self.extraction_state.reset();
 
         // --- Authority lifecycle: start a conversation run ---
@@ -1781,6 +1849,7 @@ where
                             max_tokens: effective_max_tokens,
                             temperature: effective_temperature,
                             provider_params: typed_provider_params.as_ref(),
+                            allow_empty_success: run_has_visible_or_actionable_output,
                         })
                         .await
                     {
@@ -1855,21 +1924,25 @@ where
                     let assistant_text = assistant_msg.to_string();
 
                     if !assistant_msg.has_visible_or_actionable_output() {
-                        let error = AgentError::llm_empty_response(self.client.provider());
-                        if in_extraction {
-                            return self
-                                .complete_extraction_failed(
-                                    &run_id,
-                                    turn_count,
-                                    tool_call_count,
-                                    error.to_string(),
-                                    &event_tx,
-                                )
-                                .await;
+                        if !run_has_visible_or_actionable_output {
+                            let error = AgentError::llm_empty_response(self.client.provider());
+                            if in_extraction {
+                                return self
+                                    .complete_extraction_failed(
+                                        &run_id,
+                                        turn_count,
+                                        tool_call_count,
+                                        error.to_string(),
+                                        &event_tx,
+                                    )
+                                    .await;
+                            }
+                            self.terminalize_fatal_error(&run_id, turn_count, &event_tx, &error)
+                                .await?;
+                            return Err(error);
                         }
-                        self.terminalize_fatal_error(&run_id, turn_count, &event_tx, &error)
-                            .await?;
-                        return Err(error);
+                    } else if assistant_blocks_have_user_visible_output(&assistant_msg.blocks) {
+                        run_has_visible_or_actionable_output = true;
                     }
 
                     let post_llm_invocation = HookInvocation {
@@ -2249,6 +2322,15 @@ where
                         if !pre_tool_effects.is_empty() {
                             self.apply_session_effects(&pre_tool_effects)?;
                         }
+                        let tool_batch_produced_output =
+                            tool_results.iter().any(|result| !result.is_error)
+                                || post_tool_effects.iter().any(|effect| {
+                                    matches!(
+                                        effect,
+                                        crate::ops::SessionEffect::AppendAssistantBlocks { blocks }
+                                            if crate::types::assistant_blocks_have_visible_or_actionable_output(blocks)
+                                    )
+                                });
 
                         // Add tool results to session
                         self.session.push(Message::tool_results(tool_results));
@@ -2257,6 +2339,9 @@ where
                             assistant_image_events_from_effects(&post_tool_effects);
                         if !post_tool_effects.is_empty() {
                             self.apply_session_effects(&post_tool_effects)?;
+                        }
+                        if tool_batch_produced_output {
+                            run_has_visible_or_actionable_output = true;
                         }
                         for image in assistant_image_events {
                             emit_event!(AgentEvent::AssistantImageAppended { image });
@@ -5288,6 +5373,48 @@ mod tests {
         }
     }
 
+    struct EmptyAfterImageEffectClient {
+        call_count: Mutex<u32>,
+    }
+
+    #[async_trait]
+    impl AgentLlmClient for EmptyAfterImageEffectClient {
+        async fn stream_response(
+            &self,
+            _messages: &[Message],
+            _tools: &[Arc<ToolDef>],
+            _max_tokens: u32,
+            _temperature: Option<f32>,
+            _provider_params: Option<&crate::lifecycle::run_primitive::ProviderParamsOverride>,
+        ) -> Result<super::LlmStreamResult, AgentError> {
+            let mut calls = self.call_count.lock().unwrap();
+            let response = if *calls == 0 {
+                super::LlmStreamResult::new(
+                    vec![AssistantBlock::ToolUse {
+                        id: "image-call".to_string(),
+                        name: "image_effect".into(),
+                        args: serde_json::value::RawValue::from_string("{}".to_string()).unwrap(),
+                        meta: None,
+                    }],
+                    StopReason::ToolUse,
+                    Usage::default(),
+                )
+            } else {
+                super::LlmStreamResult::new(Vec::new(), StopReason::EndTurn, Usage::default())
+            };
+            *calls += 1;
+            Ok(response)
+        }
+
+        fn provider(&self) -> &'static str {
+            "mock"
+        }
+
+        fn model(&self) -> &'static str {
+            "mock-model"
+        }
+    }
+
     struct DirectImageClient;
 
     #[async_trait]
@@ -5655,6 +5782,50 @@ mod tests {
             image_event_index
         };
         assert!(image_event_index > 0);
+    }
+
+    #[tokio::test]
+    async fn empty_completion_after_successful_tool_effect_completes_turn() {
+        let client = Arc::new(EmptyAfterImageEffectClient {
+            call_count: Mutex::new(0),
+        });
+        let tools = Arc::new(ImageEffectDispatcher::new());
+        let turn_handle =
+            Arc::new(crate::agent::test_turn_state_handle::TestTurnStateHandle::new());
+        let mut agent = AgentBuilder::new()
+            .with_turn_state_handle(turn_handle.clone())
+            .with_runtime_execution_kind_for_test(
+                crate::lifecycle::RuntimeExecutionKind::ContentTurn,
+            )
+            .build_standalone(client.clone(), tools, Arc::new(NoopStore))
+            .await;
+        agent.config.max_turns = Some(2);
+
+        let result = agent
+            .run("prompt".to_string().into())
+            .await
+            .expect("empty final completion after a successful effectful tool call should succeed");
+
+        assert_eq!(result.text, "");
+        assert_eq!(
+            *client.call_count.lock().unwrap(),
+            2,
+            "empty terminal follow-up should not be retried after successful tool output"
+        );
+        assert!(agent.session().messages().iter().any(|message| matches!(
+            message,
+            Message::BlockAssistant(blocks)
+                if blocks
+                    .blocks
+                    .iter()
+                    .any(|block| matches!(block, AssistantBlock::Image { .. }))
+        )));
+        assert_eq!(
+            turn_handle.run_completed_effect_count(),
+            1,
+            "the canonical turn authority should complete, not fail"
+        );
+        assert_eq!(turn_handle.run_failed_effect_count(), 0);
     }
 
     #[tokio::test]
@@ -7055,6 +7226,89 @@ mod tests {
             "should not retry endlessly; got {} calls",
             times.len()
         );
+    }
+
+    struct EmptyThenSucceedClient {
+        calls: Mutex<u32>,
+    }
+
+    impl EmptyThenSucceedClient {
+        fn new() -> Self {
+            Self {
+                calls: Mutex::new(0),
+            }
+        }
+
+        fn calls(&self) -> u32 {
+            *self.calls.lock().unwrap()
+        }
+    }
+
+    #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+    #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+    impl AgentLlmClient for EmptyThenSucceedClient {
+        async fn stream_response(
+            &self,
+            _messages: &[Message],
+            _tools: &[Arc<ToolDef>],
+            _max_tokens: u32,
+            _temperature: Option<f32>,
+            _provider_params: Option<&crate::lifecycle::run_primitive::ProviderParamsOverride>,
+        ) -> Result<super::LlmStreamResult, AgentError> {
+            let mut calls = self.calls.lock().unwrap();
+            *calls += 1;
+            let call = *calls;
+            drop(calls);
+
+            if call == 1 {
+                Ok(super::LlmStreamResult::new(
+                    Vec::new(),
+                    StopReason::EndTurn,
+                    Usage::default(),
+                ))
+            } else {
+                Ok(super::LlmStreamResult::new(
+                    vec![AssistantBlock::Text {
+                        text: "ok after empty retry".to_string(),
+                        meta: None,
+                    }],
+                    StopReason::EndTurn,
+                    Usage::default(),
+                ))
+            }
+        }
+
+        fn provider(&self) -> &'static str {
+            "mock"
+        }
+
+        fn model(&self) -> &'static str {
+            "mock-model"
+        }
+    }
+
+    #[tokio::test]
+    async fn empty_llm_completion_retries_before_terminal_failure() {
+        use crate::retry::RetryPolicy;
+
+        let client = Arc::new(EmptyThenSucceedClient::new());
+        let mut agent = with_test_turn_state_handle(AgentBuilder::new())
+            .retry_policy(RetryPolicy {
+                max_retries: 1,
+                initial_delay: Duration::ZERO,
+                max_delay: Duration::ZERO,
+                multiplier: 1.0,
+                call_timeout: None,
+            })
+            .build_standalone(client.clone(), Arc::new(NoTools), Arc::new(NoopStore))
+            .await;
+
+        let result = agent
+            .run("test".to_string().into())
+            .await
+            .expect("empty completed LLM response should retry and recover");
+        assert_eq!(result.text, "ok after empty retry");
+        assert_eq!(client.calls(), 2);
     }
 
     // -----------------------------------------------------------------------

--- a/meerkat-core/src/error.rs
+++ b/meerkat-core/src/error.rs
@@ -405,7 +405,7 @@ impl AgentError {
     pub fn llm_empty_response(provider: &'static str) -> Self {
         Self::llm(
             provider,
-            LlmFailureReason::ProviderError(LlmProviderError::non_retryable(
+            LlmFailureReason::ProviderError(LlmProviderError::retryable(
                 LlmProviderErrorKind::IncompleteResponse,
                 serde_json::json!({
                     "reason": "provider completed without user-visible text, images, or tool calls"

--- a/meerkat-mob-mcp/src/lib.rs
+++ b/meerkat-mob-mcp/src/lib.rs
@@ -995,11 +995,59 @@ impl MobMcpState {
             .ok_or_else(|| SessionControlError::InvalidRequest {
                 message: format!("member has no session: {identity}"),
             })?;
+        self.wait_for_member_system_context_boundary(&bridge_session_id)
+            .await?;
         let result = self
             .session_service()
             .append_system_context(&bridge_session_id, req)
             .await?;
         Ok((bridge_session_id, result))
+    }
+
+    async fn wait_for_member_system_context_boundary(
+        &self,
+        bridge_session_id: &SessionId,
+    ) -> Result<(), SessionControlError> {
+        let Some(adapter) = &self.runtime_adapter else {
+            return Ok(());
+        };
+        if !adapter.contains_session(bridge_session_id).await {
+            return Ok(());
+        }
+
+        let deadline = Instant::now() + Duration::from_secs(120);
+        loop {
+            if !adapter.contains_session(bridge_session_id).await {
+                return Ok(());
+            }
+            let Some(snapshot) = adapter
+                .meerkat_machine_spine_snapshot(bridge_session_id)
+                .await
+            else {
+                return Ok(());
+            };
+            let active_boundary = snapshot.control.phase == meerkat_runtime::RuntimeState::Running
+                || snapshot.control.current_run_id.is_some()
+                || snapshot.inputs.current_run_id.is_some()
+                || !snapshot.inputs.queue.is_empty()
+                || !snapshot.inputs.steer_queue.is_empty();
+            if !active_boundary {
+                return Ok(());
+            }
+            if Instant::now() >= deadline {
+                return Err(SessionControlError::Session(SessionError::Agent(
+                    meerkat_core::error::AgentError::InternalError(format!(
+                        "timed out waiting for member runtime boundary before appending system context for {bridge_session_id}: phase={:?}, control_run={:?}, ingress_run={:?}, queue_len={}, steer_queue_len={}",
+                        snapshot.control.phase,
+                        snapshot.control.current_run_id,
+                        snapshot.inputs.current_run_id,
+                        snapshot.inputs.queue.len(),
+                        snapshot.inputs.steer_queue.len(),
+                    )),
+                )));
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
     }
 
     pub async fn mob_resolve_bridge_session_id(

--- a/meerkat-mob/src/runtime/provisioner.rs
+++ b/meerkat-mob/src/runtime/provisioner.rs
@@ -27,6 +27,8 @@ use meerkat_core::ops::OperationId;
 use meerkat_core::ops_lifecycle::OperationStatus;
 use meerkat_core::ops_lifecycle::OpsLifecycleRegistry;
 use meerkat_core::service::{CreateSessionRequest, SessionError, StartTurnRequest};
+#[cfg(feature = "runtime-adapter")]
+use meerkat_core::time_compat::{Duration, Instant};
 use meerkat_core::types::SessionId;
 #[cfg(feature = "runtime-adapter")]
 #[allow(unused_imports)]
@@ -39,8 +41,6 @@ use meerkat_runtime::{
 use serde::de::DeserializeOwned;
 #[cfg(feature = "runtime-adapter")]
 use std::collections::HashMap;
-#[cfg(feature = "runtime-adapter")]
-use std::time::{Duration, Instant};
 #[cfg(feature = "runtime-adapter")]
 use tokio::sync::{Mutex, RwLock, mpsc, oneshot};
 
@@ -461,6 +461,7 @@ impl SessionBackend {
             return Ok(());
         };
         let deadline = Instant::now() + Duration::from_secs(30);
+        let mut terminal_abandon_requested = false;
 
         loop {
             if !adapter.contains_session(session_id).await {
@@ -480,17 +481,38 @@ impl SessionBackend {
             );
             let no_run_bound = snapshot.control.current_run_id.is_none()
                 && snapshot.inputs.current_run_id.is_none();
-            if ingress_quiescent && (lifecycle_retired || no_run_bound) {
+            let no_completion_waiters = snapshot.completion_waiters.input_count == 0
+                && snapshot.completion_waiters.waiter_count == 0;
+            if (ingress_quiescent && (lifecycle_retired || no_run_bound))
+                || (lifecycle_retired && no_run_bound && no_completion_waiters)
+            {
                 return Ok(());
+            }
+            if lifecycle_retired && no_run_bound && !terminal_abandon_requested {
+                terminal_abandon_requested = true;
+                adapter
+                    .abandon_retired_pending_inputs(
+                        session_id,
+                        "mob archive terminal retire drain cleanup".to_string(),
+                    )
+                    .await
+                    .map_err(|error| {
+                        Self::runtime_archive_error(format!(
+                            "runtime stop after terminal retire before mob archive failed for {session_id}: {error}"
+                        ))
+                    })?;
+                continue;
             }
             if Instant::now() >= deadline {
                 return Err(Self::runtime_archive_error(format!(
-                    "timed out waiting for runtime retire drain before mob archive for {session_id}: phase={:?}, control_run={:?}, ingress_run={:?}, queue_len={}, steer_queue_len={}",
+                    "timed out waiting for runtime retire drain before mob archive for {session_id}: phase={:?}, control_run={:?}, ingress_run={:?}, queue_len={}, steer_queue_len={}, completion_inputs={}, completion_waiters={}",
                     snapshot.control.phase,
                     snapshot.control.current_run_id,
                     snapshot.inputs.current_run_id,
                     snapshot.inputs.queue.len(),
                     snapshot.inputs.steer_queue.len(),
+                    snapshot.completion_waiters.input_count,
+                    snapshot.completion_waiters.waiter_count,
                 )));
             }
             tokio::time::sleep(Duration::from_millis(10)).await;

--- a/meerkat-mob/tests/smoke_mob_generated_image_comms.rs
+++ b/meerkat-mob/tests/smoke_mob_generated_image_comms.rs
@@ -3,7 +3,8 @@
 
 use meerkat::{AgentFactory, Config, FactoryAgentBuilder};
 use meerkat_core::types::{
-    AssistantBlock, ContentBlock, ContentInput, HandlingMode, Message, text_content,
+    AssistantBlock, ContentBlock, ContentInput, HandlingMode, Message, SystemNoticeBlock,
+    text_content,
 };
 use meerkat_core::{AssistantImageRef, BlobRef};
 use meerkat_mob::definition::{RoleWiringRule, WiringRules};
@@ -63,7 +64,7 @@ fn generated_image_comms_profile(
         model: model.to_string(),
         skills: vec![],
         tools: ToolConfig {
-            builtins: image_generation,
+            builtins: false,
             comms: true,
             image_generation,
             ..Default::default()
@@ -114,7 +115,7 @@ fn image_relay_profile(model: &str, peer_description: &str, image_generation: bo
         model: model.to_string(),
         skills: vec![],
         tools: ToolConfig {
-            builtins: image_generation,
+            builtins: false,
             comms: true,
             image_generation,
             ..Default::default()
@@ -282,12 +283,6 @@ async fn spawn_generated_image_comms_members(
     handle
         .spawn_spec(
             SpawnMemberSpec::new("maker", AgentIdentity::from("maker"))
-                .with_initial_message(ContentInput::Text(
-                    "Stand by for the two-turn generated-image comms smoke. \
-                     For this spawn turn, do not call tools and do not contact peers. \
-                     Reply exactly MAKER-GENERATED-IMAGE-COMMS-READY."
-                        .to_string(),
-                ))
                 .with_additional_instructions(vec![
                     "When asked to run the generated-image comms smoke, use tools, not prose. \
                      If a user says 'Turn 1', your only valid action is one generate_image tool call. \
@@ -301,12 +296,6 @@ async fn spawn_generated_image_comms_members(
     handle
         .spawn_spec(
             SpawnMemberSpec::new("reviewer", AgentIdentity::from("reviewer"))
-                .with_initial_message(ContentInput::Text(
-                    "Stand by as reviewer for the generated-image comms smoke. \
-                     For this spawn turn, do not call tools and do not contact peers. \
-                     Reply exactly REVIEWER-GENERATED-IMAGE-COMMS-READY."
-                        .to_string(),
-                ))
                 .with_additional_instructions(vec![
                     "You are reviewer. When maker sends a checksum_token request about image_receipt_check that includes an image, \
                      generate a tiny receipt image with generate_image using provider gemini and model \
@@ -328,18 +317,12 @@ async fn spawn_image_relay_members(handle: &MobHandle) -> Result<(), Box<dyn std
     handle
         .spawn_spec(
             SpawnMemberSpec::new("relay", AgentIdentity::from("relay"))
-                .with_initial_message(ContentInput::Text(
-                    "Stand by as relay for the image relay smoke. \
-                     For this spawn turn, do not call tools and do not contact peers. \
-                     Reply exactly RELAY-IMAGE-READOUT-READY."
-                        .to_string(),
-                ))
                 .with_additional_instructions(vec![
                     "When maker sends an image relay task, do not read or describe the image yourself. \
                      Extract the blob_id and media_type from maker's message. Then call send_message to \
-                     peer_id image-relay/reader/reader with handling_mode steer, a body asking reader to \
-                     read the visible text, and a blob-backed image_ref block using exactly that blob_id \
-                     and media_type. When reader replies, call send_message back to maker with body \
+                     the reader member's canonical peer_id with handling_mode steer, a body asking reader \
+                     to read the visible text, and a blob-backed image_ref block using exactly that blob_id \
+                     and media_type. If needed, call peers first to find reader's peer_id. When reader replies, call send_message back to maker with body \
                      READOUT: <reader's text>. Never invent the readout yourself."
                         .to_string(),
                 ]),
@@ -348,12 +331,6 @@ async fn spawn_image_relay_members(handle: &MobHandle) -> Result<(), Box<dyn std
     handle
         .spawn_spec(
             SpawnMemberSpec::new("reader", AgentIdentity::from("reader"))
-                .with_initial_message(ContentInput::Text(
-                    "Stand by as reader for the image relay smoke. \
-                     For this spawn turn, do not call tools and do not contact peers. \
-                     Reply exactly READER-IMAGE-READOUT-READY."
-                        .to_string(),
-                ))
                 .with_additional_instructions(vec![
                     "When relay sends you an image, inspect the image pixels and read the visible text. \
                      Reply to relay using send_message with handling_mode steer and body exactly \
@@ -366,12 +343,6 @@ async fn spawn_image_relay_members(handle: &MobHandle) -> Result<(), Box<dyn std
     handle
         .spawn_spec(
             SpawnMemberSpec::new("maker", AgentIdentity::from("maker"))
-                .with_initial_message(ContentInput::Text(
-                    "Stand by as maker for the image relay smoke. \
-                     For this spawn turn, do not call tools and do not contact peers. \
-                     Reply exactly MAKER-IMAGE-READOUT-READY."
-                        .to_string(),
-                ))
                 .with_additional_instructions(vec![
                     "When asked to run the relay smoke, use tools rather than prose. Generate the image first. \
                      After generate_image returns, send the generated image to relay with a blob-backed image_ref. \
@@ -418,7 +389,15 @@ async fn wait_for_member_histories_to_settle(
 }
 
 fn message_has_image(message: &Message) -> bool {
-    matches!(message, Message::User(user) if meerkat_core::has_images(&user.content))
+    match message {
+        Message::User(user) => meerkat_core::has_images(&user.content),
+        Message::SystemNotice(notice) => notice.blocks.iter().any(|block| match block {
+            SystemNoticeBlock::Comms { content, .. }
+            | SystemNoticeBlock::ExternalEvent { content, .. } => meerkat_core::has_images(content),
+            _ => false,
+        }),
+        _ => false,
+    }
 }
 
 fn tool_uses(message: &Message) -> Vec<(&str, Value)> {
@@ -501,6 +480,13 @@ async fn member_messages(
         .await
         .map(|page| page.messages)
         .unwrap_or_default()
+}
+
+async fn member_peer_id(handle: &MobHandle, member: &str) -> Option<String> {
+    handle
+        .get_member(&AgentIdentity::from(member))
+        .await
+        .and_then(|entry| entry.peer_id().map(|peer_id| peer_id.to_string()))
 }
 
 fn message_summary(message: &Message) -> String {
@@ -910,6 +896,13 @@ async fn wait_for_image_relay_readout_success(
     timeout: Duration,
 ) -> Result<BlobRef, String> {
     let deadline = Instant::now() + timeout;
+    let relay_peer_ids = {
+        let mut ids = vec!["image-relay/relay/relay".to_string(), "relay".to_string()];
+        if let Some(peer_id) = member_peer_id(handle, "relay").await {
+            ids.push(peer_id);
+        }
+        ids
+    };
     loop {
         let maker = member_messages(handle, service, "maker").await;
         let relay = member_messages(handle, service, "relay").await;
@@ -918,10 +911,10 @@ async fn wait_for_image_relay_readout_success(
         let maker_image = first_generated_image(&maker);
         let maker_sent_blob_to_relay = maker_image.as_ref().is_some_and(|image| {
             maker.iter().any(|message| {
-                image_ref_matches_blob_to_peer(
+                image_ref_matches_blob_to_any_peer(
                     message,
                     "send_message",
-                    "image-relay/relay/relay",
+                    &relay_peer_ids,
                     &image.blob_ref,
                 )
             })
@@ -1004,11 +997,12 @@ async fn e2e_smoke_mob_generated_image_comms_blob_request_response() {
         .send(
             ContentInput::Text(
                 "Turn 1 of the generated-image comms smoke. \
-                 You MUST call the generate_image tool exactly once now. \
-                 Use request provider gemini, model gemini-3.1-flash-image-preview, \
-                 prompt 'a simple cyan square with a small magenta dot, no text', size square1024, \
-                 quality low, format png, count 1. After the tool returns, stop. Do not call send_request, \
-                 send_message, or send_response in this turn. Do not answer with prose instead of the tool call."
+                 Call generate_image exactly once now with this JSON argument: \
+                 {\"request\":{\"intent\":\"generate\",\"provider\":\"gemini\",\
+                 \"model\":\"gemini-3.1-flash-image-preview\",\"prompt\":\"a simple cyan square with a small magenta dot, no text\",\
+                 \"size\":\"1024x1024\",\"quality\":\"low\",\"format\":\"png\",\"count\":1}}. \
+                 After the tool returns, stop. Do not call send_request, send_message, or send_response in this turn. \
+                 Do not answer with prose instead of the tool call."
                     .to_string(),
             ),
             HandlingMode::Queue,
@@ -1099,27 +1093,29 @@ async fn e2e_smoke_s86_mob_provider_image_relay_readout() {
     .await
     .expect("spawn turns should settle before relay smoke");
 
+    let relay_peer_id = member_peer_id(&handle, "relay")
+        .await
+        .expect("relay should expose a canonical comms peer id");
     let maker = handle
         .member(&AgentIdentity::from("maker"))
         .await
         .expect("maker member");
     maker
         .send(
-            ContentInput::Text(
+            ContentInput::Text(format!(
                 "Run the provider image relay smoke now. Use exactly this tool sequence, in this order:\n\
                  1. Call generate_image exactly once. The request must use provider openai, model gpt-image-2, \
                  prompt \"Create a simple white poster with only the exact large black text RKAT 7319 centered. \
                  No other letters, numbers, watermarks, captions, or symbols.\", size 1024x1024, quality low, \
                  format png, count 1.\n\
-                 2. After generate_image returns, call send_message to peer_id \"image-relay/relay/relay\" with \
+                 2. After generate_image returns, call send_message to peer_id \"{relay_peer_id}\" with \
                  handling_mode \"steer\". Attach the generated image as a blob-backed image_ref using the exact \
                  blob_id and media_type returned by generate_image. The body must tell relay to forward that same \
                  blob-backed image to reader, ask reader to read visible text, and then return reader's READOUT to you. \
                  The body and any text block you send to relay MUST NOT contain the target text from the image prompt. \
                  It may contain only the blob_id, media_type, routing instructions, and the word READOUT.\n\
                  Do not answer with prose until the tools are done."
-                    .to_string(),
-            ),
+            )),
             HandlingMode::Queue,
         )
         .await

--- a/meerkat-runtime/src/meerkat_machine/session_management.rs
+++ b/meerkat-runtime/src/meerkat_machine/session_management.rs
@@ -783,6 +783,48 @@ impl MeerkatMachine {
         .map(|_| ())
     }
 
+    /// Realize pending-input abandonment after the machine has already entered
+    /// the Retired terminal phase.
+    pub async fn abandon_retired_pending_inputs(
+        &self,
+        session_id: &SessionId,
+        reason: impl Into<String>,
+    ) -> Result<usize, RuntimeDriverError> {
+        let reason = reason.into();
+        let state = self
+            .existing_session_runtime_state(session_id)
+            .await
+            .unwrap_or(RuntimeState::Destroyed);
+        if state != RuntimeState::Retired {
+            return Err(RuntimeDriverError::NotReady { state });
+        }
+
+        let gate = self.session_mutation_gate(session_id).await;
+        let _gate_guard = match gate {
+            Some(ref g) => Some(g.lock().await),
+            None => None,
+        };
+
+        let (driver, completions) = {
+            let sessions = self.sessions.read().await;
+            let entry = sessions
+                .get(session_id)
+                .ok_or(RuntimeDriverError::NotReady {
+                    state: RuntimeState::Destroyed,
+                })?;
+            (entry.driver.clone(), entry.completions.clone())
+        };
+
+        let abandoned = {
+            let mut driver = driver.lock().await;
+            driver
+                .abandon_pending_inputs(crate::input_state::InputAbandonReason::Retired)
+                .await?
+        };
+        completions.lock().await.resolve_all_terminated(&reason);
+        Ok(abandoned)
+    }
+
     /// Stage a durable session visibility filter through the machine-owned visibility state.
     pub async fn stage_persistent_filter(
         &self,

--- a/meerkat/src/factory.rs
+++ b/meerkat/src/factory.rs
@@ -76,7 +76,9 @@ use meerkat_tools::builtin::SqliteTaskStore;
 #[cfg(not(target_arch = "wasm32"))]
 use meerkat_tools::builtin::shell::ShellConfig;
 #[cfg(not(target_arch = "wasm32"))]
-use meerkat_tools::builtin::{BuiltinToolConfig, CompositeDispatcher, TaskStore, ToolPolicyLayer};
+use meerkat_tools::builtin::{
+    BuiltinToolConfig, CompositeDispatcher, TaskStore, ToolMode, ToolPolicyLayer,
+};
 use meerkat_tools::{CatalogControlDispatcher, CatalogControlVisibilityProvider};
 #[cfg(all(not(feature = "memory-store"), not(target_arch = "wasm32")))]
 use tokio::sync::RwLock;
@@ -7589,6 +7591,47 @@ mod tests {
 
     #[cfg(not(target_arch = "wasm32"))]
     #[tokio::test]
+    async fn image_generation_visibility_does_not_enable_general_builtins() {
+        let temp = tempfile::tempdir().unwrap();
+        let runtime = Arc::new(meerkat_runtime::MeerkatMachine::ephemeral());
+        let blob_store: Arc<dyn BlobStore> = Arc::new(meerkat_store::MemoryBlobStore::default());
+        let factory = AgentFactory::new(temp.path().join("sessions"))
+            .builtins(false)
+            .with_image_generation_machine(runtime);
+
+        let mut build = AgentBuildConfig::new("claude-sonnet-4-5");
+        build.provider = Some(Provider::Anthropic);
+        build.llm_client_override = Some(Arc::new(meerkat_client::TestClient::default()));
+        build.override_builtins = ToolCategoryOverride::Disable;
+        build.override_image_generation = ToolCategoryOverride::Enable;
+        build.blob_store_override = Some(blob_store);
+
+        let agent = factory
+            .build_agent(build, &Config::default())
+            .await
+            .unwrap();
+        let visible_names = agent.tool_scope().visible_tool_names().unwrap();
+
+        assert!(
+            visible_names.contains("generate_image"),
+            "image_generation must own generate_image visibility independently of builtins"
+        );
+        assert!(
+            !visible_names.contains("task_list"),
+            "enabling image_generation must not expose general task builtins"
+        );
+        assert!(
+            !visible_names.contains("apply_patch"),
+            "enabling image_generation must not expose project mutation builtins"
+        );
+        assert!(
+            !visible_names.contains("browse_skills"),
+            "enabling image_generation must not expose skill browsing tools"
+        );
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    #[tokio::test]
     async fn session_owned_image_executor_resolution_publishes_auth_lease_visibility() {
         use meerkat_llm_core::provider_runtime::{
             ProviderAuthError, ProviderClientError, ProviderRuntime, ProviderRuntimeRegistry,
@@ -8494,7 +8537,9 @@ impl AgentFactory {
         web_search_executor: Option<Arc<dyn meerkat_llm_core::WebSearchExecutor>>,
         web_search_visibility: ToolCategoryOverride,
     ) -> Result<(Arc<dyn AgentToolDispatcher>, String), BuildAgentError> {
-        if !effective_builtins {
+        let compose_image_generation =
+            image_generation_visibility.resolve(false) && image_generation_machine.is_some();
+        if !effective_builtins && !compose_image_generation {
             // No builtins — return the external tools if provided, otherwise empty.
             return match external {
                 Some(ext) => {
@@ -8532,19 +8577,31 @@ impl AgentFactory {
             None
         };
 
-        // Create builtin tool config - enable shell tools in policy if shell is enabled
-        let builtin_config = if effective_shell {
-            BuiltinToolConfig {
-                policy: ToolPolicyLayer::new()
-                    .enable_tool("shell")
-                    .enable_tool("shell_job_status")
-                    .enable_tool("shell_jobs")
-                    .enable_tool("shell_job_cancel"),
-                ..Default::default()
+        // Create builtin tool config. When a non-builtin capability such as
+        // image generation needs the composite dispatcher, keep the general
+        // builtin namespace closed and let the capability registration add its
+        // own tool(s). This keeps profile category intent one-owner: enabling
+        // `image_generation` must not also expose task/patch/skill utilities.
+        let builtin_config = if effective_builtins {
+            if effective_shell {
+                BuiltinToolConfig {
+                    policy: ToolPolicyLayer::new()
+                        .enable_tool("shell")
+                        .enable_tool("shell_job_status")
+                        .enable_tool("shell_jobs")
+                        .enable_tool("shell_job_cancel"),
+                    ..Default::default()
+                }
+            } else {
+                BuiltinToolConfig::default()
             }
         } else {
-            BuiltinToolConfig::default()
+            BuiltinToolConfig {
+                policy: ToolPolicyLayer::new().with_mode(ToolMode::AllowList),
+                ..Default::default()
+            }
         };
+        let skill_engine = effective_builtins.then_some(skill_engine).flatten();
 
         let dispatcher = self
             .build_builtin_dispatcher_with_skills_internal(

--- a/tests/integration/tests/smoke_shared_realm.rs
+++ b/tests/integration/tests/smoke_shared_realm.rs
@@ -2752,15 +2752,18 @@ async fn e2e_scenario_54_shared_realm_mob_sessions_visible_to_cli()
         ordinary_init["error"].is_null(),
         "ordinary rpc surface should initialize cleanly: {ordinary_init}"
     );
-    // Keep this leg short: we only need to prove that an ordinary session with
-    // a mob-shaped comms name routes through the ordinary session surface.
+    // Keep this leg focused: we only need to prove that an ordinary session
+    // with a mob-shaped comms name routes through the ordinary session surface.
+    // Use the Anthropic smoke model already exercised by the mob image lanes
+    // rather than coupling this routing assertion to the moving default.
+    let ordinary_model = "claude-sonnet-4-5";
     eprintln!("[scenario 54] ordinary session/create start");
     let ordinary_started_at = Instant::now();
     rpc_send_line(
         &mut ordinary_rpc,
         &format!(
             r#"{{"jsonrpc":"2.0","id":350,"method":"session/create","params":{{"prompt":"Create an ordinary session with a mob-shaped comms name and confirm ORDINARY_SHAPED_54.","model":"{}","max_tokens":32,"comms_name":"{mob_id}/reviewer/alice"}}}}"#,
-            smoke_model()
+            ordinary_model
         ),
     )
     .await?;


### PR DESCRIPTION
## Summary
- treat empty provider completions as retryable only until a turn has produced visible/actionable output, while accepting an empty final completion after successful tool effects
- normalize Anthropic tool schemas by inlining local refs and keep comms model-facing schemas compact while preserving typed dispatch validation
- tighten mob lifecycle drains, member system-context boundaries, image-generation tool visibility, and smoke fixtures around canonical peer IDs and comms image visibility

## Verification
- MEERKAT_BUILDBUDDY=1 make e2e-smoke (39/39 passed, BuildBuddy invocation e7e4c0e4-5377-4cbc-848e-1b20f5f04c6b)
- ./scripts/repo-cargo fmt --all --check
- git diff --check
- push hook: secret scan, formatting, changed-crate clippy, machine codegen verify, Bazel freshness, workspace deterministic gate

## Notes
This intentionally keeps the fix at the runtime/schema/comms interpretation boundary rather than prompting around empty completions.