### PR TITLE
[codex] Preload mob task workflow guidance

### DIFF
--- a/meerkat-mob/src/build.rs
+++ b/meerkat-mob/src/build.rs
@@ -32,6 +32,13 @@ fn mob_realm_id(mob_id: &MobId) -> Result<RealmId, MobError> {
     })
 }
 
+fn builtin_skill_key(name: &str) -> meerkat_core::skills::SkillKey {
+    meerkat_core::skills::SkillKey::builtin(
+        meerkat_core::skills::SkillName::parse(name)
+            .expect("mob build preloads only valid builtin skill slugs"),
+    )
+}
+
 /// Derive the effective `(override_mob, authority)` for a profile.
 ///
 /// `profile.tools.mob` is the policy declaration.
@@ -174,16 +181,18 @@ pub async fn build_agent_config(
         None => {}
     }
 
-    // Mob comms instructions are delivered as an embedded skill via
-    // preload_skills. The `skills` feature is required on the meerkat
-    // dependency (enforced in Cargo.toml) so the skill engine is
-    // always available. Skills are appended as extra_sections in
-    // prompt assembly, which survives per-request system_prompt
-    // overrides.
-    config.preload_skills = Some(vec![meerkat_core::skills::SkillKey::builtin(
-        meerkat_core::skills::SkillName::parse("mob-communication")
-            .expect("mob-communication is a valid builtin skill slug"),
-    )]);
+    // Mob comms and task/work coordination instructions are delivered as
+    // embedded skills via preload_skills. The `skills` feature is required on
+    // the meerkat dependency (enforced in Cargo.toml) so the skill engine is
+    // always available. Skills are appended as extra_sections in prompt
+    // assembly, which survives per-request system_prompt overrides.
+    let mut preload_skills = vec![builtin_skill_key("mob-communication")];
+    if profile.tools.workgraph {
+        preload_skills.push(builtin_skill_key("workgraph-workflow"));
+    } else if profile.tools.builtins {
+        preload_skills.push(builtin_skill_key("task-workflow"));
+    }
+    config.preload_skills = Some(preload_skills);
 
     // Mob lifecycle notifications are typed at peer ingress. Do not rely on
     // silent_comms_intents string matching for canonical routing.
@@ -447,8 +456,56 @@ mod tests {
     use super::*;
     use crate::definition::{BackendConfig, MobDefinition, OrchestratorConfig, WiringRules};
     use crate::profile::{ProfileBinding, ToolConfig};
+    use async_trait::async_trait;
+    use meerkat_client::{LlmClient, LlmEvent, LlmRequest, TestClient};
     use std::collections::{BTreeMap, BTreeSet};
     use std::fs;
+    use std::pin::Pin;
+    use std::sync::{Arc, Mutex};
+
+    #[derive(Default)]
+    struct CaptureClient {
+        inner: TestClient,
+        seen_tools: Mutex<Vec<String>>,
+    }
+
+    impl CaptureClient {
+        fn tool_names(&self) -> Vec<String> {
+            self.seen_tools.lock().expect("capture lock").clone()
+        }
+    }
+
+    #[async_trait]
+    impl LlmClient for CaptureClient {
+        fn project_replay_messages(
+            &self,
+            messages: &[meerkat_core::Message],
+        ) -> Result<Vec<meerkat_core::Message>, meerkat_client::LlmError> {
+            Ok(messages.to_vec())
+        }
+
+        fn stream<'a>(
+            &'a self,
+            request: &'a LlmRequest,
+        ) -> Pin<
+            Box<dyn futures::Stream<Item = Result<LlmEvent, meerkat_client::LlmError>> + Send + 'a>,
+        > {
+            *self.seen_tools.lock().expect("capture lock") = request
+                .tools
+                .iter()
+                .map(|tool| tool.name.to_string())
+                .collect();
+            self.inner.stream(request)
+        }
+
+        fn provider(&self) -> &'static str {
+            self.inner.provider()
+        }
+
+        async fn health_check(&self) -> Result<(), meerkat_client::LlmError> {
+            self.inner.health_check().await
+        }
+    }
 
     fn sample_definition() -> MobDefinition {
         let mut profiles = BTreeMap::new();
@@ -825,6 +882,64 @@ mod tests {
         assert_eq!(
             config.override_mob,
             meerkat_core::ToolCategoryOverride::Disable
+        );
+    }
+
+    #[tokio::test]
+    async fn profile_workgraph_does_not_displace_builtin_task_tools_in_agent_build() {
+        let temp = tempfile::tempdir().unwrap();
+        let def = sample_definition();
+        let lead = def.profiles[&ProfileName::from("lead")]
+            .as_inline()
+            .unwrap();
+        let capture = Arc::new(CaptureClient::default());
+        let mut config = build_agent_config(BuildAgentConfigParams {
+            mob_id: &def.id,
+            profile_name: &ProfileName::from("lead"),
+            agent_identity: &MeerkatId::from("lead-1"),
+            profile: lead,
+            definition: &def,
+            external_tools: None,
+            context: None,
+            labels: None,
+            additional_instructions: None,
+            shell_env: None,
+            mob_tool_authority_context: None,
+            inherited_tool_filter: None,
+            system_prompt_override: None,
+        })
+        .await
+        .expect("build_agent_config");
+        config.llm_client_override = Some(capture.clone());
+
+        let factory = meerkat::AgentFactory::new(temp.path().join("sessions"))
+            .builtins(false)
+            .workgraph(false);
+        let mut agent = factory
+            .build_agent(config, &meerkat_core::Config::default())
+            .await
+            .expect("build agent from mob profile");
+        agent
+            .run("inspect tools".to_string().into())
+            .await
+            .expect("run agent");
+
+        let tool_names = capture.tool_names();
+        assert!(
+            tool_names.iter().any(|name| name == "task_create"),
+            "profile tools.builtins=true must keep builtin task tools visible; saw {tool_names:?}"
+        );
+        assert!(
+            tool_names.iter().any(|name| name == "task_list"),
+            "profile tools.builtins=true must keep builtin task list visible; saw {tool_names:?}"
+        );
+        assert!(
+            tool_names.iter().any(|name| name == "workgraph_create"),
+            "profile tools.workgraph=true must expose WorkGraph tools; saw {tool_names:?}"
+        );
+        assert!(
+            tool_names.iter().any(|name| name == "workgraph_ready"),
+            "profile tools.workgraph=true must expose WorkGraph readiness; saw {tool_names:?}"
         );
     }
 
@@ -1420,6 +1535,54 @@ mod tests {
                 .iter()
                 .any(|id| id.skill_name.as_str() == "mob-communication"),
             "preload_skills should include mob-communication"
+        );
+        assert!(
+            preload
+                .iter()
+                .any(|id| id.skill_name.as_str() == "workgraph-workflow"),
+            "WorkGraph-capable profiles should preload WorkGraph operating rules"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_build_agent_config_preloads_task_workflow_when_workgraph_absent() {
+        let def = sample_definition();
+        let worker = def.profiles[&ProfileName::from("worker")]
+            .as_inline()
+            .unwrap();
+        let config = build_agent_config(BuildAgentConfigParams {
+            mob_id: &def.id,
+            profile_name: &ProfileName::from("worker"),
+            agent_identity: &MeerkatId::from("w-1"),
+            profile: worker,
+            definition: &def,
+            external_tools: None,
+            context: None,
+            labels: None,
+            additional_instructions: None,
+            shell_env: None,
+            mob_tool_authority_context: None,
+            inherited_tool_filter: None,
+            system_prompt_override: None,
+        })
+        .await
+        .expect("build_agent_config");
+
+        let preload = config
+            .preload_skills
+            .as_ref()
+            .expect("preload_skills should be set");
+        assert!(
+            preload
+                .iter()
+                .any(|id| id.skill_name.as_str() == "task-workflow"),
+            "builtin-only task-capable profiles should preload local task operating rules"
+        );
+        assert!(
+            !preload
+                .iter()
+                .any(|id| id.skill_name.as_str() == "workgraph-workflow"),
+            "profiles without WorkGraph should not preload WorkGraph operating rules"
         );
     }
 


### PR DESCRIPTION
## Summary
- preload WorkGraph workflow guidance for mob profiles with `tools.workgraph = true`
- preload builtin task workflow guidance for mob profiles that have builtins but not WorkGraph
- add a provider-visible regression proving WorkGraph tools do not displace builtin `task_*` tools

## Why
`profile.tools.workgraph` was already mapped to `override_workgraph`, and the actual tool surface keeps both WorkGraph and builtin task tools when both categories are enabled. The missing piece was model guidance: mob members only preloaded `mob-communication`, leaving WorkGraph/task selection to prompt wording.

## Validation
- `./scripts/repo-cargo fmt --all`
- `./scripts/repo-cargo test -p meerkat-mob build::tests -- --nocapture`
- `./scripts/repo-cargo check -p meerkat-mob`
- `git diff --check`
- pre-push hooks: secrets, whitespace, cargo fmt, changed-crate clippy, machine codegen/verify, generated-header audit, bridge audit, Bazel freshness, deterministic gate