### PR TITLE
[codex] Fix steer admission boundary cancellation

### DIFF
--- a/meerkat-machine-schema/src/catalog/dsl/meerkat_machine.rs
+++ b/meerkat-machine-schema/src/catalog/dsl/meerkat_machine.rs
@@ -3727,7 +3727,6 @@ macro_rules! meerkat_catalog_machine_dsl {
             to Running
             emit IngressAccepted
             emit PostAdmissionSignal { signal: PostAdmissionSignalKind::InterruptYielding }
-            emit RuntimeEffectFact { kind: RuntimeEffectKind::CancelAfterBoundary, reason: "peer admission requested cooperative boundary cancel" }
         }
         // Running + immediate (immediate=true, interrupt_yielding=false)
         transition AcceptWithCompletionRunningImmediate {
@@ -3740,7 +3739,6 @@ macro_rules! meerkat_catalog_machine_dsl {
             to Running
             emit IngressAccepted
             emit PostAdmissionSignal { signal: PostAdmissionSignalKind::RequestImmediateProcessing }
-            emit RuntimeEffectFact { kind: RuntimeEffectKind::CancelAfterBoundary, reason: "peer admission requested cooperative boundary cancel" }
         }
 
         // 26. AcceptWithoutWake: Idle/Attached/Running self-loops

--- a/meerkat-mob/src/runtime/tests.rs
+++ b/meerkat-mob/src/runtime/tests.rs
@@ -25484,6 +25484,21 @@ async fn test_default_peer_response_inherits_request_steer_while_requester_runni
     .await
     .expect("default peer response should succeed");
 
+    tokio::time::sleep(Duration::from_millis(100)).await;
+    assert_eq!(
+        service
+            .applied_runtime_context_appends(&sid_requester)
+            .await
+            .len(),
+        requester_context_baseline,
+        "default response to a steer request should wait for the requester boundary, not cancel the active run"
+    );
+
+    service
+        .interrupt(&sid_requester)
+        .await
+        .expect("boundary release should let requester drain steered response");
+
     let requester_delivery = tokio::time::timeout(Duration::from_secs(2), async {
         loop {
             let appends = service
@@ -25514,7 +25529,7 @@ async fn test_default_peer_response_inherits_request_steer_while_requester_runni
             .await
             .expect("requester snapshot should exist");
         panic!(
-            "default response to a steer request should interrupt and reach requester; appends={appends:?} snapshot={snapshot:?}"
+            "default response to a steer request should drain after requester boundary; appends={appends:?} snapshot={snapshot:?}"
         );
     }
 

--- a/meerkat-runtime/src/meerkat_machine_tests.rs
+++ b/meerkat-runtime/src/meerkat_machine_tests.rs
@@ -5733,6 +5733,172 @@ async fn service_peer_admission_wakes_without_live_cancel_after_boundary() {
 }
 
 #[tokio::test]
+async fn explicit_running_steer_admission_does_not_emit_boundary_cancel_effect() {
+    struct LiveBoundaryHandle {
+        calls: Arc<AtomicUsize>,
+    }
+
+    #[async_trait::async_trait]
+    impl CoreExecutorBoundaryHandle for LiveBoundaryHandle {
+        async fn cancel_after_boundary(&self, _reason: String) -> Result<(), CoreExecutorError> {
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            Ok(())
+        }
+    }
+
+    struct BlockingExecutor {
+        apply_calls: Arc<AtomicUsize>,
+        queued_boundary_cancel_calls: Arc<AtomicUsize>,
+        live_boundary_cancel_calls: Arc<AtomicUsize>,
+        apply_started: Arc<Notify>,
+        allow_finish: Arc<Notify>,
+    }
+
+    #[async_trait::async_trait]
+    impl CoreExecutor for BlockingExecutor {
+        fn boundary_handle(&self) -> Option<Arc<dyn CoreExecutorBoundaryHandle>> {
+            Some(Arc::new(LiveBoundaryHandle {
+                calls: Arc::clone(&self.live_boundary_cancel_calls),
+            }))
+        }
+
+        async fn apply(
+            &mut self,
+            run_id: RunId,
+            primitive: RunPrimitive,
+        ) -> Result<CoreApplyOutput, CoreExecutorError> {
+            self.apply_calls.fetch_add(1, Ordering::SeqCst);
+            self.apply_started.notify_waiters();
+            self.allow_finish.notified().await;
+            Ok(CoreApplyOutput {
+                receipt: RunBoundaryReceipt {
+                    run_id,
+                    boundary: primitive.apply_boundary(),
+                    contributing_input_ids: primitive.contributing_input_ids().to_vec(),
+                    conversation_digest: None,
+                    message_count: 0,
+                    sequence: 0,
+                },
+                session_snapshot: None,
+                terminal: None,
+            })
+        }
+
+        async fn cancel_after_boundary(
+            &mut self,
+            _reason: String,
+        ) -> Result<(), CoreExecutorError> {
+            self.queued_boundary_cancel_calls
+                .fetch_add(1, Ordering::SeqCst);
+            Ok(())
+        }
+
+        async fn stop_runtime_executor(
+            &mut self,
+            _reason: String,
+        ) -> Result<(), CoreExecutorError> {
+            Ok(())
+        }
+    }
+
+    let adapter = Arc::new(MeerkatMachine::ephemeral());
+    let session_id = SessionId::new();
+    let apply_calls = Arc::new(AtomicUsize::new(0));
+    let queued_boundary_cancel_calls = Arc::new(AtomicUsize::new(0));
+    let live_boundary_cancel_calls = Arc::new(AtomicUsize::new(0));
+    let apply_started = Arc::new(Notify::new());
+    let allow_finish = Arc::new(Notify::new());
+
+    adapter
+        .register_session_with_executor(
+            session_id.clone(),
+            Box::new(BlockingExecutor {
+                apply_calls: Arc::clone(&apply_calls),
+                queued_boundary_cancel_calls: Arc::clone(&queued_boundary_cancel_calls),
+                live_boundary_cancel_calls: Arc::clone(&live_boundary_cancel_calls),
+                apply_started: Arc::clone(&apply_started),
+                allow_finish: Arc::clone(&allow_finish),
+            }),
+        )
+        .await;
+
+    let first_input = Input::Prompt(crate::input::PromptInput::new(
+        "first turn keeps the runtime busy",
+        Some(
+            meerkat_core::lifecycle::run_primitive::RuntimeTurnMetadata {
+                handling_mode: Some(meerkat_core::types::HandlingMode::Steer),
+                ..Default::default()
+            },
+        ),
+    ));
+    let (outcome, _completion_handle) = adapter
+        .accept_input_with_completion(&session_id, first_input)
+        .await
+        .expect("initial steer prompt should be accepted");
+    assert!(outcome.is_accepted());
+
+    tokio::time::timeout(Duration::from_secs(1), apply_started.notified())
+        .await
+        .expect("first apply should start");
+
+    live_boundary_cancel_calls.store(0, Ordering::SeqCst);
+    queued_boundary_cancel_calls.store(0, Ordering::SeqCst);
+
+    let steered_peer_input = Input::Peer(crate::input::PeerInput {
+        header: crate::input::InputHeader {
+            id: InputId::new(),
+            timestamp: Utc::now(),
+            source: crate::input::InputOrigin::Peer {
+                peer_id: "explicit-steer-peer".into(),
+                display_identity: None,
+                runtime_id: None,
+            },
+            durability: crate::input::InputDurability::Durable,
+            visibility: crate::input::InputVisibility::default(),
+            idempotency_key: None,
+            supersession_key: None,
+            correlation_id: None,
+        },
+        convention: Some(crate::input::PeerConvention::Message),
+        body: "explicit steer should not cancel the active run".into(),
+        payload: None,
+        blocks: None,
+        handling_mode: Some(meerkat_core::types::HandlingMode::Steer),
+    });
+
+    let result = adapter
+        .accept_input_with_completion(&session_id, steered_peer_input)
+        .await
+        .expect("running explicit steer should be accepted");
+    assert!(result.0.is_accepted());
+    assert_eq!(
+        live_boundary_cancel_calls.load(Ordering::SeqCst),
+        0,
+        "running steer admission must not call the live boundary-cancel handle"
+    );
+    assert_eq!(
+        queued_boundary_cancel_calls.load(Ordering::SeqCst),
+        0,
+        "running steer admission must not enqueue a cancel-after-boundary effect"
+    );
+
+    allow_finish.notify_waiters();
+
+    tokio::time::timeout(Duration::from_secs(1), async {
+        loop {
+            if apply_calls.load(Ordering::SeqCst) >= 2 {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .expect("steered peer input should still be processed after the active apply returns");
+    assert_eq!(live_boundary_cancel_calls.load(Ordering::SeqCst), 0);
+    assert_eq!(queued_boundary_cancel_calls.load(Ordering::SeqCst), 0);
+}
+
+#[tokio::test]
 async fn meerkat_machine_spine_snapshot_attached_steered_prompt_defers_stop_until_apply_finishes() {
     struct BlockingExecutor {
         apply_calls: Arc<AtomicUsize>,

--- a/scripts/buildbuddy-doctor
+++ b/scripts/buildbuddy-doctor
@@ -493,6 +493,7 @@ sdk_only="$(printf 'sdks/typescript/src/runtime.ts\n' | scripts/buildbuddy-edge-
 wasm_only="$(printf 'meerkat-web-runtime/src/lib.rs\n' | scripts/buildbuddy-edge-changes --paths-from-stdin)"
 feature_only="$(printf 'scripts/run-surface-feature-matrix\n' | scripts/buildbuddy-edge-changes --paths-from-stdin)"
 audit_only="$(printf 'deny.toml\n' | scripts/buildbuddy-edge-changes --paths-from-stdin)"
+machine_runtime="$(printf 'meerkat-runtime/src/meerkat_machine_tests.rs\n' | scripts/buildbuddy-edge-changes --paths-from-stdin)"
 if grep -Fq 'sdk_changed=true' <<<"${sdk_only}" &&
   grep -Fq 'wasm_changed=false' <<<"${sdk_only}" &&
   grep -Fq 'wasm_changed=true' <<<"${wasm_only}" &&
@@ -500,7 +501,12 @@ if grep -Fq 'sdk_changed=true' <<<"${sdk_only}" &&
   grep -Fq 'feature_changed=true' <<<"${feature_only}" &&
   grep -Fq 'wasm_changed=false' <<<"${feature_only}" &&
   grep -Fq 'audit_changed=true' <<<"${audit_only}" &&
-  grep -Fq 'wasm_changed=false' <<<"${audit_only}"; then
+  grep -Fq 'wasm_changed=false' <<<"${audit_only}" &&
+  grep -Fq 'wasm_changed=true' <<<"${machine_runtime}" &&
+  grep -Fq 'sdk_changed=true' <<<"${machine_runtime}" &&
+  grep -Fq 'minimal_changed=true' <<<"${machine_runtime}" &&
+  grep -Fq 'feature_changed=true' <<<"${machine_runtime}" &&
+  grep -Fq 'audit_changed=true' <<<"${machine_runtime}"; then
   pass "BuildBuddy edge lane detector keeps WASM separate from SDK, feature, and audit-only changes"
 else
   bad "BuildBuddy edge lane detector is over-triggering WASM edge lanes"

--- a/scripts/buildbuddy-edge-changes
+++ b/scripts/buildbuddy-edge-changes
@@ -38,6 +38,10 @@ mark_path() {
       mark_all
       return
       ;;
+    meerkat-machine-schema/*|meerkat-machine-kernels/*|meerkat-runtime/*|specs/machines/*|specs/compositions/*)
+      mark_all
+      return
+      ;;
     deny.toml)
       audit_changed=true
       ;;

--- a/specs/machines/meerkat_machine/contract.md
+++ b/specs/machines/meerkat_machine/contract.md
@@ -1750,7 +1750,7 @@ _Generated from the Rust machine catalog. Do not edit by hand._
   - `session_registered`
   - `request_immediate_processing`
   - `interrupt_yielding`
-- Emits: `IngressAccepted`, `PostAdmissionSignal`, `RuntimeEffectFact`
+- Emits: `IngressAccepted`, `PostAdmissionSignal`
 - To: `Running`
 
 ### `AcceptWithCompletionRunningImmediate`
@@ -1760,7 +1760,7 @@ _Generated from the Rust machine catalog. Do not edit by hand._
   - `session_registered`
   - `request_immediate_processing`
   - `interrupt_yielding`
-- Emits: `IngressAccepted`, `PostAdmissionSignal`, `RuntimeEffectFact`
+- Emits: `IngressAccepted`, `PostAdmissionSignal`
 - To: `Running`
 
 ### `AcceptWithoutWakeIdle`


### PR DESCRIPTION
## Summary
- stop running AcceptWithCompletion steer/immediate admission from emitting a CancelAfterBoundary runtime effect
- keep the machine-owned wake/drain admission signal without turning it into terminal run cancellation
- add regressions covering explicit running Steer admission and mob peer-response delivery across the requester boundary
- ensure machine/runtime/spec authority changes fan out to the SDK, minimal, feature, and audit BuildBuddy lanes instead of skipping them

## Root Cause
Running steer admission emitted PostAdmissionSignal plus RuntimeEffectFact::CancelAfterBoundary. The runtime realized that effect through the live boundary-cancel path, so a peer steer could terminalize the active run as RunCancelled instead of just admitting boundary work.

The first CI run also exposed an overly narrow BuildBuddy edge-change classifier: machine/runtime authority changes only triggered WASM/governance/static/prebuild coverage, leaving SDK/minimal/feature/security lanes skipped. This PR now treats machine/runtime/spec authority edits as broad edge changes.

## Validation
- ./scripts/repo-cargo fmt --check
- ./scripts/repo-cargo xtask machine-check-drift --all
- ./scripts/repo-cargo test -p meerkat-runtime explicit_running_steer_admission_does_not_emit_boundary_cancel_effect -- --nocapture
- ./scripts/repo-cargo test -p meerkat-runtime modeled_meerkat_accept_with_completion_running_steer_signal_matches_runtime -- --nocapture
- ./scripts/repo-cargo test -p meerkat-runtime modeled_meerkat_accept_with_completion_running_peer_wake_signal_matches_runtime -- --nocapture
- ./scripts/repo-cargo test -p meerkat-mob test_default_peer_response_inherits_request_steer_while_requester_running -- --nocapture
- printf 'meerkat-runtime/src/meerkat_machine_tests.rs\nmeerkat-machine-schema/src/catalog/dsl/meerkat_machine.rs\nspecs/machines/meerkat_machine/contract.md\n' | scripts/buildbuddy-edge-changes --paths-from-stdin
- make buildbuddy-doctor
