### PR TITLE
Fix interrupt-yielding live steer injection

### DIFF
--- a/meerkat-core/src/lifecycle/core_executor.rs
+++ b/meerkat-core/src/lifecycle/core_executor.rs
@@ -9,6 +9,7 @@ use super::run_primitive::RunPrimitive;
 use super::run_receipt::RunBoundaryReceipt;
 use crate::error::AgentError;
 use crate::service::SessionError;
+use crate::session::PendingSystemContextAppend;
 use crate::turn_execution_authority::{TurnTerminalCauseKind, TurnTerminalOutcome};
 use crate::types::RunResult;
 use serde_json::Value;
@@ -371,8 +372,7 @@ impl CoreApplyOutput {
     }
 }
 
-/// Cloneable live endpoint for asking an executor to stop at the next
-/// cooperative turn boundary.
+/// Cloneable live endpoint for cooperative in-flight turn boundaries.
 ///
 /// ```compile_fail
 /// use meerkat_core::lifecycle::CoreExecutorBoundaryHandle;
@@ -388,6 +388,22 @@ impl CoreApplyOutput {
 #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
 pub trait CoreExecutorBoundaryHandle: Send + Sync {
     async fn cancel_after_boundary(&self, reason: String) -> Result<(), CoreExecutorError>;
+
+    /// Stage runtime-owned system context for the next cooperative LLM
+    /// boundary of the active turn.
+    ///
+    /// Implementations that can serialize the staged session snapshot return
+    /// it so the runtime control plane can commit the snapshot atomically with
+    /// the consumed input state. Implementations without durable session
+    /// authority may return `None`.
+    async fn stage_system_context_at_boundary(
+        &self,
+        _appends: Vec<PendingSystemContextAppend>,
+    ) -> Result<Option<Vec<u8>>, CoreExecutorError> {
+        Err(CoreExecutorError::Internal(
+            "live boundary system-context staging is unsupported by this executor".to_string(),
+        ))
+    }
 }
 
 /// Cloneable live endpoint for hard-cancelling the active run immediately.

--- a/meerkat-mob/src/runtime/provisioner.rs
+++ b/meerkat-mob/src/runtime/provisioner.rs
@@ -1162,6 +1162,17 @@ impl CoreExecutorBoundaryHandle for MobSessionRuntimeBoundaryHandle {
             })
             .map_err(|err| CoreExecutorError::control_failed_runtime(err.to_string()))
     }
+
+    async fn stage_system_context_at_boundary(
+        &self,
+        appends: Vec<PendingSystemContextAppend>,
+    ) -> Result<Option<Vec<u8>>, CoreExecutorError> {
+        self.session_service
+            .apply_runtime_system_context_for_turn(&self.bridge_session_id, appends)
+            .await
+            .map_err(|err| CoreExecutorError::apply_failed_runtime_context(err.to_string()))?;
+        Ok(None)
+    }
 }
 
 #[cfg(feature = "runtime-adapter")]

--- a/meerkat-mob/src/runtime/tests.rs
+++ b/meerkat-mob/src/runtime/tests.rs
@@ -25325,7 +25325,7 @@ async fn test_peer_messages_reach_all_ready_autonomous_members_before_kickoff_se
 }
 
 #[tokio::test]
-async fn test_running_peer_message_to_autonomous_member_drains_after_current_apply() {
+async fn test_running_peer_message_to_autonomous_member_live_injects_during_current_apply() {
     let _serial = REAL_COMMS_TEST_LOCK.lock().expect("real-comms test lock");
     let (handle, service) =
         create_test_mob_with_runtime_backed_real_comms(sample_definition()).await;
@@ -25383,6 +25383,10 @@ async fn test_running_peer_message_to_autonomous_member_drains_after_current_app
         .expect("kickoff should resolve before we switch into blocked-turn mode");
 
     let baseline_prompts = service.applied_runtime_prompts(&sid_worker).await.len();
+    let baseline_context_appends = service
+        .applied_runtime_context_appends(&sid_worker)
+        .await
+        .len();
     service.set_keep_alive_turns_complete_immediately(false);
 
     let artist_comms = service.real_comms(&sid_artist).await.expect("artist comms");
@@ -25437,34 +25441,55 @@ async fn test_running_peer_message_to_autonomous_member_drains_after_current_app
     .await
     .expect("second peer message should succeed");
 
-    service
-        .interrupt(&sid_worker)
-        .await
-        .expect("interrupt should release blocked worker apply");
-
-    let delivered_second = tokio::time::timeout(Duration::from_secs(5), async {
+    tokio::time::timeout(Duration::from_secs(5), async {
         loop {
-            let prompts = service.applied_runtime_prompts(&sid_worker).await;
-            if prompts.iter().skip(baseline_prompts + 1).any(|prompt| {
-                prompt
-                    .text_content()
-                    .contains("body: second peer message while running")
-            }) {
+            let context_appends = service.applied_runtime_context_appends(&sid_worker).await;
+            if context_appends
+                .iter()
+                .skip(baseline_context_appends)
+                .any(|append| {
+                    append
+                        .text
+                        .contains("body: second peer message while running")
+                })
+            {
                 break;
             }
             tokio::time::sleep(Duration::from_millis(25)).await;
         }
     })
-    .await;
+    .await
+    .expect("second steer peer message should live-inject while the active turn is still blocked");
+
+    service
+        .interrupt(&sid_worker)
+        .await
+        .expect("interrupt should release blocked worker apply");
+
+    tokio::time::timeout(Duration::from_secs(2), async {
+        loop {
+            let prompts = service.applied_runtime_prompts(&sid_worker).await;
+            if prompts.len() == baseline_prompts + 1 {
+                break;
+            }
+            assert!(
+                !prompts.iter().skip(baseline_prompts + 1).any(|prompt| {
+                    prompt
+                        .text_content()
+                        .contains("body: second peer message while running")
+                }),
+                "live-injected steer must not replay as a later runtime turn"
+            );
+            tokio::time::sleep(Duration::from_millis(25)).await;
+        }
+    })
+    .await
+    .expect("live-injected steer should not schedule a second apply after release");
 
     tokio::time::timeout(Duration::from_secs(2), handle.stop())
         .await
         .expect("stop timeout after running peer message assertion")
         .expect("stop after running peer message assertion");
-
-    delivered_second.expect(
-        "second steer peer message should drain onto the next apply after the active turn completes",
-    );
 }
 
 #[tokio::test]

--- a/meerkat-runtime/src/driver/ephemeral.rs
+++ b/meerkat-runtime/src/driver/ephemeral.rs
@@ -1595,6 +1595,37 @@ impl EphemeralRuntimeDriver {
         Ok(())
     }
 
+    pub(crate) fn next_live_boundary_context_sequence(&self, run_id: &RunId) -> u64 {
+        self.ledger
+            .iter()
+            .filter_map(|(input_id, _)| {
+                (self.input_last_run_id(input_id).as_ref() == Some(run_id))
+                    .then(|| self.input_last_boundary_sequence(input_id))
+                    .flatten()
+            })
+            .max()
+            .unwrap_or(0)
+            .saturating_add(1)
+    }
+
+    pub(crate) fn machine_realize_live_boundary_context_injected(
+        &mut self,
+        run_id: &RunId,
+        input_ids: &[InputId],
+        receipt: &RunBoundaryReceipt,
+    ) -> Result<(), RuntimeDriverError> {
+        let checkpoint = self.rollback_snapshot();
+        if let Err(err) = self
+            .machine_realize_stage_batch(input_ids, run_id)
+            .and_then(|()| self.machine_realize_boundary_applied(run_id, receipt))
+            .and_then(|()| self.machine_realize_run_completed(run_id, input_ids))
+        {
+            self.restore_rollback_snapshot(checkpoint);
+            return Err(err);
+        }
+        Ok(())
+    }
+
     pub fn rollback_staged(&mut self, input_ids: &[InputId]) -> Result<(), RuntimeDriverError> {
         for input_id in input_ids {
             // Skip inputs that are no longer in Staged (terminal or never-staged).

--- a/meerkat-runtime/src/driver/persistent.rs
+++ b/meerkat-runtime/src/driver/persistent.rs
@@ -500,6 +500,54 @@ impl PersistentRuntimeDriver {
             .machine_realize_run_completed(run_id, consumed_input_ids)
     }
 
+    pub(crate) fn next_live_boundary_context_sequence(&self, run_id: &RunId) -> u64 {
+        self.inner.next_live_boundary_context_sequence(run_id)
+    }
+
+    pub(crate) async fn machine_realize_live_boundary_context_injected(
+        &mut self,
+        run_id: &RunId,
+        input_ids: &[InputId],
+        receipt: &RunBoundaryReceipt,
+        session_snapshot: Option<Vec<u8>>,
+    ) -> Result<(), RuntimeDriverError> {
+        let checkpoint = self.inner.rollback_snapshot();
+        if let Err(err) = self
+            .inner
+            .machine_realize_live_boundary_context_injected(run_id, input_ids, receipt)
+        {
+            self.inner.restore_rollback_snapshot(checkpoint);
+            return Err(err);
+        }
+        let input_updates = self.inner.stored_input_states_snapshot();
+        if let Err(err) = self
+            .store
+            .atomic_apply(
+                &self.runtime_id,
+                session_snapshot
+                    .as_ref()
+                    .map(|session_snapshot| crate::store::SessionDelta {
+                        session_snapshot: session_snapshot.clone(),
+                    }),
+                receipt.clone(),
+                input_updates,
+                session_snapshot
+                    .as_deref()
+                    .and_then(|snapshot| {
+                        serde_json::from_slice::<meerkat_core::Session>(snapshot).ok()
+                    })
+                    .map(|session| session.id().clone()),
+            )
+            .await
+        {
+            self.inner.restore_rollback_snapshot(checkpoint);
+            return Err(RuntimeDriverError::Internal(format!(
+                "runtime live-boundary context commit failed: {err}"
+            )));
+        }
+        Ok(())
+    }
+
     pub(crate) async fn machine_commit_completed_boundary_snapshot(
         &mut self,
         receipt: &RunBoundaryReceipt,

--- a/meerkat-runtime/src/input.rs
+++ b/meerkat-runtime/src/input.rs
@@ -970,6 +970,68 @@ pub(crate) fn runtime_input_projection_for_machine_batch(
     projection
 }
 
+pub(crate) fn context_append_to_pending_system_context_append(
+    append: &ConversationContextAppend,
+) -> meerkat_core::PendingSystemContextAppend {
+    let text = render_core_context_for_pending_system_context(&append.content);
+    meerkat_core::PendingSystemContextAppend {
+        text,
+        source: Some(append.key.clone()),
+        idempotency_key: Some(append.key.clone()),
+        accepted_at: meerkat_core::time_compat::SystemTime::now(),
+    }
+}
+
+pub(crate) fn projection_to_pending_system_context_appends(
+    input_id: &InputId,
+    projection: &crate::ingress_types::RuntimeInputProjection,
+) -> Vec<meerkat_core::PendingSystemContextAppend> {
+    if let Some(append) = projection.context_append.as_ref() {
+        return std::iter::once(context_append_to_pending_system_context_append(append))
+            .filter(|append| !append.text.trim().is_empty())
+            .collect();
+    }
+
+    projection
+        .append
+        .as_ref()
+        .map(|append| {
+            let key = format!("runtime:steer:{input_id}");
+            meerkat_core::PendingSystemContextAppend {
+                text: render_core_context_for_pending_system_context(&append.content),
+                source: Some(key.clone()),
+                idempotency_key: Some(key),
+                accepted_at: meerkat_core::time_compat::SystemTime::now(),
+            }
+        })
+        .into_iter()
+        .filter(|append| !append.text.trim().is_empty())
+        .collect()
+}
+
+fn render_core_context_for_pending_system_context(content: &CoreRenderable) -> String {
+    match content {
+        CoreRenderable::Text { text } => text.clone(),
+        CoreRenderable::Blocks { blocks } => meerkat_core::types::text_content(blocks),
+        CoreRenderable::Json { value } => {
+            serde_json::to_string_pretty(value).unwrap_or_else(|_| value.to_string())
+        }
+        CoreRenderable::Reference { uri, label } => match label {
+            Some(label) => format!("{label}: {uri}"),
+            None => uri.clone(),
+        },
+        CoreRenderable::SystemNotice { kind, body, blocks } => {
+            meerkat_core::types::SystemNoticeMessage::with_blocks(
+                *kind,
+                body.clone(),
+                blocks.clone(),
+            )
+            .model_projection_text()
+        }
+        _ => String::new(),
+    }
+}
+
 #[cfg(test)]
 #[allow(clippy::unwrap_used, clippy::panic)]
 mod tests {
@@ -1182,6 +1244,106 @@ mod tests {
             Some("display-agent")
         );
         assert_eq!(peer.as_ref().map(|peer| peer.id.as_str()), Some(route_id));
+    }
+
+    #[test]
+    fn steer_projection_uses_context_append_as_pending_system_context() {
+        let input_id = InputId::new();
+        let projection = crate::ingress_types::RuntimeInputProjection {
+            append: Some(ConversationAppend {
+                role: ConversationAppendRole::SystemNotice,
+                content: CoreRenderable::Text {
+                    text: "ordinary append must lose to context append".into(),
+                },
+            }),
+            additional_appends: Vec::new(),
+            context_append: Some(ConversationContextAppend {
+                key: "peer_response_terminal:peer:req".into(),
+                content: CoreRenderable::Text {
+                    text: "terminal response is ready".into(),
+                },
+            }),
+        };
+
+        let appends = projection_to_pending_system_context_appends(&input_id, &projection);
+
+        assert_eq!(appends.len(), 1);
+        assert_eq!(appends[0].text, "terminal response is ready");
+        assert_eq!(
+            appends[0].source.as_deref(),
+            Some("peer_response_terminal:peer:req")
+        );
+        assert_eq!(
+            appends[0].idempotency_key.as_deref(),
+            Some("peer_response_terminal:peer:req")
+        );
+    }
+
+    #[test]
+    fn steer_projection_falls_back_to_ordinary_peer_append() {
+        let mut header = make_header();
+        header.source = InputOrigin::Peer {
+            peer_id: "peer-a".into(),
+            display_identity: Some("Peer A".into()),
+            runtime_id: None,
+        };
+        let input = Input::Peer(PeerInput {
+            header,
+            convention: Some(PeerConvention::Message),
+            body: "please look at this while you work".into(),
+            payload: None,
+            blocks: None,
+            handling_mode: Some(HandlingMode::Steer),
+        });
+        let input_id = input.id().clone();
+        let projection = runtime_input_projection(&input);
+
+        let appends = projection_to_pending_system_context_appends(&input_id, &projection);
+
+        assert_eq!(appends.len(), 1);
+        assert!(
+            appends[0]
+                .text
+                .contains("please look at this while you work"),
+            "peer message append should be renderable as live system context: {:?}",
+            appends[0].text
+        );
+        assert_eq!(
+            appends[0].source.as_deref(),
+            Some(format!("runtime:steer:{input_id}").as_str())
+        );
+        assert_eq!(
+            appends[0].idempotency_key.as_deref(),
+            Some(format!("runtime:steer:{input_id}").as_str())
+        );
+    }
+
+    #[test]
+    fn steer_projection_filters_empty_context_and_empty_append() {
+        let input_id = InputId::new();
+        let context_projection = crate::ingress_types::RuntimeInputProjection {
+            append: None,
+            additional_appends: Vec::new(),
+            context_append: Some(ConversationContextAppend {
+                key: "empty-context".into(),
+                content: CoreRenderable::Text { text: "  ".into() },
+            }),
+        };
+        assert!(
+            projection_to_pending_system_context_appends(&input_id, &context_projection).is_empty()
+        );
+
+        let append_projection = crate::ingress_types::RuntimeInputProjection {
+            append: Some(ConversationAppend {
+                role: ConversationAppendRole::SystemNotice,
+                content: CoreRenderable::Text { text: "\n".into() },
+            }),
+            additional_appends: Vec::new(),
+            context_append: None,
+        };
+        assert!(
+            projection_to_pending_system_context_appends(&input_id, &append_projection).is_empty()
+        );
     }
 
     #[test]

--- a/meerkat-runtime/src/meerkat_machine/dispatch_ingress.rs
+++ b/meerkat-runtime/src/meerkat_machine/dispatch_ingress.rs
@@ -155,8 +155,9 @@ impl MeerkatMachine {
                         }
                     }
                 };
+                let accepted_input_id_for_live_boundary = accepted_input_id.clone();
                 let (signal, runtime_effect, effect_previous_dsl_state) = if let Some(input_id) =
-                    accepted_input_id
+                    accepted_input_id.clone()
                 {
                     let (previous_dsl_state, effects) = self
                         .apply_session_dsl_input(
@@ -208,7 +209,7 @@ impl MeerkatMachine {
                         .dispatch_cancel_after_boundary_runtime_effect(
                             &session_id,
                             effect_tx,
-                            boundary_handle,
+                            boundary_handle.clone(),
                             projected_effect,
                             "AcceptWithCompletion",
                         )
@@ -219,6 +220,72 @@ impl MeerkatMachine {
                             .await;
                     }
                     return Err(err);
+                }
+
+                if state == RuntimeState::Running
+                    && signal.should_interrupt_yielding()
+                    && resolved.policy.apply_mode == crate::policy::ApplyMode::StageRunBoundary
+                    && let (Some(input_id), Some(boundary_handle)) =
+                        (accepted_input_id_for_live_boundary, boundary_handle)
+                {
+                    let live_boundary_plan = {
+                        let driver = driver.lock().await;
+                        let run_id = driver.current_run_id();
+                        let projection = driver.driver_ingress().primitive_projection(&input_id);
+                        run_id.and_then(|run_id| {
+                            let projection = projection?;
+                            let appends =
+                                crate::input::projection_to_pending_system_context_appends(
+                                    &input_id,
+                                    &projection,
+                                );
+                            if appends.is_empty() {
+                                return None;
+                            }
+                            let sequence = driver.next_live_boundary_context_sequence(&run_id);
+                            Some((run_id, appends, sequence))
+                        })
+                    };
+
+                    if let Some((run_id, appends, sequence)) = live_boundary_plan {
+                        match boundary_handle
+                            .stage_system_context_at_boundary(appends)
+                            .await
+                        {
+                            Ok(session_snapshot) => {
+                                let receipt = meerkat_core::lifecycle::RunBoundaryReceipt {
+                                    run_id: run_id.clone(),
+                                    boundary: meerkat_core::lifecycle::run_primitive::RunApplyBoundary::RunCheckpoint,
+                                    contributing_input_ids: vec![input_id.clone()],
+                                    conversation_digest: None,
+                                    message_count: 0,
+                                    sequence,
+                                };
+                                {
+                                    let mut driver = driver.lock().await;
+                                    driver
+                                        .machine_realize_live_boundary_context_injected(
+                                            &run_id,
+                                            std::slice::from_ref(&input_id),
+                                            &receipt,
+                                            session_snapshot,
+                                        )
+                                        .await?;
+                                }
+                                let mut completions = completions.lock().await;
+                                completions.resolve_without_result(&input_id);
+                            }
+                            Err(error) => {
+                                tracing::warn!(
+                                    session_id = %session_id,
+                                    run_id = %run_id,
+                                    input_id = %input_id,
+                                    error = %error,
+                                    "live boundary context staging failed; leaving steer input queued for ordinary post-turn drain"
+                                );
+                            }
+                        }
+                    }
                 }
 
                 Ok(MeerkatMachineCommandResult::AcceptWithCompletion {

--- a/meerkat-runtime/src/meerkat_machine/driver.rs
+++ b/meerkat-runtime/src/meerkat_machine/driver.rs
@@ -471,6 +471,37 @@ impl DriverEntry {
         }
     }
 
+    pub(crate) fn next_live_boundary_context_sequence(&self, run_id: &RunId) -> u64 {
+        match self {
+            DriverEntry::Ephemeral(d) => d.next_live_boundary_context_sequence(run_id),
+            DriverEntry::Persistent(d) => d.next_live_boundary_context_sequence(run_id),
+        }
+    }
+
+    pub(crate) async fn machine_realize_live_boundary_context_injected(
+        &mut self,
+        run_id: &RunId,
+        input_ids: &[InputId],
+        receipt: &RunBoundaryReceipt,
+        session_snapshot: Option<Vec<u8>>,
+    ) -> Result<(), RuntimeDriverError> {
+        match self {
+            DriverEntry::Ephemeral(d) => {
+                let _ = session_snapshot;
+                d.machine_realize_live_boundary_context_injected(run_id, input_ids, receipt)
+            }
+            DriverEntry::Persistent(d) => {
+                d.machine_realize_live_boundary_context_injected(
+                    run_id,
+                    input_ids,
+                    receipt,
+                    session_snapshot,
+                )
+                .await
+            }
+        }
+    }
+
     /// Stage an input (Queued → Staged).
     pub(crate) fn stage_input(
         &mut self,

--- a/meerkat-runtime/src/meerkat_machine_tests.rs
+++ b/meerkat-runtime/src/meerkat_machine_tests.rs
@@ -5960,10 +5960,261 @@ async fn service_peer_admission_wakes_without_live_cancel_after_boundary() {
     );
 }
 
+#[derive(Clone)]
+struct InterruptYieldingProbe {
+    live_boundary_cancel_calls: Arc<AtomicUsize>,
+    live_boundary_stage_calls: Arc<AtomicUsize>,
+    live_boundary_staged_texts: Arc<std::sync::Mutex<Vec<String>>>,
+    fail_live_stage: Arc<AtomicBool>,
+}
+
+impl InterruptYieldingProbe {
+    fn new(fail_live_stage: bool) -> Self {
+        Self {
+            live_boundary_cancel_calls: Arc::new(AtomicUsize::new(0)),
+            live_boundary_stage_calls: Arc::new(AtomicUsize::new(0)),
+            live_boundary_staged_texts: Arc::new(std::sync::Mutex::new(Vec::new())),
+            fail_live_stage: Arc::new(AtomicBool::new(fail_live_stage)),
+        }
+    }
+
+    fn staged_texts(&self) -> Vec<String> {
+        self.live_boundary_staged_texts
+            .lock()
+            .expect("staged text mutex poisoned")
+            .clone()
+    }
+}
+
+struct InterruptYieldingBoundaryHandle {
+    probe: InterruptYieldingProbe,
+}
+
+#[async_trait::async_trait]
+impl CoreExecutorBoundaryHandle for InterruptYieldingBoundaryHandle {
+    async fn cancel_after_boundary(&self, _reason: String) -> Result<(), CoreExecutorError> {
+        self.probe
+            .live_boundary_cancel_calls
+            .fetch_add(1, Ordering::SeqCst);
+        Ok(())
+    }
+
+    async fn stage_system_context_at_boundary(
+        &self,
+        appends: Vec<meerkat_core::PendingSystemContextAppend>,
+    ) -> Result<Option<Vec<u8>>, CoreExecutorError> {
+        self.probe
+            .live_boundary_stage_calls
+            .fetch_add(1, Ordering::SeqCst);
+        if self.probe.fail_live_stage.load(Ordering::SeqCst) {
+            return Err(CoreExecutorError::Internal(
+                "test live-stage failure".to_string(),
+            ));
+        }
+        let mut staged = self
+            .probe
+            .live_boundary_staged_texts
+            .lock()
+            .expect("staged text mutex poisoned");
+        staged.extend(appends.into_iter().map(|append| append.text));
+        Ok(None)
+    }
+}
+
+struct InterruptYieldingBlockingExecutor {
+    apply_calls: Arc<AtomicUsize>,
+    queued_boundary_cancel_calls: Arc<AtomicUsize>,
+    apply_started: Arc<Notify>,
+    allow_finish: Arc<Notify>,
+    probe: Option<InterruptYieldingProbe>,
+}
+
+#[async_trait::async_trait]
+impl CoreExecutor for InterruptYieldingBlockingExecutor {
+    fn boundary_handle(&self) -> Option<Arc<dyn CoreExecutorBoundaryHandle>> {
+        self.probe.clone().map(|probe| {
+            Arc::new(InterruptYieldingBoundaryHandle { probe })
+                as Arc<dyn CoreExecutorBoundaryHandle>
+        })
+    }
+
+    async fn apply(
+        &mut self,
+        run_id: RunId,
+        primitive: RunPrimitive,
+    ) -> Result<CoreApplyOutput, CoreExecutorError> {
+        self.apply_calls.fetch_add(1, Ordering::SeqCst);
+        self.apply_started.notify_waiters();
+        self.allow_finish.notified().await;
+        Ok(CoreApplyOutput {
+            receipt: RunBoundaryReceipt {
+                run_id,
+                boundary: primitive.apply_boundary(),
+                contributing_input_ids: primitive.contributing_input_ids().to_vec(),
+                conversation_digest: None,
+                message_count: 0,
+                sequence: 0,
+            },
+            session_snapshot: None,
+            terminal: None,
+        })
+    }
+
+    async fn cancel_after_boundary(&mut self, _reason: String) -> Result<(), CoreExecutorError> {
+        self.queued_boundary_cancel_calls
+            .fetch_add(1, Ordering::SeqCst);
+        Ok(())
+    }
+
+    async fn stop_runtime_executor(&mut self, _reason: String) -> Result<(), CoreExecutorError> {
+        Ok(())
+    }
+}
+
+struct InterruptYieldingTestRig {
+    adapter: Arc<MeerkatMachine>,
+    session_id: SessionId,
+    apply_calls: Arc<AtomicUsize>,
+    queued_boundary_cancel_calls: Arc<AtomicUsize>,
+    apply_started: Arc<Notify>,
+    allow_finish: Arc<Notify>,
+    probe: Option<InterruptYieldingProbe>,
+}
+
+impl InterruptYieldingTestRig {
+    async fn new(with_live_boundary: bool, fail_live_stage: bool) -> Self {
+        let adapter = Arc::new(MeerkatMachine::ephemeral());
+        let session_id = SessionId::new();
+        let apply_calls = Arc::new(AtomicUsize::new(0));
+        let queued_boundary_cancel_calls = Arc::new(AtomicUsize::new(0));
+        let apply_started = Arc::new(Notify::new());
+        let allow_finish = Arc::new(Notify::new());
+        let probe = with_live_boundary.then(|| InterruptYieldingProbe::new(fail_live_stage));
+
+        adapter
+            .register_session_with_executor(
+                session_id.clone(),
+                Box::new(InterruptYieldingBlockingExecutor {
+                    apply_calls: Arc::clone(&apply_calls),
+                    queued_boundary_cancel_calls: Arc::clone(&queued_boundary_cancel_calls),
+                    apply_started: Arc::clone(&apply_started),
+                    allow_finish: Arc::clone(&allow_finish),
+                    probe: probe.clone(),
+                }),
+            )
+            .await;
+
+        Self {
+            adapter,
+            session_id,
+            apply_calls,
+            queued_boundary_cancel_calls,
+            apply_started,
+            allow_finish,
+            probe,
+        }
+    }
+
+    async fn start_busy_turn(&self) {
+        let first_input = Input::Prompt(crate::input::PromptInput::new(
+            "first turn keeps the runtime busy",
+            Some(
+                meerkat_core::lifecycle::run_primitive::RuntimeTurnMetadata {
+                    handling_mode: Some(meerkat_core::types::HandlingMode::Steer),
+                    ..Default::default()
+                },
+            ),
+        ));
+        let (outcome, _completion_handle) = self
+            .adapter
+            .accept_input_with_completion(&self.session_id, first_input)
+            .await
+            .expect("initial steer prompt should be accepted");
+        assert!(outcome.is_accepted());
+
+        tokio::time::timeout(Duration::from_secs(1), self.apply_started.notified())
+            .await
+            .expect("first apply should start");
+    }
+
+    async fn wait_for_apply_calls(&self, expected: usize) {
+        tokio::time::timeout(Duration::from_secs(1), async {
+            loop {
+                if self.apply_calls.load(Ordering::SeqCst) >= expected {
+                    break;
+                }
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .unwrap_or_else(|_| panic!("expected at least {expected} apply calls"));
+    }
+
+    async fn wait_until_attached_and_empty(&self) {
+        tokio::time::timeout(Duration::from_secs(1), async {
+            loop {
+                let snapshot = self
+                    .adapter
+                    .meerkat_machine_spine_snapshot(&self.session_id)
+                    .await
+                    .expect("snapshot should exist until runtime settles");
+                if snapshot.control.phase == RuntimeState::Attached
+                    && snapshot.inputs.queue.is_empty()
+                    && snapshot.inputs.steer_queue.is_empty()
+                {
+                    break;
+                }
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .expect("runtime should settle attached with empty queues");
+    }
+}
+
+fn interrupt_yielding_peer_input(
+    body: &str,
+    handling_mode: Option<meerkat_core::types::HandlingMode>,
+) -> (Input, InputId) {
+    interrupt_yielding_peer_input_with_idempotency(body, handling_mode, None)
+}
+
+fn interrupt_yielding_peer_input_with_idempotency(
+    body: &str,
+    handling_mode: Option<meerkat_core::types::HandlingMode>,
+    idempotency_key: Option<IdempotencyKey>,
+) -> (Input, InputId) {
+    let input = Input::Peer(crate::input::PeerInput {
+        header: crate::input::InputHeader {
+            id: InputId::new(),
+            timestamp: Utc::now(),
+            source: crate::input::InputOrigin::Peer {
+                peer_id: "interrupt-yielding-peer".into(),
+                display_identity: None,
+                runtime_id: None,
+            },
+            durability: crate::input::InputDurability::Durable,
+            visibility: crate::input::InputVisibility::default(),
+            idempotency_key,
+            supersession_key: None,
+            correlation_id: None,
+        },
+        convention: Some(crate::input::PeerConvention::Message),
+        body: body.to_string(),
+        payload: None,
+        blocks: None,
+        handling_mode,
+    });
+    let input_id = input.id().clone();
+    (input, input_id)
+}
+
 #[tokio::test]
-async fn explicit_running_steer_admission_does_not_emit_boundary_cancel_effect() {
+async fn explicit_running_steer_admission_injects_live_boundary_context_once() {
     struct LiveBoundaryHandle {
         calls: Arc<AtomicUsize>,
+        stage_calls: Arc<AtomicUsize>,
+        staged_texts: Arc<std::sync::Mutex<Vec<String>>>,
     }
 
     #[async_trait::async_trait]
@@ -5972,12 +6223,27 @@ async fn explicit_running_steer_admission_does_not_emit_boundary_cancel_effect()
             self.calls.fetch_add(1, Ordering::SeqCst);
             Ok(())
         }
+
+        async fn stage_system_context_at_boundary(
+            &self,
+            appends: Vec<meerkat_core::PendingSystemContextAppend>,
+        ) -> Result<Option<Vec<u8>>, CoreExecutorError> {
+            self.stage_calls.fetch_add(1, Ordering::SeqCst);
+            let mut staged = self
+                .staged_texts
+                .lock()
+                .expect("staged text mutex poisoned");
+            staged.extend(appends.into_iter().map(|append| append.text));
+            Ok(None)
+        }
     }
 
     struct BlockingExecutor {
         apply_calls: Arc<AtomicUsize>,
         queued_boundary_cancel_calls: Arc<AtomicUsize>,
         live_boundary_cancel_calls: Arc<AtomicUsize>,
+        live_boundary_stage_calls: Arc<AtomicUsize>,
+        live_boundary_staged_texts: Arc<std::sync::Mutex<Vec<String>>>,
         apply_started: Arc<Notify>,
         allow_finish: Arc<Notify>,
     }
@@ -5987,6 +6253,8 @@ async fn explicit_running_steer_admission_does_not_emit_boundary_cancel_effect()
         fn boundary_handle(&self) -> Option<Arc<dyn CoreExecutorBoundaryHandle>> {
             Some(Arc::new(LiveBoundaryHandle {
                 calls: Arc::clone(&self.live_boundary_cancel_calls),
+                stage_calls: Arc::clone(&self.live_boundary_stage_calls),
+                staged_texts: Arc::clone(&self.live_boundary_staged_texts),
             }))
         }
 
@@ -6034,6 +6302,8 @@ async fn explicit_running_steer_admission_does_not_emit_boundary_cancel_effect()
     let apply_calls = Arc::new(AtomicUsize::new(0));
     let queued_boundary_cancel_calls = Arc::new(AtomicUsize::new(0));
     let live_boundary_cancel_calls = Arc::new(AtomicUsize::new(0));
+    let live_boundary_stage_calls = Arc::new(AtomicUsize::new(0));
+    let live_boundary_staged_texts = Arc::new(std::sync::Mutex::new(Vec::new()));
     let apply_started = Arc::new(Notify::new());
     let allow_finish = Arc::new(Notify::new());
 
@@ -6044,6 +6314,8 @@ async fn explicit_running_steer_admission_does_not_emit_boundary_cancel_effect()
                 apply_calls: Arc::clone(&apply_calls),
                 queued_boundary_cancel_calls: Arc::clone(&queued_boundary_cancel_calls),
                 live_boundary_cancel_calls: Arc::clone(&live_boundary_cancel_calls),
+                live_boundary_stage_calls: Arc::clone(&live_boundary_stage_calls),
+                live_boundary_staged_texts: Arc::clone(&live_boundary_staged_texts),
                 apply_started: Arc::clone(&apply_started),
                 allow_finish: Arc::clone(&allow_finish),
             }),
@@ -6070,6 +6342,7 @@ async fn explicit_running_steer_admission_does_not_emit_boundary_cancel_effect()
         .expect("first apply should start");
 
     live_boundary_cancel_calls.store(0, Ordering::SeqCst);
+    live_boundary_stage_calls.store(0, Ordering::SeqCst);
     queued_boundary_cancel_calls.store(0, Ordering::SeqCst);
 
     let steered_peer_input = Input::Peer(crate::input::PeerInput {
@@ -6093,37 +6366,474 @@ async fn explicit_running_steer_admission_does_not_emit_boundary_cancel_effect()
         blocks: None,
         handling_mode: Some(meerkat_core::types::HandlingMode::Steer),
     });
+    let steered_peer_input_id = steered_peer_input.id().clone();
 
-    let result = adapter
+    let (outcome, completion_handle) = adapter
         .accept_input_with_completion(&session_id, steered_peer_input)
         .await
         .expect("running explicit steer should be accepted");
-    assert!(result.0.is_accepted());
+    assert!(outcome.is_accepted());
+    let completion_handle = completion_handle.expect("steered input should register completion");
+    let completion = tokio::time::timeout(Duration::from_secs(1), completion_handle.wait())
+        .await
+        .expect("live-injected steer input should resolve without waiting for outer turn");
+    assert!(
+        matches!(completion, CompletionOutcome::CompletedWithoutResult),
+        "live-injected steer input should complete without producing a separate run result, got {completion:?}"
+    );
     assert_eq!(
         live_boundary_cancel_calls.load(Ordering::SeqCst),
         0,
         "running steer admission must not call the live boundary-cancel handle"
     );
     assert_eq!(
+        live_boundary_stage_calls.load(Ordering::SeqCst),
+        1,
+        "running steer admission must stage context on the live boundary handle"
+    );
+    {
+        let staged = live_boundary_staged_texts
+            .lock()
+            .expect("staged text mutex poisoned");
+        assert_eq!(staged.len(), 1);
+        assert!(
+            staged[0].contains("explicit steer should not cancel the active run"),
+            "steered peer body should be projected into live boundary context: {staged:?}"
+        );
+    }
+    assert_eq!(
         queued_boundary_cancel_calls.load(Ordering::SeqCst),
         0,
         "running steer admission must not enqueue a cancel-after-boundary effect"
+    );
+    let after_steer = adapter
+        .meerkat_machine_spine_snapshot(&session_id)
+        .await
+        .expect("snapshot should exist while the first apply is blocked");
+    assert_eq!(after_steer.control.phase, RuntimeState::Running);
+    assert!(
+        after_steer.inputs.steer_queue.is_empty(),
+        "live-injected steer input must be consumed from the steer lane, not replayed later"
+    );
+    let steered_phase = after_steer
+        .inputs
+        .admission_order
+        .iter()
+        .find(|input| input.input_id == steered_peer_input_id)
+        .and_then(|input| input.lifecycle);
+    assert_eq!(
+        steered_phase,
+        Some(crate::input_state::InputLifecycleState::Consumed)
+    );
+    assert_eq!(
+        apply_calls.load(Ordering::SeqCst),
+        1,
+        "live-injected steer input must not start a second apply while outer turn is blocked"
     );
 
     allow_finish.notify_waiters();
 
     tokio::time::timeout(Duration::from_secs(1), async {
         loop {
-            if apply_calls.load(Ordering::SeqCst) >= 2 {
+            let snapshot = adapter
+                .meerkat_machine_spine_snapshot(&session_id)
+                .await
+                .expect("snapshot should exist until runtime settles");
+            if snapshot.control.phase == RuntimeState::Attached
+                && snapshot.inputs.queue.is_empty()
+                && snapshot.inputs.steer_queue.is_empty()
+            {
                 break;
             }
             tokio::time::sleep(Duration::from_millis(10)).await;
         }
     })
     .await
-    .expect("steered peer input should still be processed after the active apply returns");
+    .expect("outer turn should settle without replaying the live-injected steer input");
+    assert_eq!(
+        apply_calls.load(Ordering::SeqCst),
+        1,
+        "live-injected steer input must not be processed again after the outer turn returns"
+    );
     assert_eq!(live_boundary_cancel_calls.load(Ordering::SeqCst), 0);
     assert_eq!(queued_boundary_cancel_calls.load(Ordering::SeqCst), 0);
+}
+
+#[tokio::test]
+async fn interrupt_yielding_multiple_steers_are_injected_and_consumed_without_replay() {
+    let rig = InterruptYieldingTestRig::new(true, false).await;
+    rig.start_busy_turn().await;
+    let probe = rig.probe.clone().expect("live boundary probe installed");
+
+    let (first_peer, first_peer_id) = interrupt_yielding_peer_input(
+        "first live steer while outer turn is running",
+        Some(meerkat_core::types::HandlingMode::Steer),
+    );
+    let (second_peer, second_peer_id) = interrupt_yielding_peer_input(
+        "second live steer while outer turn is still running",
+        Some(meerkat_core::types::HandlingMode::Steer),
+    );
+
+    let (first_outcome, first_completion) = rig
+        .adapter
+        .accept_input_with_completion(&rig.session_id, first_peer)
+        .await
+        .expect("first running steer should be accepted");
+    assert!(first_outcome.is_accepted());
+    let (second_outcome, second_completion) = rig
+        .adapter
+        .accept_input_with_completion(&rig.session_id, second_peer)
+        .await
+        .expect("second running steer should be accepted");
+    assert!(second_outcome.is_accepted());
+
+    let first_completion = first_completion.expect("first steer should register completion");
+    let second_completion = second_completion.expect("second steer should register completion");
+    assert!(matches!(
+        tokio::time::timeout(Duration::from_secs(1), first_completion.wait())
+            .await
+            .expect("first live steer should complete immediately"),
+        CompletionOutcome::CompletedWithoutResult
+    ));
+    assert!(matches!(
+        tokio::time::timeout(Duration::from_secs(1), second_completion.wait())
+            .await
+            .expect("second live steer should complete immediately"),
+        CompletionOutcome::CompletedWithoutResult
+    ));
+
+    assert_eq!(
+        probe.live_boundary_stage_calls.load(Ordering::SeqCst),
+        2,
+        "each explicit steer should get one live context injection"
+    );
+    assert_eq!(probe.live_boundary_cancel_calls.load(Ordering::SeqCst), 0);
+    assert_eq!(
+        rig.queued_boundary_cancel_calls.load(Ordering::SeqCst),
+        0,
+        "live injection must not synthesize queued cancellation work"
+    );
+    let staged = probe.staged_texts();
+    assert_eq!(staged.len(), 2);
+    assert!(staged[0].contains("first live steer"));
+    assert!(staged[1].contains("second live steer"));
+
+    let during_busy = rig
+        .adapter
+        .meerkat_machine_spine_snapshot(&rig.session_id)
+        .await
+        .expect("snapshot should exist while busy");
+    assert_eq!(during_busy.control.phase, RuntimeState::Running);
+    assert!(
+        during_busy.inputs.steer_queue.is_empty(),
+        "live-injected steers must be removed from the steer lane"
+    );
+    let first_snapshot = during_busy
+        .inputs
+        .admission_order
+        .iter()
+        .find(|input| input.input_id == first_peer_id)
+        .expect("first peer should remain visible in admission order");
+    let second_snapshot = during_busy
+        .inputs
+        .admission_order
+        .iter()
+        .find(|input| input.input_id == second_peer_id)
+        .expect("second peer should remain visible in admission order");
+    assert_eq!(
+        first_snapshot.lifecycle,
+        Some(crate::input_state::InputLifecycleState::Consumed)
+    );
+    assert_eq!(
+        second_snapshot.lifecycle,
+        Some(crate::input_state::InputLifecycleState::Consumed)
+    );
+    assert_eq!(
+        first_snapshot.last_boundary_sequence,
+        Some(1),
+        "first live boundary receipt should not collide with the eventual turn receipt"
+    );
+    assert_eq!(
+        second_snapshot.last_boundary_sequence,
+        Some(2),
+        "subsequent live boundary receipts should be monotonically sequenced"
+    );
+    assert_eq!(
+        rig.apply_calls.load(Ordering::SeqCst),
+        1,
+        "live-injected steers must not start their own apply while the outer turn is blocked"
+    );
+
+    rig.allow_finish.notify_waiters();
+    rig.wait_until_attached_and_empty().await;
+    assert_eq!(
+        rig.apply_calls.load(Ordering::SeqCst),
+        1,
+        "live-injected steers must not replay after the outer turn completes"
+    );
+}
+
+#[tokio::test]
+async fn interrupt_yielding_deduplicated_steer_does_not_stage_twice() {
+    let rig = InterruptYieldingTestRig::new(true, false).await;
+    rig.start_busy_turn().await;
+    let probe = rig.probe.clone().expect("live boundary probe installed");
+    let key = IdempotencyKey::new("interrupt-yielding-same-message");
+
+    let (first_peer, first_peer_id) = interrupt_yielding_peer_input_with_idempotency(
+        "deduped live steer body",
+        Some(meerkat_core::types::HandlingMode::Steer),
+        Some(key.clone()),
+    );
+    let (first_outcome, first_completion) = rig
+        .adapter
+        .accept_input_with_completion(&rig.session_id, first_peer)
+        .await
+        .expect("first running steer should be accepted");
+    assert!(first_outcome.is_accepted());
+    assert!(matches!(
+        tokio::time::timeout(
+            Duration::from_secs(1),
+            first_completion
+                .expect("first steer should register completion")
+                .wait()
+        )
+        .await
+        .expect("first live steer should complete immediately"),
+        CompletionOutcome::CompletedWithoutResult
+    ));
+
+    let (duplicate_peer, duplicate_peer_id) = interrupt_yielding_peer_input_with_idempotency(
+        "deduped live steer body retry",
+        Some(meerkat_core::types::HandlingMode::Steer),
+        Some(key),
+    );
+    let (duplicate_outcome, duplicate_completion) = rig
+        .adapter
+        .accept_input_with_completion(&rig.session_id, duplicate_peer)
+        .await
+        .expect("duplicate running steer should be accepted as dedup");
+    assert!(
+        duplicate_outcome.is_deduplicated(),
+        "duplicate steer should deduplicate to the already live-injected input"
+    );
+    assert!(
+        duplicate_completion.is_none(),
+        "dedup of an already consumed live-injected steer should not register a second waiter"
+    );
+    assert_ne!(first_peer_id, duplicate_peer_id);
+    assert_eq!(
+        probe.live_boundary_stage_calls.load(Ordering::SeqCst),
+        1,
+        "deduplicated steer retry must not perform another live context injection"
+    );
+
+    let during_busy = rig
+        .adapter
+        .meerkat_machine_spine_snapshot(&rig.session_id)
+        .await
+        .expect("snapshot should exist while busy");
+    assert!(during_busy.inputs.steer_queue.is_empty());
+    assert!(
+        during_busy
+            .inputs
+            .admission_order
+            .iter()
+            .all(|input| input.input_id != duplicate_peer_id),
+        "deduplicated retry should not become its own admitted machine work item"
+    );
+
+    rig.allow_finish.notify_waiters();
+    rig.wait_until_attached_and_empty().await;
+    assert_eq!(rig.apply_calls.load(Ordering::SeqCst), 1);
+}
+
+#[tokio::test]
+async fn interrupt_yielding_attached_steer_starts_outer_turn_without_live_injection() {
+    let rig = InterruptYieldingTestRig::new(true, false).await;
+    let probe = rig.probe.clone().expect("live boundary probe installed");
+
+    let (peer_input, peer_id) = interrupt_yielding_peer_input(
+        "attached steer should start normal work",
+        Some(meerkat_core::types::HandlingMode::Steer),
+    );
+    let (outcome, completion_handle) = rig
+        .adapter
+        .accept_input_with_completion(&rig.session_id, peer_input)
+        .await
+        .expect("attached steer should be accepted");
+    assert!(outcome.is_accepted());
+    assert!(completion_handle.is_some());
+
+    rig.wait_for_apply_calls(1).await;
+    assert_eq!(
+        probe.live_boundary_stage_calls.load(Ordering::SeqCst),
+        0,
+        "idle/attached steer should start an outer turn, not inject into a live one"
+    );
+    assert_eq!(probe.live_boundary_cancel_calls.load(Ordering::SeqCst), 0);
+    let during_apply = rig
+        .adapter
+        .meerkat_machine_spine_snapshot(&rig.session_id)
+        .await
+        .expect("snapshot should exist during attached steer apply");
+    assert_eq!(during_apply.control.phase, RuntimeState::Running);
+    assert_eq!(during_apply.inputs.current_run_contributors, vec![peer_id]);
+
+    rig.allow_finish.notify_waiters();
+    rig.wait_until_attached_and_empty().await;
+    assert_eq!(rig.apply_calls.load(Ordering::SeqCst), 1);
+}
+
+#[tokio::test]
+async fn interrupt_yielding_default_peer_message_does_not_live_inject() {
+    let rig = InterruptYieldingTestRig::new(true, false).await;
+    rig.start_busy_turn().await;
+    let probe = rig.probe.clone().expect("live boundary probe installed");
+
+    let (peer_input, peer_id) = interrupt_yielding_peer_input("ordinary queued peer message", None);
+    let (outcome, completion_handle) = rig
+        .adapter
+        .accept_input_with_completion(&rig.session_id, peer_input)
+        .await
+        .expect("default peer message should be accepted");
+    assert!(outcome.is_accepted());
+    assert!(completion_handle.is_some());
+
+    assert_eq!(
+        probe.live_boundary_stage_calls.load(Ordering::SeqCst),
+        0,
+        "only explicit Steer ingress should project into the live boundary"
+    );
+    assert_eq!(probe.live_boundary_cancel_calls.load(Ordering::SeqCst), 0);
+
+    let during_busy = rig
+        .adapter
+        .meerkat_machine_spine_snapshot(&rig.session_id)
+        .await
+        .expect("snapshot should exist while busy");
+    assert!(
+        during_busy.inputs.queue.contains(&peer_id),
+        "default peer messages must remain outer-turn queued while busy"
+    );
+    assert!(during_busy.inputs.steer_queue.is_empty());
+
+    rig.allow_finish.notify_waiters();
+    rig.wait_for_apply_calls(2).await;
+    assert_eq!(probe.live_boundary_stage_calls.load(Ordering::SeqCst), 0);
+    assert_eq!(rig.queued_boundary_cancel_calls.load(Ordering::SeqCst), 0);
+    rig.allow_finish.notify_waiters();
+    rig.wait_until_attached_and_empty().await;
+}
+
+#[tokio::test]
+async fn interrupt_yielding_without_live_boundary_handle_falls_back_to_steer_queue() {
+    let rig = InterruptYieldingTestRig::new(false, false).await;
+    rig.start_busy_turn().await;
+
+    let (peer_input, peer_id) = interrupt_yielding_peer_input(
+        "explicit steer waits for post-turn drain when no live handle exists",
+        Some(meerkat_core::types::HandlingMode::Steer),
+    );
+    let (outcome, completion_handle) = rig
+        .adapter
+        .accept_input_with_completion(&rig.session_id, peer_input)
+        .await
+        .expect("running explicit steer should be accepted without a live handle");
+    assert!(outcome.is_accepted());
+    assert!(completion_handle.is_some());
+
+    let during_busy = rig
+        .adapter
+        .meerkat_machine_spine_snapshot(&rig.session_id)
+        .await
+        .expect("snapshot should exist while busy");
+    assert!(
+        during_busy.inputs.steer_queue.contains(&peer_id),
+        "without a live boundary handle, explicit steer must remain queued for ordinary drain"
+    );
+    assert!(
+        during_busy
+            .completion_waiters
+            .waiting_inputs
+            .iter()
+            .any(|waiter| waiter.input_id == peer_id),
+        "fallback steers should keep their completion waiter until the queued run consumes them"
+    );
+    assert_eq!(rig.queued_boundary_cancel_calls.load(Ordering::SeqCst), 0);
+
+    rig.allow_finish.notify_waiters();
+    rig.wait_for_apply_calls(2).await;
+    rig.allow_finish.notify_waiters();
+    rig.wait_until_attached_and_empty().await;
+    assert_eq!(
+        rig.apply_calls.load(Ordering::SeqCst),
+        2,
+        "fallback queued steer should run exactly once after the busy turn completes"
+    );
+    assert_eq!(rig.queued_boundary_cancel_calls.load(Ordering::SeqCst), 0);
+}
+
+#[tokio::test]
+async fn interrupt_yielding_live_stage_failure_leaves_accepted_work_queued() {
+    let rig = InterruptYieldingTestRig::new(true, true).await;
+    rig.start_busy_turn().await;
+    let probe = rig.probe.clone().expect("live boundary probe installed");
+
+    let (peer_input, peer_id) = interrupt_yielding_peer_input(
+        "explicit steer survives failed live staging",
+        Some(meerkat_core::types::HandlingMode::Steer),
+    );
+    let (outcome, completion_handle) = rig
+        .adapter
+        .accept_input_with_completion(&rig.session_id, peer_input)
+        .await
+        .expect("stage failure should not turn accepted ingress into admission failure");
+    assert!(outcome.is_accepted());
+    assert!(completion_handle.is_some());
+
+    assert_eq!(
+        probe.live_boundary_stage_calls.load(Ordering::SeqCst),
+        1,
+        "the live injection path should be attempted once"
+    );
+    assert!(
+        probe.staged_texts().is_empty(),
+        "failed live staging must not report a committed injection"
+    );
+    let during_busy = rig
+        .adapter
+        .meerkat_machine_spine_snapshot(&rig.session_id)
+        .await
+        .expect("snapshot should exist while busy");
+    assert!(
+        during_busy.inputs.steer_queue.contains(&peer_id),
+        "failed live staging should leave the accepted steer in the steer lane"
+    );
+    let steered_snapshot = during_busy
+        .inputs
+        .admission_order
+        .iter()
+        .find(|input| input.input_id == peer_id)
+        .expect("failed live-stage input should remain visible");
+    assert_eq!(
+        steered_snapshot.lifecycle,
+        Some(crate::input_state::InputLifecycleState::Queued)
+    );
+    assert_eq!(steered_snapshot.last_boundary_sequence, None);
+
+    probe.fail_live_stage.store(false, Ordering::SeqCst);
+    rig.allow_finish.notify_waiters();
+    rig.wait_for_apply_calls(2).await;
+    rig.allow_finish.notify_waiters();
+    rig.wait_until_attached_and_empty().await;
+    assert_eq!(
+        rig.apply_calls.load(Ordering::SeqCst),
+        2,
+        "work left queued after failed live staging should still drain once"
+    );
+    assert_eq!(rig.queued_boundary_cancel_calls.load(Ordering::SeqCst), 0);
+    assert_eq!(probe.live_boundary_cancel_calls.load(Ordering::SeqCst), 0);
 }
 
 #[tokio::test]

--- a/meerkat-session/src/persistent.rs
+++ b/meerkat-session/src/persistent.rs
@@ -1868,6 +1868,93 @@ impl<B: SessionAgentBuilder + 'static> PersistentSessionService<B> {
         Ok(())
     }
 
+    pub async fn stage_live_system_context_boundary_snapshot(
+        &self,
+        id: &SessionId,
+        appends: Vec<PendingSystemContextAppend>,
+    ) -> Result<Option<Vec<u8>>, SessionError> {
+        if appends.is_empty() {
+            return Ok(None);
+        }
+
+        let state_arc = self
+            .inner
+            .system_context_state(id)
+            .await
+            .ok_or_else(|| SessionError::NotFound { id: id.clone() })?;
+
+        let (snapshot_state, staged_state) = {
+            let mut guard = match state_arc.lock() {
+                Ok(guard) => guard,
+                Err(poisoned) => {
+                    tracing::warn!(
+                        session_id = %id,
+                        "system-context state lock poisoned while staging live boundary context"
+                    );
+                    poisoned.into_inner()
+                }
+            };
+            let snapshot_state = guard.clone();
+            let mut candidate = snapshot_state.clone();
+            for append in appends {
+                let req = AppendSystemContextRequest {
+                    text: append.text,
+                    source: append.source,
+                    idempotency_key: append.idempotency_key,
+                };
+                candidate
+                    .stage_append(&req, append.accepted_at)
+                    .map_err(|err| control_error_into_session_error(err.into_control_error(id)))?;
+            }
+            *guard = candidate.clone();
+            (snapshot_state, candidate)
+        };
+
+        let snapshot = async {
+            let mut session = self
+                .load_authoritative_session_base(id)
+                .await?
+                .ok_or_else(|| SessionError::NotFound { id: id.clone() })?;
+            self.reject_if_archived_session(id, &session)
+                .await
+                .map_err(control_error_into_session_error)?;
+            write_system_context_state(&mut session, staged_state.clone())
+                .map_err(control_error_into_session_error)?;
+            let session = self.normalized_session_for_persistence(session).await?;
+            serde_json::to_vec(&session).map_err(|err| {
+                SessionError::Agent(meerkat_core::error::AgentError::InternalError(format!(
+                    "failed to serialize live boundary context session snapshot: {err}"
+                )))
+            })
+        }
+        .await;
+
+        match snapshot {
+            Ok(snapshot) => Ok(Some(snapshot)),
+            Err(error) => {
+                let mut guard = match state_arc.lock() {
+                    Ok(guard) => guard,
+                    Err(poisoned) => {
+                        tracing::warn!(
+                            session_id = %id,
+                            "system-context state lock poisoned while rolling back live boundary context"
+                        );
+                        poisoned.into_inner()
+                    }
+                };
+                if *guard == staged_state {
+                    *guard = snapshot_state;
+                } else {
+                    tracing::warn!(
+                        session_id = %id,
+                        "live system-context state diverged after failed boundary snapshot; leaving newer live state intact"
+                    );
+                }
+                Err(error)
+            }
+        }
+    }
+
     async fn fail_closed_runtime_projection_update(
         &self,
         id: &SessionId,

--- a/meerkat/src/surface/runtime_backed.rs
+++ b/meerkat/src/surface/runtime_backed.rs
@@ -481,6 +481,16 @@ impl CoreExecutorBoundaryHandle for PersistentRuntimeBoundaryHandle {
             })
             .map_err(|error| CoreExecutorError::control_failed_runtime(error.to_string()))
     }
+
+    async fn stage_system_context_at_boundary(
+        &self,
+        appends: Vec<meerkat_core::PendingSystemContextAppend>,
+    ) -> Result<Option<Vec<u8>>, CoreExecutorError> {
+        self.service
+            .stage_live_system_context_boundary_snapshot(&self.session_id, appends)
+            .await
+            .map_err(|error| CoreExecutorError::control_failed_runtime(error.to_string()))
+    }
 }
 
 struct PersistentRuntimeInterruptHandle {


### PR DESCRIPTION
## Summary

- add a machine-owned live boundary path for interrupt-yielding steer ingress during an active run
- project accepted steer inputs into pending system context and consume them from the steer lane without cancelling or replaying the active run
- persist live boundary context snapshots for runtime-backed sessions
- expand regression coverage across projection, live injection, fallback, deduplication, idle/attached behavior, and stage-failure cases

## Why

Interrupt-yielding is intended to be cooperative injection at the next inner boundary, not cancellation and not invisible queuing until the outer turn completes. The prior path accepted steer messages but had no live boundary projection path, which let accepted peer messages stay invisible during long autonomous turns.

## Validation

- `./scripts/repo-cargo fmt --all`
- `git diff --check`
- `./scripts/repo-cargo test -p meerkat-runtime interrupt_yielding -- --nocapture`
- `./scripts/repo-cargo test -p meerkat-runtime steer_projection -- --nocapture`
- `./scripts/repo-cargo test -p meerkat-runtime peer_admission -- --nocapture`
- `./scripts/repo-cargo clippy -p meerkat-session -p meerkat-runtime -p meerkat-core -p meerkat --all-targets -- -D warnings`
- `./scripts/repo-cargo check -p meerkat-runtime -p meerkat-core -p meerkat-session -p meerkat`
- push hook: cargo fmt, changed-crates clippy, machine codegen/verify, generated-header audit, ResponseStatus bridge audit, Bazel freshness, deterministic workspace gate
