### PR TITLE
Mark lost mob sessions broken

### DIFF
--- a/meerkat-mob/src/runtime/actor.rs
+++ b/meerkat-mob/src/runtime/actor.rs
@@ -1711,7 +1711,7 @@ impl MobActor {
     }
 
     async fn machine_member_material(
-        &self,
+        &mut self,
         agent_identity: &MeerkatId,
         include_session_details: bool,
     ) -> CanonicalMemberSnapshotMaterial {
@@ -1734,10 +1734,6 @@ impl MobActor {
             .and_then(|dsl_session_id| SessionId::parse(&dsl_session_id.0).ok());
         let current_bridge_session_id = current_bridge_session_id.or(machine_bridge_session_id);
         let member_present = roster_entry.is_some();
-        let machine_lifecycle = self
-            .dsl_authority
-            .state
-            .member_lifecycle_for_identity(&dsl_identity, member_present);
 
         let (output_preview, tokens_used) = match current_bridge_session_id.as_ref() {
             None => (None, 0),
@@ -1747,12 +1743,25 @@ impl MobActor {
                         view.state.last_assistant_text.clone(),
                         view.billing.total_tokens,
                     ),
-                    Err(meerkat_core::service::SessionError::NotFound { .. }) => (None, 0),
+                    Err(meerkat_core::service::SessionError::NotFound { .. }) => {
+                        let _ = self
+                            .record_missing_member_bridge_session(
+                                agent_identity,
+                                bridge_session_id,
+                                "member_status",
+                            )
+                            .await;
+                        (None, 0)
+                    }
                     Err(_) => (None, 0),
                 }
             }
             Some(_) => (None, 0),
         };
+        let machine_lifecycle = self
+            .dsl_authority
+            .state
+            .member_lifecycle_for_identity(&dsl_identity, member_present);
 
         MobMemberLifecycleProjection::materialize(MobMemberLifecycleInput {
             member_present,
@@ -1777,8 +1786,66 @@ impl MobActor {
         })
     }
 
+    async fn record_missing_member_bridge_session(
+        &mut self,
+        agent_identity: &MeerkatId,
+        bridge_session_id: &SessionId,
+        context: &'static str,
+    ) -> Option<String> {
+        let domain_identity = crate::ids::AgentIdentity::from(agent_identity.as_str());
+        let dsl_identity = mob_dsl::AgentIdentity::from_domain(&domain_identity);
+        let current_binding_matches = self
+            .dsl_authority
+            .state
+            .member_session_bindings
+            .get(&dsl_identity)
+            .is_some_and(|session_id| session_id.0 == bridge_session_id.to_string());
+        if !current_binding_matches {
+            tracing::warn!(
+                mob_id = %self.definition.id,
+                agent_identity = %agent_identity,
+                bridge_session_id = %bridge_session_id,
+                context,
+                "observed missing bridge session for a stale/non-current member binding"
+            );
+            return None;
+        }
+        if let Some(reason) = self
+            .dsl_authority
+            .state
+            .member_restore_failures
+            .get(&dsl_identity)
+            .cloned()
+        {
+            return Some(reason);
+        }
+
+        let reason = format!("missing bridge session snapshot for '{bridge_session_id}'");
+        self.dsl_authority
+            .state
+            .member_restore_failures
+            .insert(dsl_identity, reason.clone());
+        self.restore_diagnostics.write().await.insert(
+            agent_identity.clone(),
+            super::handle::RestoreFailureDiagnostic {
+                bridge_session_id: Some(bridge_session_id.clone()),
+                reason: reason.clone(),
+            },
+        );
+        self.publish_machine_state_projection();
+        tracing::error!(
+            mob_id = %self.definition.id,
+            agent_identity = %agent_identity,
+            bridge_session_id = %bridge_session_id,
+            context,
+            reason = %reason,
+            "member bridge session is missing; marked member broken"
+        );
+        Some(reason)
+    }
+
     async fn project_member_list_from_machine(
-        &self,
+        &mut self,
         include_retiring: bool,
     ) -> Vec<MobMemberListEntry> {
         let entries: Vec<_> = {
@@ -10881,7 +10948,7 @@ impl MobActor {
     }
 
     async fn dispatch_member_turn(
-        &self,
+        &mut self,
         entry: &RosterEntry,
         content: ContentInput,
         handling_mode: meerkat_core::types::HandlingMode,
@@ -10900,13 +10967,37 @@ impl MobActor {
     }
 
     async fn dispatch_member_turn_after_machine_admission(
-        &self,
+        &mut self,
         entry: &RosterEntry,
         content: ContentInput,
         handling_mode: meerkat_core::types::HandlingMode,
         render_metadata: Option<meerkat_core::types::RenderMetadata>,
         ack_mode: crate::mob_machine::SubmitWorkAckMode,
     ) -> Result<(), MobError> {
+        if let Some(bridge_session_id) = entry.member_ref.bridge_session_id() {
+            match self.session_service.read(bridge_session_id).await {
+                Ok(_) => {}
+                Err(meerkat_core::service::SessionError::NotFound { .. }) => {
+                    let reason = self
+                        .record_missing_member_bridge_session(
+                            &entry.agent_identity,
+                            bridge_session_id,
+                            "dispatch_member_turn",
+                        )
+                        .await
+                        .unwrap_or_else(|| {
+                            format!("missing bridge session snapshot for '{bridge_session_id}'")
+                        });
+                    return Err(MobError::MemberRestoreFailed {
+                        member_id: entry.agent_identity.clone(),
+                        session_id: Some(bridge_session_id.clone()),
+                        reason,
+                    });
+                }
+                Err(error) => return Err(MobError::SessionError(error)),
+            }
+        }
+
         match entry.runtime_mode {
             crate::MobRuntimeMode::AutonomousHost => {
                 let bridge_session_id = entry.member_ref.bridge_session_id().ok_or_else(|| {

--- a/meerkat-mob/src/runtime/tests.rs
+++ b/meerkat-mob/src/runtime/tests.rs
@@ -26592,6 +26592,172 @@ async fn test_member_status_round_trips_through_machine_command_surface() {
 }
 
 #[tokio::test]
+async fn test_member_status_marks_current_missing_bridge_session_broken() {
+    let (handle, service) = create_test_mob(sample_definition()).await;
+    let receipt = handle
+        .spawn(ProfileName::from("worker"), MeerkatId::from("w-1"), None)
+        .await
+        .expect("spawn worker");
+    let bridge_session_id = receipt
+        .bridge_session_id()
+        .expect("session-backed member")
+        .clone();
+
+    service
+        .archive(&bridge_session_id)
+        .await
+        .expect("test should remove the live bridge session");
+
+    let snapshot = handle
+        .member_status(&AgentIdentity::from("w-1"))
+        .await
+        .expect("member status should still return a diagnostic snapshot");
+    assert_eq!(snapshot.status, crate::runtime::MobMemberStatus::Broken);
+    assert!(snapshot.is_final);
+    assert_eq!(snapshot.current_session_id, Some(bridge_session_id.clone()));
+    assert!(snapshot.peer_connectivity.is_none());
+    assert!(
+        snapshot
+            .error
+            .as_deref()
+            .is_some_and(|message| message.contains("missing bridge session")),
+        "broken member should surface the missing-session reason: {snapshot:?}"
+    );
+
+    let machine_state = handle
+        .query_machine_state()
+        .await
+        .expect("query MobMachine state");
+    let machine_identity =
+        crate::machines::mob_machine::AgentIdentity::from_domain(&AgentIdentity::from("w-1"));
+    assert_eq!(
+        machine_state.member_lifecycle_for_identity(&machine_identity, true),
+        crate::machines::mob_machine::MobMemberLifecycleMaterial {
+            status: crate::machines::mob_machine::MobMemberLifecycleStatus::Broken,
+            terminal_class: crate::machines::mob_machine::MobMemberTerminalClass::TerminalFailure,
+            error: Some(format!(
+                "missing bridge session snapshot for '{bridge_session_id}'"
+            )),
+        },
+        "missing bridge-session classification must be owned by MobMachine state"
+    );
+}
+
+#[tokio::test]
+async fn test_missing_bridge_session_stops_member_from_looking_runnable_after_status_probe() {
+    let (handle, service) = create_test_mob(sample_definition()).await;
+    let receipt = handle
+        .spawn(ProfileName::from("worker"), MeerkatId::from("w-1"), None)
+        .await
+        .expect("spawn worker");
+    let bridge_session_id = receipt
+        .bridge_session_id()
+        .expect("session-backed member")
+        .clone();
+
+    service
+        .archive(&bridge_session_id)
+        .await
+        .expect("test should remove the live bridge session");
+
+    let _ = handle
+        .member_status(&AgentIdentity::from("w-1"))
+        .await
+        .expect("status probe should record the missing session");
+
+    let listed = handle.list_members().await;
+    let entry = listed
+        .iter()
+        .find(|entry| entry.agent_identity == "w-1")
+        .expect("member remains visible for diagnostics");
+    assert_eq!(entry.status, crate::runtime::MobMemberStatus::Broken);
+    assert!(entry.is_final);
+    assert_eq!(entry.current_session_id, Some(bridge_session_id.clone()));
+
+    let error = handle
+        .internal_turn(
+            AgentIdentity::from("w-1"),
+            ContentInput::from("should fail fast".to_string()),
+        )
+        .await
+        .expect_err("broken member must reject queued work");
+    match error {
+        MobError::MemberRestoreFailed {
+            member_id,
+            session_id,
+            reason,
+        } => {
+            assert_eq!(member_id, MeerkatId::from("w-1"));
+            assert_eq!(session_id, Some(bridge_session_id));
+            assert!(
+                reason.contains("missing bridge session"),
+                "unexpected restore failure reason: {reason}"
+            );
+        }
+        other => panic!("expected MemberRestoreFailed, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn test_submit_work_marks_missing_bridge_session_broken_without_prior_status_probe() {
+    let (handle, service) = create_test_mob(sample_definition()).await;
+    let receipt = handle
+        .spawn(ProfileName::from("worker"), MeerkatId::from("w-1"), None)
+        .await
+        .expect("spawn worker");
+    let bridge_session_id = receipt
+        .bridge_session_id()
+        .expect("session-backed member")
+        .clone();
+    let active = handle
+        .member_status(&AgentIdentity::from("w-1"))
+        .await
+        .expect("initial member status");
+    let (runtime_id, fence_token) = active.runtime_identity_fields();
+    let runtime_id = runtime_id.clone();
+
+    service
+        .archive(&bridge_session_id)
+        .await
+        .expect("test should remove the live bridge session");
+
+    let error = handle
+        .submit_work(
+            runtime_id,
+            fence_token,
+            WorkRef::new(),
+            WorkSpec::new(
+                ContentInput::from("dispatch should fail fast".to_string()),
+                WorkOrigin::Internal,
+            ),
+        )
+        .await
+        .expect_err("submit_work should diagnose the missing bridge session");
+    match error {
+        MobError::MemberRestoreFailed {
+            member_id,
+            session_id,
+            reason,
+        } => {
+            assert_eq!(member_id, MeerkatId::from("w-1"));
+            assert_eq!(session_id, Some(bridge_session_id.clone()));
+            assert!(
+                reason.contains("missing bridge session"),
+                "unexpected restore failure reason: {reason}"
+            );
+        }
+        other => panic!("expected MemberRestoreFailed, got {other:?}"),
+    }
+
+    let after = handle
+        .member_status(&AgentIdentity::from("w-1"))
+        .await
+        .expect("post-failure member status");
+    assert_eq!(after.status, crate::runtime::MobMemberStatus::Broken);
+    assert_eq!(after.current_session_id, Some(bridge_session_id));
+}
+
+#[tokio::test]
 async fn test_member_status_surface_exposes_current_session_id_for_diagnostics_only() {
     // `current_session_id` remains observable for status/continuity
     // diagnostics, but it is not a realtime routing contract. Public

--- a/scripts/buildbuddy-doctor
+++ b/scripts/buildbuddy-doctor
@@ -495,6 +495,7 @@ feature_only="$(printf 'scripts/run-surface-feature-matrix\n' | scripts/buildbud
 audit_only="$(printf 'deny.toml\n' | scripts/buildbuddy-edge-changes --paths-from-stdin)"
 machine_runtime="$(printf 'meerkat-runtime/src/meerkat_machine_tests.rs\n' | scripts/buildbuddy-edge-changes --paths-from-stdin)"
 session_core="$(printf 'meerkat-session/src/persistent.rs\n' | scripts/buildbuddy-edge-changes --paths-from-stdin)"
+mob_core="$(printf 'meerkat-mob/src/runtime/actor.rs\n' | scripts/buildbuddy-edge-changes --paths-from-stdin)"
 if grep -Fq 'sdk_changed=true' <<<"${sdk_only}" &&
   grep -Fq 'wasm_changed=false' <<<"${sdk_only}" &&
   grep -Fq 'wasm_changed=true' <<<"${wasm_only}" &&
@@ -512,7 +513,12 @@ if grep -Fq 'sdk_changed=true' <<<"${sdk_only}" &&
   grep -Fq 'sdk_changed=true' <<<"${session_core}" &&
   grep -Fq 'minimal_changed=true' <<<"${session_core}" &&
   grep -Fq 'feature_changed=true' <<<"${session_core}" &&
-  grep -Fq 'audit_changed=true' <<<"${session_core}"; then
+  grep -Fq 'audit_changed=true' <<<"${session_core}" &&
+  grep -Fq 'wasm_changed=true' <<<"${mob_core}" &&
+  grep -Fq 'sdk_changed=true' <<<"${mob_core}" &&
+  grep -Fq 'minimal_changed=true' <<<"${mob_core}" &&
+  grep -Fq 'feature_changed=true' <<<"${mob_core}" &&
+  grep -Fq 'audit_changed=true' <<<"${mob_core}"; then
   pass "BuildBuddy edge lane detector keeps WASM separate from SDK, feature, and audit-only changes"
 else
   bad "BuildBuddy edge lane detector is over-triggering WASM edge lanes"

--- a/scripts/buildbuddy-edge-changes
+++ b/scripts/buildbuddy-edge-changes
@@ -38,7 +38,7 @@ mark_path() {
       mark_all
       return
       ;;
-    meerkat-machine-schema/*|meerkat-machine-kernels/*|meerkat-runtime/*|meerkat-session/*|specs/machines/*|specs/compositions/*)
+    meerkat-machine-schema/*|meerkat-machine-kernels/*|meerkat-runtime/*|meerkat-session/*|meerkat-mob/*|specs/machines/*|specs/compositions/*)
       mark_all
       return
       ;;


### PR DESCRIPTION
## Summary
- record a missing current mob bridge session into MobMachine-owned member_restore_failures during deep member_status inspection
- fail fast with MemberRestoreFailed when work dispatch targets a missing bridge session, instead of surfacing generic session/injector plumbing or leaving the member looking active
- add regression coverage for member_status diagnostics, post-probe list/work behavior, and direct submit_work without a prior status probe
- expand BuildBuddy edge detection so meerkat-mob/* changes run SDK, minimal, feature, WASM, and audit/security lanes

## Validation
- ./scripts/repo-cargo fmt --check
- ./scripts/repo-cargo test -p meerkat-mob missing_bridge_session -- --nocapture
- ./scripts/repo-cargo test -p meerkat-mob member_status -- --nocapture
- ./scripts/repo-cargo test -p meerkat-mob broken_member -- --nocapture
- ./scripts/repo-cargo test -p meerkat-mob
- printf 'meerkat-mob/src/runtime/actor.rs\nmeerkat-mob/src/runtime/tests.rs\n' | scripts/buildbuddy-edge-changes --paths-from-stdin
- make buildbuddy-doctor
- pre-push hooks: secrets, whitespace, fmt, changed-crate clippy, machine codegen+verify, generated-header audit, bridge invariant, Bazel freshness, deterministic workspace gate
