### PR TITLE
[codex] Add mob spawn boundary customization

### DIFF
--- a/meerkat-mob/src/build.rs
+++ b/meerkat-mob/src/build.rs
@@ -92,6 +92,8 @@ pub struct BuildAgentConfigParams<'a> {
     /// When set, stored in canonical session tool-visibility state so the
     /// runtime-backed core build restores it through the machine owner.
     pub inherited_tool_filter: Option<WitnessedToolFilter>,
+    /// Typed per-spawn system prompt replacement.
+    pub system_prompt_override: Option<crate::runtime::SpawnSystemPromptOverride>,
 }
 
 pub struct BuildResumedAgentConfigParams<'a> {
@@ -125,6 +127,7 @@ pub async fn build_agent_config(
         shell_env,
         mob_tool_authority_context,
         inherited_tool_filter,
+        system_prompt_override,
     } = params;
 
     if !profile.tools.comms {
@@ -161,8 +164,14 @@ pub async fn build_agent_config(
     config.comms_name = Some(comms_name);
     config.peer_meta = Some(peer_meta);
     config.realm_id = Some(realm_id.to_string());
-    if !system_prompt.is_empty() {
-        config.system_prompt = Some(system_prompt);
+    match system_prompt_override {
+        Some(crate::runtime::SpawnSystemPromptOverride::Replace(prompt)) => {
+            config.system_prompt = Some(prompt);
+        }
+        None if !system_prompt.is_empty() => {
+            config.system_prompt = Some(system_prompt);
+        }
+        None => {}
     }
 
     // Mob comms instructions are delivered as an embedded skill via
@@ -611,6 +620,7 @@ mod tests {
             shell_env: None,
             mob_tool_authority_context: None,
             inherited_tool_filter: None,
+            system_prompt_override: None,
         })
         .await
         .expect("build_agent_config");
@@ -637,6 +647,7 @@ mod tests {
             shell_env: None,
             mob_tool_authority_context: None,
             inherited_tool_filter: None,
+            system_prompt_override: None,
         })
         .await
         .expect("build_agent_config");
@@ -667,6 +678,7 @@ mod tests {
             shell_env: None,
             mob_tool_authority_context: None,
             inherited_tool_filter: None,
+            system_prompt_override: None,
         })
         .await
         .expect("build_agent_config");
@@ -703,6 +715,7 @@ mod tests {
             shell_env: None,
             mob_tool_authority_context: None,
             inherited_tool_filter: None,
+            system_prompt_override: None,
         })
         .await
         .expect("build_agent_config");
@@ -735,6 +748,7 @@ mod tests {
             shell_env: None,
             mob_tool_authority_context: None,
             inherited_tool_filter: None,
+            system_prompt_override: None,
         })
         .await
         .expect("build_agent_config");
@@ -784,6 +798,7 @@ mod tests {
             shell_env: None,
             mob_tool_authority_context: None,
             inherited_tool_filter: None,
+            system_prompt_override: None,
         })
         .await
         .expect("build_agent_config");
@@ -849,6 +864,7 @@ mod tests {
             shell_env: None,
             mob_tool_authority_context: None,
             inherited_tool_filter: Some(inherited_authority),
+            system_prompt_override: None,
         })
         .await
         .expect("build_agent_config");
@@ -901,6 +917,7 @@ mod tests {
             shell_env: None,
             mob_tool_authority_context: None,
             inherited_tool_filter: Some(inherited_authority.clone()),
+            system_prompt_override: None,
         })
         .await
         .expect("build_agent_config");
@@ -953,6 +970,7 @@ mod tests {
                 ),
                 Default::default(),
             )),
+            system_prompt_override: None,
         })
         .await
         .expect_err("name-only inherited filter should fail closed");
@@ -982,6 +1000,7 @@ mod tests {
             shell_env: None,
             mob_tool_authority_context: injected_authority(),
             inherited_tool_filter: None,
+            system_prompt_override: None,
         })
         .await
         .expect("build_agent_config");
@@ -1028,6 +1047,7 @@ mod tests {
                 shell_env: None,
                 mob_tool_authority_context: None,
                 inherited_tool_filter: None,
+                system_prompt_override: None,
             },
             expected_session_id: &session_id,
             resumed_session,
@@ -1074,6 +1094,7 @@ mod tests {
                 shell_env: None,
                 mob_tool_authority_context: None,
                 inherited_tool_filter: None,
+                system_prompt_override: None,
             },
             expected_session_id: &session_id,
             resumed_session,
@@ -1158,6 +1179,7 @@ mod tests {
                 shell_env: None,
                 mob_tool_authority_context: None,
                 inherited_tool_filter: Some(inherited_authority.clone()),
+                system_prompt_override: None,
             },
             expected_session_id: &session_id,
             resumed_session,
@@ -1238,6 +1260,7 @@ mod tests {
                     ),
                     &["parent_shell"],
                 )),
+                system_prompt_override: None,
             },
             expected_session_id: &session_id,
             resumed_session,
@@ -1282,6 +1305,7 @@ mod tests {
             shell_env: None,
             mob_tool_authority_context: None,
             inherited_tool_filter: None,
+            system_prompt_override: None,
         })
         .await;
         assert!(
@@ -1309,6 +1333,7 @@ mod tests {
             shell_env: None,
             mob_tool_authority_context: None,
             inherited_tool_filter: None,
+            system_prompt_override: None,
         })
         .await
         .expect("build_agent_config");
@@ -1321,6 +1346,45 @@ mod tests {
         // Mob comms instructions are delivered via preload_skills (embedded
         // skill), not baked into system_prompt — verified in the separate
         // test_build_agent_config_preloads_mob_communication_skill test.
+    }
+
+    #[tokio::test]
+    async fn test_build_agent_config_system_prompt_replace_keeps_mob_skill_preload() {
+        let def = sample_definition();
+        let lead = def.profiles[&ProfileName::from("lead")]
+            .as_inline()
+            .unwrap();
+        let config = build_agent_config(BuildAgentConfigParams {
+            mob_id: &def.id,
+            profile_name: &ProfileName::from("lead"),
+            agent_identity: &MeerkatId::from("lead-1"),
+            profile: lead,
+            definition: &def,
+            external_tools: None,
+            context: None,
+            labels: None,
+            additional_instructions: None,
+            shell_env: None,
+            mob_tool_authority_context: None,
+            inherited_tool_filter: None,
+            system_prompt_override: Some(crate::SpawnSystemPromptOverride::Replace(
+                "OB3 replacement prompt".to_string(),
+            )),
+        })
+        .await
+        .expect("build_agent_config");
+
+        assert_eq!(
+            config.system_prompt.as_deref(),
+            Some("OB3 replacement prompt"),
+            "typed Replace must bypass profile prompt assembly"
+        );
+        assert!(
+            config.preload_skills.as_ref().is_some_and(|skills| skills
+                .iter()
+                .any(|skill| skill.to_string().contains("mob-communication"))),
+            "prompt replacement must not remove required mob runtime skill wiring"
+        );
     }
 
     #[tokio::test]
@@ -1342,6 +1406,7 @@ mod tests {
             shell_env: None,
             mob_tool_authority_context: None,
             inherited_tool_filter: None,
+            system_prompt_override: None,
         })
         .await
         .expect("build_agent_config");
@@ -1377,6 +1442,7 @@ mod tests {
             shell_env: None,
             mob_tool_authority_context: None,
             inherited_tool_filter: None,
+            system_prompt_override: None,
         })
         .await
         .expect("build_agent_config");
@@ -1412,6 +1478,7 @@ mod tests {
             shell_env: None,
             mob_tool_authority_context: None,
             inherited_tool_filter: None,
+            system_prompt_override: None,
         })
         .await
         .expect("build_agent_config");
@@ -1438,6 +1505,7 @@ mod tests {
             shell_env: None,
             mob_tool_authority_context: None,
             inherited_tool_filter: None,
+            system_prompt_override: None,
         })
         .await
         .expect("build_agent_config");
@@ -1464,6 +1532,7 @@ mod tests {
             shell_env: None,
             mob_tool_authority_context: None,
             inherited_tool_filter: None,
+            system_prompt_override: None,
         })
         .await
         .expect("build_agent_config");
@@ -1511,6 +1580,7 @@ mod tests {
             shell_env: None,
             mob_tool_authority_context: None,
             inherited_tool_filter: None,
+            system_prompt_override: None,
         })
         .await
         .expect("build_agent_config");
@@ -1565,6 +1635,7 @@ mod tests {
             shell_env: None,
             mob_tool_authority_context: None,
             inherited_tool_filter: None,
+            system_prompt_override: None,
         })
         .await
         .expect("build_agent_config should resolve path skill");
@@ -1613,6 +1684,7 @@ mod tests {
             shell_env: None,
             mob_tool_authority_context: None,
             inherited_tool_filter: None,
+            system_prompt_override: None,
         })
         .await
         .expect_err("missing path skill should fail");
@@ -1646,6 +1718,7 @@ mod tests {
             shell_env: None,
             mob_tool_authority_context: None,
             inherited_tool_filter: None,
+            system_prompt_override: None,
         })
         .await
         .expect("build_agent_config");
@@ -1676,6 +1749,7 @@ mod tests {
             shell_env: None,
             mob_tool_authority_context: None,
             inherited_tool_filter: None,
+            system_prompt_override: None,
         })
         .await
         .expect("build_agent_config");
@@ -1714,6 +1788,7 @@ mod tests {
             shell_env: None,
             mob_tool_authority_context: None,
             inherited_tool_filter: None,
+            system_prompt_override: None,
         })
         .await
         .expect("build_agent_config");
@@ -1763,6 +1838,7 @@ mod tests {
             shell_env: None,
             mob_tool_authority_context: None,
             inherited_tool_filter: None,
+            system_prompt_override: None,
         })
         .await
         .expect("build_agent_config");

--- a/meerkat-mob/src/event.rs
+++ b/meerkat-mob/src/event.rs
@@ -518,6 +518,9 @@ pub struct MemberSpawnedEvent {
     /// Application-defined labels for this member.
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub labels: BTreeMap<String, String>,
+    /// Typed continuity evidence emitted at spawn finalization.
+    #[serde(default, skip_serializing_if = "crate::event::is_ephemeral_continuity")]
+    pub continuity_intent: crate::runtime::SpawnContinuityIntent,
     /// Bridge-internal member reference needed for event replay.
     /// Not part of the public identity-native contract.
     #[serde(skip, default)]
@@ -540,6 +543,7 @@ impl MemberSpawnedEvent {
             role,
             runtime_mode: MobRuntimeMode::AutonomousHost,
             labels: BTreeMap::new(),
+            continuity_intent: crate::runtime::SpawnContinuityIntent::Ephemeral,
             bridge_member_ref: None,
         }
     }
@@ -553,6 +557,10 @@ impl MemberSpawnedEvent {
     pub(crate) fn bridge_member_ref(&self) -> Option<&MemberRef> {
         self.bridge_member_ref.as_ref()
     }
+}
+
+fn is_ephemeral_continuity(intent: &crate::runtime::SpawnContinuityIntent) -> bool {
+    matches!(intent, crate::runtime::SpawnContinuityIntent::Ephemeral)
 }
 
 #[cfg(any(not(target_arch = "wasm32"), test))]

--- a/meerkat-mob/src/lib.rs
+++ b/meerkat-mob/src/lib.rs
@@ -128,8 +128,9 @@ pub use runtime::{
     MobEventRouterHandle, MobEventsSubscription, MobEventsSubscriptionConfig, MobHandle,
     MobMemberSnapshot, MobMemberStatus, MobPeerConnectivitySnapshot, MobRespawnError,
     MobSessionService, MobState, MobUnreachablePeer, MobWireMembersBatchReport, PeerMessageReceipt,
-    PeerTarget, PreviousMemberCleanupReport, SpawnMemberSpec, SpawnPolicy, SpawnResult, SpawnSpec,
-    SupervisorRotationReport, WorkDeliveryReceipt,
+    PeerTarget, PreviousMemberCleanupReport, SpawnContinuityIntent, SpawnCustomizationContext,
+    SpawnMemberCustomizer, SpawnMemberSpec, SpawnPolicy, SpawnResult, SpawnSource, SpawnSpec,
+    SpawnSystemPromptOverride, SupervisorRotationReport, WorkDeliveryReceipt,
 };
 pub use runtime::{FlowFrameKernel, FlowFrameMutator};
 pub use runtime::{FlowTurnExecutor, FlowTurnOutcome, FlowTurnTicket, TimeoutDisposition};

--- a/meerkat-mob/src/mob_machine.rs
+++ b/meerkat-mob/src/mob_machine.rs
@@ -39,6 +39,7 @@ pub(crate) enum MobMachineCommand {
     },
     Spawn {
         spec: Box<crate::runtime::SpawnMemberSpec>,
+        spawn_source: crate::runtime::SpawnSource,
         owner_context: Option<crate::runtime::CanonicalOpsOwnerContext>,
     },
     /// Declarative spawn-if-absent. Constructed by

--- a/meerkat-mob/src/runtime/actor.rs
+++ b/meerkat-mob/src/runtime/actor.rs
@@ -291,6 +291,7 @@ pub(super) struct PendingSpawn {
     /// Effective profile override from `SpawnTooling::Profile` resolution.
     /// Persisted in the roster so respawn/restore can use it.
     pub(super) effective_profile_override: Option<crate::profile::Profile>,
+    pub(super) continuity_intent: super::handle::SpawnContinuityIntent,
     pub(super) progress: Arc<std::sync::Mutex<PendingSpawnProgress>>,
     pub(super) reply_tx: oneshot::Sender<Result<super::handle::MemberSpawnReceipt, MobError>>,
 }
@@ -419,6 +420,7 @@ pub(super) struct MobActor {
     /// authority inside the actor.
     pub(super) phase_watch_tx: tokio::sync::watch::Sender<MobState>,
     pub(super) default_external_tools_provider: Option<crate::ExternalToolsProvider>,
+    pub(super) spawn_member_customizer: Option<Arc<dyn super::SpawnMemberCustomizer>>,
     pub(super) realm_profile_store: Option<Arc<dyn crate::store::RealmProfileStore>>,
     /// Typed composition binding for the `meerkat_mob_seam` composition
     /// (wave-c C-6p). Every routed effect emitted by the mob DSL travels
@@ -3139,12 +3141,14 @@ impl MobActor {
             match cmd {
                 MobCommand::Spawn {
                     spec,
+                    spawn_source,
                     owner_bridge_session_id,
                     ops_registry,
                     reply_tx,
                 } => {
                     Box::pin(self.enqueue_spawn(
                         *spec,
+                        spawn_source,
                         owner_bridge_session_id,
                         ops_registry,
                         reply_tx,
@@ -4033,16 +4037,44 @@ impl MobActor {
         canceled
     }
 
+    fn customize_spawn_spec(
+        &self,
+        spawn_source: super::handle::SpawnSource,
+        spawner: Option<&(AgentIdentity, AgentRuntimeId)>,
+        spec: &mut super::handle::SpawnMemberSpec,
+    ) -> Result<(), MobError> {
+        if let Some(customizer) = self.spawn_member_customizer.as_ref() {
+            let ctx = super::handle::SpawnCustomizationContext {
+                mob_id: self.definition.id.clone(),
+                spawn_source,
+                spawner_identity: spawner.map(|(identity, _)| identity.clone()),
+                spawner_runtime_id: spawner.map(|(_, runtime_id)| runtime_id.clone()),
+                requested_profile: spec.role_name.clone(),
+            };
+            customizer.customize_spawn(&ctx, spec)?;
+        }
+        Ok(())
+    }
+
     /// P1-T04: spawn() creates a real session.
     ///
     /// Provisioning runs in parallel tasks; final actor commit stays serialized.
     async fn enqueue_spawn(
         &mut self,
-        spec: super::handle::SpawnMemberSpec,
+        mut spec: super::handle::SpawnMemberSpec,
+        spawn_source: super::handle::SpawnSource,
         owner_bridge_session_id: Option<SessionId>,
         ops_registry: Option<Arc<dyn meerkat_core::ops_lifecycle::OpsLifecycleRegistry>>,
         reply_tx: oneshot::Sender<Result<super::handle::MemberSpawnReceipt, MobError>>,
     ) {
+        let spawner = match owner_bridge_session_id.as_ref() {
+            Some(owner_session_id) => self.spawner_for_bridge_session(owner_session_id).await,
+            None => None,
+        };
+        if let Err(error) = self.customize_spawn_spec(spawn_source, spawner.as_ref(), &mut spec) {
+            let _ = reply_tx.send(Err(error));
+            return;
+        }
         let super::handle::SpawnMemberSpec {
             role_name: profile_name,
             identity,
@@ -4063,6 +4095,9 @@ impl MobActor {
             model_override,
             provider_params_override,
             auth_binding,
+            external_tools: per_spawn_external_tools,
+            system_prompt_override,
+            continuity_intent,
         } = spec;
         let agent_identity = MeerkatId::from(identity.as_str());
         if let Err(error) = self.preview_spawn_command_admission(&agent_identity) {
@@ -4207,6 +4242,7 @@ impl MobActor {
                         owner_bridge_session_id.clone(),
                         auto_wire_parent,
                         effective_profile_override.clone(),
+                        continuity_intent.clone(),
                     ));
                 }
 
@@ -4222,7 +4258,8 @@ impl MobActor {
                             ))
                         })?;
 
-                    let external_tools = self.external_tools_for_profile(&profile)?;
+                    let external_tools =
+                        self.external_tools_for_profile(&profile, per_spawn_external_tools.clone())?;
                     let mut config = build::build_resumed_agent_config(
                         build::BuildResumedAgentConfigParams {
                             base: build::BuildAgentConfigParams {
@@ -4238,6 +4275,7 @@ impl MobActor {
                                 shell_env,
                                 mob_tool_authority_context: None,
                                 inherited_tool_filter: inherited_tool_filter.clone(),
+                                system_prompt_override: system_prompt_override.clone(),
                             },
                             expected_session_id: &resume_id,
                             resumed_session: stored_session,
@@ -4286,6 +4324,7 @@ impl MobActor {
                         owner_bridge_session_id.clone(),
                         auto_wire_parent,
                         effective_profile_override.clone(),
+                        continuity_intent.clone(),
                     ));
                 }
 
@@ -4357,7 +4396,8 @@ impl MobActor {
                 None
             };
 
-            let external_tools = self.external_tools_for_profile(&profile)?;
+            let external_tools =
+                self.external_tools_for_profile(&profile, per_spawn_external_tools.clone())?;
             let mut config = build::build_agent_config(build::BuildAgentConfigParams {
                 mob_id: &self.definition.id,
                 profile_name: &profile_name,
@@ -4371,6 +4411,7 @@ impl MobActor {
                 shell_env,
                 mob_tool_authority_context: None,
                 inherited_tool_filter,
+                system_prompt_override,
             })
             .await?;
             config.keep_alive =
@@ -4428,6 +4469,7 @@ impl MobActor {
                 owner_bridge_session_id.clone(),
                 auto_wire_parent,
                 effective_profile_override,
+                continuity_intent,
             ))
         }
         .await;
@@ -4445,6 +4487,7 @@ impl MobActor {
             spawn_owner_bridge_session_id,
             auto_wire_parent,
             effective_profile_override,
+            continuity_intent,
         ) = match prepare_result {
             Ok(prepared) => prepared,
             Err(error) => {
@@ -4515,6 +4558,7 @@ impl MobActor {
                     auto_wire_parent,
                     None,
                     effective_profile_override,
+                    continuity_intent,
                 )
                 .await
                 .map(|outcome| outcome.receipt);
@@ -4567,6 +4611,7 @@ impl MobActor {
             auto_wire_parent,
             restore_wiring: None,
             effective_profile_override,
+            continuity_intent,
             progress: pending_progress.clone(),
             reply_tx,
         };
@@ -4717,6 +4762,7 @@ impl MobActor {
                 auto_wire_parent,
                 restore_wiring,
                 effective_profile_override,
+                continuity_intent,
                 progress: _,
                 reply_tx,
             } = pending;
@@ -4752,6 +4798,7 @@ impl MobActor {
                             auto_wire_parent,
                             restore_wiring,
                             effective_profile_override,
+                            continuity_intent,
                         )
                         .await
                         .map(|outcome| outcome.receipt)
@@ -4776,8 +4823,51 @@ impl MobActor {
         &mut self,
         agent_identity: &MeerkatId,
         spawn_spec: super::spawn_policy::SpawnSpec,
+        work_ref: &WorkRef,
+        origin: WorkOrigin,
     ) -> Result<super::handle::MemberSpawnReceipt, MobError> {
         self.ensure_pending_spawn_alignment("spawn_from_policy_inline preflight")?;
+
+        let requested_identity = AgentIdentity::from(agent_identity.as_str());
+        let mut member_spec =
+            super::handle::SpawnMemberSpec::new(spawn_spec.profile, requested_identity.clone());
+        member_spec.runtime_mode = spawn_spec.runtime_mode;
+        self.customize_spawn_spec(
+            super::handle::SpawnSource::PolicySpawn,
+            None,
+            &mut member_spec,
+        )?;
+        if member_spec.identity != requested_identity {
+            return Err(MobError::Internal(format!(
+                "spawn customizer cannot change policy auto-spawn identity from '{requested_identity}' to '{}'",
+                member_spec.identity
+            )));
+        }
+
+        let super::handle::SpawnMemberSpec {
+            role_name: profile_name,
+            identity: _,
+            initial_message,
+            runtime_mode,
+            backend,
+            binding,
+            context,
+            labels,
+            launch_mode: _,
+            tool_access_policy: _tool_access_policy,
+            budget_split_policy: _budget_split_policy,
+            auto_wire_parent: _,
+            additional_instructions,
+            shell_env,
+            inherited_tool_filter,
+            override_profile,
+            model_override,
+            provider_params_override,
+            auth_binding,
+            external_tools: per_spawn_external_tools,
+            system_prompt_override,
+            continuity_intent,
+        } = member_spec;
 
         if agent_identity
             .as_str()
@@ -4805,14 +4895,39 @@ impl MobActor {
             }
         }
 
-        let profile_name = spawn_spec.profile;
-        let profile = self
-            .definition
-            .resolve_profile(&profile_name, self.realm_profile_store.as_ref())
-            .await?;
-        let runtime_mode = spawn_spec.runtime_mode.unwrap_or(profile.runtime_mode);
-        let external_tools = self.external_tools_for_profile(&profile)?;
-        let labels = std::collections::BTreeMap::new();
+        let mut profile = if let Some(p) = override_profile.clone() {
+            p
+        } else {
+            self.definition
+                .resolve_profile(&profile_name, self.realm_profile_store.as_ref())
+                .await?
+        };
+        if inherited_tool_filter.is_some() && override_profile.is_none() {
+            build::open_profile_tool_categories_for_inherited_filter(&mut profile);
+        }
+        if let Some(model) = model_override {
+            profile.model = model;
+        }
+        if provider_params_override.is_some() {
+            profile.provider_params = provider_params_override;
+        }
+        self.preview_policy_spawn_submit_work_admission(
+            &requested_identity,
+            profile.external_addressable,
+            work_ref,
+            origin,
+        )?;
+        let runtime_mode = runtime_mode.unwrap_or(profile.runtime_mode);
+        let selected_binding = resolve_binding(
+            binding,
+            backend,
+            profile.backend,
+            self.definition.backend.default,
+            agent_identity,
+        )?;
+        let runtime_mode = normalize_runtime_mode_for_binding(runtime_mode, &selected_binding);
+        let external_tools = self.external_tools_for_profile(&profile, per_spawn_external_tools)?;
+        let labels = labels.unwrap_or_default();
         let mut config = build::build_agent_config(build::BuildAgentConfigParams {
             mob_id: &self.definition.id,
             profile_name: &profile_name,
@@ -4820,28 +4935,28 @@ impl MobActor {
             profile: &profile,
             definition: &self.definition,
             external_tools,
-            context: None,
+            context,
             labels: Some(labels.clone()),
-            additional_instructions: None,
-            shell_env: None,
+            additional_instructions,
+            shell_env,
             mob_tool_authority_context: None,
-            inherited_tool_filter: None,
+            inherited_tool_filter,
+            system_prompt_override,
         })
         .await?;
         config.keep_alive = runtime_mode == crate::MobRuntimeMode::AutonomousHost;
         if let Some(ref client) = self.default_llm_client {
             config.llm_client_override = Some(client.clone());
         }
+        if let Some(ref cref) = auth_binding {
+            config.auth_binding = Some(cref.clone());
+        }
 
-        let prompt = ContentInput::from(self.fallback_spawn_prompt(&profile_name, agent_identity));
+        let prompt = initial_message.clone().unwrap_or_else(|| {
+            ContentInput::from(self.fallback_spawn_prompt(&profile_name, agent_identity))
+        });
+        let initial_turn_prompt = initial_message.as_ref().map(|_| prompt.clone());
         let req = build::to_create_session_request(&config, prompt.clone());
-        let selected_binding = resolve_binding(
-            None,
-            None,
-            profile.backend,
-            self.definition.backend.default,
-            agent_identity,
-        )?;
         let peer_name = format!("{}/{}/{}", self.definition.id, profile_name, agent_identity);
         let mut provision_request = ProvisionMemberRequest {
             create_session: req,
@@ -4862,13 +4977,14 @@ impl MobActor {
             agent_identity: agent_identity.clone(),
             admitted_bridge_session_id,
             prompt: prompt.clone(),
-            initial_turn_prompt: None,
+            initial_turn_prompt: initial_turn_prompt.clone(),
             runtime_mode,
             labels: labels.clone(),
             owner_bridge_session_id: None,
             auto_wire_parent: false,
             restore_wiring: None,
-            effective_profile_override: None,
+            effective_profile_override: override_profile.clone(),
+            continuity_intent: continuity_intent.clone(),
             progress: Arc::new(std::sync::Mutex::new(PendingSpawnProgress::default())),
             reply_tx: pending_reply_tx,
         };
@@ -4934,14 +5050,15 @@ impl MobActor {
                 fence,
                 runtime_mode,
                 prompt,
-                None,
+                initial_turn_prompt,
                 labels,
                 provision,
                 spawn_receipt.operation_id,
                 None,
                 false,
                 None,
-                None, // policy spawns use definition profiles, no override
+                override_profile, // policy spawns usually use definition profiles; customizers may supply an override
+                continuity_intent,
             )
             .await
             .map(|outcome| outcome.receipt)
@@ -4988,6 +5105,7 @@ impl MobActor {
         auto_wire_parent: bool,
         restore_wiring: Option<RestoreWiringPlan>,
         effective_profile_override: Option<crate::profile::Profile>,
+        continuity_intent: super::handle::SpawnContinuityIntent,
     ) -> Result<FinalizeSpawnOutcome, MobError> {
         let identity = crate::ids::AgentIdentity::from(agent_identity.as_str());
         let agent_runtime_id = crate::ids::AgentRuntimeId::new(identity.clone(), generation);
@@ -5146,6 +5264,7 @@ impl MobActor {
                     )));
                     event.runtime_mode = runtime_mode;
                     event.labels = labels.clone();
+                    event.continuity_intent = continuity_intent.clone();
                     event
                 }),
             })
@@ -5587,6 +5706,20 @@ impl MobActor {
                     && entry.member_ref.bridge_session_id() == Some(owner_bridge_session_id)
             })
             .map(|entry| entry.agent_identity.clone())
+    }
+
+    async fn spawner_for_bridge_session(
+        &self,
+        owner_bridge_session_id: &SessionId,
+    ) -> Option<(AgentIdentity, AgentRuntimeId)> {
+        let roster = self.roster.read().await;
+        roster
+            .list()
+            .find(|entry| {
+                entry.state == crate::roster::MemberState::Active
+                    && entry.member_ref.bridge_session_id() == Some(owner_bridge_session_id)
+            })
+            .map(|entry| (entry.agent_identity.clone(), entry.agent_runtime_id.clone()))
     }
 
     /// P1-T05: force-cancel a member's in-flight turn cooperatively.
@@ -7915,6 +8048,65 @@ impl MobActor {
             }
         };
 
+        let original_identity = AgentIdentity::from(agent_identity.as_str());
+        let mut replacement_spec = super::handle::SpawnMemberSpec::new(
+            snapshot.profile_name.clone(),
+            original_identity.clone(),
+        );
+        replacement_spec.initial_message = initial_message;
+        replacement_spec.runtime_mode = Some(snapshot.runtime_mode);
+        replacement_spec.binding = Some(snapshot.binding.clone());
+        replacement_spec.labels = Some(snapshot.labels.clone());
+        replacement_spec.override_profile = snapshot.effective_profile_override.clone();
+        self.customize_spawn_spec(
+            super::handle::SpawnSource::Respawn,
+            None,
+            &mut replacement_spec,
+        )
+        .map_err(MobRespawnError::from)?;
+        if replacement_spec.identity != original_identity {
+            return Err(MobRespawnError::from(MobError::Internal(format!(
+                "spawn customizer cannot change respawn identity from '{original_identity}' to '{}'",
+                replacement_spec.identity
+            ))));
+        }
+        if replacement_spec.role_name != snapshot.profile_name {
+            return Err(MobRespawnError::from(MobError::Internal(format!(
+                "spawn customizer cannot change respawn profile for '{original_identity}' from '{}' to '{}'",
+                snapshot.profile_name, replacement_spec.role_name
+            ))));
+        }
+        if replacement_spec.binding.as_ref() != Some(&snapshot.binding) {
+            return Err(MobRespawnError::from(MobError::Internal(format!(
+                "spawn customizer cannot change respawn runtime binding for '{original_identity}'"
+            ))));
+        }
+        let super::handle::SpawnMemberSpec {
+            role_name: _,
+            identity: _,
+            initial_message: replacement_initial_message,
+            runtime_mode: _,
+            backend: _,
+            binding: _,
+            context: replacement_context,
+            labels: replacement_labels,
+            launch_mode: _,
+            tool_access_policy: _tool_access_policy,
+            budget_split_policy: _budget_split_policy,
+            auto_wire_parent: _,
+            additional_instructions: replacement_additional_instructions,
+            shell_env: replacement_shell_env,
+            inherited_tool_filter: replacement_inherited_tool_filter,
+            override_profile: replacement_profile_override,
+            model_override: replacement_model_override,
+            provider_params_override: replacement_provider_params_override,
+            auth_binding: replacement_auth_binding,
+            external_tools: replacement_external_tools,
+            system_prompt_override: replacement_system_prompt_override,
+            continuity_intent: replacement_continuity_intent,
+        } = replacement_spec;
+        let replacement_labels = replacement_labels.unwrap_or_default();
+
         self.preview_dsl_input(
             mob_dsl::MobMachineInput::Respawn {
                 agent_runtime_id: mob_dsl::AgentRuntimeId::from_domain(&snapshot.old_runtime_id),
@@ -8003,7 +8195,7 @@ impl MobActor {
         }
 
         // 3. Rebuild the replacement spawn preserving identity, profile, labels, mode, and peer intent.
-        let (prompt, initial_turn_prompt) = match initial_message {
+        let (prompt, initial_turn_prompt) = match replacement_initial_message {
             Some(message) => {
                 let prompt = message;
                 (prompt.clone(), Some(prompt))
@@ -8016,14 +8208,24 @@ impl MobActor {
             ),
         };
         // Prefer roster's effective_profile_override on respawn for lifecycle safety.
-        let profile = if let Some(p) = snapshot.effective_profile_override.clone() {
+        let mut profile = if let Some(p) = replacement_profile_override.clone() {
             p
         } else {
             self.definition
                 .resolve_profile(&snapshot.profile_name, self.realm_profile_store.as_ref())
                 .await?
         };
-        let external_tools = self.external_tools_for_profile(&profile)?;
+        if replacement_inherited_tool_filter.is_some() && replacement_profile_override.is_none() {
+            build::open_profile_tool_categories_for_inherited_filter(&mut profile);
+        }
+        if let Some(model) = replacement_model_override {
+            profile.model = model;
+        }
+        if replacement_provider_params_override.is_some() {
+            profile.provider_params = replacement_provider_params_override;
+        }
+        let external_tools =
+            self.external_tools_for_profile(&profile, replacement_external_tools)?;
         let mut config = build::build_agent_config(build::BuildAgentConfigParams {
             mob_id: &self.definition.id,
             profile_name: &snapshot.profile_name,
@@ -8031,17 +8233,21 @@ impl MobActor {
             profile: &profile,
             definition: &self.definition,
             external_tools,
-            context: None,
-            labels: Some(snapshot.labels.clone()),
-            additional_instructions: None,
-            shell_env: None,
+            context: replacement_context,
+            labels: Some(replacement_labels.clone()),
+            additional_instructions: replacement_additional_instructions,
+            shell_env: replacement_shell_env,
             mob_tool_authority_context: None,
-            inherited_tool_filter: None,
+            inherited_tool_filter: replacement_inherited_tool_filter,
+            system_prompt_override: replacement_system_prompt_override,
         })
         .await?;
         config.keep_alive = snapshot.runtime_mode == crate::MobRuntimeMode::AutonomousHost;
         if let Some(ref client) = self.default_llm_client {
             config.llm_client_override = Some(client.clone());
+        }
+        if let Some(ref cref) = replacement_auth_binding {
+            config.auth_binding = Some(cref.clone());
         }
         let req = build::to_create_session_request(&config, prompt.clone());
         let peer_name = format!(
@@ -8073,13 +8279,14 @@ impl MobActor {
             prompt: prompt.clone(),
             initial_turn_prompt: initial_turn_prompt.clone(),
             runtime_mode: snapshot.runtime_mode,
-            labels: snapshot.labels.clone(),
+            labels: replacement_labels.clone(),
             owner_bridge_session_id: None,
             auto_wire_parent: false,
             restore_wiring: (!snapshot.restore_wiring.local_peers.is_empty()
                 || !snapshot.restore_wiring.external_peers.is_empty())
             .then_some(snapshot.restore_wiring.clone()),
-            effective_profile_override: snapshot.effective_profile_override.clone(),
+            effective_profile_override: replacement_profile_override.clone(),
+            continuity_intent: replacement_continuity_intent.clone(),
             progress: Arc::new(std::sync::Mutex::new(PendingSpawnProgress::default())),
             reply_tx: respawn_inline_reply_tx,
         };
@@ -8183,7 +8390,7 @@ impl MobActor {
                     snapshot.runtime_mode,
                     prompt,
                     initial_turn_prompt,
-                    snapshot.labels.clone(),
+                    replacement_labels,
                     provision,
                     spawn_receipt.operation_id,
                     None,
@@ -8191,7 +8398,8 @@ impl MobActor {
                     (!snapshot.restore_wiring.local_peers.is_empty()
                         || !snapshot.restore_wiring.external_peers.is_empty())
                     .then_some(snapshot.restore_wiring.clone()),
-                    snapshot.effective_profile_override.clone(),
+                    replacement_profile_override,
+                    replacement_continuity_intent,
                 )
                 .await
                 .map_err(|error| MobRespawnError::SpawnAfterRetire {
@@ -10441,23 +10649,8 @@ impl MobActor {
                 }
                 let identity = AgentIdentity::from(agent_identity.as_str());
                 if let Some(spec) = self.spawn_policy.resolve(&identity).await {
-                    let profile = self
-                        .definition
-                        .resolve_profile(&spec.profile, self.realm_profile_store.as_ref())
+                    Box::pin(self.spawn_from_policy_inline(&identity, spec, &work_ref, origin))
                         .await?;
-                    self.preview_policy_spawn_submit_work_admission(
-                        &identity,
-                        profile.external_addressable,
-                        &work_ref,
-                        origin,
-                    )?;
-                    Box::pin(self.spawn_from_policy_inline(&identity, spec))
-                        .await
-                        .map_err(|error| {
-                            MobError::Internal(format!(
-                                "auto-spawn failed for '{identity}': {error}"
-                            ))
-                        })?;
                     let spawned_entry = {
                         let roster = self.roster.read().await;
                         roster.get(&identity).cloned()
@@ -11938,6 +12131,7 @@ impl MobActor {
     fn external_tools_for_profile(
         &self,
         profile: &crate::profile::Profile,
+        per_spawn_external_tools: Option<Arc<dyn AgentToolDispatcher>>,
     ) -> Result<Option<Arc<dyn AgentToolDispatcher>>, MobError> {
         let default_tools = self
             .default_external_tools_provider
@@ -11948,6 +12142,7 @@ impl MobActor {
             &self.tool_bundles,
             self.mob_handle_for_tools(),
             default_tools,
+            per_spawn_external_tools,
             None,
         )
     }

--- a/meerkat-mob/src/runtime/builder.rs
+++ b/meerkat-mob/src/runtime/builder.rs
@@ -23,6 +23,7 @@ pub struct MobBuilder {
     tool_bundles: BTreeMap<String, Arc<dyn AgentToolDispatcher>>,
     default_llm_client: Option<Arc<dyn LlmClient>>,
     default_external_tools_provider: Option<crate::ExternalToolsProvider>,
+    spawn_member_customizer: Option<Arc<dyn super::SpawnMemberCustomizer>>,
     /// Optional realtime session factory injected for mob-provisioned
     /// members that open a realtime channel (W2-E / issue #264).
     ///
@@ -101,10 +102,9 @@ fn canonical_runtime_adapter_for_session_service(
 /// `identity_to_runtime`. It also rehydrates machine-owned local and external
 /// wiring edges from the event-projected roster so respawn/reconcile restore
 /// logic can read topology from MobMachine instead of using roster fields as
-/// authority. `external_addressable` is resolved from the definition's inline
-/// profile (realm-profile overrides are resolved asynchronously elsewhere;
-/// callers that need realm overrides can re-feed spawn events through the live
-/// pipeline).
+/// authority. `external_addressable` is resolved from the reconstructed
+/// effective profile override when present, then from the definition's inline
+/// profile.
 fn seed_mob_authority_sync_from_roster(
     authority: &mut crate::machines::mob_machine::MobMachineAuthority,
     roster: &Roster,
@@ -112,17 +112,17 @@ fn seed_mob_authority_sync_from_roster(
 ) {
     use crate::machines::mob_machine as mob_dsl;
     for entry in roster.list_all() {
-        // Use the inline profile where available. Realm-profile overrides
-        // are not observed here (the realm store is async-only); resumes
-        // that depend on a realm override for addressability would need to
-        // also emit a spawn event through the normal async pipeline, which
-        // `handle_submit_work` would then see once the entry re-enters the
-        // DSL via that path.
-        let external_addressable = definition
-            .profiles
-            .get(&entry.role)
-            .and_then(|binding| binding.as_inline())
+        let external_addressable = entry
+            .effective_profile_override
+            .as_ref()
             .map(|profile| profile.external_addressable)
+            .or_else(|| {
+                definition
+                    .profiles
+                    .get(&entry.role)
+                    .and_then(|binding| binding.as_inline())
+                    .map(|profile| profile.external_addressable)
+            })
             .unwrap_or(false);
         let dsl_identity = mob_dsl::AgentIdentity::from_domain(&entry.agent_identity);
         let dsl_runtime_id = mob_dsl::AgentRuntimeId::from_domain(&entry.agent_runtime_id);
@@ -498,6 +498,7 @@ impl MobBuilder {
             tool_bundles: BTreeMap::new(),
             default_llm_client: None,
             default_external_tools_provider: None,
+            spawn_member_customizer: None,
             realtime_session_factory: None,
         }
     }
@@ -542,6 +543,7 @@ impl MobBuilder {
             tool_bundles: BTreeMap::new(),
             default_llm_client: None,
             default_external_tools_provider: None,
+            spawn_member_customizer: None,
             realtime_session_factory: None,
         }
     }
@@ -615,6 +617,15 @@ impl MobBuilder {
         self
     }
 
+    /// Register a pre-build customizer for every mob member spawn.
+    pub fn with_spawn_member_customizer(
+        mut self,
+        customizer: Arc<dyn super::SpawnMemberCustomizer>,
+    ) -> Self {
+        self.spawn_member_customizer = Some(customizer);
+        self
+    }
+
     /// Inject a [`meerkat_client::RealtimeSessionFactory`] for mob-provisioned
     /// members that open a realtime channel (W2-E / issue #264).
     ///
@@ -645,6 +656,7 @@ impl MobBuilder {
             tool_bundles,
             default_llm_client,
             default_external_tools_provider,
+            spawn_member_customizer,
             realtime_session_factory,
         } = self;
         #[cfg(not(feature = "runtime-adapter"))]
@@ -752,6 +764,7 @@ impl MobBuilder {
             tool_bundles,
             default_llm_client,
             default_external_tools_provider,
+            spawn_member_customizer,
             storage.realm_profiles.clone(),
             realtime_session_factory,
         ))
@@ -776,6 +789,7 @@ impl MobBuilder {
             tool_bundles,
             default_llm_client,
             default_external_tools_provider,
+            spawn_member_customizer,
             realtime_session_factory,
         } = self;
         #[cfg(not(feature = "runtime-adapter"))]
@@ -992,6 +1006,7 @@ impl MobBuilder {
                 &tool_bundles,
                 &preview_handle,
                 &default_external_tools_provider,
+                &spawn_member_customizer,
                 storage.realm_profiles.clone(),
             )
             .await?;
@@ -1030,6 +1045,7 @@ impl MobBuilder {
             tool_bundles,
             default_llm_client,
             default_external_tools_provider,
+            spawn_member_customizer,
             storage.realm_profiles.clone(),
             realtime_session_factory,
         ))
@@ -1123,6 +1139,7 @@ impl MobBuilder {
         tool_bundles: &BTreeMap<String, Arc<dyn AgentToolDispatcher>>,
         tool_handle: &MobHandle,
         default_external_tools_provider: &Option<crate::ExternalToolsProvider>,
+        spawn_member_customizer: &Option<Arc<dyn super::SpawnMemberCustomizer>>,
         realm_profile_store: Option<Arc<dyn crate::store::RealmProfileStore>>,
     ) -> Result<(), MobError> {
         let provisioner = MultiBackendProvisioner::new(
@@ -1184,6 +1201,42 @@ impl MobBuilder {
                 );
             };
 
+            let mut restore_spec =
+                super::SpawnMemberSpec::new(entry.role.clone(), entry.agent_identity.clone());
+            restore_spec.runtime_mode = Some(entry.runtime_mode);
+            restore_spec.labels = Some(entry.labels.clone());
+            restore_spec.override_profile = entry.effective_profile_override.clone();
+            if let Some(customizer) = spawn_member_customizer.as_ref() {
+                let ctx = super::SpawnCustomizationContext {
+                    mob_id: definition.id.clone(),
+                    spawn_source: super::SpawnSource::Resume,
+                    spawner_identity: None,
+                    spawner_runtime_id: None,
+                    requested_profile: restore_spec.role_name.clone(),
+                };
+                customizer.customize_spawn(&ctx, &mut restore_spec)?;
+            }
+            if restore_spec.identity != entry.agent_identity {
+                return Err(MobError::Internal(format!(
+                    "spawn customizer cannot change resume restore identity from '{}' to '{}'",
+                    entry.agent_identity, restore_spec.identity
+                )));
+            }
+            if restore_spec.role_name != entry.role {
+                return Err(MobError::Internal(format!(
+                    "spawn customizer cannot change resume restore profile for '{}' from '{}' to '{}'",
+                    entry.agent_identity, entry.role, restore_spec.role_name
+                )));
+            }
+            let restore_profile_override = restore_spec.override_profile.clone();
+            let restore_labels = restore_spec
+                .labels
+                .clone()
+                .unwrap_or_else(|| entry.labels.clone());
+            if let Some(roster_entry) = roster.get_by_identity_mut(&entry.agent_identity) {
+                roster_entry.effective_profile_override = restore_profile_override.clone();
+            }
+
             if matches!(entry.member_ref, MemberRef::Session { .. })
                 && session_service.supports_persistent_sessions()
             {
@@ -1197,14 +1250,25 @@ impl MobBuilder {
                     .await;
                     continue;
                 };
-                // Prefer roster's effective_profile_override on restore for lifecycle safety.
-                let profile = if let Some(ref p) = entry.effective_profile_override {
+                // Prefer customizer/roster effective_profile_override on restore for lifecycle safety.
+                let mut profile = if let Some(ref p) = restore_profile_override {
                     p.clone()
                 } else {
                     definition
                         .resolve_profile(&entry.role, realm_profile_store.as_ref())
                         .await?
                 };
+                if restore_spec.inherited_tool_filter.is_some()
+                    && restore_profile_override.is_none()
+                {
+                    build::open_profile_tool_categories_for_inherited_filter(&mut profile);
+                }
+                if let Some(model) = restore_spec.model_override.clone() {
+                    profile.model = model;
+                }
+                if restore_spec.provider_params_override.is_some() {
+                    profile.provider_params = restore_spec.provider_params_override.clone();
+                }
                 let profile = &profile;
                 let default_ext = default_external_tools_provider.as_ref().and_then(|p| p());
                 let resumed_config =
@@ -1220,14 +1284,16 @@ impl MobBuilder {
                                 tool_bundles,
                                 tool_handle.clone(),
                                 default_ext,
+                                restore_spec.external_tools.clone(),
                                 None,
                             )?,
-                            context: None,
-                            labels: Some(entry.labels.clone()),
-                            additional_instructions: None,
-                            shell_env: None,
+                            context: restore_spec.context.clone(),
+                            labels: Some(restore_labels.clone()),
+                            additional_instructions: restore_spec.additional_instructions.clone(),
+                            shell_env: restore_spec.shell_env.clone(),
                             mob_tool_authority_context: None,
-                            inherited_tool_filter: None,
+                            inherited_tool_filter: restore_spec.inherited_tool_filter.clone(),
+                            system_prompt_override: restore_spec.system_prompt_override.clone(),
                         },
                         expected_session_id: &bridge_session_id,
                         resumed_session: stored_session,
@@ -1242,6 +1308,9 @@ impl MobBuilder {
                 };
                 resumed_config.keep_alive =
                     entry.runtime_mode == crate::MobRuntimeMode::AutonomousHost;
+                if let Some(ref auth_binding) = restore_spec.auth_binding {
+                    resumed_config.auth_binding = Some(auth_binding.clone());
+                }
                 let reconcile_client: Arc<dyn LlmClient> = default_llm_client
                     .clone()
                     .unwrap_or_else(|| Arc::new(meerkat_client::TestClient::default()));
@@ -1251,9 +1320,29 @@ impl MobBuilder {
                     entry.agent_identity, entry.role, definition.id
                 );
                 let req = build::to_create_session_request(&resumed_config, prompt.into());
-                match session_service.create_session(req).await {
-                    Ok(created) => {
-                        let created_bridge_session_id = created.session_id;
+                let peer_name =
+                    format!("{}/{}/{}", definition.id, entry.role, entry.agent_identity);
+                match provisioner
+                    .provision_member(super::provisioner::ProvisionMemberRequest {
+                        create_session: req,
+                        binding: crate::RuntimeBinding::Session,
+                        peer_name,
+                        owner_bridge_session_id: None,
+                        ops_registry: None,
+                    })
+                    .await
+                {
+                    Ok(receipt) => {
+                        let created_bridge_session_id = receipt
+                            .member_ref
+                            .bridge_session_id()
+                            .cloned()
+                            .ok_or_else(|| {
+                                MobError::Internal(format!(
+                                    "resume reconciliation provisioned non-session member for '{}'",
+                                    entry.agent_identity
+                                ))
+                            })?;
                         let _ = roster.set_bridge_session_id(
                             &entry.agent_identity,
                             created_bridge_session_id.clone(),
@@ -1274,9 +1363,22 @@ impl MobBuilder {
                 continue;
                 // Ephemeral services can still fall back to fresh-create.
             }
-            let profile = definition
-                .resolve_profile(&entry.role, realm_profile_store.as_ref())
-                .await?;
+            let mut profile = if let Some(ref p) = restore_profile_override {
+                p.clone()
+            } else {
+                definition
+                    .resolve_profile(&entry.role, realm_profile_store.as_ref())
+                    .await?
+            };
+            if restore_spec.inherited_tool_filter.is_some() && restore_profile_override.is_none() {
+                build::open_profile_tool_categories_for_inherited_filter(&mut profile);
+            }
+            if let Some(model) = restore_spec.model_override.clone() {
+                profile.model = model;
+            }
+            if restore_spec.provider_params_override.is_some() {
+                profile.provider_params = restore_spec.provider_params_override.clone();
+            }
             let default_ext_fresh = default_external_tools_provider.as_ref().and_then(|p| p());
             let mut config = build::build_agent_config(build::BuildAgentConfigParams {
                 mob_id: &definition.id,
@@ -1289,17 +1391,22 @@ impl MobBuilder {
                     tool_bundles,
                     tool_handle.clone(),
                     default_ext_fresh,
+                    restore_spec.external_tools.clone(),
                     None,
                 )?,
-                context: None,
-                labels: None,
-                additional_instructions: None,
-                shell_env: None,
+                context: restore_spec.context.clone(),
+                labels: Some(restore_labels.clone()),
+                additional_instructions: restore_spec.additional_instructions.clone(),
+                shell_env: restore_spec.shell_env.clone(),
                 mob_tool_authority_context: None,
-                inherited_tool_filter: None,
+                inherited_tool_filter: restore_spec.inherited_tool_filter.clone(),
+                system_prompt_override: restore_spec.system_prompt_override.clone(),
             })
             .await?;
             config.keep_alive = entry.runtime_mode == crate::MobRuntimeMode::AutonomousHost;
+            if let Some(ref auth_binding) = restore_spec.auth_binding {
+                config.auth_binding = Some(auth_binding.clone());
+            }
             // Resume reconciliation needs live comms runtimes, but this path is
             // infrastructure restoration and should not consume provider quota.
             // If no explicit override is configured, use the local test client
@@ -1313,8 +1420,26 @@ impl MobBuilder {
                 entry.agent_identity, entry.role, definition.id
             );
             let req = build::to_create_session_request(&config, prompt.into());
-            let created = session_service.create_session(req).await?;
-            let created_bridge_session_id = created.session_id;
+            let peer_name = format!("{}/{}/{}", definition.id, entry.role, entry.agent_identity);
+            let receipt = provisioner
+                .provision_member(super::provisioner::ProvisionMemberRequest {
+                    create_session: req,
+                    binding: crate::RuntimeBinding::Session,
+                    peer_name,
+                    owner_bridge_session_id: None,
+                    ops_registry: None,
+                })
+                .await?;
+            let created_bridge_session_id = receipt
+                .member_ref
+                .bridge_session_id()
+                .cloned()
+                .ok_or_else(|| {
+                    MobError::Internal(format!(
+                        "resume reconciliation provisioned non-session member for '{}'",
+                        entry.agent_identity
+                    ))
+                })?;
             let _ = roster
                 .set_bridge_session_id(&entry.agent_identity, created_bridge_session_id.clone());
             tool_handle
@@ -1603,6 +1728,7 @@ impl MobBuilder {
         tool_bundles: BTreeMap<String, Arc<dyn AgentToolDispatcher>>,
         default_llm_client: Option<Arc<dyn LlmClient>>,
         default_external_tools_provider: Option<crate::ExternalToolsProvider>,
+        spawn_member_customizer: Option<Arc<dyn super::SpawnMemberCustomizer>>,
         realm_profile_store: Option<Arc<dyn crate::store::RealmProfileStore>>,
         realtime_session_factory: Option<Arc<dyn meerkat_client::RealtimeSessionFactory>>,
     ) -> MobHandle {
@@ -1641,6 +1767,7 @@ impl MobBuilder {
             tool_bundles,
             default_llm_client,
             default_external_tools_provider,
+            spawn_member_customizer,
             realm_profile_store,
             realtime_session_factory,
         )
@@ -1658,6 +1785,7 @@ impl MobBuilder {
         tool_bundles: BTreeMap<String, Arc<dyn AgentToolDispatcher>>,
         default_llm_client: Option<Arc<dyn LlmClient>>,
         default_external_tools_provider: Option<crate::ExternalToolsProvider>,
+        spawn_member_customizer: Option<Arc<dyn super::SpawnMemberCustomizer>>,
         realm_profile_store: Option<Arc<dyn crate::store::RealmProfileStore>>,
         realtime_session_factory: Option<Arc<dyn meerkat_client::RealtimeSessionFactory>>,
     ) -> MobHandle {
@@ -1794,6 +1922,7 @@ impl MobBuilder {
             machine_state_watch_tx,
             phase_watch_tx: phase_watch_tx_actor,
             default_external_tools_provider,
+            spawn_member_customizer,
             realm_profile_store,
             composition_binding,
             pending_routed_effects: Vec::new(),

--- a/meerkat-mob/src/runtime/handle.rs
+++ b/meerkat-mob/src/runtime/handle.rs
@@ -852,8 +852,88 @@ impl Drop for MobEventsSubscription {
     }
 }
 
+/// Typed source of a mob member spawn request.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum SpawnSource {
+    Consumer,
+    AgentSpawnMember,
+    HelperSpawn,
+    BatchItem,
+    PolicySpawn,
+    Respawn,
+    Resume,
+    Fork,
+}
+
+impl SpawnSource {
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Consumer => "consumer",
+            Self::AgentSpawnMember => "agent_spawn_member",
+            Self::HelperSpawn => "helper_spawn",
+            Self::BatchItem => "batch_item",
+            Self::PolicySpawn => "policy_spawn",
+            Self::Respawn => "respawn",
+            Self::Resume => "resume",
+            Self::Fork => "fork",
+        }
+    }
+
+    #[must_use]
+    fn for_launch_mode(base: Self, launch_mode: &crate::launch::MemberLaunchMode) -> Self {
+        match launch_mode {
+            crate::launch::MemberLaunchMode::Resume { .. } => Self::Resume,
+            crate::launch::MemberLaunchMode::Fork { .. } => Self::Fork,
+            crate::launch::MemberLaunchMode::Fresh => base,
+        }
+    }
+}
+
+/// Typed system prompt replacement for a single spawn.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum SpawnSystemPromptOverride {
+    Replace(String),
+}
+
+/// Durable identity continuity intent attached to a spawn.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(tag = "type", rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum SpawnContinuityIntent {
+    #[default]
+    Ephemeral,
+    DurableIdentity {
+        continuity_key: String,
+    },
+}
+
+/// Build-boundary context supplied to [`SpawnMemberCustomizer`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct SpawnCustomizationContext {
+    pub mob_id: MobId,
+    pub spawn_source: SpawnSource,
+    pub spawner_identity: Option<AgentIdentity>,
+    pub spawner_runtime_id: Option<AgentRuntimeId>,
+    pub requested_profile: ProfileName,
+}
+
+/// Narrow pre-build mutator for per-spawn construction inputs.
+pub trait SpawnMemberCustomizer: Send + Sync {
+    fn customize_spawn(
+        &self,
+        ctx: &SpawnCustomizationContext,
+        spec: &mut SpawnMemberSpec,
+    ) -> Result<(), MobError>;
+}
+
 /// Spawn request for first-class batch member provisioning.
-#[derive(Clone, Debug)]
+#[derive(Clone)]
 #[non_exhaustive]
 pub struct SpawnMemberSpec {
     /// The role name (profile key) for this member in the mob roster.
@@ -915,6 +995,41 @@ pub struct SpawnMemberSpec {
     /// provide binding authority; build paths that require a binding must reject
     /// the spawn instead of promoting an ambient fallback.
     pub auth_binding: Option<meerkat_core::AuthBindingRef>,
+    /// Per-spawn external tool overlay. In-process only and not persisted.
+    pub external_tools: Option<Arc<dyn AgentToolDispatcher>>,
+    /// Typed prompt replacement for this spawn.
+    pub system_prompt_override: Option<SpawnSystemPromptOverride>,
+    /// Explicit helper/member continuity intent.
+    pub continuity_intent: SpawnContinuityIntent,
+}
+
+impl std::fmt::Debug for SpawnMemberSpec {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SpawnMemberSpec")
+            .field("role_name", &self.role_name)
+            .field("identity", &self.identity)
+            .field("initial_message", &self.initial_message)
+            .field("runtime_mode", &self.runtime_mode)
+            .field("backend", &self.backend)
+            .field("binding", &self.binding)
+            .field("context", &self.context)
+            .field("labels", &self.labels)
+            .field("launch_mode", &self.launch_mode)
+            .field("tool_access_policy", &self.tool_access_policy)
+            .field("budget_split_policy", &self.budget_split_policy)
+            .field("auto_wire_parent", &self.auto_wire_parent)
+            .field("additional_instructions", &self.additional_instructions)
+            .field("shell_env", &self.shell_env)
+            .field("inherited_tool_filter", &self.inherited_tool_filter)
+            .field("override_profile", &self.override_profile)
+            .field("model_override", &self.model_override)
+            .field("provider_params_override", &self.provider_params_override)
+            .field("auth_binding", &self.auth_binding)
+            .field("external_tools", &self.external_tools.is_some())
+            .field("system_prompt_override", &self.system_prompt_override)
+            .field("continuity_intent", &self.continuity_intent)
+            .finish()
+    }
 }
 
 impl SpawnMemberSpec {
@@ -939,6 +1054,9 @@ impl SpawnMemberSpec {
             model_override: None,
             provider_params_override: None,
             auth_binding: None,
+            external_tools: None,
+            system_prompt_override: None,
+            continuity_intent: SpawnContinuityIntent::Ephemeral,
         }
     }
 
@@ -1328,6 +1446,7 @@ impl MobHandle {
             }
             MobMachineCommand::Spawn {
                 spec,
+                spawn_source,
                 owner_context,
             } => {
                 let (owner_bridge_session_id, ops_registry) = match owner_context {
@@ -1337,6 +1456,7 @@ impl MobHandle {
                 let receipt = self
                     .send_actor_command(|reply_tx| MobCommand::Spawn {
                         spec,
+                        spawn_source,
                         owner_bridge_session_id,
                         ops_registry,
                         reply_tx,
@@ -2346,9 +2466,20 @@ impl MobHandle {
         &self,
         spec: SpawnMemberSpec,
     ) -> Result<MemberRef, MobError> {
+        self.spawn_spec_internal_with_source(spec, SpawnSource::Consumer)
+            .await
+    }
+
+    pub(crate) async fn spawn_spec_internal_with_source(
+        &self,
+        spec: SpawnMemberSpec,
+        spawn_source: SpawnSource,
+    ) -> Result<MemberRef, MobError> {
+        let spawn_source = SpawnSource::for_launch_mode(spawn_source, &spec.launch_mode);
         match self
             .execute_machine_command(MobMachineCommand::Spawn {
                 spec: Box::new(spec),
+                spawn_source,
                 owner_context: None,
             })
             .await?
@@ -2365,8 +2496,23 @@ impl MobHandle {
         spec: SpawnMemberSpec,
         owner_context: CanonicalOpsOwnerContext,
     ) -> Result<MemberSpawnReceipt, MobError> {
+        self.spawn_spec_receipt_with_owner_context_and_source(
+            spec,
+            owner_context,
+            SpawnSource::AgentSpawnMember,
+        )
+        .await
+    }
+
+    pub(super) async fn spawn_spec_receipt_with_owner_context_and_source(
+        &self,
+        spec: SpawnMemberSpec,
+        owner_context: CanonicalOpsOwnerContext,
+        spawn_source: SpawnSource,
+    ) -> Result<MemberSpawnReceipt, MobError> {
         match self
             .execute_machine_command(MobMachineCommand::Spawn {
+                spawn_source: SpawnSource::for_launch_mode(spawn_source, &spec.launch_mode),
                 spec: Box::new(spec),
                 owner_context: Some(owner_context),
             })
@@ -2386,7 +2532,22 @@ impl MobHandle {
         &self,
         specs: Vec<SpawnMemberSpec>,
     ) -> Vec<Result<SpawnResult, MobError>> {
-        futures::future::join_all(specs.into_iter().map(|spec| self.spawn_spec(spec))).await
+        futures::future::join_all(specs.into_iter().map(|spec| async move {
+            let identity = spec.identity.clone();
+            self.spawn_spec_internal_with_source(spec, SpawnSource::BatchItem)
+                .await?;
+            let entry = self.get_member(&identity).await.ok_or_else(|| {
+                MobError::Internal(format!(
+                    "spawn succeeded but roster entry missing for '{identity}'"
+                ))
+            })?;
+            Ok(SpawnResult {
+                agent_identity: entry.agent_identity,
+                agent_runtime_id: entry.agent_runtime_id,
+                fence_token: entry.fence_token,
+            })
+        }))
+        .await
     }
 
     pub(super) async fn spawn_many_receipts_with_owner_context(
@@ -2394,11 +2555,13 @@ impl MobHandle {
         specs: Vec<SpawnMemberSpec>,
         owner_context: CanonicalOpsOwnerContext,
     ) -> Vec<Result<MemberSpawnReceipt, MobError>> {
-        futures::future::join_all(
-            specs.into_iter().map(|spec| {
-                self.spawn_spec_receipt_with_owner_context(spec, owner_context.clone())
-            }),
-        )
+        futures::future::join_all(specs.into_iter().map(|spec| {
+            self.spawn_spec_receipt_with_owner_context_and_source(
+                spec,
+                owner_context.clone(),
+                SpawnSource::BatchItem,
+            )
+        }))
         .await
     }
 
@@ -3758,7 +3921,8 @@ impl MobHandle {
         spec.provider_params_override = options.provider_params_override;
         spec.auto_wire_parent = true;
 
-        self.spawn_spec(spec).await?;
+        self.spawn_spec_internal_with_source(spec, SpawnSource::HelperSpawn)
+            .await?;
         let helper_snapshot = self.member_status(&identity).await?;
         let _ = self.retire(identity).await;
 
@@ -3812,7 +3976,8 @@ impl MobHandle {
             fork_context,
         };
 
-        self.spawn_spec(spec).await?;
+        self.spawn_spec_internal_with_source(spec, SpawnSource::Fork)
+            .await?;
         let helper_snapshot = self.member_status(&identity).await?;
         let _ = self.retire(identity).await;
 
@@ -4182,5 +4347,37 @@ mod tests {
 
         assert_eq!(spec.launch_mode.resume_bridge_session_id(), Some(&sid));
         assert_eq!(spec.launch_mode.resume_bridge_session_id(), Some(&sid));
+    }
+
+    #[test]
+    fn spawn_source_launch_mode_classification_is_surface_independent() {
+        let sid = SessionId::new();
+        let resume = crate::launch::MemberLaunchMode::Resume {
+            bridge_session_id: sid,
+        };
+        let fork = crate::launch::MemberLaunchMode::Fork {
+            source_member_id: MeerkatId::from("lead-1"),
+            fork_context: crate::launch::ForkContext::LastMessages { count: 1 },
+        };
+
+        assert_eq!(
+            SpawnSource::for_launch_mode(SpawnSource::Consumer, &resume),
+            SpawnSource::Resume
+        );
+        assert_eq!(
+            SpawnSource::for_launch_mode(SpawnSource::AgentSpawnMember, &resume),
+            SpawnSource::Resume
+        );
+        assert_eq!(
+            SpawnSource::for_launch_mode(SpawnSource::BatchItem, &fork),
+            SpawnSource::Fork
+        );
+        assert_eq!(
+            SpawnSource::for_launch_mode(
+                SpawnSource::AgentSpawnMember,
+                &crate::launch::MemberLaunchMode::Fresh,
+            ),
+            SpawnSource::AgentSpawnMember
+        );
     }
 }

--- a/meerkat-mob/src/runtime/mod.rs
+++ b/meerkat-mob/src/runtime/mod.rs
@@ -128,8 +128,9 @@ pub use handle::{
     MobDestroyReport, MobEventsSubscription, MobEventsSubscriptionConfig, MobEventsView, MobHandle,
     MobMemberListEntry, MobMemberSnapshot, MobMemberStatus, MobPeerConnectivitySnapshot,
     MobRespawnError, MobUnreachablePeer, MobWireMembersBatchReport, PeerMessageReceipt, PeerTarget,
-    PreviousMemberCleanupReport, SpawnMemberSpec, SpawnResult, SupervisorRotationReport,
-    WorkDeliveryReceipt,
+    PreviousMemberCleanupReport, SpawnContinuityIntent, SpawnCustomizationContext,
+    SpawnMemberCustomizer, SpawnMemberSpec, SpawnResult, SpawnSource, SpawnSystemPromptOverride,
+    SupervisorRotationReport, WorkDeliveryReceipt,
 };
 use pending_spawn_lineage::{PendingSpawnInsertImpact, PendingSpawnLineage};
 pub use reconcile::{

--- a/meerkat-mob/src/runtime/state.rs
+++ b/meerkat-mob/src/runtime/state.rs
@@ -166,6 +166,7 @@ pub(super) struct SubmitWorkPayload {
 pub(super) enum MobCommand {
     Spawn {
         spec: Box<super::handle::SpawnMemberSpec>,
+        spawn_source: super::handle::SpawnSource,
         owner_bridge_session_id: Option<SessionId>,
         ops_registry: Option<Arc<dyn meerkat_core::ops_lifecycle::OpsLifecycleRegistry>>,
         reply_tx: oneshot::Sender<Result<super::handle::MemberSpawnReceipt, MobError>>,

--- a/meerkat-mob/src/runtime/tests.rs
+++ b/meerkat-mob/src/runtime/tests.rs
@@ -575,6 +575,7 @@ struct CreateSessionRecord {
     initial_turn: meerkat_core::service::InitialTurnPolicy,
     comms_name: Option<String>,
     peer_meta_labels: BTreeMap<String, String>,
+    runtime_build_mode_session_owned: bool,
 }
 
 /// A mock session service that creates sessions with mock comms runtimes.
@@ -1233,6 +1234,12 @@ impl SessionService for MockSessionService {
                     .as_ref()
                     .and_then(|build| build.comms_name.clone()),
                 peer_meta_labels,
+                runtime_build_mode_session_owned: req.build.as_ref().is_some_and(|build| {
+                    matches!(
+                        build.runtime_build_mode,
+                        meerkat_core::runtime_epoch::RuntimeBuildMode::SessionOwned(_)
+                    )
+                }),
             });
 
         // Record the prompt for test inspection
@@ -9937,6 +9944,7 @@ async fn profile_tools_mcp_allowlist_scopes_default_external_tools() {
         handle.clone(),
         Some(host_mcp_dispatcher),
         None,
+        None,
     )
     .expect("compose dispatcher")
     .expect("dispatcher should mount when default_external_tools is provided");
@@ -10012,6 +10020,7 @@ async fn profile_tools_mcp_empty_passes_all_default_external_tools() {
         handle.clone(),
         Some(host_mcp_dispatcher),
         None,
+        None,
     )
     .expect("compose dispatcher")
     .expect("dispatcher should mount when default_external_tools is provided");
@@ -10050,6 +10059,7 @@ async fn profile_tools_mob_true_grants_operator_dispatcher_without_persisted_aut
         profile,
         &BTreeMap::new(),
         handle.clone(),
+        None,
         None,
         None,
     )
@@ -10099,6 +10109,7 @@ async fn profile_tools_mob_false_keeps_operator_dispatcher_off() {
         handle.clone(),
         None,
         None,
+        None,
     )
     .expect("compose dispatcher");
 
@@ -10137,6 +10148,7 @@ async fn test_visible_mob_operator_reads_still_require_exact_scope() {
         profile,
         &BTreeMap::new(),
         handle.clone(),
+        None,
         None,
         Some(
             meerkat_core::service::MobToolAuthorityContext::new(
@@ -10186,6 +10198,7 @@ async fn test_visible_mob_operator_tools_deny_before_arg_validation_when_scope_m
         &BTreeMap::new(),
         handle.clone(),
         None,
+        None,
         Some(
             meerkat_core::service::MobToolAuthorityContext::new(
                 meerkat_core::service::OpaquePrincipalToken::new("out-of-scope"),
@@ -10224,6 +10237,7 @@ async fn test_visible_mob_operator_tools_emit_identity_native_member_payloads() 
         profile,
         &BTreeMap::new(),
         handle.clone(),
+        None,
         None,
         Some(
             meerkat_core::service::MobToolAuthorityContext::new(
@@ -12685,6 +12699,7 @@ async fn test_build_resumed_agent_config_rejects_mismatched_session_identity() {
                 shell_env: None,
                 mob_tool_authority_context: None,
                 inherited_tool_filter: None,
+                system_prompt_override: None,
             },
             expected_session_id: &wrong_session_id,
             resumed_session: resumed,
@@ -27996,6 +28011,115 @@ async fn test_external_tools_provider_called_per_spawn() {
 }
 
 #[tokio::test]
+async fn test_per_spawn_external_tools_compose_with_profile_and_default_tools() {
+    let provider: crate::ExternalToolsProvider = Arc::new(|| {
+        Some(
+            Arc::new(MultiToolDispatcher::new(&["default_only", "shared_tool"]))
+                as Arc<dyn AgentToolDispatcher>,
+        )
+    });
+
+    let mut definition = sample_definition();
+    definition
+        .profiles
+        .get_mut(&ProfileName::from("worker"))
+        .and_then(|binding| binding.as_inline_mut())
+        .expect("worker profile")
+        .tools
+        .rust_bundles = vec!["profile-bundle".to_string()];
+
+    let service = Arc::new(MockSessionService::new());
+    let _ = service.enable_runtime_adapter();
+    let handle = MobBuilder::new(definition, MobStorage::in_memory())
+        .with_session_service(service.clone())
+        .register_tool_bundle(
+            "profile-bundle",
+            Arc::new(MultiToolDispatcher::new(&["profile_only", "shared_tool"])),
+        )
+        .with_default_external_tools_provider(Some(provider))
+        .create()
+        .await
+        .expect("create mob");
+
+    let mut spec = SpawnMemberSpec::new("worker", "w-per-spawn");
+    spec.external_tools = Some(Arc::new(MultiToolDispatcher::new(&[
+        "spawn_only",
+        "shared_tool",
+    ])));
+    let spawned = handle.spawn_spec(spec).await.expect("spawn");
+    let session_id = handle
+        .resolve_bridge_session_id(&spawned.agent_identity)
+        .await
+        .expect("bridge session id");
+
+    let tool_names = service.external_tool_names(&session_id).await;
+    assert!(tool_names.contains(&"profile_only".to_string()));
+    assert!(tool_names.contains(&"spawn_only".to_string()));
+    assert!(tool_names.contains(&"default_only".to_string()));
+
+    let shared_count = tool_names
+        .iter()
+        .filter(|name| name.as_str() == "shared_tool")
+        .count();
+    assert_eq!(
+        shared_count, 1,
+        "profile > per-spawn > default collision order must expose one deterministic shared_tool"
+    );
+}
+
+#[tokio::test]
+async fn test_per_spawn_external_tools_are_not_restored_from_storage() {
+    let definition = sample_definition();
+    let service = Arc::new(MockSessionService::new());
+    let _ = service.enable_runtime_adapter();
+    let storage = MobStorage::in_memory();
+    let events = storage.events.clone();
+    let runtime_metadata = storage.runtime_metadata.clone();
+    let handle = MobBuilder::new(definition.clone(), storage)
+        .with_session_service(service.clone())
+        .create()
+        .await
+        .expect("create mob");
+
+    let mut spec = SpawnMemberSpec::new("worker", "w-live-dispatcher");
+    spec.external_tools = Some(Arc::new(MultiToolDispatcher::new(&["live_only"])));
+    let spawned = handle.spawn_spec(spec).await.expect("spawn");
+    let old_session_id = handle
+        .resolve_bridge_session_id(&spawned.agent_identity)
+        .await
+        .expect("old bridge session");
+    assert!(
+        service
+            .external_tool_names(&old_session_id)
+            .await
+            .contains(&"live_only".to_string()),
+        "live per-spawn dispatcher should be installed on the original create"
+    );
+
+    handle.stop().await.expect("stop");
+    service
+        .archive(&old_session_id)
+        .await
+        .expect("archive session");
+
+    let _resumed = MobBuilder::for_resume(MobStorage::with_events_and_runtime_metadata(
+        events,
+        runtime_metadata,
+    ))
+    .with_session_service(service.clone())
+    .resume()
+    .await
+    .expect("resume");
+
+    let flags = service.recorded_external_tools_flags().await;
+    assert_eq!(
+        flags.last().copied(),
+        Some(false),
+        "per-spawn trait-object dispatchers must be supplied again by the upper layer on restore"
+    );
+}
+
+#[tokio::test]
 async fn test_external_tools_name_collision_profile_wins() {
     // Provider returns a dispatcher with tool "spawn_member". When
     // profile.tools.mob = true, the canonical resolver mounts the mob-owned
@@ -28049,6 +28173,548 @@ async fn test_external_tools_name_collision_profile_wins() {
         .dispatch_external_tool_outcome(&session_id, "spawn_member", raw_args)
         .await
         .expect("mob-owned spawn_member should win and use generated definition-profile scope");
+}
+
+#[tokio::test]
+async fn test_default_helper_spawns_remain_ephemeral() {
+    let definition = sample_definition();
+    let service = Arc::new(MockSessionService::new());
+    let _ = service.enable_runtime_adapter();
+    let handle = MobBuilder::new(definition, MobStorage::in_memory())
+        .with_session_service(service)
+        .create()
+        .await
+        .expect("create mob");
+
+    handle
+        .spawn_helper(
+            AgentIdentity::from("helper-ephemeral"),
+            "short helper task",
+            HelperOptions {
+                role_name: Some(ProfileName::from("worker")),
+                runtime_mode: Some(crate::MobRuntimeMode::TurnDriven),
+                ..HelperOptions::default()
+            },
+        )
+        .await
+        .expect("helper spawn");
+
+    let events = handle.events().replay_all().await.expect("events");
+    let helper_spawn = events
+        .iter()
+        .filter_map(|event| event.kind.member_spawned())
+        .find(|spawn| spawn.agent_identity.as_str() == "helper-ephemeral")
+        .expect("helper spawn event");
+    assert_eq!(
+        helper_spawn.continuity_intent,
+        SpawnContinuityIntent::Ephemeral,
+        "helpers must not become durable unless a customizer explicitly promotes them"
+    );
+}
+
+#[derive(Clone)]
+struct RecordingSpawnCustomizer {
+    calls: Arc<Mutex<Vec<SpawnCustomizationContext>>>,
+}
+
+impl RecordingSpawnCustomizer {
+    fn new() -> Self {
+        Self {
+            calls: Arc::new(Mutex::new(Vec::new())),
+        }
+    }
+
+    fn calls(&self) -> Vec<SpawnCustomizationContext> {
+        self.calls.lock().expect("customizer calls").clone()
+    }
+}
+
+impl SpawnMemberCustomizer for RecordingSpawnCustomizer {
+    fn customize_spawn(
+        &self,
+        ctx: &SpawnCustomizationContext,
+        spec: &mut SpawnMemberSpec,
+    ) -> Result<(), MobError> {
+        self.calls
+            .lock()
+            .expect("customizer calls")
+            .push(ctx.clone());
+        spec.labels.get_or_insert_with(BTreeMap::new).insert(
+            "customized".to_string(),
+            ctx.spawn_source.as_str().to_string(),
+        );
+        let tool_name = format!("customizer_{}", ctx.spawn_source.as_str());
+        spec.external_tools = Some(Arc::new(MultiToolDispatcher::new(&[tool_name.as_str()])));
+        spec.system_prompt_override = Some(SpawnSystemPromptOverride::Replace(format!(
+            "custom prompt for {}",
+            ctx.spawn_source.as_str()
+        )));
+        if ctx.spawn_source == SpawnSource::HelperSpawn {
+            spec.continuity_intent = SpawnContinuityIntent::DurableIdentity {
+                continuity_key: format!("helper/{}", spec.identity),
+            };
+        }
+        Ok(())
+    }
+}
+
+#[derive(Clone)]
+struct ResumeAddressabilityCustomizer {
+    calls: Arc<Mutex<Vec<SpawnCustomizationContext>>>,
+    override_profile: Profile,
+}
+
+impl ResumeAddressabilityCustomizer {
+    fn new(override_profile: Profile) -> Self {
+        Self {
+            calls: Arc::new(Mutex::new(Vec::new())),
+            override_profile,
+        }
+    }
+
+    fn calls(&self) -> Vec<SpawnCustomizationContext> {
+        self.calls.lock().expect("resume customizer calls").clone()
+    }
+}
+
+impl SpawnMemberCustomizer for ResumeAddressabilityCustomizer {
+    fn customize_spawn(
+        &self,
+        ctx: &SpawnCustomizationContext,
+        spec: &mut SpawnMemberSpec,
+    ) -> Result<(), MobError> {
+        self.calls
+            .lock()
+            .expect("resume customizer calls")
+            .push(ctx.clone());
+        if ctx.spawn_source == SpawnSource::Resume {
+            spec.override_profile = Some(self.override_profile.clone());
+            spec.external_tools = Some(Arc::new(MultiToolDispatcher::new(&["customizer_resume"])));
+        }
+        Ok(())
+    }
+}
+
+#[tokio::test]
+async fn test_spawn_member_customizer_fires_with_source_and_spawner_provenance() {
+    let customizer = RecordingSpawnCustomizer::new();
+    let definition = sample_definition_with_mob_tools();
+    let service = Arc::new(MockSessionService::new());
+    let _ = service.enable_runtime_adapter();
+    let handle = MobBuilder::new(definition, MobStorage::in_memory())
+        .with_session_service(service.clone())
+        .with_spawn_member_customizer(Arc::new(customizer.clone()))
+        .create()
+        .await
+        .expect("create mob");
+
+    let lead_ref = handle
+        .spawn_spec(SpawnMemberSpec::new("lead", "lead-1"))
+        .await
+        .expect("spawn root");
+    let lead_session_id = handle
+        .resolve_bridge_session_id(&lead_ref.agent_identity)
+        .await
+        .expect("lead bridge session");
+
+    let worker_spec = SpawnMemberSpec::new("worker", "worker-agent-tool");
+    handle
+        .spawn_spec_receipt_with_owner_context(
+            worker_spec,
+            super::handle::CanonicalOpsOwnerContext {
+                owner_bridge_session_id: lead_session_id.clone(),
+                ops_registry: Arc::new(meerkat_runtime::RuntimeOpsLifecycleRegistry::new()),
+            },
+        )
+        .await
+        .expect("agent spawn_member");
+
+    let mut batch = handle
+        .spawn_many(vec![
+            SpawnMemberSpec::new("worker", "batch-a"),
+            SpawnMemberSpec::new("worker", "batch-b"),
+        ])
+        .await;
+    assert!(batch.drain(..).all(|result| result.is_ok()));
+
+    handle
+        .spawn_helper(
+            AgentIdentity::from("helper-promoted"),
+            "do helper work",
+            HelperOptions {
+                role_name: Some(ProfileName::from("worker")),
+                runtime_mode: Some(crate::MobRuntimeMode::TurnDriven),
+                ..HelperOptions::default()
+            },
+        )
+        .await
+        .expect("helper spawn");
+    handle
+        .fork_helper(
+            &AgentIdentity::from("lead-1"),
+            AgentIdentity::from("fork-helper"),
+            "do forked helper work",
+            crate::launch::ForkContext::LastMessages { count: 1 },
+            HelperOptions {
+                role_name: Some(ProfileName::from("worker")),
+                runtime_mode: Some(crate::MobRuntimeMode::TurnDriven),
+                ..HelperOptions::default()
+            },
+        )
+        .await
+        .expect("fork helper spawn");
+
+    let calls = customizer.calls();
+    assert!(
+        calls
+            .iter()
+            .any(|ctx| ctx.spawn_source == SpawnSource::Consumer
+                && ctx.spawner_identity.is_none()
+                && ctx.requested_profile.as_str() == "lead"),
+        "root spawn must be customized as Consumer without spawner provenance"
+    );
+    assert!(
+        calls
+            .iter()
+            .any(|ctx| ctx.spawn_source == SpawnSource::AgentSpawnMember
+                && ctx.spawner_identity.as_ref() == Some(&AgentIdentity::from("lead-1"))
+                && ctx
+                    .spawner_runtime_id
+                    .as_ref()
+                    .is_some_and(|id| id.identity.as_str() == "lead-1")),
+        "agent spawn_member must carry typed spawning-agent identity/runtime provenance"
+    );
+    assert!(
+        calls
+            .iter()
+            .filter(|ctx| ctx.spawn_source == SpawnSource::BatchItem)
+            .count()
+            >= 2,
+        "spawn_many items must be customized as BatchItem"
+    );
+    assert!(
+        calls
+            .iter()
+            .any(|ctx| ctx.spawn_source == SpawnSource::HelperSpawn),
+        "spawn_helper must be customized as HelperSpawn"
+    );
+    assert!(
+        calls
+            .iter()
+            .any(|ctx| ctx.spawn_source == SpawnSource::Fork),
+        "fork launch-mode spawns must be customized as Fork"
+    );
+
+    let root_labels = handle
+        .get_member(&AgentIdentity::from("lead-1"))
+        .await
+        .expect("lead roster entry")
+        .labels;
+    assert_eq!(
+        root_labels.get("customized").map(String::as_str),
+        Some("consumer"),
+        "customizer mutations must land in the created member"
+    );
+    assert!(
+        service
+            .external_tool_names(&lead_session_id)
+            .await
+            .contains(&"customizer_consumer".to_string()),
+        "customizer-attached external tools must reach the created session"
+    );
+    let lead_session = service
+        .live_session_clone(&lead_session_id)
+        .await
+        .expect("lead live session");
+    assert!(
+        matches!(
+            lead_session.messages().first(),
+            Some(Message::System(system)) if system.content == "custom prompt for consumer"
+        ),
+        "customizer system_prompt_override must reach the created session"
+    );
+
+    let events = handle.events().replay_all().await.expect("events");
+    let helper_spawn = events
+        .iter()
+        .filter_map(|event| event.kind.member_spawned())
+        .find(|spawn| spawn.agent_identity.as_str() == "helper-promoted")
+        .expect("helper spawn event");
+    assert_eq!(
+        helper_spawn.continuity_intent,
+        SpawnContinuityIntent::DurableIdentity {
+            continuity_key: "helper/helper-promoted".to_string(),
+        },
+        "promoted helper continuity intent must survive spawn finalization"
+    );
+}
+
+#[tokio::test]
+async fn test_resume_reconciliation_runs_spawn_customizer_for_missing_session_rebuild() {
+    let definition = sample_definition();
+    let mut override_profile = definition
+        .profiles
+        .get(&ProfileName::from("worker"))
+        .expect("worker profile")
+        .as_inline()
+        .expect("worker profile should be inline")
+        .clone();
+    override_profile.external_addressable = true;
+    let customizer = ResumeAddressabilityCustomizer::new(override_profile);
+    let service = Arc::new(MockSessionService::new());
+    let _ = service.enable_runtime_adapter();
+    let storage = MobStorage::in_memory();
+    let events = storage.events.clone();
+    let runtime_metadata = storage.runtime_metadata.clone();
+    let handle = MobBuilder::new(definition, storage)
+        .with_session_service(service.clone())
+        .create()
+        .await
+        .expect("create mob");
+
+    let spawned = handle
+        .spawn_spec(SpawnMemberSpec::new("worker", "resume-reconcile-member"))
+        .await
+        .expect("spawn");
+    let session_id = handle
+        .resolve_bridge_session_id(&spawned.agent_identity)
+        .await
+        .expect("bridge session");
+    service
+        .archive(&session_id)
+        .await
+        .expect("archive live session before resume reconciliation");
+
+    let resumed = MobBuilder::for_resume(MobStorage::with_events_and_runtime_metadata(
+        events,
+        runtime_metadata,
+    ))
+    .with_session_service(service.clone())
+    .with_spawn_member_customizer(Arc::new(customizer.clone()))
+    .resume()
+    .await
+    .expect("resume");
+
+    assert!(
+        customizer
+            .calls()
+            .iter()
+            .any(|ctx| ctx.spawn_source == SpawnSource::Resume
+                && ctx.requested_profile.as_str() == "worker"),
+        "resume reconciliation must call the supplied spawn customizer before rebuilding a missing session"
+    );
+    assert!(
+        service
+            .external_tool_names(&session_id)
+            .await
+            .contains(&"customizer_resume".to_string()),
+        "resume reconciliation must use customizer-supplied external tools on the rebuilt session"
+    );
+    assert!(
+        service
+            .recorded_create_requests()
+            .await
+            .last()
+            .is_some_and(|request| request.runtime_build_mode_session_owned),
+        "resume reconciliation must rebuild through the mob provisioner so runtime bindings are SessionOwned"
+    );
+    let member = resumed
+        .member(&AgentIdentity::from("resume-reconcile-member"))
+        .await
+        .expect("member handle after resume reconciliation");
+    member
+        .send(
+            "external resume hello".to_string(),
+            meerkat_core::types::HandlingMode::Queue,
+        )
+        .await
+        .expect("resume customizer effective profile must seed machine addressability");
+}
+
+struct StaticLeadSpawnPolicy;
+
+#[async_trait]
+impl super::spawn_policy::SpawnPolicy for StaticLeadSpawnPolicy {
+    async fn resolve(&self, _target: &AgentIdentity) -> Option<super::spawn_policy::SpawnSpec> {
+        Some(super::spawn_policy::SpawnSpec {
+            profile: ProfileName::from("lead"),
+            runtime_mode: Some(crate::MobRuntimeMode::TurnDriven),
+        })
+    }
+}
+
+#[derive(Clone)]
+struct PolicyAddressabilityCustomizer {
+    override_profile: Profile,
+}
+
+impl SpawnMemberCustomizer for PolicyAddressabilityCustomizer {
+    fn customize_spawn(
+        &self,
+        ctx: &SpawnCustomizationContext,
+        spec: &mut SpawnMemberSpec,
+    ) -> Result<(), MobError> {
+        if ctx.spawn_source == SpawnSource::PolicySpawn {
+            spec.override_profile = Some(self.override_profile.clone());
+            spec.external_tools = Some(Arc::new(MultiToolDispatcher::new(&[
+                "policy_override_tool",
+            ])));
+        }
+        Ok(())
+    }
+}
+
+#[tokio::test]
+async fn test_policy_auto_spawn_admission_uses_customized_effective_profile() {
+    let definition = sample_definition();
+    let mut override_profile = definition
+        .profiles
+        .get(&ProfileName::from("worker"))
+        .expect("worker profile")
+        .as_inline()
+        .expect("worker profile should be inline")
+        .clone();
+    override_profile.external_addressable = true;
+
+    let service = Arc::new(MockSessionService::new());
+    let _ = service.enable_runtime_adapter();
+    let handle = MobBuilder::new(definition, MobStorage::in_memory())
+        .with_session_service(service.clone())
+        .with_spawn_member_customizer(Arc::new(PolicyAddressabilityCustomizer {
+            override_profile,
+        }))
+        .create()
+        .await
+        .expect("create mob");
+    handle
+        .set_spawn_policy(Some(Arc::new(StaticWorkerSpawnPolicy)))
+        .await
+        .expect("set spawn policy");
+
+    let target = AgentIdentity::from("policy-customized-addressable");
+    handle
+        .submit_work(
+            AgentRuntimeId::initial(target.clone()),
+            FenceToken::new(0),
+            WorkRef::new(),
+            WorkSpec::new(
+                "queued for customized policy spawn".to_string(),
+                WorkOrigin::External,
+            ),
+        )
+        .await
+        .expect("policy auto-spawn admission should use customized effective profile");
+
+    let session_id = handle
+        .resolve_bridge_session_id(&target)
+        .await
+        .expect("policy bridge session");
+    assert!(
+        service
+            .external_tool_names(&session_id)
+            .await
+            .contains(&"policy_override_tool".to_string()),
+        "policy auto-spawn should build from the customized spec after admission"
+    );
+}
+
+#[tokio::test]
+async fn test_spawn_member_customizer_covers_policy_auto_spawn_and_respawn_builds() {
+    let customizer = RecordingSpawnCustomizer::new();
+    let service = Arc::new(MockSessionService::new());
+    let _ = service.enable_runtime_adapter();
+    let handle = MobBuilder::new(sample_definition(), MobStorage::in_memory())
+        .with_session_service(service.clone())
+        .with_spawn_member_customizer(Arc::new(customizer.clone()))
+        .create()
+        .await
+        .expect("create mob");
+
+    let target = AgentIdentity::from("policy-auto");
+    handle
+        .set_spawn_policy(Some(Arc::new(StaticLeadSpawnPolicy)))
+        .await
+        .expect("set spawn policy");
+    handle
+        .submit_work(
+            AgentRuntimeId::initial(target.clone()),
+            FenceToken::new(0),
+            WorkRef::new(),
+            WorkSpec::new("queued for policy spawn".to_string(), WorkOrigin::External),
+        )
+        .await
+        .expect("policy auto-spawn submit work");
+    let policy_session_id = handle
+        .resolve_bridge_session_id(&target)
+        .await
+        .expect("policy bridge session");
+    assert!(
+        service
+            .external_tool_names(&policy_session_id)
+            .await
+            .contains(&"customizer_policy_spawn".to_string()),
+        "policy auto-spawn must apply customizer-attached external tools"
+    );
+    let policy_session = service
+        .live_session_clone(&policy_session_id)
+        .await
+        .expect("policy live session");
+    assert!(
+        matches!(
+            policy_session.messages().first(),
+            Some(Message::System(system)) if system.content == "custom prompt for policy_spawn"
+        ),
+        "policy auto-spawn must apply customizer system prompt replacement"
+    );
+
+    handle
+        .respawn(target.clone(), None)
+        .await
+        .expect("respawn policy member");
+    let respawn_session_id = handle
+        .resolve_bridge_session_id(&target)
+        .await
+        .expect("respawn bridge session");
+    assert_ne!(
+        policy_session_id, respawn_session_id,
+        "respawn should create a replacement session"
+    );
+    assert!(
+        service
+            .external_tool_names(&respawn_session_id)
+            .await
+            .contains(&"customizer_respawn".to_string()),
+        "respawn replacement build must apply customizer-attached external tools"
+    );
+    let respawn_session = service
+        .live_session_clone(&respawn_session_id)
+        .await
+        .expect("respawn live session");
+    assert!(
+        matches!(
+            respawn_session.messages().first(),
+            Some(Message::System(system)) if system.content == "custom prompt for respawn"
+        ),
+        "respawn replacement build must apply customizer system prompt replacement"
+    );
+
+    let calls = customizer.calls();
+    assert!(
+        calls
+            .iter()
+            .any(|ctx| ctx.spawn_source == SpawnSource::PolicySpawn
+                && ctx.spawner_identity.is_none()
+                && ctx.requested_profile.as_str() == "lead"),
+        "policy auto-spawn must be customized with explicit source and no spawner"
+    );
+    assert!(
+        calls
+            .iter()
+            .any(|ctx| ctx.spawn_source == SpawnSource::Respawn
+                && ctx.spawner_identity.is_none()
+                && ctx.requested_profile.as_str() == "lead"),
+        "respawn replacement build must be customized with explicit source and no spawner"
+    );
 }
 
 #[tokio::test]

--- a/meerkat-mob/src/runtime/tools.rs
+++ b/meerkat-mob/src/runtime/tools.rs
@@ -208,6 +208,7 @@ pub(super) fn compose_external_tools_for_profile(
     tool_bundles: &BTreeMap<String, Arc<dyn AgentToolDispatcher>>,
     mob_handle: MobHandle,
     default_external_tools: Option<Arc<dyn AgentToolDispatcher>>,
+    per_spawn_external_tools: Option<Arc<dyn AgentToolDispatcher>>,
     persisted_mob_tool_authority_context: Option<MobToolAuthorityContext>,
 ) -> Result<Option<Arc<dyn AgentToolDispatcher>>, MobError> {
     let mut dispatchers: Vec<Arc<dyn AgentToolDispatcher>> = Vec::new();
@@ -247,13 +248,37 @@ pub(super) fn compose_external_tools_for_profile(
         dispatchers.push(dispatcher);
     }
 
-    // Compose default external tools (e.g. callback tools from SDK) with
-    // name-collision filtering: profile-declared tools always win.
+    // Compose per-spawn and default external tools with deterministic
+    // name-collision filtering: profile-declared tools win over per-spawn
+    // overlays, and per-spawn overlays win over mob-wide defaults.
     //
     // The dispatcher is always included even if it currently reports 0 tools,
     // because it may be dynamic (e.g. CallbackToolDispatcher backed by a shared
     // registry that gets populated later via tools/register). Dropping it here
     // would permanently disconnect the session from late-registered tools.
+    if let Some(ext) = per_spawn_external_tools {
+        let profile_names: HashSet<String> = dispatchers
+            .iter()
+            .flat_map(|d| {
+                d.tools()
+                    .iter()
+                    .map(|t| t.name.to_string())
+                    .collect::<Vec<_>>()
+            })
+            .collect();
+        let collisions: HashSet<String> = ext
+            .tools()
+            .iter()
+            .filter(|t| profile_names.contains(t.name.as_str()))
+            .map(|t| t.name.to_string())
+            .collect();
+        if collisions.is_empty() {
+            dispatchers.push(ext);
+        } else {
+            dispatchers.push(Arc::new(NameFilteredDispatcher::new(ext, collisions)));
+        }
+    }
+
     if let Some(ext) = default_external_tools {
         // Per-profile MCP source scoping: when profile.tools.mcp lists names,
         // restrict MCP-flavored tools from `ext` to those source IDs. Non-MCP


### PR DESCRIPTION
## Summary

Adds a typed Meerkat-mob spawn-boundary customization seam for OB3-style identity-aware spawn construction.

- Adds per-spawn external tool overlays on `SpawnMemberSpec` and composes them deterministically with profile/mob tools and default external tools.
- Adds `SpawnMemberCustomizer`, `SpawnCustomizationContext`, and `SpawnSource`, wired through `MobBuilder` and the actor before agent config construction.
- Adds typed system prompt replacement and keeps required mob runtime skill wiring intact.
- Adds `SpawnContinuityIntent` and emits typed continuity evidence on `MemberSpawnedEvent` so promoted helpers can be recorded by upper layers without Meerkat-mob owning MobKit continuity storage.
- Covers restore behavior: live trait-object dispatchers are not persisted and must be supplied again by the owning upper layer.

## Validation

- `./scripts/repo-cargo check -p meerkat-mob`
- `./scripts/repo-cargo clippy -p meerkat-mob --all-targets --all-features -- -D warnings`
- `./scripts/repo-cargo test -p meerkat-mob external_tools -- --nocapture`
- `./scripts/repo-cargo test -p meerkat-mob customizer -- --nocapture`
- `./scripts/repo-cargo test -p meerkat-mob system_prompt_replace -- --nocapture`
- `./scripts/repo-cargo test -p meerkat-mob member_spawned -- --nocapture`
- `./scripts/repo-cargo test -p meerkat-mob "per_spawn_external_tools" -- --nocapture`
- `./scripts/repo-cargo test -p meerkat-mob "helper_spawns" -- --nocapture`
- Pre-push hooks passed on retry, including changed-crates clippy, machine codegen/verify, generated-header audit, Bazel freshness, and workspace deterministic gate.
