### PR TITLE
[codex] Avoid blocking mob actor on turn completion

### DIFF
--- a/meerkat-mob/src/runtime/actor.rs
+++ b/meerkat-mob/src/runtime/actor.rs
@@ -39,6 +39,15 @@ impl InitialTurnHandle {
     }
 }
 
+enum SubmitWorkDispatchCompletion {
+    Completed,
+    AwaitTurnCompletion {
+        provisioner: Arc<dyn MobProvisioner>,
+        member_ref: MemberRef,
+        req: Box<meerkat_core::service::StartTurnRequest>,
+    },
+}
+
 // Sized for real mob-scale startup/shutdown fan-out (50+ members).
 #[cfg(not(target_arch = "wasm32"))]
 const MAX_PARALLEL_REMOTE_MEMBER_TEARDOWNS: usize = 64;
@@ -3443,8 +3452,26 @@ impl MobActor {
                     let _ = reply_tx.send(result);
                 }
                 MobCommand::SubmitWork { payload, reply_tx } => {
-                    let result = Box::pin(self.handle_submit_work(payload)).await;
-                    let _ = reply_tx.send(result);
+                    match Box::pin(self.handle_submit_work(payload)).await {
+                        Ok(SubmitWorkDispatchCompletion::Completed) => {
+                            let _ = reply_tx.send(Ok(()));
+                        }
+                        Ok(SubmitWorkDispatchCompletion::AwaitTurnCompletion {
+                            provisioner,
+                            member_ref,
+                            req,
+                        }) => {
+                            Self::spawn_turn_completed_reply(
+                                provisioner,
+                                member_ref,
+                                req,
+                                reply_tx,
+                            );
+                        }
+                        Err(error) => {
+                            let _ = reply_tx.send(Err(error));
+                        }
+                    }
                 }
                 MobCommand::SendPeerMessage {
                     from,
@@ -10830,7 +10857,7 @@ impl MobActor {
     async fn handle_submit_work(
         &mut self,
         payload: Box<super::state::SubmitWorkPayload>,
-    ) -> Result<(), MobError> {
+    ) -> Result<SubmitWorkDispatchCompletion, MobError> {
         let super::state::SubmitWorkPayload {
             runtime_id,
             fence_token,
@@ -10984,6 +11011,18 @@ impl MobActor {
         .await
     }
 
+    fn spawn_turn_completed_reply(
+        provisioner: Arc<dyn MobProvisioner>,
+        member_ref: MemberRef,
+        req: Box<meerkat_core::service::StartTurnRequest>,
+        reply_tx: oneshot::Sender<Result<(), MobError>>,
+    ) {
+        tokio::spawn(async move {
+            let result = provisioner.start_turn(&member_ref, *req).await;
+            let _ = reply_tx.send(result);
+        });
+    }
+
     async fn dispatch_turn_driven_spawn_initial_turn(
         &mut self,
         agent_identity: &MeerkatId,
@@ -11048,14 +11087,16 @@ impl MobActor {
             ));
         }
 
-        self.dispatch_member_turn_after_machine_admission(
-            &entry,
-            content,
-            meerkat_core::types::HandlingMode::Queue,
-            None,
-            crate::mob_machine::SubmitWorkAckMode::IngressAccepted,
-        )
-        .await
+        let completion = self
+            .dispatch_member_turn_after_machine_admission(
+                &entry,
+                content,
+                meerkat_core::types::HandlingMode::Queue,
+                None,
+                crate::mob_machine::SubmitWorkAckMode::IngressAccepted,
+            )
+            .await?;
+        self.finish_submit_work_dispatch(completion).await
     }
 
     /// Unified work-lane cancel entry.
@@ -11136,14 +11177,30 @@ impl MobActor {
         ack_mode: crate::mob_machine::SubmitWorkAckMode,
     ) -> Result<(), MobError> {
         self.ensure_pending_spawn_alignment("dispatch_member_turn preflight")?;
-        self.dispatch_member_turn_after_machine_admission(
-            entry,
-            content,
-            handling_mode,
-            render_metadata,
-            ack_mode,
-        )
-        .await
+        let completion = self
+            .dispatch_member_turn_after_machine_admission(
+                entry,
+                content,
+                handling_mode,
+                render_metadata,
+                ack_mode,
+            )
+            .await?;
+        self.finish_submit_work_dispatch(completion).await
+    }
+
+    async fn finish_submit_work_dispatch(
+        &self,
+        completion: SubmitWorkDispatchCompletion,
+    ) -> Result<(), MobError> {
+        match completion {
+            SubmitWorkDispatchCompletion::Completed => Ok(()),
+            SubmitWorkDispatchCompletion::AwaitTurnCompletion {
+                provisioner,
+                member_ref,
+                req,
+            } => provisioner.start_turn(&member_ref, *req).await,
+        }
     }
 
     async fn dispatch_member_turn_after_machine_admission(
@@ -11153,7 +11210,7 @@ impl MobActor {
         handling_mode: meerkat_core::types::HandlingMode,
         render_metadata: Option<meerkat_core::types::RenderMetadata>,
         ack_mode: crate::mob_machine::SubmitWorkAckMode,
-    ) -> Result<(), MobError> {
+    ) -> Result<SubmitWorkDispatchCompletion, MobError> {
         if let Some(bridge_session_id) = entry.member_ref.bridge_session_id() {
             match self.session_service.read(bridge_session_id).await {
                 Ok(_) => {}
@@ -11209,7 +11266,7 @@ impl MobActor {
                             entry.agent_identity, error
                         ))
                     })?;
-                Ok(())
+                Ok(SubmitWorkDispatchCompletion::Completed)
             }
             crate::MobRuntimeMode::TurnDriven => {
                 let req = meerkat_core::service::StartTurnRequest {
@@ -11228,12 +11285,16 @@ impl MobActor {
                 match ack_mode {
                     crate::mob_machine::SubmitWorkAckMode::IngressAccepted => {
                         self.provisioner.admit_turn(&entry.member_ref, req).await?;
+                        Ok(SubmitWorkDispatchCompletion::Completed)
                     }
                     crate::mob_machine::SubmitWorkAckMode::TurnCompleted => {
-                        self.provisioner.start_turn(&entry.member_ref, req).await?;
+                        Ok(SubmitWorkDispatchCompletion::AwaitTurnCompletion {
+                            provisioner: self.provisioner.clone(),
+                            member_ref: entry.member_ref.clone(),
+                            req: Box::new(req),
+                        })
                     }
                 }
-                Ok(())
             }
         }
     }

--- a/meerkat-mob/src/runtime/tests.rs
+++ b/meerkat-mob/src/runtime/tests.rs
@@ -30928,6 +30928,67 @@ async fn test_wire_external_peer_not_blocked_by_delayed_turn_driven_submit_work(
 }
 
 #[tokio::test]
+async fn test_internal_turn_completed_reply_does_not_block_actor_operations() {
+    let (handle, service) = create_test_mob(sample_definition()).await;
+    let member_id = MeerkatId::from("l-busy-internal-turn");
+    handle
+        .spawn_with_options(
+            ProfileName::from("lead"),
+            member_id.clone(),
+            None,
+            Some(crate::MobRuntimeMode::TurnDriven),
+            None,
+        )
+        .await
+        .expect("spawn turn-driven lead");
+
+    let baseline_start_turn_calls = service.start_turn_call_count();
+    service.set_start_turn_delay_ms(250);
+
+    let turn_handle = handle.clone();
+    let turn_identity = AgentIdentity::from(member_id.as_str());
+    let internal_turn = tokio::spawn(async move {
+        turn_handle
+            .internal_turn(turn_identity, "long internal turn")
+            .await
+    });
+
+    let deadline = Instant::now() + Duration::from_secs(2);
+    while service.start_turn_call_count() < baseline_start_turn_calls + 1 {
+        assert!(
+            Instant::now() < deadline,
+            "delayed internal turn should reach the runtime executor"
+        );
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+
+    tokio::time::timeout(
+        Duration::from_millis(100),
+        handle.list_members_including_retiring(),
+    )
+    .await
+    .expect("member listing must not wait behind TurnCompleted runtime completion");
+
+    tokio::time::timeout(
+        Duration::from_millis(100),
+        handle.spawn(
+            ProfileName::from("worker"),
+            MeerkatId::from("worker-after-internal-turn"),
+            None,
+        ),
+    )
+    .await
+    .expect("spawn must not wait behind TurnCompleted runtime completion")
+    .expect("spawn worker while internal turn is still running");
+
+    tokio::time::timeout(Duration::from_secs(2), internal_turn)
+        .await
+        .expect("internal_turn should complete once the runtime turn completes")
+        .expect("internal_turn task should not panic")
+        .expect("internal_turn result should succeed");
+}
+
+#[tokio::test]
 async fn test_submit_work_stale_fence_token_rejected() {
     let (handle, _service) = create_test_mob(sample_definition()).await;
     handle


### PR DESCRIPTION
## Summary
- keep `TurnCompleted` caller semantics while moving the runtime-completion wait out of the serialized `MobActor` command loop
- return to the actor loop immediately after MobMachine admits work and the shell prepares the runtime ingress
- fulfill the original `SubmitWork` reply asynchronously once the turn-driven runtime call completes
- add a regression for `internal_turn` with `TurnCompleted` plus same-actor `list_members` and `spawn` during the in-flight turn

## Root Cause
`SubmitWorkAckMode::TurnCompleted` was interpreted as an actor-loop wait. For turn-driven members, `internal_turn` called `provisioner.start_turn(...)` inside the `MobCommand::SubmitWork` arm, so the single mob actor could not service observation or mutation commands while waiting for the member turn to complete. A turn could therefore self-deadlock when it invoked same-mob operations such as `spawn_spec`, and actor-backed observation paths were starved.

The MobMachine already owned semantic admission correctly. The bug was in shell effect realization: a long-running runtime completion wait parked the authority loop instead of only delaying the caller reply.

## Validation
- Confirmed the new regression fails on `origin/main` before the implementation change
- `./scripts/repo-cargo test -p meerkat-mob test_internal_turn_completed_reply_does_not_block_actor_operations -- --nocapture`
- `./scripts/repo-cargo test -p meerkat-mob test_wire_external_peer_not_blocked_by_delayed_turn_driven_submit_work -- --nocapture`
- `./scripts/repo-cargo test -p meerkat-mob test_internal_turn_mode_routing_uses_injector_for_autonomous_and_start_turn_for_turn_driven -- --nocapture`
- `./scripts/repo-cargo clippy -p meerkat-mob --all-targets -- -D warnings`
- push hooks: cargo fmt, changed-crate clippy, machine codegen/verify, generated header audit, Bazel freshness, workspace deterministic gate
