### PR TITLE
[codex] Harden mob cleanup retry anchors

### DIFF
--- a/meerkat-mob/src/runtime/actor.rs
+++ b/meerkat-mob/src/runtime/actor.rs
@@ -72,6 +72,9 @@ const MAX_PARALLEL_PEER_RETIRE_NOTIFICATIONS: usize = 64;
 pub(super) const MAX_PENDING_PEER_DELIVERIES: usize = 1024;
 #[cfg(test)]
 pub(super) const MAX_PENDING_PEER_DELIVERIES: usize = 4;
+#[cfg(test)]
+pub(super) static SPAWN_PROVISIONED_COMMAND_DELAY_MS: std::sync::atomic::AtomicU64 =
+    std::sync::atomic::AtomicU64::new(0);
 
 fn observed_runtime_id(signal: &mob_dsl::MobMachineSignal) -> Option<&mob_dsl::AgentRuntimeId> {
     match signal {
@@ -349,6 +352,15 @@ pub(super) struct PendingSpawnProgress {
     pub(super) operation_id: Option<meerkat_core::ops::OperationId>,
 }
 
+#[derive(Clone, Debug)]
+pub(super) struct PendingSpawnCleanupAnchor {
+    spawn_ticket: u64,
+    agent_identity: MeerkatId,
+    session_id: meerkat_core::types::SessionId,
+    operation_id: meerkat_core::ops::OperationId,
+    reason: String,
+}
+
 #[derive(Clone, Debug, Default)]
 pub(super) struct RestoreWiringPlan {
     local_peers: Vec<MeerkatId>,
@@ -370,6 +382,9 @@ struct RespawnSnapshot {
     /// Effective profile override persisted in the roster.
     /// Used on respawn to avoid re-resolving from the definition.
     effective_profile_override: Option<crate::profile::Profile>,
+    /// The old member is already in a partial-retire state and respawn should
+    /// retry cleanup instead of re-admitting the original Respawn transition.
+    cleanup_retry: bool,
 }
 
 struct FinalizeSpawnOutcome {
@@ -437,6 +452,7 @@ pub(super) struct MobActor {
     /// Uses `AtomicU64` so `&self` methods (batch finalization) can issue tokens.
     pub(super) next_fence_token: std::sync::atomic::AtomicU64,
     pub(super) pending_spawns: PendingSpawnLineage,
+    pub(super) pending_spawn_cleanup_anchors: BTreeMap<u64, PendingSpawnCleanupAnchor>,
     pub(super) edge_locks: Arc<super::edge_locks::EdgeLockRegistry>,
     pub(super) lifecycle_tasks: tokio::task::JoinSet<()>,
     pub(super) next_peer_delivery_ticket: PeerDeliveryId,
@@ -3440,18 +3456,25 @@ impl MobActor {
                 } => {
                     let result = match self.require_state(&[MobState::Running, MobState::Stopped]) {
                         Ok(()) => {
-                            let canceled = self.cancel_pending_spawns_for_member(
-                                &agent_identity,
-                                "retire command received",
-                            );
-                            if canceled > 0 {
-                                tracing::info!(
-                                    agent_identity = %agent_identity,
-                                    canceled,
-                                    "retire canceled pending spawn lineage before roster retirement"
-                                );
+                            match self
+                                .cancel_pending_spawns_for_member(
+                                    &agent_identity,
+                                    "retire command received",
+                                )
+                                .await
+                            {
+                                Ok(canceled) => {
+                                    if canceled > 0 {
+                                        tracing::info!(
+                                            agent_identity = %agent_identity,
+                                            canceled,
+                                            "retire canceled pending spawn lineage before roster retirement"
+                                        );
+                                    }
+                                    self.handle_retire(agent_identity).await
+                                }
+                                Err(error) => Err(error),
                             }
-                            self.handle_retire(agent_identity).await
                         }
                         Err(error) => Err(error),
                     };
@@ -3746,27 +3769,31 @@ impl MobActor {
                         "stop_command_admission",
                     ) {
                         Ok(()) => {
-                            self.fail_all_pending_spawns("mob is stopping").await;
-                            self.cancel_pending_peer_deliveries("mob is stopping").await;
-                            self.notify_orchestrator_lifecycle(format!(
-                                "Mob '{}' is stopping.",
-                                self.definition.id
-                            ))
-                            .await;
-                            // Cancel checkpointer gates before stopping host loops so
-                            // in-flight saves that complete after the loop stops don't
-                            // race with subsequent external cleanup (e.g. DML deletes).
-                            self.provisioner.cancel_all_checkpointers().await;
-                            let mut stop_result: Result<(), MobError> = Ok(());
-                            let loop_result = self.stop_all_autonomous_members().await;
-                            if let Err(error) = loop_result {
-                                tracing::warn!(
-                                    mob_id = %self.definition.id,
-                                    error = %error,
-                                    "stop encountered autonomous loop cleanup error"
-                                );
-                                if stop_result.is_ok() {
-                                    stop_result = Err(error);
+                            let mut stop_result =
+                                self.fail_all_pending_spawns("mob is stopping").await;
+                            if stop_result.is_ok() {
+                                self.cancel_pending_peer_deliveries("mob is stopping").await;
+                                self.notify_orchestrator_lifecycle(format!(
+                                    "Mob '{}' is stopping.",
+                                    self.definition.id
+                                ))
+                                .await;
+                                // Cancel checkpointer gates before stopping host loops so
+                                // in-flight saves that complete after the loop stops don't
+                                // race with subsequent external cleanup (e.g. DML deletes).
+                                self.provisioner.cancel_all_checkpointers().await;
+                            }
+                            if stop_result.is_ok() {
+                                let loop_result = self.stop_all_autonomous_members().await;
+                                if let Err(error) = loop_result {
+                                    tracing::warn!(
+                                        mob_id = %self.definition.id,
+                                        error = %error,
+                                        "stop encountered autonomous loop cleanup error"
+                                    );
+                                    if stop_result.is_ok() {
+                                        stop_result = Err(error);
+                                    }
                                 }
                             }
                             if stop_result.is_ok() {
@@ -3867,12 +3894,14 @@ impl MobActor {
                         MobState::Completed,
                         "complete_command_admission",
                     ) {
-                        Ok(()) => {
-                            self.fail_all_pending_spawns("mob is completing").await;
-                            self.cancel_pending_peer_deliveries("mob is completing")
-                                .await;
-                            self.handle_complete().await
-                        }
+                        Ok(()) => match self.fail_all_pending_spawns("mob is completing").await {
+                            Ok(()) => {
+                                self.cancel_pending_peer_deliveries("mob is completing")
+                                    .await;
+                                self.handle_complete().await
+                            }
+                            Err(error) => Err(error),
+                        },
                         Err(error) => Err(error),
                     };
                     let _ = reply_tx.send(result);
@@ -3900,7 +3929,10 @@ impl MobActor {
                         let _ = reply_tx.send(Err(error));
                         continue;
                     }
-                    self.fail_all_pending_spawns("mob is resetting").await;
+                    if let Err(error) = self.fail_all_pending_spawns("mob is resetting").await {
+                        let _ = reply_tx.send(Err(error));
+                        continue;
+                    }
                     self.cancel_pending_peer_deliveries("mob is resetting")
                         .await;
                     let result = self.handle_reset(prior_state).await;
@@ -4092,11 +4124,17 @@ impl MobActor {
                         let _ = reply_tx.send(Err(error));
                         continue;
                     }
-                    self.fail_all_pending_spawns("mob runtime is shutting down")
+                    let mut result = self
+                        .fail_all_pending_spawns("mob runtime is shutting down")
                         .await;
-                    self.cancel_pending_peer_deliveries("mob runtime is shutting down")
-                        .await;
-                    let mut result: Result<(), MobError> = Ok(());
+                    if result.is_err() {
+                        let _ = reply_tx.send(result);
+                        continue;
+                    }
+                    if result.is_ok() {
+                        self.cancel_pending_peer_deliveries("mob runtime is shutting down")
+                            .await;
+                    }
                     if let Err(error) = self.cancel_all_flow_tasks().await {
                         tracing::warn!(error = %error, "shutdown flow cancellation encountered errors");
                         if result.is_ok() {
@@ -4163,7 +4201,98 @@ impl MobActor {
         }
     }
 
-    async fn fail_all_pending_spawns(&mut self, reason: &str) {
+    fn pending_spawn_cleanup_anchor_for_slot(
+        slot: &super::pending_spawn_lineage::PendingSpawnSlot,
+        reason: &str,
+    ) -> Option<PendingSpawnCleanupAnchor> {
+        let snapshot = {
+            let progress = slot
+                .spawn
+                .progress
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            progress
+                .bridge_session_id
+                .clone()
+                .zip(progress.operation_id.clone())
+        };
+        snapshot.map(|(session_id, operation_id)| PendingSpawnCleanupAnchor {
+            spawn_ticket: slot.ticket,
+            agent_identity: slot.spawn.agent_identity.clone(),
+            session_id,
+            operation_id,
+            reason: reason.to_string(),
+        })
+    }
+
+    async fn cleanup_pending_spawn_anchor(
+        &self,
+        anchor: &PendingSpawnCleanupAnchor,
+    ) -> Result<(), MobError> {
+        self.provisioner
+            .abort_member_provision(
+                &MemberRef::from_bridge_session_id(anchor.session_id.clone()),
+                &anchor.operation_id,
+                &anchor.reason,
+            )
+            .await
+    }
+
+    fn pending_spawn_cleanup_error(context: &str, errors: Vec<String>) -> MobError {
+        MobError::Internal(format!(
+            "{context}: pending spawn cleanup incomplete: {}",
+            errors.join("; ")
+        ))
+    }
+
+    async fn drain_pending_spawn_cleanup_anchors(&mut self, context: &str) -> Result<(), MobError> {
+        if self.pending_spawn_cleanup_anchors.is_empty() {
+            return Ok(());
+        }
+
+        let anchors = self
+            .pending_spawn_cleanup_anchors
+            .values()
+            .cloned()
+            .collect::<Vec<_>>();
+        let mut errors = Vec::new();
+        for anchor in anchors {
+            match self.cleanup_pending_spawn_anchor(&anchor).await {
+                Ok(()) => {
+                    self.pending_spawn_cleanup_anchors
+                        .remove(&anchor.spawn_ticket);
+                    tracing::info!(
+                        spawn_ticket = anchor.spawn_ticket,
+                        agent_identity = %anchor.agent_identity,
+                        operation_id = %anchor.operation_id,
+                        "retried pending spawn cleanup anchor successfully"
+                    );
+                }
+                Err(error) => {
+                    errors.push(format!(
+                        "{} ticket {} operation {}: {error}",
+                        anchor.agent_identity, anchor.spawn_ticket, anchor.operation_id
+                    ));
+                    tracing::warn!(
+                        spawn_ticket = anchor.spawn_ticket,
+                        agent_identity = %anchor.agent_identity,
+                        operation_id = %anchor.operation_id,
+                        error = %error,
+                        "pending spawn cleanup anchor still failed"
+                    );
+                }
+            }
+        }
+
+        if errors.is_empty() {
+            Ok(())
+        } else {
+            Err(Self::pending_spawn_cleanup_error(context, errors))
+        }
+    }
+
+    async fn fail_all_pending_spawns(&mut self, reason: &str) -> Result<(), MobError> {
+        self.drain_pending_spawn_cleanup_anchors(reason).await?;
         if self.pending_spawns.is_empty() {
             if let Some(message) = self.pending_spawn_alignment_violation() {
                 tracing::error!(
@@ -4172,9 +4301,10 @@ impl MobActor {
                     "pending spawn alignment violated with no local pending slots to drain"
                 );
             }
-            return;
+            return Ok(());
         }
 
+        let mut cleanup_errors = Vec::new();
         for slot in self.pending_spawns.drain_all() {
             let spawn_ticket = slot.ticket;
             let agent_identity = slot.spawn.agent_identity.clone();
@@ -4192,7 +4322,9 @@ impl MobActor {
                     "lifecycle transition cleared pending spawn",
                 );
             }
-            self.abort_pending_spawn_slot(&slot, reason).await;
+            if let Err(error) = self.abort_pending_spawn_slot(&slot, reason).await {
+                cleanup_errors.push(format!("{agent_identity} ticket {spawn_ticket}: {error}"));
+            }
             slot.fail(&format!("spawn canceled for '{agent_identity}': {reason}"));
             tracing::debug!(
                 spawn_ticket,
@@ -4210,49 +4342,47 @@ impl MobActor {
                 "pending spawn alignment still violated after lifecycle drain"
             );
         }
+        if !cleanup_errors.is_empty() {
+            return Err(Self::pending_spawn_cleanup_error(reason, cleanup_errors));
+        }
+        self.drain_pending_spawn_cleanup_anchors(reason).await?;
+        Ok(())
     }
 
     async fn abort_pending_spawn_slot(
-        &self,
+        &mut self,
         slot: &super::pending_spawn_lineage::PendingSpawnSlot,
         reason: &str,
-    ) {
-        let snapshot = {
-            let progress = slot
-                .spawn
-                .progress
-                .lock()
-                .unwrap_or_else(std::sync::PoisonError::into_inner);
-            progress
-                .bridge_session_id
-                .clone()
-                .zip(progress.operation_id.clone())
+    ) -> Result<(), MobError> {
+        let Some(anchor) = Self::pending_spawn_cleanup_anchor_for_slot(slot, reason) else {
+            return Ok(());
         };
-        if let Some((session_id, operation_id)) = snapshot
-            && let Err(error) = self
-                .provisioner
-                .abort_member_provision(
-                    &MemberRef::from_bridge_session_id(session_id),
-                    &operation_id,
-                    reason,
-                )
-                .await
-        {
+        if let Err(error) = self.cleanup_pending_spawn_anchor(&anchor).await {
+            self.pending_spawn_cleanup_anchors
+                .insert(anchor.spawn_ticket, anchor.clone());
             tracing::warn!(
-                spawn_ticket = slot.ticket,
-                agent_identity = %slot.spawn.agent_identity,
-                operation_id = %operation_id,
+                spawn_ticket = anchor.spawn_ticket,
+                agent_identity = %anchor.agent_identity,
+                operation_id = %anchor.operation_id,
                 error = %error,
-                "failed to abort pending member provision during lifecycle drain"
+                "failed to abort pending member provision during lifecycle drain; retained cleanup anchor"
             );
+            return Err(MobError::Internal(format!(
+                "pending spawn cleanup failed for '{}': {error}",
+                anchor.agent_identity
+            )));
         }
+        self.pending_spawn_cleanup_anchors
+            .remove(&anchor.spawn_ticket);
+        Ok(())
     }
 
-    fn cancel_pending_spawns_for_member(
+    async fn cancel_pending_spawns_for_member(
         &mut self,
         agent_identity: &MeerkatId,
         reason: &str,
-    ) -> usize {
+    ) -> Result<usize, MobError> {
+        self.drain_pending_spawn_cleanup_anchors(reason).await?;
         let slots = self.pending_spawns.take_for_member(agent_identity);
         if slots.is_empty() {
             if let Some(message) = self.pending_spawn_alignment_violation() {
@@ -4263,7 +4393,7 @@ impl MobActor {
                     "pending spawn alignment violated while canceling member-specific pending spawns"
                 );
             }
-            return 0;
+            return Ok(0);
         }
         let canceled = slots.len();
 
@@ -4275,51 +4405,12 @@ impl MobActor {
             );
         }
 
-        let pending_abortions = slots
-            .iter()
-            .map(|slot| {
-                (
-                    slot.ticket,
-                    slot.spawn.agent_identity.clone(),
-                    slot.spawn.progress.clone(),
-                )
-            })
-            .collect::<Vec<_>>();
-        let provisioner = self.provisioner.clone();
-        let reason_owned = reason.to_string();
-        tokio::spawn(async move {
-            for (spawn_ticket, agent_identity, progress) in pending_abortions {
-                let snapshot = {
-                    let progress = progress
-                        .lock()
-                        .unwrap_or_else(std::sync::PoisonError::into_inner);
-                    progress
-                        .bridge_session_id
-                        .clone()
-                        .zip(progress.operation_id.clone())
-                };
-                if let Some((session_id, operation_id)) = snapshot
-                    && let Err(error) = provisioner
-                        .abort_member_provision(
-                            &MemberRef::from_bridge_session_id(session_id),
-                            &operation_id,
-                            &reason_owned,
-                        )
-                        .await
-                {
-                    tracing::warn!(
-                        spawn_ticket,
-                        agent_identity = %agent_identity,
-                        operation_id = %operation_id,
-                        error = %error,
-                        "failed to abort pending member provision during member-specific cancellation"
-                    );
-                }
-            }
-        });
-
+        let mut cleanup_errors = Vec::new();
         for slot in slots {
             let spawn_ticket = slot.ticket;
+            if let Err(error) = self.abort_pending_spawn_slot(&slot, reason).await {
+                cleanup_errors.push(format!("{agent_identity} ticket {spawn_ticket}: {error}"));
+            }
             slot.fail(&format!("spawn canceled for '{agent_identity}': {reason}"));
             tracing::debug!(
                 spawn_ticket,
@@ -4336,7 +4427,11 @@ impl MobActor {
                 "pending spawn alignment violated after member-specific cancellation"
             );
         }
-        canceled
+        if cleanup_errors.is_empty() {
+            Ok(canceled)
+        } else {
+            Err(Self::pending_spawn_cleanup_error(reason, cleanup_errors))
+        }
     }
 
     fn customize_spawn_spec(
@@ -4934,6 +5029,14 @@ impl MobActor {
                     progress.bridge_session_id = Some(bridge_session_id);
                     progress.operation_id = Some(spawn_receipt.operation_id.clone());
                 }
+                #[cfg(test)]
+                {
+                    let delay_ms = SPAWN_PROVISIONED_COMMAND_DELAY_MS
+                        .load(std::sync::atomic::Ordering::Relaxed);
+                    if delay_ms > 0 {
+                        tokio::time::sleep(std::time::Duration::from_millis(delay_ms)).await;
+                    }
+                }
                 if spawn_runtime_mode == crate::MobRuntimeMode::AutonomousHost
                     && let Err(capability_error) =
                         Self::ensure_autonomous_dispatch_capability_for_provisioner(
@@ -4992,8 +5095,16 @@ impl MobActor {
                 error = %error,
                 "pending spawn alignment check failed after enqueue; canceling all pending spawns"
             );
-            self.fail_all_pending_spawns("pending spawn alignment violated after enqueue")
-                .await;
+            if let Err(cleanup_error) = self
+                .fail_all_pending_spawns("pending spawn alignment violated after enqueue")
+                .await
+            {
+                tracing::error!(
+                    spawn_ticket,
+                    error = %cleanup_error,
+                    "pending spawn cleanup failed after enqueue alignment violation"
+                );
+            }
             return;
         }
 
@@ -5014,8 +5125,15 @@ impl MobActor {
                 error = %error,
                 "pending spawn alignment check failed before spawn completion batch"
             );
-            self.fail_all_pending_spawns("pending spawn alignment violated before spawn batch")
-                .await;
+            if let Err(cleanup_error) = self
+                .fail_all_pending_spawns("pending spawn alignment violated before spawn batch")
+                .await
+            {
+                tracing::error!(
+                    error = %cleanup_error,
+                    "pending spawn cleanup failed after pre-batch alignment violation"
+                );
+            }
             return;
         }
 
@@ -5116,8 +5234,15 @@ impl MobActor {
                 error = %error,
                 "pending spawn alignment check failed after spawn completion batch"
             );
-            self.fail_all_pending_spawns("pending spawn alignment violated after spawn batch")
-                .await;
+            if let Err(cleanup_error) = self
+                .fail_all_pending_spawns("pending spawn alignment violated after spawn batch")
+                .await
+            {
+                tracing::error!(
+                    error = %cleanup_error,
+                    "pending spawn cleanup failed after spawn batch alignment violation"
+                );
+            }
         }
     }
 
@@ -5305,7 +5430,7 @@ impl MobActor {
             self.fail_all_pending_spawns(
                 "pending spawn alignment violated while staging inline policy spawn",
             )
-            .await;
+            .await?;
             return Err(error);
         }
 
@@ -5383,7 +5508,7 @@ impl MobActor {
             self.fail_all_pending_spawns(
                 "pending spawn alignment violated after inline policy spawn completion",
             )
-            .await;
+            .await?;
             return Err(error);
         }
 
@@ -7936,8 +8061,9 @@ impl MobActor {
     }
 
     ///
-    /// Mark-then-best-effort-cleanup: event first, mark Retiring, disposal
-    /// pipeline (policy-driven), then unconditional roster removal.
+    /// Mark-then-cleanup: event first, mark Retiring, disposal pipeline
+    /// (policy-driven), then roster removal only after critical archive cleanup
+    /// succeeds.
     async fn handle_retire(&mut self, agent_identity: MeerkatId) -> Result<(), MobError> {
         self.ensure_pending_spawn_alignment("handle_retire preflight")?;
         self.cancel_peer_deliveries_for_member(&agent_identity, "member is retiring")
@@ -8184,68 +8310,79 @@ impl MobActor {
             session_id: session_id_for_route,
         };
 
-        // MobMachine admits the command before the event projection records
-        // retirement. The actual transition is still applied after the durable
-        // event append so crash recovery keeps its event-first ordering.
-        self.preview_dsl_input(retire_input.clone(), "handle_retire_inner_admission")?;
-
-        // Append retire event (event-first for crash recovery).
         let retire_event_already_present = self
             .retire_event_exists(agent_identity, &entry.member_ref)
             .await?;
-        if !retire_event_already_present {
-            self.append_retire_event(agent_identity, &entry.role, &entry.member_ref)
-                .await?;
-        }
-
-        let effects = self
-            .apply_dsl_input_collect_effects(retire_input, "handle_retire_inner_mark_retiring")?;
-        let mut detach_obligations =
-            crate::generated::protocol_mob_destroying_session_ingress::extract_obligations(
-                &effects,
+        let dsl_runtime_id = mob_dsl::AgentRuntimeId::from_domain(&entry.agent_runtime_id);
+        let cleanup_retry = retire_event_already_present
+            || entry.state == crate::roster::MemberState::Retiring
+            || matches!(
+                self.dsl_authority
+                    .state
+                    .member_state_markers
+                    .get(&dsl_runtime_id),
+                Some(mob_dsl::MobMemberState::Retiring)
             );
-        if let (Some(obligation), Some(session_id)) = (detach_obligations.pop(), detach_session_id)
-        {
-            self.detach_session_ingress_for_mob_destroy(&session_id, obligation)
-                .await?;
-        }
 
-        // #31 Wave D (D-trust-reconciliation subsystem 4): flip the roster
-        // entry's state to `Retiring` so live readers of
-        // `list_members()` / `member_status()` observe the retiring state
-        // during the disposal window (notify peers, archive session).
-        // The canonical removal still runs in the finally block of
-        // `dispose_member`. Without this explicit flip the
-        // `RosterEntry.state` stayed `Active` right up to removal because
-        // the `MemberRetired` event projection is "remove-by-identity",
-        // not "mark-retiring" — there was a lost observability seam for
-        // the in-flight-retire window.
-        {
-            let mut roster = self.roster.write().await;
-            roster.mark_retiring_by_identity(&entry.agent_identity);
-        }
-
-        // Flush routed effects *before* the disposal pipeline tears down
-        // the runtime session. The `Retire` DSL input above emits a
-        // `RequestRuntimeRetire` routed effect that the `MeerkatConsumer
-        // Surface` delivers as a `Retire` input on the meerkat DSL
-        // authority; that authority lives behind the session registered
-        // with the shared `MeerkatMachine`. `dispose_member` →
-        // `dispose_stop_host_loop` → `teardown_autonomous_runtime` calls
-        // `adapter.unregister_session`, so if the routed effect hasn't
-        // been drained yet, the consumer surface fails with
-        // `ConsumerRefused { reason: "session is not registered" }` and
-        // the actor task crashes. Drain the pending queue at the natural
-        // async boundary here — before the disposal pipeline runs — so
-        // the routed-effect delivery observes the session in its
-        // pre-teardown state.
-        if let Err(error) = self.flush_routed_effects().await {
-            tracing::warn!(
+        if cleanup_retry {
+            tracing::debug!(
                 mob_id = %self.definition.id,
                 agent_identity = %agent_identity,
-                %error,
-                "pre-disposal routed-effect flush failed; proceeding with disposal"
+                "retrying member retire cleanup from retained roster anchor"
             );
+            let mut roster = self.roster.write().await;
+            roster.mark_retiring_by_identity(&entry.agent_identity);
+        } else {
+            // MobMachine admits the command before the event projection records
+            // retirement. The actual transition is still applied after the durable
+            // event append so crash recovery keeps its event-first ordering.
+            self.preview_dsl_input(retire_input.clone(), "handle_retire_inner_admission")?;
+
+            // Append retire event (event-first for crash recovery).
+            self.append_retire_event(agent_identity, &entry.role, &entry.member_ref)
+                .await?;
+
+            let effects = self.apply_dsl_input_collect_effects(
+                retire_input,
+                "handle_retire_inner_mark_retiring",
+            )?;
+            let mut detach_obligations =
+                crate::generated::protocol_mob_destroying_session_ingress::extract_obligations(
+                    &effects,
+                );
+            if let (Some(obligation), Some(session_id)) =
+                (detach_obligations.pop(), detach_session_id)
+            {
+                self.detach_session_ingress_for_mob_destroy(&session_id, obligation)
+                    .await?;
+            }
+
+            // #31 Wave D (D-trust-reconciliation subsystem 4): flip the roster
+            // entry's state to `Retiring` so live readers of
+            // `list_members()` / `member_status()` observe the retiring state
+            // during the disposal window (notify peers, archive session).
+            {
+                let mut roster = self.roster.write().await;
+                roster.mark_retiring_by_identity(&entry.agent_identity);
+            }
+
+            // Flush routed effects *before* the disposal pipeline tears down
+            // the runtime session. If this fails because the runtime registration
+            // has already disappeared, disposal's archive path still performs the
+            // machine-authoritative retire-before-unregister sequence when
+            // possible. Drop the stale per-session routed effect so the actor does
+            // not die after returning a typed lifecycle result to the caller.
+            if let Err(error) = self.flush_routed_effects().await {
+                tracing::warn!(
+                    mob_id = %self.definition.id,
+                    agent_identity = %agent_identity,
+                    %error,
+                    "pre-disposal routed-effect flush failed; proceeding with disposal"
+                );
+                if let Some(session_id) = entry.member_ref.bridge_session_id() {
+                    self.discard_pending_routed_effects_for_session(session_id);
+                }
+            }
         }
 
         // Snapshot context and run disposal pipeline.
@@ -8302,10 +8439,13 @@ impl MobActor {
         self.ensure_pending_spawn_alignment("handle_respawn preflight")
             .map_err(MobRespawnError::from)?;
 
-        let canceled = self.cancel_pending_spawns_for_member(
-            &agent_identity,
-            "respawn command superseded pending spawn",
-        );
+        let canceled = self
+            .cancel_pending_spawns_for_member(
+                &agent_identity,
+                "respawn command superseded pending spawn",
+            )
+            .await
+            .map_err(MobRespawnError::from)?;
         if canceled > 0 {
             tracing::info!(
                 agent_identity = %agent_identity,
@@ -8348,6 +8488,15 @@ impl MobActor {
                 },
                 crate::event::MemberRef::Session { .. } => crate::RuntimeBinding::Session,
             };
+            let dsl_runtime_id = mob_dsl::AgentRuntimeId::from_domain(&entry.agent_runtime_id);
+            let cleanup_retry = entry.state == crate::roster::MemberState::Retiring
+                || matches!(
+                    self.dsl_authority
+                        .state
+                        .member_state_markers
+                        .get(&dsl_runtime_id),
+                    Some(mob_dsl::MobMemberState::Retiring)
+                );
             RespawnSnapshot {
                 profile_name: entry.role.clone(),
                 runtime_mode: entry.runtime_mode,
@@ -8358,6 +8507,7 @@ impl MobActor {
                 restore_wiring,
                 binding,
                 effective_profile_override: entry.effective_profile_override,
+                cleanup_retry,
             }
         };
 
@@ -8420,13 +8570,17 @@ impl MobActor {
         } = replacement_spec;
         let replacement_labels = replacement_labels.unwrap_or_default();
 
-        self.preview_dsl_input(
-            mob_dsl::MobMachineInput::Respawn {
-                agent_runtime_id: mob_dsl::AgentRuntimeId::from_domain(&snapshot.old_runtime_id),
-            },
-            "handle_respawn_admission",
-        )
-        .map_err(|_| MobRespawnError::from(self.invalid_transition_to(MobState::Running)))?;
+        if !snapshot.cleanup_retry {
+            self.preview_dsl_input(
+                mob_dsl::MobMachineInput::Respawn {
+                    agent_runtime_id: mob_dsl::AgentRuntimeId::from_domain(
+                        &snapshot.old_runtime_id,
+                    ),
+                },
+                "handle_respawn_admission",
+            )
+            .map_err(|_| MobRespawnError::from(self.invalid_transition_to(MobState::Running)))?;
+        }
 
         let replacement_generation = snapshot.generation.next();
 
@@ -8614,10 +8768,17 @@ impl MobActor {
                 error = %error,
                 "pending spawn alignment violated while staging respawn replacement"
             );
-            self.fail_all_pending_spawns(
-                "pending spawn alignment violated while staging respawn replacement",
-            )
-            .await;
+            if let Err(cleanup_error) = self
+                .fail_all_pending_spawns(
+                    "pending spawn alignment violated while staging respawn replacement",
+                )
+                .await
+            {
+                return Err(MobRespawnError::SpawnAfterRetire {
+                    identity: AgentIdentity::from(agent_identity.as_str()),
+                    reason: cleanup_error.to_string(),
+                });
+            }
             return Err(MobRespawnError::SpawnAfterRetire {
                 identity: AgentIdentity::from(agent_identity.as_str()),
                 reason: error.to_string(),
@@ -8815,10 +8976,29 @@ impl MobActor {
             }
         }
 
-        // Finally: unconditional, outside policy control.
+        let archive_failed = report
+            .skipped
+            .iter()
+            .any(|(step, _)| *step == DisposalStep::ArchiveSession)
+            || matches!(
+                report.aborted_at.as_ref(),
+                Some((DisposalStep::ArchiveSession, _))
+            );
+
+        // Finally: edge-lock cleanup is unconditional, but roster removal is
+        // gated on critical archive success so retry has a concrete member
+        // anchor to operate on.
         self.dispose_prune_edge_locks(ctx).await;
-        self.dispose_remove_from_roster(ctx).await;
-        report.roster_removed = true;
+        if archive_failed {
+            tracing::warn!(
+                mob_id = %self.definition.id,
+                agent_identity = %ctx.agent_identity,
+                "retaining retiring roster entry after ArchiveSession failure for retry"
+            );
+        } else {
+            self.dispose_remove_from_roster(ctx).await;
+            report.roster_removed = true;
+        }
         report
     }
 
@@ -9594,7 +9774,15 @@ impl MobActor {
             report.push_error(format!("destroy marker append failed: {error}"));
             return Err(MobDestroyError::Incomplete { report });
         }
-        self.fail_all_pending_spawns("mob is destroying").await;
+        self.fail_all_pending_spawns("mob is destroying")
+            .await
+            .map_err(|error| {
+                Self::incomplete_destroy_error(
+                    report.clone(),
+                    "pending spawn cleanup during destroy failed",
+                    error,
+                )
+            })?;
         self.cancel_pending_peer_deliveries("mob is destroying")
             .await;
         if destroy_input_needed && self.has_orchestrator {
@@ -10830,7 +11018,7 @@ impl MobActor {
     async fn retire_all_members(&mut self, context: &str) -> Result<(), MobError> {
         self.ensure_pending_spawn_alignment("retire_all_members preflight")?;
         let pending_reason = format!("{context}: draining pending spawns before bulk retirement");
-        self.fail_all_pending_spawns(&pending_reason).await;
+        self.fail_all_pending_spawns(&pending_reason).await?;
         self.ensure_pending_spawn_alignment("retire_all_members after pending drain")?;
         self.cancel_pending_peer_deliveries("all members are retiring")
             .await;

--- a/meerkat-mob/src/runtime/builder.rs
+++ b/meerkat-mob/src/runtime/builder.rs
@@ -1908,6 +1908,7 @@ impl MobBuilder {
             next_spawn_ticket: 0,
             next_fence_token: std::sync::atomic::AtomicU64::new(1),
             pending_spawns: PendingSpawnLineage::new(),
+            pending_spawn_cleanup_anchors: BTreeMap::new(),
             edge_locks: Arc::new(super::edge_locks::EdgeLockRegistry::new()),
             lifecycle_tasks: tokio::task::JoinSet::new(),
             next_peer_delivery_ticket: 0,

--- a/meerkat-mob/src/runtime/tests.rs
+++ b/meerkat-mob/src/runtime/tests.rs
@@ -775,6 +775,14 @@ impl MockSessionService {
         self.sessions.read().await.len()
     }
 
+    async fn session_id_for_comms_name(&self, comms_name: &str) -> Option<SessionId> {
+        self.session_comms_names
+            .read()
+            .await
+            .iter()
+            .find_map(|(session_id, name)| (name == comms_name).then(|| session_id.clone()))
+    }
+
     async fn live_session_clone(&self, session_id: &SessionId) -> Option<Session> {
         self.live_session_data.read().await.get(session_id).cloned()
     }
@@ -4404,6 +4412,37 @@ fn test_comms_name(profile: &str, agent_identity: &str) -> String {
 
 fn test_comms_name_for(mob_id: &MobId, profile: &str, agent_identity: &str) -> String {
     format!("{mob_id}/{profile}/{agent_identity}")
+}
+
+struct SpawnProvisionedCommandDelayGuard;
+
+impl SpawnProvisionedCommandDelayGuard {
+    fn set(delay_ms: u64) -> Self {
+        super::actor::SPAWN_PROVISIONED_COMMAND_DELAY_MS.store(delay_ms, Ordering::Relaxed);
+        Self
+    }
+}
+
+impl Drop for SpawnProvisionedCommandDelayGuard {
+    fn drop(&mut self) {
+        super::actor::SPAWN_PROVISIONED_COMMAND_DELAY_MS.store(0, Ordering::Relaxed);
+    }
+}
+
+async fn wait_for_session_id_for_comms_name(
+    service: &MockSessionService,
+    comms_name: &str,
+) -> SessionId {
+    tokio::time::timeout(Duration::from_secs(2), async {
+        loop {
+            if let Some(session_id) = service.session_id_for_comms_name(comms_name).await {
+                break session_id;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .unwrap_or_else(|_| panic!("timed out waiting for session {comms_name}"))
 }
 
 async fn test_peer_route<C>(comms: &C, name: &str) -> PeerRoute
@@ -10809,7 +10848,7 @@ async fn test_respawn_ignores_machine_local_edge_to_retired_peer() {
 }
 
 #[tokio::test]
-async fn test_respawn_archive_failure_returns_cleanup_ambiguous_report() {
+async fn test_respawn_archive_failure_retains_retry_anchor_and_can_retry() {
     let (handle, service) = create_test_mob(sample_definition()).await;
     let member_id = MeerkatId::from("respawn-ambiguous");
     let member_ref = handle
@@ -10830,44 +10869,48 @@ async fn test_respawn_archive_failure_returns_cleanup_ambiguous_report() {
     let error = handle
         .respawn(AgentIdentity::from(member_id.as_str()), None)
         .await
-        .expect_err("respawn should surface ambiguous cleanup when archive fails");
+        .expect_err("respawn should surface cleanup failure when archive fails");
 
-    let report = match error {
-        crate::runtime::handle::MobRespawnError::PreviousMemberCleanupAmbiguous { report } => {
-            report
-        }
-        other => panic!("expected PreviousMemberCleanupAmbiguous, got {other:?}"),
-    };
+    assert!(
+        matches!(
+            error,
+            crate::runtime::handle::MobRespawnError::Mob(MobError::Internal(ref message))
+                if message.contains("ArchiveSession")
+        ),
+        "session-bound respawn should retain the cleanup anchor and return the archive failure directly: {error:?}"
+    );
+    let retained = handle
+        .get_member(&AgentIdentity::from(member_id.as_str()))
+        .await
+        .expect("archive failure should retain retiring member for retry");
+    assert_eq!(
+        retained.agent_runtime_id,
+        original_snapshot.agent_runtime_id
+    );
+    assert_eq!(retained.fence_token, original_snapshot.fence_token);
+    assert_eq!(retained.state, crate::roster::MemberState::Retiring);
+    assert_eq!(
+        handle.list_members_including_retiring().await.len(),
+        1,
+        "failed cleanup must leave exactly the retained retiring member, not a replacement"
+    );
 
-    assert_eq!(report.identity, AgentIdentity::from(member_id.as_str()));
-    assert_eq!(report.agent_runtime_id, original_snapshot.agent_runtime_id);
-    assert_eq!(report.fence_token, original_snapshot.fence_token);
-    assert!(
-        report.retire_attempted,
-        "respawn should have attempted retire"
-    );
-    assert!(
-        report
-            .retire_error
-            .as_deref()
-            .is_some_and(|msg| msg.contains("ArchiveSession")),
-        "cleanup report should capture the archive failure: {:?}",
-        report.retire_error
-    );
-    assert!(
-        !report.confirmatory_observation_attempted,
-        "current respawn ambiguity path should not claim a confirmatory probe"
-    );
-    assert!(
-        !report.destroy_attempted,
-        "current respawn ambiguity path should not claim a force-destroy"
-    );
-    assert!(
-        handle
-            .get_member(&AgentIdentity::from(member_id.as_str()))
-            .await
-            .is_none(),
-        "ambiguous cleanup must not create a replacement member"
+    service.clear_archive_failure(&old_session_id).await;
+    let receipt = handle
+        .respawn(
+            AgentIdentity::from(member_id.as_str()),
+            Some("retry replacement".into()),
+        )
+        .await
+        .expect("respawn retry should clean up the old session and spawn replacement");
+    assert_eq!(receipt.identity, AgentIdentity::from(member_id.as_str()));
+    let replacement = handle
+        .member_status(&AgentIdentity::from(member_id.as_str()))
+        .await
+        .expect("replacement status");
+    assert_ne!(
+        replacement.agent_runtime_id, original_snapshot.agent_runtime_id,
+        "successful retry must rotate the runtime binding"
     );
 }
 
@@ -14891,14 +14934,13 @@ async fn test_retire_archive_failure_is_not_silent() {
         "retire must return Err when ArchiveSession fails"
     );
 
-    // Member is removed from roster unconditionally (finally block).
-    assert!(
-        handle
-            .get_member(&AgentIdentity::from("w-1"))
-            .await
-            .is_none(),
-        "retire must remove roster entry even when archive fails"
-    );
+    // Critical archive failure retains the retiring roster entry so cleanup can
+    // be retried without losing the member/session anchor.
+    let retained = handle
+        .get_member(&AgentIdentity::from("w-1"))
+        .await
+        .expect("archive failure should retain retry anchor");
+    assert_eq!(retained.state, crate::roster::MemberState::Retiring);
     let events = handle.events().replay_all().await.expect("replay");
     assert!(
         events
@@ -17627,8 +17669,8 @@ async fn test_fault_injected_lifecycle_operations_preserve_transactional_invaria
         "spawn rollback should remove leaked trust edges"
     );
 
-    // Retire best-effort cleanup invariants: retire succeeds and removes
-    // roster entry even when archive is fault-injected.
+    // Retire cleanup invariants: archive failure is surfaced and retains the
+    // retiring roster entry so the cleanup can be retried.
     let (retire_handle, retire_service) = create_test_mob(sample_definition()).await;
     let sid_r1 = retire_handle
         .spawn(ProfileName::from("worker"), MeerkatId::from("r-1"), None)
@@ -17651,12 +17693,23 @@ async fn test_fault_injected_lifecycle_operations_preserve_transactional_invaria
         retire_result.is_err(),
         "retire must return Err when ArchiveSession fails"
     );
+    let retained = retire_handle
+        .get_member(&AgentIdentity::from("r-1"))
+        .await
+        .expect("retire must retain roster entry when archive fails");
+    assert_eq!(retained.state, crate::roster::MemberState::Retiring);
+
+    retire_service.clear_archive_failure(&sid_r1).await;
+    retire_handle
+        .retire(AgentIdentity::from("r-1"))
+        .await
+        .expect("retire retry should complete archive cleanup");
     assert!(
         retire_handle
             .get_member(&AgentIdentity::from("r-1"))
             .await
             .is_none(),
-        "retire must remove roster entry even when archive fails"
+        "successful retry must remove roster entry"
     );
     let r2 = retire_handle
         .get_member(&AgentIdentity::from("r-2"))
@@ -19783,6 +19836,129 @@ async fn test_stop_fails_pending_spawns_and_cleans_up_provisioned_session() {
         service.active_session_count().await,
         0,
         "canceled pending spawn should retire any provisioned session during cleanup"
+    );
+}
+
+#[tokio::test]
+async fn test_stop_pending_spawn_archive_failure_retains_cleanup_anchor_for_retry() {
+    let _delay_guard = SpawnProvisionedCommandDelayGuard::set(500);
+    let (handle, service) = create_test_mob(sample_definition()).await;
+    let agent_identity = MeerkatId::from("w-stop-archive-fail");
+    let comms_name = test_comms_name("worker", agent_identity.as_str());
+    service
+        .set_archive_failure_for_comms_name(&comms_name)
+        .await;
+
+    let pending_spawn = {
+        let handle = handle.clone();
+        let agent_identity = agent_identity.clone();
+        tokio::spawn(async move {
+            handle
+                .spawn(ProfileName::from("worker"), agent_identity, None)
+                .await
+        })
+    };
+    let session_id = wait_for_session_id_for_comms_name(&service, &comms_name).await;
+
+    let stop_error = handle
+        .stop()
+        .await
+        .expect_err("stop should fail closed while pending spawn archive cleanup is ambiguous");
+    assert!(
+        stop_error
+            .to_string()
+            .contains("pending spawn cleanup incomplete"),
+        "stop should expose pending spawn cleanup failure, got: {stop_error}"
+    );
+    assert_eq!(
+        handle.status().await.unwrap(),
+        MobState::Running,
+        "failed stop must not commit the mob into Stopped"
+    );
+
+    let spawn_error = pending_spawn
+        .await
+        .expect("spawn join")
+        .expect_err("pending spawn should fail once stop begins");
+    assert!(
+        spawn_error.to_string().contains("mob is stopping"),
+        "spawn should receive stop cancellation reason, got: {spawn_error}"
+    );
+    assert_eq!(
+        service.active_session_count().await,
+        1,
+        "archive failure must keep the provisioned session available for retry"
+    );
+
+    service.clear_archive_failure(&session_id).await;
+    handle
+        .stop()
+        .await
+        .expect("retrying stop should drain retained pending-spawn cleanup anchor");
+    assert_eq!(handle.status().await.unwrap(), MobState::Stopped);
+    assert_eq!(
+        service.active_session_count().await,
+        0,
+        "retry should archive the previously ambiguous pending-spawn session"
+    );
+}
+
+#[tokio::test]
+async fn test_member_pending_spawn_archive_failure_retains_cleanup_anchor_for_retry() {
+    let _delay_guard = SpawnProvisionedCommandDelayGuard::set(500);
+    let (handle, service) = create_test_mob(sample_definition()).await;
+    let agent_identity = MeerkatId::from("w-retire-pending-archive-fail");
+    let comms_name = test_comms_name("worker", agent_identity.as_str());
+    service
+        .set_archive_failure_for_comms_name(&comms_name)
+        .await;
+
+    let pending_spawn = {
+        let handle = handle.clone();
+        let agent_identity = agent_identity.clone();
+        tokio::spawn(async move {
+            handle
+                .spawn(ProfileName::from("worker"), agent_identity, None)
+                .await
+        })
+    };
+    let session_id = wait_for_session_id_for_comms_name(&service, &comms_name).await;
+
+    let retire_error = handle
+        .retire(AgentIdentity::from(agent_identity.as_str()))
+        .await
+        .expect_err("retire should fail before roster mutation when pending cleanup is ambiguous");
+    assert!(
+        retire_error
+            .to_string()
+            .contains("pending spawn cleanup incomplete"),
+        "retire should expose pending spawn cleanup failure, got: {retire_error}"
+    );
+    let spawn_error = pending_spawn
+        .await
+        .expect("spawn join")
+        .expect_err("pending spawn should fail once retire cancels it");
+    assert!(
+        spawn_error.to_string().contains("retire command received"),
+        "spawn should receive retire cancellation reason, got: {spawn_error}"
+    );
+    assert_eq!(
+        service.active_session_count().await,
+        1,
+        "archive failure must keep the provisioned session available for member retry"
+    );
+
+    service.clear_archive_failure(&session_id).await;
+    handle
+        .retire(AgentIdentity::from(agent_identity.as_str()))
+        .await
+        .expect(
+            "retry should drain cleanup anchor and treat the canceled pending member as retired",
+        );
+    assert_eq!(
+        service.active_session_count().await,
+        0,
+        "member retry should archive the previously ambiguous pending-spawn session"
     );
 }
 
@@ -27669,11 +27845,10 @@ async fn test_retire_sends_required_peer_retired_notifications() {
 // Disposal pipeline integration tests
 // -----------------------------------------------------------------------
 
-/// Verifies that roster removal happens even when multiple cleanup steps fail.
-/// This tests the structural guarantee that roster removal is in the "finally"
-/// block of dispose_member, outside the policy-driven loop.
+/// Verifies that critical archive failure retains the retry anchor even when
+/// best-effort peer cleanup also fails.
 #[tokio::test]
-async fn test_dispose_member_removes_roster_even_when_steps_fail() {
+async fn test_dispose_member_retains_roster_when_archive_fails() {
     let (handle, service) = create_test_mob(sample_definition()).await;
     // Configure w-1's comms to fail both send and trust removal.
     service
@@ -27718,13 +27893,23 @@ async fn test_dispose_member_removes_roster_even_when_steps_fail() {
         "retire must return Err when ArchiveSession fails, regardless of other step failures"
     );
 
-    // The structural guarantee: member is gone from roster regardless.
+    let retained = handle
+        .get_member(&AgentIdentity::from("w-1"))
+        .await
+        .expect("critical archive failure must retain member for cleanup retry");
+    assert_eq!(retained.state, crate::roster::MemberState::Retiring);
+
+    service.clear_archive_failure(&sid_w1).await;
+    handle
+        .retire(AgentIdentity::from("w-1"))
+        .await
+        .expect("retry should finish archive cleanup");
     assert!(
         handle
             .get_member(&AgentIdentity::from("w-1"))
             .await
             .is_none(),
-        "roster removal must be unconditional — member must be gone even when all steps fail"
+        "successful retry should remove the roster entry"
     );
 }
 
@@ -28585,14 +28770,11 @@ async fn test_retire_returns_err_when_archive_fails() {
         "retire must return Err when ArchiveSession fails — got Ok"
     );
 
-    // Roster removal is unconditional (finally block) even when we return Err.
-    assert!(
-        handle
-            .get_member(&AgentIdentity::from("w-1"))
-            .await
-            .is_none(),
-        "roster entry must be removed even when retire returns Err"
-    );
+    let retained = handle
+        .get_member(&AgentIdentity::from("w-1"))
+        .await
+        .expect("archive failure should retain retry anchor");
+    assert_eq!(retained.state, crate::roster::MemberState::Retiring);
 
     // Retire event was persisted before disposal (event-first).
     let events = handle.events().replay_all().await.expect("replay");
@@ -28602,6 +28784,30 @@ async fn test_retire_returns_err_when_archive_fails() {
             .any(|e| matches!(e.kind, MobEventKind::MemberRetired { .. })),
         "retire event must persist regardless of archive outcome"
     );
+}
+
+#[tokio::test]
+async fn test_retire_stale_routed_effect_does_not_drop_actor() {
+    let (handle, service) = create_test_mob(sample_definition()).await;
+    let session_id = handle
+        .spawn(ProfileName::from("worker"), MeerkatId::from("w-1"), None)
+        .await
+        .expect("spawn w-1")
+        .bridge_session_id()
+        .expect("session-backed")
+        .clone();
+    let adapter = service.enable_runtime_adapter();
+    adapter.unregister_session(&session_id).await;
+
+    handle
+        .retire(AgentIdentity::from("w-1"))
+        .await
+        .expect("retire should complete through archive even when routed retire is stale");
+
+    handle
+        .stop()
+        .await
+        .expect("mob actor must remain alive after stale routed retire cleanup");
 }
 
 /// Comms failures (NotifyPeers, RemoveTrustEdges) during retirement remain


### PR DESCRIPTION
## Summary

Hardens Meerkat mob lifecycle cleanup around session-bound members and pending spawn cancellation.

- keeps respawn/retire cleanup anchors retryable when archive/unregister fails instead of dropping roster truth early
- turns pending-spawn cancellation cleanup into a tracked retry anchor instead of detached best-effort cleanup
- fails lifecycle commands closed when pending-spawn cleanup is ambiguous, while leaving the actor alive for retry
- discards stale retire routed effects after pre-disposal dispatch failure so a handled lifecycle failure does not later drop the mob actor

## Root Cause

A lifecycle repair could partially retire or cancel a session-bound runtime, hit `ArchiveSession` failure, and then remove or lose the local cleanup anchor. For pending spawns, cancellation drained the pending slot and launched best-effort cleanup separately, so callers could proceed even though the provisioned session had not been archived. A related stale routed-effect path could report the lifecycle failure, then terminate the actor task on the next dispatch flush.

## Validation

- `./scripts/repo-cargo fmt --check`
- `./scripts/repo-cargo clippy -p meerkat-mob --all-targets -- -D warnings`
- `./scripts/repo-cargo test -p meerkat-mob pending_spawn_archive_failure`
- `./scripts/repo-cargo test -p meerkat-mob --lib`
- pre-push hook: secrets, whitespace, fmt, changed-crate clippy, codegen/header audit, bridge-layer audit, Bazel freshness, deterministic workspace gate