### PR TITLE
Fix mob observation and scoped auto-wire spawns

### DIFF
--- a/.claude/skills/meerkat-architecture/SKILL.md
+++ b/.claude/skills/meerkat-architecture/SKILL.md
@@ -56,10 +56,10 @@ For same-checkout multi-agent work, set distinct `RUST_LANE_ID` values when you
 want stable warm local output roots. Separate Git worktrees are isolated by path
 hash for both Cargo and BuildBuddy output roots.
 
-## Current 0.6.19 Release-Line Deltas
+## Current 0.6.22 Release-Line Deltas
 
 When updating architecture docs or reviewing current code, do not stop at the
-0.6.5 live-adapter picture. The 0.6.19 line also includes:
+0.6.5 live-adapter picture. The 0.6.22 line also includes:
 
 - `WorkGraphLifecycleMachine` as the sixth canonical machine, with
   `meerkat-workgraph` owning durable work items, dependencies, claims, evidence,
@@ -76,9 +76,14 @@ When updating architecture docs or reviewing current code, do not stop at the
 - Runtime-store checkpointing and runtime-committed session projection saves,
   preserving explicit broken/lost states and keeping MobKit/UnifiedRuntime
   projections in sync after the machine commit succeeds.
+- Active-turn live-boundary steer injection is a two-owner transaction:
+  session services may stage boundary context, but the runtime machine remains
+  the delivery authority. If the machine/runtime-store commit fails after
+  staging, the session-side staged context must be rolled back by the same
+  idempotency keys; otherwise the system has phantom or duplicate delivery.
 - Release/docs/SDK hardening: docs validation, version/schema freshness checks,
   BuildBuddy/Web SDK recovery lanes, Windows asset routing fixes, and current
-  contract/package examples at `0.6.19`.
+  contract/package examples at `0.6.22`.
 
 ## Runtime Dogma (first review lens)
 

--- a/meerkat-core/src/agent/builder.rs
+++ b/meerkat-core/src/agent/builder.rs
@@ -414,6 +414,13 @@ impl AgentBuilder {
             None => Arc::new(LocalToolVisibilityOwner::new()),
         };
         let mut session = self.session.unwrap_or_default();
+        let discarded_runtime_steer_context = session.discard_transient_runtime_steer_context();
+        if discarded_runtime_steer_context > 0 {
+            tracing::debug!(
+                discarded_runtime_steer_context,
+                "discarded transient runtime steer context while building agent"
+            );
+        }
         let system_context_state = Arc::new(std::sync::Mutex::new(
             session.system_context_state().unwrap_or_default(),
         ));

--- a/meerkat-core/src/agent/runner.rs
+++ b/meerkat-core/src/agent/runner.rs
@@ -678,6 +678,12 @@ where
             pending
         };
 
+        if !pending.is_empty() {
+            tracing::debug!(
+                pending_count = pending.len(),
+                "applying pending runtime system context at model boundary"
+            );
+        }
         self.sync_system_context_state_to_session();
         pending
     }

--- a/meerkat-core/src/agent/runner.rs
+++ b/meerkat-core/src/agent/runner.rs
@@ -422,6 +422,11 @@ where
         Arc::clone(&self.cancel_after_boundary_requested)
     }
 
+    /// Get the runtime-backed turn-state handle, when this agent was built with one.
+    pub fn turn_state_handle(&self) -> Option<Arc<dyn crate::TurnStateHandle>> {
+        self.turn_state_handle.clone()
+    }
+
     /// Persist the currently committed visible tool set into canonical session metadata.
     pub(crate) fn publish_committed_visible_set(&mut self) -> Result<(), AgentError> {
         // Session metadata is a durable projection/export of the canonical
@@ -671,12 +676,6 @@ where
                 }
             };
             if state.pending.is_empty() {
-                tracing::debug!(
-                    pending_count = 0usize,
-                    applied_count = state.applied.len(),
-                    active_turn_pending_count = state.active_turn_pending_keys.len(),
-                    "no pending runtime system context at model boundary"
-                );
                 return Vec::new();
             }
             let pending = state.pending.clone();

--- a/meerkat-core/src/agent/runner.rs
+++ b/meerkat-core/src/agent/runner.rs
@@ -671,6 +671,12 @@ where
                 }
             };
             if state.pending.is_empty() {
+                tracing::debug!(
+                    pending_count = 0usize,
+                    applied_count = state.applied.len(),
+                    active_turn_pending_count = state.active_turn_pending_keys.len(),
+                    "no pending runtime system context at model boundary"
+                );
                 return Vec::new();
             }
             let pending = state.pending.clone();

--- a/meerkat-core/src/agent/state.rs
+++ b/meerkat-core/src/agent/state.rs
@@ -3592,6 +3592,102 @@ mod tests {
         }
     }
 
+    struct BoundaryContextRecordingClient {
+        call_count: Mutex<u32>,
+        seen_system_messages: Mutex<Vec<String>>,
+    }
+
+    impl BoundaryContextRecordingClient {
+        fn new() -> Self {
+            Self {
+                call_count: Mutex::new(0),
+                seen_system_messages: Mutex::new(Vec::new()),
+            }
+        }
+
+        fn seen_system_messages(&self) -> Vec<String> {
+            self.seen_system_messages.lock().unwrap().clone()
+        }
+    }
+
+    #[async_trait]
+    impl AgentLlmClient for BoundaryContextRecordingClient {
+        async fn stream_response(
+            &self,
+            messages: &[Message],
+            _tools: &[Arc<ToolDef>],
+            _max_tokens: u32,
+            _temperature: Option<f32>,
+            _provider_params: Option<&crate::lifecycle::run_primitive::ProviderParamsOverride>,
+        ) -> Result<super::LlmStreamResult, AgentError> {
+            self.seen_system_messages.lock().unwrap().push(
+                messages
+                    .iter()
+                    .filter_map(|message| match message {
+                        Message::System(system) => Some(system.content.clone()),
+                        _ => None,
+                    })
+                    .collect::<Vec<_>>()
+                    .join("\n"),
+            );
+
+            let mut calls = self.call_count.lock().unwrap();
+            let response = if *calls == 0 {
+                super::LlmStreamResult::new(
+                    vec![AssistantBlock::ToolUse {
+                        id: "call-slow".to_string(),
+                        name: "slow_tool".into(),
+                        args: serde_json::value::RawValue::from_string("{}".to_string()).unwrap(),
+                        meta: None,
+                    }],
+                    StopReason::ToolUse,
+                    Usage::default(),
+                )
+            } else {
+                super::LlmStreamResult::new(
+                    vec![AssistantBlock::Text {
+                        text: "done".to_string(),
+                        meta: None,
+                    }],
+                    StopReason::EndTurn,
+                    Usage::default(),
+                )
+            };
+            *calls += 1;
+            Ok(response)
+        }
+
+        fn provider(&self) -> &'static str {
+            "mock"
+        }
+
+        fn model(&self) -> &'static str {
+            "mock-model"
+        }
+    }
+
+    struct BlockingToolDispatcher {
+        tools: Arc<[Arc<ToolDef>]>,
+        started: Arc<Notify>,
+        release: Arc<Notify>,
+    }
+
+    #[async_trait]
+    impl AgentToolDispatcher for BlockingToolDispatcher {
+        fn tools(&self) -> Arc<[Arc<ToolDef>]> {
+            Arc::clone(&self.tools)
+        }
+
+        async fn dispatch(
+            &self,
+            call: ToolCallView<'_>,
+        ) -> Result<crate::ops::ToolDispatchOutcome, ToolError> {
+            self.started.notify_waiters();
+            self.release.notified().await;
+            Ok(ToolResult::new(call.id.to_string(), "released".to_string(), false).into())
+        }
+    }
+
     struct PlaneAwareToolDispatcher {
         tools: Arc<[Arc<ToolDef>]>,
         catalog: Arc<[crate::ToolCatalogEntry]>,
@@ -4201,6 +4297,73 @@ mod tests {
         with_test_turn_state_handle(AgentBuilder::new())
             .build_standalone(client, Arc::new(NoTools), Arc::new(NoopStore))
             .await
+    }
+
+    #[tokio::test]
+    async fn active_turn_system_context_is_visible_after_tool_boundary() {
+        let client = Arc::new(BoundaryContextRecordingClient::new());
+        let tool_started = Arc::new(Notify::new());
+        let release_tool = Arc::new(Notify::new());
+        let tools = Arc::new(BlockingToolDispatcher {
+            tools: Arc::from([Arc::new(ToolDef::new(
+                "slow_tool",
+                "blocks until the test releases it",
+                serde_json::json!({ "type": "object" }),
+            ))]),
+            started: Arc::clone(&tool_started),
+            release: Arc::clone(&release_tool),
+        });
+        let mut agent = with_test_turn_state_handle(AgentBuilder::new())
+            .system_prompt("base system prompt")
+            .build_standalone(client.clone(), tools, Arc::new(NoopStore))
+            .await;
+        let state = agent.system_context_state();
+
+        let (tx, mut rx) = mpsc::channel(32);
+        let run = tokio::spawn(async move {
+            agent
+                .run_with_events("start with a tool".to_string().into(), tx)
+                .await
+        });
+
+        tokio::time::timeout(std::time::Duration::from_secs(1), tool_started.notified())
+            .await
+            .expect("tool should start");
+
+        {
+            let mut guard = state.lock().unwrap();
+            guard
+                .stage_active_turn_append(
+                    &crate::service::AppendSystemContextRequest {
+                        text: "STEER_MARKER_visible_after_tool".to_string(),
+                        source: Some("test:active-steer".to_string()),
+                        idempotency_key: Some("test:active-steer".to_string()),
+                    },
+                    crate::time_compat::SystemTime::now(),
+                )
+                .expect("active-turn append should stage");
+        }
+
+        release_tool.notify_waiters();
+        let result = tokio::time::timeout(std::time::Duration::from_secs(2), run)
+            .await
+            .expect("run should complete")
+            .expect("run task should join")
+            .expect("agent run should succeed");
+        assert_eq!(result.turns, 2);
+
+        while rx.try_recv().is_ok() {}
+        let seen = client.seen_system_messages();
+        assert!(
+            seen.len() >= 2,
+            "client should have seen both pre-tool and post-tool model requests: {seen:?}"
+        );
+        assert!(
+            seen.iter()
+                .skip(1)
+                .any(|system| system.contains("STEER_MARKER_visible_after_tool")),
+            "active-turn staged context must be present on the model request after the tool boundary; seen={seen:?}"
+        );
     }
 
     fn start_test_conversation_turn(handle: &dyn crate::TurnStateHandle) {

--- a/meerkat-core/src/lifecycle/core_executor.rs
+++ b/meerkat-core/src/lifecycle/core_executor.rs
@@ -389,6 +389,12 @@ impl CoreApplyOutput {
 pub trait CoreExecutorBoundaryHandle: Send + Sync {
     async fn cancel_after_boundary(&self, reason: String) -> Result<(), CoreExecutorError>;
 
+    /// Return true when the executor still has an active turn whose next
+    /// cooperative model boundary can receive staged system context.
+    async fn active_turn_boundary_available(&self) -> Result<bool, CoreExecutorError> {
+        Ok(false)
+    }
+
     /// Stage runtime-owned system context for the next cooperative LLM
     /// boundary of the active turn.
     ///

--- a/meerkat-core/src/lifecycle/core_executor.rs
+++ b/meerkat-core/src/lifecycle/core_executor.rs
@@ -404,6 +404,7 @@ pub trait CoreExecutorBoundaryHandle: Send + Sync {
     /// authority may return `None`.
     async fn stage_system_context_at_boundary(
         &self,
+        _expected_run_id: &RunId,
         _appends: Vec<PendingSystemContextAppend>,
     ) -> Result<Option<Vec<u8>>, CoreExecutorError> {
         Err(CoreExecutorError::Internal(

--- a/meerkat-core/src/lifecycle/core_executor.rs
+++ b/meerkat-core/src/lifecycle/core_executor.rs
@@ -411,6 +411,18 @@ pub trait CoreExecutorBoundaryHandle: Send + Sync {
             "live boundary system-context staging is unsupported by this executor".to_string(),
         ))
     }
+
+    /// Roll back live-boundary system context that was staged for an accepted
+    /// input whose runtime/machine commit did not succeed.
+    async fn discard_staged_system_context_at_boundary(
+        &self,
+        _expected_run_id: &RunId,
+        _idempotency_keys: Vec<String>,
+    ) -> Result<(), CoreExecutorError> {
+        Err(CoreExecutorError::Internal(
+            "live boundary system-context rollback is unsupported by this executor".to_string(),
+        ))
+    }
 }
 
 /// Cloneable live endpoint for hard-cancelling the active run immediately.

--- a/meerkat-core/src/session.rs
+++ b/meerkat-core/src/session.rs
@@ -298,6 +298,8 @@ pub struct SessionSystemContextState {
     pub applied: Vec<PendingSystemContextAppend>,
     #[serde(default, skip_serializing_if = "std::collections::BTreeMap::is_empty")]
     pub seen: std::collections::BTreeMap<String, SeenSystemContextKey>,
+    #[serde(default, skip_serializing_if = "std::collections::BTreeSet::is_empty")]
+    pub active_turn_pending_keys: std::collections::BTreeSet<String>,
 }
 
 /// Pending append request accepted by the control plane but not yet applied at an LLM boundary.
@@ -584,6 +586,27 @@ impl SessionSystemContextState {
         Ok(crate::service::AppendSystemContextStatus::Staged)
     }
 
+    /// Stage an append that is scoped to the currently-active turn only.
+    ///
+    /// If the active turn reaches another model boundary, normal pending
+    /// consumption moves it to `applied`. If the turn completes first, callers
+    /// should discard the still-pending active-turn keys so the context cannot
+    /// leak into an unrelated later run.
+    pub fn stage_active_turn_append(
+        &mut self,
+        req: &AppendSystemContextRequest,
+        accepted_at: SystemTime,
+    ) -> Result<crate::service::AppendSystemContextStatus, SystemContextStageError> {
+        let idempotency_key = req.idempotency_key.clone();
+        let status = self.stage_append(req, accepted_at)?;
+        if matches!(status, crate::service::AppendSystemContextStatus::Staged)
+            && let Some(key) = idempotency_key
+        {
+            self.active_turn_pending_keys.insert(key);
+        }
+        Ok(status)
+    }
+
     /// Mark all currently-pending appends as applied and clear the pending queue.
     pub fn mark_pending_applied(&mut self) {
         for pending in &self.pending {
@@ -599,6 +622,41 @@ impl SessionSystemContextState {
             }
         }
         self.pending.clear();
+        self.active_turn_pending_keys.clear();
+    }
+
+    /// Discard active-turn-only appends that were not consumed by the turn's
+    /// next LLM boundary.
+    pub fn discard_unapplied_active_turn_pending(&mut self) -> Vec<PendingSystemContextAppend> {
+        if self.active_turn_pending_keys.is_empty() {
+            return Vec::new();
+        }
+
+        let active_keys = std::mem::take(&mut self.active_turn_pending_keys);
+        let mut discarded = Vec::new();
+        self.pending.retain(|append| {
+            let should_discard = append
+                .idempotency_key
+                .as_ref()
+                .is_some_and(|key| active_keys.contains(key));
+            if should_discard {
+                discarded.push(append.clone());
+            }
+            !should_discard
+        });
+
+        for append in &discarded {
+            if let Some(key) = append.idempotency_key.as_ref()
+                && self
+                    .seen
+                    .get(key)
+                    .is_some_and(|seen| seen.state == SeenSystemContextState::Pending)
+            {
+                self.seen.remove(key);
+            }
+        }
+
+        discarded
     }
 }
 
@@ -3932,6 +3990,59 @@ mod tests {
             serde_json::from_value(serde_json::to_value(&state).expect("serialize state"))
                 .expect("deserialize state");
         assert_eq!(round_tripped.applied, state.applied);
+    }
+
+    #[test]
+    fn active_turn_system_context_is_discarded_when_not_applied() {
+        let mut state = SessionSystemContextState::default();
+        state
+            .stage_active_turn_append(
+                &AppendSystemContextRequest {
+                    text: "only for the active run".to_string(),
+                    source: Some("runtime:steer:input-1".to_string()),
+                    idempotency_key: Some("runtime:steer:input-1".to_string()),
+                },
+                SystemTime::UNIX_EPOCH,
+            )
+            .expect("active context should stage");
+
+        let discarded = state.discard_unapplied_active_turn_pending();
+
+        assert_eq!(discarded.len(), 1);
+        assert!(state.pending.is_empty());
+        assert!(state.applied.is_empty());
+        assert!(state.active_turn_pending_keys.is_empty());
+        assert!(
+            state.seen.is_empty(),
+            "discarded active-turn context should not block later idempotency keys"
+        );
+    }
+
+    #[test]
+    fn active_turn_system_context_becomes_applied_when_boundary_consumes_it() {
+        let mut state = SessionSystemContextState::default();
+        state
+            .stage_active_turn_append(
+                &AppendSystemContextRequest {
+                    text: "visible to this run".to_string(),
+                    source: Some("runtime:steer:input-2".to_string()),
+                    idempotency_key: Some("runtime:steer:input-2".to_string()),
+                },
+                SystemTime::UNIX_EPOCH,
+            )
+            .expect("active context should stage");
+
+        state.mark_pending_applied();
+        let discarded = state.discard_unapplied_active_turn_pending();
+
+        assert!(discarded.is_empty());
+        assert!(state.pending.is_empty());
+        assert_eq!(state.applied.len(), 1);
+        assert!(state.active_turn_pending_keys.is_empty());
+        assert_eq!(
+            state.seen["runtime:steer:input-2"].state,
+            SeenSystemContextState::Applied
+        );
     }
 
     #[test]

--- a/meerkat-core/src/session.rs
+++ b/meerkat-core/src/session.rs
@@ -610,16 +610,27 @@ impl SessionSystemContextState {
     /// Mark all currently-pending appends as applied and clear the pending queue.
     pub fn mark_pending_applied(&mut self) {
         for pending in &self.pending {
+            if is_runtime_steer_append(pending) {
+                continue;
+            }
             if !self.applied.contains(pending) {
                 self.applied.push(pending.clone());
             }
         }
+        let mut seen_to_remove = Vec::new();
         for pending in &self.pending {
             if let Some(key) = pending.idempotency_key.as_ref()
                 && let Some(seen) = self.seen.get_mut(key)
             {
-                seen.state = SeenSystemContextState::Applied;
+                if is_runtime_steer_append(pending) {
+                    seen_to_remove.push(key.clone());
+                } else {
+                    seen.state = SeenSystemContextState::Applied;
+                }
             }
+        }
+        for key in seen_to_remove {
+            self.seen.remove(&key);
         }
         self.pending.clear();
         self.active_turn_pending_keys.clear();
@@ -756,6 +767,18 @@ fn render_system_context_block(append: &PendingSystemContextAppend) -> String {
     rendered.push_str("\n\n");
     rendered.push_str(&append.text);
     rendered
+}
+
+fn is_runtime_steer_key(value: &str) -> bool {
+    value.starts_with("runtime:steer:")
+}
+
+fn is_runtime_steer_append(append: &PendingSystemContextAppend) -> bool {
+    append.source.as_deref().is_some_and(is_runtime_steer_key)
+        || append
+            .idempotency_key
+            .as_deref()
+            .is_some_and(is_runtime_steer_key)
 }
 
 fn seen_system_context_matches(
@@ -1565,6 +1588,73 @@ impl Session {
             inner.insert(0, Message::System(SystemMessage::new(prompt)));
         }
         self.updated_at = SystemTime::now();
+    }
+
+    /// Remove transient active-turn steer context from persisted session state.
+    ///
+    /// Operator steers accepted into an already-running turn are request-local:
+    /// they should be visible to that turn's next model boundary, then vanish
+    /// instead of replaying into later turns after persistence or resume.
+    pub fn discard_transient_runtime_steer_context(&mut self) -> usize {
+        let mut removed = 0usize;
+
+        if let Some(Message::System(system)) = self.messages.first() {
+            let parts = system
+                .content
+                .split(SYSTEM_CONTEXT_SEPARATOR)
+                .map(str::to_string)
+                .collect::<Vec<_>>();
+            let original_len = parts.len();
+            let retained = parts
+                .into_iter()
+                .filter(|part| {
+                    !(part.starts_with("[Runtime System Context]")
+                        && part.contains("\nsource: runtime:steer:"))
+                })
+                .collect::<Vec<_>>();
+            let removed_blocks = original_len.saturating_sub(retained.len());
+            if removed_blocks > 0 {
+                removed += removed_blocks;
+                self.set_system_prompt(retained.join(SYSTEM_CONTEXT_SEPARATOR));
+            }
+        }
+
+        let mut state = self.system_context_state().unwrap_or_default();
+
+        let before_pending = state.pending.len();
+        state
+            .pending
+            .retain(|append| !is_runtime_steer_append(append));
+        removed += before_pending.saturating_sub(state.pending.len());
+
+        let before_applied = state.applied.len();
+        state
+            .applied
+            .retain(|append| !is_runtime_steer_append(append));
+        removed += before_applied.saturating_sub(state.applied.len());
+
+        let before_seen = state.seen.len();
+        state.seen.retain(|key, seen| {
+            !is_runtime_steer_key(key) && !seen.source.as_deref().is_some_and(is_runtime_steer_key)
+        });
+        removed += before_seen.saturating_sub(state.seen.len());
+
+        let before_active = state.active_turn_pending_keys.len();
+        state
+            .active_turn_pending_keys
+            .retain(|key| !is_runtime_steer_key(key));
+        removed += before_active.saturating_sub(state.active_turn_pending_keys.len());
+
+        if removed > 0
+            && let Err(err) = self.set_system_context_state(state)
+        {
+            tracing::warn!(
+                error = %err,
+                "failed to persist runtime steer context cleanup"
+            );
+        }
+
+        removed
     }
 
     /// Append one or more runtime system-context blocks to the canonical system prompt.
@@ -4019,7 +4109,7 @@ mod tests {
     }
 
     #[test]
-    fn active_turn_system_context_becomes_applied_when_boundary_consumes_it() {
+    fn active_turn_system_context_is_transient_when_boundary_consumes_it() {
         let mut state = SessionSystemContextState::default();
         state
             .stage_active_turn_append(
@@ -4037,12 +4127,84 @@ mod tests {
 
         assert!(discarded.is_empty());
         assert!(state.pending.is_empty());
-        assert_eq!(state.applied.len(), 1);
+        assert!(state.applied.is_empty());
         assert!(state.active_turn_pending_keys.is_empty());
         assert_eq!(
-            state.seen["runtime:steer:input-2"].state,
-            SeenSystemContextState::Applied
+            state.seen.get("runtime:steer:input-2"),
+            None,
+            "consumed active-turn steer context must not become durable state"
         );
+    }
+
+    #[test]
+    fn discard_transient_runtime_steer_context_removes_legacy_prompt_and_state() {
+        let mut session = Session::new();
+        session.set_system_prompt(format!(
+            "base{}{}{}{}",
+            SYSTEM_CONTEXT_SEPARATOR,
+            render_system_context_block(&PendingSystemContextAppend {
+                text: "old steer".to_string(),
+                source: Some("runtime:steer:old".to_string()),
+                idempotency_key: Some("runtime:steer:old".to_string()),
+                accepted_at: SystemTime::UNIX_EPOCH,
+            }),
+            SYSTEM_CONTEXT_SEPARATOR,
+            render_system_context_block(&PendingSystemContextAppend {
+                text: "durable peer fact".to_string(),
+                source: Some("peer_response_terminal:analyst:req".to_string()),
+                idempotency_key: Some("peer_response_terminal:analyst:req".to_string()),
+                accepted_at: SystemTime::UNIX_EPOCH,
+            })
+        ));
+        session
+            .set_system_context_state(SessionSystemContextState {
+                pending: vec![PendingSystemContextAppend {
+                    text: "pending steer".to_string(),
+                    source: Some("runtime:steer:pending".to_string()),
+                    idempotency_key: Some("runtime:steer:pending".to_string()),
+                    accepted_at: SystemTime::UNIX_EPOCH,
+                }],
+                applied: vec![
+                    PendingSystemContextAppend {
+                        text: "old steer".to_string(),
+                        source: Some("runtime:steer:old".to_string()),
+                        idempotency_key: Some("runtime:steer:old".to_string()),
+                        accepted_at: SystemTime::UNIX_EPOCH,
+                    },
+                    PendingSystemContextAppend {
+                        text: "durable peer fact".to_string(),
+                        source: Some("peer_response_terminal:analyst:req".to_string()),
+                        idempotency_key: Some("peer_response_terminal:analyst:req".to_string()),
+                        accepted_at: SystemTime::UNIX_EPOCH,
+                    },
+                ],
+                seen: BTreeMap::from([(
+                    "runtime:steer:old".to_string(),
+                    SeenSystemContextKey {
+                        text: "old steer".to_string(),
+                        source: Some("runtime:steer:old".to_string()),
+                        state: SeenSystemContextState::Applied,
+                    },
+                )]),
+                active_turn_pending_keys: BTreeSet::from(["runtime:steer:pending".to_string()]),
+            })
+            .expect("system context state should serialize");
+
+        let removed = session.discard_transient_runtime_steer_context();
+
+        assert!(removed >= 4);
+        let system_prompt = match session.messages().first() {
+            Some(Message::System(system)) => system.content.as_str(),
+            other => panic!("expected system prompt, got {other:?}"),
+        };
+        assert!(!system_prompt.contains("runtime:steer:"));
+        assert!(system_prompt.contains("durable peer fact"));
+        let state = session.system_context_state().unwrap_or_default();
+        assert!(state.pending.is_empty());
+        assert_eq!(state.applied.len(), 1);
+        assert_eq!(state.applied[0].text, "durable peer fact");
+        assert!(state.seen.is_empty());
+        assert!(state.active_turn_pending_keys.is_empty());
     }
 
     #[test]

--- a/meerkat-core/src/session.rs
+++ b/meerkat-core/src/session.rs
@@ -669,6 +669,51 @@ impl SessionSystemContextState {
 
         discarded
     }
+
+    /// Discard specific active-turn-only appends that are still pending.
+    ///
+    /// This is the rollback companion for live-boundary staging. The runtime
+    /// owns the accepted input, so if that commit fails after the session has
+    /// staged context, the session-side projection must be removed by the same
+    /// idempotency keys before the caller reports failure.
+    pub fn discard_active_turn_pending_by_keys(
+        &mut self,
+        idempotency_keys: &[String],
+    ) -> Vec<PendingSystemContextAppend> {
+        if idempotency_keys.is_empty() || self.active_turn_pending_keys.is_empty() {
+            return Vec::new();
+        }
+
+        let requested_keys: std::collections::BTreeSet<&str> =
+            idempotency_keys.iter().map(String::as_str).collect();
+        let mut discarded = Vec::new();
+        let mut discarded_keys = Vec::new();
+        self.pending.retain(|append| {
+            let should_discard = append.idempotency_key.as_ref().is_some_and(|key| {
+                requested_keys.contains(key.as_str()) && self.active_turn_pending_keys.contains(key)
+            });
+            if should_discard {
+                if let Some(key) = append.idempotency_key.as_ref() {
+                    discarded_keys.push(key.clone());
+                }
+                discarded.push(append.clone());
+            }
+            !should_discard
+        });
+
+        for key in discarded_keys {
+            self.active_turn_pending_keys.remove(&key);
+            if self
+                .seen
+                .get(&key)
+                .is_some_and(|seen| seen.state == SeenSystemContextState::Pending)
+            {
+                self.seen.remove(&key);
+            }
+        }
+
+        discarded
+    }
 }
 
 impl SessionDeferredTurnState {
@@ -4105,6 +4150,49 @@ mod tests {
         assert!(
             state.seen.is_empty(),
             "discarded active-turn context should not block later idempotency keys"
+        );
+    }
+
+    #[test]
+    fn active_turn_system_context_can_roll_back_targeted_keys() {
+        let mut state = SessionSystemContextState::default();
+        for key in ["runtime:steer:input-1", "runtime:steer:input-2"] {
+            state
+                .stage_active_turn_append(
+                    &AppendSystemContextRequest {
+                        text: format!("context for {key}"),
+                        source: Some(key.to_string()),
+                        idempotency_key: Some(key.to_string()),
+                    },
+                    SystemTime::UNIX_EPOCH,
+                )
+                .expect("active context should stage");
+        }
+
+        let discarded =
+            state.discard_active_turn_pending_by_keys(&["runtime:steer:input-1".to_string()]);
+
+        assert_eq!(discarded.len(), 1);
+        assert_eq!(
+            discarded[0].idempotency_key.as_deref(),
+            Some("runtime:steer:input-1")
+        );
+        assert_eq!(state.pending.len(), 1);
+        assert_eq!(
+            state.pending[0].idempotency_key.as_deref(),
+            Some("runtime:steer:input-2")
+        );
+        assert!(!state.seen.contains_key("runtime:steer:input-1"));
+        assert!(state.seen.contains_key("runtime:steer:input-2"));
+        assert!(
+            !state
+                .active_turn_pending_keys
+                .contains("runtime:steer:input-1")
+        );
+        assert!(
+            state
+                .active_turn_pending_keys
+                .contains("runtime:steer:input-2")
         );
     }
 

--- a/meerkat-mob-mcp/src/agent_tools.rs
+++ b/meerkat-mob-mcp/src/agent_tools.rs
@@ -96,6 +96,8 @@ pub struct AgentMobToolSurface {
     comms_runtime: Option<Arc<dyn meerkat_core::agent::CommsRuntime>>,
     /// Context for capturing a parent agent's tool scope snapshot.
     snapshot_context: meerkat_core::service::MobToolSnapshotContext,
+    /// Runtime-owned ops registry for owner-bound mob operations.
+    ops_registry: Option<Arc<dyn meerkat_core::ops_lifecycle::OpsLifecycleRegistry>>,
 }
 
 impl AgentMobToolSurface {
@@ -233,6 +235,7 @@ impl AgentMobToolSurface {
             comms_peer_id,
             comms_runtime,
             snapshot_context,
+            ops_registry: None,
         }
     }
 
@@ -856,11 +859,18 @@ impl AgentMobToolSurface {
             spec.auth_binding = Some(cref);
         }
 
-        let spawn_result = self
-            .state
-            .mob_spawn_spec(&mob_id, spec)
-            .await
-            .map_err(|e| Self::map_mob_error(call, e))?;
+        let spawn_result = if let Some(ops_registry) = self.ops_registry.as_ref() {
+            audit_handle
+                .spawn_spec_with_owner_context(
+                    spec,
+                    self.owner_bridge_session_id.clone(),
+                    Arc::clone(ops_registry),
+                )
+                .await
+        } else {
+            self.state.mob_spawn_spec(&mob_id, spec).await
+        }
+        .map_err(|e| Self::map_mob_error(call, e))?;
 
         self.record_successful_operator_action(&audit_handle, call.name)
             .await;
@@ -1221,6 +1231,37 @@ impl AgentToolDispatcher for AgentMobToolSurface {
             TOOL_MOB_PROFILE_LIST_SOURCES => self.dispatch_mob_profile_list_sources(call).await,
             _ => Err(ToolError::not_found(call.name)),
         }
+    }
+
+    fn capabilities(&self) -> meerkat_core::agent::DispatcherCapabilities {
+        meerkat_core::agent::DispatcherCapabilities {
+            ops_lifecycle: true,
+        }
+    }
+
+    fn bind_ops_lifecycle(
+        self: Arc<Self>,
+        registry: Arc<dyn meerkat_core::ops_lifecycle::OpsLifecycleRegistry>,
+        owner_bridge_session_id: SessionId,
+    ) -> Result<meerkat_core::agent::BindOutcome, meerkat_core::agent::OpsLifecycleBindError> {
+        if Arc::strong_count(&self) != 1 {
+            return Err(meerkat_core::agent::OpsLifecycleBindError::SharedOwnership);
+        }
+        let this = Arc::try_unwrap(self)
+            .map_err(|_| meerkat_core::agent::OpsLifecycleBindError::SharedOwnership)?;
+        Ok(meerkat_core::agent::BindOutcome::Bound(Arc::new(Self {
+            state: this.state,
+            cached_implicit_mob_id: this.cached_implicit_mob_id,
+            effective_authority: this.effective_authority,
+            tools: this.tools,
+            owner_bridge_session_id,
+            model: this.model,
+            comms_name: this.comms_name,
+            comms_peer_id: this.comms_peer_id,
+            comms_runtime: this.comms_runtime,
+            snapshot_context: this.snapshot_context,
+            ops_registry: Some(registry),
+        })))
     }
 }
 
@@ -3664,6 +3705,73 @@ mod tests {
             unknown_profile_error,
             ToolError::AccessDenied { .. }
         ));
+    }
+
+    #[tokio::test]
+    async fn test_mob_spawn_member_auto_wire_parent_uses_bound_owner_session() {
+        let state = MobMcpState::new_in_memory();
+        let mob_id = state
+            .mob_create_definition(sample_definition("spawn-auto-wire-parent"))
+            .await
+            .expect("create mob");
+        let handle = state.handle_for(&mob_id).await.expect("handle");
+        let parent_identity = AgentIdentity::from("parent");
+        state
+            .mob_spawn_spec(
+                &mob_id,
+                SpawnMemberSpec::new(ProfileName::from("worker"), parent_identity.clone()),
+            )
+            .await
+            .expect("spawn parent");
+        let parent_bridge_session_id = handle
+            .resolve_bridge_session_id(&parent_identity)
+            .await
+            .expect("parent bridge session");
+        let surface: Arc<dyn AgentToolDispatcher> = Arc::new(AgentMobToolSurface::new(
+            Arc::clone(&state),
+            None,
+            spawn_profile_authority(mob_id.as_str(), "worker"),
+            "claude-sonnet-4-5".to_string(),
+            parent_bridge_session_id.clone(),
+            None,
+            None,
+            None,
+        ));
+        let surface = surface
+            .bind_ops_lifecycle(
+                Arc::new(meerkat_runtime::ops_lifecycle::RuntimeOpsLifecycleRegistry::new()),
+                parent_bridge_session_id,
+            )
+            .expect("bind ops lifecycle")
+            .into_dispatcher();
+
+        let spawn_args = serde_json::value::RawValue::from_string(
+            json!({
+                "mob_id": mob_id,
+                "profile": "worker",
+                "member_id": "child",
+                "auto_wire_parent": true
+            })
+            .to_string(),
+        )
+        .unwrap();
+        surface
+            .dispatch(ToolCallView {
+                id: "spawn-auto-wire-child",
+                name: "mob_spawn_member",
+                args: &spawn_args,
+            })
+            .await
+            .expect("owner-bound spawn should succeed");
+
+        let roster = handle.roster().await;
+        let child = roster
+            .get_by_identity(&AgentIdentity::from("child"))
+            .expect("child roster entry");
+        assert!(
+            child.wired_to.contains(&parent_identity),
+            "auto_wire_parent must wire the spawned member to the bound spawning member"
+        );
     }
 
     #[tokio::test]

--- a/meerkat-mob-mcp/src/agent_tools.rs
+++ b/meerkat-mob-mcp/src/agent_tools.rs
@@ -335,6 +335,29 @@ impl AgentMobToolSurface {
         Err(ToolError::access_denied(tool_name))
     }
 
+    fn ensure_spawn_member_scope(
+        &self,
+        tool_name: &str,
+        mob_id: &MobId,
+        args: &SpawnMemberArgs,
+    ) -> Result<(), ToolError> {
+        let authority = self.authority_context_snapshot();
+        if authority.can_manage_mob(mob_id.as_str()) {
+            return Ok(());
+        }
+        if args.runtime_mode.is_some()
+            || args.backend.is_some()
+            || args.tooling.is_some()
+            || args.auth_binding.is_some()
+        {
+            return Err(ToolError::access_denied(tool_name));
+        }
+        if authority.can_spawn_profile_in_mob(mob_id.as_str(), &args.profile) {
+            return Ok(());
+        }
+        Err(ToolError::access_denied(tool_name))
+    }
+
     /// Resolve spawn tooling into inherited tool filter and optional override profile.
     ///
     /// - `InheritParent`: snapshot parent's visible tools, apply overlays
@@ -766,7 +789,7 @@ impl AgentMobToolSurface {
         let args: MobIdArgs = call
             .parse_args()
             .map_err(|e| ToolError::invalid_arguments(call.name, e.to_string()))?;
-        let mob_id = MobId::from(args.mob_id);
+        let mob_id = MobId::from(args.mob_id.clone());
 
         self.ensure_mob_scope_authority(call.name, &mob_id).await?;
         let audit_handle = self.state.handle_for(&mob_id).await.ok();
@@ -805,9 +828,9 @@ impl AgentMobToolSurface {
         let args: SpawnMemberArgs = call
             .parse_args()
             .map_err(|e| ToolError::invalid_arguments(call.name, e.to_string()))?;
-        let mob_id = MobId::from(args.mob_id);
+        let mob_id = MobId::from(args.mob_id.clone());
 
-        self.ensure_mob_scope_authority(call.name, &mob_id).await?;
+        self.ensure_spawn_member_scope(call.name, &mob_id, &args)?;
         let audit_handle = self
             .state
             .handle_for(&mob_id)
@@ -2836,6 +2859,11 @@ mod tests {
             .with_managed_mob_scope([mob_id])
     }
 
+    fn spawn_profile_authority(mob_id: &str, profile: &str) -> MobToolAuthorityContext {
+        MobToolAuthorityContext::new(OpaquePrincipalToken::new("spawn-profile"), false)
+            .grant_spawn_profile_in_mob(mob_id, profile)
+    }
+
     fn create_only_authority_with_provenance() -> MobToolAuthorityContext {
         create_only_authority()
             .with_caller_provenance(
@@ -3552,6 +3580,90 @@ mod tests {
         assert_eq!(audit_events[0].0, "mob_spawn_member");
         assert_eq!(audit_events[0].1.as_str(), "scope-principal");
         assert_eq!(audit_events[0].2.as_deref(), Some("audit-scope"));
+    }
+
+    #[tokio::test]
+    async fn test_spawn_profile_scope_allows_spawn_but_not_privileged_overrides() {
+        let state = MobMcpState::new_in_memory();
+        let mob_id = state
+            .mob_create_definition(sample_definition("spawn-profile-scope"))
+            .await
+            .expect("create mob");
+        let surface = AgentMobToolSurface::new(
+            Arc::clone(&state),
+            None,
+            spawn_profile_authority(mob_id.as_str(), "worker"),
+            "claude-sonnet-4-5".to_string(),
+            SessionId::new(),
+            None,
+            None,
+            None,
+        );
+
+        let spawn_args = serde_json::value::RawValue::from_string(
+            json!({
+                "mob_id": mob_id,
+                "profile": "worker",
+                "member_id": "w-1",
+                "auto_wire_parent": true,
+                "initial_message": "hello"
+            })
+            .to_string(),
+        )
+        .unwrap();
+        surface
+            .dispatch(ToolCallView {
+                id: "spawn-profile-ok",
+                name: "mob_spawn_member",
+                args: &spawn_args,
+            })
+            .await
+            .expect("profile-scoped authority should spawn allowed definition profiles");
+
+        let runtime_override_args = serde_json::value::RawValue::from_string(
+            json!({
+                "mob_id": mob_id,
+                "profile": "worker",
+                "member_id": "w-2",
+                "runtime_mode": "autonomous_host"
+            })
+            .to_string(),
+        )
+        .unwrap();
+        let runtime_override_error = surface
+            .dispatch(ToolCallView {
+                id: "spawn-profile-runtime-override",
+                name: "mob_spawn_member",
+                args: &runtime_override_args,
+            })
+            .await
+            .expect_err("profile-scoped authority must not override runtime binding policy");
+        assert!(matches!(
+            runtime_override_error,
+            ToolError::AccessDenied { .. }
+        ));
+
+        let unknown_profile_args = serde_json::value::RawValue::from_string(
+            json!({
+                "mob_id": mob_id,
+                "profile": "unknown",
+                "member_id": "w-3"
+            })
+            .to_string(),
+        )
+        .unwrap();
+        let unknown_profile_error = surface
+            .dispatch(ToolCallView {
+                id: "spawn-profile-unknown",
+                name: "mob_spawn_member",
+                args: &unknown_profile_args,
+            })
+            .await
+            .expect_err("profile-scoped authority must not spawn ungranted profiles");
+        assert!(matches!(
+            unknown_profile_error,
+            ToolError::AccessDenied { .. }
+        ));
     }
 
     #[tokio::test]

--- a/meerkat-mob-mcp/src/lib.rs
+++ b/meerkat-mob-mcp/src/lib.rs
@@ -414,6 +414,11 @@ impl MobMcpState {
         builder
     }
 
+    fn bind_realm_profile_store(&self, mut storage: MobStorage) -> MobStorage {
+        storage.realm_profiles = self.realm_profile_store.clone();
+        storage
+    }
+
     async fn storage_for_new_mob(
         &self,
         mob_id: &MobId,
@@ -432,11 +437,11 @@ impl MobMcpState {
                 ))
             })?;
             let path = Self::persistent_storage_path(root, mob_id);
-            let storage = MobStorage::persistent(&path)?;
+            let storage = self.bind_realm_profile_store(MobStorage::persistent(&path)?);
             return Ok((storage, Some(path)));
         }
 
-        Ok((MobStorage::in_memory(), None))
+        Ok((self.bind_realm_profile_store(MobStorage::in_memory()), None))
     }
 
     async fn maybe_remove_storage_file(path: Option<&Path>) {
@@ -525,7 +530,7 @@ impl MobMcpState {
                     continue;
                 }
 
-                let storage = MobStorage::persistent(&path)?;
+                let storage = self.bind_realm_profile_store(MobStorage::persistent(&path)?);
                 if storage.events.replay_all().await?.is_empty() {
                     Self::maybe_remove_storage_file(Some(path.as_path())).await;
                     continue;
@@ -1080,7 +1085,7 @@ impl MobMcpState {
             return Ok(());
         }
 
-        let deadline = Instant::now() + Duration::from_secs(120);
+        let deadline = Instant::now() + Duration::from_mins(2);
         loop {
             if !adapter.contains_session(bridge_session_id).await {
                 return Ok(());
@@ -5708,6 +5713,56 @@ mod tests {
             panic!("expected inline seeded skill source");
         };
         assert_eq!(content, "investigation worker rules");
+    }
+
+    #[tokio::test]
+    async fn realm_ref_mob_create_spawns_against_shared_profile_store() {
+        let svc = Arc::new(MockSessionSvc::new());
+        let state = MobMcpState::new(svc);
+        let mut profile = sample_realm_profile("gpt-5.5");
+        profile.tools.comms = true;
+        state
+            .realm_profile_create("investigation-worker", &profile)
+            .await
+            .expect("realm profile seeded");
+        state
+            .realm_profile_create("person-worker", &profile)
+            .await
+            .expect("person profile seeded");
+
+        let mut definition = MobDefinition::explicit(MobId::from("nest-1779406812080"));
+        definition.wiring.auto_wire_orchestrator = true;
+        definition.profiles.insert(
+            ProfileName::from("investigation-worker"),
+            meerkat_mob::ProfileBinding::RealmRef {
+                realm_profile: "investigation-worker".to_string(),
+            },
+        );
+        definition.profiles.insert(
+            ProfileName::from("person-worker"),
+            meerkat_mob::ProfileBinding::RealmRef {
+                realm_profile: "person-worker".to_string(),
+            },
+        );
+
+        let mob_id = state
+            .mob_create_definition(definition)
+            .await
+            .expect("realm-ref mob create should succeed");
+        let mut spec = SpawnMemberSpec::new(
+            ProfileName::from("investigation-worker"),
+            AgentIdentity::from("investigation-worker-nest-1779406812080"),
+        );
+        spec.auto_wire_parent = true;
+
+        let result = state
+            .mob_spawn_spec(&mob_id, spec)
+            .await
+            .expect("realm-ref profile should resolve from shared state store");
+        assert_eq!(
+            result.agent_identity,
+            AgentIdentity::from("investigation-worker-nest-1779406812080")
+        );
     }
 
     #[tokio::test]

--- a/meerkat-mob-mcp/src/lib.rs
+++ b/meerkat-mob-mcp/src/lib.rs
@@ -54,14 +54,16 @@ use meerkat_core::types::{
     ToolProvenance, ToolResult, ToolSourceKind, Usage,
 };
 use meerkat_core::{AgentEvent, EventEnvelope, EventStream, Provider, StreamError};
+use meerkat_mob::definition::SkillSource;
 use meerkat_mob::{
     AgentIdentity, FlowId, MobBackendKind, MobBuilder, MobDefinition, MobError, MobHandle, MobId,
-    MobRuntimeMode, MobSessionService, MobState, MobStorage, ProfileName, RunId, SpawnMemberSpec,
+    MobRuntimeMode, MobSessionService, MobState, MobStorage, ProfileBinding, ProfileName, RunId,
+    SpawnMemberSpec,
 };
 use meerkat_runtime::service_ext::SessionServiceRuntimeExt as _;
 use serde::Deserialize;
 use serde_json::json;
-use std::collections::{BTreeMap, HashMap, HashSet, btree_map::Entry};
+use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet, btree_map::Entry};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::Duration;
@@ -223,6 +225,13 @@ pub struct MobMcpState {
     /// available on ephemeral surfaces. Persistent roots may upgrade that
     /// default to SQLite, but must not override an explicit caller-owned store.
     realm_profile_store_explicit: bool,
+    /// Skill sources seeded from the owning mob definition.
+    ///
+    /// Realm profiles carry skill names, not the source bodies/paths. When an
+    /// agent creates a child mob from a realm profile, copy matching source
+    /// definitions into the child so profile skills still assemble into the
+    /// spawned member's system prompt.
+    realm_skill_sources: BTreeMap<String, SkillSource>,
 }
 
 impl MobMcpState {
@@ -247,6 +256,7 @@ impl MobMcpState {
             restore_lock: Mutex::new(false),
             realm_profile_store: Some(Arc::new(meerkat_mob::InMemoryRealmProfileStore::new())),
             realm_profile_store_explicit: false,
+            realm_skill_sources: BTreeMap::new(),
         }
     }
 
@@ -309,6 +319,54 @@ impl MobMcpState {
     ) -> Self {
         self.external_tools_provider = provider;
         self
+    }
+
+    /// Seed skill source definitions available to realm-referenced profiles.
+    pub fn with_realm_skill_sources(mut self, sources: BTreeMap<String, SkillSource>) -> Self {
+        self.realm_skill_sources = sources;
+        self
+    }
+
+    async fn hydrate_definition_skill_sources(
+        &self,
+        definition: &mut MobDefinition,
+    ) -> Result<(), MobError> {
+        if self.realm_skill_sources.is_empty() {
+            return Ok(());
+        }
+
+        let mut skill_names = BTreeSet::new();
+        for binding in definition.profiles.values() {
+            match binding {
+                ProfileBinding::Inline(profile) => {
+                    skill_names.extend(profile.skills.iter().cloned());
+                }
+                ProfileBinding::RealmRef { realm_profile } => {
+                    let Some(store) = &self.realm_profile_store else {
+                        continue;
+                    };
+                    let stored = store.get(realm_profile).await.map_err(|error| {
+                        MobError::Internal(format!(
+                            "failed to load realm profile '{realm_profile}' while hydrating skill sources: {error}"
+                        ))
+                    })?;
+                    if let Some(stored) = stored {
+                        skill_names.extend(stored.profile.skills.iter().cloned());
+                    }
+                }
+            }
+        }
+
+        for skill_name in skill_names {
+            if definition.skills.contains_key(&skill_name) {
+                continue;
+            }
+            if let Some(source) = self.realm_skill_sources.get(&skill_name) {
+                definition.skills.insert(skill_name, source.clone());
+            }
+        }
+
+        Ok(())
     }
 
     fn persistent_mob_root(runtime_root: &Path) -> PathBuf {
@@ -531,8 +589,10 @@ impl MobMcpState {
 
     pub async fn mob_create_definition(
         &self,
-        definition: MobDefinition,
+        mut definition: MobDefinition,
     ) -> Result<MobId, MobError> {
+        self.hydrate_definition_skill_sources(&mut definition)
+            .await?;
         let mob_id = definition.id.clone();
         self.ensure_restored().await?;
         if self.mobs.read().await.contains_key(&mob_id) {
@@ -577,27 +637,32 @@ impl MobMcpState {
         );
     }
 
-    pub async fn mob_list(&self) -> Vec<(MobId, MobState)> {
-        if !self.ensure_restored_best_effort("mob_list").await {
+    /// Return known mob handles without asking each mob actor for live status.
+    ///
+    /// Observation surfaces use this while child mobs are actively processing:
+    /// a status query would queue behind the same actor work the UI is trying
+    /// to observe.
+    pub async fn mob_handles_snapshot(&self) -> Vec<(MobId, MobHandle)> {
+        if !self
+            .ensure_restored_best_effort("mob_handles_snapshot")
+            .await
+        {
             return Vec::new();
         }
-        let snapshot: Vec<(MobId, meerkat_mob::MobHandle)> = self
-            .mobs
+        self.mobs
             .read()
             .await
             .iter()
             .map(|(id, managed)| (id.clone(), managed.handle.clone()))
-            .collect();
-        let mut out = Vec::with_capacity(snapshot.len());
-        for (id, handle) in snapshot {
-            match handle.status().await {
-                Ok(state) => out.push((id, state)),
-                Err(err) => {
-                    tracing::warn!(mob_id = %id, error = %err, "mob_list: skipping mob whose status read failed");
-                }
-            }
-        }
-        out
+            .collect()
+    }
+
+    pub async fn mob_list(&self) -> Vec<(MobId, MobState)> {
+        self.mob_handles_snapshot()
+            .await
+            .into_iter()
+            .map(|(id, handle)| (id, handle.status_observation_snapshot()))
+            .collect()
     }
 
     pub async fn mob_status(&self, mob_id: &MobId) -> Result<MobState, MobError> {
@@ -3680,6 +3745,7 @@ mod tests {
         keep_alive_notifiers: RwLock<HashMap<SessionId, Arc<Notify>>>,
         counter: AtomicU64,
         start_turn_delay_ms: AtomicU64,
+        start_turn_calls: AtomicU64,
         runtime_adapter: Arc<meerkat_runtime::MeerkatMachine>,
     }
 
@@ -3692,12 +3758,17 @@ mod tests {
                 keep_alive_notifiers: RwLock::new(HashMap::new()),
                 counter: AtomicU64::new(0),
                 start_turn_delay_ms: AtomicU64::new(0),
+                start_turn_calls: AtomicU64::new(0),
                 runtime_adapter: Arc::new(meerkat_runtime::MeerkatMachine::ephemeral()),
             }
         }
 
         fn set_turn_delay_ms(&self, delay_ms: u64) {
             self.start_turn_delay_ms.store(delay_ms, Ordering::Relaxed);
+        }
+
+        fn start_turn_call_count(&self) -> u64 {
+            self.start_turn_calls.load(Ordering::Relaxed)
         }
 
         async fn insert_persisted_session(&self, session: Session) {
@@ -3813,6 +3884,7 @@ mod tests {
             if !self.sessions.read().await.contains_key(id) {
                 return Err(SessionError::NotFound { id: id.clone() });
             }
+            self.start_turn_calls.fetch_add(1, Ordering::Relaxed);
             let delay_ms = self.start_turn_delay_ms.load(Ordering::Relaxed);
             if delay_ms > 0 {
                 sleep(Duration::from_millis(delay_ms)).await;
@@ -4835,6 +4907,63 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_mob_list_observes_without_waiting_for_in_flight_member_turn() {
+        let svc = Arc::new(MockSessionSvc::new());
+        svc.set_turn_delay_ms(5_000);
+        let state = Arc::new(MobMcpState::new(svc.clone()));
+        let d = MobMcpDispatcher::new(Arc::clone(&state));
+
+        let mob_id = state
+            .mob_create_definition(explicit_definition("self-observation-mob"))
+            .await
+            .expect("create mob");
+        state
+            .mob_spawn(
+                &mob_id,
+                ProfileName::from("worker"),
+                AgentIdentity::from("worker-1"),
+                Some(meerkat_mob::MobRuntimeMode::TurnDriven),
+                None,
+            )
+            .await
+            .expect("spawn worker");
+
+        let baseline_start_turn_calls = svc.start_turn_call_count();
+        let turn_handle = state.handle_for(&mob_id).await.expect("handle");
+        let in_flight_turn = tokio::spawn(async move {
+            turn_handle
+                .internal_turn(AgentIdentity::from("worker-1"), "observe the mob")
+                .await
+        });
+
+        let deadline = Instant::now() + Duration::from_secs(2);
+        while svc.start_turn_call_count() <= baseline_start_turn_calls {
+            assert!(
+                Instant::now() < deadline,
+                "member turn should reach the delayed session service"
+            );
+            sleep(Duration::from_millis(10)).await;
+        }
+
+        let listed = tokio::time::timeout(
+            Duration::from_millis(100),
+            call_tool(&d, "mob_list", json!({})),
+        )
+        .await
+        .expect("mob_list must not wait behind the in-flight member turn");
+        assert_eq!(listed["mobs"].as_array().unwrap().len(), 1);
+        assert_eq!(listed["mobs"][0]["status"], "Running");
+
+        let profiles = tokio::time::timeout(Duration::from_millis(100), state.realm_profile_list())
+            .await
+            .expect("profile observation should also remain available during the turn")
+            .expect("profile list should succeed");
+        drop(profiles);
+
+        in_flight_turn.abort();
+    }
+
+    #[tokio::test]
     async fn test_mcp_stop_resume_round_trip() {
         let svc = Arc::new(MockSessionSvc::new());
         let state = Arc::new(MobMcpState::new(svc));
@@ -5533,6 +5662,52 @@ mod tests {
             output_schema: None,
             provider_params: None,
         }
+    }
+
+    #[tokio::test]
+    async fn realm_profile_child_mobs_hydrate_seeded_skill_sources() {
+        let svc = Arc::new(MockSessionSvc::new());
+        let store = Arc::new(meerkat_mob::InMemoryRealmProfileStore::new())
+            as Arc<dyn meerkat_mob::RealmProfileStore>;
+        let mut profile = sample_realm_profile("gpt-5.5");
+        profile.skills = vec!["ob3-investigation-worker".to_string()];
+        store
+            .create("investigation-worker", &profile)
+            .await
+            .expect("realm profile seeded");
+
+        let mut sources = BTreeMap::new();
+        sources.insert(
+            "ob3-investigation-worker".to_string(),
+            SkillSource::Inline {
+                content: "investigation worker rules".to_string(),
+            },
+        );
+
+        let state = MobMcpState::new(svc)
+            .with_realm_profile_store(Some(store))
+            .with_realm_skill_sources(sources);
+        let mut definition = MobDefinition::explicit(MobId::from("child-mob"));
+        definition.profiles.insert(
+            ProfileName::from("investigation-worker"),
+            meerkat_mob::ProfileBinding::RealmRef {
+                realm_profile: "investigation-worker".to_string(),
+            },
+        );
+
+        state
+            .hydrate_definition_skill_sources(&mut definition)
+            .await
+            .expect("hydration succeeds");
+
+        let SkillSource::Inline { content } = definition
+            .skills
+            .get("ob3-investigation-worker")
+            .expect("seeded source copied")
+        else {
+            panic!("expected inline seeded skill source");
+        };
+        assert_eq!(content, "investigation worker rules");
     }
 
     #[tokio::test]

--- a/meerkat-mob/src/build.rs
+++ b/meerkat-mob/src/build.rs
@@ -211,8 +211,19 @@ pub async fn build_agent_config(
         meerkat_core::ToolCategoryOverride::from_effective(profile.tools.schedule);
     config.override_image_generation =
         meerkat_core::ToolCategoryOverride::from_effective(profile.tools.image_generation);
-    let (override_mob, authority) =
+    let should_grant_default_spawn_profiles =
+        profile.tools.mob && mob_tool_authority_context.is_none();
+    let (override_mob, mut authority) =
         resolve_profile_mob_operator_access(profile, mob_tool_authority_context);
+    if should_grant_default_spawn_profiles && let Some(authority_context) = authority.take() {
+        let profile_names = definition
+            .profiles
+            .keys()
+            .map(|profile| profile.as_str().to_string())
+            .collect::<Vec<_>>();
+        authority =
+            Some(authority_context.grant_spawn_profiles_in_mob(mob_id.as_str(), profile_names));
+    }
     config.override_mob = override_mob;
     config.mob_tool_authority_context = authority;
 
@@ -837,7 +848,13 @@ mod tests {
             config.override_mob,
             meerkat_core::ToolCategoryOverride::Enable
         );
-        assert!(config.mob_tool_authority_context.is_some());
+        let authority = config
+            .mob_tool_authority_context
+            .as_ref()
+            .expect("mob profile should receive generated authority");
+        assert!(authority.can_spawn_profile_in_mob("test-mob", "lead"));
+        assert!(authority.can_spawn_profile_in_mob("test-mob", "worker"));
+        assert!(!authority.can_manage_mob("test-mob"));
         // Worker profile has builtins=true, shell=false, memory=false
         let worker = def.profiles[&ProfileName::from("worker")]
             .as_inline()

--- a/meerkat-mob/src/runtime/actor.rs
+++ b/meerkat-mob/src/runtime/actor.rs
@@ -11385,7 +11385,17 @@ impl MobActor {
 
             match adapter.runtime_state(session_id).await {
                 Ok(meerkat_runtime::RuntimeState::Running) => return Ok(true),
-                Ok(_) => return Ok(false),
+                Ok(_) => {
+                    if self
+                        .provisioner
+                        .is_member_active(&entry.member_ref)
+                        .await?
+                        .unwrap_or(false)
+                    {
+                        return Ok(true);
+                    }
+                    return Ok(false);
+                }
                 Err(error) => {
                     tracing::debug!(
                         agent_identity = %entry.agent_identity,

--- a/meerkat-mob/src/runtime/actor.rs
+++ b/meerkat-mob/src/runtime/actor.rs
@@ -41,6 +41,11 @@ impl InitialTurnHandle {
 
 enum SubmitWorkDispatchCompletion {
     Completed,
+    AwaitTurnAdmission {
+        provisioner: Arc<dyn MobProvisioner>,
+        member_ref: MemberRef,
+        req: Box<meerkat_core::service::StartTurnRequest>,
+    },
     AwaitTurnCompletion {
         provisioner: Arc<dyn MobProvisioner>,
         member_ref: MemberRef,
@@ -3455,6 +3460,18 @@ impl MobActor {
                     match Box::pin(self.handle_submit_work(payload)).await {
                         Ok(SubmitWorkDispatchCompletion::Completed) => {
                             let _ = reply_tx.send(Ok(()));
+                        }
+                        Ok(SubmitWorkDispatchCompletion::AwaitTurnAdmission {
+                            provisioner,
+                            member_ref,
+                            req,
+                        }) => {
+                            Self::spawn_turn_admission_reply(
+                                provisioner,
+                                member_ref,
+                                req,
+                                reply_tx,
+                            );
                         }
                         Ok(SubmitWorkDispatchCompletion::AwaitTurnCompletion {
                             provisioner,
@@ -11023,6 +11040,34 @@ impl MobActor {
         });
     }
 
+    fn spawn_turn_admission_reply(
+        provisioner: Arc<dyn MobProvisioner>,
+        member_ref: MemberRef,
+        req: Box<meerkat_core::service::StartTurnRequest>,
+        reply_tx: oneshot::Sender<Result<(), MobError>>,
+    ) {
+        tokio::spawn(async move {
+            let result = provisioner.admit_turn(&member_ref, *req).await;
+            let _ = reply_tx.send(result);
+        });
+    }
+
+    fn spawn_turn_admission_detached(
+        provisioner: Arc<dyn MobProvisioner>,
+        member_ref: MemberRef,
+        req: Box<meerkat_core::service::StartTurnRequest>,
+    ) {
+        tokio::spawn(async move {
+            if let Err(error) = provisioner.admit_turn(&member_ref, *req).await {
+                tracing::warn!(
+                    member_ref = ?member_ref,
+                    error = %error,
+                    "detached turn admission failed"
+                );
+            }
+        });
+    }
+
     async fn dispatch_turn_driven_spawn_initial_turn(
         &mut self,
         agent_identity: &MeerkatId,
@@ -11195,6 +11240,14 @@ impl MobActor {
     ) -> Result<(), MobError> {
         match completion {
             SubmitWorkDispatchCompletion::Completed => Ok(()),
+            SubmitWorkDispatchCompletion::AwaitTurnAdmission {
+                provisioner,
+                member_ref,
+                req,
+            } => {
+                Self::spawn_turn_admission_detached(provisioner, member_ref, req);
+                Ok(())
+            }
             SubmitWorkDispatchCompletion::AwaitTurnCompletion {
                 provisioner,
                 member_ref,
@@ -11284,8 +11337,11 @@ impl MobActor {
                 };
                 match ack_mode {
                     crate::mob_machine::SubmitWorkAckMode::IngressAccepted => {
-                        self.provisioner.admit_turn(&entry.member_ref, req).await?;
-                        Ok(SubmitWorkDispatchCompletion::Completed)
+                        Ok(SubmitWorkDispatchCompletion::AwaitTurnAdmission {
+                            provisioner: self.provisioner.clone(),
+                            member_ref: entry.member_ref.clone(),
+                            req: Box::new(req),
+                        })
                     }
                     crate::mob_machine::SubmitWorkAckMode::TurnCompleted => {
                         Ok(SubmitWorkDispatchCompletion::AwaitTurnCompletion {

--- a/meerkat-mob/src/runtime/actor.rs
+++ b/meerkat-mob/src/runtime/actor.rs
@@ -3379,6 +3379,12 @@ impl MobActor {
                     ops_registry,
                     reply_tx,
                 } => {
+                    tracing::debug!(
+                        member_id = %spec.identity,
+                        profile = %spec.role_name,
+                        owner_bound = owner_bridge_session_id.is_some(),
+                        "MobActor received Spawn command"
+                    );
                     Box::pin(self.enqueue_spawn(
                         *spec,
                         spawn_source,

--- a/meerkat-mob/src/runtime/actor.rs
+++ b/meerkat-mob/src/runtime/actor.rs
@@ -41,10 +41,6 @@ impl InitialTurnHandle {
 
 enum SubmitWorkDispatchCompletion {
     Completed,
-    AwaitInteractionAdmission {
-        interaction_id: meerkat_core::interaction::InteractionId,
-        events: mpsc::Receiver<meerkat_core::AgentEvent>,
-    },
     AwaitTurnAdmission {
         provisioner: Arc<dyn MobProvisioner>,
         member_ref: MemberRef,
@@ -3470,16 +3466,6 @@ impl MobActor {
                     match Box::pin(self.handle_submit_work(payload)).await {
                         Ok(SubmitWorkDispatchCompletion::Completed) => {
                             let _ = reply_tx.send(Ok(()));
-                        }
-                        Ok(SubmitWorkDispatchCompletion::AwaitInteractionAdmission {
-                            interaction_id,
-                            events,
-                        }) => {
-                            Self::spawn_interaction_admission_reply(
-                                interaction_id,
-                                events,
-                                reply_tx,
-                            );
                         }
                         Ok(SubmitWorkDispatchCompletion::AwaitTurnAdmission {
                             provisioner,
@@ -11060,68 +11046,6 @@ impl MobActor {
         });
     }
 
-    fn spawn_interaction_admission_reply(
-        interaction_id: meerkat_core::interaction::InteractionId,
-        events: mpsc::Receiver<meerkat_core::AgentEvent>,
-        reply_tx: oneshot::Sender<Result<(), MobError>>,
-    ) {
-        tokio::spawn(async move {
-            let result = Self::await_interaction_admission(interaction_id, events).await;
-            let _ = reply_tx.send(result);
-        });
-    }
-
-    fn spawn_interaction_admission_detached(
-        interaction_id: meerkat_core::interaction::InteractionId,
-        events: mpsc::Receiver<meerkat_core::AgentEvent>,
-    ) {
-        tokio::spawn(async move {
-            if let Err(error) = Self::await_interaction_admission(interaction_id, events).await {
-                tracing::warn!(
-                    %interaction_id,
-                    error = %error,
-                    "detached autonomous interaction admission failed"
-                );
-            }
-        });
-    }
-
-    async fn await_interaction_admission(
-        interaction_id: meerkat_core::interaction::InteractionId,
-        mut events: mpsc::Receiver<meerkat_core::AgentEvent>,
-    ) -> Result<(), MobError> {
-        while let Some(event) = events.recv().await {
-            match event {
-                meerkat_core::AgentEvent::InteractionComplete {
-                    interaction_id: observed,
-                    ..
-                } if observed == interaction_id => return Ok(()),
-                meerkat_core::AgentEvent::InteractionFailed {
-                    interaction_id: observed,
-                    error,
-                } if observed == interaction_id => {
-                    return Err(MobError::Internal(format!(
-                        "autonomous interaction admission failed for '{interaction_id}': {error}"
-                    )));
-                }
-                meerkat_core::AgentEvent::InteractionCallbackPending {
-                    interaction_id: observed,
-                    tool_name,
-                    args,
-                } if observed == interaction_id => {
-                    return Err(MobError::Internal(format!(
-                        "autonomous interaction admission reached callback boundary for '{interaction_id}' via tool '{tool_name}': {args}"
-                    )));
-                }
-                _ => {}
-            }
-        }
-
-        Err(MobError::Internal(format!(
-            "autonomous interaction admission stream closed before terminal outcome for '{interaction_id}'"
-        )))
-    }
-
     fn spawn_turn_admission_reply(
         provisioner: Arc<dyn MobProvisioner>,
         member_ref: MemberRef,
@@ -11322,13 +11246,6 @@ impl MobActor {
     ) -> Result<(), MobError> {
         match completion {
             SubmitWorkDispatchCompletion::Completed => Ok(()),
-            SubmitWorkDispatchCompletion::AwaitInteractionAdmission {
-                interaction_id,
-                events,
-            } => {
-                Self::spawn_interaction_admission_detached(interaction_id, events);
-                Ok(())
-            }
             SubmitWorkDispatchCompletion::AwaitTurnAdmission {
                 provisioner,
                 member_ref,
@@ -11386,6 +11303,29 @@ impl MobActor {
                 self.ensure_autonomous_runtime_ready(&entry.agent_identity, &entry.member_ref)
                     .await?;
 
+                if self
+                    .autonomous_steer_requires_admission_barrier(entry, handling_mode, ack_mode)
+                    .await?
+                {
+                    let req = meerkat_core::service::StartTurnRequest {
+                        prompt: content,
+                        system_prompt: None,
+                        event_tx: None,
+                        runtime: meerkat_core::service::StartTurnRuntimeSemantics::new(
+                            render_metadata,
+                            handling_mode,
+                            None,
+                            None,
+                            Vec::new(),
+                            None,
+                        ),
+                    };
+                    return Ok(SubmitWorkDispatchCompletion::AwaitTurnAdmission {
+                        provisioner: self.provisioner.clone(),
+                        member_ref: entry.member_ref.clone(),
+                        req: Box::new(req),
+                    });
+                }
                 let injector = self
                     .provisioner
                     .interaction_event_injector(bridge_session_id)
@@ -11395,28 +11335,6 @@ impl MobActor {
                         capability: crate::error::MobMemberCapability::InteractionEventInjector,
                         context: "autonomous direct turn delivery",
                     })?;
-                if self
-                    .autonomous_steer_requires_admission_barrier(entry, handling_mode, ack_mode)
-                    .await?
-                {
-                    let subscription = injector
-                        .inject_with_subscription(
-                            content,
-                            meerkat_core::PlainEventSource::Rpc,
-                            handling_mode,
-                            render_metadata,
-                        )
-                        .map_err(|error| {
-                            MobError::Internal(format!(
-                                "autonomous steer dispatch inject failed for '{}': {}",
-                                entry.agent_identity, error
-                            ))
-                        })?;
-                    return Ok(SubmitWorkDispatchCompletion::AwaitInteractionAdmission {
-                        interaction_id: subscription.id,
-                        events: subscription.events,
-                    });
-                }
                 injector
                     .inject(
                         content,

--- a/meerkat-mob/src/runtime/actor.rs
+++ b/meerkat-mob/src/runtime/actor.rs
@@ -11058,22 +11058,6 @@ impl MobActor {
         });
     }
 
-    fn spawn_turn_admission_detached(
-        provisioner: Arc<dyn MobProvisioner>,
-        member_ref: MemberRef,
-        req: Box<meerkat_core::service::StartTurnRequest>,
-    ) {
-        tokio::spawn(async move {
-            if let Err(error) = provisioner.admit_turn(&member_ref, *req).await {
-                tracing::warn!(
-                    member_ref = ?member_ref,
-                    error = %error,
-                    "detached turn admission failed"
-                );
-            }
-        });
-    }
-
     async fn dispatch_turn_driven_spawn_initial_turn(
         &mut self,
         agent_identity: &MeerkatId,
@@ -11250,10 +11234,7 @@ impl MobActor {
                 provisioner,
                 member_ref,
                 req,
-            } => {
-                Self::spawn_turn_admission_detached(provisioner, member_ref, req);
-                Ok(())
-            }
+            } => provisioner.admit_turn(&member_ref, *req).await,
             SubmitWorkDispatchCompletion::AwaitTurnCompletion {
                 provisioner,
                 member_ref,
@@ -11404,22 +11385,20 @@ impl MobActor {
 
             match adapter.runtime_state(session_id).await {
                 Ok(meerkat_runtime::RuntimeState::Running) => return Ok(true),
-                Ok(_) => {}
+                Ok(_) => return Ok(false),
                 Err(error) => {
                     tracing::debug!(
                         agent_identity = %entry.agent_identity,
                         session_id = %session_id,
                         error = %error,
-                        "runtime state unavailable while checking autonomous steer admission barrier; falling back to session activity"
+                        "runtime state unavailable while checking autonomous steer admission barrier"
                     );
+                    return Ok(false);
                 }
             }
         }
 
-        Ok(matches!(
-            self.provisioner.is_member_active(&entry.member_ref).await?,
-            Some(true)
-        ))
+        Ok(false)
     }
 
     async fn handle_run_flow(

--- a/meerkat-mob/src/runtime/actor.rs
+++ b/meerkat-mob/src/runtime/actor.rs
@@ -41,6 +41,10 @@ impl InitialTurnHandle {
 
 enum SubmitWorkDispatchCompletion {
     Completed,
+    AwaitInteractionAdmission {
+        interaction_id: meerkat_core::interaction::InteractionId,
+        events: mpsc::Receiver<meerkat_core::AgentEvent>,
+    },
     AwaitTurnAdmission {
         provisioner: Arc<dyn MobProvisioner>,
         member_ref: MemberRef,
@@ -3466,6 +3470,16 @@ impl MobActor {
                     match Box::pin(self.handle_submit_work(payload)).await {
                         Ok(SubmitWorkDispatchCompletion::Completed) => {
                             let _ = reply_tx.send(Ok(()));
+                        }
+                        Ok(SubmitWorkDispatchCompletion::AwaitInteractionAdmission {
+                            interaction_id,
+                            events,
+                        }) => {
+                            Self::spawn_interaction_admission_reply(
+                                interaction_id,
+                                events,
+                                reply_tx,
+                            );
                         }
                         Ok(SubmitWorkDispatchCompletion::AwaitTurnAdmission {
                             provisioner,
@@ -11046,6 +11060,68 @@ impl MobActor {
         });
     }
 
+    fn spawn_interaction_admission_reply(
+        interaction_id: meerkat_core::interaction::InteractionId,
+        events: mpsc::Receiver<meerkat_core::AgentEvent>,
+        reply_tx: oneshot::Sender<Result<(), MobError>>,
+    ) {
+        tokio::spawn(async move {
+            let result = Self::await_interaction_admission(interaction_id, events).await;
+            let _ = reply_tx.send(result);
+        });
+    }
+
+    fn spawn_interaction_admission_detached(
+        interaction_id: meerkat_core::interaction::InteractionId,
+        events: mpsc::Receiver<meerkat_core::AgentEvent>,
+    ) {
+        tokio::spawn(async move {
+            if let Err(error) = Self::await_interaction_admission(interaction_id, events).await {
+                tracing::warn!(
+                    %interaction_id,
+                    error = %error,
+                    "detached autonomous interaction admission failed"
+                );
+            }
+        });
+    }
+
+    async fn await_interaction_admission(
+        interaction_id: meerkat_core::interaction::InteractionId,
+        mut events: mpsc::Receiver<meerkat_core::AgentEvent>,
+    ) -> Result<(), MobError> {
+        while let Some(event) = events.recv().await {
+            match event {
+                meerkat_core::AgentEvent::InteractionComplete {
+                    interaction_id: observed,
+                    ..
+                } if observed == interaction_id => return Ok(()),
+                meerkat_core::AgentEvent::InteractionFailed {
+                    interaction_id: observed,
+                    error,
+                } if observed == interaction_id => {
+                    return Err(MobError::Internal(format!(
+                        "autonomous interaction admission failed for '{interaction_id}': {error}"
+                    )));
+                }
+                meerkat_core::AgentEvent::InteractionCallbackPending {
+                    interaction_id: observed,
+                    tool_name,
+                    args,
+                } if observed == interaction_id => {
+                    return Err(MobError::Internal(format!(
+                        "autonomous interaction admission reached callback boundary for '{interaction_id}' via tool '{tool_name}': {args}"
+                    )));
+                }
+                _ => {}
+            }
+        }
+
+        Err(MobError::Internal(format!(
+            "autonomous interaction admission stream closed before terminal outcome for '{interaction_id}'"
+        )))
+    }
+
     fn spawn_turn_admission_reply(
         provisioner: Arc<dyn MobProvisioner>,
         member_ref: MemberRef,
@@ -11246,6 +11322,13 @@ impl MobActor {
     ) -> Result<(), MobError> {
         match completion {
             SubmitWorkDispatchCompletion::Completed => Ok(()),
+            SubmitWorkDispatchCompletion::AwaitInteractionAdmission {
+                interaction_id,
+                events,
+            } => {
+                Self::spawn_interaction_admission_detached(interaction_id, events);
+                Ok(())
+            }
             SubmitWorkDispatchCompletion::AwaitTurnAdmission {
                 provisioner,
                 member_ref,
@@ -11312,6 +11395,28 @@ impl MobActor {
                         capability: crate::error::MobMemberCapability::InteractionEventInjector,
                         context: "autonomous direct turn delivery",
                     })?;
+                if self
+                    .autonomous_steer_requires_admission_barrier(entry, handling_mode, ack_mode)
+                    .await?
+                {
+                    let subscription = injector
+                        .inject_with_subscription(
+                            content,
+                            meerkat_core::PlainEventSource::Rpc,
+                            handling_mode,
+                            render_metadata,
+                        )
+                        .map_err(|error| {
+                            MobError::Internal(format!(
+                                "autonomous steer dispatch inject failed for '{}': {}",
+                                entry.agent_identity, error
+                            ))
+                        })?;
+                    return Ok(SubmitWorkDispatchCompletion::AwaitInteractionAdmission {
+                        interaction_id: subscription.id,
+                        events: subscription.events,
+                    });
+                }
                 injector
                     .inject(
                         content,
@@ -11359,6 +11464,44 @@ impl MobActor {
                 }
             }
         }
+    }
+
+    async fn autonomous_steer_requires_admission_barrier(
+        &self,
+        entry: &RosterEntry,
+        handling_mode: meerkat_core::types::HandlingMode,
+        ack_mode: crate::mob_machine::SubmitWorkAckMode,
+    ) -> Result<bool, MobError> {
+        if handling_mode != meerkat_core::types::HandlingMode::Steer
+            || ack_mode != crate::mob_machine::SubmitWorkAckMode::IngressAccepted
+        {
+            return Ok(false);
+        }
+
+        #[cfg(feature = "runtime-adapter")]
+        if let (Some(adapter), Some(session_id)) =
+            (&self.runtime_adapter, entry.member_ref.bridge_session_id())
+        {
+            use meerkat_runtime::service_ext::SessionServiceRuntimeExt as _;
+
+            match adapter.runtime_state(session_id).await {
+                Ok(meerkat_runtime::RuntimeState::Running) => return Ok(true),
+                Ok(_) => {}
+                Err(error) => {
+                    tracing::debug!(
+                        agent_identity = %entry.agent_identity,
+                        session_id = %session_id,
+                        error = %error,
+                        "runtime state unavailable while checking autonomous steer admission barrier; falling back to session activity"
+                    );
+                }
+            }
+        }
+
+        Ok(matches!(
+            self.provisioner.is_member_active(&entry.member_ref).await?,
+            Some(true)
+        ))
     }
 
     async fn handle_run_flow(

--- a/meerkat-mob/src/runtime/actor.rs
+++ b/meerkat-mob/src/runtime/actor.rs
@@ -11384,14 +11384,28 @@ impl MobActor {
             use meerkat_runtime::service_ext::SessionServiceRuntimeExt as _;
 
             match adapter.runtime_state(session_id).await {
-                Ok(meerkat_runtime::RuntimeState::Running) => return Ok(true),
-                Ok(_) => {
-                    if self
+                Ok(meerkat_runtime::RuntimeState::Running) => {
+                    tracing::debug!(
+                        agent_identity = %entry.agent_identity,
+                        session_id = %session_id,
+                        "active steer admission barrier enabled by running runtime state"
+                    );
+                    return Ok(true);
+                }
+                Ok(state) => {
+                    let session_active = self
                         .provisioner
                         .is_member_active(&entry.member_ref)
                         .await?
-                        .unwrap_or(false)
-                    {
+                        .unwrap_or(false);
+                    tracing::debug!(
+                        agent_identity = %entry.agent_identity,
+                        session_id = %session_id,
+                        runtime_state = ?state,
+                        session_active,
+                        "active steer admission barrier checked non-running runtime state"
+                    );
+                    if session_active {
                         return Ok(true);
                     }
                     return Ok(false);

--- a/meerkat-mob/src/runtime/actor.rs
+++ b/meerkat-mob/src/runtime/actor.rs
@@ -11252,9 +11252,13 @@ impl MobActor {
         ack_mode: crate::mob_machine::SubmitWorkAckMode,
     ) -> Result<SubmitWorkDispatchCompletion, MobError> {
         if let Some(bridge_session_id) = entry.member_ref.bridge_session_id() {
-            match self.session_service.read(bridge_session_id).await {
-                Ok(_) => {}
-                Err(meerkat_core::service::SessionError::NotFound { .. }) => {
+            match self
+                .session_service
+                .has_live_session(bridge_session_id)
+                .await
+            {
+                Ok(true) => {}
+                Ok(false) | Err(meerkat_core::service::SessionError::NotFound { .. }) => {
                     let reason = self
                         .record_missing_member_bridge_session(
                             &entry.agent_identity,

--- a/meerkat-mob/src/runtime/actor.rs
+++ b/meerkat-mob/src/runtime/actor.rs
@@ -53,6 +53,16 @@ enum SubmitWorkDispatchCompletion {
     },
 }
 
+impl SubmitWorkDispatchCompletion {
+    fn kind(&self) -> &'static str {
+        match self {
+            Self::Completed => "Completed",
+            Self::AwaitTurnAdmission { .. } => "AwaitTurnAdmission",
+            Self::AwaitTurnCompletion { .. } => "AwaitTurnCompletion",
+        }
+    }
+}
+
 // Sized for real mob-scale startup/shutdown fan-out (50+ members).
 #[cfg(not(target_arch = "wasm32"))]
 const MAX_PARALLEL_REMOTE_MEMBER_TEARDOWNS: usize = 64;
@@ -3371,6 +3381,7 @@ impl MobActor {
             } else {
                 break;
             };
+            tracing::debug!(command_kind = cmd.kind(), "MobActor received command");
             match cmd {
                 MobCommand::Spawn {
                     spec,
@@ -3463,6 +3474,15 @@ impl MobActor {
                     let _ = reply_tx.send(result);
                 }
                 MobCommand::SubmitWork { payload, reply_tx } => {
+                    tracing::debug!(
+                        agent_identity = %payload.runtime_id.identity,
+                        runtime_id = %payload.runtime_id,
+                        work_ref = %payload.work_ref,
+                        origin = ?payload.origin,
+                        handling_mode = ?payload.handling_mode,
+                        ack_mode = ?payload.ack_mode,
+                        "MobActor handling SubmitWork command"
+                    );
                     match Box::pin(self.handle_submit_work(payload)).await {
                         Ok(SubmitWorkDispatchCompletion::Completed) => {
                             let _ = reply_tx.send(Ok(()));
@@ -10891,6 +10911,15 @@ impl MobActor {
             render_metadata,
             ack_mode,
         } = *payload;
+        tracing::debug!(
+            agent_identity = %runtime_id.identity,
+            runtime_id = %runtime_id,
+            work_ref = %work_ref,
+            origin = ?origin,
+            handling_mode = ?handling_mode,
+            ack_mode = ?ack_mode,
+            "handle_submit_work started"
+        );
         self.ensure_pending_spawn_alignment("handle_submit_work preflight")?;
 
         let agent_identity = MeerkatId::from(&runtime_id.identity);
@@ -11024,14 +11053,25 @@ impl MobActor {
             ));
         }
 
-        self.dispatch_member_turn_after_machine_admission(
-            &entry,
-            content,
-            handling_mode,
-            render_metadata,
-            ack_mode,
-        )
-        .await
+        let completion = self
+            .dispatch_member_turn_after_machine_admission(
+                &entry,
+                content,
+                handling_mode,
+                render_metadata,
+                ack_mode,
+            )
+            .await?;
+        tracing::debug!(
+            agent_identity = %entry.agent_identity,
+            runtime_id = %entry.agent_runtime_id,
+            work_ref = %work_ref,
+            handling_mode = ?handling_mode,
+            ack_mode = ?ack_mode,
+            completion = completion.kind(),
+            "handle_submit_work dispatched after machine admission"
+        );
+        Ok(completion)
     }
 
     fn spawn_turn_completed_reply(
@@ -11251,6 +11291,14 @@ impl MobActor {
         render_metadata: Option<meerkat_core::types::RenderMetadata>,
         ack_mode: crate::mob_machine::SubmitWorkAckMode,
     ) -> Result<SubmitWorkDispatchCompletion, MobError> {
+        tracing::debug!(
+            agent_identity = %entry.agent_identity,
+            runtime_id = %entry.agent_runtime_id,
+            runtime_mode = ?entry.runtime_mode,
+            handling_mode = ?handling_mode,
+            ack_mode = ?ack_mode,
+            "dispatch_member_turn_after_machine_admission started"
+        );
         if let Some(bridge_session_id) = entry.member_ref.bridge_session_id() {
             match self
                 .session_service

--- a/meerkat-mob/src/runtime/actor.rs
+++ b/meerkat-mob/src/runtime/actor.rs
@@ -11299,7 +11299,11 @@ impl MobActor {
             ack_mode = ?ack_mode,
             "dispatch_member_turn_after_machine_admission started"
         );
-        if let Some(bridge_session_id) = entry.member_ref.bridge_session_id() {
+        let live_steer_admission = handling_mode == meerkat_core::types::HandlingMode::Steer
+            && ack_mode == crate::mob_machine::SubmitWorkAckMode::IngressAccepted;
+        if !live_steer_admission
+            && let Some(bridge_session_id) = entry.member_ref.bridge_session_id()
+        {
             match self
                 .session_service
                 .has_live_session(bridge_session_id)

--- a/meerkat-mob/src/runtime/composition.rs
+++ b/meerkat-mob/src/runtime/composition.rs
@@ -378,10 +378,25 @@ impl SignalConsumerSurface for MobSignalConsumerSurface {
         projected_fields: Vec<(FieldId, OwnedFieldValue)>,
     ) -> Result<(), String> {
         let signal = build_mob_signal(&variant, &projected_fields)?;
-        self.command_tx
-            .send(super::state::MobCommand::ProjectMachineSignal { signal })
-            .await
-            .map_err(|error| format!("mob actor signal queue closed: {error}"))
+        let command = super::state::MobCommand::ProjectMachineSignal { signal };
+        match self.command_tx.try_send(command) {
+            Ok(()) => Ok(()),
+            Err(mpsc::error::TrySendError::Full(command)) => {
+                let command_tx = self.command_tx.clone();
+                tokio::spawn(async move {
+                    if let Err(error) = command_tx.send(command).await {
+                        tracing::warn!(
+                            error = %error,
+                            "mob actor signal queue closed before deferred lifecycle signal delivery"
+                        );
+                    }
+                });
+                Ok(())
+            }
+            Err(mpsc::error::TrySendError::Closed(_command)) => {
+                Err("mob actor signal queue closed".to_string())
+            }
+        }
     }
 }
 
@@ -662,7 +677,7 @@ mod tests {
 
     #[cfg(feature = "runtime-adapter")]
     #[tokio::test]
-    async fn mob_signal_consumer_backpressures_when_actor_queue_is_full() {
+    async fn mob_signal_consumer_defers_when_actor_queue_is_full() {
         use super::super::state::MobCommand;
         use std::time::Duration;
 
@@ -678,26 +693,22 @@ mod tests {
             .expect("test precondition: bounded actor queue is full");
 
         let consumer = MobSignalConsumerSurface::new(command_tx);
-        let mut receive = tokio::spawn(async move {
-            consumer
-                .receive_signal(
-                    seam_facts::signals::observe_runtime_ready(),
-                    vec![
-                        (
-                            seam_facts::fields::agent_runtime_id(),
-                            OwnedFieldValue::Str("rt-backpressured".to_string()),
-                        ),
-                        (seam_facts::fields::fence_token(), OwnedFieldValue::U64(7)),
-                    ],
-                )
-                .await
-        });
-
-        let premature = tokio::time::timeout(Duration::from_millis(50), &mut receive).await;
-        assert!(
-            premature.is_err(),
-            "full actor queue must backpressure routed lifecycle signals instead of failing fast"
-        );
+        tokio::time::timeout(
+            Duration::from_millis(50),
+            consumer.receive_signal(
+                seam_facts::signals::observe_runtime_ready(),
+                vec![
+                    (
+                        seam_facts::fields::agent_runtime_id(),
+                        OwnedFieldValue::Str("rt-deferred".to_string()),
+                    ),
+                    (seam_facts::fields::fence_token(), OwnedFieldValue::U64(7)),
+                ],
+            ),
+        )
+        .await
+        .expect("full actor queue must not block routed lifecycle signal dispatch")
+        .expect("deferred signal delivery should be accepted");
 
         match command_rx.recv().await.expect("first queued command") {
             MobCommand::ProjectMachineSignal { signal } => assert!(matches!(
@@ -710,22 +721,17 @@ mod tests {
             _ => panic!("unexpected command in test queue"),
         }
 
-        receive
+        match tokio::time::timeout(Duration::from_secs(1), command_rx.recv())
             .await
-            .expect("signal receive task should not panic")
-            .expect("backpressured signal enqueue should complete once capacity opens");
-
-        match command_rx
-            .recv()
-            .await
-            .expect("backpressured signal command")
+            .expect("deferred signal should enqueue once capacity opens")
+            .expect("deferred signal command")
         {
             MobCommand::ProjectMachineSignal { signal } => assert!(matches!(
                 signal,
                 mob_dsl::MobMachineSignal::ObserveRuntimeReady {
                     agent_runtime_id,
                     fence_token: mob_dsl::FenceToken(7),
-                } if agent_runtime_id.0 == "rt-backpressured"
+                } if agent_runtime_id.0 == "rt-deferred"
             )),
             _ => panic!("unexpected command in test queue"),
         }

--- a/meerkat-mob/src/runtime/handle.rs
+++ b/meerkat-mob/src/runtime/handle.rs
@@ -1404,10 +1404,12 @@ impl MobHandle {
         build: impl FnOnce(oneshot::Sender<R>) -> MobCommand,
     ) -> Result<R, MobError> {
         let (reply_tx, reply_rx) = oneshot::channel();
+        tracing::debug!("MobHandle::send_actor_command sending command");
         self.command_tx
             .send(build(reply_tx))
             .await
             .map_err(|_| MobError::Internal("actor task dropped".into()))?;
+        tracing::debug!("MobHandle::send_actor_command command sent; awaiting reply");
         reply_rx
             .await
             .map_err(|_| MobError::Internal("actor reply dropped".into()))

--- a/meerkat-mob/src/runtime/handle.rs
+++ b/meerkat-mob/src/runtime/handle.rs
@@ -1836,6 +1836,15 @@ impl MobHandle {
         }
     }
 
+    /// Last actor-published mob lifecycle phase.
+    ///
+    /// Observation-only surfaces use this when they must remain live while the
+    /// mob actor is awaiting an in-flight member turn. Control paths that need
+    /// the authoritative current phase must keep using [`Self::status`].
+    pub fn status_observation_snapshot(&self) -> MobState {
+        *self.phase_watch_rx.borrow()
+    }
+
     /// Access the mob definition.
     pub fn definition(&self) -> &MobDefinition {
         &self.definition
@@ -1986,6 +1995,24 @@ impl MobHandle {
             }
             Err(_) => Vec::new(),
         }
+    }
+
+    /// Observation-only member projection that never enters the mob actor queue.
+    ///
+    /// Source truth is the shared roster projection plus the actor-published
+    /// MobMachine state watch. The actor is the sole writer for the machine
+    /// watch; this handle only reads the last published value, so the status
+    /// fields can be stale until the actor publishes the next transition.
+    ///
+    /// Use boundary: console/event observation and backfill discovery only.
+    /// This includes retiring rows so observers can keep showing in-flight
+    /// teardown. Control paths that decide routability, mutation legality, or
+    /// active-membership policy must keep using the identity-native command
+    /// APIs; this projection must not become a parallel authority.
+    pub async fn list_members_observation_snapshot(&self) -> Vec<MobMemberListEntry> {
+        let entries = self.roster.read().await.list_all().cloned().collect();
+        let machine_state = self.machine_state_watch_rx.borrow().clone();
+        self.project_member_list_entries_from_machine_state(entries, &machine_state)
     }
 
     async fn inflight_retiring_member_list(&self) -> Option<Vec<MobMemberListEntry>> {
@@ -2156,6 +2183,23 @@ impl MobHandle {
             .and_then(|entry| entry.member_ref.bridge_session_id().cloned())
     }
 
+    /// Observation-only bridge-session lookup that never enters the actor queue.
+    ///
+    /// This reads the roster's current member binding as a projection for
+    /// observers that need to attach to session event/history streams. It is
+    /// not a control admission seam and must not be used to decide membership
+    /// legality.
+    pub async fn resolve_bridge_session_id_observation(
+        &self,
+        identity: &AgentIdentity,
+    ) -> Option<SessionId> {
+        self.roster
+            .read()
+            .await
+            .get_by_identity(identity)
+            .and_then(|entry| entry.member_ref.bridge_session_id().cloned())
+    }
+
     /// Acquire a capability-bearing handle for a specific active member.
     pub async fn member(&self, identity: &AgentIdentity) -> Result<MemberHandle, MobError> {
         let meerkat_id = MeerkatId::from(identity);
@@ -2227,6 +2271,43 @@ impl MobHandle {
                 "unexpected command result variant".into(),
             )),
         }
+    }
+
+    /// Observation-only event subscription that reads the session binding from
+    /// the roster directly instead of sending a command through the mob actor.
+    ///
+    /// The subscription authority remains the session service for the resolved
+    /// bridge session. This helper only projects the identity-to-session
+    /// binding for observation surfaces that cannot queue behind the mob actor.
+    pub async fn subscribe_agent_events_observation(
+        &self,
+        identity: &AgentIdentity,
+    ) -> Result<EventStream, MobError> {
+        let session_id = {
+            let roster = self.roster.read().await;
+            let entry = roster
+                .get_by_identity(identity)
+                .ok_or_else(|| MobError::MemberNotFound(MeerkatId::from(identity)))?;
+            entry
+                .member_ref
+                .bridge_session_id()
+                .cloned()
+                .ok_or_else(|| MobError::UnsupportedForMode {
+                    mode: entry.runtime_mode,
+                    reason: "agent event subscriptions are not supported for peer-only members"
+                        .to_string(),
+                })?
+        };
+        crate::runtime::session_service::MobSessionService::subscribe_session_events(
+            self.session_service.as_ref(),
+            &session_id,
+        )
+        .await
+        .map_err(|error| {
+            MobError::Internal(format!(
+                "failed to subscribe to agent events for '{identity}': {error}"
+            ))
+        })
     }
 
     /// Subscribe to agent events for all active members (point-in-time snapshot).
@@ -3104,12 +3185,30 @@ impl MobHandle {
         work_ref: WorkRef,
         spec: WorkSpec,
     ) -> Result<WorkDeliveryReceipt, MobError> {
+        self.submit_work_with_mode(runtime_id, fence_token, work_ref, spec, HandlingMode::Queue)
+            .await
+    }
+
+    /// Submit a unit of work to a mob member with an explicit turn handling mode.
+    ///
+    /// This is the ingress-acknowledged work-lane counterpart to member send.
+    /// The caller supplies the already-authorized runtime binding and fence
+    /// token; the mob machine still owns work-origin legality and stale-fence
+    /// rejection.
+    pub async fn submit_work_with_mode(
+        &self,
+        runtime_id: AgentRuntimeId,
+        fence_token: FenceToken,
+        work_ref: WorkRef,
+        spec: WorkSpec,
+        handling_mode: HandlingMode,
+    ) -> Result<WorkDeliveryReceipt, MobError> {
         let cmd = Box::new(crate::mob_machine::SubmitWorkCommand {
             runtime_id: runtime_id.clone(),
             fence_token,
             work_ref: work_ref.clone(),
             spec,
-            handling_mode: HandlingMode::Queue,
+            handling_mode,
             render_metadata: None,
             ack_mode: crate::mob_machine::SubmitWorkAckMode::IngressAccepted,
         });

--- a/meerkat-mob/src/runtime/handle.rs
+++ b/meerkat-mob/src/runtime/handle.rs
@@ -3123,13 +3123,19 @@ impl MobHandle {
         message: meerkat_core::types::ContentInput,
         handling_mode: HandlingMode,
         render_metadata: Option<RenderMetadata>,
-    ) -> Result<(), MobError> {
-        let snapshot = self
-            .member_status(&AgentIdentity::from(agent_identity.as_str()))
-            .await?;
+    ) -> Result<MemberDeliveryReceipt, MobError> {
+        let identity = AgentIdentity::from(agent_identity.as_str());
+        let entry = self
+            .get_member(&identity)
+            .await
+            .ok_or_else(|| MobError::MemberNotFound(agent_identity.clone()))?;
+        if entry.state != crate::roster::MemberState::Active {
+            return Err(MobError::MemberNotFound(agent_identity));
+        }
+
         let cmd = Box::new(crate::mob_machine::SubmitWorkCommand {
-            runtime_id: snapshot.agent_runtime_id,
-            fence_token: snapshot.fence_token,
+            runtime_id: entry.agent_runtime_id.clone(),
+            fence_token: entry.fence_token,
             work_ref: WorkRef::new(),
             spec: WorkSpec::new(message, WorkOrigin::External),
             handling_mode,
@@ -3138,7 +3144,12 @@ impl MobHandle {
         });
         self.execute_machine_command(MobMachineCommand::SubmitWork(cmd))
             .await?;
-        Ok(())
+        Ok(MemberDeliveryReceipt {
+            identity,
+            agent_runtime_id: entry.agent_runtime_id,
+            fence_token: entry.fence_token,
+            handling_mode,
+        })
     }
 
     pub(super) async fn internal_turn_for_member(
@@ -4197,7 +4208,8 @@ impl MemberHandle {
         handling_mode: HandlingMode,
         render_metadata: Option<RenderMetadata>,
     ) -> Result<MemberDeliveryReceipt, MobError> {
-        self.mob
+        let receipt = self
+            .mob
             .external_turn_for_member(
                 self.agent_identity.clone(),
                 content.into(),
@@ -4205,16 +4217,7 @@ impl MemberHandle {
                 render_metadata,
             )
             .await?;
-        let snapshot = self
-            .mob
-            .member_status(&AgentIdentity::from(self.agent_identity.as_str()))
-            .await?;
-        Ok(MemberDeliveryReceipt {
-            identity: self.identity(),
-            agent_runtime_id: snapshot.agent_runtime_id,
-            fence_token: snapshot.fence_token,
-            handling_mode,
-        })
+        Ok(receipt)
     }
 
     /// Send typed peer communication from this member to another mob member.

--- a/meerkat-mob/src/runtime/handle.rs
+++ b/meerkat-mob/src/runtime/handle.rs
@@ -1404,12 +1404,20 @@ impl MobHandle {
         build: impl FnOnce(oneshot::Sender<R>) -> MobCommand,
     ) -> Result<R, MobError> {
         let (reply_tx, reply_rx) = oneshot::channel();
-        tracing::debug!("MobHandle::send_actor_command sending command");
+        let command = build(reply_tx);
+        let command_kind = command.kind();
+        tracing::debug!(
+            command_kind,
+            "MobHandle::send_actor_command sending command"
+        );
         self.command_tx
-            .send(build(reply_tx))
+            .send(command)
             .await
             .map_err(|_| MobError::Internal("actor task dropped".into()))?;
-        tracing::debug!("MobHandle::send_actor_command command sent; awaiting reply");
+        tracing::debug!(
+            command_kind,
+            "MobHandle::send_actor_command command sent; awaiting reply"
+        );
         reply_rx
             .await
             .map_err(|_| MobError::Internal("actor reply dropped".into()))

--- a/meerkat-mob/src/runtime/handle.rs
+++ b/meerkat-mob/src/runtime/handle.rs
@@ -1449,6 +1449,12 @@ impl MobHandle {
                 spawn_source,
                 owner_context,
             } => {
+                tracing::debug!(
+                    member_id = %spec.identity,
+                    profile = %spec.role_name,
+                    owner_bound = owner_context.is_some(),
+                    "MobHandle::execute_machine_command spawn dispatch"
+                );
                 let (owner_bridge_session_id, ops_registry) = match owner_context {
                     Some(ctx) => (Some(ctx.owner_bridge_session_id), Some(ctx.ops_registry)),
                     None => (None, None),

--- a/meerkat-mob/src/runtime/handle.rs
+++ b/meerkat-mob/src/runtime/handle.rs
@@ -2558,6 +2558,38 @@ impl MobHandle {
         })
     }
 
+    /// Spawn a member from an agent-owned tool call.
+    ///
+    /// This preserves the owning bridge session so MobMachine-owned spawn
+    /// policies such as `auto_wire_parent` can resolve the actual spawning
+    /// member rather than falling back to ownerless consumer semantics.
+    pub async fn spawn_spec_with_owner_context(
+        &self,
+        spec: SpawnMemberSpec,
+        owner_bridge_session_id: SessionId,
+        ops_registry: Arc<dyn OpsLifecycleRegistry>,
+    ) -> Result<SpawnResult, MobError> {
+        let identity = spec.identity.clone();
+        self.spawn_spec_receipt_with_owner_context(
+            spec,
+            CanonicalOpsOwnerContext {
+                owner_bridge_session_id,
+                ops_registry,
+            },
+        )
+        .await?;
+        let entry = self.get_member(&identity).await.ok_or_else(|| {
+            MobError::Internal(format!(
+                "spawn succeeded but roster entry missing for '{identity}'"
+            ))
+        })?;
+        Ok(SpawnResult {
+            agent_identity: entry.agent_identity,
+            agent_runtime_id: entry.agent_runtime_id,
+            fence_token: entry.fence_token,
+        })
+    }
+
     /// Internal spawn that returns the raw `MemberRef` for crate-internal callers.
     pub(crate) async fn spawn_spec_internal(
         &self,

--- a/meerkat-mob/src/runtime/provisioner.rs
+++ b/meerkat-mob/src/runtime/provisioner.rs
@@ -1186,6 +1186,21 @@ impl CoreExecutorBoundaryHandle for MobSessionRuntimeBoundaryHandle {
             .await
             .map_err(|err| CoreExecutorError::apply_failed_runtime_context(err.to_string()))
     }
+
+    async fn discard_staged_system_context_at_boundary(
+        &self,
+        expected_run_id: &CoreRunId,
+        idempotency_keys: Vec<String>,
+    ) -> Result<(), CoreExecutorError> {
+        self.session_service
+            .discard_runtime_system_context_for_active_turn(
+                &self.bridge_session_id,
+                expected_run_id,
+                idempotency_keys,
+            )
+            .await
+            .map_err(|err| CoreExecutorError::control_failed_runtime(err.to_string()))
+    }
 }
 
 #[cfg(feature = "runtime-adapter")]

--- a/meerkat-mob/src/runtime/provisioner.rs
+++ b/meerkat-mob/src/runtime/provisioner.rs
@@ -1164,6 +1164,16 @@ impl CoreExecutorBoundaryHandle for MobSessionRuntimeBoundaryHandle {
     }
 
     async fn active_turn_boundary_available(&self) -> Result<bool, CoreExecutorError> {
+        if let Some(snapshot) = self
+            .runtime_adapter
+            .meerkat_machine_spine_snapshot(&self.bridge_session_id)
+            .await
+            && snapshot.control.phase == meerkat_runtime::RuntimeState::Running
+            && snapshot.control.current_run_id.is_some()
+        {
+            return Ok(true);
+        }
+
         self.session_service
             .read(&self.bridge_session_id)
             .await

--- a/meerkat-mob/src/runtime/provisioner.rs
+++ b/meerkat-mob/src/runtime/provisioner.rs
@@ -1164,6 +1164,15 @@ impl CoreExecutorBoundaryHandle for MobSessionRuntimeBoundaryHandle {
     }
 
     async fn active_turn_boundary_available(&self) -> Result<bool, CoreExecutorError> {
+        if let Some(available) = self
+            .session_service
+            .active_turn_system_context_boundary_available(&self.bridge_session_id)
+            .await
+            .map_err(|err| CoreExecutorError::control_failed_runtime(err.to_string()))?
+        {
+            return Ok(available);
+        }
+
         if let Some(snapshot) = self
             .runtime_adapter
             .meerkat_machine_spine_snapshot(&self.bridge_session_id)

--- a/meerkat-mob/src/runtime/provisioner.rs
+++ b/meerkat-mob/src/runtime/provisioner.rs
@@ -1163,6 +1163,14 @@ impl CoreExecutorBoundaryHandle for MobSessionRuntimeBoundaryHandle {
             .map_err(|err| CoreExecutorError::control_failed_runtime(err.to_string()))
     }
 
+    async fn active_turn_boundary_available(&self) -> Result<bool, CoreExecutorError> {
+        self.session_service
+            .read(&self.bridge_session_id)
+            .await
+            .map(|view| view.state.is_active)
+            .map_err(|err| CoreExecutorError::control_failed_runtime(err.to_string()))
+    }
+
     async fn stage_system_context_at_boundary(
         &self,
         appends: Vec<PendingSystemContextAppend>,

--- a/meerkat-mob/src/runtime/provisioner.rs
+++ b/meerkat-mob/src/runtime/provisioner.rs
@@ -1164,38 +1164,25 @@ impl CoreExecutorBoundaryHandle for MobSessionRuntimeBoundaryHandle {
     }
 
     async fn active_turn_boundary_available(&self) -> Result<bool, CoreExecutorError> {
-        if let Some(available) = self
+        Ok(self
             .session_service
             .active_turn_system_context_boundary_available(&self.bridge_session_id)
             .await
             .map_err(|err| CoreExecutorError::control_failed_runtime(err.to_string()))?
-        {
-            return Ok(available);
-        }
-
-        if let Some(snapshot) = self
-            .runtime_adapter
-            .meerkat_machine_spine_snapshot(&self.bridge_session_id)
-            .await
-            && snapshot.control.phase == meerkat_runtime::RuntimeState::Running
-            && snapshot.control.current_run_id.is_some()
-        {
-            return Ok(true);
-        }
-
-        self.session_service
-            .read(&self.bridge_session_id)
-            .await
-            .map(|view| view.state.is_active)
-            .map_err(|err| CoreExecutorError::control_failed_runtime(err.to_string()))
+            .unwrap_or(false))
     }
 
     async fn stage_system_context_at_boundary(
         &self,
+        expected_run_id: &CoreRunId,
         appends: Vec<PendingSystemContextAppend>,
     ) -> Result<Option<Vec<u8>>, CoreExecutorError> {
         self.session_service
-            .stage_runtime_system_context_for_active_turn(&self.bridge_session_id, appends)
+            .stage_runtime_system_context_for_active_turn(
+                &self.bridge_session_id,
+                expected_run_id,
+                appends,
+            )
             .await
             .map_err(|err| CoreExecutorError::apply_failed_runtime_context(err.to_string()))
     }

--- a/meerkat-mob/src/runtime/provisioner.rs
+++ b/meerkat-mob/src/runtime/provisioner.rs
@@ -1168,10 +1168,9 @@ impl CoreExecutorBoundaryHandle for MobSessionRuntimeBoundaryHandle {
         appends: Vec<PendingSystemContextAppend>,
     ) -> Result<Option<Vec<u8>>, CoreExecutorError> {
         self.session_service
-            .apply_runtime_system_context_for_turn(&self.bridge_session_id, appends)
+            .stage_runtime_system_context_for_active_turn(&self.bridge_session_id, appends)
             .await
-            .map_err(|err| CoreExecutorError::apply_failed_runtime_context(err.to_string()))?;
-        Ok(None)
+            .map_err(|err| CoreExecutorError::apply_failed_runtime_context(err.to_string()))
     }
 }
 

--- a/meerkat-mob/src/runtime/session_service.rs
+++ b/meerkat-mob/src/runtime/session_service.rs
@@ -326,11 +326,13 @@ pub trait MobSessionService:
     async fn stage_runtime_system_context_for_active_turn(
         &self,
         session_id: &SessionId,
+        expected_run_id: &RunId,
         appends: Vec<PendingSystemContextAppend>,
     ) -> Result<Option<Vec<u8>>, SessionError> {
-        self.apply_runtime_system_context_for_turn(session_id, appends)
-            .await?;
-        Ok(None)
+        let _ = (session_id, expected_run_id, appends);
+        Err(SessionError::Agent(
+            meerkat_core::error::AgentError::NoPendingBoundary,
+        ))
     }
 
     async fn active_turn_system_context_boundary_available(
@@ -542,10 +544,14 @@ where
     async fn stage_runtime_system_context_for_active_turn(
         &self,
         session_id: &SessionId,
+        expected_run_id: &RunId,
         appends: Vec<PendingSystemContextAppend>,
     ) -> Result<Option<Vec<u8>>, SessionError> {
         meerkat_session::EphemeralSessionService::<B>::stage_runtime_system_context_for_active_turn(
-            self, session_id, appends,
+            self,
+            session_id,
+            expected_run_id,
+            appends,
         )
         .await?;
         Ok(None)
@@ -770,10 +776,14 @@ where
     async fn stage_runtime_system_context_for_active_turn(
         &self,
         session_id: &SessionId,
+        expected_run_id: &RunId,
         appends: Vec<PendingSystemContextAppend>,
     ) -> Result<Option<Vec<u8>>, SessionError> {
         meerkat_session::PersistentSessionService::<B>::stage_live_system_context_boundary_snapshot(
-            self, session_id, appends,
+            self,
+            session_id,
+            expected_run_id,
+            appends,
         )
         .await
     }

--- a/meerkat-mob/src/runtime/session_service.rs
+++ b/meerkat-mob/src/runtime/session_service.rs
@@ -319,6 +319,20 @@ pub trait MobSessionService:
         ))
     }
 
+    /// Stage runtime-owned context for an already-active turn's next LLM
+    /// boundary. Unlike `apply_runtime_system_context_for_turn`, this must not
+    /// route through the session task mailbox: the session task may be the
+    /// active turn currently waiting for that boundary.
+    async fn stage_runtime_system_context_for_active_turn(
+        &self,
+        session_id: &SessionId,
+        appends: Vec<PendingSystemContextAppend>,
+    ) -> Result<Option<Vec<u8>>, SessionError> {
+        self.apply_runtime_system_context_for_turn(session_id, appends)
+            .await?;
+        Ok(None)
+    }
+
     async fn checkpoint_committed_runtime_session_snapshot(
         &self,
         _session_id: &SessionId,
@@ -516,6 +530,18 @@ where
             self, session_id, appends,
         )
         .await
+    }
+
+    async fn stage_runtime_system_context_for_active_turn(
+        &self,
+        session_id: &SessionId,
+        appends: Vec<PendingSystemContextAppend>,
+    ) -> Result<Option<Vec<u8>>, SessionError> {
+        meerkat_session::EphemeralSessionService::<B>::stage_runtime_system_context_for_active_turn(
+            self, session_id, appends,
+        )
+        .await?;
+        Ok(None)
     }
 }
 
@@ -719,6 +745,17 @@ where
         appends: Vec<PendingSystemContextAppend>,
     ) -> Result<(), SessionError> {
         meerkat_session::PersistentSessionService::<B>::apply_runtime_system_context_for_turn(
+            self, session_id, appends,
+        )
+        .await
+    }
+
+    async fn stage_runtime_system_context_for_active_turn(
+        &self,
+        session_id: &SessionId,
+        appends: Vec<PendingSystemContextAppend>,
+    ) -> Result<Option<Vec<u8>>, SessionError> {
+        meerkat_session::PersistentSessionService::<B>::stage_live_system_context_boundary_snapshot(
             self, session_id, appends,
         )
         .await

--- a/meerkat-mob/src/runtime/session_service.rs
+++ b/meerkat-mob/src/runtime/session_service.rs
@@ -333,6 +333,13 @@ pub trait MobSessionService:
         Ok(None)
     }
 
+    async fn active_turn_system_context_boundary_available(
+        &self,
+        _session_id: &SessionId,
+    ) -> Result<Option<bool>, SessionError> {
+        Ok(None)
+    }
+
     async fn checkpoint_committed_runtime_session_snapshot(
         &self,
         _session_id: &SessionId,
@@ -542,6 +549,16 @@ where
         )
         .await?;
         Ok(None)
+    }
+
+    async fn active_turn_system_context_boundary_available(
+        &self,
+        session_id: &SessionId,
+    ) -> Result<Option<bool>, SessionError> {
+        meerkat_session::EphemeralSessionService::<B>::active_turn_system_context_boundary_available(
+            self, session_id,
+        )
+        .await
     }
 }
 
@@ -757,6 +774,16 @@ where
     ) -> Result<Option<Vec<u8>>, SessionError> {
         meerkat_session::PersistentSessionService::<B>::stage_live_system_context_boundary_snapshot(
             self, session_id, appends,
+        )
+        .await
+    }
+
+    async fn active_turn_system_context_boundary_available(
+        &self,
+        session_id: &SessionId,
+    ) -> Result<Option<bool>, SessionError> {
+        meerkat_session::PersistentSessionService::<B>::active_turn_system_context_boundary_available(
+            self, session_id,
         )
         .await
     }

--- a/meerkat-mob/src/runtime/session_service.rs
+++ b/meerkat-mob/src/runtime/session_service.rs
@@ -335,6 +335,18 @@ pub trait MobSessionService:
         ))
     }
 
+    async fn discard_runtime_system_context_for_active_turn(
+        &self,
+        session_id: &SessionId,
+        expected_run_id: &RunId,
+        idempotency_keys: Vec<String>,
+    ) -> Result<(), SessionError> {
+        let _ = (session_id, expected_run_id, idempotency_keys);
+        Err(SessionError::Agent(
+            meerkat_core::error::AgentError::NoPendingBoundary,
+        ))
+    }
+
     async fn active_turn_system_context_boundary_available(
         &self,
         _session_id: &SessionId,
@@ -555,6 +567,22 @@ where
         )
         .await?;
         Ok(None)
+    }
+
+    async fn discard_runtime_system_context_for_active_turn(
+        &self,
+        session_id: &SessionId,
+        expected_run_id: &RunId,
+        idempotency_keys: Vec<String>,
+    ) -> Result<(), SessionError> {
+        meerkat_session::EphemeralSessionService::<B>::discard_runtime_system_context_for_active_turn(
+            self,
+            session_id,
+            expected_run_id,
+            idempotency_keys,
+        )
+        .await?;
+        Ok(())
     }
 
     async fn active_turn_system_context_boundary_available(
@@ -786,6 +814,22 @@ where
             appends,
         )
         .await
+    }
+
+    async fn discard_runtime_system_context_for_active_turn(
+        &self,
+        session_id: &SessionId,
+        expected_run_id: &RunId,
+        idempotency_keys: Vec<String>,
+    ) -> Result<(), SessionError> {
+        meerkat_session::PersistentSessionService::<B>::discard_live_system_context_boundary_staging(
+            self,
+            session_id,
+            expected_run_id,
+            idempotency_keys,
+        )
+        .await?;
+        Ok(())
     }
 
     async fn active_turn_system_context_boundary_available(

--- a/meerkat-mob/src/runtime/state.rs
+++ b/meerkat-mob/src/runtime/state.rs
@@ -408,3 +408,64 @@ pub(super) enum MobCommand {
         reply_tx: oneshot::Sender<MobState>,
     },
 }
+
+impl MobCommand {
+    pub(super) fn kind(&self) -> &'static str {
+        match self {
+            Self::Spawn { .. } => "Spawn",
+            Self::SpawnProvisioned { .. } => "SpawnProvisioned",
+            Self::Retire { .. } => "Retire",
+            Self::Respawn { .. } => "Respawn",
+            Self::RetireAll { .. } => "RetireAll",
+            Self::SubmitWork { .. } => "SubmitWork",
+            Self::SendPeerMessage { .. } => "SendPeerMessage",
+            Self::CancelAllWork { .. } => "CancelAllWork",
+            #[cfg(feature = "runtime-adapter")]
+            Self::KickoffOutcomeResolved { .. } => "KickoffOutcomeResolved",
+            Self::RunFlow { .. } => "RunFlow",
+            Self::CancelFlow { .. } => "CancelFlow",
+            Self::FlowStatus { .. } => "FlowStatus",
+            Self::CommitFlowRunCommand { .. } => "CommitFlowRunCommand",
+            Self::CommitFlowTerminalization { .. } => "CommitFlowTerminalization",
+            Self::CommitFlowFrameStorePlan { .. } => "CommitFlowFrameStorePlan",
+            Self::ProjectMachineInput { .. } => "ProjectMachineInput",
+            Self::PreviewMachineInput { .. } => "PreviewMachineInput",
+            Self::QueryMachineState { .. } => "QueryMachineState",
+            Self::ProjectMachineSignal { .. } => "ProjectMachineSignal",
+            Self::FlowFinished { .. } => "FlowFinished",
+            Self::FlowCanceledCleanup { .. } => "FlowCanceledCleanup",
+            #[cfg(test)]
+            Self::FlowTrackerCounts { .. } => "FlowTrackerCounts",
+            #[cfg(test)]
+            Self::OrchestratorSnapshot { .. } => "OrchestratorSnapshot",
+            #[cfg(test)]
+            Self::LifecycleSnapshot { .. } => "LifecycleSnapshot",
+            #[cfg(test)]
+            Self::LifecycleNotificationBurst { .. } => "LifecycleNotificationBurst",
+            #[cfg(test)]
+            Self::DslT2Snapshot { .. } => "DslT2Snapshot",
+            Self::StartupKickoffSnapshot { .. } => "StartupKickoffSnapshot",
+            Self::ProjectMemberList { .. } => "ProjectMemberList",
+            Self::ProjectMemberStatus { .. } => "ProjectMemberStatus",
+            Self::MemberMachineProjection { .. } => "MemberMachineProjection",
+            Self::Stop { .. } => "Stop",
+            Self::ResumeLifecycle { .. } => "ResumeLifecycle",
+            Self::Complete { .. } => "Complete",
+            Self::Destroy { .. } => "Destroy",
+            Self::Reset { .. } => "Reset",
+            Self::SubscribeAgentEvents { .. } => "SubscribeAgentEvents",
+            Self::SubscribeAllAgentEvents { .. } => "SubscribeAllAgentEvents",
+            Self::RotateSupervisor { .. } => "RotateSupervisor",
+            Self::PollEvents { .. } => "PollEvents",
+            Self::ReplayAllEvents { .. } => "ReplayAllEvents",
+            Self::RecordOperatorActionProvenance { .. } => "RecordOperatorActionProvenance",
+            Self::ForceCancel { .. } => "ForceCancel",
+            Self::Wire { .. } => "Wire",
+            Self::WireMembersBatch { .. } => "WireMembersBatch",
+            Self::Unwire { .. } => "Unwire",
+            Self::SetSpawnPolicy { .. } => "SetSpawnPolicy",
+            Self::Shutdown { .. } => "Shutdown",
+            Self::QueryPhase { .. } => "QueryPhase",
+        }
+    }
+}

--- a/meerkat-mob/src/runtime/tests.rs
+++ b/meerkat-mob/src/runtime/tests.rs
@@ -23993,6 +23993,12 @@ struct RuntimeBackedRealCommsSessionService {
     runtime_adapter: Arc<meerkat_runtime::MeerkatMachine>,
     keep_alive_turns_complete_immediately: std::sync::atomic::AtomicBool,
     append_system_context_delay_ms: AtomicU64,
+    block_runtime_turns: AtomicBool,
+    runtime_turn_started: tokio::sync::Notify,
+    release_runtime_turns: tokio::sync::Notify,
+    block_session_reads: AtomicBool,
+    session_read_entered: tokio::sync::Notify,
+    release_session_reads: tokio::sync::Notify,
     applied_runtime_prompts: RwLock<HashMap<SessionId, Vec<ContentInput>>>,
     applied_runtime_context_appends: RwLock<HashMap<SessionId, Vec<AppendSystemContextRequest>>>,
     applied_runtime_render_metadata:
@@ -24009,6 +24015,12 @@ impl RuntimeBackedRealCommsSessionService {
             runtime_adapter: Arc::new(meerkat_runtime::MeerkatMachine::ephemeral()),
             keep_alive_turns_complete_immediately: std::sync::atomic::AtomicBool::new(false),
             append_system_context_delay_ms: AtomicU64::new(0),
+            block_runtime_turns: AtomicBool::new(false),
+            runtime_turn_started: tokio::sync::Notify::new(),
+            release_runtime_turns: tokio::sync::Notify::new(),
+            block_session_reads: AtomicBool::new(false),
+            session_read_entered: tokio::sync::Notify::new(),
+            release_session_reads: tokio::sync::Notify::new(),
             applied_runtime_prompts: RwLock::new(HashMap::new()),
             applied_runtime_context_appends: RwLock::new(HashMap::new()),
             applied_runtime_render_metadata: RwLock::new(HashMap::new()),
@@ -24023,6 +24035,22 @@ impl RuntimeBackedRealCommsSessionService {
     fn set_append_system_context_delay_ms(&self, delay_ms: u64) {
         self.append_system_context_delay_ms
             .store(delay_ms, Ordering::Relaxed);
+    }
+
+    fn set_block_runtime_turns(&self, enabled: bool) {
+        self.block_runtime_turns.store(enabled, Ordering::Relaxed);
+    }
+
+    fn release_runtime_turns(&self) {
+        self.release_runtime_turns.notify_waiters();
+    }
+
+    fn set_block_session_reads(&self, enabled: bool) {
+        self.block_session_reads.store(enabled, Ordering::Relaxed);
+    }
+
+    fn release_session_reads(&self) {
+        self.release_session_reads.notify_waiters();
     }
 
     async fn real_comms(&self, session_id: &SessionId) -> Option<Arc<meerkat_comms::CommsRuntime>> {
@@ -24200,6 +24228,11 @@ impl SessionService for RuntimeBackedRealCommsSessionService {
         let sessions = self.sessions.read().await;
         if !sessions.contains_key(id) {
             return Err(SessionError::NotFound { id: id.clone() });
+        }
+        drop(sessions);
+        if self.block_session_reads.load(Ordering::Relaxed) {
+            self.session_read_entered.notify_waiters();
+            self.release_session_reads.notified().await;
         }
         Ok(SessionView {
             state: SessionInfo {
@@ -24406,6 +24439,11 @@ impl MobSessionService for RuntimeBackedRealCommsSessionService {
             .entry(session_id.clone())
             .or_default()
             .push(req.runtime.render_metadata.clone());
+
+        if self.block_runtime_turns.load(Ordering::Relaxed) {
+            self.runtime_turn_started.notify_waiters();
+            self.release_runtime_turns.notified().await;
+        }
 
         if let Some(notifier) = self
             .keep_alive_notifiers
@@ -25760,6 +25798,119 @@ async fn test_active_internal_submit_work_steer_live_injects_for_identity_bridge
         .await
         .expect("stop timeout after internal active steer assertion")
         .expect("stop after internal active steer assertion");
+}
+
+#[tokio::test]
+async fn test_turn_driven_submit_work_steer_admits_while_active_runtime_apply_blocks() {
+    let _serial = REAL_COMMS_TEST_LOCK.lock().expect("real-comms test lock");
+    let (handle, service) =
+        create_test_mob_with_runtime_backed_real_comms(sample_definition()).await;
+
+    let sid_worker = handle
+        .spawn_with_options(
+            ProfileName::from("lead"),
+            MeerkatId::from("w-turn-driven-active-steer"),
+            None,
+            Some(crate::MobRuntimeMode::TurnDriven),
+            None,
+        )
+        .await
+        .expect("spawn turn-driven worker")
+        .bridge_session_id()
+        .expect("session-backed")
+        .clone();
+
+    handle
+        .wait_for_ready(Some(Duration::from_secs(2)))
+        .await
+        .expect("startup should settle");
+
+    let prompt_baseline = service.applied_runtime_prompts(&sid_worker).await.len();
+    let context_baseline = service
+        .applied_runtime_context_appends(&sid_worker)
+        .await
+        .len();
+    let entry = handle
+        .get_member(&AgentIdentity::from("w-turn-driven-active-steer"))
+        .await
+        .expect("member entry");
+
+    service.set_block_runtime_turns(true);
+    let first_handle = handle.clone();
+    let first_runtime_id = entry.agent_runtime_id.clone();
+    let first_fence = entry.fence_token;
+    let first_turn = tokio::spawn(async move {
+        first_handle
+            .submit_work(
+                first_runtime_id,
+                first_fence,
+                WorkRef::new(),
+                WorkSpec::new(
+                    "first turn blocks inside runtime apply".to_string(),
+                    WorkOrigin::Internal,
+                ),
+            )
+            .await
+    });
+
+    tokio::time::timeout(
+        Duration::from_secs(2),
+        service.runtime_turn_started.notified(),
+    )
+    .await
+    .expect("first runtime apply should start and block");
+    tokio::time::timeout(Duration::from_secs(2), first_turn)
+        .await
+        .expect("first ingress admission should not wait for blocked apply")
+        .expect("first submit task should join")
+        .expect("first submit should be admitted");
+
+    service.set_block_session_reads(true);
+    let steer_handle = handle.clone();
+    let steer_runtime_id = entry.agent_runtime_id.clone();
+    let steer_fence = entry.fence_token;
+    let steer = tokio::spawn(async move {
+        steer_handle
+            .submit_work_with_mode(
+                steer_runtime_id,
+                steer_fence,
+                WorkRef::new(),
+                WorkSpec::new(
+                    "turn-driven active steer must stage while apply is blocked".to_string(),
+                    WorkOrigin::Internal,
+                ),
+                HandlingMode::Steer,
+            )
+            .await
+    });
+
+    tokio::time::timeout(Duration::from_millis(200), steer)
+        .await
+        .expect("active steer admission must not wait for blocked runtime apply or session reads")
+        .expect("steer submit task should join")
+        .expect("active steer should be admitted");
+
+    let appends = service.applied_runtime_context_appends(&sid_worker).await;
+    assert!(
+        appends.iter().skip(context_baseline).any(|append| append
+            .text
+            .contains("turn-driven active steer must stage while apply is blocked")),
+        "turn-driven active steer should stage for the live boundary before the active apply releases; appends={appends:?}"
+    );
+    assert_eq!(
+        service.applied_runtime_prompts(&sid_worker).await.len(),
+        prompt_baseline + 1,
+        "active steer must not schedule a second full turn while the first runtime apply is blocked"
+    );
+
+    service.set_block_session_reads(false);
+    service.release_session_reads();
+    service.set_block_runtime_turns(false);
+    service.release_runtime_turns();
+    tokio::time::timeout(Duration::from_secs(2), handle.stop())
+        .await
+        .expect("stop timeout after active steer runtime-apply assertion")
+        .expect("stop after active steer runtime-apply assertion");
 }
 
 #[tokio::test]

--- a/meerkat-mob/src/runtime/tests.rs
+++ b/meerkat-mob/src/runtime/tests.rs
@@ -25656,6 +25656,113 @@ async fn test_active_autonomous_direct_steer_ack_waits_for_live_admission_not_tu
 }
 
 #[tokio::test]
+async fn test_active_internal_submit_work_steer_live_injects_for_identity_bridge() {
+    let _serial = REAL_COMMS_TEST_LOCK.lock().expect("real-comms test lock");
+    let (handle, service) =
+        create_test_mob_with_runtime_backed_real_comms(sample_definition()).await;
+    service.set_keep_alive_turns_complete_immediately(true);
+
+    let sid_worker = handle
+        .spawn(
+            ProfileName::from("lead"),
+            MeerkatId::from("w-internal-steer"),
+            None,
+        )
+        .await
+        .expect("spawn worker")
+        .bridge_session_id()
+        .expect("session-backed")
+        .clone();
+
+    handle
+        .wait_for_ready(Some(Duration::from_secs(2)))
+        .await
+        .expect("startup should settle");
+    handle
+        .wait_for_members_kickoff_complete(
+            &[AgentIdentity::from("w-internal-steer")],
+            Some(Duration::from_secs(2)),
+        )
+        .await
+        .expect("kickoff should resolve before blocked direct turn");
+
+    let prompt_baseline = service.applied_runtime_prompts(&sid_worker).await.len();
+    let context_baseline = service
+        .applied_runtime_context_appends(&sid_worker)
+        .await
+        .len();
+
+    service.set_keep_alive_turns_complete_immediately(false);
+    let worker = handle
+        .member(&AgentIdentity::from("w-internal-steer"))
+        .await
+        .expect("worker handle");
+    worker
+        .send(
+            "first direct prompt holds active apply",
+            HandlingMode::Steer,
+        )
+        .await
+        .expect("first direct steer should be admitted");
+
+    tokio::time::timeout(Duration::from_secs(2), async {
+        loop {
+            let prompts = service.applied_runtime_prompts(&sid_worker).await;
+            if prompts
+                .iter()
+                .skip(prompt_baseline)
+                .any(|prompt| prompt.text_content().contains("first direct prompt"))
+            {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(25)).await;
+        }
+    })
+    .await
+    .expect("first direct steer should enter active apply");
+
+    let entry = handle
+        .get_member(&AgentIdentity::from("w-internal-steer"))
+        .await
+        .expect("member entry");
+    handle
+        .submit_work_with_mode(
+            entry.agent_runtime_id,
+            entry.fence_token,
+            WorkRef::new(),
+            WorkSpec::new(
+                "internal identity bridge steer must stage live".to_string(),
+                WorkOrigin::Internal,
+            ),
+            HandlingMode::Steer,
+        )
+        .await
+        .expect("internal active steer should be admitted");
+
+    let appends = service.applied_runtime_context_appends(&sid_worker).await;
+    assert!(
+        appends.iter().skip(context_baseline).any(|append| append
+            .text
+            .contains("internal identity bridge steer must stage live")),
+        "internal active steer should stage for the live boundary; appends={appends:?}"
+    );
+    assert_eq!(
+        service.applied_runtime_prompts(&sid_worker).await.len(),
+        prompt_baseline + 1,
+        "internal active steer must not schedule a second full turn before the blocked apply is released"
+    );
+
+    service
+        .interrupt(&sid_worker)
+        .await
+        .expect("interrupt should release blocked worker apply");
+    tokio::time::timeout(Duration::from_secs(2), handle.stop())
+        .await
+        .expect("stop timeout after internal active steer assertion")
+        .expect("stop after internal active steer assertion");
+}
+
+#[tokio::test]
 async fn test_peer_response_reaches_requester_in_runtime_backed_real_comms() {
     let _serial = REAL_COMMS_TEST_LOCK.lock().expect("real-comms test lock");
     let (handle, service) =

--- a/meerkat-mob/src/runtime/tests.rs
+++ b/meerkat-mob/src/runtime/tests.rs
@@ -26548,6 +26548,89 @@ async fn test_turn_completed_submission_does_not_block_actor_commands() {
     turn_task.abort();
 }
 
+#[tokio::test]
+async fn test_internal_queued_submit_work_drains_after_running_turn() {
+    let (handle, service) = create_test_mob(sample_definition()).await;
+    let member_id = MeerkatId::from("lead-internal-queue-drain");
+    handle
+        .spawn_with_options(
+            ProfileName::from("lead"),
+            member_id.clone(),
+            None,
+            Some(crate::MobRuntimeMode::TurnDriven),
+            None,
+        )
+        .await
+        .expect("spawn turn-driven lead");
+
+    let entry = handle
+        .get_member(&AgentIdentity::from(member_id.as_str()))
+        .await
+        .expect("member exists");
+    service.set_start_turn_delay_ms(500);
+
+    handle
+        .submit_work_with_mode(
+            entry.agent_runtime_id.clone(),
+            entry.fence_token,
+            WorkRef::new(),
+            WorkSpec::new(
+                "first internal queued turn".to_string(),
+                WorkOrigin::Internal,
+            ),
+            HandlingMode::Queue,
+        )
+        .await
+        .expect("first internal queued turn should be admitted");
+
+    wait_for_start_turn_call_count(
+        &service,
+        1,
+        "first internal queued turn should start running",
+    )
+    .await;
+
+    handle
+        .submit_work_with_mode(
+            entry.agent_runtime_id.clone(),
+            entry.fence_token,
+            WorkRef::new(),
+            WorkSpec::new(
+                "second internal queued turn".to_string(),
+                WorkOrigin::Internal,
+            ),
+            HandlingMode::Queue,
+        )
+        .await
+        .expect("second internal queued turn should be admitted while first is running");
+
+    wait_for_start_turn_call_count(
+        &service,
+        2,
+        "second internal queued turn should drain after the running turn completes",
+    )
+    .await;
+
+    let prompts: Vec<String> = service
+        .recorded_start_turn_prompts()
+        .await
+        .into_iter()
+        .map(|(_, prompt)| prompt)
+        .collect();
+    assert!(
+        prompts
+            .iter()
+            .any(|prompt| prompt == "first internal queued turn"),
+        "first prompt should be delivered to runtime: {prompts:?}"
+    );
+    assert!(
+        prompts
+            .iter()
+            .any(|prompt| prompt == "second internal queued turn"),
+        "second prompt should drain to runtime after first completes: {prompts:?}"
+    );
+}
+
 static REAL_COMMS_TEST_LOCK: Mutex<()> = Mutex::new(());
 
 #[tokio::test]

--- a/meerkat-mob/src/runtime/tests.rs
+++ b/meerkat-mob/src/runtime/tests.rs
@@ -26497,6 +26497,57 @@ async fn test_queued_steer_during_running_turn_does_not_block_actor_commands() {
     steer_task.abort();
 }
 
+#[tokio::test]
+async fn test_turn_completed_submission_does_not_block_actor_commands() {
+    let (handle, service) = create_test_mob(sample_definition()).await;
+    service.set_start_turn_delay_ms(600_000);
+
+    handle
+        .spawn_with_options(
+            ProfileName::from("lead"),
+            MeerkatId::from("lead-completed-busy"),
+            None,
+            Some(crate::MobRuntimeMode::TurnDriven),
+            None,
+        )
+        .await
+        .expect("spawn turn-driven lead");
+
+    let turn_handle = handle.clone();
+    let turn_task = tokio::spawn(async move {
+        turn_handle
+            .internal_turn_for_member(
+                MeerkatId::from("lead-completed-busy"),
+                ContentInput::Text("hold turn-completed submission open".into()),
+            )
+            .await
+    });
+
+    tokio::time::timeout(Duration::from_secs(2), async {
+        while service.start_turn_call_count() == 0 {
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .expect("runtime should start the long-running turn");
+
+    tokio::time::timeout(
+        Duration::from_millis(250),
+        handle.spawn_with_options(
+            ProfileName::from("worker"),
+            MeerkatId::from("worker-after-turn-completed"),
+            None,
+            Some(crate::MobRuntimeMode::TurnDriven),
+            None,
+        ),
+    )
+    .await
+    .expect("turn-completed submission must not park the mob actor")
+    .expect("unrelated actor command should still be processed");
+
+    turn_task.abort();
+}
+
 static REAL_COMMS_TEST_LOCK: Mutex<()> = Mutex::new(());
 
 #[tokio::test]

--- a/meerkat-mob/src/runtime/tests.rs
+++ b/meerkat-mob/src/runtime/tests.rs
@@ -11522,6 +11522,39 @@ async fn test_spawn_member_tool_dispatches_backend_selection() {
 }
 
 #[tokio::test]
+async fn test_spawn_member_profile_scope_allows_auto_wire_parent() {
+    let (handle, service) = create_test_mob(sample_definition_with_mob_tools()).await;
+    let sid = handle
+        .spawn(ProfileName::from("worker"), MeerkatId::from("w-1"), None)
+        .await
+        .expect("spawn w-1")
+        .bridge_session_id()
+        .expect("session-backed")
+        .clone();
+
+    service
+        .dispatch_external_tool_outcome(
+            &sid,
+            "spawn_member",
+            serde_json::json!({
+                "profile": "worker",
+                "member_id": "w-auto-wire",
+                "auto_wire_parent": true
+            }),
+        )
+        .await
+        .expect("profile-scoped spawn should allow auto_wire_parent");
+
+    assert!(
+        handle
+            .get_member(&AgentIdentity::from("w-auto-wire"))
+            .await
+            .is_some(),
+        "profile-scoped auto-wired spawn should provision the requested member"
+    );
+}
+
+#[tokio::test]
 async fn test_tool_flag_enforcement_blocks_mob_tools() {
     let (handle, service) = create_test_mob(sample_definition_without_mob_flags()).await;
     let sid = handle
@@ -26312,6 +26345,87 @@ async fn test_mob_session_service_subscribe_session_events_available() {
         stream_result.is_ok(),
         "expected session-wide event stream contract from mob session service"
     );
+}
+
+#[tokio::test]
+async fn test_observation_member_reads_bypass_saturated_actor_command_queue() {
+    let (handle, _service) = create_test_mob(sample_definition()).await;
+    let identity = AgentIdentity::from("w-observe");
+    handle
+        .spawn(
+            ProfileName::from("worker"),
+            MeerkatId::from(identity.as_str()),
+            None,
+        )
+        .await
+        .expect("spawn observable worker");
+    let session_id = handle
+        .resolve_bridge_session_id(&identity)
+        .await
+        .expect("session-backed worker");
+
+    let (blocked_tx, _blocked_rx) = tokio::sync::mpsc::channel(1);
+    let (reply_tx, _reply_rx) = tokio::sync::oneshot::channel();
+    blocked_tx
+        .try_send(super::state::MobCommand::Retire {
+            agent_identity: MeerkatId::from("queued-command"),
+            reply_tx,
+        })
+        .expect("test command channel should accept first command");
+    let blocked_handle = MobHandle {
+        command_tx: blocked_tx,
+        ..handle.clone()
+    };
+
+    let actor_routed = tokio::time::timeout(Duration::from_millis(50), handle.list_members()).await;
+    assert!(
+        actor_routed.is_ok(),
+        "control handle should remain healthy before swapping in blocked command queue"
+    );
+
+    let actor_routed =
+        tokio::time::timeout(Duration::from_millis(50), blocked_handle.list_members()).await;
+    assert!(
+        actor_routed.is_err(),
+        "actor-routed list_members should queue behind a saturated command channel"
+    );
+
+    assert_eq!(
+        blocked_handle.status_observation_snapshot(),
+        MobState::Running,
+        "observation phase snapshot must not wait for the actor queue"
+    );
+
+    let observed = tokio::time::timeout(
+        Duration::from_millis(50),
+        blocked_handle.list_members_observation_snapshot(),
+    )
+    .await
+    .expect("observation snapshot must not wait for the actor queue");
+    let observed_member = observed
+        .iter()
+        .find(|member| member.agent_identity == identity)
+        .expect("observation snapshot should include the active member");
+    assert_eq!(
+        observed_member.current_bridge_session_id.as_ref(),
+        Some(&session_id)
+    );
+
+    let observed_session = tokio::time::timeout(
+        Duration::from_millis(50),
+        blocked_handle.resolve_bridge_session_id_observation(&identity),
+    )
+    .await
+    .expect("observation session lookup must not wait for the actor queue");
+    assert_eq!(observed_session.as_ref(), Some(&session_id));
+
+    let _stream = tokio::time::timeout(
+        Duration::from_millis(50),
+        blocked_handle.subscribe_agent_events_observation(&identity),
+    )
+    .await
+    .expect("observation event subscription must not wait for the actor queue")
+    .expect("session-backed member should expose an event stream");
 }
 
 static REAL_COMMS_TEST_LOCK: Mutex<()> = Mutex::new(());

--- a/meerkat-mob/src/runtime/tests.rs
+++ b/meerkat-mob/src/runtime/tests.rs
@@ -24270,6 +24270,10 @@ impl SessionService for RuntimeBackedRealCommsSessionService {
     }
 
     async fn has_live_session(&self, id: &SessionId) -> Result<bool, SessionError> {
+        if self.block_session_reads.load(Ordering::Relaxed) {
+            self.session_read_entered.notify_waiters();
+            self.release_session_reads.notified().await;
+        }
         Ok(self.sessions.read().await.contains_key(id))
     }
 

--- a/meerkat-mob/src/runtime/tests.rs
+++ b/meerkat-mob/src/runtime/tests.rs
@@ -24003,6 +24003,7 @@ struct RuntimeBackedRealCommsSessionService {
     applied_runtime_context_appends: RwLock<HashMap<SessionId, Vec<AppendSystemContextRequest>>>,
     applied_runtime_render_metadata:
         RwLock<HashMap<SessionId, Vec<Option<meerkat_core::types::RenderMetadata>>>>,
+    active_runtime_runs: RwLock<HashMap<SessionId, meerkat_core::RunId>>,
 }
 
 impl RuntimeBackedRealCommsSessionService {
@@ -24024,6 +24025,7 @@ impl RuntimeBackedRealCommsSessionService {
             applied_runtime_prompts: RwLock::new(HashMap::new()),
             applied_runtime_context_appends: RwLock::new(HashMap::new()),
             applied_runtime_render_metadata: RwLock::new(HashMap::new()),
+            active_runtime_runs: RwLock::new(HashMap::new()),
         }
     }
 
@@ -24443,6 +24445,10 @@ impl MobSessionService for RuntimeBackedRealCommsSessionService {
             .entry(session_id.clone())
             .or_default()
             .push(req.runtime.render_metadata.clone());
+        self.active_runtime_runs
+            .write()
+            .await
+            .insert(session_id.clone(), run_id.clone());
 
         if self.block_runtime_turns.load(Ordering::Relaxed) {
             self.runtime_turn_started.notify_waiters();
@@ -24461,6 +24467,8 @@ impl MobSessionService for RuntimeBackedRealCommsSessionService {
         {
             notifier.notified().await;
         }
+
+        self.active_runtime_runs.write().await.remove(session_id);
 
         Ok(meerkat_core::lifecycle::core_executor::CoreApplyOutput {
             receipt: meerkat_core::lifecycle::run_receipt::RunBoundaryReceipt {
@@ -24547,6 +24555,41 @@ impl MobSessionService for RuntimeBackedRealCommsSessionService {
         Ok(())
     }
 
+    async fn stage_runtime_system_context_for_active_turn(
+        &self,
+        session_id: &SessionId,
+        expected_run_id: &meerkat_core::RunId,
+        appends: Vec<meerkat_core::PendingSystemContextAppend>,
+    ) -> Result<Option<Vec<u8>>, SessionError> {
+        let active_run = self
+            .active_runtime_runs
+            .read()
+            .await
+            .get(session_id)
+            .cloned();
+        if active_run.as_ref() != Some(expected_run_id) {
+            return Err(SessionError::Agent(
+                meerkat_core::error::AgentError::NoPendingBoundary,
+            ));
+        }
+
+        self.apply_runtime_system_context_for_turn(session_id, appends)
+            .await?;
+        Ok(None)
+    }
+
+    async fn active_turn_system_context_boundary_available(
+        &self,
+        session_id: &SessionId,
+    ) -> Result<Option<bool>, SessionError> {
+        Ok(Some(
+            self.active_runtime_runs
+                .read()
+                .await
+                .contains_key(session_id),
+        ))
+    }
+
     async fn discard_live_session(&self, session_id: &SessionId) -> Result<(), SessionError> {
         self.sessions.write().await.remove(session_id);
         self.keep_alive_notifiers.write().await.remove(session_id);
@@ -24563,6 +24606,7 @@ impl MobSessionService for RuntimeBackedRealCommsSessionService {
             .write()
             .await
             .remove(session_id);
+        self.active_runtime_runs.write().await.remove(session_id);
         Ok(())
     }
 }

--- a/meerkat-mob/src/runtime/tests.rs
+++ b/meerkat-mob/src/runtime/tests.rs
@@ -26428,6 +26428,75 @@ async fn test_observation_member_reads_bypass_saturated_actor_command_queue() {
     .expect("session-backed member should expose an event stream");
 }
 
+#[tokio::test]
+async fn test_queued_steer_during_running_turn_does_not_block_actor_commands() {
+    let (handle, service) = create_test_mob(sample_definition()).await;
+    service.set_start_turn_delay_ms(600_000);
+
+    handle
+        .spawn_with_options(
+            ProfileName::from("lead"),
+            MeerkatId::from("lead-busy"),
+            None,
+            Some(crate::MobRuntimeMode::TurnDriven),
+            None,
+        )
+        .await
+        .expect("spawn turn-driven lead");
+
+    handle
+        .member(&AgentIdentity::from("lead-busy"))
+        .await
+        .expect("lead member")
+        .send_with_render_metadata(
+            ContentInput::Text("hold the current turn open".into()),
+            HandlingMode::Queue,
+            None,
+        )
+        .await
+        .expect("first turn should be admitted");
+
+    tokio::time::timeout(Duration::from_secs(2), async {
+        while service.start_turn_call_count() == 0 {
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .expect("runtime should start the long-running turn");
+
+    let steer_member = handle
+        .member(&AgentIdentity::from("lead-busy"))
+        .await
+        .expect("lead member for steer");
+    let steer_task = tokio::spawn(async move {
+        steer_member
+            .send_with_render_metadata(
+                ContentInput::Text("queued steer while busy".into()),
+                HandlingMode::Steer,
+                None,
+            )
+            .await
+    });
+
+    tokio::time::sleep(Duration::from_millis(50)).await;
+
+    tokio::time::timeout(
+        Duration::from_millis(250),
+        handle.spawn_with_options(
+            ProfileName::from("worker"),
+            MeerkatId::from("worker-after-steer"),
+            None,
+            Some(crate::MobRuntimeMode::TurnDriven),
+            None,
+        ),
+    )
+    .await
+    .expect("queued steer admission must not park the mob actor")
+    .expect("unrelated actor command should still be processed");
+
+    steer_task.abort();
+}
+
 static REAL_COMMS_TEST_LOCK: Mutex<()> = Mutex::new(());
 
 #[tokio::test]

--- a/meerkat-mob/src/runtime/tests.rs
+++ b/meerkat-mob/src/runtime/tests.rs
@@ -28969,6 +28969,80 @@ async fn test_external_tools_name_collision_profile_wins() {
 }
 
 #[tokio::test]
+async fn test_spawn_member_with_initial_turn_returns_before_child_turn_completion() {
+    let mut definition = sample_definition_with_mob_tools();
+    definition
+        .profiles
+        .get_mut(&ProfileName::from("worker"))
+        .and_then(|binding| binding.as_inline_mut())
+        .expect("worker profile")
+        .runtime_mode = crate::MobRuntimeMode::TurnDriven;
+    let service = Arc::new(MockSessionService::new());
+    let _ = service.enable_runtime_adapter();
+    let storage = MobStorage::in_memory();
+    let handle = MobBuilder::new(definition, storage)
+        .with_session_service(service.clone())
+        .create()
+        .await
+        .expect("create mob");
+
+    let member_ref = handle
+        .spawn(
+            ProfileName::from("worker"),
+            MeerkatId::from("spawner"),
+            None,
+        )
+        .await
+        .expect("spawn should expose spawn_member");
+    let session_id = member_ref
+        .bridge_session_id()
+        .expect("session-backed spawner")
+        .clone();
+
+    service.set_start_turn_delay_ms(600_000);
+    let raw_args = serde_json::json!({
+        "profile": "worker",
+        "member_id": "child-with-slow-initial-turn",
+        "initial_message": "hold child turn open"
+    });
+
+    let outcome = tokio::time::timeout(
+        Duration::from_millis(250),
+        service.dispatch_external_tool_outcome(&session_id, "spawn_member", raw_args),
+    )
+    .await
+    .expect("spawn_member tool must return after child turn ingress admission")
+    .expect("spawn_member should dispatch");
+
+    let payload: serde_json::Value =
+        serde_json::from_str(&outcome.result.text_content()).expect("spawn result json");
+    assert_eq!(
+        payload["agent_identity"],
+        serde_json::json!("child-with-slow-initial-turn")
+    );
+
+    tokio::time::timeout(Duration::from_secs(2), async {
+        while service.start_turn_call_count() == 0 {
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .expect("detached child initial turn should start after spawn_member returns");
+
+    let child = tokio::time::timeout(
+        Duration::from_millis(250),
+        handle.get_member(&AgentIdentity::from("child-with-slow-initial-turn")),
+    )
+    .await
+    .expect("actor must stay responsive while child initial turn is still running")
+    .expect("child should be visible in roster");
+    assert_eq!(
+        child.agent_identity,
+        AgentIdentity::from("child-with-slow-initial-turn")
+    );
+}
+
+#[tokio::test]
 async fn test_default_helper_spawns_remain_ephemeral() {
     let definition = sample_definition();
     let service = Arc::new(MockSessionService::new());

--- a/meerkat-mob/src/runtime/tests.rs
+++ b/meerkat-mob/src/runtime/tests.rs
@@ -23992,6 +23992,7 @@ struct RuntimeBackedRealCommsSessionService {
     session_counter: AtomicU64,
     runtime_adapter: Arc<meerkat_runtime::MeerkatMachine>,
     keep_alive_turns_complete_immediately: std::sync::atomic::AtomicBool,
+    append_system_context_delay_ms: AtomicU64,
     applied_runtime_prompts: RwLock<HashMap<SessionId, Vec<ContentInput>>>,
     applied_runtime_context_appends: RwLock<HashMap<SessionId, Vec<AppendSystemContextRequest>>>,
     applied_runtime_render_metadata:
@@ -24007,6 +24008,7 @@ impl RuntimeBackedRealCommsSessionService {
             session_counter: AtomicU64::new(0),
             runtime_adapter: Arc::new(meerkat_runtime::MeerkatMachine::ephemeral()),
             keep_alive_turns_complete_immediately: std::sync::atomic::AtomicBool::new(false),
+            append_system_context_delay_ms: AtomicU64::new(0),
             applied_runtime_prompts: RwLock::new(HashMap::new()),
             applied_runtime_context_appends: RwLock::new(HashMap::new()),
             applied_runtime_render_metadata: RwLock::new(HashMap::new()),
@@ -24016,6 +24018,11 @@ impl RuntimeBackedRealCommsSessionService {
     fn set_keep_alive_turns_complete_immediately(&self, enabled: bool) {
         self.keep_alive_turns_complete_immediately
             .store(enabled, Ordering::Relaxed);
+    }
+
+    fn set_append_system_context_delay_ms(&self, delay_ms: u64) {
+        self.append_system_context_delay_ms
+            .store(delay_ms, Ordering::Relaxed);
     }
 
     async fn real_comms(&self, session_id: &SessionId) -> Option<Arc<meerkat_comms::CommsRuntime>> {
@@ -24286,6 +24293,10 @@ impl SessionServiceControlExt for RuntimeBackedRealCommsSessionService {
     ) -> Result<AppendSystemContextResult, SessionControlError> {
         if !self.sessions.read().await.contains_key(id) {
             return Err(SessionError::NotFound { id: id.clone() }.into());
+        }
+        let delay_ms = self.append_system_context_delay_ms.load(Ordering::Relaxed);
+        if delay_ms > 0 {
+            tokio::time::sleep(Duration::from_millis(delay_ms)).await;
         }
         let mut appends = self.applied_runtime_context_appends.write().await;
         let session_appends = appends.entry(id.clone()).or_default();
@@ -25523,6 +25534,125 @@ async fn test_running_peer_message_to_autonomous_member_live_injects_during_curr
         .await
         .expect("stop timeout after running peer message assertion")
         .expect("stop after running peer message assertion");
+}
+
+#[tokio::test]
+async fn test_active_autonomous_direct_steer_ack_waits_for_live_admission_not_turn_completion() {
+    let _serial = REAL_COMMS_TEST_LOCK.lock().expect("real-comms test lock");
+    let (handle, service) =
+        create_test_mob_with_runtime_backed_real_comms(sample_definition()).await;
+    service.set_keep_alive_turns_complete_immediately(true);
+
+    let sid_worker = handle
+        .spawn(
+            ProfileName::from("lead"),
+            MeerkatId::from("w-direct-steer"),
+            None,
+        )
+        .await
+        .expect("spawn worker")
+        .bridge_session_id()
+        .expect("session-backed")
+        .clone();
+
+    handle
+        .wait_for_ready(Some(Duration::from_secs(2)))
+        .await
+        .expect("startup should settle");
+    handle
+        .wait_for_members_kickoff_complete(
+            &[AgentIdentity::from("w-direct-steer")],
+            Some(Duration::from_secs(2)),
+        )
+        .await
+        .expect("kickoff should resolve before blocked direct turn");
+
+    let prompt_baseline = service.applied_runtime_prompts(&sid_worker).await.len();
+    let context_baseline = service
+        .applied_runtime_context_appends(&sid_worker)
+        .await
+        .len();
+
+    service.set_keep_alive_turns_complete_immediately(false);
+    let worker = handle
+        .member(&AgentIdentity::from("w-direct-steer"))
+        .await
+        .expect("worker handle");
+    worker
+        .send(
+            "first direct prompt holds active apply",
+            HandlingMode::Steer,
+        )
+        .await
+        .expect("first direct steer should be admitted");
+
+    tokio::time::timeout(Duration::from_secs(2), async {
+        loop {
+            let prompts = service.applied_runtime_prompts(&sid_worker).await;
+            if prompts
+                .iter()
+                .skip(prompt_baseline)
+                .any(|prompt| prompt.text_content().contains("first direct prompt"))
+            {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(25)).await;
+        }
+    })
+    .await
+    .expect("first direct steer should enter active apply");
+
+    service.set_append_system_context_delay_ms(250);
+    let steer_worker = handle
+        .member(&AgentIdentity::from("w-direct-steer"))
+        .await
+        .expect("worker handle for active steer");
+    let steer_task = tokio::spawn(async move {
+        steer_worker
+            .send(
+                "second direct steer must stage before ack",
+                HandlingMode::Steer,
+            )
+            .await
+    });
+
+    tokio::time::sleep(Duration::from_millis(50)).await;
+    assert!(
+        !steer_task.is_finished(),
+        "active direct steer must not ack before runtime live-boundary admission completes"
+    );
+
+    tokio::time::timeout(Duration::from_millis(100), handle.list_members())
+        .await
+        .expect("actor mailbox should not wait behind active steer admission");
+
+    tokio::time::timeout(Duration::from_secs(2), steer_task)
+        .await
+        .expect("active steer admission should not wait for full active turn completion")
+        .expect("active steer task should join")
+        .expect("active steer should be admitted");
+
+    let appends = service.applied_runtime_context_appends(&sid_worker).await;
+    assert!(
+        appends.iter().skip(context_baseline).any(|append| append
+            .text
+            .contains("second direct steer must stage before ack")),
+        "active direct steer ack should imply the steer was staged for the live boundary; appends={appends:?}"
+    );
+    assert_eq!(
+        service.applied_runtime_prompts(&sid_worker).await.len(),
+        prompt_baseline + 1,
+        "active steer admission must not wait for or schedule a second full turn before the blocked apply is released"
+    );
+
+    service
+        .interrupt(&sid_worker)
+        .await
+        .expect("interrupt should release blocked worker apply");
+    tokio::time::timeout(Duration::from_secs(2), handle.stop())
+        .await
+        .expect("stop timeout after direct active steer assertion")
+        .expect("stop after direct active steer assertion");
 }
 
 #[tokio::test]

--- a/meerkat-mob/src/runtime/tests.rs
+++ b/meerkat-mob/src/runtime/tests.rs
@@ -25914,6 +25914,104 @@ async fn test_turn_driven_submit_work_steer_admits_while_active_runtime_apply_bl
 }
 
 #[tokio::test]
+async fn test_member_send_steer_admits_while_active_runtime_apply_blocks() {
+    let _serial = REAL_COMMS_TEST_LOCK.lock().expect("real-comms test lock");
+    let (handle, service) =
+        create_test_mob_with_runtime_backed_real_comms(sample_definition()).await;
+
+    let sid_worker = handle
+        .spawn_with_options(
+            ProfileName::from("lead"),
+            MeerkatId::from("w-member-send-active-steer"),
+            None,
+            Some(crate::MobRuntimeMode::TurnDriven),
+            None,
+        )
+        .await
+        .expect("spawn turn-driven worker")
+        .bridge_session_id()
+        .expect("session-backed")
+        .clone();
+
+    handle
+        .wait_for_ready(Some(Duration::from_secs(2)))
+        .await
+        .expect("startup should settle");
+
+    let prompt_baseline = service.applied_runtime_prompts(&sid_worker).await.len();
+    let context_baseline = service
+        .applied_runtime_context_appends(&sid_worker)
+        .await
+        .len();
+    let worker = handle
+        .member(&AgentIdentity::from("w-member-send-active-steer"))
+        .await
+        .expect("worker handle");
+
+    service.set_block_runtime_turns(true);
+    let first_worker = worker.clone();
+    let first_turn = tokio::spawn(async move {
+        first_worker
+            .send(
+                "first member send blocks inside runtime apply",
+                HandlingMode::Queue,
+            )
+            .await
+    });
+
+    tokio::time::timeout(
+        Duration::from_secs(2),
+        service.runtime_turn_started.notified(),
+    )
+    .await
+    .expect("first runtime apply should start and block");
+    tokio::time::timeout(Duration::from_secs(2), first_turn)
+        .await
+        .expect("first member send admission should not wait for blocked apply")
+        .expect("first member send task should join")
+        .expect("first member send should be admitted");
+
+    service.set_block_session_reads(true);
+    let steer_worker = worker.clone();
+    let steer = tokio::spawn(async move {
+        steer_worker
+            .send(
+                "member send active steer must stage while apply is blocked",
+                HandlingMode::Steer,
+            )
+            .await
+    });
+
+    tokio::time::timeout(Duration::from_millis(200), steer)
+        .await
+        .expect("active member-send steer admission must not wait for blocked runtime apply or session reads")
+        .expect("active member-send steer task should join")
+        .expect("active member-send steer should be admitted");
+
+    let appends = service.applied_runtime_context_appends(&sid_worker).await;
+    assert!(
+        appends.iter().skip(context_baseline).any(|append| append
+            .text
+            .contains("member send active steer must stage while apply is blocked")),
+        "member-send active steer should stage for the live boundary before the active apply releases; appends={appends:?}"
+    );
+    assert_eq!(
+        service.applied_runtime_prompts(&sid_worker).await.len(),
+        prompt_baseline + 1,
+        "active member-send steer must not schedule a second full turn while the first runtime apply is blocked"
+    );
+
+    service.set_block_session_reads(false);
+    service.release_session_reads();
+    service.set_block_runtime_turns(false);
+    service.release_runtime_turns();
+    tokio::time::timeout(Duration::from_secs(2), handle.stop())
+        .await
+        .expect("stop timeout after active member-send steer assertion")
+        .expect("stop after active member-send steer assertion");
+}
+
+#[tokio::test]
 async fn test_peer_response_reaches_requester_in_runtime_backed_real_comms() {
     let _serial = REAL_COMMS_TEST_LOCK.lock().expect("real-comms test lock");
     let (handle, service) =
@@ -33496,7 +33594,7 @@ async fn mob_runtime_parity_execute_probe(
                 None,
             )
             .await
-            .map(|()| summarize_mob_runtime_success(probe, "bridge_session")),
+            .map(|_| summarize_mob_runtime_success(probe, "member_delivery")),
         MobRuntimeParityProbeInput::InternalTurn => fixture
             .handle
             .internal_turn(

--- a/meerkat-mob/src/runtime/tools.rs
+++ b/meerkat-mob/src/runtime/tools.rs
@@ -555,7 +555,6 @@ impl MobOperatorToolDispatcher {
             || args.launch_mode.is_some()
             || args.tool_access_policy.is_some()
             || args.budget_split_policy.is_some()
-            || args.auto_wire_parent.is_some()
         {
             return Err(ToolError::access_denied(tool_name));
         }

--- a/meerkat-mob/src/runtime/tools.rs
+++ b/meerkat-mob/src/runtime/tools.rs
@@ -817,6 +817,12 @@ impl AgentToolDispatcher for MobOperatorToolDispatcher {
                 let args: SpawnMemberArgs = call
                     .parse_args()
                     .map_err(|error| ToolError::invalid_arguments(call.name, error.to_string()))?;
+                tracing::debug!(
+                    member_id = %args.member_id,
+                    profile = %args.profile,
+                    owner_bound = self.owner_bridge_session_id.is_some(),
+                    "MobOperatorToolDispatcher::spawn_member dispatch start"
+                );
                 self.ensure_spawn_member_scope(call.name, &args)?;
                 let agent_identity = AgentIdentity::from(args.member_id.as_str());
                 let mut spec = SpawnMemberSpec::from_wire(

--- a/meerkat-runtime/src/meerkat_machine/dispatch_ingress.rs
+++ b/meerkat-runtime/src/meerkat_machine/dispatch_ingress.rs
@@ -83,9 +83,23 @@ impl MeerkatMachine {
 
                 let (resolved, outcome, handle, accepted_input_id, signal) = {
                     let mut driver = driver.lock().await;
+                    let input_kind = input.kind();
                     let runtime_idle =
                         state.is_idle_or_attached() && !active_turn_boundary_available;
                     let resolved = driver.resolve_admission_for_runtime_idle(&input, runtime_idle);
+                    tracing::debug!(
+                        session_id = %session_id,
+                        input_kind = ?input_kind,
+                        runtime_state = ?state,
+                        visible_state = ?visible_state,
+                        runtime_idle,
+                        active_turn_boundary_available,
+                        immediate = resolved.coarse_flags.request_immediate_processing,
+                        interrupt_yielding = resolved.coarse_flags.interrupt_yielding,
+                        wake_if_idle = resolved.coarse_flags.wake_if_idle,
+                        apply_mode = ?resolved.policy.apply_mode,
+                        "resolved runtime ingress admission"
+                    );
                     self.preview_session_dsl_input(
                         &session_id,
                         crate::meerkat_machine::dsl::MeerkatMachineInput::AcceptWithCompletion {
@@ -247,6 +261,8 @@ impl MeerkatMachine {
                     return Err(err);
                 }
 
+                let has_live_boundary_input = accepted_input_id_for_live_boundary.is_some();
+                let has_boundary_handle = boundary_handle.is_some();
                 if (state == RuntimeState::Running || active_turn_boundary_available)
                     && signal.should_interrupt_yielding()
                     && resolved.policy.apply_mode == crate::policy::ApplyMode::StageRunBoundary
@@ -317,7 +333,26 @@ impl MeerkatMachine {
                                 );
                             }
                         }
+                    } else {
+                        tracing::debug!(
+                            session_id = %session_id,
+                            input_id = %input_id,
+                            runtime_state = ?state,
+                            active_turn_boundary_available,
+                            "accepted steer input had no live boundary plan; leaving input queued for ordinary post-turn drain"
+                        );
                     }
+                } else if signal.should_interrupt_yielding()
+                    && resolved.policy.apply_mode == crate::policy::ApplyMode::StageRunBoundary
+                {
+                    tracing::debug!(
+                        session_id = %session_id,
+                        runtime_state = ?state,
+                        active_turn_boundary_available,
+                        has_boundary_handle,
+                        has_input_id = has_live_boundary_input,
+                        "accepted steer input did not meet live boundary staging preconditions"
+                    );
                 }
 
                 Ok(MeerkatMachineCommandResult::AcceptWithCompletion {

--- a/meerkat-runtime/src/meerkat_machine/dispatch_ingress.rs
+++ b/meerkat-runtime/src/meerkat_machine/dispatch_ingress.rs
@@ -57,6 +57,7 @@ impl MeerkatMachine {
                     .unwrap_or(RuntimeState::Destroyed);
                 Self::reject_visible_terminal_ingress(visible_state)?;
 
+                let input_kind = input.kind();
                 let (resolved, outcome, handle, accepted_input_id, signal) = {
                     let mut driver = driver.lock().await;
                     let runtime_idle = state.is_idle_or_attached();
@@ -225,6 +226,7 @@ impl MeerkatMachine {
                 if state == RuntimeState::Running
                     && signal.should_interrupt_yielding()
                     && resolved.policy.apply_mode == crate::policy::ApplyMode::StageRunBoundary
+                    && !matches!(input_kind, crate::identifiers::InputKind::Prompt)
                     && let (Some(input_id), Some(boundary_handle)) =
                         (accepted_input_id_for_live_boundary, boundary_handle)
                 {

--- a/meerkat-runtime/src/meerkat_machine/dispatch_ingress.rs
+++ b/meerkat-runtime/src/meerkat_machine/dispatch_ingress.rs
@@ -73,6 +73,13 @@ impl MeerkatMachine {
                     } else {
                         false
                     };
+                if active_turn_boundary_available {
+                    tracing::debug!(
+                        session_id = %session_id,
+                        runtime_state = ?state,
+                        "active turn boundary available during ingress admission"
+                    );
+                }
 
                 let (resolved, outcome, handle, accepted_input_id, signal) = {
                     let mut driver = driver.lock().await;
@@ -266,6 +273,13 @@ impl MeerkatMachine {
                     };
 
                     if let Some((run_id, appends, sequence)) = live_boundary_plan {
+                        tracing::debug!(
+                            session_id = %session_id,
+                            run_id = %run_id,
+                            input_id = %input_id,
+                            append_count = appends.len(),
+                            "staging live boundary context for accepted steer input"
+                        );
                         match boundary_handle
                             .stage_system_context_at_boundary(appends)
                             .await

--- a/meerkat-runtime/src/meerkat_machine/dispatch_ingress.rs
+++ b/meerkat-runtime/src/meerkat_machine/dispatch_ingress.rs
@@ -263,7 +263,7 @@ impl MeerkatMachine {
 
                 let has_live_boundary_input = accepted_input_id_for_live_boundary.is_some();
                 let has_boundary_handle = boundary_handle.is_some();
-                if (state == RuntimeState::Running || active_turn_boundary_available)
+                if active_turn_boundary_available
                     && signal.should_interrupt_yielding()
                     && resolved.policy.apply_mode == crate::policy::ApplyMode::StageRunBoundary
                     && let (Some(input_id), Some(boundary_handle)) =
@@ -297,7 +297,7 @@ impl MeerkatMachine {
                             "staging live boundary context for accepted steer input"
                         );
                         match boundary_handle
-                            .stage_system_context_at_boundary(appends)
+                            .stage_system_context_at_boundary(&run_id, appends)
                             .await
                         {
                             Ok(session_snapshot) => {

--- a/meerkat-runtime/src/meerkat_machine/dispatch_ingress.rs
+++ b/meerkat-runtime/src/meerkat_machine/dispatch_ingress.rs
@@ -289,6 +289,10 @@ impl MeerkatMachine {
                     };
 
                     if let Some((run_id, appends, sequence)) = live_boundary_plan {
+                        let rollback_keys = appends
+                            .iter()
+                            .filter_map(|append| append.idempotency_key.clone())
+                            .collect::<Vec<_>>();
                         tracing::debug!(
                             session_id = %session_id,
                             run_id = %run_id,
@@ -309,7 +313,7 @@ impl MeerkatMachine {
                                     message_count: 0,
                                     sequence,
                                 };
-                                {
+                                let commit_result = {
                                     let mut driver = driver.lock().await;
                                     driver
                                         .machine_realize_live_boundary_context_injected(
@@ -318,7 +322,41 @@ impl MeerkatMachine {
                                             &receipt,
                                             session_snapshot,
                                         )
-                                        .await?;
+                                        .await
+                                };
+                                if let Err(error) = commit_result {
+                                    let rollback_result = if rollback_keys.is_empty() {
+                                        Ok(())
+                                    } else {
+                                        boundary_handle
+                                            .discard_staged_system_context_at_boundary(
+                                                &run_id,
+                                                rollback_keys,
+                                            )
+                                            .await
+                                    };
+                                    match rollback_result {
+                                        Ok(()) => {
+                                            tracing::warn!(
+                                                session_id = %session_id,
+                                                run_id = %run_id,
+                                                input_id = %input_id,
+                                                error = %error,
+                                                "live boundary runtime commit failed; rolled back staged session context"
+                                            );
+                                        }
+                                        Err(rollback_error) => {
+                                            tracing::error!(
+                                                session_id = %session_id,
+                                                run_id = %run_id,
+                                                input_id = %input_id,
+                                                error = %error,
+                                                rollback_error = %rollback_error,
+                                                "live boundary runtime commit failed and staged session context rollback failed"
+                                            );
+                                        }
+                                    }
+                                    return Err(error);
                                 }
                                 let mut completions = completions.lock().await;
                                 completions.resolve_without_result(&input_id);

--- a/meerkat-runtime/src/meerkat_machine/dispatch_ingress.rs
+++ b/meerkat-runtime/src/meerkat_machine/dispatch_ingress.rs
@@ -57,7 +57,6 @@ impl MeerkatMachine {
                     .unwrap_or(RuntimeState::Destroyed);
                 Self::reject_visible_terminal_ingress(visible_state)?;
 
-                let input_kind = input.kind();
                 let (resolved, outcome, handle, accepted_input_id, signal) = {
                     let mut driver = driver.lock().await;
                     let runtime_idle = state.is_idle_or_attached();
@@ -226,7 +225,6 @@ impl MeerkatMachine {
                 if state == RuntimeState::Running
                     && signal.should_interrupt_yielding()
                     && resolved.policy.apply_mode == crate::policy::ApplyMode::StageRunBoundary
-                    && !matches!(input_kind, crate::identifiers::InputKind::Prompt)
                     && let (Some(input_id), Some(boundary_handle)) =
                         (accepted_input_id_for_live_boundary, boundary_handle)
                 {

--- a/meerkat-runtime/src/meerkat_machine/dispatch_ingress.rs
+++ b/meerkat-runtime/src/meerkat_machine/dispatch_ingress.rs
@@ -57,9 +57,27 @@ impl MeerkatMachine {
                     .unwrap_or(RuntimeState::Destroyed);
                 Self::reject_visible_terminal_ingress(visible_state)?;
 
+                let active_turn_boundary_available =
+                    if let Some(boundary_handle) = boundary_handle.as_ref() {
+                        boundary_handle
+                            .active_turn_boundary_available()
+                            .await
+                            .unwrap_or_else(|error| {
+                                tracing::debug!(
+                                    session_id = %session_id,
+                                    error = %error,
+                                    "active turn boundary availability check failed"
+                                );
+                                false
+                            })
+                    } else {
+                        false
+                    };
+
                 let (resolved, outcome, handle, accepted_input_id, signal) = {
                     let mut driver = driver.lock().await;
-                    let runtime_idle = state.is_idle_or_attached();
+                    let runtime_idle =
+                        state.is_idle_or_attached() && !active_turn_boundary_available;
                     let resolved = driver.resolve_admission_for_runtime_idle(&input, runtime_idle);
                     self.preview_session_dsl_input(
                         &session_id,
@@ -222,7 +240,7 @@ impl MeerkatMachine {
                     return Err(err);
                 }
 
-                if state == RuntimeState::Running
+                if (state == RuntimeState::Running || active_turn_boundary_available)
                     && signal.should_interrupt_yielding()
                     && resolved.policy.apply_mode == crate::policy::ApplyMode::StageRunBoundary
                     && let (Some(input_id), Some(boundary_handle)) =

--- a/meerkat-runtime/src/meerkat_machine_tests.rs
+++ b/meerkat-runtime/src/meerkat_machine_tests.rs
@@ -6005,6 +6005,7 @@ impl CoreExecutorBoundaryHandle for InterruptYieldingBoundaryHandle {
 
     async fn stage_system_context_at_boundary(
         &self,
+        _expected_run_id: &meerkat_core::RunId,
         appends: Vec<meerkat_core::PendingSystemContextAppend>,
     ) -> Result<Option<Vec<u8>>, CoreExecutorError> {
         self.probe
@@ -6234,6 +6235,7 @@ async fn explicit_running_steer_admission_injects_live_boundary_context_once() {
 
         async fn stage_system_context_at_boundary(
             &self,
+            _expected_run_id: &meerkat_core::RunId,
             appends: Vec<meerkat_core::PendingSystemContextAppend>,
         ) -> Result<Option<Vec<u8>>, CoreExecutorError> {
             self.stage_calls.fetch_add(1, Ordering::SeqCst);

--- a/meerkat-runtime/src/meerkat_machine_tests.rs
+++ b/meerkat-runtime/src/meerkat_machine_tests.rs
@@ -5964,7 +5964,9 @@ async fn service_peer_admission_wakes_without_live_cancel_after_boundary() {
 struct InterruptYieldingProbe {
     live_boundary_cancel_calls: Arc<AtomicUsize>,
     live_boundary_stage_calls: Arc<AtomicUsize>,
+    live_boundary_discard_calls: Arc<AtomicUsize>,
     live_boundary_staged_texts: Arc<std::sync::Mutex<Vec<String>>>,
+    live_boundary_discarded_keys: Arc<std::sync::Mutex<Vec<String>>>,
     fail_live_stage: Arc<AtomicBool>,
 }
 
@@ -5973,7 +5975,9 @@ impl InterruptYieldingProbe {
         Self {
             live_boundary_cancel_calls: Arc::new(AtomicUsize::new(0)),
             live_boundary_stage_calls: Arc::new(AtomicUsize::new(0)),
+            live_boundary_discard_calls: Arc::new(AtomicUsize::new(0)),
             live_boundary_staged_texts: Arc::new(std::sync::Mutex::new(Vec::new())),
+            live_boundary_discarded_keys: Arc::new(std::sync::Mutex::new(Vec::new())),
             fail_live_stage: Arc::new(AtomicBool::new(fail_live_stage)),
         }
     }
@@ -5982,6 +5986,13 @@ impl InterruptYieldingProbe {
         self.live_boundary_staged_texts
             .lock()
             .expect("staged text mutex poisoned")
+            .clone()
+    }
+
+    fn discarded_keys(&self) -> Vec<String> {
+        self.live_boundary_discarded_keys
+            .lock()
+            .expect("discarded keys mutex poisoned")
             .clone()
     }
 }
@@ -6023,6 +6034,23 @@ impl CoreExecutorBoundaryHandle for InterruptYieldingBoundaryHandle {
             .expect("staged text mutex poisoned");
         staged.extend(appends.into_iter().map(|append| append.text));
         Ok(None)
+    }
+
+    async fn discard_staged_system_context_at_boundary(
+        &self,
+        _expected_run_id: &meerkat_core::RunId,
+        idempotency_keys: Vec<String>,
+    ) -> Result<(), CoreExecutorError> {
+        self.probe
+            .live_boundary_discard_calls
+            .fetch_add(1, Ordering::SeqCst);
+        let mut discarded = self
+            .probe
+            .live_boundary_discarded_keys
+            .lock()
+            .expect("discarded keys mutex poisoned");
+        discarded.extend(idempotency_keys);
+        Ok(())
     }
 }
 
@@ -6088,7 +6116,19 @@ struct InterruptYieldingTestRig {
 
 impl InterruptYieldingTestRig {
     async fn new(with_live_boundary: bool, fail_live_stage: bool) -> Self {
-        let adapter = Arc::new(MeerkatMachine::ephemeral());
+        Self::new_with_adapter(
+            Arc::new(MeerkatMachine::ephemeral()),
+            with_live_boundary,
+            fail_live_stage,
+        )
+        .await
+    }
+
+    async fn new_with_adapter(
+        adapter: Arc<MeerkatMachine>,
+        with_live_boundary: bool,
+        fail_live_stage: bool,
+    ) -> Self {
         let session_id = SessionId::new();
         let apply_calls = Arc::new(AtomicUsize::new(0));
         let queued_boundary_cancel_calls = Arc::new(AtomicUsize::new(0));
@@ -6925,6 +6965,79 @@ async fn interrupt_yielding_live_stage_failure_leaves_accepted_work_queued() {
     );
     assert_eq!(rig.queued_boundary_cancel_calls.load(Ordering::SeqCst), 0);
     assert_eq!(probe.live_boundary_cancel_calls.load(Ordering::SeqCst), 0);
+}
+
+#[tokio::test]
+async fn interrupt_yielding_live_commit_failure_rolls_back_staged_context() {
+    let inner = Arc::new(crate::store::InMemoryRuntimeStore::new());
+    let store = Arc::new(RuntimeCommitAtomicityStore::pass_through(Arc::clone(
+        &inner,
+    )));
+    let runtime_store: Arc<dyn RuntimeStore> = store.clone();
+    let rig = InterruptYieldingTestRig::new_with_adapter(
+        Arc::new(MeerkatMachine::persistent(
+            runtime_store,
+            memory_blob_store(),
+        )),
+        true,
+        false,
+    )
+    .await;
+    rig.start_busy_turn().await;
+    let probe = rig.probe.clone().expect("live boundary probe installed");
+
+    store.fail_atomic_apply.store(true, Ordering::SeqCst);
+    let (peer_input, peer_id) = interrupt_yielding_peer_input(
+        "explicit steer rolls back if the runtime commit fails",
+        Some(meerkat_core::types::HandlingMode::Steer),
+    );
+    let err = rig
+        .adapter
+        .accept_input_with_completion(&rig.session_id, peer_input)
+        .await
+        .expect_err("live boundary runtime-store failure should reject dispatch");
+    assert!(
+        err.to_string().contains("synthetic atomic_apply failure"),
+        "unexpected live boundary commit error: {err}"
+    );
+
+    assert_eq!(
+        probe.live_boundary_stage_calls.load(Ordering::SeqCst),
+        1,
+        "the live injection path should stage before the persistent commit"
+    );
+    assert_eq!(
+        probe.live_boundary_discard_calls.load(Ordering::SeqCst),
+        1,
+        "failed persistent live-boundary commit must roll back session-side staging"
+    );
+    let discarded_keys = probe.discarded_keys();
+    assert_eq!(discarded_keys, vec![format!("runtime:steer:{peer_id}")]);
+
+    let during_busy = rig
+        .adapter
+        .meerkat_machine_spine_snapshot(&rig.session_id)
+        .await
+        .expect("snapshot should remain available after failed live commit");
+    assert!(
+        during_busy.inputs.steer_queue.contains(&peer_id),
+        "the runtime input should remain queued when live-boundary commit fails"
+    );
+    let steered_snapshot = during_busy
+        .inputs
+        .admission_order
+        .iter()
+        .find(|input| input.input_id == peer_id)
+        .expect("failed live-commit input should remain visible");
+    assert_eq!(
+        steered_snapshot.lifecycle,
+        Some(crate::input_state::InputLifecycleState::Queued)
+    );
+
+    rig.allow_finish.notify_waiters();
+    rig.wait_for_apply_calls(2).await;
+    rig.allow_finish.notify_waiters();
+    rig.wait_until_attached_and_empty().await;
 }
 
 #[tokio::test]

--- a/meerkat-runtime/src/meerkat_machine_tests.rs
+++ b/meerkat-runtime/src/meerkat_machine_tests.rs
@@ -6775,13 +6775,13 @@ async fn interrupt_yielding_without_live_boundary_handle_falls_back_to_steer_que
 }
 
 #[tokio::test]
-async fn running_steered_operator_prompt_with_live_boundary_runs_as_followup_turn() {
+async fn running_steered_operator_prompt_with_live_boundary_injects_live_context() {
     let rig = InterruptYieldingTestRig::new(true, false).await;
     rig.start_busy_turn().await;
     let probe = rig.probe.clone().expect("live boundary probe installed");
 
     let prompt = Input::Prompt(crate::input::PromptInput::new(
-        "operator steer must produce a followup assistant turn",
+        "operator steer must reach the active assistant turn",
         Some(
             meerkat_core::lifecycle::run_primitive::RuntimeTurnMetadata {
                 handling_mode: Some(meerkat_core::types::HandlingMode::Steer),
@@ -6799,10 +6799,22 @@ async fn running_steered_operator_prompt_with_live_boundary_runs_as_followup_tur
     let completion_handle =
         completion_handle.expect("operator steer should register a completion waiter");
 
+    assert!(matches!(
+        tokio::time::timeout(Duration::from_secs(1), completion_handle.wait())
+            .await
+            .expect("operator steer completion should resolve through live injection"),
+        CompletionOutcome::CompletedWithoutResult
+    ));
     assert_eq!(
         probe.live_boundary_stage_calls.load(Ordering::SeqCst),
-        0,
-        "operator prompts must not be consumed by live-boundary context injection"
+        1,
+        "operator prompt steers should stage context on the live boundary handle"
+    );
+    let staged = probe.staged_texts();
+    assert_eq!(staged.len(), 1);
+    assert!(
+        staged[0].contains("operator steer must reach the active assistant turn"),
+        "operator steer prompt should be projected into live boundary context: {staged:?}"
     );
     let during_busy = rig
         .adapter
@@ -6810,45 +6822,36 @@ async fn running_steered_operator_prompt_with_live_boundary_runs_as_followup_tur
         .await
         .expect("snapshot should exist while busy");
     assert!(
-        during_busy.inputs.steer_queue.contains(&prompt_id),
-        "operator steer must stay runnable until the active turn reaches a boundary"
+        during_busy.inputs.steer_queue.is_empty(),
+        "live-injected operator steer must be consumed from the steer lane"
     );
-    assert!(
+    assert_eq!(
         during_busy
             .completion_waiters
             .waiting_inputs
             .iter()
-            .any(|waiter| waiter.input_id == prompt_id),
-        "operator steer must not complete merely by being staged as context"
+            .filter(|waiter| waiter.input_id == prompt_id)
+            .count(),
+        0,
+        "live-injected operator steer should not leave a completion waiter behind"
     );
-
-    rig.allow_finish.notify_waiters();
-    rig.wait_for_apply_calls(2).await;
-    let second_turn = rig
-        .adapter
-        .meerkat_machine_spine_snapshot(&rig.session_id)
-        .await
-        .expect("snapshot should exist while followup prompt is running");
-    assert_eq!(second_turn.control.phase, RuntimeState::Running);
+    let steered_phase = during_busy
+        .inputs
+        .admission_order
+        .iter()
+        .find(|input| input.input_id == prompt_id)
+        .and_then(|input| input.lifecycle);
     assert_eq!(
-        second_turn.inputs.current_run_contributors,
-        vec![prompt_id.clone()],
-        "the followup run must be driven by the operator steer prompt"
+        steered_phase,
+        Some(crate::input_state::InputLifecycleState::Consumed)
     );
-    assert_eq!(probe.live_boundary_stage_calls.load(Ordering::SeqCst), 0);
 
     rig.allow_finish.notify_waiters();
     rig.wait_until_attached_and_empty().await;
-    assert!(matches!(
-        tokio::time::timeout(Duration::from_secs(1), completion_handle.wait())
-            .await
-            .expect("operator steer completion should resolve"),
-        CompletionOutcome::CompletedWithoutResult
-    ));
     assert_eq!(
         rig.apply_calls.load(Ordering::SeqCst),
-        2,
-        "operator steer must run exactly once after the active turn"
+        1,
+        "live-injected operator steer must not start a followup apply"
     );
 }
 

--- a/meerkat-runtime/src/meerkat_machine_tests.rs
+++ b/meerkat-runtime/src/meerkat_machine_tests.rs
@@ -6775,6 +6775,84 @@ async fn interrupt_yielding_without_live_boundary_handle_falls_back_to_steer_que
 }
 
 #[tokio::test]
+async fn running_steered_operator_prompt_with_live_boundary_runs_as_followup_turn() {
+    let rig = InterruptYieldingTestRig::new(true, false).await;
+    rig.start_busy_turn().await;
+    let probe = rig.probe.clone().expect("live boundary probe installed");
+
+    let prompt = Input::Prompt(crate::input::PromptInput::new(
+        "operator steer must produce a followup assistant turn",
+        Some(
+            meerkat_core::lifecycle::run_primitive::RuntimeTurnMetadata {
+                handling_mode: Some(meerkat_core::types::HandlingMode::Steer),
+                ..Default::default()
+            },
+        ),
+    ));
+    let prompt_id = prompt.id().clone();
+    let (outcome, completion_handle) = rig
+        .adapter
+        .accept_input_with_completion(&rig.session_id, prompt)
+        .await
+        .expect("running operator steer should be accepted");
+    assert!(outcome.is_accepted());
+    let completion_handle =
+        completion_handle.expect("operator steer should register a completion waiter");
+
+    assert_eq!(
+        probe.live_boundary_stage_calls.load(Ordering::SeqCst),
+        0,
+        "operator prompts must not be consumed by live-boundary context injection"
+    );
+    let during_busy = rig
+        .adapter
+        .meerkat_machine_spine_snapshot(&rig.session_id)
+        .await
+        .expect("snapshot should exist while busy");
+    assert!(
+        during_busy.inputs.steer_queue.contains(&prompt_id),
+        "operator steer must stay runnable until the active turn reaches a boundary"
+    );
+    assert!(
+        during_busy
+            .completion_waiters
+            .waiting_inputs
+            .iter()
+            .any(|waiter| waiter.input_id == prompt_id),
+        "operator steer must not complete merely by being staged as context"
+    );
+
+    rig.allow_finish.notify_waiters();
+    rig.wait_for_apply_calls(2).await;
+    let second_turn = rig
+        .adapter
+        .meerkat_machine_spine_snapshot(&rig.session_id)
+        .await
+        .expect("snapshot should exist while followup prompt is running");
+    assert_eq!(second_turn.control.phase, RuntimeState::Running);
+    assert_eq!(
+        second_turn.inputs.current_run_contributors,
+        vec![prompt_id.clone()],
+        "the followup run must be driven by the operator steer prompt"
+    );
+    assert_eq!(probe.live_boundary_stage_calls.load(Ordering::SeqCst), 0);
+
+    rig.allow_finish.notify_waiters();
+    rig.wait_until_attached_and_empty().await;
+    assert!(matches!(
+        tokio::time::timeout(Duration::from_secs(1), completion_handle.wait())
+            .await
+            .expect("operator steer completion should resolve"),
+        CompletionOutcome::CompletedWithoutResult
+    ));
+    assert_eq!(
+        rig.apply_calls.load(Ordering::SeqCst),
+        2,
+        "operator steer must run exactly once after the active turn"
+    );
+}
+
+#[tokio::test]
 async fn interrupt_yielding_live_stage_failure_leaves_accepted_work_queued() {
     let rig = InterruptYieldingTestRig::new(true, true).await;
     rig.start_busy_turn().await;

--- a/meerkat-runtime/src/meerkat_machine_tests.rs
+++ b/meerkat-runtime/src/meerkat_machine_tests.rs
@@ -5999,6 +5999,10 @@ impl CoreExecutorBoundaryHandle for InterruptYieldingBoundaryHandle {
         Ok(())
     }
 
+    async fn active_turn_boundary_available(&self) -> Result<bool, CoreExecutorError> {
+        Ok(true)
+    }
+
     async fn stage_system_context_at_boundary(
         &self,
         appends: Vec<meerkat_core::PendingSystemContextAppend>,
@@ -6222,6 +6226,10 @@ async fn explicit_running_steer_admission_injects_live_boundary_context_once() {
         async fn cancel_after_boundary(&self, _reason: String) -> Result<(), CoreExecutorError> {
             self.calls.fetch_add(1, Ordering::SeqCst);
             Ok(())
+        }
+
+        async fn active_turn_boundary_available(&self) -> Result<bool, CoreExecutorError> {
+            Ok(true)
         }
 
         async fn stage_system_context_at_boundary(

--- a/meerkat-runtime/src/policy_table.rs
+++ b/meerkat-runtime/src/policy_table.rs
@@ -87,11 +87,7 @@ impl DefaultPolicyTable {
             return match mode {
                 meerkat_core::types::HandlingMode::Queue => pd(
                     ApplyMode::StageRunStart,
-                    if runtime_idle {
-                        WakeMode::WakeIfIdle
-                    } else {
-                        WakeMode::None
-                    },
+                    WakeMode::WakeIfIdle,
                     QueueMode::Fifo,
                     ConsumePoint::OnRunComplete,
                     DrainPolicy::QueueNextTurn,

--- a/meerkat-runtime/src/policy_table.rs
+++ b/meerkat-runtime/src/policy_table.rs
@@ -711,8 +711,8 @@ mod tests {
         );
         assert_eq!(
             running_decision.wake_mode,
-            WakeMode::None,
-            "explicit queue means next boundary, not interrupt-yielding, while the target is running"
+            WakeMode::WakeIfIdle,
+            "explicit queue means next boundary and may wake the loop once idle, but must not interrupt-yield while the target is running"
         );
     }
 

--- a/meerkat-runtime/tests/driver_ephemeral.rs
+++ b/meerkat-runtime/tests/driver_ephemeral.rs
@@ -31,6 +31,33 @@ fn make_prompt_input(text: &str) -> Input {
     })
 }
 
+fn make_prompt_input_with_handling_mode(
+    text: &str,
+    handling_mode: meerkat_core::types::HandlingMode,
+) -> Input {
+    Input::Prompt(PromptInput {
+        header: InputHeader {
+            id: InputId::new(),
+            timestamp: Utc::now(),
+            source: InputOrigin::Operator,
+            durability: InputDurability::Durable,
+            visibility: InputVisibility::default(),
+            idempotency_key: None,
+            supersession_key: None,
+            correlation_id: None,
+        },
+        text: text.into(),
+        blocks: None,
+        typed_turn_appends: Vec::new(),
+        turn_metadata: Some(
+            meerkat_core::lifecycle::run_primitive::RuntimeTurnMetadata {
+                handling_mode: Some(handling_mode),
+                ..Default::default()
+            },
+        ),
+    })
+}
+
 fn make_peer_terminal(body: &str) -> Input {
     Input::Peer(PeerInput {
         header: InputHeader {
@@ -171,6 +198,26 @@ async fn accept_prompt_running_queues_and_wakes() {
     // Prompt always wakes (but runtime is running so wake_mode is still WakeIfIdle,
     // but runtime_idle=false so wake_requested should be false)
     assert!(!driver.take_wake_requested());
+}
+
+#[tokio::test]
+async fn accept_explicit_queue_prompt_running_wakes_after_current_turn() {
+    let mut driver = EphemeralRuntimeDriver::new(LogicalRuntimeId::new("test"));
+    bind_running(&mut driver, RunId::new(), RuntimeState::Idle);
+
+    let input = make_prompt_input_with_handling_mode(
+        "queued direct console input",
+        meerkat_core::types::HandlingMode::Queue,
+    );
+    let result = driver.accept_input(input).await.unwrap();
+
+    assert!(result.is_accepted());
+    assert_machine_owned_admission_signal(&result, false, PostAdmissionSignal::WakeLoop);
+    assert_eq!(
+        driver.take_post_admission_signal(),
+        PostAdmissionSignal::WakeLoop,
+        "explicit HandlingMode::Queue while running must wake the loop after the active turn"
+    );
 }
 
 // WIP: see `accept_prompt_idle_queues_and_wakes` for the shared

--- a/meerkat-session/src/ephemeral.rs
+++ b/meerkat-session/src/ephemeral.rs
@@ -3529,6 +3529,15 @@ async fn session_task<A: SessionAgent>(
                     continue;
                 }
 
+                let discarded_stale_active_context =
+                    agent.discard_unapplied_active_turn_system_context();
+                if discarded_stale_active_context > 0 {
+                    tracing::debug!(
+                        discarded_stale_active_context,
+                        "discarded stale active-turn system context before starting a new run"
+                    );
+                }
+
                 agent.set_skill_references(skill_references);
                 if let Err(error) = agent.set_flow_tool_overlay(flow_tool_overlay) {
                     restore_deferred_turn_inputs(
@@ -4695,6 +4704,101 @@ mod runtime_turn_metadata_tests {
             after.seen.is_empty(),
             "discarded active-turn context should not reserve idempotency keys"
         );
+    }
+
+    #[tokio::test]
+    async fn stale_active_turn_context_is_discarded_before_next_turn_boundary() {
+        let started = Arc::new(tokio::sync::Notify::new());
+        let release = Arc::new(tokio::sync::Notify::new());
+        let service = Arc::new(EphemeralSessionService::new(
+            BlockingBoundaryBuilder {
+                started: Arc::clone(&started),
+                release: Arc::clone(&release),
+            },
+            1,
+        ));
+
+        let result = service
+            .create_session(CreateSessionRequest {
+                model: "blocking-boundary-model".to_string(),
+                prompt: ContentInput::Text("defer".to_string()),
+                render_metadata: None,
+                system_prompt: None,
+                max_tokens: None,
+                event_tx: None,
+                skill_references: None,
+                initial_turn: InitialTurnPolicy::Defer,
+                deferred_prompt_policy: DeferredPromptPolicy::Discard,
+                build: Some(SessionBuildOptions::default()),
+                labels: None,
+            })
+            .await
+            .expect("deferred boundary snapshot session should create");
+
+        service
+            .stage_runtime_system_context_for_active_turn(
+                &result.session_id,
+                vec![PendingSystemContextAppend {
+                    text: "STALE_ACTIVE_STEER_SHOULD_NOT_REACH_NEXT_TURN".to_string(),
+                    source: Some("console:steer:stale".to_string()),
+                    idempotency_key: Some("console:steer:stale".to_string()),
+                    accepted_at: meerkat_core::time_compat::SystemTime::now(),
+                }],
+            )
+            .await
+            .expect("synthetic stale active-turn context should stage");
+
+        let run_service = Arc::clone(&service);
+        let run_session_id = result.session_id.clone();
+        let run = tokio::spawn(async move {
+            run_service
+                .start_turn(
+                    &run_session_id,
+                    StartTurnRequest {
+                        prompt: ContentInput::Text("unrelated next turn".to_string()),
+                        system_prompt: None,
+                        event_tx: None,
+                        runtime: meerkat_core::service::StartTurnRuntimeSemantics::new(
+                            None,
+                            meerkat_core::types::HandlingMode::Queue,
+                            None,
+                            None,
+                            Vec::new(),
+                            Some(RuntimeTurnMetadata {
+                                execution_kind: Some(RuntimeExecutionKind::ContentTurn),
+                                ..Default::default()
+                            }),
+                        ),
+                    },
+                )
+                .await
+        });
+
+        tokio::time::timeout(std::time::Duration::from_secs(1), started.notified())
+            .await
+            .expect("next turn should enter the blocking agent");
+
+        let state = service
+            .system_context_state(&result.session_id)
+            .await
+            .expect("session state should exist");
+        {
+            let guard = state
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            assert!(guard.pending.is_empty());
+            assert!(guard.applied.is_empty());
+            assert!(guard.active_turn_pending_keys.is_empty());
+            assert!(
+                guard.seen.is_empty(),
+                "discarded stale active-turn context should not reserve idempotency keys"
+            );
+        }
+
+        release.notify_waiters();
+        run.await
+            .expect("start_turn task should join")
+            .expect("next turn should complete after release");
     }
 
     #[tokio::test]

--- a/meerkat-session/src/ephemeral.rs
+++ b/meerkat-session/src/ephemeral.rs
@@ -1391,6 +1391,58 @@ impl<B: SessionAgentBuilder + 'static> EphemeralSessionService<B> {
         })
     }
 
+    /// Stage runtime-owned context for the active turn's next model boundary.
+    ///
+    /// This path intentionally mutates the shared system-context state directly
+    /// instead of sending a command to the session task. During a long turn the
+    /// session task is busy inside `run_turn_with_events`, and mailbox delivery
+    /// would make an operator steer visible only after the turn had already
+    /// completed.
+    pub async fn stage_runtime_system_context_for_active_turn(
+        &self,
+        id: &SessionId,
+        appends: Vec<PendingSystemContextAppend>,
+    ) -> Result<(), SessionError> {
+        if appends.is_empty() {
+            return Ok(());
+        }
+
+        let state = self
+            .system_context_state(id)
+            .await
+            .ok_or_else(|| SessionError::NotFound { id: id.clone() })?;
+
+        let mut guard = match state.lock() {
+            Ok(guard) => guard,
+            Err(poisoned) => {
+                tracing::warn!(
+                    session_id = %id,
+                    "system-context state lock poisoned while staging active-turn context"
+                );
+                poisoned.into_inner()
+            }
+        };
+
+        let mut candidate = guard.clone();
+        for append in appends {
+            let req = AppendSystemContextRequest {
+                text: append.text,
+                source: append.source,
+                idempotency_key: append.idempotency_key,
+            };
+            candidate
+                .stage_append(&req, append.accepted_at)
+                .map_err(|err| {
+                    SessionError::Agent(AgentError::InternalError(
+                        err.into_control_error(id).to_string(),
+                    ))
+                })?;
+        }
+        *guard = candidate;
+
+        Ok(())
+    }
+
     pub async fn publish_runtime_system_context_events(
         &self,
         id: &SessionId,
@@ -4108,6 +4160,127 @@ mod runtime_turn_metadata_tests {
         }
     }
 
+    #[derive(Clone)]
+    struct BlockingBoundaryBuilder {
+        started: Arc<tokio::sync::Notify>,
+        release: Arc<tokio::sync::Notify>,
+    }
+
+    struct BlockingBoundaryAgent {
+        session_id: SessionId,
+        started: Arc<tokio::sync::Notify>,
+        release: Arc<tokio::sync::Notify>,
+        system_context_state: Arc<std::sync::Mutex<meerkat_core::SessionSystemContextState>>,
+    }
+
+    #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+    #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+    impl SessionAgentBuilder for BlockingBoundaryBuilder {
+        type Agent = BlockingBoundaryAgent;
+
+        async fn build_agent(
+            &self,
+            _req: &CreateSessionRequest,
+            _event_tx: mpsc::Sender<AgentEvent>,
+        ) -> Result<Self::Agent, SessionError> {
+            Ok(BlockingBoundaryAgent {
+                session_id: SessionId::new(),
+                started: Arc::clone(&self.started),
+                release: Arc::clone(&self.release),
+                system_context_state: Arc::new(std::sync::Mutex::new(Default::default())),
+            })
+        }
+    }
+
+    #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+    #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+    impl SessionAgent for BlockingBoundaryAgent {
+        async fn run_with_events(
+            &mut self,
+            _prompt: ContentInput,
+            _event_tx: mpsc::Sender<AgentEvent>,
+        ) -> Result<RunResult, AgentError> {
+            self.started.notify_waiters();
+            self.release.notified().await;
+            Ok(RunResult {
+                text: "released".to_string(),
+                session_id: self.session_id.clone(),
+                usage: Usage::default(),
+                turns: 1,
+                tool_calls: 0,
+                terminal_cause_kind: None,
+                structured_output: None,
+                extraction_error: None,
+                schema_warnings: None,
+                skill_diagnostics: None,
+            })
+        }
+
+        fn cancel(&mut self) {}
+
+        fn set_skill_references(&mut self, _refs: Option<Vec<SkillKey>>) {}
+
+        fn set_flow_tool_overlay(
+            &mut self,
+            _overlay: Option<TurnToolOverlay>,
+        ) -> Result<(), AgentError> {
+            Ok(())
+        }
+
+        fn hot_swap_llm_identity(
+            &mut self,
+            _client: Arc<dyn meerkat_core::AgentLlmClient>,
+            _identity: SessionLlmIdentity,
+            _request_policy: meerkat_core::SessionLlmRequestPolicy,
+        ) -> Result<(), AgentError> {
+            Ok(())
+        }
+
+        fn session_id(&self) -> SessionId {
+            self.session_id.clone()
+        }
+
+        fn snapshot(&self) -> SessionSnapshot {
+            SessionSnapshot {
+                created_at: SystemTime::now(),
+                updated_at: SystemTime::now(),
+                message_count: 0,
+                total_tokens: 0,
+                usage: Usage::default(),
+                last_assistant_text: None,
+            }
+        }
+
+        fn session_clone(&self) -> meerkat_core::Session {
+            let mut session = meerkat_core::Session::new();
+            let state = self
+                .system_context_state
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .clone();
+            session
+                .set_system_context_state(state)
+                .expect("test system context state should serialize");
+            session
+        }
+
+        fn apply_runtime_system_context(&mut self, appends: &[PendingSystemContextAppend]) {
+            let mut session = self.session_clone();
+            session.append_system_context_blocks(appends);
+            let state = session.system_context_state().unwrap_or_default();
+            *self
+                .system_context_state
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner) = state;
+        }
+
+        fn system_context_state(
+            &self,
+        ) -> Arc<std::sync::Mutex<meerkat_core::SessionSystemContextState>> {
+            Arc::clone(&self.system_context_state)
+        }
+    }
+
     #[tokio::test]
     async fn eager_initial_turn_forwards_full_runtime_metadata_carrier() {
         let observed_skill_references = Arc::new(Mutex::new(Vec::new()));
@@ -4376,6 +4549,170 @@ mod runtime_turn_metadata_tests {
         assert!(
             ticks.last().copied().unwrap_or_default() > stale_runtime_context_ms,
             "post-commit runtime context tick must move past the current projection watermark"
+        );
+    }
+
+    #[tokio::test]
+    async fn active_turn_context_staging_does_not_wait_for_session_task_mailbox() {
+        let started = Arc::new(tokio::sync::Notify::new());
+        let release = Arc::new(tokio::sync::Notify::new());
+        let service = Arc::new(EphemeralSessionService::new(
+            BlockingBoundaryBuilder {
+                started: Arc::clone(&started),
+                release: Arc::clone(&release),
+            },
+            1,
+        ));
+
+        let result = service
+            .create_session(CreateSessionRequest {
+                model: "blocking-boundary-model".to_string(),
+                prompt: ContentInput::Text("defer".to_string()),
+                render_metadata: None,
+                system_prompt: None,
+                max_tokens: None,
+                event_tx: None,
+                skill_references: None,
+                initial_turn: InitialTurnPolicy::Defer,
+                deferred_prompt_policy: DeferredPromptPolicy::Discard,
+                build: Some(SessionBuildOptions::default()),
+                labels: None,
+            })
+            .await
+            .expect("deferred blocking session should create");
+
+        let run_service = Arc::clone(&service);
+        let run_session_id = result.session_id.clone();
+        let run = tokio::spawn(async move {
+            run_service
+                .start_turn(
+                    &run_session_id,
+                    StartTurnRequest {
+                        prompt: ContentInput::Text("hold the turn open".to_string()),
+                        system_prompt: None,
+                        event_tx: None,
+                        runtime: meerkat_core::service::StartTurnRuntimeSemantics::new(
+                            None,
+                            meerkat_core::types::HandlingMode::Queue,
+                            None,
+                            None,
+                            Vec::new(),
+                            Some(RuntimeTurnMetadata {
+                                execution_kind: Some(RuntimeExecutionKind::ContentTurn),
+                                ..Default::default()
+                            }),
+                        ),
+                    },
+                )
+                .await
+        });
+
+        tokio::time::timeout(std::time::Duration::from_secs(1), started.notified())
+            .await
+            .expect("turn should enter the blocking agent");
+
+        let appends = vec![PendingSystemContextAppend {
+            text: "active-turn steer context".to_string(),
+            source: Some("console:steer:test".to_string()),
+            idempotency_key: Some("console:steer:test".to_string()),
+            accepted_at: meerkat_core::time_compat::SystemTime::now(),
+        }];
+
+        tokio::time::timeout(
+            std::time::Duration::from_millis(200),
+            service.stage_runtime_system_context_for_active_turn(&result.session_id, appends),
+        )
+        .await
+        .expect("active-turn staging must not wait for the busy session task")
+        .expect("active-turn staging should succeed");
+
+        let state = service
+            .system_context_state(&result.session_id)
+            .await
+            .expect("session state should exist");
+        let pending = state
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .pending
+            .clone();
+        assert_eq!(pending.len(), 1);
+        assert_eq!(pending[0].text, "active-turn steer context");
+
+        release.notify_waiters();
+        run.await
+            .expect("start_turn task should join")
+            .expect("blocked turn should complete after release");
+    }
+
+    #[tokio::test]
+    async fn active_turn_context_staging_is_atomic_on_batch_conflict() {
+        let started = Arc::new(tokio::sync::Notify::new());
+        let release = Arc::new(tokio::sync::Notify::new());
+        let service = Arc::new(EphemeralSessionService::new(
+            BlockingBoundaryBuilder {
+                started: Arc::clone(&started),
+                release,
+            },
+            1,
+        ));
+
+        let result = service
+            .create_session(CreateSessionRequest {
+                model: "blocking-boundary-model".to_string(),
+                prompt: ContentInput::Text("defer".to_string()),
+                render_metadata: None,
+                system_prompt: None,
+                max_tokens: None,
+                event_tx: None,
+                skill_references: None,
+                initial_turn: InitialTurnPolicy::Defer,
+                deferred_prompt_policy: DeferredPromptPolicy::Discard,
+                build: Some(SessionBuildOptions::default()),
+                labels: None,
+            })
+            .await
+            .expect("deferred blocking session should create");
+
+        let accepted_at = meerkat_core::time_compat::SystemTime::now();
+        let err = service
+            .stage_runtime_system_context_for_active_turn(
+                &result.session_id,
+                vec![
+                    PendingSystemContextAppend {
+                        text: "first staged context".to_string(),
+                        source: Some("console:steer:test".to_string()),
+                        idempotency_key: Some("console:steer:conflict".to_string()),
+                        accepted_at,
+                    },
+                    PendingSystemContextAppend {
+                        text: "conflicting staged context".to_string(),
+                        source: Some("console:steer:test".to_string()),
+                        idempotency_key: Some("console:steer:conflict".to_string()),
+                        accepted_at,
+                    },
+                ],
+            )
+            .await
+            .expect_err("conflicting batch should fail");
+        assert!(
+            err.to_string().contains("idempotency conflict"),
+            "unexpected error: {err}"
+        );
+
+        let state = service
+            .system_context_state(&result.session_id)
+            .await
+            .expect("session state should exist");
+        let guard = state
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        assert!(
+            guard.pending.is_empty(),
+            "failed active-turn staging batch must not leave partial pending context"
+        );
+        assert!(
+            guard.seen.is_empty(),
+            "failed active-turn staging batch must not reserve idempotency keys"
         );
     }
 

--- a/meerkat-session/src/ephemeral.rs
+++ b/meerkat-session/src/ephemeral.rs
@@ -26,7 +26,7 @@ use meerkat_core::{
     DeferredFirstTurnPhase, InputId, PendingDeferredPrompt, PendingSystemContextAppend,
     PendingToolResultsMessage, RealtimeTranscriptApplyOutcome, RealtimeTranscriptEvent,
     RealtimeTranscriptMaterializedMessage, RunId, SessionDeferredTurnState, SessionLlmIdentity,
-    SessionSystemContextState,
+    SessionSystemContextState, TurnPhase, TurnStateHandle,
 };
 use sha2::{Digest, Sha256};
 use std::collections::BTreeMap;
@@ -213,6 +213,8 @@ struct SessionHandle {
     comms_runtime: Option<Arc<dyn meerkat_core::agent::CommsRuntime>>,
     /// Shared runtime control state for system-context appends.
     system_context_state: Arc<std::sync::Mutex<SessionSystemContextState>>,
+    /// Runtime-owned turn phase handle for active-boundary probes.
+    turn_state_handle: Option<Arc<dyn TurnStateHandle>>,
     /// Shared control state for deferred first-turn prompt and staged tool results.
     deferred_turn_state: Arc<std::sync::Mutex<SessionDeferredTurnState>>,
     /// Capacity reserved for a deferred first turn while the session is staged.
@@ -545,6 +547,12 @@ pub trait SessionAgent: Send {
 
     /// Shared live control flag for cancel-after-boundary requests.
     fn cancel_after_boundary_handle(&self) -> Option<Arc<AtomicBool>> {
+        None
+    }
+
+    /// Runtime-owned turn-state handle, when the agent was built through a
+    /// machine-backed runtime binding.
+    fn turn_state_handle(&self) -> Option<Arc<dyn TurnStateHandle>> {
         None
     }
 
@@ -1471,6 +1479,40 @@ impl<B: SessionAgentBuilder + 'static> EphemeralSessionService<B> {
         Ok(())
     }
 
+    /// Report whether the current runtime-owned turn phase still has a
+    /// cooperative model boundary that can consume active-turn system context.
+    pub async fn active_turn_system_context_boundary_available(
+        &self,
+        id: &SessionId,
+    ) -> Result<Option<bool>, SessionError> {
+        let turn_state_handle = {
+            let sessions = self.sessions.read().await;
+            let handle = sessions
+                .get(id)
+                .ok_or_else(|| SessionError::NotFound { id: id.clone() })?;
+            handle.turn_state_handle.clone()
+        };
+
+        let Some(turn_state_handle) = turn_state_handle else {
+            return Ok(None);
+        };
+
+        let snapshot = turn_state_handle.snapshot();
+        let available = snapshot.active_run_id.is_some()
+            && matches!(
+                snapshot.turn_phase,
+                TurnPhase::ApplyingPrimitive | TurnPhase::WaitingForOps
+            );
+        tracing::debug!(
+            session_id = %id,
+            active_run_id = ?snapshot.active_run_id,
+            turn_phase = %snapshot.turn_phase,
+            available,
+            "observed runtime turn phase for live system-context boundary"
+        );
+        Ok(Some(available))
+    }
+
     pub async fn publish_runtime_system_context_events(
         &self,
         id: &SessionId,
@@ -2305,6 +2347,7 @@ impl<B: SessionAgentBuilder + 'static> EphemeralSessionService<B> {
         let interaction_event_injector = agent.interaction_event_injector();
         let comms_runtime = agent.comms_runtime();
         let cancel_after_boundary_handle = agent.cancel_after_boundary_handle();
+        let turn_state_handle = agent.turn_state_handle();
         let system_context_state = agent.system_context_state();
         // W2-E: capture the session-context DSL handle so the session task
         // can fire `AdvanceSessionContext` on every summary-publish site.
@@ -2378,6 +2421,7 @@ impl<B: SessionAgentBuilder + 'static> EphemeralSessionService<B> {
             interaction_event_injector,
             comms_runtime,
             system_context_state,
+            turn_state_handle,
             deferred_turn_state,
             staged_capacity_permit,
             active_capacity_lease,
@@ -4005,12 +4049,14 @@ mod runtime_turn_metadata_tests {
     use super::*;
     use async_trait::async_trait;
     use meerkat_core::handles::SessionContextHandle;
+    use meerkat_core::handles::TurnStateHandle;
     use meerkat_core::lifecycle::RuntimeExecutionKind;
     use meerkat_core::lifecycle::run_primitive::RuntimeTurnMetadata;
     use meerkat_core::service::{
         DeferredPromptPolicy, InitialTurnPolicy, SessionBuildOptions, SessionService,
     };
     use meerkat_core::skills::{SkillKey, SkillName};
+    use meerkat_core::turn_execution_authority::{ContentShape, TurnPrimitiveKind};
     use std::sync::{Arc, Mutex};
 
     #[derive(Clone)]
@@ -4324,6 +4370,207 @@ mod runtime_turn_metadata_tests {
         ) -> Arc<std::sync::Mutex<meerkat_core::SessionSystemContextState>> {
             Arc::clone(&self.system_context_state)
         }
+    }
+
+    #[derive(Clone)]
+    struct BoundaryPhaseProbeBuilder {
+        turn_state: Arc<meerkat_core::agent::test_turn_state_handle::TestTurnStateHandle>,
+    }
+
+    struct BoundaryPhaseProbeAgent {
+        session_id: SessionId,
+        turn_state: Arc<meerkat_core::agent::test_turn_state_handle::TestTurnStateHandle>,
+        system_context_state: Arc<std::sync::Mutex<meerkat_core::SessionSystemContextState>>,
+    }
+
+    #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+    #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+    impl SessionAgentBuilder for BoundaryPhaseProbeBuilder {
+        type Agent = BoundaryPhaseProbeAgent;
+
+        async fn build_agent(
+            &self,
+            _req: &CreateSessionRequest,
+            _event_tx: mpsc::Sender<AgentEvent>,
+        ) -> Result<Self::Agent, SessionError> {
+            Ok(BoundaryPhaseProbeAgent {
+                session_id: SessionId::new(),
+                turn_state: Arc::clone(&self.turn_state),
+                system_context_state: Arc::new(std::sync::Mutex::new(Default::default())),
+            })
+        }
+    }
+
+    #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+    #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+    impl SessionAgent for BoundaryPhaseProbeAgent {
+        async fn run_with_events(
+            &mut self,
+            _prompt: ContentInput,
+            _event_tx: mpsc::Sender<AgentEvent>,
+        ) -> Result<RunResult, AgentError> {
+            Ok(RunResult {
+                text: "ok".to_string(),
+                session_id: self.session_id.clone(),
+                usage: Usage::default(),
+                turns: 1,
+                tool_calls: 0,
+                terminal_cause_kind: None,
+                structured_output: None,
+                extraction_error: None,
+                schema_warnings: None,
+                skill_diagnostics: None,
+            })
+        }
+
+        fn cancel(&mut self) {}
+
+        fn set_skill_references(&mut self, _refs: Option<Vec<SkillKey>>) {}
+
+        fn set_flow_tool_overlay(
+            &mut self,
+            _overlay: Option<TurnToolOverlay>,
+        ) -> Result<(), AgentError> {
+            Ok(())
+        }
+
+        fn hot_swap_llm_identity(
+            &mut self,
+            _client: Arc<dyn meerkat_core::AgentLlmClient>,
+            _identity: SessionLlmIdentity,
+            _request_policy: meerkat_core::SessionLlmRequestPolicy,
+        ) -> Result<(), AgentError> {
+            Ok(())
+        }
+
+        fn session_id(&self) -> SessionId {
+            self.session_id.clone()
+        }
+
+        fn snapshot(&self) -> SessionSnapshot {
+            SessionSnapshot {
+                created_at: SystemTime::now(),
+                updated_at: SystemTime::now(),
+                message_count: 0,
+                total_tokens: 0,
+                usage: Usage::default(),
+                last_assistant_text: None,
+            }
+        }
+
+        fn session_clone(&self) -> meerkat_core::Session {
+            meerkat_core::Session::with_id(self.session_id.clone())
+        }
+
+        fn turn_state_handle(&self) -> Option<Arc<dyn TurnStateHandle>> {
+            let handle: Arc<dyn TurnStateHandle> = self.turn_state.clone();
+            Some(handle)
+        }
+
+        fn apply_runtime_system_context(&mut self, appends: &[PendingSystemContextAppend]) {
+            let mut state = self
+                .system_context_state
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            for append in appends {
+                state.pending.push(append.clone());
+            }
+        }
+
+        fn system_context_state(
+            &self,
+        ) -> Arc<std::sync::Mutex<meerkat_core::SessionSystemContextState>> {
+            Arc::clone(&self.system_context_state)
+        }
+    }
+
+    #[tokio::test]
+    async fn active_turn_boundary_probe_uses_turn_phase_not_running_latch() {
+        let turn_state =
+            Arc::new(meerkat_core::agent::test_turn_state_handle::TestTurnStateHandle::new());
+        let service = EphemeralSessionService::new(
+            BoundaryPhaseProbeBuilder {
+                turn_state: Arc::clone(&turn_state),
+            },
+            1,
+        );
+        let created = service
+            .create_session(CreateSessionRequest {
+                model: "phase-probe".to_string(),
+                prompt: ContentInput::Text("hello".to_string()),
+                render_metadata: None,
+                system_prompt: None,
+                max_tokens: None,
+                event_tx: None,
+                skill_references: None,
+                initial_turn: InitialTurnPolicy::Defer,
+                deferred_prompt_policy: DeferredPromptPolicy::Discard,
+                build: None,
+                labels: None,
+            })
+            .await
+            .expect("create probe session");
+
+        assert_eq!(
+            service
+                .active_turn_system_context_boundary_available(&created.session_id)
+                .await
+                .expect("boundary probe should succeed"),
+            Some(false),
+            "no active run means no active-turn boundary"
+        );
+
+        let run_id = RunId::new();
+        turn_state
+            .start_conversation_run(
+                run_id.clone(),
+                TurnPrimitiveKind::ConversationTurn,
+                ContentShape::Conversation,
+                false,
+                false,
+                0,
+            )
+            .expect("start conversation run");
+        assert_eq!(
+            service
+                .active_turn_system_context_boundary_available(&created.session_id)
+                .await
+                .expect("boundary probe should succeed"),
+            Some(true),
+            "pre-LLM applying primitive can still consume staged context"
+        );
+
+        turn_state.primitive_applied().expect("enter calling LLM");
+        assert_eq!(
+            service
+                .active_turn_system_context_boundary_available(&created.session_id)
+                .await
+                .expect("boundary probe should succeed"),
+            Some(false),
+            "an in-flight model request has already built its context"
+        );
+
+        turn_state
+            .llm_returned_tool_calls(1)
+            .expect("enter waiting for ops");
+        assert_eq!(
+            service
+                .active_turn_system_context_boundary_available(&created.session_id)
+                .await
+                .expect("boundary probe should succeed"),
+            Some(true),
+            "tool execution phase has a deterministic post-tool model boundary"
+        );
+
+        turn_state.tool_calls_resolved().expect("drain boundary");
+        assert_eq!(
+            service
+                .active_turn_system_context_boundary_available(&created.session_id)
+                .await
+                .expect("boundary probe should succeed"),
+            Some(false),
+            "draining boundary is not enough to prove another LLM request remains"
+        );
     }
 
     #[tokio::test]

--- a/meerkat-session/src/ephemeral.rs
+++ b/meerkat-session/src/ephemeral.rs
@@ -1541,6 +1541,50 @@ impl<B: SessionAgentBuilder + 'static> EphemeralSessionService<B> {
         Ok(())
     }
 
+    /// Roll back active-turn-only runtime context that is still pending.
+    ///
+    /// This is intentionally best-effort with respect to the current turn
+    /// phase: the runtime calls it after its own commit failed, and the cleanup
+    /// must still remove the staged session projection if the turn has already
+    /// advanced or finished.
+    pub async fn discard_runtime_system_context_for_active_turn(
+        &self,
+        id: &SessionId,
+        expected_run_id: &RunId,
+        idempotency_keys: Vec<String>,
+    ) -> Result<usize, SessionError> {
+        if idempotency_keys.is_empty() {
+            return Ok(0);
+        }
+
+        let state = self
+            .system_context_state(id)
+            .await
+            .ok_or_else(|| SessionError::NotFound { id: id.clone() })?;
+
+        let mut guard = match state.lock() {
+            Ok(guard) => guard,
+            Err(poisoned) => {
+                tracing::warn!(
+                    session_id = %id,
+                    "system-context state lock poisoned while rolling back active-turn context"
+                );
+                poisoned.into_inner()
+            }
+        };
+
+        let discarded = guard.discard_active_turn_pending_by_keys(&idempotency_keys);
+        if !discarded.is_empty() {
+            tracing::debug!(
+                session_id = %id,
+                expected_run_id = %expected_run_id,
+                discarded_count = discarded.len(),
+                "rolled back staged active-turn runtime system context"
+            );
+        }
+        Ok(discarded.len())
+    }
+
     /// Report whether the current runtime-owned turn phase still has a
     /// cooperative model boundary that can consume active-turn system context.
     pub async fn active_turn_system_context_boundary_available(

--- a/meerkat-session/src/ephemeral.rs
+++ b/meerkat-session/src/ephemeral.rs
@@ -1460,6 +1460,12 @@ impl<B: SessionAgentBuilder + 'static> EphemeralSessionService<B> {
                     ))
                 })?;
         }
+        tracing::debug!(
+            session_id = %id,
+            pending_count = candidate.pending.len(),
+            active_turn_pending_count = candidate.active_turn_pending_keys.len(),
+            "staged active-turn runtime system context"
+        );
         *guard = candidate;
 
         Ok(())

--- a/meerkat-session/src/ephemeral.rs
+++ b/meerkat-session/src/ephemeral.rs
@@ -685,6 +685,28 @@ pub trait SessionAgent: Send {
     /// Synchronize the shared system-context control state into the canonical session metadata.
     fn sync_system_context_state(&mut self) {}
 
+    /// Drop active-turn-only context that missed the active turn's model
+    /// boundary so it cannot become ordinary context for the next run.
+    fn discard_unapplied_active_turn_system_context(&mut self) -> usize {
+        let discarded_count = {
+            let state = self.system_context_state();
+            let mut guard = match state.lock() {
+                Ok(guard) => guard,
+                Err(poisoned) => {
+                    tracing::warn!(
+                        "system-context state lock poisoned while discarding active-turn context"
+                    );
+                    poisoned.into_inner()
+                }
+            };
+            guard.discard_unapplied_active_turn_pending().len()
+        };
+        if discarded_count > 0 {
+            self.sync_system_context_state();
+        }
+        discarded_count
+    }
+
     /// Replace live semantic session state from durable authority while preserving live mechanics.
     #[cfg(all(feature = "session-store", not(target_arch = "wasm32")))]
     fn sync_session_from_durable_snapshot(
@@ -1431,7 +1453,7 @@ impl<B: SessionAgentBuilder + 'static> EphemeralSessionService<B> {
                 idempotency_key: append.idempotency_key,
             };
             candidate
-                .stage_append(&req, append.accepted_at)
+                .stage_active_turn_append(&req, append.accepted_at)
                 .map_err(|err| {
                     SessionError::Agent(AgentError::InternalError(
                         err.into_control_error(id).to_string(),
@@ -3681,6 +3703,14 @@ async fn session_task<A: SessionAgent>(
                     (r, resolved_phase)
                 }; // run_fut dropped here
 
+                let discarded_active_context = agent.discard_unapplied_active_turn_system_context();
+                if discarded_active_context > 0 {
+                    tracing::debug!(
+                        discarded_active_context,
+                        "discarded active-turn system context that missed the run boundary"
+                    );
+                }
+
                 let resolve_phase = resolved_phase.or_else(|| {
                     let mut slot = lock_turn_admission(&control.turn_admission);
                     slot.resolve().ok()
@@ -4642,6 +4672,23 @@ mod runtime_turn_metadata_tests {
         run.await
             .expect("start_turn task should join")
             .expect("blocked turn should complete after release");
+
+        let after = state
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .clone();
+        assert!(
+            after.pending.is_empty(),
+            "active-turn context that missed the run boundary must not leak into the next run"
+        );
+        assert!(
+            after.applied.is_empty(),
+            "missed active-turn context was never applied at an LLM boundary"
+        );
+        assert!(
+            after.seen.is_empty(),
+            "discarded active-turn context should not reserve idempotency keys"
+        );
     }
 
     #[tokio::test]

--- a/meerkat-session/src/ephemeral.rs
+++ b/meerkat-session/src/ephemeral.rs
@@ -26,7 +26,7 @@ use meerkat_core::{
     DeferredFirstTurnPhase, InputId, PendingDeferredPrompt, PendingSystemContextAppend,
     PendingToolResultsMessage, RealtimeTranscriptApplyOutcome, RealtimeTranscriptEvent,
     RealtimeTranscriptMaterializedMessage, RunId, SessionDeferredTurnState, SessionLlmIdentity,
-    SessionSystemContextState, TurnPhase, TurnStateHandle,
+    SessionSystemContextState, TurnPhase, TurnStateHandle, TurnStateSnapshot,
 };
 use sha2::{Digest, Sha256};
 use std::collections::BTreeMap;
@@ -72,6 +72,12 @@ pub struct SessionSnapshot {
     pub total_tokens: u64,
     pub usage: Usage,
     pub last_assistant_text: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ActiveTurnBoundaryStagingToken {
+    pub(crate) active_run_id: RunId,
+    pub(crate) boundary_count: u64,
 }
 
 // ---------------------------------------------------------------------------
@@ -843,6 +849,41 @@ impl<B: SessionAgentBuilder + 'static> EphemeralSessionService<B> {
         }
     }
 
+    pub(crate) fn active_turn_boundary_staging_token_from_snapshot(
+        snapshot: &TurnStateSnapshot,
+    ) -> Option<ActiveTurnBoundaryStagingToken> {
+        if matches!(
+            snapshot.turn_phase,
+            TurnPhase::ApplyingPrimitive | TurnPhase::WaitingForOps
+        ) {
+            return snapshot.active_run_id.clone().map(|active_run_id| {
+                ActiveTurnBoundaryStagingToken {
+                    active_run_id,
+                    boundary_count: snapshot.boundary_count,
+                }
+            });
+        }
+        None
+    }
+
+    pub(crate) fn active_turn_boundary_staging_token(
+        turn_state_handle: &dyn TurnStateHandle,
+    ) -> Option<ActiveTurnBoundaryStagingToken> {
+        let snapshot = turn_state_handle.snapshot();
+        Self::active_turn_boundary_staging_token_from_snapshot(&snapshot)
+    }
+
+    pub(crate) async fn active_turn_state_handle(
+        &self,
+        id: &SessionId,
+    ) -> Result<Option<Arc<dyn TurnStateHandle>>, SessionError> {
+        let sessions = self.sessions.read().await;
+        let handle = sessions
+            .get(id)
+            .ok_or_else(|| SessionError::NotFound { id: id.clone() })?;
+        Ok(handle.turn_state_handle.clone())
+    }
+
     async fn build_runtime_output(
         &self,
         id: &SessionId,
@@ -1431,10 +1472,20 @@ impl<B: SessionAgentBuilder + 'static> EphemeralSessionService<B> {
     pub async fn stage_runtime_system_context_for_active_turn(
         &self,
         id: &SessionId,
+        expected_run_id: &RunId,
         appends: Vec<PendingSystemContextAppend>,
     ) -> Result<(), SessionError> {
         if appends.is_empty() {
             return Ok(());
+        }
+
+        let turn_state_handle = self.active_turn_state_handle(id).await?;
+        let turn_state_handle =
+            turn_state_handle.ok_or_else(|| SessionError::NotRunning { id: id.clone() })?;
+        let initial_token = Self::active_turn_boundary_staging_token(turn_state_handle.as_ref())
+            .ok_or_else(|| SessionError::NotRunning { id: id.clone() })?;
+        if initial_token.active_run_id != *expected_run_id {
+            return Err(SessionError::NotRunning { id: id.clone() });
         }
 
         let state = self
@@ -1453,6 +1504,12 @@ impl<B: SessionAgentBuilder + 'static> EphemeralSessionService<B> {
             }
         };
 
+        let locked_token = Self::active_turn_boundary_staging_token(turn_state_handle.as_ref())
+            .ok_or_else(|| SessionError::NotRunning { id: id.clone() })?;
+        if locked_token != initial_token {
+            return Err(SessionError::NotRunning { id: id.clone() });
+        }
+
         let mut candidate = guard.clone();
         for append in appends {
             let req = AppendSystemContextRequest {
@@ -1467,6 +1524,11 @@ impl<B: SessionAgentBuilder + 'static> EphemeralSessionService<B> {
                         err.into_control_error(id).to_string(),
                     ))
                 })?;
+        }
+        let staged_token = Self::active_turn_boundary_staging_token(turn_state_handle.as_ref())
+            .ok_or_else(|| SessionError::NotRunning { id: id.clone() })?;
+        if staged_token != initial_token {
+            return Err(SessionError::NotRunning { id: id.clone() });
         }
         tracing::debug!(
             session_id = %id,
@@ -1485,24 +1547,14 @@ impl<B: SessionAgentBuilder + 'static> EphemeralSessionService<B> {
         &self,
         id: &SessionId,
     ) -> Result<Option<bool>, SessionError> {
-        let turn_state_handle = {
-            let sessions = self.sessions.read().await;
-            let handle = sessions
-                .get(id)
-                .ok_or_else(|| SessionError::NotFound { id: id.clone() })?;
-            handle.turn_state_handle.clone()
-        };
+        let turn_state_handle = self.active_turn_state_handle(id).await?;
 
         let Some(turn_state_handle) = turn_state_handle else {
             return Ok(None);
         };
 
         let snapshot = turn_state_handle.snapshot();
-        let available = snapshot.active_run_id.is_some()
-            && matches!(
-                snapshot.turn_phase,
-                TurnPhase::ApplyingPrimitive | TurnPhase::WaitingForOps
-            );
+        let available = Self::active_turn_boundary_staging_token_from_snapshot(&snapshot).is_some();
         tracing::debug!(
             session_id = %id,
             active_run_id = ?snapshot.active_run_id,
@@ -4255,12 +4307,14 @@ mod runtime_turn_metadata_tests {
     struct BlockingBoundaryBuilder {
         started: Arc<tokio::sync::Notify>,
         release: Arc<tokio::sync::Notify>,
+        turn_state: Option<Arc<meerkat_core::agent::test_turn_state_handle::TestTurnStateHandle>>,
     }
 
     struct BlockingBoundaryAgent {
         session_id: SessionId,
         started: Arc<tokio::sync::Notify>,
         release: Arc<tokio::sync::Notify>,
+        turn_state: Option<Arc<meerkat_core::agent::test_turn_state_handle::TestTurnStateHandle>>,
         system_context_state: Arc<std::sync::Mutex<meerkat_core::SessionSystemContextState>>,
     }
 
@@ -4278,6 +4332,7 @@ mod runtime_turn_metadata_tests {
                 session_id: SessionId::new(),
                 started: Arc::clone(&self.started),
                 release: Arc::clone(&self.release),
+                turn_state: self.turn_state.clone(),
                 system_context_state: Arc::new(std::sync::Mutex::new(Default::default())),
             })
         }
@@ -4291,8 +4346,28 @@ mod runtime_turn_metadata_tests {
             _prompt: ContentInput,
             _event_tx: mpsc::Sender<AgentEvent>,
         ) -> Result<RunResult, AgentError> {
+            if let Some(turn_state) = self.turn_state.as_ref() {
+                turn_state
+                    .start_conversation_run(
+                        RunId::new(),
+                        TurnPrimitiveKind::ConversationTurn,
+                        ContentShape::Conversation,
+                        false,
+                        false,
+                        0,
+                    )
+                    .map_err(|err| AgentError::InternalError(err.to_string()))?;
+            }
             self.started.notify_waiters();
             self.release.notified().await;
+            if let Some(turn_state) = self.turn_state.as_ref() {
+                turn_state
+                    .primitive_applied()
+                    .map_err(|err| AgentError::InternalError(err.to_string()))?;
+                turn_state
+                    .llm_returned_terminal()
+                    .map_err(|err| AgentError::InternalError(err.to_string()))?;
+            }
             Ok(RunResult {
                 text: "released".to_string(),
                 session_id: self.session_id.clone(),
@@ -4363,6 +4438,12 @@ mod runtime_turn_metadata_tests {
                 .system_context_state
                 .lock()
                 .unwrap_or_else(std::sync::PoisonError::into_inner) = state;
+        }
+
+        fn turn_state_handle(&self) -> Option<Arc<dyn TurnStateHandle>> {
+            self.turn_state
+                .as_ref()
+                .map(|turn_state| Arc::clone(turn_state) as Arc<dyn TurnStateHandle>)
         }
 
         fn system_context_state(
@@ -4848,10 +4929,13 @@ mod runtime_turn_metadata_tests {
     async fn active_turn_context_staging_does_not_wait_for_session_task_mailbox() {
         let started = Arc::new(tokio::sync::Notify::new());
         let release = Arc::new(tokio::sync::Notify::new());
+        let turn_state =
+            Arc::new(meerkat_core::agent::test_turn_state_handle::TestTurnStateHandle::new());
         let service = Arc::new(EphemeralSessionService::new(
             BlockingBoundaryBuilder {
                 started: Arc::clone(&started),
                 release: Arc::clone(&release),
+                turn_state: Some(Arc::clone(&turn_state)),
             },
             1,
         ));
@@ -4902,6 +4986,10 @@ mod runtime_turn_metadata_tests {
         tokio::time::timeout(std::time::Duration::from_secs(1), started.notified())
             .await
             .expect("turn should enter the blocking agent");
+        let active_run_id = turn_state
+            .snapshot()
+            .active_run_id
+            .expect("blocking turn should expose active run id");
 
         let appends = vec![PendingSystemContextAppend {
             text: "active-turn steer context".to_string(),
@@ -4912,7 +5000,11 @@ mod runtime_turn_metadata_tests {
 
         tokio::time::timeout(
             std::time::Duration::from_millis(200),
-            service.stage_runtime_system_context_for_active_turn(&result.session_id, appends),
+            service.stage_runtime_system_context_for_active_turn(
+                &result.session_id,
+                &active_run_id,
+                appends,
+            ),
         )
         .await
         .expect("active-turn staging must not wait for the busy session task")
@@ -4954,20 +5046,19 @@ mod runtime_turn_metadata_tests {
     }
 
     #[tokio::test]
-    async fn stale_active_turn_context_is_discarded_before_next_turn_boundary() {
-        let started = Arc::new(tokio::sync::Notify::new());
-        let release = Arc::new(tokio::sync::Notify::new());
-        let service = Arc::new(EphemeralSessionService::new(
-            BlockingBoundaryBuilder {
-                started: Arc::clone(&started),
-                release: Arc::clone(&release),
+    async fn active_turn_context_staging_revalidates_after_positive_probe() {
+        let turn_state =
+            Arc::new(meerkat_core::agent::test_turn_state_handle::TestTurnStateHandle::new());
+        let service = EphemeralSessionService::new(
+            BoundaryPhaseProbeBuilder {
+                turn_state: Arc::clone(&turn_state),
             },
             1,
-        ));
+        );
 
         let result = service
             .create_session(CreateSessionRequest {
-                model: "blocking-boundary-model".to_string(),
+                model: "boundary-phase-probe".to_string(),
                 prompt: ContentInput::Text("defer".to_string()),
                 render_metadata: None,
                 system_prompt: None,
@@ -4980,50 +5071,49 @@ mod runtime_turn_metadata_tests {
                 labels: None,
             })
             .await
-            .expect("deferred boundary snapshot session should create");
+            .expect("deferred boundary probe session should create");
 
-        service
+        let run_id = RunId::new();
+        turn_state
+            .start_conversation_run(
+                run_id.clone(),
+                TurnPrimitiveKind::ConversationTurn,
+                ContentShape::Conversation,
+                false,
+                false,
+                0,
+            )
+            .expect("start active run");
+
+        assert_eq!(
+            service
+                .active_turn_system_context_boundary_available(&result.session_id)
+                .await
+                .expect("boundary probe should succeed"),
+            Some(true)
+        );
+
+        turn_state
+            .primitive_applied()
+            .expect("advance past boundary");
+
+        let err = service
             .stage_runtime_system_context_for_active_turn(
                 &result.session_id,
+                &run_id,
                 vec![PendingSystemContextAppend {
-                    text: "STALE_ACTIVE_STEER_SHOULD_NOT_REACH_NEXT_TURN".to_string(),
+                    text: "STALE_ACTIVE_STEER_SHOULD_NOT_STAGE".to_string(),
                     source: Some("console:steer:stale".to_string()),
                     idempotency_key: Some("console:steer:stale".to_string()),
                     accepted_at: meerkat_core::time_compat::SystemTime::now(),
                 }],
             )
             .await
-            .expect("synthetic stale active-turn context should stage");
-
-        let run_service = Arc::clone(&service);
-        let run_session_id = result.session_id.clone();
-        let run = tokio::spawn(async move {
-            run_service
-                .start_turn(
-                    &run_session_id,
-                    StartTurnRequest {
-                        prompt: ContentInput::Text("unrelated next turn".to_string()),
-                        system_prompt: None,
-                        event_tx: None,
-                        runtime: meerkat_core::service::StartTurnRuntimeSemantics::new(
-                            None,
-                            meerkat_core::types::HandlingMode::Queue,
-                            None,
-                            None,
-                            Vec::new(),
-                            Some(RuntimeTurnMetadata {
-                                execution_kind: Some(RuntimeExecutionKind::ContentTurn),
-                                ..Default::default()
-                            }),
-                        ),
-                    },
-                )
-                .await
-        });
-
-        tokio::time::timeout(std::time::Duration::from_secs(1), started.notified())
-            .await
-            .expect("next turn should enter the blocking agent");
+            .expect_err("staging must revalidate the active turn phase");
+        assert!(
+            matches!(err, SessionError::NotRunning { .. }),
+            "unexpected error: {err}"
+        );
 
         let state = service
             .system_context_state(&result.session_id)
@@ -5041,24 +5131,89 @@ mod runtime_turn_metadata_tests {
                 "discarded stale active-turn context should not reserve idempotency keys"
             );
         }
+    }
 
-        release.notify_waiters();
-        run.await
-            .expect("start_turn task should join")
-            .expect("next turn should complete after release");
+    #[tokio::test]
+    async fn active_turn_context_staging_rejects_wrong_run_token() {
+        let turn_state =
+            Arc::new(meerkat_core::agent::test_turn_state_handle::TestTurnStateHandle::new());
+        let service = EphemeralSessionService::new(
+            BoundaryPhaseProbeBuilder {
+                turn_state: Arc::clone(&turn_state),
+            },
+            1,
+        );
+
+        let result = service
+            .create_session(CreateSessionRequest {
+                model: "boundary-phase-probe".to_string(),
+                prompt: ContentInput::Text("defer".to_string()),
+                render_metadata: None,
+                system_prompt: None,
+                max_tokens: None,
+                event_tx: None,
+                skill_references: None,
+                initial_turn: InitialTurnPolicy::Defer,
+                deferred_prompt_policy: DeferredPromptPolicy::Discard,
+                build: Some(SessionBuildOptions::default()),
+                labels: None,
+            })
+            .await
+            .expect("deferred boundary probe session should create");
+
+        let run_id = RunId::new();
+        turn_state
+            .start_conversation_run(
+                run_id,
+                TurnPrimitiveKind::ConversationTurn,
+                ContentShape::Conversation,
+                false,
+                false,
+                0,
+            )
+            .expect("start active run");
+
+        let wrong_run_id = RunId::new();
+        let err = service
+            .stage_runtime_system_context_for_active_turn(
+                &result.session_id,
+                &wrong_run_id,
+                vec![PendingSystemContextAppend {
+                    text: "WRONG_RUN_STEER_SHOULD_NOT_STAGE".to_string(),
+                    source: Some("console:steer:wrong-run".to_string()),
+                    idempotency_key: Some("console:steer:wrong-run".to_string()),
+                    accepted_at: meerkat_core::time_compat::SystemTime::now(),
+                }],
+            )
+            .await
+            .expect_err("staging must be bound to the active run token");
+        assert!(
+            matches!(err, SessionError::NotRunning { .. }),
+            "unexpected error: {err}"
+        );
+
+        let state = service
+            .system_context_state(&result.session_id)
+            .await
+            .expect("session state should exist");
+        let guard = state
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        assert!(guard.pending.is_empty());
+        assert!(guard.active_turn_pending_keys.is_empty());
+        assert!(guard.seen.is_empty());
     }
 
     #[tokio::test]
     async fn active_turn_context_staging_is_atomic_on_batch_conflict() {
-        let started = Arc::new(tokio::sync::Notify::new());
-        let release = Arc::new(tokio::sync::Notify::new());
-        let service = Arc::new(EphemeralSessionService::new(
-            BlockingBoundaryBuilder {
-                started: Arc::clone(&started),
-                release,
+        let turn_state =
+            Arc::new(meerkat_core::agent::test_turn_state_handle::TestTurnStateHandle::new());
+        let service = EphemeralSessionService::new(
+            BoundaryPhaseProbeBuilder {
+                turn_state: Arc::clone(&turn_state),
             },
             1,
-        ));
+        );
 
         let result = service
             .create_session(CreateSessionRequest {
@@ -5077,10 +5232,23 @@ mod runtime_turn_metadata_tests {
             .await
             .expect("deferred blocking session should create");
 
+        let run_id = RunId::new();
+        turn_state
+            .start_conversation_run(
+                run_id.clone(),
+                TurnPrimitiveKind::ConversationTurn,
+                ContentShape::Conversation,
+                false,
+                false,
+                0,
+            )
+            .expect("start active run");
+
         let accepted_at = meerkat_core::time_compat::SystemTime::now();
         let err = service
             .stage_runtime_system_context_for_active_turn(
                 &result.session_id,
+                &run_id,
                 vec![
                     PendingSystemContextAppend {
                         text: "first staged context".to_string(),

--- a/meerkat-session/src/persistent.rs
+++ b/meerkat-session/src/persistent.rs
@@ -1903,7 +1903,7 @@ impl<B: SessionAgentBuilder + 'static> PersistentSessionService<B> {
                     idempotency_key: append.idempotency_key,
                 };
                 candidate
-                    .stage_append(&req, append.accepted_at)
+                    .stage_active_turn_append(&req, append.accepted_at)
                     .map_err(|err| control_error_into_session_error(err.into_control_error(id)))?;
             }
             *guard = candidate.clone();

--- a/meerkat-session/src/persistent.rs
+++ b/meerkat-session/src/persistent.rs
@@ -1871,10 +1871,22 @@ impl<B: SessionAgentBuilder + 'static> PersistentSessionService<B> {
     pub async fn stage_live_system_context_boundary_snapshot(
         &self,
         id: &SessionId,
+        expected_run_id: &RunId,
         appends: Vec<PendingSystemContextAppend>,
     ) -> Result<Option<Vec<u8>>, SessionError> {
         if appends.is_empty() {
             return Ok(None);
+        }
+
+        let turn_state_handle = self.inner.active_turn_state_handle(id).await?;
+        let turn_state_handle =
+            turn_state_handle.ok_or_else(|| SessionError::NotRunning { id: id.clone() })?;
+        let initial_token = EphemeralSessionService::<B>::active_turn_boundary_staging_token(
+            turn_state_handle.as_ref(),
+        )
+        .ok_or_else(|| SessionError::NotRunning { id: id.clone() })?;
+        if initial_token.active_run_id != *expected_run_id {
+            return Err(SessionError::NotRunning { id: id.clone() });
         }
 
         let state_arc = self
@@ -1894,6 +1906,13 @@ impl<B: SessionAgentBuilder + 'static> PersistentSessionService<B> {
                     poisoned.into_inner()
                 }
             };
+            let locked_token = EphemeralSessionService::<B>::active_turn_boundary_staging_token(
+                turn_state_handle.as_ref(),
+            )
+            .ok_or_else(|| SessionError::NotRunning { id: id.clone() })?;
+            if locked_token != initial_token {
+                return Err(SessionError::NotRunning { id: id.clone() });
+            }
             let snapshot_state = guard.clone();
             let mut candidate = snapshot_state.clone();
             for append in appends {
@@ -1905,6 +1924,13 @@ impl<B: SessionAgentBuilder + 'static> PersistentSessionService<B> {
                 candidate
                     .stage_active_turn_append(&req, append.accepted_at)
                     .map_err(|err| control_error_into_session_error(err.into_control_error(id)))?;
+            }
+            let staged_token = EphemeralSessionService::<B>::active_turn_boundary_staging_token(
+                turn_state_handle.as_ref(),
+            )
+            .ok_or_else(|| SessionError::NotRunning { id: id.clone() })?;
+            if staged_token != initial_token {
+                return Err(SessionError::NotRunning { id: id.clone() });
             }
             *guard = candidate.clone();
             tracing::debug!(

--- a/meerkat-session/src/persistent.rs
+++ b/meerkat-session/src/persistent.rs
@@ -1907,6 +1907,13 @@ impl<B: SessionAgentBuilder + 'static> PersistentSessionService<B> {
                     .map_err(|err| control_error_into_session_error(err.into_control_error(id)))?;
             }
             *guard = candidate.clone();
+            tracing::debug!(
+                session_id = %id,
+                pending_count = candidate.pending.len(),
+                applied_count = candidate.applied.len(),
+                active_turn_pending_count = candidate.active_turn_pending_keys.len(),
+                "staged live active-turn runtime system context"
+            );
             (snapshot_state, candidate)
         };
 

--- a/meerkat-session/src/persistent.rs
+++ b/meerkat-session/src/persistent.rs
@@ -1962,6 +1962,15 @@ impl<B: SessionAgentBuilder + 'static> PersistentSessionService<B> {
         }
     }
 
+    pub async fn active_turn_system_context_boundary_available(
+        &self,
+        id: &SessionId,
+    ) -> Result<Option<bool>, SessionError> {
+        self.inner
+            .active_turn_system_context_boundary_available(id)
+            .await
+    }
+
     async fn fail_closed_runtime_projection_update(
         &self,
         id: &SessionId,

--- a/meerkat-session/src/persistent.rs
+++ b/meerkat-session/src/persistent.rs
@@ -1997,6 +1997,17 @@ impl<B: SessionAgentBuilder + 'static> PersistentSessionService<B> {
             .await
     }
 
+    pub async fn discard_live_system_context_boundary_staging(
+        &self,
+        id: &SessionId,
+        expected_run_id: &RunId,
+        idempotency_keys: Vec<String>,
+    ) -> Result<usize, SessionError> {
+        self.inner
+            .discard_runtime_system_context_for_active_turn(id, expected_run_id, idempotency_keys)
+            .await
+    }
+
     async fn fail_closed_runtime_projection_update(
         &self,
         id: &SessionId,

--- a/meerkat-web-runtime/src/lib.rs
+++ b/meerkat-web-runtime/src/lib.rs
@@ -1356,6 +1356,12 @@ fn merge_runtime_system_context_state(
         }
     }
 
+    for key in &current_state.active_turn_pending_keys {
+        if !starting_state.active_turn_pending_keys.contains(key) {
+            agent_state.active_turn_pending_keys.insert(key.clone());
+        }
+    }
+
     agent_state
 }
 
@@ -2806,6 +2812,7 @@ capabilities = [{capability_values}]
                     state: SeenSystemContextState::Pending,
                 },
             )]),
+            active_turn_pending_keys: Default::default(),
         };
         let agent_state = SessionSystemContextState {
             pending: Vec::new(),
@@ -2818,6 +2825,7 @@ capabilities = [{capability_values}]
                     state: SeenSystemContextState::Applied,
                 },
             )]),
+            active_turn_pending_keys: Default::default(),
         };
         let current_registry_state = SessionSystemContextState {
             pending: vec![initial_pending, concurrent_pending.clone()],
@@ -2840,6 +2848,9 @@ capabilities = [{capability_values}]
                     },
                 ),
             ]),
+            active_turn_pending_keys: std::collections::BTreeSet::from([
+                "ctx-concurrent".to_string()
+            ]),
         };
 
         let merged = merge_runtime_system_context_state(
@@ -2857,6 +2868,7 @@ capabilities = [{capability_values}]
             merged.seen.get("ctx-concurrent").map(|seen| seen.state),
             Some(SeenSystemContextState::Pending)
         );
+        assert!(merged.active_turn_pending_keys.contains("ctx-concurrent"));
     }
 
     #[test]

--- a/meerkat/src/service_factory.rs
+++ b/meerkat/src/service_factory.rs
@@ -344,6 +344,10 @@ impl SessionAgent for FactoryAgent {
         Some(self.agent.cancel_after_boundary_handle())
     }
 
+    fn turn_state_handle(&self) -> Option<Arc<dyn meerkat_core::TurnStateHandle>> {
+        self.agent.turn_state_handle()
+    }
+
     fn session_context_handle(
         &self,
     ) -> Option<Arc<dyn meerkat_core::handles::SessionContextHandle>> {

--- a/meerkat/src/surface/runtime_backed.rs
+++ b/meerkat/src/surface/runtime_backed.rs
@@ -484,10 +484,11 @@ impl CoreExecutorBoundaryHandle for PersistentRuntimeBoundaryHandle {
 
     async fn stage_system_context_at_boundary(
         &self,
+        expected_run_id: &meerkat_core::RunId,
         appends: Vec<meerkat_core::PendingSystemContextAppend>,
     ) -> Result<Option<Vec<u8>>, CoreExecutorError> {
         self.service
-            .stage_live_system_context_boundary_snapshot(&self.session_id, appends)
+            .stage_live_system_context_boundary_snapshot(&self.session_id, expected_run_id, appends)
             .await
             .map_err(|error| CoreExecutorError::control_failed_runtime(error.to_string()))
     }

--- a/meerkat/src/surface/runtime_backed.rs
+++ b/meerkat/src/surface/runtime_backed.rs
@@ -501,6 +501,22 @@ impl CoreExecutorBoundaryHandle for PersistentRuntimeBoundaryHandle {
             .await
             .map_err(|error| CoreExecutorError::control_failed_runtime(error.to_string()))
     }
+
+    async fn discard_staged_system_context_at_boundary(
+        &self,
+        expected_run_id: &meerkat_core::RunId,
+        idempotency_keys: Vec<String>,
+    ) -> Result<(), CoreExecutorError> {
+        self.service
+            .discard_live_system_context_boundary_staging(
+                &self.session_id,
+                expected_run_id,
+                idempotency_keys,
+            )
+            .await
+            .map(|_| ())
+            .map_err(|error| CoreExecutorError::control_failed_runtime(error.to_string()))
+    }
 }
 
 struct PersistentRuntimeInterruptHandle {

--- a/meerkat/src/surface/runtime_backed.rs
+++ b/meerkat/src/surface/runtime_backed.rs
@@ -482,6 +482,15 @@ impl CoreExecutorBoundaryHandle for PersistentRuntimeBoundaryHandle {
             .map_err(|error| CoreExecutorError::control_failed_runtime(error.to_string()))
     }
 
+    async fn active_turn_boundary_available(&self) -> Result<bool, CoreExecutorError> {
+        Ok(self
+            .service
+            .active_turn_system_context_boundary_available(&self.session_id)
+            .await
+            .map_err(|error| CoreExecutorError::control_failed_runtime(error.to_string()))?
+            .unwrap_or(false))
+    }
+
     async fn stage_system_context_at_boundary(
         &self,
         expected_run_id: &meerkat_core::RunId,
@@ -821,7 +830,7 @@ mod tests {
     ))]
     use std::collections::VecDeque;
     use std::path::PathBuf;
-    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 
     #[cfg(all(
         feature = "openai",
@@ -1064,6 +1073,87 @@ mod tests {
 
         async fn health_check(&self) -> Result<(), meerkat_client::LlmError> {
             Ok(())
+        }
+    }
+
+    struct OneToolThenOkClient {
+        calls: AtomicUsize,
+    }
+
+    #[async_trait::async_trait]
+    impl LlmClient for OneToolThenOkClient {
+        fn project_replay_messages(
+            &self,
+            messages: &[meerkat_core::Message],
+        ) -> Result<Vec<meerkat_core::Message>, LlmError> {
+            Ok(messages.to_vec())
+        }
+
+        fn stream<'a>(&'a self, _request: &'a LlmRequest) -> LlmStream<'a> {
+            let call_index = self.calls.fetch_add(1, Ordering::SeqCst);
+            let events = if call_index == 0 {
+                vec![
+                    LlmEvent::ToolCallComplete {
+                        id: "toolu_blocking".to_string(),
+                        name: "blocking_tool".to_string(),
+                        args: serde_json::json!({}),
+                        meta: None,
+                    },
+                    LlmEvent::Done {
+                        outcome: LlmDoneOutcome::Success {
+                            stop_reason: meerkat_core::StopReason::ToolUse,
+                        },
+                    },
+                ]
+            } else {
+                vec![
+                    LlmEvent::TextDelta {
+                        delta: "ok".to_string(),
+                        meta: None,
+                    },
+                    LlmEvent::Done {
+                        outcome: LlmDoneOutcome::Success {
+                            stop_reason: meerkat_core::StopReason::EndTurn,
+                        },
+                    },
+                ]
+            };
+            Box::pin(futures::stream::iter(events.into_iter().map(Ok)))
+        }
+
+        fn provider(&self) -> &'static str {
+            "one-tool-then-ok-test"
+        }
+
+        async fn health_check(&self) -> Result<(), LlmError> {
+            Ok(())
+        }
+    }
+
+    struct BlockingToolDispatcher {
+        started: Arc<Notify>,
+        release: Arc<Notify>,
+    }
+
+    #[async_trait::async_trait]
+    impl meerkat_core::AgentToolDispatcher for BlockingToolDispatcher {
+        fn tools(&self) -> Arc<[Arc<meerkat_core::ToolDef>]> {
+            Arc::from([Arc::new(meerkat_core::ToolDef::new(
+                "blocking_tool",
+                "blocks until the test releases it",
+                serde_json::json!({ "type": "object", "properties": {} }),
+            ))])
+        }
+
+        async fn dispatch(
+            &self,
+            call: meerkat_core::ToolCallView<'_>,
+        ) -> Result<meerkat_core::ToolDispatchOutcome, meerkat_core::ToolError> {
+            self.started.notify_waiters();
+            self.release.notified().await;
+            Ok(meerkat_core::ToolDispatchOutcome::sync_result(
+                meerkat_core::ToolResult::new(call.id.to_string(), "released".to_string(), false),
+            ))
         }
     }
 
@@ -1322,6 +1412,82 @@ mod tests {
             "shared default executor prompt",
         )
         .await;
+        service
+            .discard_live_session(&result.session_id)
+            .await
+            .expect("discard live session");
+        adapter.unregister_session(&result.session_id).await;
+    }
+
+    #[tokio::test]
+    async fn persistent_runtime_boundary_handle_reports_active_tool_boundary() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let (service, adapter) = build_test_service_with_llm(
+            &temp,
+            Arc::new(OneToolThenOkClient {
+                calls: AtomicUsize::new(0),
+            }),
+        )
+        .await;
+        let tool_started = Arc::new(Notify::new());
+        let tool_release = Arc::new(Notify::new());
+        let mut build = SessionBuildOptions {
+            external_tools: Some(Arc::new(BlockingToolDispatcher {
+                started: Arc::clone(&tool_started),
+                release: Arc::clone(&tool_release),
+            })),
+            ..Default::default()
+        };
+        build.override_builtins = meerkat_core::ToolCategoryOverride::Disable;
+        let result = Box::pin(materialize_session(
+            &service,
+            &adapter,
+            Session::new(),
+            make_request(build),
+            {
+                let service = Arc::clone(&service);
+                let adapter = Arc::clone(&adapter);
+                move |session_id| default_persistent_executor(service, adapter, session_id)
+            },
+        ))
+        .await
+        .expect("create runtime-backed tool session");
+
+        let (_outcome, completion) = adapter
+            .accept_input_with_completion(
+                &result.session_id,
+                Input::Prompt(PromptInput::new("run blocking tool", None)),
+            )
+            .await
+            .expect("accept runtime-backed prompt");
+        let completion = completion.expect("completion handle");
+
+        tokio::time::timeout(Duration::from_secs(2), tool_started.notified())
+            .await
+            .expect("tool should start");
+
+        let boundary = PersistentRuntimeBoundaryHandle {
+            service: Arc::clone(&service),
+            adapter: Arc::clone(&adapter),
+            session_id: result.session_id.clone(),
+        };
+        assert!(
+            boundary
+                .active_turn_boundary_available()
+                .await
+                .expect("boundary probe should succeed"),
+            "runtime-backed surface must expose the active post-tool LLM boundary"
+        );
+
+        tool_release.notify_waiters();
+        let outcome = tokio::time::timeout(Duration::from_secs(2), completion.wait())
+            .await
+            .expect("prompt should complete");
+        assert!(
+            matches!(outcome, CompletionOutcome::Completed(ref run) if run.text == "ok"),
+            "unexpected completion outcome: {outcome:?}"
+        );
+
         service
             .discard_live_session(&result.session_id)
             .await

--- a/scripts/check-rust-release-config.sh
+++ b/scripts/check-rust-release-config.sh
@@ -3,7 +3,7 @@
 set -euo pipefail
 
 ROOT="${ROOT:-$(cd "$(dirname "$0")/.." && pwd)}"
-PYTHON="${PYTHON:-python3}"
+PYTHON="${PYTHON:-$(command -v python3.11 2>/dev/null || command -v python3)}"
 
 RELEASE_CRATES=()
 while IFS= read -r crate; do

--- a/scripts/check-rust-release-packaging.sh
+++ b/scripts/check-rust-release-packaging.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 
 ROOT="${ROOT:-$(cd "$(dirname "$0")/.." && pwd)}"
 CARGO="${CARGO:-$ROOT/scripts/repo-cargo}"
-PYTHON="${PYTHON:-python3}"
+PYTHON="${PYTHON:-$(command -v python3.11 2>/dev/null || command -v python3)}"
 JOBS="${MEERKAT_RELEASE_PACKAGING_JOBS:-${MEERKAT_PUBLISH_DRY_RUN_JOBS:-4}}"
 TARGET_ROOT="${CARGO_TARGET_DIR:-/tmp/meerkat-release-packaging-target}"
 ISOLATED_TARGETS="${MEERKAT_RELEASE_PACKAGING_ISOLATED_TARGETS:-0}"

--- a/scripts/check_rust_release_packaging.py
+++ b/scripts/check_rust_release_packaging.py
@@ -5,7 +5,11 @@ from __future__ import annotations
 
 import pathlib
 import sys
-import tomllib
+
+try:
+    import tomllib
+except ModuleNotFoundError:  # pragma: no cover - exercised only on Python < 3.11
+    import tomli as tomllib
 
 
 def main() -> int:

--- a/tests/integration/tests/phase2_mode_routing.rs
+++ b/tests/integration/tests/phase2_mode_routing.rs
@@ -200,6 +200,10 @@ impl SessionService for MockSessionService {
         }
         Ok(())
     }
+
+    async fn has_live_session(&self, id: &SessionId) -> Result<bool, SessionError> {
+        Ok(self.sessions.read().await.contains_key(id))
+    }
 }
 
 #[async_trait]


### PR DESCRIPTION
## Summary
- make broad mob observation use actor-published snapshots instead of querying each mob actor
- allow profile-scoped legacy spawn_member calls to request auto_wire_parent without full manage authority
- add regressions for nonblocking mob_list/profile observation and auto-wired profile-scoped spawns

## Verification
- cargo test -p meerkat-mob-mcp test_mob_list_observes_without_waiting_for_in_flight_member_turn -- --nocapture
- cargo check -p meerkat-mob-mcp --all-targets
- cargo test -p meerkat-mob spawn_member_tool_dispatches_backend_selection -- --nocapture
- cargo test -p meerkat-mob spawn_member_profile_scope_allows_auto_wire_parent -- --nocapture
- git push pre-push gates