### PR TITLE
[codex] Add mob peer send and tool bridge parity

### DIFF
--- a/meerkat-cli/src/main.rs
+++ b/meerkat-cli/src/main.rs
@@ -14114,6 +14114,7 @@ default_model = "gemma"
             comms: meerkat_core::ToolCategoryOverride::Enable,
             mob: meerkat_core::ToolCategoryOverride::Disable,
             memory: meerkat_core::ToolCategoryOverride::Disable,
+            schedule: meerkat_core::ToolCategoryOverride::Inherit,
             workgraph: meerkat_core::ToolCategoryOverride::Disable,
             image_generation: meerkat_core::ToolCategoryOverride::Disable,
             web_search: meerkat_core::ToolCategoryOverride::Disable,

--- a/meerkat-contracts/src/wire/mob.rs
+++ b/meerkat-contracts/src/wire/mob.rs
@@ -130,6 +130,8 @@ pub struct WireMobToolConfig {
     #[serde(default)]
     pub memory: bool,
     #[serde(default)]
+    pub workgraph: bool,
+    #[serde(default)]
     pub mob: bool,
     #[serde(default)]
     pub schedule: bool,
@@ -210,6 +212,8 @@ pub struct MobToolConfigInput {
     pub comms: bool,
     #[serde(default)]
     pub memory: bool,
+    #[serde(default)]
+    pub workgraph: bool,
     #[serde(default)]
     pub mob: bool,
     #[serde(default)]

--- a/meerkat-contracts/tests/mob_wire.rs
+++ b/meerkat-contracts/tests/mob_wire.rs
@@ -3,14 +3,17 @@ use meerkat_contracts::wire::WireMobToolConfig;
 #[test]
 fn wire_mob_tool_config_image_generation_roundtrips_and_defaults() -> serde_json::Result<()> {
     let tools = WireMobToolConfig {
+        workgraph: true,
         image_generation: true,
         ..WireMobToolConfig::default()
     };
     let encoded = serde_json::to_string(&tools)?;
     let decoded: WireMobToolConfig = serde_json::from_str(&encoded)?;
+    assert!(decoded.workgraph);
     assert!(decoded.image_generation);
 
     let decoded_legacy: WireMobToolConfig = serde_json::from_str("{}")?;
+    assert!(!decoded_legacy.workgraph);
     assert!(!decoded_legacy.image_generation);
     Ok(())
 }

--- a/meerkat-core/src/service/mod.rs
+++ b/meerkat-core/src/service/mod.rs
@@ -679,6 +679,7 @@ pub struct ResumeOverrideMask {
     pub override_builtins: bool,
     pub override_shell: bool,
     pub override_memory: bool,
+    pub override_schedule: bool,
     pub override_workgraph: bool,
     pub override_mob: bool,
     pub override_image_generation: bool,

--- a/meerkat-core/src/session.rs
+++ b/meerkat-core/src/session.rs
@@ -2684,6 +2684,9 @@ pub struct SessionTooling {
     /// Semantic memory.
     #[serde(default, deserialize_with = "deserialize_tool_category_compat")]
     pub memory: ToolCategoryOverride,
+    /// Scheduler tools.
+    #[serde(default, deserialize_with = "deserialize_tool_category_compat")]
+    pub schedule: ToolCategoryOverride,
     /// WorkGraph durable work tools.
     #[serde(default, deserialize_with = "deserialize_tool_category_compat")]
     pub workgraph: ToolCategoryOverride,

--- a/meerkat-core/src/session_recovery.rs
+++ b/meerkat-core/src/session_recovery.rs
@@ -41,6 +41,7 @@ pub struct SurfaceSessionRecoveryOverrides {
     pub override_builtins: Option<bool>,
     pub override_shell: Option<bool>,
     pub override_memory: Option<bool>,
+    pub override_schedule: Option<bool>,
     pub override_workgraph: Option<bool>,
     pub override_mob: Option<bool>,
     pub override_image_generation: Option<bool>,
@@ -215,6 +216,8 @@ pub fn has_materialization_overrides(overrides: &SurfaceSessionRecoveryOverrides
         || overrides.override_builtins.is_some()
         || overrides.override_shell.is_some()
         || overrides.override_memory.is_some()
+        || overrides.override_schedule.is_some()
+        || overrides.override_workgraph.is_some()
         || overrides.override_mob.is_some()
         || overrides.override_image_generation.is_some()
         || overrides.override_web_search.is_some()
@@ -320,6 +323,7 @@ pub fn resolve_effective_turn_config(
         override_builtins: overrides.override_builtins.is_some(),
         override_shell: overrides.override_shell.is_some(),
         override_memory: overrides.override_memory.is_some(),
+        override_schedule: overrides.override_schedule.is_some(),
         override_workgraph: overrides.override_workgraph.is_some(),
         override_mob: overrides.override_mob.is_some(),
         override_image_generation: overrides.override_image_generation.is_some(),
@@ -401,7 +405,10 @@ pub fn resolve_effective_turn_config(
             .override_memory
             .map(ToolCategoryOverride::from_effective)
             .unwrap_or(metadata.tooling.memory),
-        override_schedule: ToolCategoryOverride::Inherit,
+        override_schedule: overrides
+            .override_schedule
+            .map(ToolCategoryOverride::from_effective)
+            .unwrap_or(metadata.tooling.schedule),
         override_workgraph: overrides
             .override_workgraph
             .map(ToolCategoryOverride::from_effective)
@@ -528,7 +535,8 @@ mod tests {
                     comms: ToolCategoryOverride::Inherit,
                     mob: ToolCategoryOverride::Inherit,
                     memory: ToolCategoryOverride::Enable,
-                    workgraph: ToolCategoryOverride::Inherit,
+                    schedule: ToolCategoryOverride::Enable,
+                    workgraph: ToolCategoryOverride::Enable,
                     image_generation: ToolCategoryOverride::Inherit,
                     web_search: ToolCategoryOverride::Inherit,
                     active_skills: Some(vec![skill_key("persisted-skill")]),
@@ -630,6 +638,11 @@ mod tests {
         assert_eq!(effective.build.override_builtins, metadata.tooling.builtins);
         assert_eq!(effective.build.override_shell, metadata.tooling.shell);
         assert_eq!(effective.build.override_memory, metadata.tooling.memory);
+        assert_eq!(effective.build.override_schedule, metadata.tooling.schedule);
+        assert_eq!(
+            effective.build.override_workgraph,
+            metadata.tooling.workgraph
+        );
         assert_eq!(
             effective.build.override_mob,
             ToolCategoryOverride::Enable,
@@ -877,6 +890,8 @@ mod tests {
                 override_builtins: Some(true),
                 override_shell: Some(false),
                 override_memory: Some(false),
+                override_schedule: Some(false),
+                override_workgraph: Some(false),
                 override_mob: Some(true),
                 preload_skills: Some(vec![skill_key("override-skill")]),
                 app_context: Some(json!({ "surface": "override" })),
@@ -911,6 +926,8 @@ mod tests {
         assert_eq!(build.override_builtins, ToolCategoryOverride::Enable);
         assert_eq!(build.override_shell, ToolCategoryOverride::Disable);
         assert_eq!(build.override_memory, ToolCategoryOverride::Disable);
+        assert_eq!(build.override_schedule, ToolCategoryOverride::Disable);
+        assert_eq!(build.override_workgraph, ToolCategoryOverride::Disable);
         assert_eq!(build.override_mob, ToolCategoryOverride::Enable);
         assert_eq!(
             build.preload_skills,
@@ -1122,6 +1139,20 @@ mod tests {
         assert!(
             has_materialization_overrides(&overrides),
             "tooling overrides require recovery/materialization"
+        );
+
+        overrides.override_builtins = None;
+        overrides.override_schedule = Some(true);
+        assert!(
+            has_materialization_overrides(&overrides),
+            "schedule tooling overrides require recovery/materialization"
+        );
+
+        overrides.override_schedule = None;
+        overrides.override_workgraph = Some(true);
+        assert!(
+            has_materialization_overrides(&overrides),
+            "WorkGraph tooling overrides require recovery/materialization"
         );
     }
 

--- a/meerkat-core/tests/rct_contracts.rs
+++ b/meerkat-core/tests/rct_contracts.rs
@@ -95,6 +95,7 @@ fn test_resume_metadata_contract() -> Result<(), Box<dyn std::error::Error>> {
             comms: meerkat_core::ToolCategoryOverride::Disable,
             mob: meerkat_core::ToolCategoryOverride::Disable,
             memory: meerkat_core::ToolCategoryOverride::Disable,
+            schedule: meerkat_core::ToolCategoryOverride::Inherit,
             workgraph: meerkat_core::ToolCategoryOverride::Inherit,
             image_generation: meerkat_core::ToolCategoryOverride::Disable,
             web_search: meerkat_core::ToolCategoryOverride::Disable,

--- a/meerkat-mcp-server/src/lib.rs
+++ b/meerkat-mcp-server/src/lib.rs
@@ -203,6 +203,12 @@ pub struct MeerkatRunInput {
     /// Enable semantic memory.
     #[serde(default)]
     pub enable_memory: Option<bool>,
+    /// Enable schedule tools.
+    #[serde(default)]
+    pub enable_schedule: Option<bool>,
+    /// Enable WorkGraph tools.
+    #[serde(default)]
+    pub enable_workgraph: Option<bool>,
     /// Enable mob tools.
     #[serde(default)]
     pub enable_mob: Option<bool>,
@@ -271,6 +277,8 @@ fn mcp_resume_requires_rebuild(input: &MeerkatResumeInput) -> bool {
             .as_ref()
             .is_some_and(|cfg| cfg.enable_shell.is_some())
         || input.enable_memory.is_some()
+        || input.enable_schedule.is_some()
+        || input.enable_workgraph.is_some()
         || input.enable_mob.is_some()
         || input.enable_web_search.is_some()
         || input.budget_limits.is_some()
@@ -1019,6 +1027,12 @@ pub struct MeerkatResumeInput {
     /// Enable semantic memory.
     #[serde(default)]
     pub enable_memory: Option<bool>,
+    /// Enable schedule tools.
+    #[serde(default)]
+    pub enable_schedule: Option<bool>,
+    /// Enable WorkGraph tools.
+    #[serde(default)]
+    pub enable_workgraph: Option<bool>,
     /// Enable mob tools.
     #[serde(default)]
     pub enable_mob: Option<bool>,
@@ -2927,6 +2941,8 @@ async fn handle_meerkat_help(
         peer_meta: None,
         hooks_override: None,
         enable_memory: Some(false),
+        enable_schedule: Some(false),
+        enable_workgraph: Some(false),
         enable_mob: Some(false),
         enable_web_search: Some(false),
         provider_params: None,
@@ -3140,8 +3156,8 @@ async fn handle_meerkat_run(
         override_builtins: ToolCategoryOverride::from_override(input.enable_builtins),
         override_shell: ToolCategoryOverride::from_override(enable_shell_override),
         override_memory: ToolCategoryOverride::from_override(input.enable_memory),
-        override_schedule: ToolCategoryOverride::Inherit,
-        override_workgraph: ToolCategoryOverride::Inherit,
+        override_schedule: ToolCategoryOverride::from_override(input.enable_schedule),
+        override_workgraph: ToolCategoryOverride::from_override(input.enable_workgraph),
         override_mob: ToolCategoryOverride::Inherit,
         override_image_generation: ToolCategoryOverride::Inherit,
         override_web_search: ToolCategoryOverride::from_override(input.enable_web_search),
@@ -3174,6 +3190,8 @@ async fn handle_meerkat_run(
             keep_alive: keep_alive_override.is_some(),
             comms_name: input.comms_name.is_some(),
             peer_meta: input.peer_meta.is_some(),
+            override_schedule: input.enable_schedule.is_some(),
+            override_workgraph: input.enable_workgraph.is_some(),
             override_web_search: input.enable_web_search.is_some(),
             ..Default::default()
         },
@@ -3512,8 +3530,8 @@ async fn handle_meerkat_resume(
             override_builtins: ToolCategoryOverride::from_override(enable_builtins_override),
             override_shell: ToolCategoryOverride::from_override(enable_shell_override),
             override_memory: ToolCategoryOverride::from_override(input.enable_memory),
-            override_schedule: ToolCategoryOverride::Inherit,
-            override_workgraph: ToolCategoryOverride::Inherit,
+            override_schedule: ToolCategoryOverride::from_override(input.enable_schedule),
+            override_workgraph: ToolCategoryOverride::from_override(input.enable_workgraph),
             override_mob: ToolCategoryOverride::Inherit,
             override_image_generation: ToolCategoryOverride::Inherit,
             override_web_search: ToolCategoryOverride::from_override(input.enable_web_search),
@@ -3554,6 +3572,8 @@ async fn handle_meerkat_resume(
                 keep_alive: keep_alive_override.is_some(),
                 comms_name: input.comms_name.is_some(),
                 peer_meta: input.peer_meta.is_some(),
+                override_schedule: input.enable_schedule.is_some(),
+                override_workgraph: input.enable_workgraph.is_some(),
                 override_web_search: input.enable_web_search.is_some(),
                 ..Default::default()
             },
@@ -5149,6 +5169,8 @@ mod tests {
                 peer_meta: None,
                 hooks_override: None,
                 enable_memory: None,
+                enable_schedule: None,
+                enable_workgraph: None,
                 enable_mob: None,
                 enable_web_search: None,
                 provider_params: None,
@@ -5199,6 +5221,8 @@ mod tests {
                 peer_meta: None,
                 hooks_override: None,
                 enable_memory: None,
+                enable_schedule: None,
+                enable_workgraph: None,
                 enable_mob: None,
                 enable_web_search: None,
                 provider_params: None,
@@ -5303,6 +5327,8 @@ mod tests {
                 peer_meta: None,
                 hooks_override: None,
                 enable_memory: None,
+                enable_schedule: None,
+                enable_workgraph: None,
                 enable_mob: None,
                 enable_web_search: None,
                 provider_params: None,
@@ -5385,6 +5411,8 @@ mod tests {
                 peer_meta: None,
                 hooks_override: None,
                 enable_memory: None,
+                enable_schedule: None,
+                enable_workgraph: None,
                 enable_mob: None,
                 enable_web_search: None,
                 provider_params: None,
@@ -5447,6 +5475,8 @@ mod tests {
                 peer_meta: None,
                 hooks_override: None,
                 enable_memory: None,
+                enable_schedule: None,
+                enable_workgraph: None,
                 enable_mob: None,
                 enable_web_search: None,
                 provider_params: None,
@@ -5580,6 +5610,8 @@ mod tests {
                 peer_meta: None,
                 hooks_override: None,
                 enable_memory: None,
+                enable_schedule: None,
+                enable_workgraph: None,
                 enable_mob: None,
                 enable_web_search: None,
                 provider_params: None,
@@ -5699,6 +5731,8 @@ mod tests {
                 peer_meta: None,
                 hooks_override: None,
                 enable_memory: None,
+                enable_schedule: None,
+                enable_workgraph: None,
                 enable_mob: None,
                 enable_web_search: None,
                 provider_params: None,
@@ -5816,6 +5850,8 @@ mod tests {
                 peer_meta: None,
                 hooks_override: None,
                 enable_memory: None,
+                enable_schedule: None,
+                enable_workgraph: None,
                 enable_mob: None,
                 enable_web_search: None,
                 provider_params: None,
@@ -5912,6 +5948,8 @@ mod tests {
                 peer_meta: None,
                 hooks_override: None,
                 enable_memory: None,
+                enable_schedule: None,
+                enable_workgraph: None,
                 enable_mob: None,
                 enable_web_search: None,
                 provider_params: None,
@@ -6005,6 +6043,8 @@ mod tests {
                 peer_meta: None,
                 hooks_override: None,
                 enable_memory: None,
+                enable_schedule: None,
+                enable_workgraph: None,
                 enable_mob: None,
                 enable_web_search: None,
                 provider_params: None,
@@ -6085,6 +6125,14 @@ mod tests {
         });
         assert!(mcp_resume_requires_rebuild(&input));
         input.builtin_config = None;
+
+        input.enable_schedule = Some(true);
+        assert!(mcp_resume_requires_rebuild(&input));
+        input.enable_schedule = None;
+
+        input.enable_workgraph = Some(true);
+        assert!(mcp_resume_requires_rebuild(&input));
+        input.enable_workgraph = None;
 
         input.comms_name = Some("agent-a".to_string());
         assert!(mcp_resume_requires_rebuild(&input));

--- a/meerkat-mob-mcp/src/public_definition.rs
+++ b/meerkat-mob-mcp/src/public_definition.rs
@@ -99,6 +99,7 @@ fn decode_profile(input: MobProfileInput) -> Result<Profile, String> {
             shell: input.tools.shell,
             comms: input.tools.comms,
             memory: input.tools.memory,
+            workgraph: input.tools.workgraph,
             mob: input.tools.mob,
             schedule: input.tools.schedule,
             image_generation: input.tools.image_generation,
@@ -367,6 +368,7 @@ mod tests {
                 skills: vec!["triage".to_string()],
                 tools: MobToolConfigInput {
                     comms: true,
+                    workgraph: true,
                     mob: true,
                     ..MobToolConfigInput::default()
                 },
@@ -474,6 +476,7 @@ mod tests {
             .expect("lead profile should be inline");
         assert_eq!(lead.backend, Some(MobBackendKind::External));
         assert_eq!(lead.runtime_mode, MobRuntimeMode::TurnDriven);
+        assert!(lead.tools.workgraph);
         assert_eq!(lead.tools.rust_bundles, Vec::<String>::new());
 
         let flow = definition

--- a/meerkat-mob/src/build.rs
+++ b/meerkat-mob/src/build.rs
@@ -60,6 +60,7 @@ pub(crate) fn open_profile_tool_categories_for_inherited_filter(profile: &mut Pr
     profile.tools.shell = true;
     profile.tools.comms = true;
     profile.tools.memory = true;
+    profile.tools.workgraph = true;
     profile.tools.mob = true;
     profile.tools.schedule = true;
     profile.tools.image_generation = true;
@@ -186,6 +187,8 @@ pub async fn build_agent_config(
     config.override_shell = meerkat_core::ToolCategoryOverride::from_effective(profile.tools.shell);
     config.override_memory =
         meerkat_core::ToolCategoryOverride::from_effective(profile.tools.memory);
+    config.override_workgraph =
+        meerkat_core::ToolCategoryOverride::from_effective(profile.tools.workgraph);
     config.override_schedule =
         meerkat_core::ToolCategoryOverride::from_effective(profile.tools.schedule);
     config.override_image_generation =
@@ -342,6 +345,8 @@ fn apply_resumed_session_metadata(
     config.override_builtins = metadata.tooling.builtins;
     config.override_shell = metadata.tooling.shell;
     config.override_memory = metadata.tooling.memory;
+    config.override_schedule = metadata.tooling.schedule;
+    config.override_workgraph = metadata.tooling.workgraph;
     config.override_image_generation = metadata.tooling.image_generation;
     if matches!(
         config.override_mob,
@@ -448,6 +453,7 @@ mod tests {
                     shell: true,
                     comms: true,
                     memory: false,
+                    workgraph: true,
                     mob: true,
                     schedule: false,
                     image_generation: true,
@@ -473,6 +479,7 @@ mod tests {
                     shell: false,
                     comms: true,
                     memory: false,
+                    workgraph: false,
                     mob: false,
                     schedule: false,
                     image_generation: false,
@@ -566,7 +573,8 @@ mod tests {
                     comms: meerkat_core::session::ToolCategoryOverride::Enable,
                     mob: meerkat_core::session::ToolCategoryOverride::Enable,
                     memory: meerkat_core::session::ToolCategoryOverride::Disable,
-                    workgraph: meerkat_core::session::ToolCategoryOverride::Inherit,
+                    schedule: meerkat_core::session::ToolCategoryOverride::Enable,
+                    workgraph: meerkat_core::session::ToolCategoryOverride::Enable,
                     image_generation: meerkat_core::session::ToolCategoryOverride::Enable,
                     web_search: meerkat_core::session::ToolCategoryOverride::Inherit,
                     active_skills: None,
@@ -743,6 +751,10 @@ mod tests {
             meerkat_core::ToolCategoryOverride::Disable
         );
         assert_eq!(
+            config.override_workgraph,
+            meerkat_core::ToolCategoryOverride::Enable
+        );
+        assert_eq!(
             config.override_image_generation,
             meerkat_core::ToolCategoryOverride::Enable
         );
@@ -785,6 +797,10 @@ mod tests {
         );
         assert_eq!(
             config.override_memory,
+            meerkat_core::ToolCategoryOverride::Disable
+        );
+        assert_eq!(
+            config.override_workgraph,
             meerkat_core::ToolCategoryOverride::Disable
         );
         assert_eq!(
@@ -847,6 +863,10 @@ mod tests {
         );
         assert_eq!(
             config.override_memory,
+            meerkat_core::ToolCategoryOverride::Enable
+        );
+        assert_eq!(
+            config.override_workgraph,
             meerkat_core::ToolCategoryOverride::Enable
         );
         assert_eq!(
@@ -1024,6 +1044,52 @@ mod tests {
         assert!(
             config.mob_tool_authority_context.is_some(),
             "resolver must synthesize an authority context when profile says enable"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_build_resumed_agent_config_preserves_persisted_schedule_and_workgraph_overrides()
+    {
+        let def = sample_definition();
+        let mut lead = def.profiles[&ProfileName::from("lead")]
+            .as_inline()
+            .unwrap()
+            .clone();
+        lead.tools.workgraph = false;
+        lead.tools.schedule = false;
+        let session_id = SessionId::new();
+        let resumed_session = resumed_session_with_metadata(session_id.clone());
+
+        let config = build_resumed_agent_config(BuildResumedAgentConfigParams {
+            base: BuildAgentConfigParams {
+                mob_id: &def.id,
+                profile_name: &ProfileName::from("lead"),
+                agent_identity: &MeerkatId::from("lead-1"),
+                profile: &lead,
+                definition: &def,
+                external_tools: None,
+                context: None,
+                labels: None,
+                additional_instructions: None,
+                shell_env: None,
+                mob_tool_authority_context: None,
+                inherited_tool_filter: None,
+            },
+            expected_session_id: &session_id,
+            resumed_session,
+        })
+        .await
+        .expect("build_resumed_agent_config");
+
+        assert_eq!(
+            config.override_schedule,
+            meerkat_core::ToolCategoryOverride::Enable,
+            "resumed mob members must keep durable schedule exposure intent from metadata"
+        );
+        assert_eq!(
+            config.override_workgraph,
+            meerkat_core::ToolCategoryOverride::Enable,
+            "resumed mob members must keep durable WorkGraph exposure intent from metadata"
         );
     }
 

--- a/meerkat-mob/src/lib.rs
+++ b/meerkat-mob/src/lib.rs
@@ -127,8 +127,8 @@ pub use runtime::{
     MemberRespawnReceipt, MobBuilder, MobDestroyError, MobDestroyReport, MobEventRouterConfig,
     MobEventRouterHandle, MobEventsSubscription, MobEventsSubscriptionConfig, MobHandle,
     MobMemberSnapshot, MobMemberStatus, MobPeerConnectivitySnapshot, MobRespawnError,
-    MobSessionService, MobState, MobUnreachablePeer, MobWireMembersBatchReport, PeerTarget,
-    PreviousMemberCleanupReport, SpawnMemberSpec, SpawnPolicy, SpawnResult, SpawnSpec,
+    MobSessionService, MobState, MobUnreachablePeer, MobWireMembersBatchReport, PeerMessageReceipt,
+    PeerTarget, PreviousMemberCleanupReport, SpawnMemberSpec, SpawnPolicy, SpawnResult, SpawnSpec,
     SupervisorRotationReport, WorkDeliveryReceipt,
 };
 pub use runtime::{FlowFrameKernel, FlowFrameMutator};

--- a/meerkat-mob/src/profile.rs
+++ b/meerkat-mob/src/profile.rs
@@ -25,6 +25,9 @@ pub struct ToolConfig {
     /// Enable memory/semantic search tools.
     #[serde(default)]
     pub memory: bool,
+    /// Expose the realm-scoped WorkGraph commitment tools to this member.
+    #[serde(default)]
+    pub workgraph: bool,
     /// Enable mob management tools (spawn, retire, wire, unwire, list).
     #[serde(default)]
     pub mob: bool,
@@ -206,6 +209,7 @@ mod tests {
             shell: false,
             comms: true,
             memory: false,
+            workgraph: true,
             mob: true,
             schedule: true,
             image_generation: true,
@@ -224,6 +228,7 @@ mod tests {
             shell: true,
             comms: false,
             memory: false,
+            workgraph: false,
             mob: false,
             schedule: false,
             image_generation: false,
@@ -245,6 +250,7 @@ mod tests {
                 shell: false,
                 comms: true,
                 memory: false,
+                workgraph: true,
                 mob: true,
                 schedule: false,
                 image_generation: false,
@@ -274,6 +280,7 @@ mod tests {
                 shell: true,
                 comms: true,
                 memory: false,
+                workgraph: false,
                 mob: false,
                 schedule: false,
                 image_generation: false,
@@ -300,6 +307,7 @@ mod tests {
         assert!(!config.shell);
         assert!(!config.comms);
         assert!(!config.memory);
+        assert!(!config.workgraph);
         assert!(!config.mob);
         assert!(!config.schedule);
         assert!(config.mcp.is_empty());

--- a/meerkat-mob/src/runtime/actor.rs
+++ b/meerkat-mob/src/runtime/actor.rs
@@ -3223,6 +3223,18 @@ impl MobActor {
                     let result = Box::pin(self.handle_submit_work(payload)).await;
                     let _ = reply_tx.send(result);
                 }
+                MobCommand::SendPeerMessage {
+                    from,
+                    to,
+                    content,
+                    handling_mode,
+                    reply_tx,
+                } => {
+                    let result =
+                        Box::pin(self.handle_send_peer_message(from, to, content, handling_mode))
+                            .await;
+                    let _ = reply_tx.send(result);
+                }
                 #[cfg(feature = "runtime-adapter")]
                 MobCommand::KickoffOutcomeResolved {
                     agent_identity,
@@ -6325,6 +6337,86 @@ impl MobActor {
             already_wired,
             wired,
         })
+    }
+
+    async fn handle_send_peer_message(
+        &mut self,
+        from: MeerkatId,
+        to: MeerkatId,
+        content: ContentInput,
+        handling_mode: meerkat_core::types::HandlingMode,
+    ) -> Result<meerkat_core::comms::SendReceipt, MobError> {
+        self.require_state(&[MobState::Running])?;
+        if from == to {
+            return Err(MobError::WiringError(format!(
+                "peer message requires distinct members (got '{from}')"
+            )));
+        }
+        self.ensure_member_not_broken(&from).await?;
+        self.ensure_member_not_broken(&to).await?;
+
+        let (sender_entry, recipient_entry) = {
+            let roster = self.roster.read().await;
+            (
+                roster
+                    .get(&from)
+                    .cloned()
+                    .ok_or_else(|| MobError::MemberNotFound(from.clone()))?,
+                roster
+                    .get(&to)
+                    .cloned()
+                    .ok_or_else(|| MobError::MemberNotFound(to.clone()))?,
+            )
+        };
+
+        let edge = mob_dsl::WiringEdge::new(
+            mob_dsl::AgentIdentity::from_domain(&AgentIdentity::from(from.as_str())),
+            mob_dsl::AgentIdentity::from_domain(&AgentIdentity::from(to.as_str())),
+        );
+        let wired_by_machine = self
+            .dsl_authority
+            .state
+            .wiring_edges
+            .iter()
+            .any(|existing| existing == &edge);
+        if !wired_by_machine {
+            return Err(MobError::WiringError(format!(
+                "peer message requires wired members '{from}' and '{to}'"
+            )));
+        }
+
+        let sender_comms = self
+            .provisioner_comms(&sender_entry.member_ref)
+            .await
+            .ok_or_else(|| {
+                MobError::WiringError(format!(
+                    "peer message requires sender comms runtime for '{from}'"
+                ))
+            })?;
+        let recipient_endpoint = self
+            .resolve_wiring_endpoint(&recipient_entry, "peer_message")
+            .await?;
+        let recipient_spec = match recipient_endpoint {
+            WiringEndpoint::Local { spec, .. } | WiringEndpoint::PeerOnly { spec, .. } => spec,
+        };
+        let route =
+            PeerRoute::with_display_name(recipient_spec.peer_id, recipient_spec.name.clone());
+        let (body, blocks) = match content {
+            ContentInput::Text(body) => (body, None),
+            ContentInput::Blocks(blocks) => {
+                (meerkat_core::types::text_content(&blocks), Some(blocks))
+            }
+        };
+
+        sender_comms
+            .send(CommsCommand::PeerMessage {
+                to: route,
+                body,
+                blocks,
+                handling_mode,
+            })
+            .await
+            .map_err(MobError::from)
     }
 
     async fn rollback_wire_members_batch(

--- a/meerkat-mob/src/runtime/handle.rs
+++ b/meerkat-mob/src/runtime/handle.rs
@@ -22,7 +22,8 @@ use crate::runtime::terminalization::{TerminalizationOutcome, TerminalizationTar
 #[cfg(target_arch = "wasm32")]
 use crate::tokio;
 use meerkat_core::comms::{
-    PeerDirectoryEntry, PeerId, PeerReachability, PeerReachabilityReason, TrustedPeerDescriptor,
+    CommsCommand, PeerDirectoryEntry, PeerId, PeerReachability, PeerReachabilityReason,
+    SendReceipt, TrustedPeerDescriptor,
 };
 use meerkat_core::ops::OperationId;
 use meerkat_core::ops_lifecycle::OpsLifecycleRegistry;
@@ -576,6 +577,22 @@ pub struct MemberDeliveryReceipt {
     /// Binding-era atom: bridge-internal, `pub(crate)` + `#[serde(skip)]`.
     #[serde(skip)]
     pub(crate) fence_token: FenceToken,
+}
+
+/// Receipt returned by sender-aware mob peer-message delivery.
+#[derive(Debug, Clone, Serialize)]
+#[non_exhaustive]
+pub struct PeerMessageReceipt {
+    /// Sender mob-member identity.
+    pub from: AgentIdentity,
+    /// Recipient mob-member identity.
+    pub to: AgentIdentity,
+    /// Transport envelope id for the typed peer message.
+    pub envelope_id: uuid::Uuid,
+    /// Whether the transport reported an acknowledgement.
+    pub acked: bool,
+    /// How the recipient should handle the peer message.
+    pub handling_mode: HandlingMode,
 }
 
 /// Receipt confirming that a unit of work was accepted by the work lane.
@@ -2759,6 +2776,41 @@ impl MobHandle {
         }
     }
 
+    /// Send typed peer communication from one mob member to another.
+    ///
+    /// This uses the sender member's comms runtime and the mob's installed
+    /// wiring/trust state. It is deliberately distinct from
+    /// [`MemberHandle::send`], which submits anonymous external work.
+    pub async fn send_peer_message(
+        &self,
+        from: AgentIdentity,
+        to: AgentIdentity,
+        content: impl Into<meerkat_core::types::ContentInput>,
+        handling_mode: HandlingMode,
+    ) -> Result<PeerMessageReceipt, MobError> {
+        let receipt = self
+            .send_actor_command(|reply_tx| MobCommand::SendPeerMessage {
+                from: MeerkatId::from(&from),
+                to: MeerkatId::from(&to),
+                content: content.into(),
+                handling_mode,
+                reply_tx,
+            })
+            .await??;
+        match receipt {
+            SendReceipt::PeerMessageSent { envelope_id, acked } => Ok(PeerMessageReceipt {
+                from,
+                to,
+                envelope_id,
+                acked,
+                handling_mode,
+            }),
+            other => Err(MobError::Internal(format!(
+                "unexpected peer-message receipt variant: {other:?}"
+            ))),
+        }
+    }
+
     /// Unwire a local member from either another local member or an external peer.
     pub async fn unwire<T>(&self, local: AgentIdentity, target: T) -> Result<(), MobError>
     where
@@ -3891,6 +3943,21 @@ impl MemberHandle {
             fence_token: snapshot.fence_token,
             handling_mode,
         })
+    }
+
+    /// Send typed peer communication from this member to another mob member.
+    ///
+    /// Unlike [`Self::send`], this preserves sender/recipient attribution by
+    /// routing through this member's comms runtime.
+    pub async fn send_peer_message(
+        &self,
+        to: AgentIdentity,
+        content: impl Into<meerkat_core::types::ContentInput>,
+        handling_mode: HandlingMode,
+    ) -> Result<PeerMessageReceipt, MobError> {
+        self.mob
+            .send_peer_message(self.identity(), to, content, handling_mode)
+            .await
     }
 
     /// Submit internal work to this member without external addressability checks.

--- a/meerkat-mob/src/runtime/mod.rs
+++ b/meerkat-mob/src/runtime/mod.rs
@@ -127,7 +127,7 @@ pub use handle::{
     HelperResult, MemberDeliveryReceipt, MemberHandle, MemberRespawnReceipt, MobDestroyError,
     MobDestroyReport, MobEventsSubscription, MobEventsSubscriptionConfig, MobEventsView, MobHandle,
     MobMemberListEntry, MobMemberSnapshot, MobMemberStatus, MobPeerConnectivitySnapshot,
-    MobRespawnError, MobUnreachablePeer, MobWireMembersBatchReport, PeerTarget,
+    MobRespawnError, MobUnreachablePeer, MobWireMembersBatchReport, PeerMessageReceipt, PeerTarget,
     PreviousMemberCleanupReport, SpawnMemberSpec, SpawnResult, SupervisorRotationReport,
     WorkDeliveryReceipt,
 };

--- a/meerkat-mob/src/runtime/state.rs
+++ b/meerkat-mob/src/runtime/state.rs
@@ -200,6 +200,18 @@ pub(super) enum MobCommand {
         payload: Box<SubmitWorkPayload>,
         reply_tx: oneshot::Sender<Result<(), MobError>>,
     },
+    /// Sender-aware peer communication between mob members.
+    ///
+    /// This is not work-lane ingress. The actor resolves the sender member's
+    /// comms runtime and the recipient peer route from the mob wiring graph,
+    /// then submits a typed `CommsCommand::PeerMessage`.
+    SendPeerMessage {
+        from: MeerkatId,
+        to: MeerkatId,
+        content: ContentInput,
+        handling_mode: meerkat_core::types::HandlingMode,
+        reply_tx: oneshot::Sender<Result<meerkat_core::comms::SendReceipt, MobError>>,
+    },
     /// Unified work-lane cancellation: the MobMachine DSL owns live-runtime
     /// membership and phase legality via the `CancelAllWork` transition;
     /// fence-token freshness is a shell-level concurrency invariant. The

--- a/meerkat-mob/src/runtime/tests.rs
+++ b/meerkat-mob/src/runtime/tests.rs
@@ -1159,6 +1159,9 @@ impl SessionService for MockSessionService {
                     memory: build
                         .map(|b| b.override_memory)
                         .unwrap_or(ToolCategoryOverride::from_effective(false)),
+                    schedule: build
+                        .map(|b| b.override_schedule)
+                        .unwrap_or(ToolCategoryOverride::Inherit),
                     workgraph: build
                         .map(|b| b.override_workgraph)
                         .unwrap_or(ToolCategoryOverride::Inherit),
@@ -2827,6 +2830,7 @@ fn sample_definition() -> MobDefinition {
                 shell: false,
                 comms: true,
                 memory: false,
+                workgraph: false,
                 mob: true,
                 schedule: false,
                 image_generation: false,
@@ -12640,6 +12644,7 @@ async fn test_build_resumed_agent_config_rejects_mismatched_session_identity() {
                 comms: ToolCategoryOverride::Enable,
                 mob: ToolCategoryOverride::Disable,
                 memory: ToolCategoryOverride::Disable,
+                schedule: ToolCategoryOverride::Inherit,
                 workgraph: ToolCategoryOverride::Inherit,
                 image_generation: ToolCategoryOverride::Inherit,
                 web_search: ToolCategoryOverride::Inherit,
@@ -24514,13 +24519,10 @@ async fn test_peer_message_reaches_idle_autonomous_member_after_kickoff_completi
         create_test_mob_with_runtime_backed_real_comms(sample_definition()).await;
     service.set_keep_alive_turns_complete_immediately(true);
 
-    let sid_a = handle
+    handle
         .spawn(ProfileName::from("lead"), MeerkatId::from("l-1"), None)
         .await
-        .expect("spawn lead")
-        .bridge_session_id()
-        .expect("session-backed")
-        .clone();
+        .expect("spawn lead");
     let sid_b = handle
         .spawn(ProfileName::from("worker"), MeerkatId::from("w-1"), None)
         .await
@@ -24528,6 +24530,23 @@ async fn test_peer_message_reaches_idle_autonomous_member_after_kickoff_completi
         .bridge_session_id()
         .expect("session-backed")
         .clone();
+
+    let unwired = handle
+        .send_peer_message(
+            AgentIdentity::from("l-1"),
+            AgentIdentity::from("w-1"),
+            "unwired peer send should fail",
+            meerkat_core::types::HandlingMode::Queue,
+        )
+        .await;
+    assert!(
+        matches!(
+            unwired,
+            Err(MobError::WiringError(ref message))
+                if message.contains("requires wired members")
+        ),
+        "sender-aware peer send must enforce mob wiring before delivery: {unwired:?}"
+    );
 
     handle
         .wire(AgentIdentity::from("l-1"), MeerkatId::from("w-1"))
@@ -24537,13 +24556,11 @@ async fn test_peer_message_reaches_idle_autonomous_member_after_kickoff_completi
     tokio::time::sleep(Duration::from_millis(50)).await;
     let baseline_prompts = service.applied_runtime_prompts(&sid_b).await.len();
 
-    let comms_a = service.real_comms(&sid_a).await.expect("comms for l-1");
-    let receipt = CoreCommsRuntime::send(
-        &*comms_a,
-        CommsCommand::PeerMessage {
-            to: test_peer_route(&*comms_a, &test_comms_name("worker", "w-1")).await,
-            body: "body: please inspect this image".to_string(),
-            blocks: Some(vec![
+    let receipt = handle
+        .send_peer_message(
+            AgentIdentity::from("l-1"),
+            AgentIdentity::from("w-1"),
+            meerkat_core::types::ContentInput::Blocks(vec![
                 meerkat_core::types::ContentBlock::Text {
                     text: "caption: this block text should survive".to_string(),
                 },
@@ -24552,14 +24569,15 @@ async fn test_peer_message_reaches_idle_autonomous_member_after_kickoff_completi
                     data: "aGVsbG8=".into(),
                 },
             ]),
-            handling_mode: meerkat_core::types::HandlingMode::Queue,
-        },
-    )
-    .await
-    .expect("PeerMessage should succeed");
-    assert!(
-        matches!(receipt, SendReceipt::PeerMessageSent { .. }),
-        "expected PeerMessageSent receipt, got: {receipt:?}"
+            meerkat_core::types::HandlingMode::Queue,
+        )
+        .await
+        .expect("MobHandle peer message should succeed");
+    assert_eq!(receipt.from, AgentIdentity::from("l-1"));
+    assert_eq!(receipt.to, AgentIdentity::from("w-1"));
+    assert_eq!(
+        receipt.handling_mode,
+        meerkat_core::types::HandlingMode::Queue
     );
 
     let delivered = tokio::time::timeout(Duration::from_secs(2), async {
@@ -24570,9 +24588,7 @@ async fn test_peer_message_reaches_idle_autonomous_member_after_kickoff_completi
                 .skip(baseline_prompts)
                 .find(|prompt| {
                     let text = prompt.text_content();
-                    prompt.has_images()
-                        || text.contains("body: please inspect this image")
-                        || text.contains("caption: this block text should survive")
+                    prompt.has_images() || text.contains("caption: this block text should survive")
                 })
                 .cloned()
             {

--- a/meerkat-rest/src/lib.rs
+++ b/meerkat-rest/src/lib.rs
@@ -4199,6 +4199,7 @@ async fn create_session_inner(
             keep_alive: keep_alive_override.is_some(),
             comms_name: req.comms_name.is_some(),
             peer_meta: req.peer_meta.is_some(),
+            override_schedule: req.enable_schedule.is_some(),
             override_web_search: req.enable_web_search.is_some(),
             ..Default::default()
         },

--- a/meerkat-rest/src/lib.rs
+++ b/meerkat-rest/src/lib.rs
@@ -1821,6 +1821,27 @@ fn rest_continue_requires_rebuild(req: &ContinueSessionRequest) -> bool {
         || req.peer_meta.is_some()
 }
 
+fn create_session_resume_override_mask(
+    req: &CreateSessionRequest,
+    keep_alive_override: Option<bool>,
+) -> ResumeOverrideMask {
+    ResumeOverrideMask {
+        model: req.model.is_some(),
+        provider: req.provider.is_some(),
+        max_tokens: req.max_tokens.is_some(),
+        structured_output_retries: req.structured_output_retries.is_some(),
+        provider_params: req.provider_params.is_some(),
+        preload_skills: req.preload_skills.is_some(),
+        keep_alive: keep_alive_override.is_some(),
+        comms_name: req.comms_name.is_some(),
+        peer_meta: req.peer_meta.is_some(),
+        override_schedule: req.enable_schedule.is_some(),
+        override_workgraph: req.enable_workgraph.is_some(),
+        override_web_search: req.enable_web_search.is_some(),
+        ..Default::default()
+    }
+}
+
 async fn canonical_skill_keys_for_state(
     state: &AppState,
     skill_refs: Option<Vec<meerkat_core::skills::SkillRef>>,
@@ -3988,6 +4009,7 @@ async fn create_session_inner(
     let keep_alive = keep_alive_override.unwrap_or(false);
     let model_was_explicit = req.model.is_some();
     let provider_was_explicit = req.provider.is_some();
+    let resume_override_mask = create_session_resume_override_mask(&req, keep_alive_override);
     let model = req.model.unwrap_or_else(|| state.default_model.clone());
     let max_tokens = req.max_tokens.unwrap_or(state.max_tokens);
     let skill_references = match canonical_skill_keys_for_state(state, req.skill_refs.clone()).await
@@ -4189,20 +4211,7 @@ async fn create_session_inner(
         additional_instructions: req.additional_instructions,
         initial_metadata_entries: std::collections::BTreeMap::new(),
         shell_env: req.shell_env,
-        resume_override_mask: ResumeOverrideMask {
-            model: model_was_explicit,
-            provider: req.provider.is_some(),
-            max_tokens: req.max_tokens.is_some(),
-            structured_output_retries: req.structured_output_retries.is_some(),
-            provider_params: req.provider_params.is_some(),
-            preload_skills: req.preload_skills.is_some(),
-            keep_alive: keep_alive_override.is_some(),
-            comms_name: req.comms_name.is_some(),
-            peer_meta: req.peer_meta.is_some(),
-            override_schedule: req.enable_schedule.is_some(),
-            override_web_search: req.enable_web_search.is_some(),
-            ..Default::default()
-        },
+        resume_override_mask,
         call_timeout_override: Default::default(),
         blob_store_override: None,
         mob_tools: None,
@@ -9025,6 +9034,22 @@ mod tests {
         let req: CreateSessionRequest = serde_json::from_value(req_json).unwrap();
         assert_eq!(req.keep_alive, None);
         assert!(req.comms_name.is_none());
+    }
+
+    #[test]
+    fn test_create_session_resume_override_mask_marks_workgraph_with_schedule() {
+        let req_json = serde_json::json!({
+            "prompt": "Hello",
+            "enable_schedule": false,
+            "enable_workgraph": true
+        });
+
+        let req: CreateSessionRequest = serde_json::from_value(req_json).unwrap();
+        let mask = create_session_resume_override_mask(&req, None);
+
+        assert!(mask.override_schedule);
+        assert!(mask.override_workgraph);
+        assert!(!mask.override_web_search);
     }
 
     #[test]

--- a/meerkat-rpc/src/handlers/mob.rs
+++ b/meerkat-rpc/src/handlers/mob.rs
@@ -128,6 +128,7 @@ fn profile_from_wire(profile: WireMobProfile) -> Profile {
             shell: tools.shell,
             comms: tools.comms,
             memory: tools.memory,
+            workgraph: tools.workgraph,
             mob: tools.mob,
             schedule: tools.schedule,
             image_generation: tools.image_generation,

--- a/meerkat/src/factory.rs
+++ b/meerkat/src/factory.rs
@@ -2306,6 +2306,12 @@ impl AgentFactory {
         if !mask.override_memory {
             build_config.override_memory = metadata.tooling.memory;
         }
+        if !mask.override_schedule {
+            build_config.override_schedule = metadata.tooling.schedule;
+        }
+        if !mask.override_workgraph {
+            build_config.override_workgraph = metadata.tooling.workgraph;
+        }
         if !mask.override_mob {
             build_config.override_mob = metadata.tooling.mob;
             build_config.mob_tool_authority_context = build_config
@@ -3207,6 +3213,10 @@ impl AgentFactory {
             !matches!(build_config.override_shell, ToolCategoryOverride::Inherit);
         build_config.resume_override_mask.override_memory |=
             !matches!(build_config.override_memory, ToolCategoryOverride::Inherit);
+        build_config.resume_override_mask.override_schedule |= !matches!(
+            build_config.override_schedule,
+            ToolCategoryOverride::Inherit
+        );
         build_config.resume_override_mask.override_workgraph |= !matches!(
             build_config.override_workgraph,
             ToolCategoryOverride::Inherit
@@ -4575,6 +4585,7 @@ impl AgentFactory {
             // (metadata.tooling.comms is left unchanged)
             metadata.tooling.mob = build_config.override_mob;
             metadata.tooling.memory = build_config.override_memory;
+            metadata.tooling.schedule = build_config.override_schedule;
             metadata.tooling.workgraph = build_config.override_workgraph;
             metadata.tooling.image_generation = build_config.override_image_generation;
             metadata.tooling.web_search = build_config.override_web_search;
@@ -4605,6 +4616,7 @@ impl AgentFactory {
                     comms: ToolCategoryOverride::Inherit,
                     mob: build_config.override_mob,
                     memory: build_config.override_memory,
+                    schedule: build_config.override_schedule,
                     workgraph: build_config.override_workgraph,
                     image_generation: build_config.override_image_generation,
                     web_search: build_config.override_web_search,

--- a/meerkat/tests/factory_build_agent.rs
+++ b/meerkat/tests/factory_build_agent.rs
@@ -1057,7 +1057,8 @@ async fn build_agent_with_resume_uses_stored_metadata() {
             comms: ToolCategoryOverride::Disable,
             mob: ToolCategoryOverride::Disable,
             memory: ToolCategoryOverride::Disable,
-            workgraph: ToolCategoryOverride::Inherit,
+            schedule: ToolCategoryOverride::Enable,
+            workgraph: ToolCategoryOverride::Enable,
             image_generation: ToolCategoryOverride::Inherit,
             web_search: ToolCategoryOverride::Inherit,
             active_skills: None,
@@ -1109,6 +1110,16 @@ async fn build_agent_with_resume_uses_stored_metadata() {
         "resumed durable comms identity should win over current build defaults"
     );
     assert_eq!(
+        metadata.tooling.schedule,
+        ToolCategoryOverride::Enable,
+        "resumed durable schedule exposure intent should survive the factory metadata merge"
+    );
+    assert_eq!(
+        metadata.tooling.workgraph,
+        ToolCategoryOverride::Enable,
+        "resumed durable WorkGraph exposure intent should survive the factory metadata merge"
+    );
+    assert_eq!(
         metadata
             .peer_meta
             .as_ref()
@@ -1142,6 +1153,7 @@ async fn build_agent_with_resume_preserves_explicit_override_masked_fields() {
                 comms: ToolCategoryOverride::Disable,
                 mob: ToolCategoryOverride::Disable,
                 memory: ToolCategoryOverride::Disable,
+                schedule: ToolCategoryOverride::Inherit,
                 workgraph: ToolCategoryOverride::Inherit,
                 image_generation: ToolCategoryOverride::Inherit,
                 web_search: ToolCategoryOverride::Inherit,
@@ -1231,6 +1243,7 @@ async fn build_agent_with_resume_preserves_persisted_system_prompt() {
                 comms: ToolCategoryOverride::Disable,
                 mob: ToolCategoryOverride::Disable,
                 memory: ToolCategoryOverride::Disable,
+                schedule: ToolCategoryOverride::Inherit,
                 workgraph: ToolCategoryOverride::Inherit,
                 image_generation: ToolCategoryOverride::Inherit,
                 web_search: ToolCategoryOverride::Inherit,
@@ -1288,7 +1301,8 @@ async fn build_agent_with_resume_preserves_explicit_inherit_tool_override() {
                 comms: ToolCategoryOverride::Inherit,
                 mob: ToolCategoryOverride::Inherit,
                 memory: ToolCategoryOverride::Inherit,
-                workgraph: ToolCategoryOverride::Inherit,
+                schedule: ToolCategoryOverride::Enable,
+                workgraph: ToolCategoryOverride::Enable,
                 image_generation: ToolCategoryOverride::Inherit,
                 web_search: ToolCategoryOverride::Inherit,
                 active_skills: None,
@@ -1308,9 +1322,13 @@ async fn build_agent_with_resume_preserves_explicit_inherit_tool_override() {
         llm_client_override: Some(Arc::new(MockLlmClient)),
         resume_session: Some(session),
         override_builtins: ToolCategoryOverride::Inherit,
+        override_schedule: ToolCategoryOverride::Disable,
+        override_workgraph: ToolCategoryOverride::Disable,
         ..AgentBuildConfig::new("gpt-5.4")
     };
     build_config.resume_override_mask.override_builtins = true;
+    build_config.resume_override_mask.override_schedule = true;
+    build_config.resume_override_mask.override_workgraph = true;
 
     let agent = factory.build_agent(build_config, &config).await.unwrap();
     let metadata = agent
@@ -1319,6 +1337,8 @@ async fn build_agent_with_resume_preserves_explicit_inherit_tool_override() {
         .expect("session should have metadata");
 
     assert_eq!(metadata.tooling.builtins, ToolCategoryOverride::Inherit);
+    assert_eq!(metadata.tooling.schedule, ToolCategoryOverride::Disable);
+    assert_eq!(metadata.tooling.workgraph, ToolCategoryOverride::Disable);
 }
 
 #[cfg(feature = "comms")]
@@ -1345,6 +1365,7 @@ async fn build_agent_with_resume_preserves_session_scoped_inproc_peer_id() {
                 comms: ToolCategoryOverride::Enable,
                 mob: ToolCategoryOverride::Disable,
                 memory: ToolCategoryOverride::Disable,
+                schedule: ToolCategoryOverride::Inherit,
                 workgraph: ToolCategoryOverride::Inherit,
                 image_generation: ToolCategoryOverride::Inherit,
                 web_search: ToolCategoryOverride::Inherit,
@@ -1427,6 +1448,7 @@ async fn build_agent_with_resume_preserves_session_scoped_inproc_peer_id_across_
                 comms: ToolCategoryOverride::Enable,
                 mob: ToolCategoryOverride::Disable,
                 memory: ToolCategoryOverride::Disable,
+                schedule: ToolCategoryOverride::Inherit,
                 workgraph: ToolCategoryOverride::Inherit,
                 image_generation: ToolCategoryOverride::Inherit,
                 web_search: ToolCategoryOverride::Inherit,
@@ -1763,6 +1785,7 @@ async fn test_resume_does_not_mutate_persisted_active_skills_when_current_surfac
                 comms: ToolCategoryOverride::Disable,
                 mob: ToolCategoryOverride::Disable,
                 memory: ToolCategoryOverride::Disable,
+                schedule: ToolCategoryOverride::Inherit,
                 workgraph: ToolCategoryOverride::Inherit,
                 image_generation: ToolCategoryOverride::Inherit,
                 web_search: ToolCategoryOverride::Inherit,
@@ -1911,6 +1934,7 @@ async fn resume_with_inherit_mob_allows_factory_default() {
                 comms: ToolCategoryOverride::Disable,
                 mob: ToolCategoryOverride::Inherit, // <-- key: no opinion
                 memory: ToolCategoryOverride::Inherit,
+                schedule: ToolCategoryOverride::Inherit,
                 workgraph: ToolCategoryOverride::Inherit,
                 image_generation: ToolCategoryOverride::Inherit,
                 web_search: ToolCategoryOverride::Inherit,
@@ -1967,6 +1991,7 @@ async fn resume_with_disable_mob_stays_disabled() {
                 comms: ToolCategoryOverride::Disable,
                 mob: ToolCategoryOverride::Disable, // <-- explicitly off
                 memory: ToolCategoryOverride::Disable,
+                schedule: ToolCategoryOverride::Inherit,
                 workgraph: ToolCategoryOverride::Inherit,
                 image_generation: ToolCategoryOverride::Inherit,
                 web_search: ToolCategoryOverride::Inherit,
@@ -2021,6 +2046,7 @@ async fn resume_with_enable_mob_stays_enabled() {
                 comms: ToolCategoryOverride::Disable,
                 mob: ToolCategoryOverride::Enable, // <-- explicitly on
                 memory: ToolCategoryOverride::Disable,
+                schedule: ToolCategoryOverride::Inherit,
                 workgraph: ToolCategoryOverride::Inherit,
                 image_generation: ToolCategoryOverride::Inherit,
                 web_search: ToolCategoryOverride::Inherit,
@@ -2097,6 +2123,7 @@ async fn resumed_enable_mob_metadata_does_not_imply_operator_capabilities() {
                 comms: ToolCategoryOverride::Disable,
                 mob: ToolCategoryOverride::Enable,
                 memory: ToolCategoryOverride::Disable,
+                schedule: ToolCategoryOverride::Inherit,
                 workgraph: ToolCategoryOverride::Inherit,
                 image_generation: ToolCategoryOverride::Inherit,
                 web_search: ToolCategoryOverride::Inherit,
@@ -2241,6 +2268,7 @@ async fn resumed_explicit_mob_override_generates_create_only_operator_capabiliti
                 comms: ToolCategoryOverride::Disable,
                 mob: ToolCategoryOverride::Disable,
                 memory: ToolCategoryOverride::Disable,
+                schedule: ToolCategoryOverride::Inherit,
                 workgraph: ToolCategoryOverride::Inherit,
                 image_generation: ToolCategoryOverride::Inherit,
                 web_search: ToolCategoryOverride::Inherit,
@@ -2338,6 +2366,7 @@ async fn resumed_persisted_mob_authority_is_forwarded_to_mob_tools_factory() {
                 comms: ToolCategoryOverride::Disable,
                 mob: ToolCategoryOverride::Inherit,
                 memory: ToolCategoryOverride::Disable,
+                schedule: ToolCategoryOverride::Inherit,
                 workgraph: ToolCategoryOverride::Inherit,
                 image_generation: ToolCategoryOverride::Inherit,
                 web_search: ToolCategoryOverride::Inherit,


### PR DESCRIPTION
## Summary

- bridge mob profile tooling for WorkGraph through wire/RPC/MCP/profile config into `AgentBuildConfig`
- persist and restore schedule/tooling override state across session recovery and resume paths
- add sender-aware `MobHandle::send_peer_message` / `MemberHandle::send_peer_message` so callers can deliver typed peer communication without holding a direct `CommsRuntime`
- expose schedule and WorkGraph overrides on the standalone MCP server run/resume inputs

## Root Cause

Mob profile tooling had WorkGraph and schedule gaps where some surfaces stayed inherit-only or failed to map profile/wire intent into the build/resume configuration. Separately, app-level SessionHook tool dispatchers could only reach `MemberHandle::send`, which is external work ingress and cannot truthfully represent `A -> B` peer communication.

## Validation

- `./scripts/repo-cargo fmt --all`
- `git diff --check`
- `RUST_LANE_ID=schedule-bridges ./scripts/repo-cargo check -p meerkat-core -p meerkat -p meerkat-mob -p meerkat-rpc -p meerkat-rest -p meerkat-mcp-server -p meerkat-mob-mcp -p rkat`
- `RUST_LANE_ID=schedule-bridges ./scripts/repo-cargo test -p meerkat-core session_recovery`
- `RUST_LANE_ID=schedule-bridges-b ./scripts/repo-cargo test -p meerkat build_agent_with_resume`
- `RUST_LANE_ID=schedule-bridges ./scripts/repo-cargo test -p meerkat-mob test_build_resumed_agent_config_preserves_persisted_schedule_and_workgraph_overrides`
- `RUST_LANE_ID=schedule-mcp ./scripts/repo-cargo check -p meerkat-mcp-server`
- `RUST_LANE_ID=schedule-mcp-test ./scripts/repo-cargo test -p meerkat-mcp-server test_mcp_resume_requires_rebuild_for_tool_results_and_config_changes`
- `RUST_LANE_ID=peer-send-api ./scripts/repo-cargo test -p meerkat-mob test_peer_message_reaches_idle_autonomous_member_after_kickoff_completion`
- `RUST_LANE_ID=peer-send-check ./scripts/repo-cargo check -p meerkat-mob -p meerkat-mob-mcp`
- pre-push hooks: hardcoded secrets, whitespace/end-of-file, cargo fmt check, changed-crate clippy, machine codegen/verify, generated headers, bridge response-status guard, Bazel freshness, workspace deterministic gate
