### PR TITLE
Checkpoint runtime-committed session projections

### DIFF
--- a/meerkat-core/src/lifecycle/core_executor.rs
+++ b/meerkat-core/src/lifecycle/core_executor.rs
@@ -436,6 +436,19 @@ pub trait CoreExecutor: Send + Sync {
         primitive: RunPrimitive,
     ) -> Result<CoreApplyOutput, CoreExecutorError>;
 
+    /// Persist or project the committed session snapshot after the runtime
+    /// control plane has durably committed the machine boundary.
+    ///
+    /// RuntimeStore remains the authority for runtime-backed turns; this hook
+    /// is for compatibility projections such as `SessionStore` snapshots that
+    /// must not be written before the machine commit succeeds.
+    async fn checkpoint_committed_session_snapshot(
+        &mut self,
+        _session_snapshot: &[u8],
+    ) -> Result<(), CoreExecutorError> {
+        Ok(())
+    }
+
     /// Request cancellation at the next cooperative boundary.
     async fn cancel_after_boundary(&mut self, reason: String) -> Result<(), CoreExecutorError>;
 

--- a/meerkat-mob/src/runtime/provisioner.rs
+++ b/meerkat-mob/src/runtime/provisioner.rs
@@ -1339,6 +1339,19 @@ impl CoreExecutor for MobSessionRuntimeExecutor {
             .map_err(CoreExecutorError::apply_failed_from_session_error)
     }
 
+    async fn checkpoint_committed_session_snapshot(
+        &mut self,
+        session_snapshot: &[u8],
+    ) -> Result<(), CoreExecutorError> {
+        self.session_service
+            .checkpoint_committed_runtime_session_snapshot(
+                &self.bridge_session_id,
+                session_snapshot,
+            )
+            .await
+            .map_err(CoreExecutorError::apply_failed_from_session_error)
+    }
+
     async fn cancel_after_boundary(&mut self, _reason: String) -> Result<(), CoreExecutorError> {
         self.session_service
             .cancel_after_boundary_with_machine_authority(

--- a/meerkat-mob/src/runtime/session_service.rs
+++ b/meerkat-mob/src/runtime/session_service.rs
@@ -319,6 +319,14 @@ pub trait MobSessionService:
         ))
     }
 
+    async fn checkpoint_committed_runtime_session_snapshot(
+        &self,
+        _session_id: &SessionId,
+        _session_snapshot: &[u8],
+    ) -> Result<(), SessionError> {
+        Ok(())
+    }
+
     async fn discard_live_session(&self, _session_id: &SessionId) -> Result<(), SessionError> {
         Ok(())
     }
@@ -712,6 +720,19 @@ where
     ) -> Result<(), SessionError> {
         meerkat_session::PersistentSessionService::<B>::apply_runtime_system_context_for_turn(
             self, session_id, appends,
+        )
+        .await
+    }
+
+    async fn checkpoint_committed_runtime_session_snapshot(
+        &self,
+        session_id: &SessionId,
+        session_snapshot: &[u8],
+    ) -> Result<(), SessionError> {
+        meerkat_session::PersistentSessionService::<B>::checkpoint_committed_runtime_session_snapshot(
+            self,
+            session_id,
+            session_snapshot,
         )
         .await
     }

--- a/meerkat-runtime/src/meerkat_machine_tests.rs
+++ b/meerkat-runtime/src/meerkat_machine_tests.rs
@@ -1698,6 +1698,234 @@ async fn completion_preserves_structured_output_when_runtime_finalization_fails(
 }
 
 #[tokio::test]
+async fn runtime_loop_checkpoints_session_snapshot_after_machine_commit() {
+    struct SnapshotCheckpointExecutor {
+        session_id: SessionId,
+        runtime_store: std::sync::Arc<crate::store::InMemoryRuntimeStore>,
+        checkpoint_calls: std::sync::Arc<AtomicUsize>,
+        observed_committed_snapshot: std::sync::Arc<AtomicBool>,
+    }
+
+    #[async_trait::async_trait]
+    impl CoreExecutor for SnapshotCheckpointExecutor {
+        async fn apply(
+            &mut self,
+            run_id: RunId,
+            primitive: RunPrimitive,
+        ) -> Result<CoreApplyOutput, CoreExecutorError> {
+            let receipt = RunBoundaryReceipt {
+                run_id,
+                boundary: RunApplyBoundary::RunStart,
+                contributing_input_ids: primitive.contributing_input_ids().to_vec(),
+                conversation_digest: None,
+                message_count: 0,
+                sequence: 0,
+            };
+            let session = meerkat_core::Session::with_id(self.session_id.clone());
+            let session_snapshot = serde_json::to_vec(&session)
+                .map_err(|err| CoreExecutorError::Internal(err.to_string()))?;
+            Ok(CoreApplyOutput::with_run_result(
+                receipt,
+                Some(session_snapshot),
+                meerkat_core::RunResult {
+                    text: "done".to_string(),
+                    session_id: self.session_id.clone(),
+                    usage: Default::default(),
+                    turns: 1,
+                    tool_calls: 0,
+                    terminal_cause_kind: None,
+                    structured_output: None,
+                    extraction_error: None,
+                    schema_warnings: None,
+                    skill_diagnostics: None,
+                },
+            ))
+        }
+
+        async fn checkpoint_committed_session_snapshot(
+            &mut self,
+            session_snapshot: &[u8],
+        ) -> Result<(), CoreExecutorError> {
+            self.checkpoint_calls.fetch_add(1, Ordering::SeqCst);
+            let runtime_id = crate::identifiers::LogicalRuntimeId::for_session(&self.session_id);
+            let committed = crate::store::RuntimeStore::load_session_snapshot(
+                self.runtime_store.as_ref(),
+                &runtime_id,
+            )
+            .await
+            .map_err(|err| CoreExecutorError::Internal(err.to_string()))?;
+            if committed.as_deref() == Some(session_snapshot) {
+                self.observed_committed_snapshot
+                    .store(true, Ordering::SeqCst);
+            }
+            Ok(())
+        }
+
+        async fn cancel_after_boundary(
+            &mut self,
+            _reason: String,
+        ) -> Result<(), CoreExecutorError> {
+            Ok(())
+        }
+
+        async fn stop_runtime_executor(
+            &mut self,
+            _reason: String,
+        ) -> Result<(), CoreExecutorError> {
+            Ok(())
+        }
+    }
+
+    let runtime_store = std::sync::Arc::new(crate::store::InMemoryRuntimeStore::new());
+    let checkpoint_calls = std::sync::Arc::new(AtomicUsize::new(0));
+    let observed_committed_snapshot = std::sync::Arc::new(AtomicBool::new(false));
+    let adapter = std::sync::Arc::new(MeerkatMachine::persistent(
+        runtime_store.clone(),
+        memory_blob_store(),
+    ));
+    let session_id = SessionId::new();
+    adapter
+        .register_session_with_executor(
+            session_id.clone(),
+            Box::new(SnapshotCheckpointExecutor {
+                session_id: session_id.clone(),
+                runtime_store,
+                checkpoint_calls: checkpoint_calls.clone(),
+                observed_committed_snapshot: observed_committed_snapshot.clone(),
+            }),
+        )
+        .await;
+
+    let (_accept_outcome, completion_handle) = adapter
+        .accept_input_with_completion(&session_id, make_prompt("checkpoint after commit"))
+        .await
+        .expect("input should be accepted");
+    let completion = tokio::time::timeout(
+        Duration::from_secs(1),
+        completion_handle
+            .expect("accepted input should register a completion waiter")
+            .wait(),
+    )
+    .await
+    .expect("completion waiter should resolve");
+
+    assert!(matches!(completion, CompletionOutcome::Completed(_)));
+    assert_eq!(checkpoint_calls.load(Ordering::SeqCst), 1);
+    assert!(
+        observed_committed_snapshot.load(Ordering::SeqCst),
+        "checkpoint hook must run after the RuntimeStore session snapshot commit is visible"
+    );
+}
+
+#[tokio::test]
+async fn runtime_loop_checkpoint_failure_is_completion_finalization_failure() {
+    struct FailingCheckpointExecutor {
+        session_id: SessionId,
+    }
+
+    #[async_trait::async_trait]
+    impl CoreExecutor for FailingCheckpointExecutor {
+        async fn apply(
+            &mut self,
+            run_id: RunId,
+            primitive: RunPrimitive,
+        ) -> Result<CoreApplyOutput, CoreExecutorError> {
+            let receipt = RunBoundaryReceipt {
+                run_id,
+                boundary: RunApplyBoundary::RunStart,
+                contributing_input_ids: primitive.contributing_input_ids().to_vec(),
+                conversation_digest: None,
+                message_count: 0,
+                sequence: 0,
+            };
+            let session = meerkat_core::Session::with_id(self.session_id.clone());
+            let session_snapshot = serde_json::to_vec(&session)
+                .map_err(|err| CoreExecutorError::Internal(err.to_string()))?;
+            Ok(CoreApplyOutput::with_run_result(
+                receipt,
+                Some(session_snapshot),
+                meerkat_core::RunResult {
+                    text: "checkpoint-fails-after-output".to_string(),
+                    session_id: self.session_id.clone(),
+                    usage: Default::default(),
+                    turns: 1,
+                    tool_calls: 0,
+                    terminal_cause_kind: None,
+                    structured_output: None,
+                    extraction_error: None,
+                    schema_warnings: None,
+                    skill_diagnostics: None,
+                },
+            ))
+        }
+
+        async fn checkpoint_committed_session_snapshot(
+            &mut self,
+            _session_snapshot: &[u8],
+        ) -> Result<(), CoreExecutorError> {
+            Err(CoreExecutorError::apply_failed_unknown(
+                "synthetic checkpoint projection failure",
+            ))
+        }
+
+        async fn cancel_after_boundary(
+            &mut self,
+            _reason: String,
+        ) -> Result<(), CoreExecutorError> {
+            Ok(())
+        }
+
+        async fn stop_runtime_executor(
+            &mut self,
+            _reason: String,
+        ) -> Result<(), CoreExecutorError> {
+            Ok(())
+        }
+    }
+
+    let adapter = std::sync::Arc::new(MeerkatMachine::persistent(
+        std::sync::Arc::new(crate::store::InMemoryRuntimeStore::new()),
+        memory_blob_store(),
+    ));
+    let session_id = SessionId::new();
+    adapter
+        .register_session_with_executor(
+            session_id.clone(),
+            Box::new(FailingCheckpointExecutor {
+                session_id: session_id.clone(),
+            }),
+        )
+        .await;
+
+    let (_accept_outcome, completion_handle) = adapter
+        .accept_input_with_completion(&session_id, make_prompt("checkpoint failure"))
+        .await
+        .expect("input should be accepted");
+    let completion = tokio::time::timeout(
+        Duration::from_secs(1),
+        completion_handle
+            .expect("accepted input should register a completion waiter")
+            .wait(),
+    )
+    .await
+    .expect("completion waiter should resolve");
+
+    match completion {
+        CompletionOutcome::CompletedWithFinalizationFailure { result, error } => {
+            assert_eq!(result.text, "checkpoint-fails-after-output");
+            assert!(
+                error
+                    .detail
+                    .as_deref()
+                    .is_some_and(|detail| detail.contains("checkpoint projection failure")),
+                "checkpoint failure detail should remain available: {error:?}"
+            );
+        }
+        other => panic!("expected completed output with finalization failure, got {other:?}"),
+    }
+}
+
+#[tokio::test]
 async fn hook_denial_terminalizes_with_typed_machine_apply_failure_cause() {
     use meerkat_core::lifecycle::core_executor::CoreApplyFailureCause;
 

--- a/meerkat-runtime/src/runtime_loop.rs
+++ b/meerkat-runtime/src/runtime_loop.rs
@@ -931,6 +931,7 @@ async fn process_queue(
                             terminal,
                         } = output;
                         drop(d);
+                        let committed_session_snapshot = session_snapshot.clone();
                         if let Err(err) = crate::meerkat_machine::commit_runtime_loop_run(
                             driver,
                             run_id.clone(),
@@ -959,6 +960,41 @@ async fn process_queue(
                                 completions,
                                 executor,
                                 format!("runtime loop commit failed for run {run_id}: {err}"),
+                            )
+                            .await;
+                            return should_stop;
+                        }
+
+                        if let Some(session_snapshot) = committed_session_snapshot.as_deref()
+                            && let Err(err) = executor
+                                .checkpoint_committed_session_snapshot(session_snapshot)
+                                .await
+                        {
+                            tracing::error!(
+                                %run_id,
+                                error = %err,
+                                "failed to checkpoint committed runtime session snapshot"
+                            );
+                            let completion_error =
+                                meerkat_core::TurnErrorMetadata::runtime_apply_failure(format!(
+                                    "runtime session checkpoint failed after commit: {err}"
+                                ));
+                            if let Some(completions) = completions.as_ref() {
+                                let mut completions = completions.lock().await;
+                                resolve_completion_waiters_with_finalization_failure(
+                                    &mut completions,
+                                    &input_ids,
+                                    terminal,
+                                    completion_error,
+                                );
+                            }
+                            let should_stop = stop_runtime_loop_executor_from_dsl_effect(
+                                driver,
+                                completions,
+                                executor,
+                                format!(
+                                    "runtime session checkpoint failed after commit for run {run_id}: {err}"
+                                ),
                             )
                             .await;
                             return should_stop;

--- a/meerkat-session/src/persistent.rs
+++ b/meerkat-session/src/persistent.rs
@@ -1831,6 +1831,43 @@ impl<B: SessionAgentBuilder + 'static> PersistentSessionService<B> {
         Ok(session)
     }
 
+    pub async fn checkpoint_committed_runtime_session_snapshot(
+        &self,
+        id: &SessionId,
+        session_snapshot: &[u8],
+    ) -> Result<(), SessionError> {
+        if self.runtime_store.is_none() {
+            return Ok(());
+        }
+
+        let session: Session = serde_json::from_slice(session_snapshot).map_err(|err| {
+            SessionError::Agent(meerkat_core::error::AgentError::InternalError(format!(
+                "failed to deserialize committed runtime session snapshot: {err}"
+            )))
+        })?;
+        if session.id() != id {
+            return Err(SessionError::Agent(
+                meerkat_core::error::AgentError::InternalError(format!(
+                    "committed runtime session snapshot id mismatch: expected {id}, got {}",
+                    session.id()
+                )),
+            ));
+        }
+
+        let gate = self.gate_for_session(id).await;
+        let guard = gate.cancelled.lock().await;
+        if *guard {
+            return Ok(());
+        }
+        if let Err(error) = self.store.save(&session).await {
+            drop(guard);
+            return Err(self
+                .fail_closed_runtime_projection_update(session.id(), error)
+                .await);
+        }
+        Ok(())
+    }
+
     async fn fail_closed_runtime_projection_update(
         &self,
         id: &SessionId,
@@ -7178,6 +7215,57 @@ mod tests {
                 .as_ref()
                 .map(|session| session.messages().len() + 1),
             "runtime-backed sessions must checkpoint changed turns into the SessionStore projection"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_committed_runtime_session_checkpoint_updates_session_store_projection() {
+        let store: Arc<dyn SessionStore> = Arc::new(MemoryStore::new());
+        let runtime_store = Arc::new(InMemoryRuntimeStore::new());
+        let service = PersistentSessionService::new(
+            DummyBuilder,
+            4,
+            Arc::clone(&store),
+            Some(runtime_store),
+            memory_blob_store(),
+        );
+
+        let result = service
+            .create_session(create_request(
+                "hello",
+                meerkat_core::service::InitialTurnPolicy::Defer,
+            ))
+            .await
+            .expect("create_session should succeed");
+        let original = store
+            .load(&result.session_id)
+            .await
+            .expect("raw store load should succeed")
+            .expect("create_session should persist a projection");
+
+        let mut committed = original.clone();
+        committed.push(meerkat_core::types::Message::User(
+            meerkat_core::types::UserMessage::text(
+                "runtime machine committed this turn first".to_string(),
+            ),
+        ));
+        let session_snapshot =
+            serde_json::to_vec(&committed).expect("committed snapshot should serialize");
+
+        service
+            .checkpoint_committed_runtime_session_snapshot(&result.session_id, &session_snapshot)
+            .await
+            .expect("committed runtime snapshot should update SessionStore projection");
+
+        let raw_after = store
+            .load(&result.session_id)
+            .await
+            .expect("raw store load should succeed")
+            .expect("projection should remain present");
+        assert_eq!(
+            raw_after.messages().len(),
+            original.messages().len() + 1,
+            "post-commit runtime checkpoint must make the SessionStore projection current"
         );
     }
 


### PR DESCRIPTION
## Summary
- add a post-machine-commit CoreExecutor hook for committed session snapshots
- have the mob runtime executor save runtime-committed snapshots back to the SessionStore projection
- add runtime ordering/failure tests and a persistent-service projection regression test

## Why
0.6.18 made StoreCheckpointer save-capable for runtime-backed sessions, but the MeerkatMachine-owned runtime loop committed turns through RuntimeStore without invoking the SessionStore projection save path. This wires the projection update after the machine commit succeeds, avoiding a pre-commit split-brain while restoring per-turn SessionStore saves for MobKit/UnifiedRuntime consumers.

## Tests
- ./scripts/repo-cargo fmt --check
- ./scripts/repo-cargo test -p meerkat-runtime runtime_loop_checkpoint -- --nocapture
- ./scripts/repo-cargo test -p meerkat-session --features session-store checkpoint_updates_session_store_projection -- --nocapture
- ./scripts/repo-cargo test -p meerkat-session --features session-store store_checkpointer -- --nocapture
- ./scripts/repo-cargo test -p meerkat-mob checkpoint_committed -- --nocapture
- git diff --check
