### PR TITLE
Fix Windows BuildBuddy release endpoint

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -484,7 +484,7 @@ jobs:
         with:
           profile: native
 
-      - name: Use BuildBuddy Windows release endpoint
+      - name: Use hosted BuildBuddy Windows release endpoint
         if: ${{ matrix.target == 'x86_64-pc-windows-msvc' }}
         shell: bash
         run: |
@@ -509,7 +509,8 @@ jobs:
         shell: bash
         env:
           BUILDBUDDY_BAZEL_COMMAND: ${{ matrix.bb_command }}
-          BUILDBUDDY_ENDPOINT: ${{ matrix.bb_command == 'release-build-windows-x86' && secrets.BUILDBUDDY_ENDPOINT || '' }}
+          BUILDBUDDY_GRPC_URL: ${{ matrix.bb_command == 'release-build-windows-x86' && 'grpcs://king.europe.buildbuddy.io' || '' }}
+          BUILDBUDDY_HTTP_URL: ${{ matrix.bb_command == 'release-build-windows-x86' && 'https://king.europe.buildbuddy.io' || '' }}
           BUILDBUDDY_OUTPUT_LANE: release-build-${{ matrix.target }}
           BUILDBUDDY_OUTPUT_BASE: ${{ runner.temp }}/bb-release-${{ matrix.target }}
           MEERKAT_BUILDBUDDY_OUTPUT_ROOT: ${{ runner.temp }}/bb-release

--- a/scripts/release-doctor
+++ b/scripts/release-doctor
@@ -130,14 +130,15 @@ else
   bad "Release workflow should build Linux/macOS/Windows assets on BuildBuddy for owner releases"
 fi
 
-if grep -Fq 'Use BuildBuddy Windows release endpoint' .github/workflows/release.yml &&
-  grep -Fq 'BUILDBUDDY_ENDPOINT:' .github/workflows/release.yml &&
-  grep -Fq 'secrets.BUILDBUDDY_ENDPOINT' .github/workflows/release.yml &&
+if grep -Fq 'Use hosted BuildBuddy Windows release endpoint' .github/workflows/release.yml &&
+  grep -Fq 'BUILDBUDDY_GRPC_URL:' .github/workflows/release.yml &&
+  grep -Fq 'grpcs://king.europe.buildbuddy.io' .github/workflows/release.yml &&
+  ! grep -Fq "release-build-windows-x86' && secrets.BUILDBUDDY_ENDPOINT" .github/workflows/release.yml &&
   grep -Fq 'build:buildbuddy-windows-rbe --remote_default_exec_properties=use-self-hosted-executors=true' .bazelrc &&
   grep -Fq '"use-self-hosted-executors": "true"' platforms/BUILD.bazel; then
-  pass "Release workflow routes Windows recovery builds to the hosted BuildBuddy endpoint"
+  pass "Release workflow routes Windows builds to the hosted King BuildBuddy endpoint"
 else
-  bad "Release workflow should route Windows recovery builds to the hosted BuildBuddy endpoint"
+  bad "Release workflow should route Windows builds to grpcs://king.europe.buildbuddy.io, not a private/stale secret endpoint"
 fi
 
 web_build_timeout="$(


### PR DESCRIPTION
## Summary
- route Windows release BuildBuddy builds directly to hosted King BuildBuddy (`grpcs://king.europe.buildbuddy.io`) instead of the mutable `BUILDBUDDY_ENDPOINT` secret
- keep the existing self-hosted Windows executor selector, which is the path that successfully schedules Meerkat Windows builds
- update `release-doctor` so it fails if the release workflow regresses to the stale/private secret endpoint path

## Verification
- `make release-doctor`
- `git diff --check`
- `BUILDBUDDY_BAZEL_COMMAND=release-build-windows-x86 BUILDBUDDY_GRPC_URL=grpcs://king.europe.buildbuddy.io BUILDBUDDY_HTTP_URL=https://king.europe.buildbuddy.io BUILDBUDDY_OUTPUT_LANE=windows-release-flow-fix scripts/buildbuddy-bazel-poc //meerkat-cli:rkat --jobs=64 --color=no --curses=no`
  - BuildBuddy invocation: https://king.europe.buildbuddy.io/invocation/eee2ef89-e5dd-4613-928b-bdb08a0015cf
