### PR TITLE
[codex] Fix mob runtime session continuity

### DIFF
--- a/meerkat-core/src/agent/state.rs
+++ b/meerkat-core/src/agent/state.rs
@@ -298,6 +298,17 @@ where
     T: AgentToolDispatcher + ?Sized + 'static,
     S: AgentSessionStore + ?Sized + 'static,
 {
+    async fn save_session_best_effort(&mut self) {
+        self.sync_system_context_state_to_session();
+        if let Some(ref checkpointer) = self.checkpointer {
+            checkpointer.checkpoint(&self.session).await;
+            return;
+        }
+        if let Err(e) = self.store.save(&self.session).await {
+            tracing::warn!("Failed to save session: {}", e);
+        }
+    }
+
     /// Snapshot the runtime-backed turn-state authority.
     ///
     /// Pre-wave-a, a missing `turn_state_handle` fell through to a
@@ -1200,9 +1211,7 @@ where
             schema_warnings: self.extraction_state.take_schema_warnings(),
             skill_diagnostics: self.collect_skill_diagnostics().await,
         };
-        if let Err(e) = self.store.save(&self.session).await {
-            tracing::warn!("Failed to save session: {}", e);
-        }
+        self.save_session_best_effort().await;
         self.emit_extraction_failed_event(&extraction_error, event_tx.as_ref())
             .await;
         Ok(result)
@@ -2541,9 +2550,7 @@ where
                                     schema_warnings: self.extraction_state.take_schema_warnings(),
                                     skill_diagnostics: self.collect_skill_diagnostics().await,
                                 };
-                                if let Err(e) = self.store.save(&self.session).await {
-                                    tracing::warn!("Failed to save session: {}", e);
-                                }
+                                self.save_session_best_effort().await;
                                 self.emit_extraction_failed_event(
                                     &extraction_error,
                                     event_tx.as_ref(),
@@ -2581,9 +2588,7 @@ where
                             },
                         )?;
                         self.execute_turn_effects(&t, turn_count, &event_tx).await;
-                        if let Err(e) = self.store.save(&self.session).await {
-                            tracing::warn!("Failed to save session: {}", e);
-                        }
+                        self.save_session_best_effort().await;
                         if let Some(structured_output) = result.structured_output.clone() {
                             self.emit_extraction_succeeded_event(
                                 structured_output,
@@ -2696,9 +2701,7 @@ where
                                     run_id: run_id.clone(),
                                 })?;
                             self.execute_turn_effects(&t, turn_count, &event_tx).await;
-                            if let Err(e) = self.store.save(&self.session).await {
-                                tracing::warn!("Failed to save session: {}", e);
-                            }
+                            self.save_session_best_effort().await;
                             return self.build_result(turn_count + 1, tool_call_count).await;
                         }
 
@@ -2733,9 +2736,7 @@ where
                         self.execute_turn_effects(&t, turn_count, &event_tx).await;
 
                         // Save session
-                        if let Err(e) = self.store.save(&self.session).await {
-                            tracing::warn!("Failed to save session: {}", e);
-                        }
+                        self.save_session_best_effort().await;
 
                         return Ok(result);
                     }

--- a/meerkat-core/src/session_store.rs
+++ b/meerkat-core/src/session_store.rs
@@ -18,6 +18,7 @@
 //! [`SessionStore`] and the [`append_only_save_guard`] helper.
 
 use async_trait::async_trait;
+use sha2::{Digest, Sha256};
 
 use crate::session::{SYSTEM_CONTEXT_SEPARATOR, SessionMeta};
 use crate::time_compat::SystemTime;
@@ -94,6 +95,16 @@ pub enum SessionStoreError {
     Internal(String),
 }
 
+/// Stable compare token for a full persisted session projection row.
+pub fn session_projection_cas_token(session: &Session) -> Result<String, SessionStoreError> {
+    let bytes = serde_json::to_vec(session).map_err(|err| {
+        SessionStoreError::Serialization(format!(
+            "failed to serialize session projection CAS token: {err}"
+        ))
+    })?;
+    Ok(format!("row-sha256:{:x}", Sha256::digest(bytes)))
+}
+
 /// Shared append-only guard for `SessionStore::save` implementations.
 ///
 /// Backends call this at the top of their `save` method with the new
@@ -111,42 +122,71 @@ pub fn append_only_save_guard(
     incoming: &Session,
     previous: Option<&Session>,
 ) -> Result<(), SessionStoreError> {
-    let Some(previous) = previous else {
-        return Ok(());
-    };
-
     incoming
         .validate_transcript_history_state()
         .map_err(|err| SessionStoreError::InvalidTranscriptRewrite {
             id: incoming.id().clone(),
             reason: format!("incoming transcript history state is malformed: {err}"),
         })?;
-    let previous_had_history = previous
-        .transcript_history_state()
-        .map_err(|err| SessionStoreError::InvalidTranscriptRewrite {
-            id: incoming.id().clone(),
-            reason: format!("previous transcript history state is malformed: {err}"),
-        })?
-        .is_some();
-    let incoming_has_history = incoming
-        .transcript_history_state()
-        .map_err(|err| SessionStoreError::InvalidTranscriptRewrite {
+    let incoming_revision =
+        transcript_messages_digest(incoming.messages()).map_err(SessionStoreError::from)?;
+    let incoming_state = incoming.transcript_history_state().map_err(|err| {
+        SessionStoreError::InvalidTranscriptRewrite {
             id: incoming.id().clone(),
             reason: format!("incoming transcript history state is malformed: {err}"),
-        })?
-        .is_some();
+        }
+    })?;
+    if let Some(state) = incoming_state.as_ref()
+        && state.head != incoming_revision
+    {
+        return Err(SessionStoreError::InvalidTranscriptRewrite {
+            id: incoming.id().clone(),
+            reason: format!(
+                "incoming transcript graph head {} does not match current message digest {incoming_revision}",
+                state.head
+            ),
+        });
+    }
+
+    let Some(previous) = previous else {
+        if incoming_state.is_some() {
+            return Err(SessionStoreError::InvalidTranscriptRewrite {
+                id: incoming.id().clone(),
+                reason: "incoming first save would seed transcript history state outside the rewrite/audit path"
+                    .to_string(),
+            });
+        }
+        validate_plain_save_transcript_history_preservation(
+            incoming,
+            None,
+            None,
+            incoming_state.as_ref(),
+        )?;
+        return Ok(());
+    };
+    let previous_state = previous.transcript_history_state().map_err(|err| {
+        SessionStoreError::InvalidTranscriptRewrite {
+            id: incoming.id().clone(),
+            reason: format!("previous transcript history state is malformed: {err}"),
+        }
+    })?;
+    let previous_had_history = previous_state.is_some();
+    let incoming_has_history = incoming_state.is_some();
     if previous_had_history && !incoming_has_history {
         return Err(SessionStoreError::InvalidTranscriptRewrite {
             id: incoming.id().clone(),
             reason: "incoming save would erase retained transcript history state".to_string(),
         });
     }
-
     let previous_revision =
         transcript_messages_digest(previous.messages()).map_err(SessionStoreError::from)?;
-    let incoming_revision =
-        transcript_messages_digest(incoming.messages()).map_err(SessionStoreError::from)?;
     if previous_revision == incoming_revision {
+        validate_plain_save_transcript_history_preservation(
+            incoming,
+            Some(previous),
+            previous_state.as_ref(),
+            incoming_state.as_ref(),
+        )?;
         return Ok(());
     }
 
@@ -156,13 +196,31 @@ pub fn append_only_save_guard(
         let incoming_prefix_revision = transcript_messages_digest(&incoming.messages()[..prev_len])
             .map_err(SessionStoreError::from)?;
         if incoming_prefix_revision == previous_revision {
+            validate_plain_save_transcript_history_preservation(
+                incoming,
+                Some(previous),
+                previous_state.as_ref(),
+                incoming_state.as_ref(),
+            )?;
             return Ok(());
         }
     }
     if incoming_preserves_conversation_tail_with_system_context_append(incoming, previous)? {
+        validate_plain_save_transcript_history_preservation(
+            incoming,
+            Some(previous),
+            previous_state.as_ref(),
+            incoming_state.as_ref(),
+        )?;
         return Ok(());
     }
     if incoming_preserves_prefix_after_transient_notice_cleanup(incoming, previous)? {
+        validate_plain_save_transcript_history_preservation(
+            incoming,
+            Some(previous),
+            previous_state.as_ref(),
+            incoming_state.as_ref(),
+        )?;
         return Ok(());
     }
     if new_len < prev_len {
@@ -181,12 +239,183 @@ pub fn append_only_save_guard(
     })
 }
 
+fn validate_plain_save_transcript_history_preservation(
+    incoming: &Session,
+    previous: Option<&Session>,
+    previous_state: Option<&TranscriptHistoryState>,
+    incoming_state: Option<&TranscriptHistoryState>,
+) -> Result<(), SessionStoreError> {
+    let Some(previous) = previous else {
+        if incoming_state.is_some() {
+            return Err(SessionStoreError::InvalidTranscriptRewrite {
+                id: incoming.id().clone(),
+                reason: "incoming first save would seed transcript history state outside the rewrite/audit path"
+                    .to_string(),
+            });
+        }
+        return Ok(());
+    };
+    if previous_state.is_none() && incoming_state.is_some() {
+        return Err(SessionStoreError::InvalidTranscriptRewrite {
+            id: incoming.id().clone(),
+            reason: "incoming append-only save would seed transcript history state outside the rewrite/audit path"
+                .to_string(),
+        });
+    }
+    let Some(previous_state) = previous_state else {
+        return Ok(());
+    };
+    let Some(incoming_state) = incoming_state else {
+        return Err(SessionStoreError::InvalidTranscriptRewrite {
+            id: incoming.id().clone(),
+            reason: "incoming append-only save would erase retained transcript history state"
+                .to_string(),
+        });
+    };
+    let previous_commits = previous_state.commits.as_slice();
+    let incoming_commits = incoming_state.commits.as_slice();
+    if incoming_commits != previous_commits {
+        return Err(SessionStoreError::InvalidTranscriptRewrite {
+            id: incoming.id().clone(),
+            reason: "incoming append-only save would change retained transcript rewrite commits"
+                .to_string(),
+        });
+    }
+    let retained_revisions_preserved =
+        transcript_revision_bodies_preserved(previous_state, incoming_state)?;
+    if retained_revisions_preserved
+        && incoming_state.revisions.len() == previous_state.revisions.len()
+        && incoming_state.head == previous_state.head
+    {
+        return Ok(());
+    }
+    if incoming_state.revisions.len() != previous_state.revisions.len() + 1
+        || !retained_revisions_preserved
+    {
+        return Err(SessionStoreError::InvalidTranscriptRewrite {
+            id: incoming.id().clone(),
+            reason: "incoming append-only save would change retained transcript revision graph"
+                .to_string(),
+        });
+    }
+    let incoming_revision =
+        transcript_messages_digest(incoming.messages()).map_err(SessionStoreError::from)?;
+    let previous_revision =
+        transcript_messages_digest(previous.messages()).map_err(SessionStoreError::from)?;
+    if previous_state.head != previous_revision {
+        return Err(SessionStoreError::InvalidTranscriptRewrite {
+            id: incoming.id().clone(),
+            reason: "previous transcript history head does not match persisted message digest"
+                .to_string(),
+        });
+    }
+    let added = &incoming_state.revisions[previous_state.revisions.len()];
+    if incoming_state.head != incoming_revision
+        || added.revision != incoming_revision
+        || added.parent_revision.as_deref() != Some(previous_state.head.as_str())
+        || transcript_messages_digest(&added.messages).map_err(SessionStoreError::from)?
+            != incoming_revision
+    {
+        return Err(SessionStoreError::InvalidTranscriptRewrite {
+            id: incoming.id().clone(),
+            reason: "incoming append-only save would add a transcript revision body that is not the current append"
+                .to_string(),
+        });
+    }
+    Ok(())
+}
+
+fn transcript_revision_bodies_preserved(
+    previous_state: &TranscriptHistoryState,
+    incoming_state: &TranscriptHistoryState,
+) -> Result<bool, SessionStoreError> {
+    if incoming_state.revisions.len() < previous_state.revisions.len() {
+        return Ok(false);
+    }
+    previous_state
+        .revisions
+        .iter()
+        .zip(incoming_state.revisions.iter())
+        .map(|(previous, incoming)| {
+            Ok(previous.revision == incoming.revision
+                && previous.parent_revision == incoming.parent_revision
+                && previous.created_at == incoming.created_at
+                && transcript_messages_digest(&previous.messages)
+                    .map_err(SessionStoreError::from)?
+                    == transcript_messages_digest(&incoming.messages)
+                        .map_err(SessionStoreError::from)?)
+        })
+        .try_fold(true, |acc, preserved| {
+            preserved.map(|preserved| acc && preserved)
+        })
+}
+
+fn validate_rewrite_save_retains_previous_commits(
+    incoming: &Session,
+    previous: &Session,
+    incoming_state: &TranscriptHistoryState,
+) -> Result<(), SessionStoreError> {
+    let previous_state = previous.transcript_history_state().map_err(|err| {
+        SessionStoreError::InvalidTranscriptRewrite {
+            id: incoming.id().clone(),
+            reason: format!("previous transcript history state is malformed: {err}"),
+        }
+    })?;
+    let Some(previous_state) = previous_state.as_ref() else {
+        return Ok(());
+    };
+    if incoming_state.commits.len() < previous_state.commits.len()
+        || incoming_state.commits[..previous_state.commits.len()] != previous_state.commits
+    {
+        return Err(SessionStoreError::InvalidTranscriptRewrite {
+            id: incoming.id().clone(),
+            reason: "incoming rewrite save would drop retained transcript rewrite commits"
+                .to_string(),
+        });
+    }
+    Ok(())
+}
+
+/// Validate that an authoritative projection write still targets the row that
+/// the caller proved continuity against.
+pub fn authoritative_projection_current_revision_guard(
+    incoming: &Session,
+    previous: Option<&Session>,
+    expected_current_revision: Option<&str>,
+) -> Result<(), SessionStoreError> {
+    let previous_token = previous.map(session_projection_cas_token).transpose()?;
+    if previous_token.as_deref() == expected_current_revision {
+        return Ok(());
+    }
+    let incoming_revision =
+        transcript_messages_digest(incoming.messages()).map_err(SessionStoreError::from)?;
+    Err(SessionStoreError::TranscriptContinuityViolation {
+        id: incoming.id().clone(),
+        previous_revision: previous_token.unwrap_or_else(|| "<missing>".to_string()),
+        incoming_revision,
+        reason: format!(
+            "authoritative projection expected persisted projection token {}, but current row has diverged",
+            expected_current_revision.unwrap_or("<missing>")
+        ),
+    })
+}
+
 fn incoming_preserves_conversation_tail_with_system_context_append(
     incoming: &Session,
     previous: &Session,
 ) -> Result<bool, SessionStoreError> {
-    let (previous_system, previous_tail) = split_single_leading_system(previous.messages());
-    let (incoming_system, incoming_tail) = split_single_leading_system(incoming.messages());
+    messages_preserve_conversation_tail_with_system_context_append(
+        incoming.messages(),
+        previous.messages(),
+    )
+}
+
+fn messages_preserve_conversation_tail_with_system_context_append(
+    incoming: &[Message],
+    previous: &[Message],
+) -> Result<bool, SessionStoreError> {
+    let (previous_system, previous_tail) = split_single_leading_system(previous);
+    let (incoming_system, incoming_tail) = split_single_leading_system(incoming);
     let Some(incoming_system) = incoming_system else {
         return Ok(false);
     };
@@ -281,8 +510,6 @@ pub fn run_boundary_snapshot_save_guard(
             let Some(previous) = previous else {
                 return Err(append_error);
             };
-            let previous_revision =
-                transcript_messages_digest(previous.messages()).map_err(SessionStoreError::from)?;
             let incoming_revision =
                 transcript_messages_digest(incoming.messages()).map_err(SessionStoreError::from)?;
             let Some(state) = incoming.transcript_history_state().map_err(|err| {
@@ -294,11 +521,13 @@ pub fn run_boundary_snapshot_save_guard(
             else {
                 return Err(append_error);
             };
-            let Some(commits) = find_transcript_rewrite_commit_chain_extending(
+            validate_rewrite_save_retains_previous_commits(incoming, previous, &state)?;
+            let commits = find_transcript_rewrite_commit_chain_extending_session(
                 &state,
-                &previous_revision,
+                previous,
                 &incoming_revision,
-            ) else {
+            )?;
+            let Some(commits) = commits else {
                 return Err(append_error);
             };
             let Some(commit) = commits.first() else {
@@ -353,6 +582,151 @@ pub fn find_transcript_rewrite_commit_chain_extending<'a>(
         cursor = &commit.revision;
         chain.push(commit);
     }
+}
+
+/// Find a rewrite chain whose first parent may be an append-only continuation
+/// of a previously persisted snapshot.
+///
+/// Runtime-backed sessions can append messages in the runtime store before a
+/// core-owned compaction rewrite is checkpointed to the compatibility
+/// `SessionStore`. In that case the first rewrite commit's parent revision is
+/// not equal to the persisted row's digest, but its retained parent body proves
+/// a normal append path from that persisted row.
+pub fn find_transcript_rewrite_commit_chain_extending_session<'a>(
+    state: &'a TranscriptHistoryState,
+    previous: &Session,
+    incoming_revision: &str,
+) -> Result<Option<Vec<&'a TranscriptRewriteCommit>>, SessionStoreError> {
+    let previous_revision =
+        transcript_messages_digest(previous.messages()).map_err(SessionStoreError::from)?;
+    let mut chain = Vec::new();
+    let mut cursor = previous_revision.as_str();
+    let mut visited = std::collections::BTreeSet::new();
+    loop {
+        if incoming_revision == cursor {
+            return Ok(Some(chain));
+        }
+        if !visited.insert(cursor.to_string()) {
+            return Ok(None);
+        }
+
+        let Some(cursor_messages) = transcript_history_messages_for_revision(
+            state,
+            cursor,
+            &previous_revision,
+            previous.messages(),
+        ) else {
+            return Ok(None);
+        };
+        let mut selected = None;
+        for commit in &state.commits {
+            if !transcript_history_revision_extends(state, incoming_revision, &commit.revision) {
+                continue;
+            }
+            let parent_extends_cursor = commit.parent_revision == cursor
+                || revision_body_preserves_append_continuation_prefix(
+                    state,
+                    &commit.parent_revision,
+                    cursor_messages,
+                    cursor,
+                )?;
+            if parent_extends_cursor {
+                selected = Some(commit);
+                break;
+            }
+        }
+
+        let Some(commit) = selected else {
+            if revision_body_preserves_append_continuation_prefix(
+                state,
+                incoming_revision,
+                cursor_messages,
+                cursor,
+            )? {
+                return Ok(Some(chain));
+            }
+            return Ok(None);
+        };
+        cursor = &commit.revision;
+        chain.push(commit);
+    }
+}
+
+fn transcript_history_messages_for_revision<'a>(
+    state: &'a TranscriptHistoryState,
+    revision: &str,
+    previous_revision: &str,
+    previous_messages: &'a [Message],
+) -> Option<&'a [Message]> {
+    if revision == previous_revision {
+        return Some(previous_messages);
+    }
+    state
+        .revisions
+        .iter()
+        .find(|body| body.revision == revision)
+        .map(|body| body.messages.as_slice())
+}
+
+fn revision_body_preserves_append_continuation_prefix(
+    state: &TranscriptHistoryState,
+    revision: &str,
+    ancestor_messages: &[Message],
+    ancestor_revision: &str,
+) -> Result<bool, SessionStoreError> {
+    if revision == ancestor_revision {
+        return Ok(true);
+    }
+    let Some(body) = state
+        .revisions
+        .iter()
+        .find(|body| body.revision == revision)
+    else {
+        return Ok(false);
+    };
+    if body.messages.len() >= ancestor_messages.len() {
+        let prefix_revision = transcript_messages_digest(&body.messages[..ancestor_messages.len()])
+            .map_err(SessionStoreError::from)?;
+        if prefix_revision == ancestor_revision {
+            return Ok(true);
+        }
+    }
+    Ok(
+        messages_preserve_conversation_tail_with_system_context_append(
+            &body.messages,
+            ancestor_messages,
+        )? || messages_preserve_tail_after_leading_system_refresh(
+            &body.messages,
+            ancestor_messages,
+        )?,
+    )
+}
+
+fn messages_preserve_tail_after_leading_system_refresh(
+    incoming: &[Message],
+    previous: &[Message],
+) -> Result<bool, SessionStoreError> {
+    let (Some(Message::System(_)), Some(Message::System(_))) = (incoming.first(), previous.first())
+    else {
+        return Ok(false);
+    };
+    if incoming.len() < previous.len() {
+        return Ok(false);
+    }
+    let previous_tail_len = previous.len().saturating_sub(1);
+    if previous_tail_len == 0 {
+        return Ok(true);
+    }
+    let previous_tail_revision =
+        transcript_messages_digest(&previous[1..]).map_err(SessionStoreError::from)?;
+    let incoming_tail = &incoming[1..];
+    if incoming_tail.len() < previous_tail_len {
+        return Ok(false);
+    }
+    let incoming_tail_prefix_revision =
+        transcript_messages_digest(&incoming_tail[..previous_tail_len])
+            .map_err(SessionStoreError::from)?;
+    Ok(incoming_tail_prefix_revision == previous_tail_revision)
 }
 
 fn transcript_history_revision_extends(
@@ -415,6 +789,12 @@ pub fn transcript_rewrite_save_guard(
     previous: Option<&Session>,
     commit: &TranscriptRewriteCommit,
 ) -> Result<(), SessionStoreError> {
+    incoming
+        .validate_transcript_history_state()
+        .map_err(|err| SessionStoreError::InvalidTranscriptRewrite {
+            id: incoming.id().clone(),
+            reason: format!("incoming transcript history state is malformed: {err}"),
+        })?;
     let Some(previous) = previous else {
         return Err(SessionStoreError::InvalidTranscriptRewrite {
             id: incoming.id().clone(),
@@ -503,6 +883,7 @@ pub fn transcript_rewrite_save_guard(
             reason: "incoming rewrite did not persist a transcript revision graph".to_string(),
         });
     };
+    validate_rewrite_save_retains_previous_commits(incoming, previous, &incoming_state)?;
     validate_transcript_rewrite_commit_bodies(incoming, commit, &incoming_state)
 }
 
@@ -786,6 +1167,20 @@ pub trait SessionStore: Send + Sync {
         self.save(session).await
     }
 
+    /// Save an authoritative projection only if the persisted row is still the
+    /// revision that the caller already validated.
+    async fn save_authoritative_projection_if_current_revision(
+        &self,
+        session: &Session,
+        expected_current_revision: Option<String>,
+    ) -> Result<(), SessionStoreError> {
+        let _ = (session, expected_current_revision);
+        Err(SessionStoreError::Internal(
+            "save_authoritative_projection_if_current_revision is not supported by this SessionStore"
+                .to_string(),
+        ))
+    }
+
     /// Load a session by ID.
     async fn load(&self, id: &SessionId) -> Result<Option<Session>, SessionStoreError>;
 
@@ -794,6 +1189,14 @@ pub trait SessionStore: Send + Sync {
 
     /// Delete a session.
     async fn delete(&self, id: &SessionId) -> Result<(), SessionStoreError>;
+
+    /// Delete a compatibility projection only if it is still the revision that
+    /// the caller already validated as unsafe to expose.
+    async fn delete_if_current_revision(
+        &self,
+        id: &SessionId,
+        expected_current_revision: &str,
+    ) -> Result<bool, SessionStoreError>;
 
     /// Check if a session exists.
     async fn exists(&self, id: &SessionId) -> Result<bool, SessionStoreError> {
@@ -860,7 +1263,671 @@ mod tests {
     }
 
     #[test]
-    fn append_only_guard_accepts_transient_mcp_pending_notice_cleanup()
+    fn run_boundary_guard_accepts_compaction_after_uncheckpointed_runtime_append()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let mut previous = Session::new();
+        previous.push(Message::System(SystemMessage::new("base system")));
+        previous.push(Message::User(UserMessage::text("turn one".to_string())));
+        previous.push(Message::Assistant(AssistantMessage {
+            content: "answer one".to_string(),
+            tool_calls: Vec::new(),
+            stop_reason: StopReason::EndTurn,
+            usage: Usage::default(),
+            created_at: crate::types::message_timestamp_now(),
+        }));
+
+        let mut parent = previous.clone();
+        parent.set_system_prompt("refreshed runtime system projection".to_string());
+        parent.push(Message::User(UserMessage::text(
+            "runtime-only turn".to_string(),
+        )));
+        parent.push(Message::Assistant(AssistantMessage {
+            content: "runtime-only answer".to_string(),
+            tool_calls: Vec::new(),
+            stop_reason: StopReason::EndTurn,
+            usage: Usage::default(),
+            created_at: crate::types::message_timestamp_now(),
+        }));
+        let parent_revision = parent.transcript_revision()?;
+
+        let mut incoming = parent.clone();
+        let mut replacement = vec![
+            parent.messages()[0].clone(),
+            Message::User(UserMessage::text("[Context compacted] summary".to_string())),
+        ];
+        replacement.extend_from_slice(&parent.messages()[1..]);
+        incoming.commit_transcript_rewrite(
+            TranscriptRewriteSelection::MessageRange {
+                start: 0,
+                end: parent.messages().len(),
+            },
+            replacement,
+            crate::TranscriptRewriteReason::new("compaction"),
+            Some("meerkat-core".to_string()),
+            Some(parent_revision),
+        )?;
+
+        assert!(matches!(
+            append_only_save_guard(&incoming, Some(&previous)),
+            Err(SessionStoreError::TranscriptContinuityViolation { .. })
+        ));
+        assert!(run_boundary_snapshot_save_guard(&incoming, Some(&previous)).is_ok());
+        Ok(())
+    }
+
+    #[test]
+    fn run_boundary_guard_accepts_compaction_with_retained_tail_window()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let mut previous = Session::new();
+        previous.push(Message::System(SystemMessage::new("base system")));
+        previous.push(Message::User(UserMessage::text("turn one".to_string())));
+        previous.push(Message::BlockAssistant(BlockAssistantMessage::new(
+            vec![crate::types::AssistantBlock::Text {
+                text: "answer one".to_string(),
+                meta: None,
+            }],
+            StopReason::EndTurn,
+        )));
+
+        let mut parent = previous.clone();
+        parent.set_system_prompt("refreshed runtime system projection".to_string());
+        parent.push(Message::SystemNotice(SystemNoticeMessage::new(
+            SystemNoticeKind::Comms,
+            "peer response queued",
+        )));
+        let parent_revision = parent.transcript_revision()?;
+
+        let mut incoming = parent.clone();
+        let mut replacement = vec![
+            parent.messages()[0].clone(),
+            Message::User(UserMessage::text("[Context compacted] summary".to_string())),
+        ];
+        replacement.extend_from_slice(&parent.messages()[1..]);
+        incoming.commit_transcript_rewrite(
+            TranscriptRewriteSelection::MessageRange {
+                start: 0,
+                end: parent.messages().len(),
+            },
+            replacement,
+            crate::TranscriptRewriteReason::new("compaction"),
+            Some("meerkat-core".to_string()),
+            Some(parent_revision),
+        )?;
+
+        assert!(matches!(
+            append_only_save_guard(&incoming, Some(&previous)),
+            Err(SessionStoreError::TranscriptContinuityViolation { .. })
+        ));
+        assert!(run_boundary_snapshot_save_guard(&incoming, Some(&previous)).is_ok());
+        Ok(())
+    }
+
+    #[test]
+    fn run_boundary_guard_rejects_commitless_history_parent_edge()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let mut previous = Session::new();
+        previous.push(Message::System(SystemMessage::new("base system")));
+        previous.push(Message::User(UserMessage::text("turn one".to_string())));
+        let previous_revision = previous.transcript_revision()?;
+
+        let mut incoming = previous.clone();
+        incoming.set_system_prompt("forged replacement system".to_string());
+        let incoming_revision = incoming.transcript_revision()?;
+        let history = TranscriptHistoryState {
+            head: incoming_revision.clone(),
+            commits: Vec::new(),
+            revisions: vec![
+                crate::TranscriptRevisionBody {
+                    revision: previous_revision,
+                    parent_revision: None,
+                    messages: previous.messages().to_vec(),
+                    created_at: previous.updated_at(),
+                },
+                crate::TranscriptRevisionBody {
+                    revision: incoming_revision,
+                    parent_revision: Some(previous.transcript_revision()?),
+                    messages: incoming.messages().to_vec(),
+                    created_at: incoming.updated_at(),
+                },
+            ],
+        };
+        incoming.set_metadata(
+            crate::session::SESSION_TRANSCRIPT_HISTORY_STATE_KEY,
+            serde_json::to_value(history)?,
+        );
+
+        assert!(matches!(
+            append_only_save_guard(&incoming, Some(&previous)),
+            Err(SessionStoreError::TranscriptContinuityViolation { .. })
+        ));
+        assert!(matches!(
+            run_boundary_snapshot_save_guard(&incoming, Some(&previous)),
+            Err(SessionStoreError::TranscriptContinuityViolation { .. }
+                | SessionStoreError::MonotonicityViolation { .. })
+        ));
+        Ok(())
+    }
+
+    #[test]
+    fn append_only_guard_rejects_history_head_that_does_not_match_current_messages()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let mut previous = Session::new();
+        previous.push(Message::User(UserMessage::text("persisted".to_string())));
+
+        let mut incoming = previous.clone();
+        incoming.push(Message::User(UserMessage::text("append".to_string())));
+        let poisoned_messages = vec![Message::User(UserMessage::text(
+            "unrelated poisoned history".to_string(),
+        ))];
+        let poisoned_revision = transcript_messages_digest(&poisoned_messages)?;
+        incoming.set_metadata(
+            crate::session::SESSION_TRANSCRIPT_HISTORY_STATE_KEY,
+            serde_json::to_value(TranscriptHistoryState {
+                head: poisoned_revision.clone(),
+                commits: Vec::new(),
+                revisions: vec![crate::TranscriptRevisionBody {
+                    revision: poisoned_revision,
+                    parent_revision: None,
+                    messages: poisoned_messages,
+                    created_at: incoming.updated_at(),
+                }],
+            })?,
+        );
+
+        assert!(matches!(
+            append_only_save_guard(&incoming, Some(&previous)),
+            Err(SessionStoreError::InvalidTranscriptRewrite { .. })
+        ));
+        assert!(matches!(
+            append_only_save_guard(&incoming, None),
+            Err(SessionStoreError::InvalidTranscriptRewrite { .. })
+        ));
+        assert!(matches!(
+            run_boundary_snapshot_save_guard(&incoming, Some(&previous)),
+            Err(SessionStoreError::InvalidTranscriptRewrite { .. })
+        ));
+        Ok(())
+    }
+
+    #[test]
+    fn append_only_guard_rejects_new_rewrite_commits_on_plain_append()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let mut previous = Session::new();
+        previous.push(Message::User(UserMessage::text("persisted".to_string())));
+        let previous_revision = previous.transcript_revision()?;
+
+        let mut incoming = previous.clone();
+        let appended = Message::Assistant(AssistantMessage {
+            content: "plain append".to_string(),
+            tool_calls: Vec::new(),
+            stop_reason: StopReason::EndTurn,
+            usage: Usage::default(),
+            created_at: crate::types::message_timestamp_now(),
+        });
+        incoming.commit_transcript_rewrite(
+            TranscriptRewriteSelection::MessageRange { start: 1, end: 1 },
+            vec![appended],
+            crate::TranscriptRewriteReason::new("forged-append"),
+            Some("unit-test".to_string()),
+            Some(previous_revision),
+        )?;
+
+        assert!(matches!(
+            append_only_save_guard(&incoming, Some(&previous)),
+            Err(SessionStoreError::InvalidTranscriptRewrite { .. })
+        ));
+        Ok(())
+    }
+
+    #[test]
+    fn append_only_guard_rejects_first_save_with_rewrite_commits()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let mut incoming = Session::new();
+        incoming.push(Message::User(UserMessage::text("seed".to_string())));
+        let parent_messages = incoming.messages().to_vec();
+        let parent_updated_at = incoming.updated_at();
+        let parent_revision = incoming.transcript_revision()?;
+        let commit = incoming.commit_transcript_rewrite(
+            TranscriptRewriteSelection::MessageRange { start: 0, end: 1 },
+            vec![Message::User(UserMessage::text(
+                "compacted seed".to_string(),
+            ))],
+            crate::TranscriptRewriteReason::new("compaction"),
+            Some("meerkat-core".to_string()),
+            Some(parent_revision),
+        )?;
+        let incoming_revision = incoming.transcript_revision()?;
+        let commit_parent_revision = commit.parent_revision.clone();
+        incoming.set_metadata(
+            crate::session::SESSION_TRANSCRIPT_HISTORY_STATE_KEY,
+            serde_json::to_value(TranscriptHistoryState {
+                head: incoming_revision.clone(),
+                commits: vec![commit],
+                revisions: vec![
+                    crate::TranscriptRevisionBody {
+                        revision: commit_parent_revision.clone(),
+                        parent_revision: None,
+                        messages: parent_messages,
+                        created_at: parent_updated_at,
+                    },
+                    crate::TranscriptRevisionBody {
+                        revision: incoming_revision,
+                        parent_revision: Some(commit_parent_revision),
+                        messages: incoming.messages().to_vec(),
+                        created_at: incoming.updated_at(),
+                    },
+                ],
+            })?,
+        );
+
+        assert!(matches!(
+            append_only_save_guard(&incoming, None),
+            Err(SessionStoreError::InvalidTranscriptRewrite { .. })
+        ));
+        Ok(())
+    }
+
+    #[test]
+    fn transcript_rewrite_guard_rejects_poisoned_history_graph()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let mut previous = Session::new();
+        previous.push(Message::User(UserMessage::text("persisted".to_string())));
+        let parent_revision = previous.transcript_revision()?;
+
+        let mut first = previous.clone();
+        let first_commit = first.commit_transcript_rewrite(
+            TranscriptRewriteSelection::MessageRange { start: 0, end: 1 },
+            vec![Message::User(UserMessage::text(
+                "compacted persisted".to_string(),
+            ))],
+            crate::TranscriptRewriteReason::new("compaction"),
+            Some("unit-test".to_string()),
+            Some(parent_revision),
+        )?;
+        let first_snapshot = first.clone();
+
+        first.commit_transcript_rewrite(
+            TranscriptRewriteSelection::MessageRange { start: 0, end: 1 },
+            vec![Message::User(UserMessage::text(
+                "uncommitted poisoned fork".to_string(),
+            ))],
+            crate::TranscriptRewriteReason::new("poison"),
+            Some("unit-test".to_string()),
+            Some(first_commit.revision.clone()),
+        )?;
+        let mut poisoned_state = first
+            .transcript_history_state()?
+            .ok_or_else(|| "second rewrite should retain history state".to_string())?;
+        poisoned_state.head = first_commit.revision.clone();
+
+        let mut poisoned = first_snapshot;
+        poisoned.set_metadata(
+            crate::session::SESSION_TRANSCRIPT_HISTORY_STATE_KEY,
+            serde_json::to_value(poisoned_state)?,
+        );
+
+        assert!(matches!(
+            transcript_rewrite_save_guard(&poisoned, Some(&previous), &first_commit),
+            Err(SessionStoreError::InvalidTranscriptRewrite { reason, .. })
+                if reason.contains("incoming transcript history state is malformed")
+        ));
+        Ok(())
+    }
+
+    #[test]
+    fn authoritative_projection_guard_rejects_changed_persisted_revision()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let mut previous = Session::new();
+        previous.push(Message::User(UserMessage::text("persisted A".to_string())));
+        let expected_revision = previous.transcript_revision()?;
+
+        let mut current = previous.clone();
+        current.push(Message::Assistant(AssistantMessage {
+            content: "persisted B".to_string(),
+            tool_calls: Vec::new(),
+            stop_reason: StopReason::EndTurn,
+            usage: Usage::default(),
+            created_at: crate::types::message_timestamp_now(),
+        }));
+        let mut incoming = previous.clone();
+        incoming.push(Message::User(UserMessage::text(
+            "incoming from A".to_string(),
+        )));
+
+        assert!(matches!(
+            authoritative_projection_current_revision_guard(
+                &incoming,
+                Some(&current),
+                Some(&expected_revision)
+            ),
+            Err(SessionStoreError::TranscriptContinuityViolation { .. })
+        ));
+        Ok(())
+    }
+
+    #[test]
+    fn append_only_guard_rejects_rewrite_commits_on_first_save()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let mut incoming = Session::new();
+        incoming.push(Message::User(UserMessage::text("persisted".to_string())));
+        let parent_revision = incoming.transcript_revision()?;
+        incoming.commit_transcript_rewrite(
+            TranscriptRewriteSelection::MessageRange { start: 0, end: 1 },
+            vec![Message::User(UserMessage::text("rewritten".to_string()))],
+            crate::TranscriptRewriteReason::new("forged-first-save"),
+            Some("unit-test".to_string()),
+            Some(parent_revision),
+        )?;
+
+        assert!(matches!(
+            append_only_save_guard(&incoming, None),
+            Err(SessionStoreError::InvalidTranscriptRewrite { .. })
+        ));
+        Ok(())
+    }
+
+    #[test]
+    fn append_only_guard_rejects_commitless_history_on_first_save()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let mut incoming = Session::new();
+        incoming.push(Message::User(UserMessage::text("persisted".to_string())));
+        let incoming_revision = incoming.transcript_revision()?;
+        incoming.set_metadata(
+            crate::session::SESSION_TRANSCRIPT_HISTORY_STATE_KEY,
+            serde_json::to_value(TranscriptHistoryState {
+                head: incoming_revision.clone(),
+                commits: Vec::new(),
+                revisions: vec![crate::TranscriptRevisionBody {
+                    revision: incoming_revision,
+                    parent_revision: None,
+                    messages: incoming.messages().to_vec(),
+                    created_at: incoming.updated_at(),
+                }],
+            })?,
+        );
+
+        assert!(matches!(
+            append_only_save_guard(&incoming, None),
+            Err(SessionStoreError::InvalidTranscriptRewrite { reason, .. })
+                if reason.contains("first save would seed transcript history state")
+        ));
+        Ok(())
+    }
+
+    #[test]
+    fn append_only_guard_rejects_commitless_history_seed_on_plain_append()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let mut previous = Session::new();
+        previous.push(Message::User(UserMessage::text("persisted".to_string())));
+        let previous_revision = previous.transcript_revision()?;
+
+        let mut incoming = previous.clone();
+        incoming.push(Message::Assistant(AssistantMessage {
+            content: "plain append".to_string(),
+            tool_calls: Vec::new(),
+            stop_reason: StopReason::EndTurn,
+            usage: Usage::default(),
+            created_at: crate::types::message_timestamp_now(),
+        }));
+        let incoming_revision = incoming.transcript_revision()?;
+        incoming.set_metadata(
+            crate::session::SESSION_TRANSCRIPT_HISTORY_STATE_KEY,
+            serde_json::to_value(TranscriptHistoryState {
+                head: incoming_revision.clone(),
+                commits: Vec::new(),
+                revisions: vec![
+                    crate::TranscriptRevisionBody {
+                        revision: previous_revision,
+                        parent_revision: None,
+                        messages: previous.messages().to_vec(),
+                        created_at: previous.updated_at(),
+                    },
+                    crate::TranscriptRevisionBody {
+                        revision: incoming_revision,
+                        parent_revision: Some(previous.transcript_revision()?),
+                        messages: incoming.messages().to_vec(),
+                        created_at: incoming.updated_at(),
+                    },
+                ],
+            })?,
+        );
+
+        assert!(matches!(
+            append_only_save_guard(&incoming, Some(&previous)),
+            Err(SessionStoreError::InvalidTranscriptRewrite { reason, .. })
+                if reason.contains("append-only save would seed transcript history state")
+        ));
+        Ok(())
+    }
+
+    #[test]
+    fn append_only_guard_rejects_new_rewrite_commits_on_system_context_append()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let mut previous = Session::new();
+        previous.push(Message::System(SystemMessage::new("base system")));
+        previous.push(Message::User(UserMessage::text("persisted".to_string())));
+        let mut incoming = previous.clone();
+        incoming.set_system_prompt(format!(
+            "base system{SYSTEM_CONTEXT_SEPARATOR}[Runtime System Context]\nsource: unit-test\n\nextra context"
+        ));
+        incoming.push(Message::Assistant(AssistantMessage {
+            content: "plain append".to_string(),
+            tool_calls: Vec::new(),
+            stop_reason: StopReason::EndTurn,
+            usage: Usage::default(),
+            created_at: crate::types::message_timestamp_now(),
+        }));
+        let incoming_revision = incoming.transcript_revision()?;
+        incoming.set_metadata(
+            crate::session::SESSION_TRANSCRIPT_HISTORY_STATE_KEY,
+            serde_json::to_value(TranscriptHistoryState {
+                head: incoming_revision.clone(),
+                commits: vec![TranscriptRewriteCommit {
+                    parent_revision: previous.transcript_revision()?,
+                    revision: incoming_revision.clone(),
+                    selection: TranscriptRewriteSelection::MessageRange { start: 0, end: 0 },
+                    original_span_digest: transcript_messages_digest(&[])?,
+                    replacement_digest: transcript_messages_digest(&[])?,
+                    messages_before: previous.messages().len(),
+                    messages_after: incoming.messages().len(),
+                    reason: crate::TranscriptRewriteReason::new("forged"),
+                    actor: Some("unit-test".to_string()),
+                    committed_at: incoming.updated_at(),
+                }],
+                revisions: vec![crate::TranscriptRevisionBody {
+                    revision: incoming_revision,
+                    parent_revision: None,
+                    messages: incoming.messages().to_vec(),
+                    created_at: incoming.updated_at(),
+                }],
+            })?,
+        );
+
+        assert!(matches!(
+            append_only_save_guard(&incoming, Some(&previous)),
+            Err(SessionStoreError::InvalidTranscriptRewrite { .. })
+        ));
+        Ok(())
+    }
+
+    #[test]
+    fn append_only_guard_rejects_new_rewrite_commits_on_transient_notice_cleanup()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let mut previous = Session::new();
+        previous.push(Message::SystemNotice(SystemNoticeMessage::new(
+            SystemNoticeKind::Comms,
+            "transient peer delivery notice",
+        )));
+        previous.push(Message::User(UserMessage::text("persisted".to_string())));
+
+        let mut incoming = Session::new();
+        incoming.push(Message::User(UserMessage::text("persisted".to_string())));
+        incoming.push(Message::Assistant(AssistantMessage {
+            content: "plain append after notice cleanup".to_string(),
+            tool_calls: Vec::new(),
+            stop_reason: StopReason::EndTurn,
+            usage: Usage::default(),
+            created_at: crate::types::message_timestamp_now(),
+        }));
+        let incoming_revision = incoming.transcript_revision()?;
+        incoming.set_metadata(
+            crate::session::SESSION_TRANSCRIPT_HISTORY_STATE_KEY,
+            serde_json::to_value(TranscriptHistoryState {
+                head: incoming_revision.clone(),
+                commits: vec![TranscriptRewriteCommit {
+                    parent_revision: previous.transcript_revision()?,
+                    revision: incoming_revision.clone(),
+                    selection: TranscriptRewriteSelection::MessageRange { start: 0, end: 0 },
+                    original_span_digest: transcript_messages_digest(&[])?,
+                    replacement_digest: transcript_messages_digest(&[])?,
+                    messages_before: previous.messages().len(),
+                    messages_after: incoming.messages().len(),
+                    reason: crate::TranscriptRewriteReason::new("forged"),
+                    actor: Some("unit-test".to_string()),
+                    committed_at: incoming.updated_at(),
+                }],
+                revisions: vec![crate::TranscriptRevisionBody {
+                    revision: incoming_revision,
+                    parent_revision: None,
+                    messages: incoming.messages().to_vec(),
+                    created_at: incoming.updated_at(),
+                }],
+            })?,
+        );
+
+        assert!(matches!(
+            append_only_save_guard(&incoming, Some(&previous)),
+            Err(SessionStoreError::InvalidTranscriptRewrite { .. })
+        ));
+        Ok(())
+    }
+
+    #[test]
+    fn run_boundary_guard_rejects_runtime_parent_with_inserted_message_before_tail()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let mut previous = Session::new();
+        previous.push(Message::System(SystemMessage::new("base system")));
+        previous.push(Message::User(UserMessage::text("turn one".to_string())));
+        previous.push(Message::Assistant(AssistantMessage {
+            content: "answer one".to_string(),
+            tool_calls: Vec::new(),
+            stop_reason: StopReason::EndTurn,
+            usage: Usage::default(),
+            created_at: crate::types::message_timestamp_now(),
+        }));
+
+        let parent_messages = vec![
+            Message::System(SystemMessage::new("refreshed runtime system projection")),
+            Message::User(UserMessage::text(
+                "injected before retained tail".to_string(),
+            )),
+            previous.messages()[1].clone(),
+            previous.messages()[2].clone(),
+        ];
+        let parent_revision = transcript_messages_digest(&parent_messages)?;
+        let mut parent = previous.clone();
+        parent.apply_transcript_history_state(TranscriptHistoryState {
+            head: parent_revision.clone(),
+            commits: Vec::new(),
+            revisions: vec![crate::TranscriptRevisionBody {
+                revision: parent_revision,
+                parent_revision: None,
+                messages: parent_messages,
+                created_at: parent.updated_at(),
+            }],
+        })?;
+        let parent_revision = parent.transcript_revision()?;
+
+        let mut incoming = parent.clone();
+        incoming.commit_transcript_rewrite(
+            TranscriptRewriteSelection::MessageRange {
+                start: 0,
+                end: parent.messages().len(),
+            },
+            vec![Message::User(UserMessage::text(
+                "[Context compacted] summary".to_string(),
+            ))],
+            crate::TranscriptRewriteReason::new("compaction"),
+            Some("meerkat-core".to_string()),
+            Some(parent_revision),
+        )?;
+
+        assert!(matches!(
+            run_boundary_snapshot_save_guard(&incoming, Some(&previous)),
+            Err(SessionStoreError::TranscriptContinuityViolation { .. }
+                | SessionStoreError::MonotonicityViolation { .. })
+        ));
+        Ok(())
+    }
+
+    #[test]
+    fn run_boundary_guard_rejects_forged_parent_edge_before_real_rewrite_commit()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let mut previous = Session::new();
+        previous.push(Message::System(SystemMessage::new("base system")));
+        previous.push(Message::User(UserMessage::text("turn one".to_string())));
+        previous.push(Message::Assistant(AssistantMessage {
+            content: "answer one".to_string(),
+            tool_calls: Vec::new(),
+            stop_reason: StopReason::EndTurn,
+            usage: Usage::default(),
+            created_at: crate::types::message_timestamp_now(),
+        }));
+        let previous_revision = previous.transcript_revision()?;
+
+        let forged_parent_messages = vec![
+            Message::System(SystemMessage::new("refreshed runtime system projection")),
+            Message::User(UserMessage::text(
+                "forged insertion before retained tail".to_string(),
+            )),
+            previous.messages()[1].clone(),
+            previous.messages()[2].clone(),
+        ];
+        let forged_parent_revision = transcript_messages_digest(&forged_parent_messages)?;
+        let mut forged_parent = previous.clone();
+        forged_parent.apply_transcript_history_state(TranscriptHistoryState {
+            head: forged_parent_revision.clone(),
+            commits: Vec::new(),
+            revisions: vec![
+                crate::TranscriptRevisionBody {
+                    revision: previous_revision.clone(),
+                    parent_revision: None,
+                    messages: previous.messages().to_vec(),
+                    created_at: previous.updated_at(),
+                },
+                crate::TranscriptRevisionBody {
+                    revision: forged_parent_revision.clone(),
+                    parent_revision: Some(previous_revision),
+                    messages: forged_parent_messages,
+                    created_at: forged_parent.updated_at(),
+                },
+            ],
+        })?;
+
+        let mut incoming = forged_parent.clone();
+        incoming.commit_transcript_rewrite(
+            TranscriptRewriteSelection::MessageRange {
+                start: 0,
+                end: forged_parent.messages().len(),
+            },
+            vec![Message::User(UserMessage::text(
+                "[Context compacted] forged branch".to_string(),
+            ))],
+            crate::TranscriptRewriteReason::new("compaction"),
+            Some("meerkat-core".to_string()),
+            Some(forged_parent_revision),
+        )?;
+
+        assert!(matches!(
+            run_boundary_snapshot_save_guard(&incoming, Some(&previous)),
+            Err(SessionStoreError::TranscriptContinuityViolation { .. }
+                | SessionStoreError::MonotonicityViolation { .. })
+        ));
+        Ok(())
+    }
+
+    #[test]
+    fn append_only_guard_rejects_transient_mcp_pending_notice_cleanup_with_unaudited_commit()
     -> Result<(), crate::TranscriptEditError> {
         let mut previous = Session::new();
         previous.push(Message::User(UserMessage::text("hello".to_string())));
@@ -897,7 +1964,10 @@ mod tests {
         )?;
         incoming.push(Message::User(UserMessage::text("again".to_string())));
 
-        assert!(append_only_save_guard(&incoming, Some(&previous)).is_ok());
+        assert!(matches!(
+            append_only_save_guard(&incoming, Some(&previous)),
+            Err(SessionStoreError::InvalidTranscriptRewrite { .. })
+        ));
         Ok::<(), crate::TranscriptEditError>(())
     }
 
@@ -967,6 +2037,67 @@ mod tests {
         assert_eq!(chain.len(), 2);
         assert_eq!(chain[0].revision, first.revision);
         assert_eq!(chain[1].revision, second.revision);
+        Ok(())
+    }
+
+    #[test]
+    fn run_boundary_guard_rejects_dropped_retained_rewrite_commits()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let mut base = Session::new();
+        base.push(Message::User(UserMessage::text("turn one".to_string())));
+        base.push(Message::Assistant(AssistantMessage {
+            content: "verbose answer".to_string(),
+            tool_calls: Vec::new(),
+            stop_reason: StopReason::EndTurn,
+            usage: Usage::default(),
+            created_at: crate::types::message_timestamp_now(),
+        }));
+        let base_revision = base.transcript_revision()?;
+
+        let mut previous = base.clone();
+        let _retained_commit = previous.commit_transcript_rewrite(
+            TranscriptRewriteSelection::MessageRange { start: 1, end: 2 },
+            vec![Message::Assistant(AssistantMessage {
+                content: "first compact answer".to_string(),
+                tool_calls: Vec::new(),
+                stop_reason: StopReason::EndTurn,
+                usage: Usage::default(),
+                created_at: crate::types::message_timestamp_now(),
+            })],
+            crate::TranscriptRewriteReason::new("compaction"),
+            Some("unit-test".to_string()),
+            Some(base_revision),
+        )?;
+        let previous_revision = previous.transcript_revision()?;
+
+        let mut incoming = previous.clone();
+        let new_commit = incoming.commit_transcript_rewrite(
+            TranscriptRewriteSelection::MessageRange { start: 1, end: 2 },
+            vec![Message::Assistant(AssistantMessage {
+                content: "second compact answer".to_string(),
+                tool_calls: Vec::new(),
+                stop_reason: StopReason::EndTurn,
+                usage: Usage::default(),
+                created_at: crate::types::message_timestamp_now(),
+            })],
+            crate::TranscriptRewriteReason::new("compaction"),
+            Some("unit-test".to_string()),
+            Some(previous_revision),
+        )?;
+        let mut state = incoming
+            .transcript_history_state()?
+            .ok_or_else(|| std::io::Error::other("incoming rewrite should retain history"))?;
+        state.commits = vec![new_commit];
+        incoming.set_metadata(
+            crate::session::SESSION_TRANSCRIPT_HISTORY_STATE_KEY,
+            serde_json::to_value(state)?,
+        );
+
+        assert!(matches!(
+            run_boundary_snapshot_save_guard(&incoming, Some(&previous)),
+            Err(SessionStoreError::InvalidTranscriptRewrite { reason, .. })
+                if reason.contains("drop retained transcript rewrite commits")
+        ));
         Ok(())
     }
 }

--- a/meerkat-mob/tests/smoke_mob_flow_runtime.rs
+++ b/meerkat-mob/tests/smoke_mob_flow_runtime.rs
@@ -96,6 +96,21 @@ fn gemini_api_key() -> Option<String> {
     first_env(&["RKAT_GEMINI_API_KEY", "GEMINI_API_KEY", "GOOGLE_API_KEY"])
 }
 
+fn default_gemini_flow_smoke_model() -> &'static str {
+    meerkat_core::model_profile::catalog::default_model("gemini")
+        .expect("Gemini must have a catalog default model")
+}
+
+#[test]
+fn flow_runtime_smoke_gemini_default_tracks_catalog() {
+    assert_eq!(
+        default_gemini_flow_smoke_model(),
+        meerkat_core::model_profile::catalog::default_model("gemini")
+            .expect("Gemini must have a catalog default model")
+    );
+    assert_eq!(default_gemini_flow_smoke_model(), "gemini-3.5-flash");
+}
+
 #[derive(Clone, Debug)]
 struct FlowSmokeModels {
     lead: String,
@@ -141,7 +156,7 @@ fn flow_smoke_models() -> Option<FlowSmokeModels> {
             lead: "claude-haiku-4-5-20251001".to_string(),
             worker: "claude-haiku-4-5-20251001".to_string(),
             reviewer: "claude-haiku-4-5-20251001".to_string(),
-            analyst: "gemini-3.1-flash-lite-preview".to_string(),
+            analyst: default_gemini_flow_smoke_model().to_string(),
         }),
         (true, false) => Some(FlowSmokeModels {
             lead: "claude-haiku-4-5-20251001".to_string(),
@@ -150,10 +165,10 @@ fn flow_smoke_models() -> Option<FlowSmokeModels> {
             analyst: "claude-haiku-4-5-20251001".to_string(),
         }),
         (false, true) => Some(FlowSmokeModels {
-            lead: "gemini-3.1-flash-lite-preview".to_string(),
-            worker: "gemini-3.1-flash-lite-preview".to_string(),
-            reviewer: "gemini-3.1-flash-lite-preview".to_string(),
-            analyst: "gemini-3.1-flash-lite-preview".to_string(),
+            lead: default_gemini_flow_smoke_model().to_string(),
+            worker: default_gemini_flow_smoke_model().to_string(),
+            reviewer: default_gemini_flow_smoke_model().to_string(),
+            analyst: default_gemini_flow_smoke_model().to_string(),
         }),
         (false, false) => None,
     }

--- a/meerkat-rpc/src/session_runtime.rs
+++ b/meerkat-rpc/src/session_runtime.rs
@@ -8475,6 +8475,34 @@ mod tests {
             self.inner.load_session_snapshot(runtime_id).await
         }
 
+        async fn clear_session_snapshot(
+            &self,
+            runtime_id: &meerkat_runtime::identifiers::LogicalRuntimeId,
+        ) -> Result<(), meerkat_runtime::RuntimeStoreError> {
+            self.inner.clear_session_snapshot(runtime_id).await
+        }
+
+        async fn replace_session_snapshot_if_current(
+            &self,
+            runtime_id: &meerkat_runtime::identifiers::LogicalRuntimeId,
+            expected_current: &[u8],
+            replacement: Vec<u8>,
+        ) -> Result<bool, meerkat_runtime::RuntimeStoreError> {
+            self.inner
+                .replace_session_snapshot_if_current(runtime_id, expected_current, replacement)
+                .await
+        }
+
+        async fn clear_session_snapshot_if_current(
+            &self,
+            runtime_id: &meerkat_runtime::identifiers::LogicalRuntimeId,
+            expected_current: &[u8],
+        ) -> Result<bool, meerkat_runtime::RuntimeStoreError> {
+            self.inner
+                .clear_session_snapshot_if_current(runtime_id, expected_current)
+                .await
+        }
+
         async fn persist_input_state(
             &self,
             runtime_id: &meerkat_runtime::identifiers::LogicalRuntimeId,
@@ -11555,6 +11583,16 @@ mod tests {
 
         async fn delete(&self, id: &SessionId) -> Result<(), meerkat_store::SessionStoreError> {
             self.inner.delete(id).await
+        }
+
+        async fn delete_if_current_revision(
+            &self,
+            id: &SessionId,
+            expected_current_revision: &str,
+        ) -> Result<bool, meerkat_store::SessionStoreError> {
+            self.inner
+                .delete_if_current_revision(id, expected_current_revision)
+                .await
         }
     }
 

--- a/meerkat-runtime/src/handles/oauth_flow.rs
+++ b/meerkat-runtime/src/handles/oauth_flow.rs
@@ -1851,6 +1851,36 @@ mod tests {
             ))
         }
 
+        async fn clear_session_snapshot(
+            &self,
+            _runtime_id: &LogicalRuntimeId,
+        ) -> Result<(), RuntimeStoreError> {
+            Err(RuntimeStoreError::Unsupported(
+                "clear_session_snapshot".to_string(),
+            ))
+        }
+
+        async fn replace_session_snapshot_if_current(
+            &self,
+            _runtime_id: &LogicalRuntimeId,
+            _expected_current: &[u8],
+            _replacement: Vec<u8>,
+        ) -> Result<bool, RuntimeStoreError> {
+            Err(RuntimeStoreError::Unsupported(
+                "replace_session_snapshot_if_current".to_string(),
+            ))
+        }
+
+        async fn clear_session_snapshot_if_current(
+            &self,
+            _runtime_id: &LogicalRuntimeId,
+            _expected_current: &[u8],
+        ) -> Result<bool, RuntimeStoreError> {
+            Err(RuntimeStoreError::Unsupported(
+                "clear_session_snapshot_if_current".to_string(),
+            ))
+        }
+
         async fn persist_input_state(
             &self,
             _runtime_id: &LogicalRuntimeId,

--- a/meerkat-runtime/src/meerkat_machine_tests.rs
+++ b/meerkat-runtime/src/meerkat_machine_tests.rs
@@ -3457,6 +3457,34 @@ async fn persistent_destroy_durable_commit_observes_canonical_destroy_truth() {
             self.inner.load_session_snapshot(runtime_id).await
         }
 
+        async fn clear_session_snapshot(
+            &self,
+            runtime_id: &LogicalRuntimeId,
+        ) -> Result<(), crate::store::RuntimeStoreError> {
+            self.inner.clear_session_snapshot(runtime_id).await
+        }
+
+        async fn replace_session_snapshot_if_current(
+            &self,
+            runtime_id: &LogicalRuntimeId,
+            expected_current: &[u8],
+            replacement: Vec<u8>,
+        ) -> Result<bool, crate::store::RuntimeStoreError> {
+            self.inner
+                .replace_session_snapshot_if_current(runtime_id, expected_current, replacement)
+                .await
+        }
+
+        async fn clear_session_snapshot_if_current(
+            &self,
+            runtime_id: &LogicalRuntimeId,
+            expected_current: &[u8],
+        ) -> Result<bool, crate::store::RuntimeStoreError> {
+            self.inner
+                .clear_session_snapshot_if_current(runtime_id, expected_current)
+                .await
+        }
+
         async fn persist_input_state(
             &self,
             runtime_id: &LogicalRuntimeId,
@@ -14793,6 +14821,34 @@ impl RuntimeStore for RuntimeCommitAtomicityStore {
         runtime_id: &LogicalRuntimeId,
     ) -> Result<Option<Vec<u8>>, crate::store::RuntimeStoreError> {
         self.inner.load_session_snapshot(runtime_id).await
+    }
+
+    async fn clear_session_snapshot(
+        &self,
+        runtime_id: &LogicalRuntimeId,
+    ) -> Result<(), crate::store::RuntimeStoreError> {
+        self.inner.clear_session_snapshot(runtime_id).await
+    }
+
+    async fn replace_session_snapshot_if_current(
+        &self,
+        runtime_id: &LogicalRuntimeId,
+        expected_current: &[u8],
+        replacement: Vec<u8>,
+    ) -> Result<bool, crate::store::RuntimeStoreError> {
+        self.inner
+            .replace_session_snapshot_if_current(runtime_id, expected_current, replacement)
+            .await
+    }
+
+    async fn clear_session_snapshot_if_current(
+        &self,
+        runtime_id: &LogicalRuntimeId,
+        expected_current: &[u8],
+    ) -> Result<bool, crate::store::RuntimeStoreError> {
+        self.inner
+            .clear_session_snapshot_if_current(runtime_id, expected_current)
+            .await
     }
 
     async fn persist_input_state(

--- a/meerkat-runtime/src/store/memory.rs
+++ b/meerkat-runtime/src/store/memory.rs
@@ -253,6 +253,50 @@ impl RuntimeStore for InMemoryRuntimeStore {
         Ok(inner.sessions.get(&runtime_id.0).cloned())
     }
 
+    async fn clear_session_snapshot(
+        &self,
+        runtime_id: &LogicalRuntimeId,
+    ) -> Result<(), RuntimeStoreError> {
+        let mut inner = self.inner.lock().await;
+        inner.sessions.remove(&runtime_id.0);
+        Ok(())
+    }
+
+    async fn replace_session_snapshot_if_current(
+        &self,
+        runtime_id: &LogicalRuntimeId,
+        expected_current: &[u8],
+        replacement: Vec<u8>,
+    ) -> Result<bool, RuntimeStoreError> {
+        let _: meerkat_core::Session = serde_json::from_slice(&replacement)
+            .map_err(|err| RuntimeStoreError::WriteFailed(err.to_string()))?;
+        let mut inner = self.inner.lock().await;
+        let Some(current) = inner.sessions.get_mut(&runtime_id.0) else {
+            return Ok(false);
+        };
+        if current.as_slice() != expected_current {
+            return Ok(false);
+        }
+        *current = replacement;
+        Ok(true)
+    }
+
+    async fn clear_session_snapshot_if_current(
+        &self,
+        runtime_id: &LogicalRuntimeId,
+        expected_current: &[u8],
+    ) -> Result<bool, RuntimeStoreError> {
+        let mut inner = self.inner.lock().await;
+        let Some(current) = inner.sessions.get(&runtime_id.0) else {
+            return Ok(false);
+        };
+        if current.as_slice() != expected_current {
+            return Ok(false);
+        }
+        inner.sessions.remove(&runtime_id.0);
+        Ok(true)
+    }
+
     async fn persist_input_state(
         &self,
         runtime_id: &LogicalRuntimeId,

--- a/meerkat-runtime/src/store/mod.rs
+++ b/meerkat-runtime/src/store/mod.rs
@@ -193,6 +193,39 @@ pub trait RuntimeStore: Send + Sync {
         runtime_id: &LogicalRuntimeId,
     ) -> Result<Option<Vec<u8>>, RuntimeStoreError>;
 
+    /// Remove the latest committed session snapshot for a runtime.
+    ///
+    /// This is used only as a fail-closed quarantine path after a compatibility
+    /// projection write rejects a runtime snapshot that was already staged as
+    /// runtime authority and the service cannot restore the previous snapshot.
+    async fn clear_session_snapshot(
+        &self,
+        runtime_id: &LogicalRuntimeId,
+    ) -> Result<(), RuntimeStoreError>;
+
+    /// Replace the latest committed session snapshot only if it still matches
+    /// `expected_current`.
+    ///
+    /// Used by fail-closed recovery after a compatibility projection rejected
+    /// a runtime snapshot. Implementations must compare and write atomically so
+    /// recovery cannot overwrite a newer runtime-authoritative snapshot.
+    async fn replace_session_snapshot_if_current(
+        &self,
+        runtime_id: &LogicalRuntimeId,
+        expected_current: &[u8],
+        replacement: Vec<u8>,
+    ) -> Result<bool, RuntimeStoreError>;
+
+    /// Remove the latest committed session snapshot only if it still matches
+    /// `expected_current`.
+    ///
+    /// This is the conditional variant of the fail-closed quarantine path.
+    async fn clear_session_snapshot_if_current(
+        &self,
+        runtime_id: &LogicalRuntimeId,
+        expected_current: &[u8],
+    ) -> Result<bool, RuntimeStoreError>;
+
     /// Persist a single input state (for durable-before-ack).
     async fn persist_input_state(
         &self,

--- a/meerkat-runtime/src/store/sqlite.rs
+++ b/meerkat-runtime/src/store/sqlite.rs
@@ -5,9 +5,7 @@ mod inner {
     use std::path::{Path, PathBuf};
 
     use meerkat_core::lifecycle::{InputId, RunBoundaryReceipt, RunId};
-    use meerkat_store::sqlite_store::{
-        begin_immediate_transaction, open_connection, write_session_snapshot_in_txn,
-    };
+    use meerkat_store::sqlite_store::{begin_immediate_transaction, open_connection};
     use rusqlite::{Connection, OptionalExtension, Transaction, params};
 
     use crate::identifiers::LogicalRuntimeId;
@@ -259,14 +257,11 @@ CREATE TABLE IF NOT EXISTS runtime_auth_oauth_flow_state (
             let path = self.path.clone();
             let runtime_id = runtime_id.clone();
             tokio::task::spawn_blocking(move || {
-                let session = serde_json::from_slice::<meerkat_core::Session>(
-                    &session_delta.session_snapshot,
-                )
-                .map_err(|err| RuntimeStoreError::WriteFailed(err.to_string()))?;
+                let _: meerkat_core::Session =
+                    serde_json::from_slice(&session_delta.session_snapshot)
+                        .map_err(|err| RuntimeStoreError::WriteFailed(err.to_string()))?;
                 let mut conn = open_runtime_connection(&path)?;
                 let tx = begin_runtime_transaction(&mut conn)?;
-                write_session_snapshot_in_txn(&tx, &session)
-                    .map_err(|err| RuntimeStoreError::WriteFailed(err.to_string()))?;
                 upsert_runtime_snapshot(&tx, &runtime_id, &session_delta.session_snapshot)?;
                 tx.commit()
                     .map_err(|err| RuntimeStoreError::WriteFailed(err.to_string()))?;
@@ -316,8 +311,6 @@ CREATE TABLE IF NOT EXISTS runtime_auth_oauth_flow_state (
                     } => RuntimeStoreError::TranscriptRevisionConflict { expected, actual },
                     other => RuntimeStoreError::WriteFailed(other.to_string()),
                 })?;
-                write_session_snapshot_in_txn(&tx, &incoming)
-                    .map_err(|err| RuntimeStoreError::WriteFailed(err.to_string()))?;
                 upsert_runtime_snapshot(&tx, &runtime_id, &session_delta.session_snapshot)?;
                 tx.commit()
                     .map_err(|err| RuntimeStoreError::WriteFailed(err.to_string()))?;
@@ -375,8 +368,6 @@ CREATE TABLE IF NOT EXISTS runtime_auth_oauth_flow_state (
                         previous.as_ref(),
                     )
                     .map_err(|err| RuntimeStoreError::WriteFailed(err.to_string()))?;
-                    write_session_snapshot_in_txn(&tx, session)
-                        .map_err(|err| RuntimeStoreError::WriteFailed(err.to_string()))?;
                     if let Some(delta) = session_delta.as_ref() {
                         upsert_runtime_snapshot(&tx, &runtime_id, &delta.session_snapshot)?;
                     }
@@ -478,6 +469,97 @@ CREATE TABLE IF NOT EXISTS runtime_auth_oauth_flow_state (
                 )
                 .optional()
                 .map_err(|err| RuntimeStoreError::ReadFailed(err.to_string()))
+            })
+            .await
+            .map_err(|err| RuntimeStoreError::Internal(format!("Task join failed: {err}")))?
+        }
+
+        async fn clear_session_snapshot(
+            &self,
+            runtime_id: &LogicalRuntimeId,
+        ) -> Result<(), RuntimeStoreError> {
+            let path = self.path.clone();
+            let runtime_id = runtime_id.clone();
+            tokio::task::spawn_blocking(move || {
+                let mut conn = open_runtime_connection(&path)?;
+                let tx = begin_runtime_transaction(&mut conn)?;
+                tx.execute(
+                    "DELETE FROM runtime_session_snapshots WHERE runtime_id = ?1",
+                    params![runtime_id_text(&runtime_id)],
+                )
+                .map_err(|err| RuntimeStoreError::WriteFailed(err.to_string()))?;
+                tx.commit()
+                    .map_err(|err| RuntimeStoreError::WriteFailed(err.to_string()))?;
+                Ok(())
+            })
+            .await
+            .map_err(|err| RuntimeStoreError::Internal(format!("Task join failed: {err}")))?
+        }
+
+        async fn replace_session_snapshot_if_current(
+            &self,
+            runtime_id: &LogicalRuntimeId,
+            expected_current: &[u8],
+            replacement: Vec<u8>,
+        ) -> Result<bool, RuntimeStoreError> {
+            let _: meerkat_core::Session = serde_json::from_slice(&replacement)
+                .map_err(|err| RuntimeStoreError::WriteFailed(err.to_string()))?;
+            let path = self.path.clone();
+            let runtime_id = runtime_id.clone();
+            let expected_current = expected_current.to_vec();
+            tokio::task::spawn_blocking(move || {
+                let mut conn = open_runtime_connection(&path)?;
+                let tx = begin_runtime_transaction(&mut conn)?;
+                let current = tx
+                    .query_row(
+                        "SELECT session_snapshot FROM runtime_session_snapshots WHERE runtime_id = ?1",
+                        params![runtime_id_text(&runtime_id)],
+                        |row| row.get::<_, Vec<u8>>(0),
+                    )
+                    .optional()
+                    .map_err(|err| RuntimeStoreError::ReadFailed(err.to_string()))?;
+                if current.as_deref() != Some(expected_current.as_slice()) {
+                    return Ok(false);
+                }
+                upsert_runtime_snapshot(&tx, &runtime_id, &replacement)?;
+                tx.commit()
+                    .map_err(|err| RuntimeStoreError::WriteFailed(err.to_string()))?;
+                Ok(true)
+            })
+            .await
+            .map_err(|err| RuntimeStoreError::Internal(format!("Task join failed: {err}")))?
+        }
+
+        async fn clear_session_snapshot_if_current(
+            &self,
+            runtime_id: &LogicalRuntimeId,
+            expected_current: &[u8],
+        ) -> Result<bool, RuntimeStoreError> {
+            let path = self.path.clone();
+            let runtime_id = runtime_id.clone();
+            let expected_current = expected_current.to_vec();
+            tokio::task::spawn_blocking(move || {
+                let mut conn = open_runtime_connection(&path)?;
+                let tx = begin_runtime_transaction(&mut conn)?;
+                let current = tx
+                    .query_row(
+                        "SELECT session_snapshot FROM runtime_session_snapshots WHERE runtime_id = ?1",
+                        params![runtime_id_text(&runtime_id)],
+                        |row| row.get::<_, Vec<u8>>(0),
+                    )
+                    .optional()
+                    .map_err(|err| RuntimeStoreError::ReadFailed(err.to_string()))?;
+                if current.as_deref() != Some(expected_current.as_slice()) {
+                    return Ok(false);
+                }
+                tx.execute(
+                    "DELETE FROM runtime_session_snapshots WHERE runtime_id = ?1",
+                    params![runtime_id_text(&runtime_id)],
+                )
+                .map_err(|err| RuntimeStoreError::WriteFailed(err.to_string()))?;
+                tx.commit()
+                    .map_err(|err| RuntimeStoreError::WriteFailed(err.to_string()))?;
+                Ok(true)
             })
             .await
             .map_err(|err| RuntimeStoreError::Internal(format!("Task join failed: {err}")))?
@@ -648,8 +730,10 @@ CREATE TABLE IF NOT EXISTS runtime_auth_oauth_flow_state (
         use crate::input_state::StoredInputState;
         use meerkat_core::lifecycle::run_primitive::RunApplyBoundary;
         use meerkat_core::lifecycle::{InputId, RunBoundaryReceipt, RunId};
+        use meerkat_core::session_store::SessionStore as _;
         use meerkat_core::types::{AssistantMessage, Message, StopReason, UserMessage};
         use meerkat_core::{Session, TranscriptRewriteReason, TranscriptRewriteSelection};
+        use meerkat_store::SqliteSessionStore;
 
         fn temp_store() -> (TempDir, SqliteRuntimeStore) {
             let dir = TempDir::new().unwrap();
@@ -757,6 +841,39 @@ CREATE TABLE IF NOT EXISTS runtime_auth_oauth_flow_state (
                     .await
                     .unwrap()
                     .is_empty()
+            );
+        }
+
+        #[tokio::test]
+        async fn commit_session_snapshot_does_not_write_session_projection_row() {
+            let dir = TempDir::new().unwrap();
+            let path = dir.path().join("sessions.sqlite3");
+            let store = SqliteRuntimeStore::new(path.clone()).unwrap();
+            let runtime_id = runtime_id();
+            let session = meerkat_core::Session::new();
+            let session_id = session.id().clone();
+
+            store
+                .commit_session_snapshot(
+                    &runtime_id,
+                    SessionDelta {
+                        session_snapshot: serde_json::to_vec(&session).unwrap(),
+                    },
+                )
+                .await
+                .unwrap();
+
+            let session_store = SqliteSessionStore::open(path).unwrap();
+            assert!(
+                session_store.load(&session_id).await.unwrap().is_none(),
+                "runtime snapshot commits must not contaminate the SessionStore projection row before checkpoint continuity validation"
+            );
+            assert!(
+                store
+                    .load_session_snapshot(&runtime_id)
+                    .await
+                    .unwrap()
+                    .is_some()
             );
         }
 

--- a/meerkat-runtime/tests/driver_persistent.rs
+++ b/meerkat-runtime/tests/driver_persistent.rs
@@ -230,6 +230,34 @@ impl RuntimeStore for FailPersistInputStore {
         self.inner.load_session_snapshot(runtime_id).await
     }
 
+    async fn clear_session_snapshot(
+        &self,
+        runtime_id: &LogicalRuntimeId,
+    ) -> Result<(), RuntimeStoreError> {
+        self.inner.clear_session_snapshot(runtime_id).await
+    }
+
+    async fn replace_session_snapshot_if_current(
+        &self,
+        runtime_id: &LogicalRuntimeId,
+        expected_current: &[u8],
+        replacement: Vec<u8>,
+    ) -> Result<bool, RuntimeStoreError> {
+        self.inner
+            .replace_session_snapshot_if_current(runtime_id, expected_current, replacement)
+            .await
+    }
+
+    async fn clear_session_snapshot_if_current(
+        &self,
+        runtime_id: &LogicalRuntimeId,
+        expected_current: &[u8],
+    ) -> Result<bool, RuntimeStoreError> {
+        self.inner
+            .clear_session_snapshot_if_current(runtime_id, expected_current)
+            .await
+    }
+
     async fn persist_input_state(
         &self,
         runtime_id: &LogicalRuntimeId,

--- a/meerkat-runtime/tests/meerkat_machine.rs
+++ b/meerkat-runtime/tests/meerkat_machine.rs
@@ -285,6 +285,34 @@ impl RuntimeStore for HarnessRuntimeStore {
         self.inner.load_session_snapshot(runtime_id).await
     }
 
+    async fn clear_session_snapshot(
+        &self,
+        runtime_id: &meerkat_runtime::identifiers::LogicalRuntimeId,
+    ) -> Result<(), RuntimeStoreError> {
+        self.inner.clear_session_snapshot(runtime_id).await
+    }
+
+    async fn replace_session_snapshot_if_current(
+        &self,
+        runtime_id: &meerkat_runtime::identifiers::LogicalRuntimeId,
+        expected_current: &[u8],
+        replacement: Vec<u8>,
+    ) -> Result<bool, RuntimeStoreError> {
+        self.inner
+            .replace_session_snapshot_if_current(runtime_id, expected_current, replacement)
+            .await
+    }
+
+    async fn clear_session_snapshot_if_current(
+        &self,
+        runtime_id: &meerkat_runtime::identifiers::LogicalRuntimeId,
+        expected_current: &[u8],
+    ) -> Result<bool, RuntimeStoreError> {
+        self.inner
+            .clear_session_snapshot_if_current(runtime_id, expected_current)
+            .await
+    }
+
     async fn persist_input_state(
         &self,
         runtime_id: &meerkat_runtime::identifiers::LogicalRuntimeId,

--- a/meerkat-runtime/tests/ops_lifecycle_persistence.rs
+++ b/meerkat-runtime/tests/ops_lifecycle_persistence.rs
@@ -481,6 +481,34 @@ impl RuntimeStore for FailingOpsLifecycleStore {
         self.inner.load_session_snapshot(runtime_id).await
     }
 
+    async fn clear_session_snapshot(
+        &self,
+        runtime_id: &meerkat_runtime::identifiers::LogicalRuntimeId,
+    ) -> Result<(), meerkat_runtime::RuntimeStoreError> {
+        self.inner.clear_session_snapshot(runtime_id).await
+    }
+
+    async fn replace_session_snapshot_if_current(
+        &self,
+        runtime_id: &meerkat_runtime::identifiers::LogicalRuntimeId,
+        expected_current: &[u8],
+        replacement: Vec<u8>,
+    ) -> Result<bool, meerkat_runtime::RuntimeStoreError> {
+        self.inner
+            .replace_session_snapshot_if_current(runtime_id, expected_current, replacement)
+            .await
+    }
+
+    async fn clear_session_snapshot_if_current(
+        &self,
+        runtime_id: &meerkat_runtime::identifiers::LogicalRuntimeId,
+        expected_current: &[u8],
+    ) -> Result<bool, meerkat_runtime::RuntimeStoreError> {
+        self.inner
+            .clear_session_snapshot_if_current(runtime_id, expected_current)
+            .await
+    }
+
     async fn persist_input_state(
         &self,
         runtime_id: &meerkat_runtime::identifiers::LogicalRuntimeId,

--- a/meerkat-session/src/persistent.rs
+++ b/meerkat-session/src/persistent.rs
@@ -237,6 +237,10 @@ fn control_error_into_session_error(err: SessionControlError) -> SessionError {
     }
 }
 
+fn runtime_backed_store_projection_can_recover_authority(session: &Session) -> bool {
+    session.session_metadata().is_some() || session.build_state().is_some()
+}
+
 fn is_durable_session_sync_unsupported(err: &SessionError) -> bool {
     matches!(
         err,
@@ -380,9 +384,6 @@ async fn find_transcript_rewrite_commit_chain_extending_session_with_storage_nor
     }
 
     for commit in state.commits.iter().rev() {
-        if !transcript_state_revision_extends(state, incoming_revision, &commit.revision) {
-            continue;
-        }
         let Some(commits) =
             meerkat_core::session_store::find_transcript_rewrite_commit_chain_extending_session(
                 state,
@@ -402,6 +403,19 @@ async fn find_transcript_rewrite_commit_chain_extending_session_with_storage_nor
         else {
             continue;
         };
+        let incoming_extends_commit =
+            transcript_state_revision_extends(state, incoming_revision, &commit.revision)
+                || transcript_revision_preserves_storage_normalized_append_prefix(
+                    blob_store,
+                    state,
+                    incoming_revision,
+                    incoming_messages,
+                    &revision_body.messages,
+                )
+                .await?;
+        if !incoming_extends_commit {
+            continue;
+        }
         if transcript_revision_preserves_storage_normalized_append_prefix(
             blob_store,
             state,
@@ -427,15 +441,19 @@ async fn transcript_revision_preserves_storage_normalized_append_prefix(
 ) -> Result<bool, SessionStoreError> {
     let mut revision_messages = if revision == state.head {
         current_messages.to_vec()
-    } else {
-        let Some(body) = state
-            .revisions
-            .iter()
-            .find(|body| body.revision == revision)
-        else {
-            return Ok(false);
-        };
+    } else if let Some(body) = state
+        .revisions
+        .iter()
+        .find(|body| body.revision == revision)
+    {
         body.messages.clone()
+    } else if meerkat_core::transcript_messages_digest(current_messages)
+        .map_err(SessionStoreError::from)?
+        == revision
+    {
+        current_messages.to_vec()
+    } else {
+        return Ok(false);
     };
     let mut normalized_ancestor = ancestor_messages.to_vec();
     externalize_messages_from(blob_store, &mut normalized_ancestor, 0)
@@ -850,7 +868,10 @@ async fn save_session_projection_with_storage_normalization_bridge(
 ) -> Result<(), SessionStoreError> {
     match store.save(session).await {
         Ok(()) => Ok(()),
-        Err(error @ SessionStoreError::TranscriptContinuityViolation { .. }) => {
+        Err(
+            error @ (SessionStoreError::TranscriptContinuityViolation { .. }
+            | SessionStoreError::InvalidTranscriptRewrite { .. }),
+        ) => {
             let Some(previous) = store.load(session.id()).await? else {
                 return Err(error);
             };
@@ -873,6 +894,7 @@ async fn save_session_projection_with_storage_normalization_bridge(
             if normalized_revision == previous_revision {
                 if save_verified_transcript_history_projection(
                     store,
+                    blob_store,
                     session,
                     &normalized_previous,
                     previous_projection_token.clone(),
@@ -895,6 +917,7 @@ async fn save_session_projection_with_storage_normalization_bridge(
                 );
                 if save_verified_transcript_history_projection(
                     store,
+                    blob_store,
                     session,
                     &normalized_previous,
                     previous_projection_token.clone(),
@@ -919,6 +942,7 @@ async fn save_session_projection_with_storage_normalization_bridge(
 
 async fn save_verified_transcript_history_projection(
     store: &dyn SessionStore,
+    blob_store: &dyn BlobStore,
     session: &Session,
     previous: &Session,
     expected_current_revision: String,
@@ -957,6 +981,14 @@ async fn save_verified_transcript_history_projection(
     }
     if let Err(error) =
         meerkat_core::session_store::run_boundary_snapshot_save_guard(session, Some(previous))
+        && !transcript_revision_preserves_storage_normalized_append_prefix(
+            blob_store,
+            &state,
+            &incoming_revision,
+            session.messages(),
+            previous.messages(),
+        )
+        .await?
     {
         tracing::debug!(
             session_id = %session.id(),
@@ -1154,6 +1186,9 @@ pub struct PersistentSessionService<B: SessionAgentBuilder> {
     /// stored-only session is rebuilt at most once and archived snapshots
     /// cannot become writable again through rehydration races.
     recovery_gates: Mutex<HashMap<SessionId, Arc<Mutex<()>>>>,
+    /// Runtime snapshots quarantined after rejecting a checkpoint may fall back
+    /// to the latest store projection for recovery in this service process.
+    quarantined_runtime_projection_fallbacks: Mutex<HashSet<SessionId>>,
 }
 
 /// Extract session labels from a metadata map.
@@ -1515,11 +1550,22 @@ impl<B: SessionAgentBuilder + 'static> PersistentSessionService<B> {
         let session = if let Some(runtime_store) = self.runtime_store.as_ref() {
             match Self::load_runtime_session_snapshot_for_session(runtime_store, id).await? {
                 Some(session) => Some(session),
-                None => self
-                    .store
-                    .load(id)
-                    .await
-                    .map_err(|e| SessionError::Store(Box::new(e)))?,
+                None => {
+                    let store_projection = self
+                        .store
+                        .load(id)
+                        .await
+                        .map_err(|e| SessionError::Store(Box::new(e)))?;
+                    match store_projection {
+                        Some(session)
+                            if runtime_backed_store_projection_can_recover_authority(&session)
+                                || self.runtime_projection_fallback_quarantined(id).await =>
+                        {
+                            Some(session)
+                        }
+                        _ => None,
+                    }
+                }
             }
         } else {
             self.store
@@ -2737,10 +2783,14 @@ impl<B: SessionAgentBuilder + 'static> PersistentSessionService<B> {
             if commits.last().map(|commit| commit.revision.as_str())
                 != Some(incoming_revision.as_str())
             {
-                self.store
-                    .save(&session)
-                    .await
-                    .map_err(|err| SessionError::Store(Box::new(err)))?;
+                save_session_projection_after_verified_rewrite_chain(
+                    self.store.as_ref(),
+                    self.blob_store.as_ref(),
+                    &session,
+                    &incoming_revision,
+                )
+                .await
+                .map_err(|err| SessionError::Store(Box::new(err)))?;
             }
         }
         if converge_live {
@@ -3007,6 +3057,7 @@ impl<B: SessionAgentBuilder + 'static> PersistentSessionService<B> {
             projector: None,
             checkpointer_gates: Mutex::new(HashMap::new()),
             recovery_gates: Mutex::new(HashMap::new()),
+            quarantined_runtime_projection_fallbacks: Mutex::new(HashSet::new()),
         }
     }
 
@@ -3880,34 +3931,13 @@ impl<B: SessionAgentBuilder + 'static> PersistentSessionService<B> {
         &self,
         id: &SessionId,
         error: SessionStoreError,
-        rejected_snapshot: Option<&[u8]>,
+        _rejected_snapshot: Option<&[u8]>,
     ) -> SessionError {
         tracing::error!(
             session_id = %id,
             error = %error,
             "session-store projection update failed after runtime authority commit; failing closed"
         );
-        let restore_error = match rejected_snapshot {
-            Some(rejected_snapshot) => self
-                .restore_runtime_snapshot_from_session_store_if_current(id, rejected_snapshot)
-                .await
-                .err(),
-            None => self
-                .restore_runtime_snapshot_from_session_store(id)
-                .await
-                .err(),
-        };
-        let quarantine_error = if restore_error.is_some() {
-            match rejected_snapshot {
-                Some(rejected_snapshot) => self
-                    .quarantine_runtime_session_snapshot_if_current(id, rejected_snapshot)
-                    .await
-                    .err(),
-                None => self.quarantine_runtime_session_snapshot(id).await.err(),
-            }
-        } else {
-            None
-        };
         match self.discard_live_session(id).await {
             Ok(()) | Err(SessionError::NotFound { .. }) => {}
             Err(discard_error) => {
@@ -3917,18 +3947,6 @@ impl<B: SessionAgentBuilder + 'static> PersistentSessionService<B> {
                     "failed to discard live session after runtime-backed projection update failure"
                 );
             }
-        }
-        if let Some(restore_error) = restore_error {
-            if let Some(quarantine_error) = quarantine_error {
-                return SessionError::Agent(meerkat_core::error::AgentError::InternalError(
-                    format!(
-                        "session-store projection update failed ({error}); runtime snapshot restore failed: {restore_error}; runtime snapshot quarantine also failed: {quarantine_error}"
-                    ),
-                ));
-            }
-            return SessionError::Agent(meerkat_core::error::AgentError::InternalError(format!(
-                "session-store projection update failed ({error}); runtime snapshot restore failed and runtime snapshot was quarantined: {restore_error}"
-            )));
         }
         SessionError::Store(Box::new(error))
     }
@@ -3966,23 +3984,6 @@ impl<B: SessionAgentBuilder + 'static> PersistentSessionService<B> {
         SessionError::Store(Box::new(error))
     }
 
-    async fn quarantine_runtime_session_snapshot(
-        &self,
-        id: &SessionId,
-    ) -> Result<(), SessionError> {
-        let Some(runtime_store) = self.runtime_store.as_ref() else {
-            return Ok(());
-        };
-        runtime_store
-            .clear_session_snapshot(&Self::runtime_id_for_session(id))
-            .await
-            .map_err(|error| {
-                SessionError::Agent(meerkat_core::error::AgentError::InternalError(format!(
-                    "failed to quarantine rejected runtime session snapshot: {error}"
-                )))
-            })
-    }
-
     async fn quarantine_runtime_session_snapshot_if_current(
         &self,
         id: &SessionId,
@@ -3999,7 +4000,12 @@ impl<B: SessionAgentBuilder + 'static> PersistentSessionService<B> {
                     "failed to quarantine rejected runtime session snapshot: {error}"
                 )))
             })?;
-        if !cleared {
+        if cleared {
+            self.quarantined_runtime_projection_fallbacks
+                .lock()
+                .await
+                .insert(id.clone());
+        } else {
             tracing::warn!(
                 session_id = %id,
                 "runtime snapshot changed before fail-closed quarantine; leaving newer runtime authority intact"
@@ -4008,137 +4014,11 @@ impl<B: SessionAgentBuilder + 'static> PersistentSessionService<B> {
         Ok(())
     }
 
-    async fn restore_runtime_snapshot_from_session_store(
-        &self,
-        id: &SessionId,
-    ) -> Result<(), SessionError> {
-        let Some(runtime_store) = self.runtime_store.as_ref() else {
-            return Ok(());
-        };
-        let session = match self.store.load(id).await {
-            Ok(Some(session)) => session,
-            Ok(None) => {
-                tracing::warn!(
-                    session_id = %id,
-                    "cannot restore runtime snapshot after projection failure because SessionStore row is missing"
-                );
-                return Err(SessionError::Agent(
-                    meerkat_core::error::AgentError::InternalError(format!(
-                        "cannot restore runtime snapshot after projection failure because SessionStore row {id} is missing"
-                    )),
-                ));
-            }
-            Err(error) => {
-                tracing::error!(
-                    session_id = %id,
-                    error = %error,
-                    "failed to load SessionStore row for runtime snapshot restore"
-                );
-                return Err(SessionError::Store(Box::new(error)));
-            }
-        };
-        let session_snapshot = match serde_json::to_vec(&session) {
-            Ok(session_snapshot) => session_snapshot,
-            Err(error) => {
-                tracing::error!(
-                    session_id = %id,
-                    error = %error,
-                    "failed to serialize SessionStore row for runtime snapshot restore"
-                );
-                return Err(SessionError::Agent(
-                    meerkat_core::error::AgentError::InternalError(format!(
-                        "failed to serialize SessionStore row for runtime snapshot restore: {error}"
-                    )),
-                ));
-            }
-        };
-        runtime_store
-            .commit_session_snapshot(
-                &Self::runtime_id_for_session(id),
-                SessionDelta { session_snapshot },
-            )
+    async fn runtime_projection_fallback_quarantined(&self, id: &SessionId) -> bool {
+        self.quarantined_runtime_projection_fallbacks
+            .lock()
             .await
-            .map_err(|error| {
-                tracing::error!(
-                    session_id = %id,
-                    error = %error,
-                    "failed to restore runtime snapshot from SessionStore row after projection failure"
-                );
-                SessionError::Agent(meerkat_core::error::AgentError::InternalError(format!(
-                    "failed to restore runtime snapshot from SessionStore row after projection failure: {error}"
-                )))
-            })
-    }
-
-    async fn restore_runtime_snapshot_from_session_store_if_current(
-        &self,
-        id: &SessionId,
-        rejected_snapshot: &[u8],
-    ) -> Result<(), SessionError> {
-        let Some(runtime_store) = self.runtime_store.as_ref() else {
-            return Ok(());
-        };
-        let session = match self.store.load(id).await {
-            Ok(Some(session)) => session,
-            Ok(None) => {
-                tracing::warn!(
-                    session_id = %id,
-                    "cannot restore runtime snapshot after projection failure because SessionStore row is missing"
-                );
-                return Err(SessionError::Agent(
-                    meerkat_core::error::AgentError::InternalError(format!(
-                        "cannot restore runtime snapshot after projection failure because SessionStore row {id} is missing"
-                    )),
-                ));
-            }
-            Err(error) => {
-                tracing::error!(
-                    session_id = %id,
-                    error = %error,
-                    "failed to load SessionStore row for runtime snapshot restore"
-                );
-                return Err(SessionError::Store(Box::new(error)));
-            }
-        };
-        let replacement = match serde_json::to_vec(&session) {
-            Ok(session_snapshot) => session_snapshot,
-            Err(error) => {
-                tracing::error!(
-                    session_id = %id,
-                    error = %error,
-                    "failed to serialize SessionStore row for runtime snapshot restore"
-                );
-                return Err(SessionError::Agent(
-                    meerkat_core::error::AgentError::InternalError(format!(
-                        "failed to serialize SessionStore row for runtime snapshot restore: {error}"
-                    )),
-                ));
-            }
-        };
-        let restored = runtime_store
-            .replace_session_snapshot_if_current(
-                &Self::runtime_id_for_session(id),
-                rejected_snapshot,
-                replacement,
-            )
-            .await
-            .map_err(|error| {
-                tracing::error!(
-                    session_id = %id,
-                    error = %error,
-                    "failed to conditionally restore runtime snapshot from SessionStore row after projection failure"
-                );
-                SessionError::Agent(meerkat_core::error::AgentError::InternalError(format!(
-                    "failed to conditionally restore runtime snapshot from SessionStore row after projection failure: {error}"
-                )))
-            })?;
-        if !restored {
-            tracing::warn!(
-                session_id = %id,
-                "runtime snapshot changed before fail-closed restore; leaving newer runtime authority intact"
-            );
-        }
-        Ok(())
+            .contains(id)
     }
 
     async fn fail_closed_runtime_projection_preflight(
@@ -9306,6 +9186,7 @@ mod tests {
 
         let saved = save_verified_transcript_history_projection(
             store.as_ref(),
+            memory_blob_store().as_ref(),
             &incoming,
             &previous,
             previous_revision.clone(),
@@ -13365,7 +13246,7 @@ mod tests {
 
         let recovery_store: Arc<dyn SessionStore> = Arc::new(MemoryStore::new());
         recovery_store
-            .save(&stale_partial_graph)
+            .save_authoritative_projection_if_current_revision(&stale_partial_graph, None)
             .await
             .expect("seed stale partial graph projection");
         let recovery_dir = tempfile::tempdir().expect("recovery tempdir");
@@ -13630,7 +13511,7 @@ mod tests {
 
         let recovery_store: Arc<dyn SessionStore> = Arc::new(MemoryStore::new());
         recovery_store
-            .save(&stale_projection)
+            .save_authoritative_projection_if_current_revision(&stale_projection, None)
             .await
             .expect("seed stale projection before second rewrite");
         let recovery_dir = tempfile::tempdir().expect("recovery tempdir");

--- a/meerkat-session/src/persistent.rs
+++ b/meerkat-session/src/persistent.rs
@@ -341,6 +341,17 @@ fn session_materialized_at_transcript_revision(
         .revisions
         .retain(|body| retained_revisions.contains(&body.revision));
     let mut materialized = session.clone();
+    if state.commits.is_empty() {
+        materialized
+            .apply_transcript_history_state(state)
+            .map_err(|err| {
+                SessionError::Agent(meerkat_core::error::AgentError::InternalError(format!(
+                    "failed to materialize transcript revision {revision}: {err}"
+                )))
+            })?;
+        materialized.remove_metadata(meerkat_core::session::SESSION_TRANSCRIPT_HISTORY_STATE_KEY);
+        return Ok(materialized);
+    }
     materialized
         .apply_transcript_history_state(state)
         .map_err(|err| {
@@ -349,6 +360,107 @@ fn session_materialized_at_transcript_revision(
             )))
         })?;
     Ok(materialized)
+}
+
+async fn find_transcript_rewrite_commit_chain_extending_session_with_storage_normalization<'a>(
+    blob_store: &dyn BlobStore,
+    state: &'a meerkat_core::TranscriptHistoryState,
+    previous: &Session,
+    incoming_revision: &str,
+    incoming_messages: &[meerkat_core::Message],
+) -> Result<Option<Vec<&'a meerkat_core::TranscriptRewriteCommit>>, SessionStoreError> {
+    if let Some(commits) =
+        meerkat_core::session_store::find_transcript_rewrite_commit_chain_extending_session(
+            state,
+            previous,
+            incoming_revision,
+        )?
+    {
+        return Ok(Some(commits));
+    }
+
+    for commit in state.commits.iter().rev() {
+        if !transcript_state_revision_extends(state, incoming_revision, &commit.revision) {
+            continue;
+        }
+        let Some(commits) =
+            meerkat_core::session_store::find_transcript_rewrite_commit_chain_extending_session(
+                state,
+                previous,
+                &commit.revision,
+            )?
+        else {
+            continue;
+        };
+        if commits.is_empty() {
+            continue;
+        }
+        let Some(revision_body) = state
+            .revisions
+            .iter()
+            .find(|body| body.revision == commit.revision)
+        else {
+            continue;
+        };
+        if transcript_revision_preserves_storage_normalized_append_prefix(
+            blob_store,
+            state,
+            incoming_revision,
+            incoming_messages,
+            &revision_body.messages,
+        )
+        .await?
+        {
+            return Ok(Some(commits));
+        }
+    }
+
+    Ok(None)
+}
+
+async fn transcript_revision_preserves_storage_normalized_append_prefix(
+    blob_store: &dyn BlobStore,
+    state: &meerkat_core::TranscriptHistoryState,
+    revision: &str,
+    current_messages: &[meerkat_core::Message],
+    ancestor_messages: &[meerkat_core::Message],
+) -> Result<bool, SessionStoreError> {
+    let mut revision_messages = if revision == state.head {
+        current_messages.to_vec()
+    } else {
+        let Some(body) = state
+            .revisions
+            .iter()
+            .find(|body| body.revision == revision)
+        else {
+            return Ok(false);
+        };
+        body.messages.clone()
+    };
+    let mut normalized_ancestor = ancestor_messages.to_vec();
+    externalize_messages_from(blob_store, &mut normalized_ancestor, 0)
+        .await
+        .map_err(|err| {
+            SessionStoreError::Internal(format!(
+                "failed to normalize ancestor transcript revision body for rewrite chain discovery: {err}"
+            ))
+        })?;
+    externalize_messages_from(blob_store, &mut revision_messages, 0)
+        .await
+        .map_err(|err| {
+            SessionStoreError::Internal(format!(
+                "failed to normalize incoming transcript revision body for rewrite chain discovery: {err}"
+            ))
+        })?;
+    if revision_messages.len() < normalized_ancestor.len() {
+        return Ok(false);
+    }
+    let ancestor_revision = meerkat_core::transcript_messages_digest(&normalized_ancestor)
+        .map_err(SessionStoreError::from)?;
+    let prefix_revision =
+        meerkat_core::transcript_messages_digest(&revision_messages[..normalized_ancestor.len()])
+            .map_err(SessionStoreError::from)?;
+    Ok(prefix_revision == ancestor_revision)
 }
 
 fn transcript_state_revision_extends(
@@ -469,6 +581,7 @@ async fn append_transcript_rewrite_commit_events(
 
 async fn save_session_projection_allowing_internal_rewrite(
     store: &dyn SessionStore,
+    blob_store: &dyn BlobStore,
     event_store: Option<&Arc<dyn EventStore>>,
     projector: Option<&Arc<SessionProjector>>,
     session: &Session,
@@ -478,10 +591,11 @@ async fn save_session_projection_allowing_internal_rewrite(
         .await
         .map_err(|err| SessionError::Store(Box::new(err)))?;
     let Some(previous) = previous else {
-        return store
-            .save(session)
-            .await
-            .map_err(|err| SessionError::Store(Box::new(err)));
+        return save_session_projection_with_storage_normalization_bridge(
+            store, blob_store, session,
+        )
+        .await
+        .map_err(|err| SessionError::Store(Box::new(err)));
     };
     let previous_revision =
         meerkat_core::transcript_messages_digest(previous.messages()).map_err(|err| {
@@ -489,6 +603,9 @@ async fn save_session_projection_allowing_internal_rewrite(
                 "failed to digest previous transcript for projection save: {err}"
             )))
         })?;
+    let previous_projection_token =
+        meerkat_core::session_store::session_projection_cas_token(&previous)
+            .map_err(|err| SessionError::Store(Box::new(err)))?;
     let incoming_revision =
         meerkat_core::transcript_messages_digest(session.messages()).map_err(|err| {
             SessionError::Agent(meerkat_core::error::AgentError::InternalError(format!(
@@ -501,35 +618,100 @@ async fn save_session_projection_allowing_internal_rewrite(
         )))
     })?
     else {
-        return store
-            .save(session)
-            .await
-            .map_err(|err| SessionError::Store(Box::new(err)));
+        return save_session_projection_with_storage_normalization_bridge(
+            store, blob_store, session,
+        )
+        .await
+        .map_err(|err| SessionError::Store(Box::new(err)));
     };
-    let Some(commits) = meerkat_core::session_store::find_transcript_rewrite_commit_chain_extending(
-        &state,
-        &previous_revision,
-        &incoming_revision,
-    ) else {
-        return store
-            .save(session)
+    let mut normalized_previous_for_chain = None;
+    let mut commits =
+        find_transcript_rewrite_commit_chain_extending_session_with_storage_normalization(
+            blob_store,
+            &state,
+            &previous,
+            &incoming_revision,
+            session.messages(),
+        )
+        .await
+        .map_err(|err| SessionError::Store(Box::new(err)))?;
+    if commits.is_none() {
+        let mut normalized_previous = previous.clone();
+        normalized_previous
+            .externalize_media(blob_store, 0)
             .await
-            .map_err(|err| SessionError::Store(Box::new(err)));
+            .map_err(|err| {
+                SessionError::Agent(meerkat_core::error::AgentError::InternalError(format!(
+                    "failed to externalize previous persisted projection for projection rewrite chain discovery: {err}"
+                )))
+            })?;
+        let normalized_revision = meerkat_core::transcript_messages_digest(
+            normalized_previous.messages(),
+        )
+        .map_err(|err| {
+            SessionError::Agent(meerkat_core::error::AgentError::InternalError(format!(
+                "failed to digest normalized previous transcript for projection save: {err}"
+            )))
+        })?;
+        if normalized_revision != previous_revision {
+            commits =
+                find_transcript_rewrite_commit_chain_extending_session_with_storage_normalization(
+                    blob_store,
+                    &state,
+                    &normalized_previous,
+                    &incoming_revision,
+                    session.messages(),
+                )
+                .await
+                .map_err(|err| SessionError::Store(Box::new(err)))?;
+            if commits.is_some() {
+                normalized_previous_for_chain = Some(normalized_previous);
+            }
+        }
+    }
+    let Some(commits) = commits else {
+        return save_session_projection_with_storage_normalization_bridge(
+            store, blob_store, session,
+        )
+        .await
+        .map_err(|err| SessionError::Store(Box::new(err)));
     };
+    let proof_previous = normalized_previous_for_chain.as_ref().unwrap_or(&previous);
     if commits.is_empty() {
-        return store
-            .save(session)
-            .await
-            .map_err(|err| SessionError::Store(Box::new(err)));
+        if !state.commits.is_empty()
+            && meerkat_core::session_store::run_boundary_snapshot_save_guard(
+                session,
+                Some(proof_previous),
+            )
+            .is_ok()
+        {
+            store
+                .save_authoritative_projection_if_current_revision(
+                    session,
+                    Some(previous_projection_token.clone()),
+                )
+                .await
+                .map_err(|err| SessionError::Store(Box::new(err)))?;
+            return Ok(());
+        }
+        return save_session_projection_with_storage_normalization_bridge(
+            store, blob_store, session,
+        )
+        .await
+        .map_err(|err| SessionError::Store(Box::new(err)));
     }
     let mut last_audited_projection = Some(previous.clone());
     let mut persisted_revision = Some(previous_revision);
+    let mut persisted_projection_token = Some(previous_projection_token);
     for commit in &commits {
         if persisted_revision.as_deref() != Some(commit.parent_revision.as_str()) {
             let bridge =
                 session_materialized_at_transcript_revision(session, &commit.parent_revision)?;
             store
-                .save(&bridge)
+                .save_authoritative_projection_if_current_revision(
+                    &bridge,
+                    persisted_projection_token.clone(),
+                )
                 .await
                 .map_err(|err| SessionError::Store(Box::new(err)))?;
         }
@@ -538,6 +720,9 @@ async fn save_session_projection_allowing_internal_rewrite(
             .save_transcript_rewrite(&rewritten, commit)
             .await
             .map_err(transcript_rewrite_store_error_to_session_error)?;
+        let rewritten_projection_token =
+            meerkat_core::session_store::session_projection_cas_token(&rewritten)
+                .map_err(|err| SessionError::Store(Box::new(err)))?;
         let commit_record = (*commit).clone();
         if let Err(error) = append_transcript_rewrite_commit_events(
             event_store,
@@ -548,27 +733,346 @@ async fn save_session_projection_allowing_internal_rewrite(
         .await
         {
             if let Some(rollback_target) = last_audited_projection.as_ref()
-                && let Err(rollback_error) =
-                    store.save_authoritative_projection(rollback_target).await
+                && let Err(rollback_error) = store
+                    .save_authoritative_projection_if_current_revision(
+                        rollback_target,
+                        Some(rewritten_projection_token.clone()),
+                    )
+                    .await
             {
                 tracing::error!(
                     session_id = %session.id(),
                     error = %rollback_error,
                     "failed to roll back checkpoint transcript rewrite projection after audit append failure"
                 );
+                match store
+                    .delete_if_current_revision(session.id(), &rewritten_projection_token)
+                    .await
+                {
+                    Ok(true) => {
+                        return Err(SessionError::Agent(
+                            meerkat_core::error::AgentError::InternalError(format!(
+                                "checkpoint transcript rewrite audit append failed ({error}); projection rollback also failed: {rollback_error}; unaudited projection was quarantined"
+                            )),
+                        ));
+                    }
+                    Ok(false) => {
+                        return Err(SessionError::Agent(
+                            meerkat_core::error::AgentError::InternalError(format!(
+                                "checkpoint transcript rewrite audit append failed ({error}); projection rollback also failed: {rollback_error}; projection changed before unaudited quarantine"
+                            )),
+                        ));
+                    }
+                    Err(quarantine_error) => {
+                        return Err(SessionError::Agent(
+                            meerkat_core::error::AgentError::InternalError(format!(
+                                "checkpoint transcript rewrite audit append failed ({error}); projection rollback also failed: {rollback_error}; unaudited projection quarantine also failed: {quarantine_error}"
+                            )),
+                        ));
+                    }
+                }
             }
             return Err(error);
         }
         last_audited_projection = Some(rewritten);
         persisted_revision = Some(commit.revision.clone());
+        persisted_projection_token = Some(rewritten_projection_token);
     }
     if commits.last().map(|commit| commit.revision.as_str()) != Some(incoming_revision.as_str()) {
-        store
-            .save(session)
-            .await
-            .map_err(|err| SessionError::Store(Box::new(err)))?;
+        save_session_projection_after_verified_rewrite_chain(
+            store,
+            blob_store,
+            session,
+            &incoming_revision,
+        )
+        .await
+        .map_err(|err| SessionError::Store(Box::new(err)))?;
     }
     Ok(())
+}
+
+async fn save_session_projection_after_verified_rewrite_chain(
+    store: &dyn SessionStore,
+    blob_store: &dyn BlobStore,
+    session: &Session,
+    incoming_revision: &str,
+) -> Result<(), SessionStoreError> {
+    match save_session_projection_with_storage_normalization_bridge(store, blob_store, session)
+        .await
+    {
+        Ok(()) => Ok(()),
+        Err(error) => {
+            let Some(previous) = store.load(session.id()).await? else {
+                return Err(error);
+            };
+            let previous_projection_token =
+                meerkat_core::session_store::session_projection_cas_token(&previous)?;
+            let Some(state) = session.transcript_history_state().map_err(|err| {
+                SessionStoreError::InvalidTranscriptRewrite {
+                    id: session.id().clone(),
+                    reason: format!("incoming transcript history state is malformed: {err}"),
+                }
+            })?
+            else {
+                return Err(error);
+            };
+            if transcript_rewrite_commit_metadata_preserved(&previous, &state)?
+                && (meerkat_core::session_store::run_boundary_snapshot_save_guard(
+                    session,
+                    Some(&previous),
+                )
+                .is_ok()
+                    || transcript_revision_preserves_storage_normalized_append_prefix(
+                        blob_store,
+                        &state,
+                        incoming_revision,
+                        session.messages(),
+                        previous.messages(),
+                    )
+                    .await?)
+            {
+                return store
+                    .save_authoritative_projection_if_current_revision(
+                        session,
+                        Some(previous_projection_token),
+                    )
+                    .await;
+            }
+            Err(error)
+        }
+    }
+}
+
+async fn save_session_projection_with_storage_normalization_bridge(
+    store: &dyn SessionStore,
+    blob_store: &dyn BlobStore,
+    session: &Session,
+) -> Result<(), SessionStoreError> {
+    match store.save(session).await {
+        Ok(()) => Ok(()),
+        Err(error @ SessionStoreError::TranscriptContinuityViolation { .. }) => {
+            let Some(previous) = store.load(session.id()).await? else {
+                return Err(error);
+            };
+            let previous_revision = meerkat_core::transcript_messages_digest(previous.messages())
+                .map_err(SessionStoreError::from)?;
+            let previous_projection_token =
+                meerkat_core::session_store::session_projection_cas_token(&previous)?;
+            let mut normalized_previous = previous.clone();
+            normalized_previous
+                .externalize_media(blob_store, 0)
+                .await
+                .map_err(|err| {
+                    SessionStoreError::Internal(format!(
+                        "failed to externalize previous persisted projection for save bridge: {err}"
+                    ))
+                })?;
+            let normalized_revision =
+                meerkat_core::transcript_messages_digest(normalized_previous.messages())
+                    .map_err(SessionStoreError::from)?;
+            if normalized_revision == previous_revision {
+                if save_verified_transcript_history_projection(
+                    store,
+                    session,
+                    &normalized_previous,
+                    previous_projection_token.clone(),
+                )
+                .await?
+                {
+                    return Ok(());
+                }
+                return Err(error);
+            }
+            if let Err(bridge_error) = meerkat_core::session_store::append_only_save_guard(
+                session,
+                Some(&normalized_previous),
+            ) {
+                tracing::debug!(
+                    session_id = %session.id(),
+                    original_error = %error,
+                    bridge_error = %bridge_error,
+                    "storage-normalized previous projection does not prove incoming save continuity"
+                );
+                if save_verified_transcript_history_projection(
+                    store,
+                    session,
+                    &normalized_previous,
+                    previous_projection_token.clone(),
+                )
+                .await?
+                {
+                    return Ok(());
+                }
+                return Err(error);
+            }
+            store
+                .save_authoritative_projection_if_current_revision(
+                    &normalized_previous,
+                    Some(previous_projection_token),
+                )
+                .await?;
+            store.save(session).await
+        }
+        Err(error) => Err(error),
+    }
+}
+
+async fn save_verified_transcript_history_projection(
+    store: &dyn SessionStore,
+    session: &Session,
+    previous: &Session,
+    expected_current_revision: String,
+) -> Result<bool, SessionStoreError> {
+    let Some(state) = session.transcript_history_state().map_err(|err| {
+        SessionStoreError::InvalidTranscriptRewrite {
+            id: session.id().clone(),
+            reason: format!("incoming transcript history state is malformed: {err}"),
+        }
+    })?
+    else {
+        return Ok(false);
+    };
+    session.validate_transcript_history_state().map_err(|err| {
+        SessionStoreError::InvalidTranscriptRewrite {
+            id: session.id().clone(),
+            reason: format!("incoming transcript history state is malformed: {err}"),
+        }
+    })?;
+    let incoming_revision = meerkat_core::transcript_messages_digest(session.messages())
+        .map_err(SessionStoreError::from)?;
+    if state.head != incoming_revision
+        || !state
+            .revisions
+            .iter()
+            .any(|body| body.revision == incoming_revision)
+    {
+        return Ok(false);
+    }
+    if !transcript_rewrite_commit_metadata_preserved(previous, &state)? {
+        tracing::debug!(
+            session_id = %session.id(),
+            "transcript-history projection would introduce rewrite commits without audit authority"
+        );
+        return Ok(false);
+    }
+    if let Err(error) =
+        meerkat_core::session_store::run_boundary_snapshot_save_guard(session, Some(previous))
+    {
+        tracing::debug!(
+            session_id = %session.id(),
+            bridge_error = %error,
+            "transcript-history projection does not extend persisted previous revision"
+        );
+        return Ok(false);
+    }
+    store
+        .save_authoritative_projection_if_current_revision(session, Some(expected_current_revision))
+        .await?;
+    Ok(true)
+}
+
+fn transcript_rewrite_commit_metadata_preserved(
+    previous: &Session,
+    incoming_state: &meerkat_core::TranscriptHistoryState,
+) -> Result<bool, SessionStoreError> {
+    let previous_state = previous.transcript_history_state().map_err(|err| {
+        SessionStoreError::InvalidTranscriptRewrite {
+            id: previous.id().clone(),
+            reason: format!("previous transcript history state is malformed: {err}"),
+        }
+    })?;
+    let previous_commits = previous_state
+        .as_ref()
+        .map(|state| state.commits.as_slice())
+        .unwrap_or_default();
+    Ok(previous_commits == incoming_state.commits.as_slice())
+}
+
+#[cfg(test)]
+async fn save_authoritative_projection_after_persisted_continuity_guard(
+    store: &dyn SessionStore,
+    blob_store: &dyn BlobStore,
+    session: &Session,
+) -> Result<(), SessionStoreError> {
+    reject_projection_only_rewrite_commits(session)?;
+    save_audited_authoritative_projection_after_persisted_continuity_guard(
+        store, blob_store, session,
+    )
+    .await
+}
+
+async fn save_audited_authoritative_projection_after_persisted_continuity_guard(
+    store: &dyn SessionStore,
+    blob_store: &dyn BlobStore,
+    session: &Session,
+) -> Result<(), SessionStoreError> {
+    let expected_current_revision =
+        verify_authoritative_projection_persisted_continuity(store, blob_store, session).await?;
+    store
+        .save_authoritative_projection_if_current_revision(session, expected_current_revision)
+        .await
+}
+
+#[cfg(test)]
+fn reject_projection_only_rewrite_commits(session: &Session) -> Result<(), SessionStoreError> {
+    let Some(state) = session.transcript_history_state().map_err(|err| {
+        SessionStoreError::InvalidTranscriptRewrite {
+            id: session.id().clone(),
+            reason: format!("incoming transcript history state is malformed: {err}"),
+        }
+    })?
+    else {
+        return Ok(());
+    };
+    if state.commits.is_empty() {
+        return Ok(());
+    }
+    Err(SessionStoreError::InvalidTranscriptRewrite {
+        id: session.id().clone(),
+        reason: "projection-only authoritative save cannot introduce transcript rewrite commits"
+            .to_string(),
+    })
+}
+
+async fn verify_authoritative_projection_persisted_continuity(
+    store: &dyn SessionStore,
+    blob_store: &dyn BlobStore,
+    session: &Session,
+) -> Result<Option<String>, SessionStoreError> {
+    let Some(previous) = store.load(session.id()).await? else {
+        return Ok(None);
+    };
+    let previous_revision = meerkat_core::transcript_messages_digest(previous.messages())
+        .map_err(SessionStoreError::from)?;
+    let previous_projection_token =
+        meerkat_core::session_store::session_projection_cas_token(&previous)?;
+    match meerkat_core::session_store::run_boundary_snapshot_save_guard(session, Some(&previous)) {
+        Ok(()) => Ok(Some(previous_projection_token)),
+        Err(raw_error) => {
+            let mut normalized_previous = previous.clone();
+            normalized_previous
+                .externalize_media(blob_store, 0)
+                .await
+                .map_err(|err| {
+                    SessionStoreError::Internal(format!(
+                        "failed to externalize previous persisted projection for authoritative save guard: {err}"
+                    ))
+                })?;
+            let normalized_revision =
+                meerkat_core::transcript_messages_digest(normalized_previous.messages())
+                    .map_err(SessionStoreError::from)?;
+            if normalized_revision != previous_revision
+                && meerkat_core::session_store::run_boundary_snapshot_save_guard(
+                    session,
+                    Some(&normalized_previous),
+                )
+                .is_ok()
+            {
+                return Ok(Some(previous_projection_token));
+            }
+            Err(raw_error)
+        }
+    }
 }
 
 #[async_trait]
@@ -614,6 +1118,7 @@ impl meerkat_core::checkpoint::SessionCheckpointer for StoreCheckpointer {
         }
         if let Err(e) = save_session_projection_allowing_internal_rewrite(
             self.store.as_ref(),
+            self.blob_store.as_ref(),
             self.event_store.as_ref(),
             self.projector.as_ref(),
             &persisted,
@@ -1008,13 +1513,20 @@ impl<B: SessionAgentBuilder + 'static> PersistentSessionService<B> {
         id: &SessionId,
     ) -> Result<(Option<Session>, bool), SessionError> {
         let session = if let Some(runtime_store) = self.runtime_store.as_ref() {
-            Self::load_runtime_session_snapshot_for_session(runtime_store, id).await
+            match Self::load_runtime_session_snapshot_for_session(runtime_store, id).await? {
+                Some(session) => Some(session),
+                None => self
+                    .store
+                    .load(id)
+                    .await
+                    .map_err(|e| SessionError::Store(Box::new(e)))?,
+            }
         } else {
             self.store
                 .load(id)
                 .await
-                .map_err(|e| SessionError::Store(Box::new(e)))
-        }?;
+                .map_err(|e| SessionError::Store(Box::new(e)))?
+        };
         self.apply_transcript_rewrite_replay(id, session).await
     }
 
@@ -1770,16 +2282,34 @@ impl<B: SessionAgentBuilder + 'static> PersistentSessionService<B> {
         &self,
         session: &Session,
     ) -> Result<(), SessionError> {
-        if let Some(runtime_store) = self.runtime_store.as_ref() {
-            let session_snapshot = serde_json::to_vec(session).map_err(|err| {
+        let expected_current_revision = self
+            .store
+            .load(session.id())
+            .await
+            .map_err(|err| SessionError::Store(Box::new(err)))?
+            .as_ref()
+            .map(meerkat_core::session_store::session_projection_cas_token)
+            .transpose()
+            .map_err(|err| SessionError::Store(Box::new(err)))?;
+        let runtime_session_snapshot = if self.runtime_store.is_some() {
+            Some(serde_json::to_vec(session).map_err(|err| {
                 SessionError::Agent(meerkat_core::error::AgentError::InternalError(format!(
                     "failed to serialize replay-recovered session snapshot: {err}"
                 )))
-            })?;
+            })?)
+        } else {
+            None
+        };
+        if let (Some(runtime_store), Some(session_snapshot)) = (
+            self.runtime_store.as_ref(),
+            runtime_session_snapshot.as_ref(),
+        ) {
             runtime_store
                 .commit_session_snapshot(
                     &Self::runtime_id_for_session(session.id()),
-                    SessionDelta { session_snapshot },
+                    SessionDelta {
+                        session_snapshot: session_snapshot.clone(),
+                    },
                 )
                 .await
                 .map_err(|err| {
@@ -1788,10 +2318,23 @@ impl<B: SessionAgentBuilder + 'static> PersistentSessionService<B> {
                     )))
                 })?;
         }
-        self.store
-            .save_authoritative_projection(session)
+        if let Err(error) = self
+            .store
+            .save_authoritative_projection_if_current_revision(session, expected_current_revision)
             .await
-            .map_err(|e| SessionError::Store(Box::new(e)))
+        {
+            if self.runtime_store.is_some() {
+                return Err(self
+                    .fail_closed_runtime_projection_update(
+                        session.id(),
+                        error,
+                        runtime_session_snapshot.as_deref(),
+                    )
+                    .await);
+            }
+            return Err(SessionError::Store(Box::new(error)));
+        }
+        Ok(())
     }
 
     async fn transcript_edit_mutation_guard(
@@ -1878,6 +2421,17 @@ impl<B: SessionAgentBuilder + 'static> PersistentSessionService<B> {
                 .map_err(|err| SessionError::Store(Box::new(err)))?
         };
         if let Some(runtime_store) = self.runtime_store.as_ref() {
+            if let Err(error) = verify_authoritative_projection_persisted_continuity(
+                self.store.as_ref(),
+                self.blob_store.as_ref(),
+                &session,
+            )
+            .await
+            {
+                return Err(self
+                    .fail_closed_runtime_projection_preflight(session.id(), error)
+                    .await);
+            }
             let mut last_audited_projection = previous.clone();
             let mut persisted_revision = previous
                 .as_ref()
@@ -1923,7 +2477,9 @@ impl<B: SessionAgentBuilder + 'static> PersistentSessionService<B> {
                 runtime_store
                     .commit_session_transcript_rewrite_snapshot(
                         &Self::runtime_id_for_session(session.id()),
-                        SessionDelta { session_snapshot },
+                        SessionDelta {
+                            session_snapshot: session_snapshot.clone(),
+                        },
                         commit,
                     )
                     .await
@@ -1949,22 +2505,36 @@ impl<B: SessionAgentBuilder + 'static> PersistentSessionService<B> {
                 )
                 .await
                 {
+                    let mut rollback_failure = None;
                     if let Some(rollback_target) = last_audited_projection.as_ref() {
                         if let Some(runtime_store) = self.runtime_store.as_ref() {
                             match serde_json::to_vec(rollback_target) {
-                                Ok(session_snapshot) => {
-                                    if let Err(rollback_error) = runtime_store
-                                        .commit_session_snapshot(
+                                Ok(rollback_snapshot) => {
+                                    match runtime_store
+                                        .replace_session_snapshot_if_current(
                                             &Self::runtime_id_for_session(rollback_target.id()),
-                                            SessionDelta { session_snapshot },
+                                            &session_snapshot,
+                                            rollback_snapshot,
                                         )
                                         .await
                                     {
-                                        tracing::error!(
-                                            session_id = %rollback_target.id(),
-                                            error = %rollback_error,
-                                            "failed to roll back runtime transcript rewrite snapshot after audit append failure"
-                                        );
+                                        Ok(true) => {}
+                                        Ok(false) => {
+                                            tracing::warn!(
+                                                session_id = %rollback_target.id(),
+                                                "runtime snapshot changed before transcript rewrite audit rollback; leaving newer runtime authority intact"
+                                            );
+                                        }
+                                        Err(rollback_error) => {
+                                            tracing::error!(
+                                                session_id = %rollback_target.id(),
+                                                error = %rollback_error,
+                                                "failed to roll back runtime transcript rewrite snapshot after audit append failure"
+                                            );
+                                            rollback_failure = Some(format!(
+                                                "runtime snapshot rollback failed: {rollback_error}"
+                                            ));
+                                        }
                                     }
                                 }
                                 Err(rollback_error) => {
@@ -1973,12 +2543,21 @@ impl<B: SessionAgentBuilder + 'static> PersistentSessionService<B> {
                                         error = %rollback_error,
                                         "failed to serialize previous runtime transcript snapshot for rollback"
                                     );
+                                    rollback_failure = Some(format!(
+                                        "runtime rollback snapshot serialization failed: {rollback_error}"
+                                    ));
                                 }
                             }
                         }
                         if let Err(rollback_error) = self
                             .store
-                            .save_authoritative_projection(rollback_target)
+                            .save_authoritative_projection_if_current_revision(
+                                rollback_target,
+                                meerkat_core::session_store::session_projection_cas_token(
+                                    rollback_target,
+                                )
+                                .ok(),
+                            )
                             .await
                         {
                             tracing::error!(
@@ -1986,7 +2565,30 @@ impl<B: SessionAgentBuilder + 'static> PersistentSessionService<B> {
                                 error = %rollback_error,
                                 "failed to roll back transcript rewrite projection after audit append failure"
                             );
+                            rollback_failure =
+                                Some(format!("projection rollback failed: {rollback_error}"));
                         }
+                    }
+                    if let Some(rollback_failure) = rollback_failure {
+                        let quarantine_error = self
+                            .quarantine_runtime_session_snapshot_if_current(
+                                session.id(),
+                                session_snapshot.as_slice(),
+                            )
+                            .await
+                            .err();
+                        if let Some(quarantine_error) = quarantine_error {
+                            return Err(SessionError::Agent(
+                                meerkat_core::error::AgentError::InternalError(format!(
+                                    "transcript rewrite audit append failed ({error}); {rollback_failure}; runtime snapshot quarantine also failed: {quarantine_error}"
+                                )),
+                            ));
+                        }
+                        return Err(SessionError::Agent(
+                            meerkat_core::error::AgentError::InternalError(format!(
+                                "transcript rewrite audit append failed ({error}); {rollback_failure}; runtime snapshot was quarantined"
+                            )),
+                        ));
                     }
                     return Err(error);
                 }
@@ -1999,18 +2601,20 @@ impl<B: SessionAgentBuilder + 'static> PersistentSessionService<B> {
                         "failed to digest incoming transcript rewrite snapshot: {err}"
                     )))
                 })?;
+            let latest_session_snapshot = serde_json::to_vec(&session).map_err(|err| {
+                SessionError::Agent(meerkat_core::error::AgentError::InternalError(format!(
+                    "failed to serialize latest runtime transcript rewrite snapshot: {err}"
+                )))
+            })?;
             if commits.last().map(|commit| commit.revision.as_str())
                 != Some(incoming_revision.as_str())
             {
-                let session_snapshot = serde_json::to_vec(&session).map_err(|err| {
-                    SessionError::Agent(meerkat_core::error::AgentError::InternalError(format!(
-                        "failed to serialize post-rewrite session snapshot for runtime persistence: {err}"
-                    )))
-                })?;
                 runtime_store
                     .commit_session_snapshot(
                         &Self::runtime_id_for_session(session.id()),
-                        SessionDelta { session_snapshot },
+                        SessionDelta {
+                            session_snapshot: latest_session_snapshot.clone(),
+                        },
                     )
                     .await
                     .map_err(|err| {
@@ -2019,9 +2623,20 @@ impl<B: SessionAgentBuilder + 'static> PersistentSessionService<B> {
                         ))
                     })?;
             }
-            if let Err(error) = self.store.save_authoritative_projection(&session).await {
+            if let Err(error) =
+                save_audited_authoritative_projection_after_persisted_continuity_guard(
+                    self.store.as_ref(),
+                    self.blob_store.as_ref(),
+                    &session,
+                )
+                .await
+            {
                 return Err(self
-                    .fail_closed_runtime_projection_update(session.id(), error)
+                    .fail_closed_runtime_projection_update(
+                        session.id(),
+                        error,
+                        Some(latest_session_snapshot.as_slice()),
+                    )
                     .await);
             }
         } else {
@@ -2047,10 +2662,13 @@ impl<B: SessionAgentBuilder + 'static> PersistentSessionService<B> {
                         &session,
                         &commit.parent_revision,
                     )?;
-                    self.store
-                        .save(&bridge)
-                        .await
-                        .map_err(|err| SessionError::Store(Box::new(err)))?;
+                    save_session_projection_with_storage_normalization_bridge(
+                        self.store.as_ref(),
+                        self.blob_store.as_ref(),
+                        &bridge,
+                    )
+                    .await
+                    .map_err(|err| SessionError::Store(Box::new(err)))?;
                 }
                 let rewritten =
                     session_materialized_at_transcript_revision(&session, &commit.revision)?;
@@ -2058,6 +2676,9 @@ impl<B: SessionAgentBuilder + 'static> PersistentSessionService<B> {
                     .save_transcript_rewrite(&rewritten, commit)
                     .await
                     .map_err(transcript_rewrite_store_error_to_session_error)?;
+                let rewritten_projection_token =
+                    meerkat_core::session_store::session_projection_cas_token(&rewritten)
+                        .map_err(|err| SessionError::Store(Box::new(err)))?;
                 if let Err(error) = append_transcript_rewrite_commit_events(
                     self.event_store.as_ref(),
                     self.projector.as_ref(),
@@ -2069,7 +2690,10 @@ impl<B: SessionAgentBuilder + 'static> PersistentSessionService<B> {
                     if let Some(rollback_target) = last_audited_projection.as_ref()
                         && let Err(rollback_error) = self
                             .store
-                            .save_authoritative_projection(rollback_target)
+                            .save_authoritative_projection_if_current_revision(
+                                rollback_target,
+                                Some(rewritten_projection_token.clone()),
+                            )
                             .await
                     {
                         tracing::error!(
@@ -2077,6 +2701,33 @@ impl<B: SessionAgentBuilder + 'static> PersistentSessionService<B> {
                             error = %rollback_error,
                             "failed to roll back transcript rewrite projection after audit append failure"
                         );
+                        match self
+                            .store
+                            .delete_if_current_revision(session.id(), &rewritten_projection_token)
+                            .await
+                        {
+                            Ok(true) => {
+                                return Err(SessionError::Agent(
+                                    meerkat_core::error::AgentError::InternalError(format!(
+                                        "transcript rewrite audit append failed ({error}); projection rollback also failed: {rollback_error}; unaudited projection was quarantined"
+                                    )),
+                                ));
+                            }
+                            Ok(false) => {
+                                return Err(SessionError::Agent(
+                                    meerkat_core::error::AgentError::InternalError(format!(
+                                        "transcript rewrite audit append failed ({error}); projection rollback also failed: {rollback_error}; projection changed before unaudited quarantine"
+                                    )),
+                                ));
+                            }
+                            Err(quarantine_error) => {
+                                return Err(SessionError::Agent(
+                                    meerkat_core::error::AgentError::InternalError(format!(
+                                        "transcript rewrite audit append failed ({error}); projection rollback also failed: {rollback_error}; unaudited projection quarantine also failed: {quarantine_error}"
+                                    )),
+                                ));
+                            }
+                        }
                     }
                     return Err(error);
                 }
@@ -2854,6 +3505,17 @@ impl<B: SessionAgentBuilder + 'static> PersistentSessionService<B> {
                 .await;
         }
         if let Some(runtime_store) = self.runtime_store.as_ref() {
+            if let Err(error) = verify_authoritative_projection_persisted_continuity(
+                self.store.as_ref(),
+                self.blob_store.as_ref(),
+                &session,
+            )
+            .await
+            {
+                return Err(self
+                    .fail_closed_runtime_projection_preflight(session.id(), error)
+                    .await);
+            }
             let session_snapshot = serde_json::to_vec(&session).map_err(|err| {
                 SessionError::Agent(meerkat_core::error::AgentError::InternalError(format!(
                     "failed to serialize session snapshot for runtime persistence: {err}"
@@ -2862,7 +3524,9 @@ impl<B: SessionAgentBuilder + 'static> PersistentSessionService<B> {
             runtime_store
                 .commit_session_snapshot(
                     &Self::runtime_id_for_session(session.id()),
-                    SessionDelta { session_snapshot },
+                    SessionDelta {
+                        session_snapshot: session_snapshot.clone(),
+                    },
                 )
                 .await
                 .map_err(|err| {
@@ -2870,16 +3534,29 @@ impl<B: SessionAgentBuilder + 'static> PersistentSessionService<B> {
                         "runtime snapshot persistence failed: {err}"
                     )))
                 })?;
-            if let Err(error) = self.store.save(&session).await {
+            if let Err(error) = save_session_projection_with_storage_normalization_bridge(
+                self.store.as_ref(),
+                self.blob_store.as_ref(),
+                &session,
+            )
+            .await
+            {
                 return Err(self
-                    .fail_closed_runtime_projection_update(session.id(), error)
+                    .fail_closed_runtime_projection_update(
+                        session.id(),
+                        error,
+                        Some(session_snapshot.as_slice()),
+                    )
                     .await);
             }
         } else {
-            self.store
-                .save(&session)
-                .await
-                .map_err(|e| SessionError::Store(Box::new(e)))?;
+            save_session_projection_with_storage_normalization_bridge(
+                self.store.as_ref(),
+                self.blob_store.as_ref(),
+                &session,
+            )
+            .await
+            .map_err(|e| SessionError::Store(Box::new(e)))?;
         }
         Ok(session)
     }
@@ -2911,31 +3588,68 @@ impl<B: SessionAgentBuilder + 'static> PersistentSessionService<B> {
                     "failed to digest incoming transcript for persistence: {err}"
                 )))
             })?;
-        if previous_revision == incoming_revision
-            || Self::incoming_extends_previous_transcript(&previous, session, &previous_revision)?
-        {
-            return Ok(Vec::new());
-        }
-
-        let Some(state) = session.transcript_history_state().map_err(|err| {
+        let incoming_state = session.transcript_history_state().map_err(|err| {
             SessionError::Agent(meerkat_core::error::AgentError::InternalError(format!(
                 "failed to read transcript history for persistence: {err}"
             )))
-        })?
-        else {
+        })?;
+        if previous_revision == incoming_revision
+            || Self::incoming_extends_previous_transcript(&previous, session, &previous_revision)?
+        {
+            let Some(state) = incoming_state.as_ref() else {
+                return Ok(Vec::new());
+            };
+            if transcript_rewrite_commit_metadata_preserved(&previous, state)
+                .map_err(|err| SessionError::Store(Box::new(err)))?
+            {
+                return Ok(Vec::new());
+            }
+        }
+
+        let Some(state) = incoming_state else {
             return Ok(Vec::new());
         };
-        Ok(
-            meerkat_core::session_store::find_transcript_rewrite_commit_chain_extending(
+        let mut commits =
+            find_transcript_rewrite_commit_chain_extending_session_with_storage_normalization(
+                self.blob_store.as_ref(),
                 &state,
-                &previous_revision,
+                &previous,
                 &incoming_revision,
+                session.messages(),
             )
-            .unwrap_or_default()
-            .into_iter()
-            .cloned()
-            .collect(),
-        )
+            .await
+            .map_err(|err| SessionError::Store(Box::new(err)))?;
+        if commits.is_none() {
+            let mut normalized_previous = previous.clone();
+            normalized_previous
+                .externalize_media(self.blob_store.as_ref(), 0)
+                .await
+                .map_err(|err| {
+                    SessionError::Agent(meerkat_core::error::AgentError::InternalError(format!(
+                        "failed to externalize previous persisted projection for rewrite chain discovery: {err}"
+                    )))
+                })?;
+            let normalized_revision = meerkat_core::transcript_messages_digest(
+                normalized_previous.messages(),
+            )
+            .map_err(|err| {
+                SessionError::Agent(meerkat_core::error::AgentError::InternalError(format!(
+                    "failed to digest normalized previous transcript for persistence: {err}"
+                )))
+            })?;
+            if normalized_revision != previous_revision {
+                commits = find_transcript_rewrite_commit_chain_extending_session_with_storage_normalization(
+                    self.blob_store.as_ref(),
+                    &state,
+                    &normalized_previous,
+                    &incoming_revision,
+                    session.messages(),
+                )
+                .await
+                .map_err(|err| SessionError::Store(Box::new(err)))?;
+            }
+        }
+        Ok(commits.unwrap_or_default().into_iter().cloned().collect())
     }
 
     fn incoming_extends_previous_transcript(
@@ -2980,6 +3694,7 @@ impl<B: SessionAgentBuilder + 'static> PersistentSessionService<B> {
             ));
         }
 
+        let _projection_guard = self.recovery_gate_for_session(id).await.lock_owned().await;
         let gate = self.gate_for_session(id).await;
         let guard = gate.cancelled.lock().await;
         if *guard {
@@ -2987,6 +3702,7 @@ impl<B: SessionAgentBuilder + 'static> PersistentSessionService<B> {
         }
         if let Err(error) = save_session_projection_allowing_internal_rewrite(
             self.store.as_ref(),
+            self.blob_store.as_ref(),
             self.event_store.as_ref(),
             self.projector.as_ref(),
             &session,
@@ -2998,13 +3714,21 @@ impl<B: SessionAgentBuilder + 'static> PersistentSessionService<B> {
                 SessionError::Store(store_error) => {
                     let store_error = SessionStoreError::Internal(store_error.to_string());
                     Err(self
-                        .fail_closed_runtime_projection_update(session.id(), store_error)
+                        .quarantine_failed_runtime_projection_update(
+                            session.id(),
+                            store_error,
+                            session_snapshot,
+                        )
                         .await)
                 }
                 other => {
                     let store_error = SessionStoreError::Internal(other.to_string());
                     Err(self
-                        .fail_closed_runtime_projection_update(session.id(), store_error)
+                        .quarantine_failed_runtime_projection_update(
+                            session.id(),
+                            store_error,
+                            session_snapshot,
+                        )
                         .await)
                 }
             };
@@ -3156,12 +3880,34 @@ impl<B: SessionAgentBuilder + 'static> PersistentSessionService<B> {
         &self,
         id: &SessionId,
         error: SessionStoreError,
+        rejected_snapshot: Option<&[u8]>,
     ) -> SessionError {
         tracing::error!(
             session_id = %id,
             error = %error,
             "session-store projection update failed after runtime authority commit; failing closed"
         );
+        let restore_error = match rejected_snapshot {
+            Some(rejected_snapshot) => self
+                .restore_runtime_snapshot_from_session_store_if_current(id, rejected_snapshot)
+                .await
+                .err(),
+            None => self
+                .restore_runtime_snapshot_from_session_store(id)
+                .await
+                .err(),
+        };
+        let quarantine_error = if restore_error.is_some() {
+            match rejected_snapshot {
+                Some(rejected_snapshot) => self
+                    .quarantine_runtime_session_snapshot_if_current(id, rejected_snapshot)
+                    .await
+                    .err(),
+                None => self.quarantine_runtime_session_snapshot(id).await.err(),
+            }
+        } else {
+            None
+        };
         match self.discard_live_session(id).await {
             Ok(()) | Err(SessionError::NotFound { .. }) => {}
             Err(discard_error) => {
@@ -3169,6 +3915,249 @@ impl<B: SessionAgentBuilder + 'static> PersistentSessionService<B> {
                     session_id = %id,
                     error = %discard_error,
                     "failed to discard live session after runtime-backed projection update failure"
+                );
+            }
+        }
+        if let Some(restore_error) = restore_error {
+            if let Some(quarantine_error) = quarantine_error {
+                return SessionError::Agent(meerkat_core::error::AgentError::InternalError(
+                    format!(
+                        "session-store projection update failed ({error}); runtime snapshot restore failed: {restore_error}; runtime snapshot quarantine also failed: {quarantine_error}"
+                    ),
+                ));
+            }
+            return SessionError::Agent(meerkat_core::error::AgentError::InternalError(format!(
+                "session-store projection update failed ({error}); runtime snapshot restore failed and runtime snapshot was quarantined: {restore_error}"
+            )));
+        }
+        SessionError::Store(Box::new(error))
+    }
+
+    async fn quarantine_failed_runtime_projection_update(
+        &self,
+        id: &SessionId,
+        error: SessionStoreError,
+        rejected_snapshot: &[u8],
+    ) -> SessionError {
+        tracing::error!(
+            session_id = %id,
+            error = %error,
+            "session-store projection update failed after committed runtime checkpoint; quarantining rejected runtime snapshot"
+        );
+        let quarantine_error = self
+            .quarantine_runtime_session_snapshot_if_current(id, rejected_snapshot)
+            .await
+            .err();
+        match self.discard_live_session(id).await {
+            Ok(()) | Err(SessionError::NotFound { .. }) => {}
+            Err(discard_error) => {
+                tracing::warn!(
+                    session_id = %id,
+                    error = %discard_error,
+                    "failed to discard live session after runtime checkpoint projection failure"
+                );
+            }
+        }
+        if let Some(quarantine_error) = quarantine_error {
+            return SessionError::Agent(meerkat_core::error::AgentError::InternalError(format!(
+                "session-store projection update failed ({error}); rejected runtime snapshot quarantine also failed: {quarantine_error}"
+            )));
+        }
+        SessionError::Store(Box::new(error))
+    }
+
+    async fn quarantine_runtime_session_snapshot(
+        &self,
+        id: &SessionId,
+    ) -> Result<(), SessionError> {
+        let Some(runtime_store) = self.runtime_store.as_ref() else {
+            return Ok(());
+        };
+        runtime_store
+            .clear_session_snapshot(&Self::runtime_id_for_session(id))
+            .await
+            .map_err(|error| {
+                SessionError::Agent(meerkat_core::error::AgentError::InternalError(format!(
+                    "failed to quarantine rejected runtime session snapshot: {error}"
+                )))
+            })
+    }
+
+    async fn quarantine_runtime_session_snapshot_if_current(
+        &self,
+        id: &SessionId,
+        rejected_snapshot: &[u8],
+    ) -> Result<(), SessionError> {
+        let Some(runtime_store) = self.runtime_store.as_ref() else {
+            return Ok(());
+        };
+        let cleared = runtime_store
+            .clear_session_snapshot_if_current(&Self::runtime_id_for_session(id), rejected_snapshot)
+            .await
+            .map_err(|error| {
+                SessionError::Agent(meerkat_core::error::AgentError::InternalError(format!(
+                    "failed to quarantine rejected runtime session snapshot: {error}"
+                )))
+            })?;
+        if !cleared {
+            tracing::warn!(
+                session_id = %id,
+                "runtime snapshot changed before fail-closed quarantine; leaving newer runtime authority intact"
+            );
+        }
+        Ok(())
+    }
+
+    async fn restore_runtime_snapshot_from_session_store(
+        &self,
+        id: &SessionId,
+    ) -> Result<(), SessionError> {
+        let Some(runtime_store) = self.runtime_store.as_ref() else {
+            return Ok(());
+        };
+        let session = match self.store.load(id).await {
+            Ok(Some(session)) => session,
+            Ok(None) => {
+                tracing::warn!(
+                    session_id = %id,
+                    "cannot restore runtime snapshot after projection failure because SessionStore row is missing"
+                );
+                return Err(SessionError::Agent(
+                    meerkat_core::error::AgentError::InternalError(format!(
+                        "cannot restore runtime snapshot after projection failure because SessionStore row {id} is missing"
+                    )),
+                ));
+            }
+            Err(error) => {
+                tracing::error!(
+                    session_id = %id,
+                    error = %error,
+                    "failed to load SessionStore row for runtime snapshot restore"
+                );
+                return Err(SessionError::Store(Box::new(error)));
+            }
+        };
+        let session_snapshot = match serde_json::to_vec(&session) {
+            Ok(session_snapshot) => session_snapshot,
+            Err(error) => {
+                tracing::error!(
+                    session_id = %id,
+                    error = %error,
+                    "failed to serialize SessionStore row for runtime snapshot restore"
+                );
+                return Err(SessionError::Agent(
+                    meerkat_core::error::AgentError::InternalError(format!(
+                        "failed to serialize SessionStore row for runtime snapshot restore: {error}"
+                    )),
+                ));
+            }
+        };
+        runtime_store
+            .commit_session_snapshot(
+                &Self::runtime_id_for_session(id),
+                SessionDelta { session_snapshot },
+            )
+            .await
+            .map_err(|error| {
+                tracing::error!(
+                    session_id = %id,
+                    error = %error,
+                    "failed to restore runtime snapshot from SessionStore row after projection failure"
+                );
+                SessionError::Agent(meerkat_core::error::AgentError::InternalError(format!(
+                    "failed to restore runtime snapshot from SessionStore row after projection failure: {error}"
+                )))
+            })
+    }
+
+    async fn restore_runtime_snapshot_from_session_store_if_current(
+        &self,
+        id: &SessionId,
+        rejected_snapshot: &[u8],
+    ) -> Result<(), SessionError> {
+        let Some(runtime_store) = self.runtime_store.as_ref() else {
+            return Ok(());
+        };
+        let session = match self.store.load(id).await {
+            Ok(Some(session)) => session,
+            Ok(None) => {
+                tracing::warn!(
+                    session_id = %id,
+                    "cannot restore runtime snapshot after projection failure because SessionStore row is missing"
+                );
+                return Err(SessionError::Agent(
+                    meerkat_core::error::AgentError::InternalError(format!(
+                        "cannot restore runtime snapshot after projection failure because SessionStore row {id} is missing"
+                    )),
+                ));
+            }
+            Err(error) => {
+                tracing::error!(
+                    session_id = %id,
+                    error = %error,
+                    "failed to load SessionStore row for runtime snapshot restore"
+                );
+                return Err(SessionError::Store(Box::new(error)));
+            }
+        };
+        let replacement = match serde_json::to_vec(&session) {
+            Ok(session_snapshot) => session_snapshot,
+            Err(error) => {
+                tracing::error!(
+                    session_id = %id,
+                    error = %error,
+                    "failed to serialize SessionStore row for runtime snapshot restore"
+                );
+                return Err(SessionError::Agent(
+                    meerkat_core::error::AgentError::InternalError(format!(
+                        "failed to serialize SessionStore row for runtime snapshot restore: {error}"
+                    )),
+                ));
+            }
+        };
+        let restored = runtime_store
+            .replace_session_snapshot_if_current(
+                &Self::runtime_id_for_session(id),
+                rejected_snapshot,
+                replacement,
+            )
+            .await
+            .map_err(|error| {
+                tracing::error!(
+                    session_id = %id,
+                    error = %error,
+                    "failed to conditionally restore runtime snapshot from SessionStore row after projection failure"
+                );
+                SessionError::Agent(meerkat_core::error::AgentError::InternalError(format!(
+                    "failed to conditionally restore runtime snapshot from SessionStore row after projection failure: {error}"
+                )))
+            })?;
+        if !restored {
+            tracing::warn!(
+                session_id = %id,
+                "runtime snapshot changed before fail-closed restore; leaving newer runtime authority intact"
+            );
+        }
+        Ok(())
+    }
+
+    async fn fail_closed_runtime_projection_preflight(
+        &self,
+        id: &SessionId,
+        error: SessionStoreError,
+    ) -> SessionError {
+        tracing::error!(
+            session_id = %id,
+            error = %error,
+            "session-store projection continuity preflight failed before runtime authority commit; failing closed"
+        );
+        match self.discard_live_session(id).await {
+            Ok(()) | Err(SessionError::NotFound { .. }) => {}
+            Err(discard_error) => {
+                tracing::warn!(
+                    session_id = %id,
+                    error = %discard_error,
+                    "failed to discard live session after runtime-backed projection preflight failure"
                 );
             }
         }
@@ -5341,6 +6330,19 @@ mod tests {
             self.inner.save_authoritative_projection(session).await
         }
 
+        async fn save_authoritative_projection_if_current_revision(
+            &self,
+            session: &Session,
+            expected_current_revision: Option<String>,
+        ) -> Result<(), SessionStoreError> {
+            self.inner
+                .save_authoritative_projection_if_current_revision(
+                    session,
+                    expected_current_revision,
+                )
+                .await
+        }
+
         async fn load(&self, id: &SessionId) -> Result<Option<Session>, SessionStoreError> {
             self.inner.load(id).await
         }
@@ -5354,6 +6356,16 @@ mod tests {
 
         async fn delete(&self, id: &SessionId) -> Result<(), SessionStoreError> {
             self.inner.delete(id).await
+        }
+
+        async fn delete_if_current_revision(
+            &self,
+            id: &SessionId,
+            expected_current_revision: &str,
+        ) -> Result<bool, SessionStoreError> {
+            self.inner
+                .delete_if_current_revision(id, expected_current_revision)
+                .await
         }
     }
 
@@ -5394,6 +6406,19 @@ mod tests {
             self.inner.save_authoritative_projection(session).await
         }
 
+        async fn save_authoritative_projection_if_current_revision(
+            &self,
+            session: &Session,
+            expected_current_revision: Option<String>,
+        ) -> Result<(), SessionStoreError> {
+            self.inner
+                .save_authoritative_projection_if_current_revision(
+                    session,
+                    expected_current_revision,
+                )
+                .await
+        }
+
         async fn load(&self, id: &SessionId) -> Result<Option<Session>, SessionStoreError> {
             self.inner.load(id).await
         }
@@ -5407,6 +6432,16 @@ mod tests {
 
         async fn delete(&self, id: &SessionId) -> Result<(), SessionStoreError> {
             self.inner.delete(id).await
+        }
+
+        async fn delete_if_current_revision(
+            &self,
+            id: &SessionId,
+            expected_current_revision: &str,
+        ) -> Result<bool, SessionStoreError> {
+            self.inner
+                .delete_if_current_revision(id, expected_current_revision)
+                .await
         }
     }
 
@@ -5452,6 +6487,103 @@ mod tests {
 
         async fn delete(&self, id: &SessionId) -> Result<(), SessionStoreError> {
             self.inner.delete(id).await
+        }
+
+        async fn delete_if_current_revision(
+            &self,
+            id: &SessionId,
+            expected_current_revision: &str,
+        ) -> Result<bool, SessionStoreError> {
+            self.inner
+                .delete_if_current_revision(id, expected_current_revision)
+                .await
+        }
+    }
+
+    struct FailAuthoritativeProjectionStore {
+        inner: MemoryStore,
+        fail_authoritative_projection_cas: AtomicBool,
+    }
+
+    impl FailAuthoritativeProjectionStore {
+        fn new() -> Self {
+            Self {
+                inner: MemoryStore::new(),
+                fail_authoritative_projection_cas: AtomicBool::new(false),
+            }
+        }
+
+        fn fail_authoritative_projection_cas(&self) {
+            self.fail_authoritative_projection_cas
+                .store(true, Ordering::Release);
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl SessionStore for FailAuthoritativeProjectionStore {
+        async fn save(&self, session: &Session) -> Result<(), SessionStoreError> {
+            self.inner.save(session).await
+        }
+
+        async fn save_transcript_rewrite(
+            &self,
+            session: &Session,
+            commit: &meerkat_core::TranscriptRewriteCommit,
+        ) -> Result<(), SessionStoreError> {
+            self.inner.save_transcript_rewrite(session, commit).await
+        }
+
+        async fn save_authoritative_projection(
+            &self,
+            session: &Session,
+        ) -> Result<(), SessionStoreError> {
+            self.inner.save_authoritative_projection(session).await
+        }
+
+        async fn save_authoritative_projection_if_current_revision(
+            &self,
+            session: &Session,
+            expected_current_revision: Option<String>,
+        ) -> Result<(), SessionStoreError> {
+            if self
+                .fail_authoritative_projection_cas
+                .load(Ordering::Acquire)
+            {
+                return Err(SessionStoreError::Internal(
+                    "forced authoritative projection CAS failure".to_string(),
+                ));
+            }
+            self.inner
+                .save_authoritative_projection_if_current_revision(
+                    session,
+                    expected_current_revision,
+                )
+                .await
+        }
+
+        async fn load(&self, id: &SessionId) -> Result<Option<Session>, SessionStoreError> {
+            self.inner.load(id).await
+        }
+
+        async fn list(
+            &self,
+            filter: meerkat_store::SessionFilter,
+        ) -> Result<Vec<meerkat_core::SessionMeta>, SessionStoreError> {
+            self.inner.list(filter).await
+        }
+
+        async fn delete(&self, id: &SessionId) -> Result<(), SessionStoreError> {
+            self.inner.delete(id).await
+        }
+
+        async fn delete_if_current_revision(
+            &self,
+            id: &SessionId,
+            expected_current_revision: &str,
+        ) -> Result<bool, SessionStoreError> {
+            self.inner
+                .delete_if_current_revision(id, expected_current_revision)
+                .await
         }
     }
 
@@ -5511,13 +6643,26 @@ mod tests {
         async fn delete(&self, id: &SessionId) -> Result<(), SessionStoreError> {
             self.inner.delete(id).await
         }
+
+        async fn delete_if_current_revision(
+            &self,
+            id: &SessionId,
+            expected_current_revision: &str,
+        ) -> Result<bool, SessionStoreError> {
+            self.inner
+                .delete_if_current_revision(id, expected_current_revision)
+                .await
+        }
     }
 
     struct GatedSnapshotRuntimeStore {
         inner: InMemoryRuntimeStore,
         hidden_snapshot_loads: AtomicUsize,
         fail_snapshot_commits: AtomicBool,
+        fail_snapshot_replaces: AtomicBool,
         session_snapshot_overrides: Mutex<HashMap<LogicalRuntimeId, Vec<u8>>>,
+        replace_snapshot_interlopers: Mutex<HashMap<LogicalRuntimeId, Vec<u8>>>,
+        clear_snapshot_interlopers: Mutex<HashMap<LogicalRuntimeId, Vec<u8>>>,
         input_state_load_errors: Mutex<HashSet<LogicalRuntimeId>>,
         boundary_commits: Mutex<Vec<meerkat_core::lifecycle::RunBoundaryReceipt>>,
     }
@@ -5528,7 +6673,10 @@ mod tests {
                 inner: InMemoryRuntimeStore::new(),
                 hidden_snapshot_loads: AtomicUsize::new(0),
                 fail_snapshot_commits: AtomicBool::new(false),
+                fail_snapshot_replaces: AtomicBool::new(false),
                 session_snapshot_overrides: Mutex::new(HashMap::new()),
+                replace_snapshot_interlopers: Mutex::new(HashMap::new()),
+                clear_snapshot_interlopers: Mutex::new(HashMap::new()),
                 input_state_load_errors: Mutex::new(HashSet::new()),
                 boundary_commits: Mutex::new(Vec::new()),
             }
@@ -5536,6 +6684,10 @@ mod tests {
 
         fn set_fail_snapshot_commits(&self, fail: bool) {
             self.fail_snapshot_commits.store(fail, Ordering::Release);
+        }
+
+        fn set_fail_snapshot_replaces(&self, fail: bool) {
+            self.fail_snapshot_replaces.store(fail, Ordering::Release);
         }
 
         fn hide_next_session_snapshot_loads(&self, count: usize) {
@@ -5573,6 +6725,28 @@ mod tests {
                 .insert(runtime_id, snapshot);
         }
 
+        async fn interlope_before_snapshot_replace(
+            &self,
+            runtime_id: LogicalRuntimeId,
+            snapshot: Vec<u8>,
+        ) {
+            self.replace_snapshot_interlopers
+                .lock()
+                .await
+                .insert(runtime_id, snapshot);
+        }
+
+        async fn interlope_before_snapshot_clear(
+            &self,
+            runtime_id: LogicalRuntimeId,
+            snapshot: Vec<u8>,
+        ) {
+            self.clear_snapshot_interlopers
+                .lock()
+                .await
+                .insert(runtime_id, snapshot);
+        }
+
         async fn fail_input_state_load_for(&self, runtime_id: LogicalRuntimeId) {
             self.input_state_load_errors.lock().await.insert(runtime_id);
         }
@@ -5589,6 +6763,21 @@ mod tests {
                 return Err(meerkat_runtime::store::RuntimeStoreError::WriteFailed(
                     "synthetic runtime snapshot commit failure".to_string(),
                 ));
+            }
+            if let Some(interloper) = self
+                .replace_snapshot_interlopers
+                .lock()
+                .await
+                .remove(runtime_id)
+            {
+                self.inner
+                    .commit_session_snapshot(
+                        runtime_id,
+                        SessionDelta {
+                            session_snapshot: interloper,
+                        },
+                    )
+                    .await?;
             }
             self.inner
                 .commit_session_snapshot(runtime_id, session_delta)
@@ -5678,6 +6867,113 @@ mod tests {
                 return Ok(Some(snapshot));
             }
             self.inner.load_session_snapshot(runtime_id).await
+        }
+
+        async fn clear_session_snapshot(
+            &self,
+            runtime_id: &LogicalRuntimeId,
+        ) -> Result<(), meerkat_runtime::store::RuntimeStoreError> {
+            if let Some(interloper) = self
+                .clear_snapshot_interlopers
+                .lock()
+                .await
+                .remove(runtime_id)
+            {
+                self.inner
+                    .commit_session_snapshot(
+                        runtime_id,
+                        SessionDelta {
+                            session_snapshot: interloper,
+                        },
+                    )
+                    .await?;
+            }
+            self.session_snapshot_overrides
+                .lock()
+                .await
+                .remove(runtime_id);
+            self.inner.clear_session_snapshot(runtime_id).await
+        }
+
+        async fn replace_session_snapshot_if_current(
+            &self,
+            runtime_id: &LogicalRuntimeId,
+            expected_current: &[u8],
+            replacement: Vec<u8>,
+        ) -> Result<bool, meerkat_runtime::store::RuntimeStoreError> {
+            if self.fail_snapshot_commits.load(Ordering::Acquire) {
+                return Err(meerkat_runtime::store::RuntimeStoreError::WriteFailed(
+                    "synthetic runtime snapshot commit failure".to_string(),
+                ));
+            }
+            if self.fail_snapshot_replaces.load(Ordering::Acquire) {
+                return Err(meerkat_runtime::store::RuntimeStoreError::WriteFailed(
+                    "synthetic runtime snapshot replace failure".to_string(),
+                ));
+            }
+            if let Some(interloper) = self
+                .replace_snapshot_interlopers
+                .lock()
+                .await
+                .remove(runtime_id)
+            {
+                self.inner
+                    .commit_session_snapshot(
+                        runtime_id,
+                        SessionDelta {
+                            session_snapshot: interloper,
+                        },
+                    )
+                    .await?;
+            }
+            {
+                let mut overrides = self.session_snapshot_overrides.lock().await;
+                if let Some(current) = overrides.get_mut(runtime_id) {
+                    if current.as_slice() != expected_current {
+                        return Ok(false);
+                    }
+                    *current = replacement;
+                    return Ok(true);
+                }
+            }
+            self.inner
+                .replace_session_snapshot_if_current(runtime_id, expected_current, replacement)
+                .await
+        }
+
+        async fn clear_session_snapshot_if_current(
+            &self,
+            runtime_id: &LogicalRuntimeId,
+            expected_current: &[u8],
+        ) -> Result<bool, meerkat_runtime::store::RuntimeStoreError> {
+            if let Some(interloper) = self
+                .clear_snapshot_interlopers
+                .lock()
+                .await
+                .remove(runtime_id)
+            {
+                self.inner
+                    .commit_session_snapshot(
+                        runtime_id,
+                        SessionDelta {
+                            session_snapshot: interloper,
+                        },
+                    )
+                    .await?;
+            }
+            {
+                let mut overrides = self.session_snapshot_overrides.lock().await;
+                if let Some(current) = overrides.get(runtime_id) {
+                    if current.as_slice() != expected_current {
+                        return Ok(false);
+                    }
+                    overrides.remove(runtime_id);
+                    return Ok(true);
+                }
+            }
+            self.inner
+                .clear_session_snapshot_if_current(runtime_id, expected_current)
+                .await
         }
 
         async fn persist_input_state(
@@ -7763,6 +9059,1160 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_save_normalized_session_bridges_previous_inline_media_projection() {
+        let store: Arc<dyn SessionStore> = Arc::new(MemoryStore::new());
+        let service = PersistentSessionService::new(
+            ImagePreservingBuilder,
+            4,
+            Arc::clone(&store),
+            None,
+            memory_blob_store(),
+        );
+
+        let created = service
+            .create_session(create_request("seed", InitialTurnPolicy::Defer))
+            .await
+            .expect("create_session should succeed");
+        let mut previous = store
+            .load(&created.session_id)
+            .await
+            .expect("load should succeed")
+            .expect("created session should exist");
+        previous.push(Message::User(UserMessage::with_blocks(vec![
+            ContentBlock::Text {
+                text: "inline image from legacy projection".to_string(),
+            },
+            inline_image_block("legacy-projection"),
+        ])));
+        store
+            .save_authoritative_projection(&previous)
+            .await
+            .expect("test setup should install legacy inline projection");
+
+        let mut incoming = previous.clone();
+        incoming.push(Message::Assistant(meerkat_core::AssistantMessage {
+            content: "after image".to_string(),
+            tool_calls: Vec::new(),
+            stop_reason: StopReason::EndTurn,
+            usage: Usage::default(),
+            created_at: meerkat_core::types::message_timestamp_now(),
+        }));
+
+        service
+            .save_normalized_session(incoming)
+            .await
+            .expect("media-normalized append should bridge the previous projection");
+        let saved = store
+            .load(&created.session_id)
+            .await
+            .expect("load should succeed")
+            .expect("saved session should exist");
+        assert_no_inline_images_in_session(&saved);
+        assert_eq!(saved.messages().len(), previous.messages().len() + 1);
+    }
+
+    #[tokio::test]
+    async fn test_save_normalized_session_bridges_compaction_after_uncheckpointed_append() {
+        let store: Arc<dyn SessionStore> = Arc::new(MemoryStore::new());
+        let service = PersistentSessionService::new(
+            DummyBuilder,
+            4,
+            Arc::clone(&store),
+            None,
+            memory_blob_store(),
+        );
+
+        let created = service
+            .create_session(create_request("seed", InitialTurnPolicy::Defer))
+            .await
+            .expect("create_session should succeed");
+        let previous = store
+            .load(&created.session_id)
+            .await
+            .expect("load should succeed")
+            .expect("created session should exist");
+
+        let mut parent = previous.clone();
+        parent.set_system_prompt("refreshed runtime system projection".to_string());
+        parent.push(Message::User(UserMessage::text(
+            "runtime-only prompt".to_string(),
+        )));
+        parent.push(Message::Assistant(meerkat_core::AssistantMessage {
+            content: "runtime-only answer".to_string(),
+            tool_calls: Vec::new(),
+            stop_reason: StopReason::EndTurn,
+            usage: Usage::default(),
+            created_at: meerkat_core::types::message_timestamp_now(),
+        }));
+        let parent_revision = parent.transcript_revision().expect("parent revision");
+
+        let mut incoming = parent.clone();
+        let mut replacement = vec![
+            parent.messages()[0].clone(),
+            Message::User(UserMessage::text(
+                "[Context compacted] fast regression summary".to_string(),
+            )),
+        ];
+        replacement.extend_from_slice(&parent.messages()[1..]);
+        incoming
+            .commit_transcript_rewrite(
+                TranscriptRewriteSelection::MessageRange {
+                    start: 0,
+                    end: parent.messages().len(),
+                },
+                replacement,
+                TranscriptRewriteReason::new("compaction"),
+                Some("meerkat-core".to_string()),
+                Some(parent_revision),
+            )
+            .expect("compaction rewrite should commit");
+        let incoming_revision = incoming.transcript_revision().expect("incoming revision");
+
+        service
+            .save_normalized_session(incoming)
+            .await
+            .expect("compaction after uncheckpointed append should persist through a bridge");
+        let saved = store
+            .load(&created.session_id)
+            .await
+            .expect("load should succeed")
+            .expect("saved session should exist");
+        assert_eq!(
+            saved.transcript_revision().expect("saved revision"),
+            incoming_revision
+        );
+    }
+
+    #[tokio::test]
+    async fn test_projection_continuity_save_normalized_session_bridges_inline_media_compaction_history()
+    -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+        let store: Arc<dyn SessionStore> = Arc::new(MemoryStore::new());
+        let blob_store = memory_blob_store();
+        let event_store = Arc::new(RecordingEventStore::default());
+        let event_store_trait: Arc<dyn EventStore> = event_store.clone();
+        let dir = tempfile::tempdir()?;
+        let service = PersistentSessionService::new(
+            DummyBuilder,
+            4,
+            Arc::clone(&store),
+            None,
+            Arc::clone(&blob_store),
+        )
+        .with_event_projection(
+            event_store_trait,
+            Arc::new(SessionProjector::new(dir.path().join(".rkat"))),
+        );
+
+        let created = service
+            .create_session(create_request("seed", InitialTurnPolicy::Defer))
+            .await?;
+        let mut previous = store
+            .load(&created.session_id)
+            .await?
+            .ok_or_else(|| std::io::Error::other("created session should exist"))?;
+        previous.push(Message::User(UserMessage::with_blocks(vec![
+            ContentBlock::Text {
+                text: "inline image from legacy projection".to_string(),
+            },
+            inline_image_block("legacy-compaction-parent"),
+        ])));
+        store.save_authoritative_projection(&previous).await?;
+
+        let mut normalized_parent = previous.clone();
+        normalized_parent
+            .externalize_media(blob_store.as_ref(), 0)
+            .await?;
+        let normalized_parent_revision = normalized_parent.transcript_revision()?;
+
+        let mut incoming = normalized_parent.clone();
+        incoming
+            .commit_transcript_rewrite(
+                TranscriptRewriteSelection::MessageRange {
+                    start: 0,
+                    end: normalized_parent.messages().len(),
+                },
+                vec![Message::User(UserMessage::text(
+                    "[Context compacted] normalized legacy image prompt".to_string(),
+                ))],
+                TranscriptRewriteReason::new("compaction"),
+                Some("meerkat-core".to_string()),
+                Some(normalized_parent_revision.clone()),
+            )
+            .map_err(|err| std::io::Error::other(format!("rewrite should commit: {err}")))?;
+        let incoming_revision = incoming.transcript_revision()?;
+
+        service.save_normalized_session(incoming).await?;
+
+        let saved = store
+            .load(&created.session_id)
+            .await?
+            .ok_or_else(|| std::io::Error::other("saved session should exist"))?;
+        assert_eq!(saved.transcript_revision()?, incoming_revision);
+        assert_no_inline_images_in_session(&saved);
+        let events = service
+            .event_log_read_from(&created.session_id, 1)
+            .await?
+            .ok_or_else(|| std::io::Error::other("event projection should be installed"))?;
+        let audit = events
+            .iter()
+            .find_map(|stored| match &stored.event {
+                AgentEvent::TranscriptRewriteCommitted { record, .. } => Some(record),
+                _ => None,
+            })
+            .ok_or_else(|| std::io::Error::other("rewrite audit event should be appended"))?;
+        assert_eq!(audit.commit.parent_revision, normalized_parent_revision);
+        assert_eq!(audit.commit.revision, incoming_revision);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_projection_continuity_verified_projection_refuses_unaudited_rewrite_commits()
+    -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+        let store: Arc<dyn SessionStore> = Arc::new(MemoryStore::new());
+        let blob_store = memory_blob_store();
+
+        let mut previous = Session::new();
+        previous.push(Message::User(UserMessage::text(
+            "persisted prompt".to_string(),
+        )));
+        store.save(&previous).await?;
+        let previous_revision = previous.transcript_revision()?;
+
+        let mut parent = previous.clone();
+        parent.push(Message::Assistant(meerkat_core::AssistantMessage {
+            content: "runtime-only answer".to_string(),
+            tool_calls: Vec::new(),
+            stop_reason: StopReason::EndTurn,
+            usage: Usage::default(),
+            created_at: meerkat_core::types::message_timestamp_now(),
+        }));
+        let parent_revision = parent.transcript_revision()?;
+
+        let mut incoming = parent.clone();
+        incoming
+            .commit_transcript_rewrite(
+                TranscriptRewriteSelection::MessageRange {
+                    start: 0,
+                    end: parent.messages().len(),
+                },
+                vec![Message::User(UserMessage::text(
+                    "[Context compacted] unaudited summary".to_string(),
+                ))],
+                TranscriptRewriteReason::new("compaction"),
+                Some("meerkat-core".to_string()),
+                Some(parent_revision),
+            )
+            .map_err(|err| std::io::Error::other(format!("rewrite should commit: {err}")))?;
+
+        let saved = save_verified_transcript_history_projection(
+            store.as_ref(),
+            &incoming,
+            &previous,
+            previous_revision.clone(),
+        )
+        .await?;
+        assert!(
+            !saved,
+            "projection-only bridge must not introduce rewrite commits without audit authority"
+        );
+
+        save_session_projection_with_storage_normalization_bridge(
+            store.as_ref(),
+            blob_store.as_ref(),
+            &incoming,
+        )
+        .await
+        .expect_err("projection-only bridge should not bypass audit for new rewrite commits");
+
+        let persisted = store
+            .load(previous.id())
+            .await?
+            .ok_or_else(|| std::io::Error::other("previous session should remain persisted"))?;
+        assert_eq!(persisted.transcript_revision()?, previous_revision);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_projection_continuity_checkpoint_committed_runtime_snapshot_audits_inline_media_compaction_history()
+    -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+        let store: Arc<dyn SessionStore> = Arc::new(MemoryStore::new());
+        let runtime_store: Arc<dyn RuntimeStore> = Arc::new(InMemoryRuntimeStore::new());
+        let blob_store = memory_blob_store();
+        let event_store = Arc::new(RecordingEventStore::default());
+        let event_store_trait: Arc<dyn EventStore> = event_store.clone();
+        let dir = tempfile::tempdir()?;
+        let service = PersistentSessionService::new(
+            DummyBuilder,
+            4,
+            Arc::clone(&store),
+            Some(Arc::clone(&runtime_store)),
+            Arc::clone(&blob_store),
+        )
+        .with_event_projection(
+            event_store_trait,
+            Arc::new(SessionProjector::new(dir.path().join(".rkat"))),
+        );
+
+        let created = service
+            .create_session(create_request("seed", InitialTurnPolicy::Defer))
+            .await?;
+        let mut previous = store
+            .load(&created.session_id)
+            .await?
+            .ok_or_else(|| std::io::Error::other("created session should exist"))?;
+        previous.push(Message::User(UserMessage::with_blocks(vec![
+            ContentBlock::Text {
+                text: "inline image from legacy checkpoint projection".to_string(),
+            },
+            inline_image_block("legacy-checkpoint-compaction-parent"),
+        ])));
+        store.save_authoritative_projection(&previous).await?;
+
+        let mut normalized_parent = previous.clone();
+        normalized_parent
+            .externalize_media(blob_store.as_ref(), 0)
+            .await?;
+        let normalized_parent_revision = normalized_parent.transcript_revision()?;
+
+        let mut incoming = normalized_parent.clone();
+        incoming
+            .commit_transcript_rewrite(
+                TranscriptRewriteSelection::MessageRange {
+                    start: 0,
+                    end: normalized_parent.messages().len(),
+                },
+                vec![Message::User(UserMessage::text(
+                    "[Context compacted] checkpoint normalized legacy image prompt".to_string(),
+                ))],
+                TranscriptRewriteReason::new("compaction"),
+                Some("meerkat-core".to_string()),
+                Some(normalized_parent_revision.clone()),
+            )
+            .map_err(|err| std::io::Error::other(format!("rewrite should commit: {err}")))?;
+        let incoming_revision = incoming.transcript_revision()?;
+        let snapshot = serde_json::to_vec(&incoming)?;
+        let runtime_id =
+            PersistentSessionService::<DummyBuilder>::runtime_id_for_session(&created.session_id);
+        runtime_store
+            .commit_session_snapshot(
+                &runtime_id,
+                SessionDelta {
+                    session_snapshot: snapshot.clone(),
+                },
+            )
+            .await?;
+
+        service
+            .checkpoint_committed_runtime_session_snapshot(&created.session_id, &snapshot)
+            .await?;
+
+        let saved = store
+            .load(&created.session_id)
+            .await?
+            .ok_or_else(|| std::io::Error::other("saved session should exist"))?;
+        assert_eq!(saved.transcript_revision()?, incoming_revision);
+        assert_no_inline_images_in_session(&saved);
+        let events = service
+            .event_log_read_from(&created.session_id, 1)
+            .await?
+            .ok_or_else(|| std::io::Error::other("event projection should be installed"))?;
+        let audit = events
+            .iter()
+            .find_map(|stored| match &stored.event {
+                AgentEvent::TranscriptRewriteCommitted { record, .. } => Some(record),
+                _ => None,
+            })
+            .ok_or_else(|| std::io::Error::other("rewrite audit event should be appended"))?;
+        assert_eq!(audit.commit.parent_revision, normalized_parent_revision);
+        assert_eq!(audit.commit.revision, incoming_revision);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_checkpoint_committed_runtime_snapshot_bridges_externalized_compaction_append() {
+        let store: Arc<dyn SessionStore> = Arc::new(MemoryStore::new());
+        let runtime_store = Arc::new(InMemoryRuntimeStore::new());
+        let blob_store = memory_blob_store();
+        let service = PersistentSessionService::new(
+            DummyBuilder,
+            4,
+            Arc::clone(&store),
+            Some(runtime_store),
+            Arc::clone(&blob_store),
+        );
+
+        let created = service
+            .create_session(create_request("seed", InitialTurnPolicy::Defer))
+            .await
+            .expect("create_session should succeed");
+        let previous = store
+            .load(&created.session_id)
+            .await
+            .expect("load should succeed")
+            .expect("created session should exist");
+
+        let mut parent = previous.clone();
+        parent.set_system_prompt("refreshed runtime system projection".to_string());
+        parent.push(Message::User(UserMessage::with_blocks(vec![
+            ContentBlock::Text {
+                text: "runtime-only image prompt".to_string(),
+            },
+            inline_image_block("runtime-parent"),
+        ])));
+        parent.push(Message::Assistant(meerkat_core::AssistantMessage {
+            content: "runtime-only answer".to_string(),
+            tool_calls: Vec::new(),
+            stop_reason: StopReason::EndTurn,
+            usage: Usage::default(),
+            created_at: meerkat_core::types::message_timestamp_now(),
+        }));
+        let parent_revision = parent.transcript_revision().expect("parent revision");
+
+        let mut incoming = parent.clone();
+        let mut replacement = vec![
+            parent.messages()[0].clone(),
+            Message::User(UserMessage::text(
+                "[Context compacted] retained image prompt".to_string(),
+            )),
+        ];
+        replacement.extend_from_slice(&parent.messages()[1..]);
+        incoming
+            .commit_transcript_rewrite(
+                TranscriptRewriteSelection::MessageRange {
+                    start: 0,
+                    end: parent.messages().len(),
+                },
+                replacement,
+                TranscriptRewriteReason::new("compaction"),
+                Some("meerkat-core".to_string()),
+                Some(parent_revision),
+            )
+            .expect("compaction rewrite should commit");
+        incoming.push(Message::Assistant(meerkat_core::AssistantMessage {
+            content: "final peer response".to_string(),
+            tool_calls: Vec::new(),
+            stop_reason: StopReason::EndTurn,
+            usage: Usage::default(),
+            created_at: meerkat_core::types::message_timestamp_now(),
+        }));
+        incoming
+            .externalize_media(blob_store.as_ref(), 0)
+            .await
+            .expect("runtime snapshot normalization should succeed");
+        let incoming_revision = incoming.transcript_revision().expect("incoming revision");
+        let snapshot = serde_json::to_vec(&incoming).expect("snapshot should serialize");
+
+        service
+            .checkpoint_committed_runtime_session_snapshot(&created.session_id, &snapshot)
+            .await
+            .expect("checkpoint should bridge externalized compaction append");
+        let saved = store
+            .load(&created.session_id)
+            .await
+            .expect("load should succeed")
+            .expect("saved session should exist");
+        assert_no_inline_images_in_session(&saved);
+        assert_eq!(
+            saved.transcript_revision().expect("saved revision"),
+            incoming_revision
+        );
+    }
+
+    #[tokio::test]
+    async fn test_projection_continuity_checkpoint_committed_runtime_snapshot_rejects_unrelated_history_projection()
+    -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+        let store: Arc<dyn SessionStore> = Arc::new(MemoryStore::new());
+        let runtime_store: Arc<dyn RuntimeStore> = Arc::new(InMemoryRuntimeStore::new());
+        let service = PersistentSessionService::new(
+            DummyBuilder,
+            4,
+            Arc::clone(&store),
+            Some(Arc::clone(&runtime_store)),
+            memory_blob_store(),
+        );
+
+        let created = service
+            .create_session(create_request("seed", InitialTurnPolicy::Defer))
+            .await?;
+        let baseline = store
+            .load(&created.session_id)
+            .await?
+            .ok_or_else(|| std::io::Error::other("created session should exist"))?;
+
+        let mut newer_projection = baseline.clone();
+        newer_projection.push(Message::User(UserMessage::text(
+            "newer persisted turn that stale runtime snapshots must preserve".to_string(),
+        )));
+        let newer_revision = newer_projection.transcript_revision()?;
+        store
+            .save_authoritative_projection(&newer_projection)
+            .await?;
+
+        let mut stale_parent = baseline;
+        stale_parent.set_system_prompt("stale runtime system projection".to_string());
+        stale_parent.push(Message::User(UserMessage::text(
+            "stale runtime branch prompt".to_string(),
+        )));
+        stale_parent.push(Message::Assistant(meerkat_core::AssistantMessage {
+            content: "stale runtime branch answer".to_string(),
+            tool_calls: Vec::new(),
+            stop_reason: StopReason::EndTurn,
+            usage: Usage::default(),
+            created_at: meerkat_core::types::message_timestamp_now(),
+        }));
+        let stale_parent_revision = stale_parent.transcript_revision()?;
+
+        let mut incoming = stale_parent.clone();
+        incoming
+            .commit_transcript_rewrite(
+                TranscriptRewriteSelection::MessageRange {
+                    start: 0,
+                    end: stale_parent.messages().len(),
+                },
+                vec![Message::User(UserMessage::text(
+                    "[Context compacted] stale runtime branch".to_string(),
+                ))],
+                TranscriptRewriteReason::new("compaction"),
+                Some("meerkat-core".to_string()),
+                Some(stale_parent_revision.clone()),
+            )
+            .map_err(|err| std::io::Error::other(format!("rewrite should commit: {err}")))?;
+        incoming.push(Message::Assistant(meerkat_core::AssistantMessage {
+            content: "stale branch final response".to_string(),
+            tool_calls: Vec::new(),
+            stop_reason: StopReason::EndTurn,
+            usage: Usage::default(),
+            created_at: meerkat_core::types::message_timestamp_now(),
+        }));
+        let incoming_revision = incoming.transcript_revision()?;
+        let snapshot = serde_json::to_vec(&incoming)?;
+        runtime_store
+            .commit_session_snapshot(
+                &PersistentSessionService::<DummyBuilder>::runtime_id_for_session(
+                    &created.session_id,
+                ),
+                SessionDelta {
+                    session_snapshot: snapshot.clone(),
+                },
+            )
+            .await?;
+
+        let checkpoint_result = service
+            .checkpoint_committed_runtime_session_snapshot(&created.session_id, &snapshot)
+            .await;
+        assert!(
+            checkpoint_result.is_err(),
+            "stale runtime history must not bypass the persisted-row continuity guard"
+        );
+
+        let saved = store
+            .load(&created.session_id)
+            .await?
+            .ok_or_else(|| std::io::Error::other("persisted session should remain present"))?;
+        assert_eq!(saved.transcript_revision()?, newer_revision);
+        assert_ne!(saved.transcript_revision()?, incoming_revision);
+        assert!(
+            runtime_store
+                .load_session_snapshot(
+                    &PersistentSessionService::<DummyBuilder>::runtime_id_for_session(
+                        &created.session_id,
+                    ),
+                )
+                .await?
+                .is_none(),
+            "rejected checkpoint snapshot should be quarantined instead of restored from a possibly-mutated projection"
+        );
+        let recovered = service
+            .load_authoritative_session_base(&created.session_id)
+            .await?
+            .ok_or_else(|| std::io::Error::other("store fallback should recover latest row"))?;
+        assert_eq!(recovered.transcript_revision()?, newer_revision);
+        assert_ne!(recovered.transcript_revision()?, incoming_revision);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_projection_continuity_checkpoint_restore_failure_quarantines_runtime_snapshot()
+    -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+        let store: Arc<dyn SessionStore> = Arc::new(MemoryStore::new());
+        let gated_runtime_store = Arc::new(GatedSnapshotRuntimeStore::new());
+        let runtime_store: Arc<dyn RuntimeStore> = gated_runtime_store.clone();
+        let service = PersistentSessionService::new(
+            DummyBuilder,
+            4,
+            Arc::clone(&store),
+            Some(Arc::clone(&runtime_store)),
+            memory_blob_store(),
+        );
+
+        let created = service
+            .create_session(create_request("seed", InitialTurnPolicy::Defer))
+            .await?;
+        let baseline = store
+            .load(&created.session_id)
+            .await?
+            .ok_or_else(|| std::io::Error::other("created session should exist"))?;
+
+        let mut newer_projection = baseline.clone();
+        newer_projection.push(Message::User(UserMessage::text(
+            "newer persisted turn that must survive quarantine".to_string(),
+        )));
+        let newer_revision = newer_projection.transcript_revision()?;
+        store
+            .save_authoritative_projection(&newer_projection)
+            .await?;
+
+        let mut incoming = baseline;
+        incoming.push(Message::User(UserMessage::text(
+            "stale runtime branch that should be rejected".to_string(),
+        )));
+        let incoming_revision = incoming.transcript_revision()?;
+        let snapshot = serde_json::to_vec(&incoming)?;
+        let runtime_id =
+            PersistentSessionService::<DummyBuilder>::runtime_id_for_session(&created.session_id);
+        runtime_store
+            .commit_session_snapshot(
+                &runtime_id,
+                SessionDelta {
+                    session_snapshot: snapshot.clone(),
+                },
+            )
+            .await?;
+
+        gated_runtime_store.set_fail_snapshot_commits(true);
+        let checkpoint_result = service
+            .checkpoint_committed_runtime_session_snapshot(&created.session_id, &snapshot)
+            .await;
+        assert!(
+            checkpoint_result.is_err(),
+            "projection rejection plus restore failure must fail closed"
+        );
+        let saved = store
+            .load(&created.session_id)
+            .await?
+            .ok_or_else(|| std::io::Error::other("persisted session should remain present"))?;
+        assert_eq!(saved.transcript_revision()?, newer_revision);
+        assert_ne!(saved.transcript_revision()?, incoming_revision);
+        assert!(
+            runtime_store
+                .load_session_snapshot(&runtime_id)
+                .await?
+                .is_none(),
+            "failed restore must quarantine the rejected runtime snapshot"
+        );
+        let recovered = service
+            .load_authoritative_session_base(&created.session_id)
+            .await?
+            .ok_or_else(|| {
+                std::io::Error::other("quarantined runtime snapshot should fall back to store row")
+            })?;
+        assert_eq!(recovered.transcript_revision()?, newer_revision);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_projection_continuity_checkpoint_audit_rollback_failure_quarantines_store_projection()
+    -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+        let store = Arc::new(FailAuthoritativeProjectionStore::new());
+        let store_trait: Arc<dyn SessionStore> = store.clone();
+        let runtime_store: Arc<dyn RuntimeStore> = Arc::new(InMemoryRuntimeStore::new());
+        let event_store = Arc::new(RecordingEventStore::default());
+        let event_store_trait: Arc<dyn EventStore> = event_store.clone();
+        let dir = tempfile::tempdir()?;
+        let service = PersistentSessionService::new(
+            DummyBuilder,
+            4,
+            Arc::clone(&store_trait),
+            Some(Arc::clone(&runtime_store)),
+            memory_blob_store(),
+        )
+        .with_event_projection(
+            event_store_trait,
+            Arc::new(SessionProjector::new(dir.path().join(".rkat"))),
+        );
+
+        let created = service
+            .create_session(create_request("seed", InitialTurnPolicy::Defer))
+            .await?;
+        let original = store_trait
+            .load(&created.session_id)
+            .await?
+            .ok_or_else(|| std::io::Error::other("created session should exist"))?;
+        let parent_revision = original.transcript_revision()?;
+
+        let mut incoming = original.clone();
+        let commit = incoming
+            .commit_transcript_rewrite(
+                TranscriptRewriteSelection::MessageRange {
+                    start: 0,
+                    end: original.messages().len(),
+                },
+                vec![Message::User(UserMessage::text(
+                    "[Context compacted] unaudited checkpoint".to_string(),
+                ))],
+                TranscriptRewriteReason::new("compaction"),
+                Some("meerkat-core".to_string()),
+                Some(parent_revision),
+            )
+            .map_err(|err| std::io::Error::other(format!("rewrite should commit: {err}")))?;
+        let snapshot = serde_json::to_vec(&incoming)?;
+        let runtime_id =
+            PersistentSessionService::<DummyBuilder>::runtime_id_for_session(&created.session_id);
+        runtime_store
+            .commit_session_snapshot(
+                &runtime_id,
+                SessionDelta {
+                    session_snapshot: snapshot.clone(),
+                },
+            )
+            .await?;
+
+        event_store.fail_appends();
+        store.fail_authoritative_projection_cas();
+        let checkpoint_result = service
+            .checkpoint_committed_runtime_session_snapshot(&created.session_id, &snapshot)
+            .await;
+        let err = checkpoint_result.expect_err(
+            "checkpoint rewrite must fail closed when audit append and projection rollback fail",
+        );
+        assert!(
+            err.to_string()
+                .contains("unaudited projection was quarantined"),
+            "unexpected error: {err}"
+        );
+        assert!(
+            store_trait.load(&created.session_id).await?.is_none(),
+            "failed audit rollback must not leave the unaudited rewrite as store fallback"
+        );
+        assert!(
+            runtime_store
+                .load_session_snapshot(&runtime_id)
+                .await?
+                .is_none(),
+            "runtime snapshot should be quarantined after failed checkpoint projection update"
+        );
+        assert_ne!(original.transcript_revision()?, commit.revision);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_projection_continuity_fail_closed_cleanup_preserves_newer_runtime_snapshot()
+    -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+        let store: Arc<dyn SessionStore> = Arc::new(MemoryStore::new());
+        let runtime_store: Arc<dyn RuntimeStore> = Arc::new(InMemoryRuntimeStore::new());
+        let service = PersistentSessionService::new(
+            DummyBuilder,
+            4,
+            Arc::clone(&store),
+            Some(Arc::clone(&runtime_store)),
+            memory_blob_store(),
+        );
+
+        let mut persisted = Session::new();
+        persisted.push(Message::User(UserMessage::text("persisted".to_string())));
+        store.save(&persisted).await?;
+
+        let mut rejected = persisted.clone();
+        rejected.push(Message::Assistant(meerkat_core::AssistantMessage {
+            content: "rejected runtime snapshot".to_string(),
+            tool_calls: Vec::new(),
+            stop_reason: StopReason::EndTurn,
+            usage: Usage::default(),
+            created_at: meerkat_core::types::message_timestamp_now(),
+        }));
+        let rejected_snapshot = serde_json::to_vec(&rejected)?;
+
+        let mut newer = rejected.clone();
+        newer.push(Message::User(UserMessage::text(
+            "newer runtime authority".to_string(),
+        )));
+        let newer_snapshot = serde_json::to_vec(&newer)?;
+        let runtime_id =
+            PersistentSessionService::<DummyBuilder>::runtime_id_for_session(persisted.id());
+        runtime_store
+            .commit_session_snapshot(
+                &runtime_id,
+                SessionDelta {
+                    session_snapshot: newer_snapshot.clone(),
+                },
+            )
+            .await?;
+
+        let err = service
+            .fail_closed_runtime_projection_update(
+                persisted.id(),
+                SessionStoreError::Internal("forced projection rejection".to_string()),
+                Some(rejected_snapshot.as_slice()),
+            )
+            .await;
+        assert!(
+            err.to_string().contains("forced projection rejection"),
+            "unexpected error: {err}"
+        );
+        let current = runtime_store
+            .load_session_snapshot(&runtime_id)
+            .await?
+            .ok_or_else(|| std::io::Error::other("runtime snapshot should remain present"))?;
+        assert_eq!(current, newer_snapshot);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_projection_continuity_fail_closed_quarantine_preserves_newer_runtime_snapshot()
+    -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+        let store: Arc<dyn SessionStore> = Arc::new(MemoryStore::new());
+        let gated_runtime_store = Arc::new(GatedSnapshotRuntimeStore::new());
+        let runtime_store: Arc<dyn RuntimeStore> = gated_runtime_store.clone();
+        let service = PersistentSessionService::new(
+            DummyBuilder,
+            4,
+            Arc::clone(&store),
+            Some(Arc::clone(&runtime_store)),
+            memory_blob_store(),
+        );
+
+        let mut persisted = Session::new();
+        persisted.push(Message::User(UserMessage::text("persisted".to_string())));
+        store.save(&persisted).await?;
+
+        let mut rejected = persisted.clone();
+        rejected.push(Message::Assistant(meerkat_core::AssistantMessage {
+            content: "rejected runtime snapshot".to_string(),
+            tool_calls: Vec::new(),
+            stop_reason: StopReason::EndTurn,
+            usage: Usage::default(),
+            created_at: meerkat_core::types::message_timestamp_now(),
+        }));
+        let rejected_snapshot = serde_json::to_vec(&rejected)?;
+
+        let mut newer = rejected.clone();
+        newer.push(Message::User(UserMessage::text(
+            "newer runtime authority before quarantine".to_string(),
+        )));
+        let newer_snapshot = serde_json::to_vec(&newer)?;
+        let runtime_id =
+            PersistentSessionService::<DummyBuilder>::runtime_id_for_session(persisted.id());
+        runtime_store
+            .commit_session_snapshot(
+                &runtime_id,
+                SessionDelta {
+                    session_snapshot: newer_snapshot.clone(),
+                },
+            )
+            .await?;
+
+        gated_runtime_store.set_fail_snapshot_commits(true);
+        let err = service
+            .fail_closed_runtime_projection_update(
+                persisted.id(),
+                SessionStoreError::Internal("forced projection rejection".to_string()),
+                Some(rejected_snapshot.as_slice()),
+            )
+            .await;
+        assert!(
+            err.to_string().contains("forced projection rejection"),
+            "unexpected error: {err}"
+        );
+        let current = runtime_store
+            .load_session_snapshot(&runtime_id)
+            .await?
+            .ok_or_else(|| std::io::Error::other("newer runtime snapshot should remain present"))?;
+        assert_eq!(current, newer_snapshot);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_projection_continuity_runtime_audit_rollback_preserves_newer_runtime_snapshot()
+    -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+        let store: Arc<dyn SessionStore> = Arc::new(MemoryStore::new());
+        let gated_runtime_store = Arc::new(GatedSnapshotRuntimeStore::new());
+        let runtime_store: Arc<dyn RuntimeStore> = gated_runtime_store.clone();
+        let event_store = Arc::new(RecordingEventStore::default());
+        let event_store_trait: Arc<dyn EventStore> = event_store.clone();
+        let dir = tempfile::tempdir()?;
+        let service = PersistentSessionService::new(
+            DummyBuilder,
+            4,
+            Arc::clone(&store),
+            Some(Arc::clone(&runtime_store)),
+            memory_blob_store(),
+        )
+        .with_event_projection(
+            event_store_trait,
+            Arc::new(SessionProjector::new(dir.path().join(".rkat"))),
+        );
+
+        let created = service
+            .create_session(create_request("seed", InitialTurnPolicy::Defer))
+            .await?;
+        let original = store
+            .load(&created.session_id)
+            .await?
+            .ok_or_else(|| std::io::Error::other("created session should exist"))?;
+        let parent_revision = original.transcript_revision()?;
+
+        let mut incoming = original.clone();
+        let commit = incoming
+            .commit_transcript_rewrite(
+                TranscriptRewriteSelection::MessageRange {
+                    start: 0,
+                    end: original.messages().len(),
+                },
+                vec![Message::User(UserMessage::text(
+                    "[Context compacted] audit failure".to_string(),
+                ))],
+                TranscriptRewriteReason::new("compaction"),
+                Some("meerkat-core".to_string()),
+                Some(parent_revision),
+            )
+            .map_err(|err| std::io::Error::other(format!("rewrite should commit: {err}")))?;
+        let runtime_id =
+            PersistentSessionService::<DummyBuilder>::runtime_id_for_session(&created.session_id);
+        runtime_store
+            .commit_session_snapshot(
+                &runtime_id,
+                SessionDelta {
+                    session_snapshot: serde_json::to_vec(&original)?,
+                },
+            )
+            .await?;
+
+        let mut newer = incoming.clone();
+        newer.push(Message::Assistant(meerkat_core::AssistantMessage {
+            content: "newer runtime authority".to_string(),
+            tool_calls: Vec::new(),
+            stop_reason: StopReason::EndTurn,
+            usage: Usage::default(),
+            created_at: meerkat_core::types::message_timestamp_now(),
+        }));
+        let newer_snapshot = serde_json::to_vec(&newer)?;
+        gated_runtime_store
+            .interlope_before_snapshot_replace(runtime_id.clone(), newer_snapshot.clone())
+            .await;
+
+        event_store.fail_appends();
+        let save_result = service.save_normalized_session(incoming).await;
+        let err = save_result
+            .expect_err("rewrite snapshot persistence must fail closed when audit append fails");
+        assert!(
+            err.to_string()
+                .contains("synthetic transcript rewrite audit append failure"),
+            "unexpected error: {err}"
+        );
+
+        let saved = store
+            .load(&created.session_id)
+            .await?
+            .ok_or_else(|| std::io::Error::other("persisted session should remain present"))?;
+        assert_eq!(
+            saved.transcript_revision()?,
+            original.transcript_revision()?
+        );
+        assert_ne!(saved.transcript_revision()?, commit.revision);
+        let current = runtime_store
+            .load_session_snapshot(&runtime_id)
+            .await?
+            .ok_or_else(|| std::io::Error::other("newer runtime snapshot should remain present"))?;
+        assert_eq!(current, newer_snapshot);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_projection_continuity_runtime_audit_quarantine_preserves_newer_runtime_snapshot()
+    -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+        let store: Arc<dyn SessionStore> = Arc::new(MemoryStore::new());
+        let gated_runtime_store = Arc::new(GatedSnapshotRuntimeStore::new());
+        let runtime_store: Arc<dyn RuntimeStore> = gated_runtime_store.clone();
+        let event_store = Arc::new(RecordingEventStore::default());
+        let event_store_trait: Arc<dyn EventStore> = event_store.clone();
+        let dir = tempfile::tempdir()?;
+        let service = PersistentSessionService::new(
+            DummyBuilder,
+            4,
+            Arc::clone(&store),
+            Some(Arc::clone(&runtime_store)),
+            memory_blob_store(),
+        )
+        .with_event_projection(
+            event_store_trait,
+            Arc::new(SessionProjector::new(dir.path().join(".rkat"))),
+        );
+
+        let created = service
+            .create_session(create_request("seed", InitialTurnPolicy::Defer))
+            .await?;
+        let original = store
+            .load(&created.session_id)
+            .await?
+            .ok_or_else(|| std::io::Error::other("created session should exist"))?;
+        let parent_revision = original.transcript_revision()?;
+
+        let mut incoming = original.clone();
+        let commit = incoming
+            .commit_transcript_rewrite(
+                TranscriptRewriteSelection::MessageRange {
+                    start: 0,
+                    end: original.messages().len(),
+                },
+                vec![Message::User(UserMessage::text(
+                    "[Context compacted] audit failure".to_string(),
+                ))],
+                TranscriptRewriteReason::new("compaction"),
+                Some("meerkat-core".to_string()),
+                Some(parent_revision),
+            )
+            .map_err(|err| std::io::Error::other(format!("rewrite should commit: {err}")))?;
+        let runtime_id =
+            PersistentSessionService::<DummyBuilder>::runtime_id_for_session(&created.session_id);
+        runtime_store
+            .commit_session_snapshot(
+                &runtime_id,
+                SessionDelta {
+                    session_snapshot: serde_json::to_vec(&original)?,
+                },
+            )
+            .await?;
+
+        let mut newer = incoming.clone();
+        newer.push(Message::Assistant(meerkat_core::AssistantMessage {
+            content: "newer runtime authority before quarantine".to_string(),
+            tool_calls: Vec::new(),
+            stop_reason: StopReason::EndTurn,
+            usage: Usage::default(),
+            created_at: meerkat_core::types::message_timestamp_now(),
+        }));
+        let newer_snapshot = serde_json::to_vec(&newer)?;
+        gated_runtime_store.set_fail_snapshot_replaces(true);
+        gated_runtime_store
+            .interlope_before_snapshot_clear(runtime_id.clone(), newer_snapshot.clone())
+            .await;
+
+        event_store.fail_appends();
+        let save_result = service.save_normalized_session(incoming).await;
+        let err = save_result.expect_err(
+            "rewrite snapshot persistence must fail closed when audit append and rollback fail",
+        );
+        assert!(
+            err.to_string().contains("runtime snapshot was quarantined"),
+            "unexpected error: {err}"
+        );
+
+        let saved = store
+            .load(&created.session_id)
+            .await?
+            .ok_or_else(|| std::io::Error::other("persisted session should remain present"))?;
+        assert_eq!(
+            saved.transcript_revision()?,
+            original.transcript_revision()?
+        );
+        assert_ne!(saved.transcript_revision()?, commit.revision);
+        let current = runtime_store
+            .load_session_snapshot(&runtime_id)
+            .await?
+            .ok_or_else(|| std::io::Error::other("newer runtime snapshot should remain present"))?;
+        assert_eq!(current, newer_snapshot);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_projection_continuity_save_normalized_session_rejects_runtime_rewrite_chain_not_connected_to_store()
+    -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+        let store: Arc<dyn SessionStore> = Arc::new(MemoryStore::new());
+        let runtime_store: Arc<dyn RuntimeStore> = Arc::new(InMemoryRuntimeStore::new());
+        let service = PersistentSessionService::new(
+            DummyBuilder,
+            4,
+            Arc::clone(&store),
+            Some(Arc::clone(&runtime_store)),
+            memory_blob_store(),
+        );
+
+        let created = service
+            .create_session(create_request("seed", InitialTurnPolicy::Defer))
+            .await?;
+        let baseline = store
+            .load(&created.session_id)
+            .await?
+            .ok_or_else(|| std::io::Error::other("created session should exist"))?;
+
+        let mut newer_projection = baseline.clone();
+        newer_projection.push(Message::User(UserMessage::text(
+            "newer persisted turn that runtime rewrite persistence must preserve".to_string(),
+        )));
+        let newer_revision = newer_projection.transcript_revision()?;
+        store
+            .save_authoritative_projection(&newer_projection)
+            .await?;
+
+        let mut stale_parent = baseline;
+        stale_parent.set_system_prompt("stale runtime system projection".to_string());
+        stale_parent.push(Message::User(UserMessage::text(
+            "stale runtime branch prompt".to_string(),
+        )));
+        stale_parent.push(Message::Assistant(meerkat_core::AssistantMessage {
+            content: "stale runtime branch answer".to_string(),
+            tool_calls: Vec::new(),
+            stop_reason: StopReason::EndTurn,
+            usage: Usage::default(),
+            created_at: meerkat_core::types::message_timestamp_now(),
+        }));
+        let stale_parent_revision = stale_parent.transcript_revision()?;
+        runtime_store
+            .commit_session_snapshot(
+                &PersistentSessionService::<DummyBuilder>::runtime_id_for_session(
+                    &created.session_id,
+                ),
+                SessionDelta {
+                    session_snapshot: serde_json::to_vec(&stale_parent)?,
+                },
+            )
+            .await?;
+
+        let mut incoming = stale_parent.clone();
+        incoming
+            .commit_transcript_rewrite(
+                TranscriptRewriteSelection::MessageRange {
+                    start: 0,
+                    end: stale_parent.messages().len(),
+                },
+                vec![Message::User(UserMessage::text(
+                    "[Context compacted] stale runtime branch".to_string(),
+                ))],
+                TranscriptRewriteReason::new("compaction"),
+                Some("meerkat-core".to_string()),
+                Some(stale_parent_revision.clone()),
+            )
+            .map_err(|err| std::io::Error::other(format!("rewrite should commit: {err}")))?;
+        let incoming_revision = incoming.transcript_revision()?;
+
+        let save_result = service.save_normalized_session(incoming).await;
+        assert!(
+            save_result.is_err(),
+            "runtime rewrite-chain persistence must not overwrite a newer SessionStore row"
+        );
+
+        let runtime_saved =
+            PersistentSessionService::<DummyBuilder>::load_runtime_session_snapshot(
+                &runtime_store,
+                &PersistentSessionService::<DummyBuilder>::runtime_id_for_session(
+                    &created.session_id,
+                ),
+            )
+            .await?
+            .ok_or_else(|| std::io::Error::other("runtime snapshot should remain present"))?;
+        assert_eq!(runtime_saved.transcript_revision()?, stale_parent_revision);
+        assert_ne!(runtime_saved.transcript_revision()?, incoming_revision);
+
+        let saved = store
+            .load(&created.session_id)
+            .await?
+            .ok_or_else(|| std::io::Error::other("persisted session should remain present"))?;
+        assert_eq!(saved.transcript_revision()?, newer_revision);
+        assert_ne!(saved.transcript_revision()?, incoming_revision);
+        Ok(())
+    }
+
+    #[tokio::test]
     async fn test_apply_runtime_turn_externalizes_inline_images_in_runtime_snapshot() {
         let store: Arc<dyn SessionStore> = Arc::new(MemoryStore::new());
         let runtime_store = Arc::new(InMemoryRuntimeStore::new());
@@ -9838,6 +12288,83 @@ mod tests {
             .read_history(&session_id, SessionHistoryQuery::default())
             .await
             .expect("failed audit append must leave the previous projection readable");
+    }
+
+    #[tokio::test]
+    async fn test_persistent_save_normalized_quarantines_unaudited_projection_when_rollback_fails()
+    {
+        let fail_store = Arc::new(FailAuthoritativeProjectionStore::new());
+        let store: Arc<dyn SessionStore> = fail_store.clone();
+        let event_store = Arc::new(RecordingEventStore::default());
+        let event_store_trait: Arc<dyn EventStore> = event_store.clone();
+        let dir = tempfile::tempdir().expect("tempdir");
+        let service = PersistentSessionService::new(
+            DummyBuilder,
+            4,
+            Arc::clone(&store),
+            None,
+            memory_blob_store(),
+        )
+        .with_event_projection(
+            event_store_trait,
+            Arc::new(SessionProjector::new(dir.path().join(".rkat"))),
+        );
+
+        let created = service
+            .create_session(create_request("seed", InitialTurnPolicy::Defer))
+            .await
+            .expect("create_session should succeed");
+        let session_id = created.session_id;
+        let original = store
+            .load(&session_id)
+            .await
+            .expect("load before rewrite")
+            .expect("session should exist");
+        let parent_revision = original
+            .transcript_revision()
+            .expect("parent revision should digest");
+
+        let mut incoming = original.clone();
+        let commit = incoming
+            .commit_transcript_rewrite(
+                TranscriptRewriteSelection::MessageRange {
+                    start: 0,
+                    end: original.messages().len(),
+                },
+                vec![Message::User(UserMessage::text(
+                    "[Context compacted] unaudited no-runtime save".to_string(),
+                ))],
+                TranscriptRewriteReason::new("compaction"),
+                Some("test".to_string()),
+                Some(parent_revision),
+            )
+            .expect("rewrite should commit");
+
+        event_store.fail_appends();
+        fail_store.fail_authoritative_projection_cas();
+        let err = service
+            .save_normalized_session(incoming)
+            .await
+            .expect_err("audit append plus rollback failure must fail closed");
+        assert!(
+            err.to_string()
+                .contains("unaudited projection was quarantined"),
+            "unexpected error: {err}"
+        );
+        assert!(
+            store
+                .load(&session_id)
+                .await
+                .expect("load after quarantine")
+                .is_none(),
+            "failed rollback must not leave unaudited rewrite as store fallback"
+        );
+        assert_ne!(
+            original
+                .transcript_revision()
+                .expect("original revision should digest"),
+            commit.revision
+        );
     }
 
     #[tokio::test]

--- a/meerkat-store/src/jsonl.rs
+++ b/meerkat-store/src/jsonl.rs
@@ -465,6 +465,29 @@ impl SessionStore for JsonlStore {
             .map_err(into_session_store_error)
     }
 
+    async fn save_authoritative_projection_if_current_revision(
+        &self,
+        session: &Session,
+        expected_current_revision: Option<String>,
+    ) -> Result<(), SessionStoreError> {
+        let _write_lock = self
+            .acquire_session_write_lock(session.id())
+            .await
+            .map_err(into_session_store_error)?;
+        let previous = self
+            .load_impl(session.id())
+            .await
+            .map_err(into_session_store_error)?;
+        meerkat_core::session_store::authoritative_projection_current_revision_guard(
+            session,
+            previous.as_ref(),
+            expected_current_revision.as_deref(),
+        )?;
+        self.save_impl(session)
+            .await
+            .map_err(into_session_store_error)
+    }
+
     async fn load(&self, id: &SessionId) -> Result<Option<Session>, SessionStoreError> {
         self.load_impl(id).await.map_err(into_session_store_error)
     }
@@ -477,6 +500,28 @@ impl SessionStore for JsonlStore {
 
     async fn delete(&self, id: &SessionId) -> Result<(), SessionStoreError> {
         self.delete_impl(id).await.map_err(into_session_store_error)
+    }
+
+    async fn delete_if_current_revision(
+        &self,
+        id: &SessionId,
+        expected_current_revision: &str,
+    ) -> Result<bool, SessionStoreError> {
+        let _write_lock = self
+            .acquire_session_write_lock(id)
+            .await
+            .map_err(into_session_store_error)?;
+        let Some(previous) = self.load_impl(id).await.map_err(into_session_store_error)? else {
+            return Ok(false);
+        };
+        let previous_token = meerkat_core::session_store::session_projection_cas_token(&previous)?;
+        if previous_token != expected_current_revision {
+            return Ok(false);
+        }
+        self.delete_impl(id)
+            .await
+            .map_err(into_session_store_error)?;
+        Ok(true)
     }
 }
 
@@ -821,6 +866,78 @@ mod tests {
             .await?
             .expect("session should remain saved");
         assert_eq!(saved.messages().len(), newer.messages().len());
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_jsonl_authoritative_projection_expected_revision_rejects_stale_writer()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let temp_dir = tempfile::tempdir()?;
+        let first = JsonlStore::new(temp_dir.path().to_path_buf());
+        let second = JsonlStore::new(temp_dir.path().to_path_buf());
+
+        let mut session = Session::new();
+        session.push(Message::User(UserMessage::text("base".to_string())));
+        first.save(&session).await?;
+        let expected_revision = session.transcript_revision()?;
+
+        let mut newer = second.load(session.id()).await?.expect("session exists");
+        newer.push(Message::User(UserMessage::text("newer".to_string())));
+        second.save(&newer).await?;
+
+        let mut stale_projection = session.clone();
+        stale_projection.push(Message::User(UserMessage::text("stale".to_string())));
+        let err = first
+            .save_authoritative_projection_if_current_revision(
+                &stale_projection,
+                Some(expected_revision),
+            )
+            .await
+            .expect_err("stale authoritative projection should be rejected");
+        assert!(
+            matches!(err, SessionStoreError::TranscriptContinuityViolation { .. }),
+            "unexpected error: {err}"
+        );
+
+        let saved = first
+            .load(session.id())
+            .await?
+            .expect("session should remain saved");
+        assert_eq!(saved.messages().len(), newer.messages().len());
+        assert_eq!(saved.transcript_revision()?, newer.transcript_revision()?);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_jsonl_delete_if_current_revision_only_deletes_matching_projection()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let temp_dir = tempfile::tempdir()?;
+        let first = JsonlStore::new(temp_dir.path().to_path_buf());
+        let second = JsonlStore::new(temp_dir.path().to_path_buf());
+
+        let mut session = Session::new();
+        session.push(Message::User(UserMessage::text("base".to_string())));
+        first.save(&session).await?;
+        let stale_token = meerkat_core::session_store::session_projection_cas_token(&session)?;
+
+        let mut newer = second.load(session.id()).await?.expect("session exists");
+        newer.push(Message::User(UserMessage::text("newer".to_string())));
+        second.save(&newer).await?;
+
+        assert!(
+            !first
+                .delete_if_current_revision(session.id(), &stale_token)
+                .await?
+        );
+        assert!(first.load(session.id()).await?.is_some());
+
+        let current_token = meerkat_core::session_store::session_projection_cas_token(&newer)?;
+        assert!(
+            first
+                .delete_if_current_revision(session.id(), &current_token)
+                .await?
+        );
+        assert!(first.load(session.id()).await?.is_none());
         Ok(())
     }
 }

--- a/meerkat-store/src/memory.rs
+++ b/meerkat-store/src/memory.rs
@@ -66,6 +66,22 @@ impl SessionStore for MemoryStore {
         Ok(())
     }
 
+    async fn save_authoritative_projection_if_current_revision(
+        &self,
+        session: &Session,
+        expected_current_revision: Option<String>,
+    ) -> Result<(), SessionStoreError> {
+        let mut sessions = self.sessions.write().await;
+        let previous = sessions.get(session.id());
+        meerkat_core::session_store::authoritative_projection_current_revision_guard(
+            session,
+            previous,
+            expected_current_revision.as_deref(),
+        )?;
+        sessions.insert(session.id().clone(), session.clone());
+        Ok(())
+    }
+
     async fn load(&self, id: &SessionId) -> Result<Option<Session>, SessionStoreError> {
         let sessions = self.sessions.read().await;
         Ok(sessions.get(id).cloned())
@@ -106,6 +122,23 @@ impl SessionStore for MemoryStore {
         sessions.remove(id);
         Ok(())
     }
+
+    async fn delete_if_current_revision(
+        &self,
+        id: &SessionId,
+        expected_current_revision: &str,
+    ) -> Result<bool, SessionStoreError> {
+        let mut sessions = self.sessions.write().await;
+        let Some(previous) = sessions.get(id) else {
+            return Ok(false);
+        };
+        let previous_token = meerkat_core::session_store::session_projection_cas_token(previous)?;
+        if previous_token != expected_current_revision {
+            return Ok(false);
+        }
+        sessions.remove(id);
+        Ok(true)
+    }
 }
 
 #[cfg(test)]
@@ -128,6 +161,73 @@ mod tests {
         let loaded = store.load(&id).await?.ok_or("session not found")?;
         assert_eq!(loaded.id(), &id);
         assert_eq!(loaded.messages().len(), 1);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn authoritative_projection_expected_revision_rejects_stale_writer()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let store = MemoryStore::new();
+
+        let mut session = Session::new();
+        session.push(Message::User(UserMessage::text("base".to_string())));
+        store.save(&session).await?;
+        let expected_revision = session.transcript_revision()?;
+
+        let mut newer = session.clone();
+        newer.push(Message::User(UserMessage::text("newer".to_string())));
+        store.save(&newer).await?;
+
+        let mut stale_projection = session.clone();
+        stale_projection.push(Message::User(UserMessage::text("stale".to_string())));
+        let err = store
+            .save_authoritative_projection_if_current_revision(
+                &stale_projection,
+                Some(expected_revision),
+            )
+            .await
+            .expect_err("stale authoritative projection should be rejected");
+        assert!(matches!(
+            err,
+            SessionStoreError::TranscriptContinuityViolation { .. }
+        ));
+
+        let saved = store
+            .load(session.id())
+            .await?
+            .expect("session should remain saved");
+        assert_eq!(saved.messages().len(), newer.messages().len());
+        assert_eq!(saved.transcript_revision()?, newer.transcript_revision()?);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn delete_if_current_revision_only_deletes_matching_projection()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let store = MemoryStore::new();
+
+        let mut session = Session::new();
+        session.push(Message::User(UserMessage::text("base".to_string())));
+        store.save(&session).await?;
+        let stale_token = meerkat_core::session_store::session_projection_cas_token(&session)?;
+
+        let mut newer = session.clone();
+        newer.push(Message::User(UserMessage::text("newer".to_string())));
+        store.save(&newer).await?;
+        assert!(
+            !store
+                .delete_if_current_revision(session.id(), &stale_token)
+                .await?
+        );
+        assert!(store.load(session.id()).await?.is_some());
+
+        let current_token = meerkat_core::session_store::session_projection_cas_token(&newer)?;
+        assert!(
+            store
+                .delete_if_current_revision(session.id(), &current_token)
+                .await?
+        );
+        assert!(store.load(session.id()).await?.is_none());
         Ok(())
     }
 }

--- a/meerkat-store/src/sqlite_store.rs
+++ b/meerkat-store/src/sqlite_store.rs
@@ -320,6 +320,34 @@ impl SessionStore for SqliteSessionStore {
             .map_err(into_session_store_error)
     }
 
+    async fn save_authoritative_projection_if_current_revision(
+        &self,
+        session: &Session,
+        expected_current_revision: Option<String>,
+    ) -> Result<(), SessionStoreError> {
+        let path = self.path.clone();
+        let session = session.clone();
+        tokio::task::spawn_blocking(move || -> Result<(), SessionStoreError> {
+            let mut conn = open_connection(&path).map_err(into_session_store_error)?;
+            let tx = begin_immediate_transaction(&mut conn).map_err(into_session_store_error)?;
+            let previous = load_session_snapshot_in_txn(&tx, session.id())
+                .map_err(into_session_store_error)?;
+            meerkat_core::session_store::authoritative_projection_current_revision_guard(
+                &session,
+                previous.as_ref(),
+                expected_current_revision.as_deref(),
+            )?;
+            write_session_snapshot_in_txn(&tx, &session).map_err(into_session_store_error)?;
+            tx.commit()
+                .map_err(StoreError::from)
+                .map_err(into_session_store_error)?;
+            Ok(())
+        })
+        .await
+        .map_err(StoreError::Join)
+        .map_err(into_session_store_error)?
+    }
+
     async fn load(&self, id: &SessionId) -> Result<Option<Session>, SessionStoreError> {
         self.load_impl(id).await.map_err(into_session_store_error)
     }
@@ -332,6 +360,49 @@ impl SessionStore for SqliteSessionStore {
 
     async fn delete(&self, id: &SessionId) -> Result<(), SessionStoreError> {
         self.delete_impl(id).await.map_err(into_session_store_error)
+    }
+
+    async fn delete_if_current_revision(
+        &self,
+        id: &SessionId,
+        expected_current_revision: &str,
+    ) -> Result<bool, SessionStoreError> {
+        let path = self.path.clone();
+        let session_id = id.clone();
+        let expected_current_revision = expected_current_revision.to_string();
+        tokio::task::spawn_blocking(move || -> Result<bool, SessionStoreError> {
+            let mut conn = open_connection(&path).map_err(into_session_store_error)?;
+            let tx = begin_immediate_transaction(&mut conn).map_err(into_session_store_error)?;
+            let previous =
+                load_session_snapshot_in_txn(&tx, &session_id).map_err(into_session_store_error)?;
+            let Some(previous) = previous else {
+                tx.commit()
+                    .map_err(StoreError::from)
+                    .map_err(into_session_store_error)?;
+                return Ok(false);
+            };
+            let previous_token =
+                meerkat_core::session_store::session_projection_cas_token(&previous)?;
+            if previous_token != expected_current_revision {
+                tx.commit()
+                    .map_err(StoreError::from)
+                    .map_err(into_session_store_error)?;
+                return Ok(false);
+            }
+            tx.execute(
+                "DELETE FROM sessions WHERE session_id = ?1",
+                params![session_id.to_string()],
+            )
+            .map_err(StoreError::from)
+            .map_err(into_session_store_error)?;
+            tx.commit()
+                .map_err(StoreError::from)
+                .map_err(into_session_store_error)?;
+            Ok(true)
+        })
+        .await
+        .map_err(StoreError::Join)
+        .map_err(into_session_store_error)?
     }
 }
 
@@ -460,5 +531,79 @@ mod tests {
 
         let saved = first.load(session.id()).await.unwrap().unwrap();
         assert_eq!(saved.messages().len(), newer.messages().len());
+    }
+
+    #[tokio::test]
+    async fn authoritative_projection_expected_revision_rejects_stale_writer() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("sessions.sqlite3");
+        let first = SqliteSessionStore::open(&path).unwrap();
+        let second = SqliteSessionStore::open(&path).unwrap();
+
+        let mut session = Session::new();
+        session.push(Message::User(UserMessage::text("base".to_string())));
+        first.save(&session).await.unwrap();
+        let expected_revision = session.transcript_revision().unwrap();
+
+        let mut newer = second.load(session.id()).await.unwrap().unwrap();
+        newer.push(Message::User(UserMessage::text("newer".to_string())));
+        second.save(&newer).await.unwrap();
+
+        let mut stale_projection = session.clone();
+        stale_projection.push(Message::User(UserMessage::text("stale".to_string())));
+        let err = first
+            .save_authoritative_projection_if_current_revision(
+                &stale_projection,
+                Some(expected_revision),
+            )
+            .await
+            .expect_err("stale authoritative projection should be rejected");
+        assert!(
+            matches!(err, SessionStoreError::TranscriptContinuityViolation { .. }),
+            "unexpected error: {err}"
+        );
+
+        let saved = first.load(session.id()).await.unwrap().unwrap();
+        assert_eq!(saved.messages().len(), newer.messages().len());
+        assert_eq!(
+            saved.transcript_revision().unwrap(),
+            newer.transcript_revision().unwrap()
+        );
+    }
+
+    #[tokio::test]
+    async fn delete_if_current_revision_only_deletes_matching_projection() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("sessions.sqlite3");
+        let first = SqliteSessionStore::open(&path).unwrap();
+        let second = SqliteSessionStore::open(&path).unwrap();
+
+        let mut session = Session::new();
+        session.push(Message::User(UserMessage::text("base".to_string())));
+        first.save(&session).await.unwrap();
+        let stale_token =
+            meerkat_core::session_store::session_projection_cas_token(&session).unwrap();
+
+        let mut newer = second.load(session.id()).await.unwrap().unwrap();
+        newer.push(Message::User(UserMessage::text("newer".to_string())));
+        second.save(&newer).await.unwrap();
+
+        assert!(
+            !first
+                .delete_if_current_revision(session.id(), &stale_token)
+                .await
+                .unwrap()
+        );
+        assert!(first.load(session.id()).await.unwrap().is_some());
+
+        let current_token =
+            meerkat_core::session_store::session_projection_cas_token(&newer).unwrap();
+        assert!(
+            first
+                .delete_if_current_revision(session.id(), &current_token)
+                .await
+                .unwrap()
+        );
+        assert!(first.load(session.id()).await.unwrap().is_none());
     }
 }

--- a/meerkat/src/factory.rs
+++ b/meerkat/src/factory.rs
@@ -132,6 +132,22 @@ impl SessionStore for EphemeralSessionStore {
         Ok(())
     }
 
+    async fn save_authoritative_projection_if_current_revision(
+        &self,
+        session: &Session,
+        expected_current_revision: Option<String>,
+    ) -> Result<(), meerkat_store::SessionStoreError> {
+        let mut sessions = self.sessions.write().await;
+        let previous = sessions.get(session.id());
+        meerkat_core::session_store::authoritative_projection_current_revision_guard(
+            session,
+            previous,
+            expected_current_revision.as_deref(),
+        )?;
+        sessions.insert(session.id().clone(), session.clone());
+        Ok(())
+    }
+
     async fn load(
         &self,
         id: &SessionId,
@@ -172,6 +188,23 @@ impl SessionStore for EphemeralSessionStore {
     async fn delete(&self, id: &SessionId) -> Result<(), meerkat_store::SessionStoreError> {
         self.sessions.write().await.remove(id);
         Ok(())
+    }
+
+    async fn delete_if_current_revision(
+        &self,
+        id: &SessionId,
+        expected_current_revision: &str,
+    ) -> Result<bool, meerkat_store::SessionStoreError> {
+        let mut sessions = self.sessions.write().await;
+        let Some(previous) = sessions.get(id) else {
+            return Ok(false);
+        };
+        let previous_token = meerkat_core::session_store::session_projection_cas_token(previous)?;
+        if previous_token != expected_current_revision {
+            return Ok(false);
+        }
+        sessions.remove(id);
+        Ok(true)
     }
 }
 
@@ -4948,6 +4981,14 @@ mod tests {
             _id: &meerkat_core::SessionId,
         ) -> Result<(), meerkat_store::SessionStoreError> {
             Ok(())
+        }
+
+        async fn delete_if_current_revision(
+            &self,
+            _id: &meerkat_core::SessionId,
+            _expected_current_revision: &str,
+        ) -> Result<bool, meerkat_store::SessionStoreError> {
+            Ok(false)
         }
     }
 

--- a/meerkat/src/persistence.rs
+++ b/meerkat/src/persistence.rs
@@ -369,6 +369,26 @@ mod tests {
             self.inner.save(session).await
         }
 
+        async fn save_authoritative_projection(
+            &self,
+            session: &Session,
+        ) -> Result<(), SessionStoreError> {
+            self.inner.save_authoritative_projection(session).await
+        }
+
+        async fn save_authoritative_projection_if_current_revision(
+            &self,
+            session: &Session,
+            expected_current_revision: Option<String>,
+        ) -> Result<(), SessionStoreError> {
+            self.inner
+                .save_authoritative_projection_if_current_revision(
+                    session,
+                    expected_current_revision,
+                )
+                .await
+        }
+
         async fn load(&self, id: &SessionId) -> Result<Option<Session>, SessionStoreError> {
             self.inner.load(id).await
         }
@@ -379,6 +399,16 @@ mod tests {
 
         async fn delete(&self, id: &SessionId) -> Result<(), SessionStoreError> {
             self.inner.delete(id).await
+        }
+
+        async fn delete_if_current_revision(
+            &self,
+            id: &SessionId,
+            expected_current_revision: &str,
+        ) -> Result<bool, SessionStoreError> {
+            self.inner
+                .delete_if_current_revision(id, expected_current_revision)
+                .await
         }
     }
 

--- a/meerkat/tests/factory_build_agent.rs
+++ b/meerkat/tests/factory_build_agent.rs
@@ -1872,6 +1872,14 @@ impl SessionStore for TrackingSessionStore {
     async fn delete(&self, _id: &SessionId) -> Result<(), SessionStoreError> {
         Ok(())
     }
+
+    async fn delete_if_current_revision(
+        &self,
+        _id: &SessionId,
+        _expected_current_revision: &str,
+    ) -> Result<bool, SessionStoreError> {
+        Ok(false)
+    }
 }
 
 /// 12. `build_agent` with custom session store uses the provided store.

--- a/meerkat/tests/support/test_session_store.rs
+++ b/meerkat/tests/support/test_session_store.rs
@@ -25,6 +25,33 @@ impl SessionStore for TestSessionStore {
         Ok(())
     }
 
+    async fn save_authoritative_projection(
+        &self,
+        session: &Session,
+    ) -> Result<(), SessionStoreError> {
+        self.sessions
+            .write()
+            .await
+            .insert(session.id().clone(), session.clone());
+        Ok(())
+    }
+
+    async fn save_authoritative_projection_if_current_revision(
+        &self,
+        session: &Session,
+        expected_current_revision: Option<String>,
+    ) -> Result<(), SessionStoreError> {
+        let mut sessions = self.sessions.write().await;
+        let previous = sessions.get(session.id());
+        meerkat_core::session_store::authoritative_projection_current_revision_guard(
+            session,
+            previous,
+            expected_current_revision.as_deref(),
+        )?;
+        sessions.insert(session.id().clone(), session.clone());
+        Ok(())
+    }
+
     async fn load(&self, id: &SessionId) -> Result<Option<Session>, SessionStoreError> {
         Ok(self.sessions.read().await.get(id).cloned())
     }
@@ -53,5 +80,22 @@ impl SessionStore for TestSessionStore {
     async fn delete(&self, id: &SessionId) -> Result<(), SessionStoreError> {
         self.sessions.write().await.remove(id);
         Ok(())
+    }
+
+    async fn delete_if_current_revision(
+        &self,
+        id: &SessionId,
+        expected_current_revision: &str,
+    ) -> Result<bool, SessionStoreError> {
+        let mut sessions = self.sessions.write().await;
+        let Some(previous) = sessions.get(id) else {
+            return Ok(false);
+        };
+        let previous_token = meerkat_core::session_store::session_projection_cas_token(previous)?;
+        if previous_token != expected_current_revision {
+            return Ok(false);
+        }
+        sessions.remove(id);
+        Ok(true)
     }
 }

--- a/scripts/run-build-backend-lane
+++ b/scripts/run-build-backend-lane
@@ -66,7 +66,8 @@ case "${lane}" in
     # which duplicates `--workspace` and trips clap's "cannot be used
     # multiple times" guard. Expand the alias inline until the upstream
     # aliases are normalized to string form on `main`.
-    exec "${cargo_bin}" nextest run --workspace --profile fast --show-progress none --status-level none --final-status-level fail
+    "${cargo_bin}" nextest run --workspace --profile fast --show-progress none --status-level none --final-status-level fail
+    exec "${cargo_bin}" test -p meerkat-session --features session-store projection_continuity -- --quiet
     ;;
   test-all)
     if meerkat_buildbuddy_enabled; then


### PR DESCRIPTION
## Summary

Fixes two mob runtime regressions found while investigating the flow/runtime and image comms failures:

- Moves the mob flow smoke Gemini default to the provider catalog default (`gemini-3.5-flash`) so analyst-role smoke tests do not use the stale `gemini-3.1-flash-lite-preview` model.
- Teaches session-store projection checkpointing to accept valid runtime-backed transcript shapes where the runtime appends messages, refreshes system context, performs a typed compaction rewrite, and then advances the projection head.
- Routes terminal agent saves through the installed checkpointer so media externalization and projection guards are applied consistently.

## Root Cause

The analyst smoke failures were caused by a stale hardcoded Gemini model in the smoke matrix.

The session-store failures were a Meerkat regression from transcript/session-store hardening. The compatibility `SessionStore` row lagged behind runtime authority, then rejected a valid committed runtime snapshot because the typed transcript graph extended the persisted row through a runtime parent and compaction rewrite rather than through a plain append-only prefix.

## Validation

- `./scripts/repo-cargo test -p meerkat-core run_boundary_guard_accepts_compaction -- --nocapture`
- `./scripts/repo-cargo test -p meerkat-session --features session-store test_save_normalized_session_bridges -- --nocapture`
- `./scripts/repo-cargo test -p meerkat-session --features session-store test_checkpoint_committed_runtime_snapshot_bridges_externalized_compaction_append -- --nocapture`
- `./scripts/repo-cargo test -p meerkat-mob --features integration-real-tests --test smoke_mob_flow_runtime flow_runtime_smoke_gemini_default_tracks_catalog -- --nocapture`
- `./scripts/repo-cargo test -p meerkat-mob --features integration-real-tests --test smoke_mob_generated_image_comms e2e_smoke_mob_generated_image_comms_blob_request_response -- --ignored --nocapture`
- `./scripts/repo-cargo fmt --check`
- `git diff --check`
- pre-push hooks: secrets, whitespace, fmt, changed-crate clippy, machine codegen/verify, generated-header audit, bridge W2-F, Bazel freshness, workspace deterministic gate

The generated-image comms smoke passed cleanly after the fix with no session-store continuity warnings.