### PR TITLE
Fix classified inbox wake and peer delivery lifecycle

### DIFF
--- a/meerkat-comms/src/inbox.rs
+++ b/meerkat-comms/src/inbox.rs
@@ -26,6 +26,19 @@ use meerkat_core::{
 
 const DEFAULT_INBOX_CAPACITY: usize = 1024;
 
+#[cfg(test)]
+tokio::task_local! {
+    static CLASSIFIED_SEND_WAIT_BEFORE_AWAIT_HOOK: Arc<dyn Fn() + Send + Sync>;
+}
+
+#[cfg(test)]
+fn run_classified_send_wait_before_await_hook() {
+    let _ = CLASSIFIED_SEND_WAIT_BEFORE_AWAIT_HOOK.try_with(|hook| hook());
+}
+
+#[cfg(not(test))]
+fn run_classified_send_wait_before_await_hook() {}
+
 /// Reason an ingress item was dropped before it reached the classified queue.
 ///
 /// Every variant is a semantic failure mode — the envelope or event did not
@@ -281,6 +294,7 @@ impl ClassifiedInboxQueue {
 
     fn close(&mut self) {
         self.closed = true;
+        self.capacity_notify.notify_waiters();
     }
 
     fn snapshot(&self) -> PeerIngressQueueSnapshot {
@@ -837,9 +851,14 @@ impl InboxSender {
         let kind = result.kind;
         let is_actionable = result.class.is_actionable();
         let mut prepared = Some(result);
+        let capacity_notify = classified_queue.lock().capacity_notifier();
 
         loop {
-            let capacity_notify = {
+            let notified = capacity_notify.notified();
+            tokio::pin!(notified);
+            notified.as_mut().enable();
+
+            {
                 let mut queue = classified_queue.lock();
                 if queue.closed {
                     tracing::warn!(
@@ -882,9 +901,9 @@ impl InboxSender {
                     self.notify.notify_waiters();
                     return AdmissionOutcome::Admitted;
                 }
-                queue.capacity_notifier()
-            };
-            capacity_notify.notified().await;
+            }
+            run_classified_send_wait_before_await_hook();
+            notified.await;
         }
     }
 
@@ -1968,6 +1987,138 @@ mod tests {
             0,
             "revoked ingress must not be queued after capacity opens"
         );
+    }
+
+    #[tokio::test]
+    async fn test_classified_send_wait_cannot_miss_capacity_notify_between_check_and_await() {
+        let sender_pubkey = PubKey::new([1u8; 32]);
+        let ctx = make_classification_context(make_trusted("peer", &sender_pubkey), false);
+        let actionable_notify = Arc::new(Notify::new());
+        let notify = Arc::new(Notify::new());
+        let queue = ClassifiedInboxQueue::new(1, ctx.require_peer_auth, ctx.trusted_peers.clone());
+        let counter = queue.dropped_counter();
+        let classified_queue = Arc::new(Mutex::new(queue));
+        let (tx, _rx) = mpsc::channel::<InboxItem>(1);
+        let sender = InboxSender {
+            tx,
+            notify,
+            classification_context: Some(ctx),
+            classified_queue: Some(classified_queue.clone()),
+            actionable_notify: Some(actionable_notify),
+            dropped_count: Some(counter.clone()),
+        };
+
+        assert_eq!(
+            sender.send_classified(InboxItem::External {
+                envelope: make_test_envelope(),
+            }),
+            AdmissionOutcome::Admitted
+        );
+
+        let released_capacity = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let hook_queue = classified_queue.clone();
+        let hook_released_capacity = released_capacity.clone();
+        let hook: Arc<dyn Fn() + Send + Sync> = Arc::new(move || {
+            if !hook_released_capacity.swap(true, Ordering::SeqCst) {
+                assert!(
+                    hook_queue.lock().pop_front().is_some(),
+                    "test hook must free the exactly-full queue"
+                );
+            }
+        });
+
+        let waiting_sender = sender.clone();
+        let waiting = tokio::spawn(CLASSIFIED_SEND_WAIT_BEFORE_AWAIT_HOOK.scope(
+            hook,
+            async move {
+                waiting_sender
+                    .send_wait(InboxItem::External {
+                        envelope: make_test_envelope(),
+                    })
+                    .await
+            },
+        ));
+
+        assert_eq!(
+            tokio::time::timeout(std::time::Duration::from_secs(1), waiting)
+                .await
+                .expect("send_wait must observe the capacity wake registered before awaiting")
+                .expect("send_wait task should join"),
+            AdmissionOutcome::Admitted
+        );
+        assert!(
+            released_capacity.load(Ordering::SeqCst),
+            "test hook must have exercised the full-queue wait path"
+        );
+        assert_eq!(
+            classified_queue.lock().entries.len(),
+            1,
+            "waiting send should be admitted after the raced capacity wake"
+        );
+        assert_eq!(counter.load(Ordering::Relaxed), 0);
+    }
+
+    #[tokio::test]
+    async fn test_classified_send_wait_wakes_when_queue_closes_while_full() {
+        let sender_pubkey = PubKey::new([1u8; 32]);
+        let ctx = make_classification_context(make_trusted("peer", &sender_pubkey), false);
+        let actionable_notify = Arc::new(Notify::new());
+        let notify = Arc::new(Notify::new());
+        let queue = ClassifiedInboxQueue::new(1, ctx.require_peer_auth, ctx.trusted_peers.clone());
+        let counter = queue.dropped_counter();
+        let classified_queue = Arc::new(Mutex::new(queue));
+        let (tx, _rx) = mpsc::channel::<InboxItem>(1);
+        let sender = InboxSender {
+            tx,
+            notify,
+            classification_context: Some(ctx),
+            classified_queue: Some(classified_queue.clone()),
+            actionable_notify: Some(actionable_notify),
+            dropped_count: Some(counter.clone()),
+        };
+
+        assert_eq!(
+            sender.send_classified(InboxItem::External {
+                envelope: make_test_envelope(),
+            }),
+            AdmissionOutcome::Admitted
+        );
+
+        let closed_queue = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let hook_queue = classified_queue.clone();
+        let hook_closed_queue = closed_queue.clone();
+        let hook: Arc<dyn Fn() + Send + Sync> = Arc::new(move || {
+            if !hook_closed_queue.swap(true, Ordering::SeqCst) {
+                hook_queue.lock().close();
+            }
+        });
+
+        let waiting_sender = sender.clone();
+        let waiting = tokio::spawn(CLASSIFIED_SEND_WAIT_BEFORE_AWAIT_HOOK.scope(
+            hook,
+            async move {
+                waiting_sender
+                    .send_wait(InboxItem::External {
+                        envelope: make_test_envelope(),
+                    })
+                    .await
+            },
+        ));
+
+        assert_eq!(
+            tokio::time::timeout(std::time::Duration::from_secs(1), waiting)
+                .await
+                .expect("send_wait must wake when a full queue is closed")
+                .expect("send_wait task should join"),
+            AdmissionOutcome::Dropped {
+                reason: DropReason::SessionClosed
+            }
+        );
+        assert!(
+            closed_queue.load(Ordering::SeqCst),
+            "test hook must have exercised the full-queue close path"
+        );
+        assert_eq!(counter.load(Ordering::Relaxed), 1);
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 4)]

--- a/meerkat-mob/src/runtime/actor.rs
+++ b/meerkat-mob/src/runtime/actor.rs
@@ -44,6 +44,10 @@ impl InitialTurnHandle {
 const MAX_PARALLEL_REMOTE_MEMBER_TEARDOWNS: usize = 64;
 const MAX_LIFECYCLE_NOTIFICATION_TASKS: usize = 16;
 const MAX_PARALLEL_PEER_RETIRE_NOTIFICATIONS: usize = 64;
+#[cfg(not(test))]
+pub(super) const MAX_PENDING_PEER_DELIVERIES: usize = 1024;
+#[cfg(test)]
+pub(super) const MAX_PENDING_PEER_DELIVERIES: usize = 4;
 
 fn observed_runtime_id(signal: &mob_dsl::MobMachineSignal) -> Option<&mob_dsl::AgentRuntimeId> {
     match signal {
@@ -90,8 +94,22 @@ struct LocalBatchWiringEndpoint {
 }
 
 struct PeerMessageDeliveryPlan {
+    from: MeerkatId,
+    to: MeerkatId,
     sender_comms: Arc<dyn CoreCommsRuntime>,
     command: CommsCommand,
+}
+
+type PeerDeliveryId = u64;
+
+pub(super) struct PeerDeliveryCompletion {
+    id: PeerDeliveryId,
+}
+
+pub(super) struct PeerDeliveryInflight {
+    from: MeerkatId,
+    to: MeerkatId,
+    cancel_token: tokio_util::sync::CancellationToken,
 }
 
 struct SupervisorPrivateTrustInstall {
@@ -397,6 +415,10 @@ pub(super) struct MobActor {
     pub(super) pending_spawns: PendingSpawnLineage,
     pub(super) edge_locks: Arc<super::edge_locks::EdgeLockRegistry>,
     pub(super) lifecycle_tasks: tokio::task::JoinSet<()>,
+    pub(super) next_peer_delivery_ticket: PeerDeliveryId,
+    pub(super) peer_delivery_tasks: tokio::task::JoinSet<PeerDeliveryCompletion>,
+    pub(super) peer_delivery_inflight: BTreeMap<PeerDeliveryId, PeerDeliveryInflight>,
+    pub(super) peer_delivery_permits: Arc<tokio::sync::Semaphore>,
     pub(super) session_service: Arc<dyn MobSessionService>,
     #[cfg(feature = "runtime-adapter")]
     pub(super) runtime_adapter: Option<Arc<meerkat_runtime::MeerkatMachine>>,
@@ -2172,6 +2194,130 @@ impl MobActor {
         }
     }
 
+    fn drain_completed_peer_delivery_tasks(&mut self) {
+        while let Some(result) = self.peer_delivery_tasks.try_join_next() {
+            match result {
+                Ok(completion) => {
+                    self.peer_delivery_inflight.remove(&completion.id);
+                }
+                Err(error) => {
+                    tracing::debug!(error = %error, "peer delivery task failed");
+                    if self.peer_delivery_tasks.is_empty() {
+                        self.peer_delivery_inflight.clear();
+                    }
+                }
+            }
+        }
+    }
+
+    fn spawn_peer_message_delivery(
+        &mut self,
+        plan: PeerMessageDeliveryPlan,
+        reply_tx: tokio::sync::oneshot::Sender<Result<meerkat_core::comms::SendReceipt, MobError>>,
+    ) {
+        let permit = match self.peer_delivery_permits.clone().try_acquire_owned() {
+            Ok(permit) => permit,
+            Err(_) => {
+                let _ = reply_tx.send(Err(MobError::Internal(format!(
+                    "peer message delivery lane saturated (limit={MAX_PENDING_PEER_DELIVERIES})"
+                ))));
+                return;
+            }
+        };
+        let id = self.next_peer_delivery_ticket;
+        self.next_peer_delivery_ticket = self.next_peer_delivery_ticket.wrapping_add(1);
+        let cancel_token = tokio_util::sync::CancellationToken::new();
+        self.peer_delivery_inflight.insert(
+            id,
+            PeerDeliveryInflight {
+                from: plan.from.clone(),
+                to: plan.to.clone(),
+                cancel_token: cancel_token.clone(),
+            },
+        );
+        self.peer_delivery_tasks.spawn(async move {
+            let _permit = permit;
+            let result = tokio::select! {
+                result = plan.sender_comms.send(plan.command) => result.map_err(MobError::from),
+                () = cancel_token.cancelled() => Err(MobError::Internal(
+                    "peer message delivery canceled because mob topology or lifecycle changed".to_string(),
+                )),
+            };
+            let _ = reply_tx.send(result);
+            PeerDeliveryCompletion { id }
+        });
+    }
+
+    async fn cancel_pending_peer_deliveries(&mut self, reason: &'static str) {
+        self.cancel_peer_deliveries_matching(reason, |_| true).await;
+    }
+
+    async fn cancel_peer_deliveries_for_member(
+        &mut self,
+        member: &MeerkatId,
+        reason: &'static str,
+    ) {
+        self.cancel_peer_deliveries_matching(reason, |delivery| {
+            &delivery.from == member || &delivery.to == member
+        })
+        .await;
+    }
+
+    async fn cancel_peer_deliveries_for_edge(
+        &mut self,
+        a: &MeerkatId,
+        b: &MeerkatId,
+        reason: &'static str,
+    ) {
+        self.cancel_peer_deliveries_matching(reason, |delivery| {
+            (&delivery.from == a && &delivery.to == b) || (&delivery.from == b && &delivery.to == a)
+        })
+        .await;
+    }
+
+    async fn cancel_peer_deliveries_matching(
+        &mut self,
+        reason: &'static str,
+        mut predicate: impl FnMut(&PeerDeliveryInflight) -> bool,
+    ) {
+        let ids = self
+            .peer_delivery_inflight
+            .iter()
+            .filter_map(|(id, delivery)| predicate(delivery).then_some(*id))
+            .collect::<BTreeSet<_>>();
+        if ids.is_empty() {
+            return;
+        }
+        tracing::debug!(
+            mob_id = %self.definition.id,
+            pending = ids.len(),
+            reason,
+            "canceling pending peer delivery tasks"
+        );
+        for id in &ids {
+            if let Some(delivery) = self.peer_delivery_inflight.get(id) {
+                delivery.cancel_token.cancel();
+            }
+        }
+        while ids
+            .iter()
+            .any(|id| self.peer_delivery_inflight.contains_key(id))
+        {
+            match self.peer_delivery_tasks.join_next().await {
+                Some(Ok(completion)) => {
+                    self.peer_delivery_inflight.remove(&completion.id);
+                }
+                Some(Err(error)) => {
+                    tracing::debug!(error = %error, "peer delivery task failed during cancellation");
+                }
+                None => break,
+            }
+        }
+        for id in ids {
+            self.peer_delivery_inflight.remove(&id);
+        }
+    }
+
     async fn notify_orchestrator_lifecycle(&mut self, message: String) {
         // Drain completed lifecycle tasks (non-blocking).
         while let Some(result) = self.lifecycle_tasks.try_join_next() {
@@ -3203,6 +3349,7 @@ impl MobActor {
         }
         let mut deferred_commands = VecDeque::new();
         loop {
+            self.drain_completed_peer_delivery_tasks();
             let cmd = if let Some(cmd) = deferred_commands.pop_front() {
                 cmd
             } else if let Some(cmd) = command_rx.recv().await {
@@ -3310,14 +3457,7 @@ impl MobActor {
                         .await
                     {
                         Ok(plan) => {
-                            tokio::spawn(async move {
-                                let result = plan
-                                    .sender_comms
-                                    .send(plan.command)
-                                    .await
-                                    .map_err(MobError::from);
-                                let _ = reply_tx.send(result);
-                            });
+                            self.spawn_peer_message_delivery(plan, reply_tx);
                         }
                         Err(error) => {
                             let _ = reply_tx.send(Err(error));
@@ -3537,6 +3677,7 @@ impl MobActor {
                     ) {
                         Ok(()) => {
                             self.fail_all_pending_spawns("mob is stopping").await;
+                            self.cancel_pending_peer_deliveries("mob is stopping").await;
                             self.notify_orchestrator_lifecycle(format!(
                                 "Mob '{}' is stopping.",
                                 self.definition.id
@@ -3658,6 +3799,8 @@ impl MobActor {
                     ) {
                         Ok(()) => {
                             self.fail_all_pending_spawns("mob is completing").await;
+                            self.cancel_pending_peer_deliveries("mob is completing")
+                                .await;
                             self.handle_complete().await
                         }
                         Err(error) => Err(error),
@@ -3688,6 +3831,8 @@ impl MobActor {
                         continue;
                     }
                     self.fail_all_pending_spawns("mob is resetting").await;
+                    self.cancel_pending_peer_deliveries("mob is resetting")
+                        .await;
                     let result = self.handle_reset(prior_state).await;
                     let _ = reply_tx.send(result);
                 }
@@ -3878,6 +4023,8 @@ impl MobActor {
                         continue;
                     }
                     self.fail_all_pending_spawns("mob runtime is shutting down")
+                        .await;
+                    self.cancel_pending_peer_deliveries("mob runtime is shutting down")
                         .await;
                     let mut result: Result<(), MobError> = Ok(());
                     if let Err(error) = self.cancel_all_flow_tasks().await {
@@ -6627,6 +6774,8 @@ impl MobActor {
         };
 
         Ok(PeerMessageDeliveryPlan {
+            from,
+            to,
             sender_comms,
             command: CommsCommand::PeerMessage {
                 to: route,
@@ -6927,6 +7076,8 @@ impl MobActor {
                 return Ok(());
             }
 
+            self.cancel_peer_deliveries_for_edge(&local, &peer_meerkat_id, "members are unwiring")
+                .await;
             let dsl_removed = self.apply_unwire_members_idempotent(&edge)?;
             if let Err(error) = self
                 .unwire_peer_only_recipient(
@@ -7039,6 +7190,9 @@ impl MobActor {
             let _ = peer_comms.remove_trusted_peer(&local_peer_id).await;
             return Ok(());
         }
+
+        self.cancel_peer_deliveries_for_edge(&local, &peer_meerkat_id, "members are unwiring")
+            .await;
 
         // Submit DSL input first. Idempotent rejection (edge absent) is
         // handled above; here we expect acceptance (or a non-idempotent
@@ -7716,6 +7870,8 @@ impl MobActor {
     /// pipeline (policy-driven), then unconditional roster removal.
     async fn handle_retire(&mut self, agent_identity: MeerkatId) -> Result<(), MobError> {
         self.ensure_pending_spawn_alignment("handle_retire preflight")?;
+        self.cancel_peer_deliveries_for_member(&agent_identity, "member is retiring")
+            .await;
         self.handle_retire_inner(&agent_identity, false, false)
             .await?;
         self.ensure_pending_spawn_alignment("handle_retire completion")
@@ -8087,6 +8243,8 @@ impl MobActor {
                 "respawn canceled pending spawn lineage before replacement workflow"
             );
         }
+        self.cancel_peer_deliveries_for_member(&agent_identity, "member is respawning")
+            .await;
 
         // 1. Snapshot all replacement inputs before retiring. Topology comes
         // from the MobMachine authority; the roster is only the read model
@@ -9367,6 +9525,8 @@ impl MobActor {
             return Err(MobDestroyError::Incomplete { report });
         }
         self.fail_all_pending_spawns("mob is destroying").await;
+        self.cancel_pending_peer_deliveries("mob is destroying")
+            .await;
         if destroy_input_needed && self.has_orchestrator {
             self.apply_dsl_signal(
                 mob_dsl::MobMachineSignal::StopOrchestrator,
@@ -10602,6 +10762,8 @@ impl MobActor {
         let pending_reason = format!("{context}: draining pending spawns before bulk retirement");
         self.fail_all_pending_spawns(&pending_reason).await;
         self.ensure_pending_spawn_alignment("retire_all_members after pending drain")?;
+        self.cancel_pending_peer_deliveries("all members are retiring")
+            .await;
 
         let ids = {
             let roster = self.roster.read().await;

--- a/meerkat-mob/src/runtime/actor.rs
+++ b/meerkat-mob/src/runtime/actor.rs
@@ -89,6 +89,11 @@ struct LocalBatchWiringEndpoint {
     removal_key: String,
 }
 
+struct PeerMessageDeliveryPlan {
+    sender_comms: Arc<dyn CoreCommsRuntime>,
+    command: CommsCommand,
+}
+
 struct SupervisorPrivateTrustInstall {
     peer_id: String,
     epoch: u64,
@@ -3301,10 +3306,23 @@ impl MobActor {
                     handling_mode,
                     reply_tx,
                 } => {
-                    let result =
-                        Box::pin(self.handle_send_peer_message(from, to, content, handling_mode))
-                            .await;
-                    let _ = reply_tx.send(result);
+                    match Box::pin(self.prepare_send_peer_message(from, to, content, handling_mode))
+                        .await
+                    {
+                        Ok(plan) => {
+                            tokio::spawn(async move {
+                                let result = plan
+                                    .sender_comms
+                                    .send(plan.command)
+                                    .await
+                                    .map_err(MobError::from);
+                                let _ = reply_tx.send(result);
+                            });
+                        }
+                        Err(error) => {
+                            let _ = reply_tx.send(Err(error));
+                        }
+                    }
                 }
                 #[cfg(feature = "runtime-adapter")]
                 MobCommand::KickoffOutcomeResolved {
@@ -6539,13 +6557,13 @@ impl MobActor {
         })
     }
 
-    async fn handle_send_peer_message(
+    async fn prepare_send_peer_message(
         &mut self,
         from: MeerkatId,
         to: MeerkatId,
         content: ContentInput,
         handling_mode: meerkat_core::types::HandlingMode,
-    ) -> Result<meerkat_core::comms::SendReceipt, MobError> {
+    ) -> Result<PeerMessageDeliveryPlan, MobError> {
         self.require_state(&[MobState::Running])?;
         if from == to {
             return Err(MobError::WiringError(format!(
@@ -6608,15 +6626,15 @@ impl MobActor {
             }
         };
 
-        sender_comms
-            .send(CommsCommand::PeerMessage {
+        Ok(PeerMessageDeliveryPlan {
+            sender_comms,
+            command: CommsCommand::PeerMessage {
                 to: route,
                 body,
                 blocks,
                 handling_mode,
-            })
-            .await
-            .map_err(MobError::from)
+            },
+        })
     }
 
     async fn rollback_wire_members_batch(

--- a/meerkat-mob/src/runtime/builder.rs
+++ b/meerkat-mob/src/runtime/builder.rs
@@ -1910,6 +1910,12 @@ impl MobBuilder {
             pending_spawns: PendingSpawnLineage::new(),
             edge_locks: Arc::new(super::edge_locks::EdgeLockRegistry::new()),
             lifecycle_tasks: tokio::task::JoinSet::new(),
+            next_peer_delivery_ticket: 0,
+            peer_delivery_tasks: tokio::task::JoinSet::new(),
+            peer_delivery_inflight: BTreeMap::new(),
+            peer_delivery_permits: Arc::new(tokio::sync::Semaphore::new(
+                super::actor::MAX_PENDING_PEER_DELIVERIES,
+            )),
             session_service: handle_session_service,
             #[cfg(feature = "runtime-adapter")]
             runtime_adapter,

--- a/meerkat-mob/src/runtime/tests.rs
+++ b/meerkat-mob/src/runtime/tests.rs
@@ -189,6 +189,7 @@ struct MockCommsBehavior {
     fail_send_peer_retired: bool,
     fail_send_peer_unwired: bool,
     peer_lifecycle_delay_ms: u64,
+    peer_message_delay_ms: u64,
 }
 
 struct MockCommsRuntime {
@@ -506,6 +507,36 @@ impl CoreCommsRuntime for MockCommsRuntime {
                     envelope_id: uuid::Uuid::new_v4(),
                     interaction_id: InteractionId(uuid::Uuid::new_v4()),
                     stream_reserved: false,
+                })
+            }
+            CommsCommand::PeerMessage { to, .. } => {
+                {
+                    let trusted = self.trusted_peers.read().await;
+                    let peer_id = to.peer_id.as_str();
+                    if !trusted.contains_key(&peer_id) {
+                        return Err(SendError::PeerNotFound(to.label()));
+                    }
+                }
+
+                let delay_ms = self
+                    .behavior
+                    .read()
+                    .expect("poisoned behavior lock in mock runtime")
+                    .peer_message_delay_ms;
+                self.sent_intents
+                    .write()
+                    .await
+                    .push("peer_message_started".to_string());
+                if delay_ms > 0 {
+                    tokio::time::sleep(Duration::from_millis(delay_ms)).await;
+                }
+                self.sent_intents
+                    .write()
+                    .await
+                    .push("peer_message".to_string());
+                Ok(SendReceipt::PeerMessageSent {
+                    envelope_id: uuid::Uuid::new_v4(),
+                    acked: false,
                 })
             }
             unsupported => Err(SendError::Unsupported(format!(
@@ -24525,6 +24556,93 @@ fn assert_peer_response_terminal_consumed(
         ),
         "peer_response_terminal should be consumed after the runtime context append apply: {terminal:?}"
     );
+}
+
+#[tokio::test]
+async fn test_peer_message_delivery_backpressure_does_not_block_actor_mailbox() {
+    let (handle, service) = create_test_mob(sample_definition()).await;
+    service
+        .set_comms_behavior(
+            &test_comms_name("lead", "l-backpressure"),
+            MockCommsBehavior {
+                peer_message_delay_ms: 500,
+                ..MockCommsBehavior::default()
+            },
+        )
+        .await;
+
+    let sid_l = handle
+        .spawn(
+            ProfileName::from("lead"),
+            MeerkatId::from("l-backpressure"),
+            None,
+        )
+        .await
+        .expect("spawn lead")
+        .bridge_session_id()
+        .expect("session-backed")
+        .clone();
+    handle
+        .spawn(
+            ProfileName::from("worker"),
+            MeerkatId::from("w-backpressure"),
+            None,
+        )
+        .await
+        .expect("spawn worker");
+
+    handle
+        .wire(
+            AgentIdentity::from("l-backpressure"),
+            MeerkatId::from("w-backpressure"),
+        )
+        .await
+        .expect("wire should succeed");
+
+    let send_handle = handle.clone();
+    let delivery = tokio::spawn(async move {
+        send_handle
+            .send_peer_message(
+                AgentIdentity::from("l-backpressure"),
+                AgentIdentity::from("w-backpressure"),
+                "slow peer message",
+                meerkat_core::types::HandlingMode::Queue,
+            )
+            .await
+    });
+
+    tokio::time::timeout(Duration::from_secs(1), async {
+        loop {
+            if service
+                .sent_intents(&sid_l)
+                .await
+                .iter()
+                .any(|intent| intent == "peer_message_started")
+            {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .expect("peer message delivery should enter the slow comms send path");
+    assert!(
+        !delivery.is_finished(),
+        "mock peer delivery should still be waiting on artificial backpressure"
+    );
+
+    let members = tokio::time::timeout(Duration::from_millis(100), handle.list_members())
+        .await
+        .expect("actor mailbox commands must not queue behind peer delivery backpressure");
+    assert_eq!(members.len(), 2);
+
+    let receipt = tokio::time::timeout(Duration::from_secs(2), delivery)
+        .await
+        .expect("peer delivery should finish after the artificial delay")
+        .expect("delivery task should join")
+        .expect("peer message should succeed");
+    assert_eq!(receipt.from, AgentIdentity::from("l-backpressure"));
+    assert_eq!(receipt.to, AgentIdentity::from("w-backpressure"));
 }
 
 #[tokio::test]

--- a/meerkat-mob/src/runtime/tests.rs
+++ b/meerkat-mob/src/runtime/tests.rs
@@ -24646,6 +24646,292 @@ async fn test_peer_message_delivery_backpressure_does_not_block_actor_mailbox() 
 }
 
 #[tokio::test]
+async fn test_peer_message_delivery_canceled_when_mob_lifecycle_stops() {
+    let (handle, service) = create_test_mob(sample_definition()).await;
+    service
+        .set_comms_behavior(
+            &test_comms_name("lead", "l-stop-delivery"),
+            MockCommsBehavior {
+                peer_message_delay_ms: 5_000,
+                ..MockCommsBehavior::default()
+            },
+        )
+        .await;
+
+    let sid_l = handle
+        .spawn(
+            ProfileName::from("lead"),
+            MeerkatId::from("l-stop-delivery"),
+            None,
+        )
+        .await
+        .expect("spawn lead")
+        .bridge_session_id()
+        .expect("session-backed")
+        .clone();
+    handle
+        .spawn(
+            ProfileName::from("worker"),
+            MeerkatId::from("w-stop-delivery"),
+            None,
+        )
+        .await
+        .expect("spawn worker");
+
+    handle
+        .wire(
+            AgentIdentity::from("l-stop-delivery"),
+            MeerkatId::from("w-stop-delivery"),
+        )
+        .await
+        .expect("wire should succeed");
+
+    let send_handle = handle.clone();
+    let delivery = tokio::spawn(async move {
+        send_handle
+            .send_peer_message(
+                AgentIdentity::from("l-stop-delivery"),
+                AgentIdentity::from("w-stop-delivery"),
+                "pending peer message",
+                meerkat_core::types::HandlingMode::Queue,
+            )
+            .await
+    });
+
+    tokio::time::timeout(Duration::from_secs(1), async {
+        loop {
+            if service
+                .sent_intents(&sid_l)
+                .await
+                .iter()
+                .any(|intent| intent == "peer_message_started")
+            {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .expect("peer message delivery should enter the slow comms send path");
+
+    handle.stop().await.expect("stop should succeed");
+
+    let result = tokio::time::timeout(Duration::from_secs(1), delivery)
+        .await
+        .expect("delivery should be released by lifecycle cancellation")
+        .expect("delivery task should join");
+    assert!(
+        matches!(result, Err(MobError::Internal(ref message)) if message.contains("topology or lifecycle changed")),
+        "pending peer delivery should fail through the lifecycle cancellation path: {result:?}"
+    );
+    assert!(
+        !service
+            .sent_intents(&sid_l)
+            .await
+            .iter()
+            .any(|intent| intent == "peer_message"),
+        "pending peer delivery must not commit after the mob stops"
+    );
+}
+
+#[tokio::test]
+async fn test_peer_message_delivery_canceled_when_members_unwire() {
+    let (handle, service) = create_test_mob(sample_definition()).await;
+    service
+        .set_comms_behavior(
+            &test_comms_name("lead", "l-unwire-delivery"),
+            MockCommsBehavior {
+                peer_message_delay_ms: 5_000,
+                ..MockCommsBehavior::default()
+            },
+        )
+        .await;
+
+    let sid_l = handle
+        .spawn(
+            ProfileName::from("lead"),
+            MeerkatId::from("l-unwire-delivery"),
+            None,
+        )
+        .await
+        .expect("spawn lead")
+        .bridge_session_id()
+        .expect("session-backed")
+        .clone();
+    handle
+        .spawn(
+            ProfileName::from("worker"),
+            MeerkatId::from("w-unwire-delivery"),
+            None,
+        )
+        .await
+        .expect("spawn worker");
+
+    handle
+        .wire(
+            AgentIdentity::from("l-unwire-delivery"),
+            MeerkatId::from("w-unwire-delivery"),
+        )
+        .await
+        .expect("wire should succeed");
+
+    let send_handle = handle.clone();
+    let delivery = tokio::spawn(async move {
+        send_handle
+            .send_peer_message(
+                AgentIdentity::from("l-unwire-delivery"),
+                AgentIdentity::from("w-unwire-delivery"),
+                "pending peer message",
+                meerkat_core::types::HandlingMode::Queue,
+            )
+            .await
+    });
+
+    tokio::time::timeout(Duration::from_secs(1), async {
+        loop {
+            if service
+                .sent_intents(&sid_l)
+                .await
+                .iter()
+                .any(|intent| intent == "peer_message_started")
+            {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .expect("peer message delivery should enter the slow comms send path");
+
+    handle
+        .unwire(
+            AgentIdentity::from("l-unwire-delivery"),
+            AgentIdentity::from("w-unwire-delivery"),
+        )
+        .await
+        .expect("unwire should succeed");
+
+    let result = tokio::time::timeout(Duration::from_secs(1), delivery)
+        .await
+        .expect("delivery should be released by topology cancellation")
+        .expect("delivery task should join");
+    assert!(
+        matches!(result, Err(MobError::Internal(ref message)) if message.contains("topology or lifecycle changed")),
+        "pending peer delivery should fail through the topology cancellation path: {result:?}"
+    );
+    assert!(
+        !service
+            .sent_intents(&sid_l)
+            .await
+            .iter()
+            .any(|intent| intent == "peer_message"),
+        "pending peer delivery must not commit after the members unwire"
+    );
+}
+
+#[tokio::test]
+async fn test_peer_message_delivery_lane_is_bounded() {
+    let (handle, service) = create_test_mob(sample_definition()).await;
+    service
+        .set_comms_behavior(
+            &test_comms_name("lead", "l-bounded-delivery"),
+            MockCommsBehavior {
+                peer_message_delay_ms: 5_000,
+                ..MockCommsBehavior::default()
+            },
+        )
+        .await;
+
+    let sid_l = handle
+        .spawn(
+            ProfileName::from("lead"),
+            MeerkatId::from("l-bounded-delivery"),
+            None,
+        )
+        .await
+        .expect("spawn lead")
+        .bridge_session_id()
+        .expect("session-backed")
+        .clone();
+    handle
+        .spawn(
+            ProfileName::from("worker"),
+            MeerkatId::from("w-bounded-delivery"),
+            None,
+        )
+        .await
+        .expect("spawn worker");
+
+    handle
+        .wire(
+            AgentIdentity::from("l-bounded-delivery"),
+            MeerkatId::from("w-bounded-delivery"),
+        )
+        .await
+        .expect("wire should succeed");
+
+    let mut deliveries = Vec::new();
+    for _ in 0..super::actor::MAX_PENDING_PEER_DELIVERIES {
+        let send_handle = handle.clone();
+        deliveries.push(tokio::spawn(async move {
+            send_handle
+                .send_peer_message(
+                    AgentIdentity::from("l-bounded-delivery"),
+                    AgentIdentity::from("w-bounded-delivery"),
+                    "pending peer message",
+                    meerkat_core::types::HandlingMode::Queue,
+                )
+                .await
+        }));
+    }
+
+    tokio::time::timeout(Duration::from_secs(1), async {
+        loop {
+            let started = service
+                .sent_intents(&sid_l)
+                .await
+                .iter()
+                .filter(|intent| intent.as_str() == "peer_message_started")
+                .count();
+            if started == super::actor::MAX_PENDING_PEER_DELIVERIES {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .expect("all delivery-lane permits should be occupied");
+
+    let saturated = handle
+        .send_peer_message(
+            AgentIdentity::from("l-bounded-delivery"),
+            AgentIdentity::from("w-bounded-delivery"),
+            "one too many peer messages",
+            meerkat_core::types::HandlingMode::Queue,
+        )
+        .await;
+    assert!(
+        matches!(saturated, Err(MobError::Internal(ref message)) if message.contains("delivery lane saturated")),
+        "extra peer delivery should fail instead of spawning unbounded work: {saturated:?}"
+    );
+
+    handle
+        .stop()
+        .await
+        .expect("stop should cancel pending sends");
+    for delivery in deliveries {
+        let result = tokio::time::timeout(Duration::from_secs(1), delivery)
+            .await
+            .expect("delivery should be released by stop")
+            .expect("delivery task should join");
+        assert!(
+            matches!(result, Err(MobError::Internal(ref message)) if message.contains("topology or lifecycle changed")),
+            "pending peer delivery should fail through lifecycle cancellation: {result:?}"
+        );
+    }
+}
+
+#[tokio::test]
 async fn test_peer_message_reaches_idle_autonomous_member_after_kickoff_completion() {
     let _serial = REAL_COMMS_TEST_LOCK.lock().expect("real-comms test lock");
     let (handle, service) =


### PR DESCRIPTION
## Summary

- fix classified inbox capacity waiting so `send_classified_wait` registers its wake before checking capacity and wakes senders on close
- move Mob peer-message delivery out of the actor command loop so backpressured recipients do not wedge unrelated `mob.handle.*` calls
- keep offloaded peer deliveries actor-owned with a bounded delivery lane, per-delivery cancellation, member/edge topology fences, and lifecycle cancellation on stop, complete, reset, destroy, and shutdown

## Validation

- `./scripts/repo-cargo test -p meerkat-comms classified_send_wait -- --nocapture`
- `./scripts/repo-cargo test -p meerkat-mob peer_message_delivery -- --nocapture`
- `./scripts/repo-cargo test -p meerkat-mob peer_message -- --nocapture`
- `./scripts/repo-cargo fmt --check`
- `git diff --check`
- `./scripts/repo-cargo clippy -p meerkat-mob -p meerkat-comms --all-targets -- -D warnings`
- pre-push hook: changed-crates clippy, machine codegen verify, generated header audit, bridge ResponseStatus audit, Bazel freshness, workspace deterministic gate
