### PR TITLE
Route external bind replies to supervisor bridge

### DIFF
--- a/artifacts/schemas/params.json
+++ b/artifacts/schemas/params.json
@@ -2634,6 +2634,16 @@
         "properties": {
           "address_base": {
             "type": "string"
+          },
+          "supervisor_bridge": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/MobSupervisorBridgeEndpointConfigInput"
+              },
+              {
+                "type": "null"
+              }
+            ]
           }
         },
         "required": [
@@ -3126,6 +3136,24 @@
           "text"
         ],
         "type": "string"
+      },
+      "MobSupervisorBridgeEndpointConfigInput": {
+        "additionalProperties": false,
+        "properties": {
+          "advertised_address": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "bind_address": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "type": "object"
       },
       "MobSupervisorSpecInput": {
         "additionalProperties": false,

--- a/artifacts/schemas/wire-types.json
+++ b/artifacts/schemas/wire-types.json
@@ -14547,6 +14547,16 @@
         "properties": {
           "address_base": {
             "type": "string"
+          },
+          "supervisor_bridge": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/MobSupervisorBridgeEndpointConfigInput"
+              },
+              {
+                "type": "null"
+              }
+            ]
           }
         },
         "required": [
@@ -15039,6 +15049,24 @@
           "text"
         ],
         "type": "string"
+      },
+      "MobSupervisorBridgeEndpointConfigInput": {
+        "additionalProperties": false,
+        "properties": {
+          "advertised_address": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "bind_address": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "type": "object"
       },
       "MobSupervisorSpecInput": {
         "additionalProperties": false,

--- a/meerkat-comms/src/runtime/comms_runtime.rs
+++ b/meerkat-comms/src/runtime/comms_runtime.rs
@@ -1277,7 +1277,7 @@ pub struct CommsRuntime {
     #[cfg(target_arch = "wasm32")]
     inproc_namespace: Option<String>,
     #[cfg(not(target_arch = "wasm32"))]
-    listener_handles: Vec<ListenerHandle>,
+    listener_handles: Mutex<Vec<ListenerHandle>>,
     #[cfg(not(target_arch = "wasm32"))]
     listeners_started: bool,
     #[cfg(not(target_arch = "wasm32"))]
@@ -1425,7 +1425,7 @@ impl CommsRuntime {
             inbox: Arc::new(AsyncMutex::new(inbox)),
             inbox_notify,
             config: config.clone(),
-            listener_handles: Vec::new(),
+            listener_handles: Mutex::new(Vec::new()),
             listeners_started: false,
             _session_identity_claim: None,
             bridge_bootstrap_token: Self::derive_bridge_bootstrap_token(&keypair),
@@ -1539,7 +1539,7 @@ impl CommsRuntime {
             #[cfg(target_arch = "wasm32")]
             inproc_namespace: namespace.clone(),
             #[cfg(not(target_arch = "wasm32"))]
-            listener_handles: Vec::new(),
+            listener_handles: Mutex::new(Vec::new()),
             #[cfg(not(target_arch = "wasm32"))]
             listeners_started: false,
             #[cfg(not(target_arch = "wasm32"))]
@@ -1570,6 +1570,18 @@ impl CommsRuntime {
             crate::PeerMeta::default(),
         );
         Ok(runtime)
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    pub fn set_listen_tcp_for_unstarted_runtime(
+        &mut self,
+        listen_tcp: std::net::SocketAddr,
+    ) -> Result<(), CommsRuntimeError> {
+        if self.listeners_started {
+            return Err(CommsRuntimeError::AlreadyStarted);
+        }
+        self.config.listen_tcp = Some(listen_tcp);
+        Ok(())
     }
 
     /// Construct two inproc-only `CommsRuntime` instances with mutual trust
@@ -1669,7 +1681,7 @@ impl CommsRuntime {
             inbox: Arc::new(AsyncMutex::new(inbox)),
             inbox_notify,
             config,
-            listener_handles: Vec::new(),
+            listener_handles: Mutex::new(Vec::new()),
             listeners_started: false,
             _session_identity_claim: Some(claim),
             bridge_bootstrap_token: Self::derive_bridge_bootstrap_token(&keypair),
@@ -1987,7 +1999,7 @@ impl CommsRuntime {
                 inbox_sender.clone(),
             )
             .await?;
-            self.listener_handles.push(handle);
+            self.listener_handles.lock().push(handle);
         }
 
         if let Some(ref addr) = self.config.listen_tcp {
@@ -1999,7 +2011,10 @@ impl CommsRuntime {
                 inbox_sender.clone(),
             )
             .await?;
-            self.listener_handles.push(handle);
+            if let Some(local_addr) = handle.local_addr {
+                self.config.listen_tcp = Some(local_addr);
+            }
+            self.listener_handles.lock().push(handle);
         }
 
         // === Plain event listeners — run ADDITIONALLY when auth=Open ===
@@ -2023,14 +2038,14 @@ impl CommsRuntime {
                     max_line_length,
                 )
                 .await?;
-                self.listener_handles.push(handle);
+                self.listener_handles.lock().push(handle);
             }
 
             #[cfg(unix)]
             if let Some(ref path) = self.config.event_listen_uds {
                 let handle =
                     spawn_plain_uds_listener(path, inbox_sender.clone(), max_line_length).await?;
-                self.listener_handles.push(handle);
+                self.listener_handles.lock().push(handle);
             }
         }
 
@@ -2765,10 +2780,25 @@ impl CommsRuntime {
     pub fn shutdown(&mut self) {
         #[cfg(not(target_arch = "wasm32"))]
         {
-            for handle in self.listener_handles.drain(..) {
+            for handle in self.listener_handles.lock().drain(..) {
                 handle.abort();
             }
             self.listeners_started = false;
+        }
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    pub fn abort_listeners_for_rebind(&self) {
+        for handle in self.listener_handles.lock().drain(..) {
+            handle.abort();
+        }
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    pub async fn stop_listeners_for_rebind(&self) {
+        let handles = self.listener_handles.lock().drain(..).collect::<Vec<_>>();
+        for handle in handles {
+            handle.abort_and_wait().await;
         }
     }
 }
@@ -2805,12 +2835,18 @@ impl Drop for CommsRuntime {
 #[cfg(not(target_arch = "wasm32"))]
 pub struct ListenerHandle {
     handle: JoinHandle<()>,
+    local_addr: Option<std::net::SocketAddr>,
 }
 
 #[cfg(not(target_arch = "wasm32"))]
 impl ListenerHandle {
     pub fn abort(&self) {
         self.handle.abort();
+    }
+
+    async fn abort_and_wait(self) {
+        self.handle.abort();
+        let _ = self.handle.await;
     }
 }
 
@@ -2847,7 +2883,10 @@ async fn spawn_uds_listener(
             });
         }
     });
-    Ok(ListenerHandle { handle })
+    Ok(ListenerHandle {
+        handle,
+        local_addr: None,
+    })
 }
 
 #[cfg(not(target_arch = "wasm32"))]
@@ -2859,6 +2898,7 @@ async fn spawn_tcp_listener(
     inbox_sender: InboxSender,
 ) -> Result<ListenerHandle, std::io::Error> {
     let listener = TcpListener::bind(addr).await?;
+    let local_addr = listener.local_addr()?;
     let handle = tokio::spawn(async move {
         while let Ok((stream, _)) = listener.accept().await {
             let (keypair, trusted, inbox_sender) =
@@ -2873,7 +2913,10 @@ async fn spawn_tcp_listener(
             });
         }
     });
-    Ok(ListenerHandle { handle })
+    Ok(ListenerHandle {
+        handle,
+        local_addr: Some(local_addr),
+    })
 }
 
 /// Max concurrent connections for the plain listener (DoS protection).
@@ -2907,7 +2950,10 @@ async fn spawn_plain_tcp_listener(
             });
         }
     });
-    Ok(ListenerHandle { handle })
+    Ok(ListenerHandle {
+        handle,
+        local_addr: None,
+    })
 }
 
 #[cfg(unix)]
@@ -2947,7 +2993,10 @@ async fn spawn_plain_uds_listener(
             });
         }
     });
-    Ok(ListenerHandle { handle })
+    Ok(ListenerHandle {
+        handle,
+        local_addr: None,
+    })
 }
 
 #[cfg(all(test, not(target_arch = "wasm32")))]

--- a/meerkat-contracts/src/wire/mob.rs
+++ b/meerkat-contracts/src/wire/mob.rs
@@ -276,6 +276,18 @@ pub struct MobProfileInput {
 #[serde(deny_unknown_fields)]
 pub struct MobExternalBackendConfigInput {
     pub address_base: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub supervisor_bridge: Option<MobSupervisorBridgeEndpointConfigInput>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[serde(deny_unknown_fields)]
+pub struct MobSupervisorBridgeEndpointConfigInput {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub bind_address: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub advertised_address: Option<String>,
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]

--- a/meerkat-mob-mcp/src/public_definition.rs
+++ b/meerkat-mob-mcp/src/public_definition.rs
@@ -15,8 +15,8 @@ use meerkat_mob::{
         BackendConfig, CollectionPolicy, ConditionExpr, DependencyMode, DispatchMode,
         EventRouterConfig, ExternalBackendConfig, FlowNodeSpec, FlowSpec, FlowStepSpec, FrameSpec,
         FrameStepSpec, LimitsSpec, OrchestratorConfig, PolicyMode, RepeatUntilSpec, RoleWiringRule,
-        SessionCleanupPolicy, SkillSource, SpawnPolicyConfig, StepOutputFormat, SupervisorSpec,
-        TopologyRule, TopologySpec, WiringRules,
+        SessionCleanupPolicy, SkillSource, SpawnPolicyConfig, StepOutputFormat,
+        SupervisorBridgeEndpointConfig, SupervisorSpec, TopologyRule, TopologySpec, WiringRules,
     },
 };
 use std::convert::TryFrom;
@@ -134,6 +134,12 @@ fn decode_backend(input: MobBackendConfigInput) -> BackendConfig {
         default: decode_backend_kind(input.default),
         external: input.external.map(|external| ExternalBackendConfig {
             address_base: external.address_base,
+            supervisor_bridge: external.supervisor_bridge.map(|supervisor_bridge| {
+                SupervisorBridgeEndpointConfig {
+                    bind_address: supervisor_bridge.bind_address,
+                    advertised_address: supervisor_bridge.advertised_address,
+                }
+            }),
         }),
     }
 }

--- a/meerkat-mob/src/definition.rs
+++ b/meerkat-mob/src/definition.rs
@@ -65,6 +65,23 @@ pub struct WiringRules {
 pub struct ExternalBackendConfig {
     /// Base address prefix used to publish external peer addresses.
     pub address_base: String,
+    /// Supervisor bridge endpoint used by remote external members to send
+    /// bridge replies back to this mob supervisor.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub supervisor_bridge: Option<SupervisorBridgeEndpointConfig>,
+}
+
+/// TCP endpoint configuration for the mob supervisor bridge.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub struct SupervisorBridgeEndpointConfig {
+    /// Local socket address the supervisor bridge should bind, for example
+    /// `0.0.0.0:42000` or `127.0.0.1:0`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub bind_address: Option<String>,
+    /// Address advertised to external members, for example
+    /// `tcp://supervisor.example.com:42000`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub advertised_address: Option<String>,
 }
 
 /// Backend selection and backend-specific settings for the mob.

--- a/meerkat-mob/src/runtime/actor.rs
+++ b/meerkat-mob/src/runtime/actor.rs
@@ -915,6 +915,31 @@ impl MobActor {
         self.supervisor_payload_for_authority(&authority)
     }
 
+    async fn bridge_supervisor_payload_for_recipient(
+        &self,
+        recipient: &TrustedPeerDescriptor,
+    ) -> Result<super::bridge_protocol::BridgeSupervisorPayload, MobError> {
+        let authority = self.supervisor_bridge.authority().await;
+        self.bridge_supervisor_payload_for_authority_and_recipient(&authority, recipient)
+            .await
+    }
+
+    async fn bridge_supervisor_payload_for_authority_and_recipient(
+        &self,
+        authority: &crate::store::SupervisorAuthorityRecord,
+        recipient: &TrustedPeerDescriptor,
+    ) -> Result<super::bridge_protocol::BridgeSupervisorPayload, MobError> {
+        let spec = self
+            .supervisor_bridge
+            .supervisor_spec_for_authority_and_recipient(authority, recipient)
+            .await?;
+        Ok(super::bridge_protocol::BridgeSupervisorPayload {
+            supervisor: spec.into(),
+            epoch: authority.epoch,
+            protocol_version: authority.protocol_version,
+        })
+    }
+
     fn supervisor_payload_for_authority(
         &self,
         authority: &crate::store::SupervisorAuthorityRecord,
@@ -955,7 +980,7 @@ impl MobActor {
         peer: &TrustedPeerDescriptor,
         binding: &crate::RuntimeBinding,
     ) -> Result<super::bridge_protocol::BridgeBindResponse, MobError> {
-        let payload = self.bridge_supervisor_payload().await?;
+        let payload = self.bridge_supervisor_payload_for_recipient(peer).await?;
         self.bind_peer_only_member_for_binding_with_payload(peer, binding, &payload)
             .await
     }
@@ -1074,7 +1099,7 @@ impl MobActor {
         peer: &TrustedPeerDescriptor,
         binding: Option<&crate::RuntimeBinding>,
     ) -> Result<TrustedPeerDescriptor, MobError> {
-        let payload = self.bridge_supervisor_payload().await?;
+        let payload = self.bridge_supervisor_payload_for_recipient(peer).await?;
         let protocol_version = payload.protocol_version;
         let command = super::bridge_protocol::BridgeCommand::AuthorizeSupervisor(payload);
         self.supervisor_bridge.trust_recipient(peer).await?;
@@ -1254,7 +1279,7 @@ impl MobActor {
         let peer = self
             .ensure_supervisor_authorized(&peer, Some(binding))
             .await?;
-        let payload = self.bridge_supervisor_payload().await?;
+        let payload = self.bridge_supervisor_payload_for_recipient(&peer).await?;
         let command = super::bridge_protocol::BridgeCommand::ObserveMember(payload);
         self.send_bridge_command_typed(&peer, &command, timeout)
             .await
@@ -1269,7 +1294,7 @@ impl MobActor {
         let peer = self
             .ensure_supervisor_authorized(&peer, Some(binding))
             .await?;
-        let payload = self.bridge_supervisor_payload().await?;
+        let payload = self.bridge_supervisor_payload_for_recipient(&peer).await?;
         let command = super::bridge_protocol::BridgeCommand::DestroyMember(payload);
         self.send_bridge_command_typed(&peer, &command, timeout)
             .await
@@ -1285,7 +1310,7 @@ impl MobActor {
         let peer = self
             .ensure_supervisor_authorized(&peer, Some(binding))
             .await?;
-        let payload = self.bridge_supervisor_payload().await?;
+        let payload = self.bridge_supervisor_payload_for_recipient(&peer).await?;
         let command = super::bridge_protocol::BridgeCommand::RevokeSupervisor(payload);
         let _ack: super::bridge_protocol::BridgeAck = self
             .send_bridge_command_typed(&peer, &command, timeout)
@@ -1304,7 +1329,10 @@ impl MobActor {
             .ensure_supervisor_authorized(recipient, recipient_binding)
             .await?;
         let authority = self.supervisor_bridge.authority().await;
-        let sup_spec = self.supervisor_bridge.supervisor_spec().await?;
+        let sup_spec = self
+            .supervisor_bridge
+            .supervisor_spec_for_recipient(&recipient)
+            .await?;
         let command = super::bridge_protocol::BridgeCommand::WireMember(
             super::bridge_protocol::BridgePeerWiringPayload {
                 supervisor: sup_spec.into(),
@@ -1330,7 +1358,10 @@ impl MobActor {
             .ensure_supervisor_authorized(recipient, recipient_binding)
             .await?;
         let authority = self.supervisor_bridge.authority().await;
-        let sup_spec = self.supervisor_bridge.supervisor_spec().await?;
+        let sup_spec = self
+            .supervisor_bridge
+            .supervisor_spec_for_recipient(&recipient)
+            .await?;
         let command = super::bridge_protocol::BridgeCommand::UnwireMember(
             super::bridge_protocol::BridgePeerWiringPayload {
                 supervisor: sup_spec.into(),
@@ -10043,36 +10074,17 @@ impl MobActor {
             };
         }
         if !remote_bindings.is_empty() {
-            let next_public_key = next.keypair().public_key();
-            let next_sup_spec: super::bridge_protocol::BridgePeerSpec =
-                meerkat_core::comms::TrustedPeerDescriptor::unsigned_with_pubkey(
-                    format!("{}/__mob_supervisor__", self.definition.id),
-                    next.public_peer_id.clone(),
-                    *next_public_key.as_bytes(),
-                    format!("inproc://{}/__mob_supervisor__", self.definition.id),
-                )
-                .map_err(|error| {
-                    MobError::WiringError(format!("invalid rotated supervisor spec: {error}"))
-                })?
-                .into();
-            let next_payload = super::bridge_protocol::BridgeSupervisorPayload {
-                supervisor: next_sup_spec,
-                epoch: next.epoch,
-                protocol_version: next.protocol_version,
-            };
-            let current_payload = super::bridge_protocol::BridgeSupervisorPayload {
-                supervisor: Self::supervisor_spec_for_authority(
-                    &self.definition.id,
-                    &stable_current,
-                )?
-                .into(),
-                epoch: stable_current.epoch,
-                protocol_version: stable_current.protocol_version,
-            };
-            let next_command =
-                super::bridge_protocol::BridgeCommand::AuthorizeSupervisor(next_payload.clone());
             for binding in remote_bindings.iter().cloned() {
                 let peer = Self::peer_only_spec_for_binding(&binding, "handle_rotate_supervisor")?;
+                let next_payload = self
+                    .bridge_supervisor_payload_for_authority_and_recipient(&next, &peer)
+                    .await?;
+                let current_payload = self
+                    .bridge_supervisor_payload_for_authority_and_recipient(&stable_current, &peer)
+                    .await?;
+                let next_command = super::bridge_protocol::BridgeCommand::AuthorizeSupervisor(
+                    next_payload.clone(),
+                );
                 let peer_id = peer.peer_id.to_string();
                 let mut already_pending = accepted_peer_ids.contains(&peer_id);
                 if already_pending {
@@ -10208,11 +10220,21 @@ impl MobActor {
                                         self.supervisor_bridge
                                             .trust_recipient(&effective_peer)
                                             .await?;
+                                        let retry_next_payload = self
+                                            .bridge_supervisor_payload_for_authority_and_recipient(
+                                                &next,
+                                                &effective_peer,
+                                            )
+                                            .await?;
+                                        let retry_next_command =
+                                            super::bridge_protocol::BridgeCommand::AuthorizeSupervisor(
+                                                retry_next_payload.clone(),
+                                            );
                                         let retry = self
                                             .supervisor_bridge
                                             .send_bridge_command(
                                                 &effective_peer,
-                                                &next_command,
+                                                &retry_next_command,
                                                 std::time::Duration::from_secs(5),
                                             )
                                             .await;
@@ -10220,7 +10242,7 @@ impl MobActor {
                                             Ok(value) => {
                                                 if let Some(retry_rejection) =
                                                     Self::bridge_rejection_reply(
-                                                        next_payload.protocol_version,
+                                                        retry_next_payload.protocol_version,
                                                         &value,
                                                     )
                                                 {
@@ -10632,14 +10654,10 @@ impl MobActor {
         current: &crate::store::SupervisorAuthorityRecord,
         rotated_peers: &[(TrustedPeerDescriptor, crate::RuntimeBinding)],
     ) -> Result<(), MobError> {
-        let current_sup_spec: super::bridge_protocol::BridgePeerSpec =
-            Self::supervisor_spec_for_authority(&self.definition.id, current)?.into();
-        let current_payload = super::bridge_protocol::BridgeSupervisorPayload {
-            supervisor: current_sup_spec,
-            epoch: current.epoch,
-            protocol_version: current.protocol_version,
-        };
         for (peer, binding) in rotated_peers {
+            let current_payload = self
+                .bridge_supervisor_payload_for_authority_and_recipient(current, peer)
+                .await?;
             let bind = self
                 .bind_peer_only_member_for_binding_with_payload(peer, binding, &current_payload)
                 .await
@@ -10702,13 +10720,17 @@ impl MobActor {
             self.rotate_supervisor_bridge_to(target).await?;
             return Ok(());
         }
-        let target_payload = self.supervisor_payload_for_authority(target)?;
-        let target_command =
-            super::bridge_protocol::BridgeCommand::AuthorizeSupervisor(target_payload.clone());
-        let attempted_payload = self.supervisor_payload_for_authority(attempted)?;
-        let revoke_attempted_command =
-            super::bridge_protocol::BridgeCommand::RevokeSupervisor(attempted_payload);
         for (peer, binding) in rotated_peers {
+            let target_payload = self
+                .bridge_supervisor_payload_for_authority_and_recipient(target, peer)
+                .await?;
+            let target_command =
+                super::bridge_protocol::BridgeCommand::AuthorizeSupervisor(target_payload.clone());
+            let attempted_payload = self
+                .bridge_supervisor_payload_for_authority_and_recipient(attempted, peer)
+                .await?;
+            let revoke_attempted_command =
+                super::bridge_protocol::BridgeCommand::RevokeSupervisor(attempted_payload);
             let authorize_result = self
                 .supervisor_bridge
                 .send_bridge_command_as_authority(

--- a/meerkat-mob/src/runtime/builder.rs
+++ b/meerkat-mob/src/runtime/builder.rs
@@ -746,10 +746,18 @@ impl MobBuilder {
                     definition.id
                 ))
             })?;
-        let supervisor_bridge = Arc::new(MobSupervisorBridge::new(
-            &definition.id,
-            supervisor_authority,
-        )?);
+        let supervisor_bridge = Arc::new(
+            MobSupervisorBridge::new(
+                &definition.id,
+                supervisor_authority,
+                definition
+                    .backend
+                    .external
+                    .as_ref()
+                    .and_then(|external| external.supervisor_bridge.clone()),
+            )
+            .await?,
+        );
 
         Ok(Self::start_runtime(
             definition,
@@ -942,10 +950,18 @@ impl MobBuilder {
                 )));
             }
         };
-        let supervisor_bridge = Arc::new(MobSupervisorBridge::new(
-            &definition.id,
-            supervisor_authority,
-        )?);
+        let supervisor_bridge = Arc::new(
+            MobSupervisorBridge::new(
+                &definition.id,
+                supervisor_authority,
+                definition
+                    .backend
+                    .external
+                    .as_ref()
+                    .and_then(|external| external.supervisor_bridge.clone()),
+            )
+            .await?,
+        );
         let mut roster = Roster::project(&mob_events);
         #[cfg(not(target_arch = "wasm32"))]
         Self::normalize_sessionless_backend_runtime_modes(&mut roster);

--- a/meerkat-mob/src/runtime/provisioner.rs
+++ b/meerkat-mob/src/runtime/provisioner.rs
@@ -2097,6 +2097,22 @@ impl MultiBackendProvisioner {
         })
     }
 
+    async fn bridge_supervisor_payload_for_recipient(
+        &self,
+        recipient: &TrustedPeerDescriptor,
+    ) -> Result<super::bridge_protocol::BridgeSupervisorPayload, MobError> {
+        let authority = self.supervisor_bridge.authority().await;
+        let spec = self
+            .supervisor_bridge
+            .supervisor_spec_for_recipient(recipient)
+            .await?;
+        Ok(super::bridge_protocol::BridgeSupervisorPayload {
+            supervisor: spec.into(),
+            epoch: authority.epoch,
+            protocol_version: authority.protocol_version,
+        })
+    }
+
     fn bridge_rejection_reply(
         protocol_version: super::bridge_protocol::BridgeProtocolVersion,
         value: &serde_json::Value,
@@ -2113,7 +2129,7 @@ impl MultiBackendProvisioner {
         peer: &TrustedPeerDescriptor,
         binding: Option<PeerOnlyBindingParts<'_>>,
     ) -> Result<TrustedPeerDescriptor, MobError> {
-        let payload = self.bridge_supervisor_payload().await?;
+        let payload = self.bridge_supervisor_payload_for_recipient(peer).await?;
         let protocol_version = payload.protocol_version;
         let command = super::bridge_protocol::BridgeCommand::AuthorizeSupervisor(payload);
         self.supervisor_bridge.trust_recipient(peer).await?;
@@ -2239,7 +2255,10 @@ impl MultiBackendProvisioner {
     ) -> Result<super::bridge_protocol::BridgeBindResponse, MobError> {
         let bootstrap_token = Self::bridge_bootstrap_token_from_binding(address, bootstrap_token)?;
         let authority = self.supervisor_bridge.authority().await;
-        let sup_spec = self.supervisor_bridge.supervisor_spec().await?;
+        let sup_spec = self
+            .supervisor_bridge
+            .supervisor_spec_for_recipient(peer)
+            .await?;
         let command = super::bridge_protocol::BridgeCommand::BindMember(
             super::bridge_protocol::BridgeBindPayload {
                 supervisor: sup_spec.into(),
@@ -2480,7 +2499,7 @@ impl MobProvisioner for MultiBackendProvisioner {
                         )),
                     )
                     .await?;
-                let payload = self.bridge_supervisor_payload().await?;
+                let payload = self.bridge_supervisor_payload_for_recipient(&peer).await?;
                 let command = super::bridge_protocol::BridgeCommand::RetireMember(payload);
                 let _retire: super::bridge_protocol::BridgeRetireResponse = self
                     .send_bridge_command_typed(&peer, &command, Duration::from_secs(10))
@@ -2518,7 +2537,7 @@ impl MobProvisioner for MultiBackendProvisioner {
                         )),
                     )
                     .await?;
-                let payload = self.bridge_supervisor_payload().await?;
+                let payload = self.bridge_supervisor_payload_for_recipient(&peer).await?;
                 let command = super::bridge_protocol::BridgeCommand::InterruptMember(payload);
                 let _ack: super::bridge_protocol::BridgeAck = self
                     .send_bridge_command_typed(&peer, &command, Duration::from_secs(5))
@@ -2581,7 +2600,10 @@ impl MobProvisioner for MultiBackendProvisioner {
                     )
                     .await?;
                 let authority = self.supervisor_bridge.authority().await;
-                let sup_spec = self.supervisor_bridge.supervisor_spec().await?;
+                let sup_spec = self
+                    .supervisor_bridge
+                    .supervisor_spec_for_recipient(&peer)
+                    .await?;
                 let command = super::bridge_protocol::BridgeCommand::DeliverMemberInput(
                     super::bridge_protocol::BridgeDeliveryPayload {
                         supervisor: sup_spec.into(),
@@ -2657,7 +2679,10 @@ impl MobProvisioner for MultiBackendProvisioner {
             )
             .await?;
         let authority = self.supervisor_bridge.authority().await;
-        let sup_spec = self.supervisor_bridge.supervisor_spec().await?;
+        let sup_spec = self
+            .supervisor_bridge
+            .supervisor_spec_for_recipient(&peer)
+            .await?;
         for spec in desired_specs {
             let command = super::bridge_protocol::BridgeCommand::WireMember(
                 super::bridge_protocol::BridgePeerWiringPayload {

--- a/meerkat-mob/src/runtime/supervisor_bridge.rs
+++ b/meerkat-mob/src/runtime/supervisor_bridge.rs
@@ -1,10 +1,12 @@
 use crate::MobError;
+use crate::definition::SupervisorBridgeEndpointConfig;
 use crate::store::SupervisorAuthorityRecord;
 #[cfg(target_arch = "wasm32")]
 use crate::tokio;
 use meerkat_core::agent::CommsRuntime as CoreCommsRuntime;
 use meerkat_core::comms::{
-    CommsCommand, InputStreamMode, PeerId, PeerRoute, SendReceipt, TrustedPeerDescriptor,
+    CommsCommand, InputStreamMode, PeerAddress, PeerId, PeerRoute, PeerTransport, SendReceipt,
+    TrustedPeerDescriptor,
 };
 use meerkat_core::interaction::{InteractionContent, PeerInputCandidate, TerminalityClass};
 use meerkat_core::time_compat::{Duration, Instant};
@@ -15,6 +17,7 @@ use tokio::sync::{Mutex, RwLock};
 
 pub(crate) struct MobSupervisorBridge {
     participant_name: String,
+    endpoint_config: SupervisorBridgeEndpointConfig,
     authority: RwLock<SupervisorAuthorityRecord>,
     runtime: RwLock<Arc<meerkat_comms::CommsRuntime>>,
     buffered_candidates: Mutex<VecDeque<PeerInputCandidate>>,
@@ -28,14 +31,17 @@ pub(crate) struct MobSupervisorBridge {
 }
 
 impl MobSupervisorBridge {
-    pub(crate) fn new(
+    pub(crate) async fn new(
         mob_id: &crate::MobId,
         authority: SupervisorAuthorityRecord,
+        endpoint_config: Option<SupervisorBridgeEndpointConfig>,
     ) -> Result<Self, MobError> {
         let participant_name = format!("{mob_id}/__mob_supervisor__");
-        let runtime = Self::build_runtime(&participant_name, &authority)?;
+        let endpoint_config = endpoint_config.unwrap_or_default();
+        let runtime = Self::build_runtime(&participant_name, &authority, &endpoint_config).await?;
         Ok(Self {
             participant_name,
+            endpoint_config,
             authority: RwLock::new(authority),
             runtime: RwLock::new(runtime),
             buffered_candidates: Mutex::new(VecDeque::new()),
@@ -43,9 +49,10 @@ impl MobSupervisorBridge {
         })
     }
 
-    fn build_runtime(
+    async fn build_runtime(
         participant_name: &str,
         authority: &SupervisorAuthorityRecord,
+        endpoint_config: &SupervisorBridgeEndpointConfig,
     ) -> Result<Arc<meerkat_comms::CommsRuntime>, MobError> {
         let runtime = meerkat_comms::CommsRuntime::inproc_only_with_keypair_and_silent_intents(
             participant_name,
@@ -58,9 +65,73 @@ impl MobSupervisorBridge {
                 "failed to construct mob supervisor comms runtime '{participant_name}': {error}"
             ))
         })?;
-        let runtime = Arc::new(runtime);
-        Self::install_supervisor_peer_request_response_authority(&runtime, participant_name)?;
-        Ok(runtime)
+        #[cfg(not(target_arch = "wasm32"))]
+        {
+            let mut runtime = runtime;
+            let bind_address = Self::supervisor_bind_address(endpoint_config)?;
+            runtime
+                .set_listen_tcp_for_unstarted_runtime(bind_address)
+                .map_err(|error| {
+                    MobError::Internal(format!(
+                        "failed to configure mob supervisor comms listener '{participant_name}': {error}"
+                    ))
+                })?;
+            runtime.start_listeners().await.map_err(|error| {
+                MobError::Internal(format!(
+                    "failed to start mob supervisor comms listener '{participant_name}': {error}"
+                ))
+            })?;
+            let runtime = Arc::new(runtime);
+            Self::install_supervisor_peer_request_response_authority(&runtime, participant_name)?;
+            Ok(runtime)
+        }
+        #[cfg(target_arch = "wasm32")]
+        {
+            let runtime = Arc::new(runtime);
+            Self::install_supervisor_peer_request_response_authority(&runtime, participant_name)?;
+            Ok(runtime)
+        }
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    fn supervisor_bind_address(
+        endpoint_config: &SupervisorBridgeEndpointConfig,
+    ) -> Result<std::net::SocketAddr, MobError> {
+        match endpoint_config.bind_address.as_deref() {
+            Some(raw) => raw.parse::<std::net::SocketAddr>().map_err(|error| {
+                MobError::WiringError(format!(
+                    "invalid mob supervisor bridge bind_address '{raw}': {error}"
+                ))
+            }),
+            None => Ok(std::net::SocketAddr::from(([127, 0, 0, 1], 0))),
+        }
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    fn has_fixed_supervisor_bind_port(
+        endpoint_config: &SupervisorBridgeEndpointConfig,
+    ) -> Result<bool, MobError> {
+        Ok(endpoint_config
+            .bind_address
+            .as_deref()
+            .map(|raw| {
+                raw.parse::<std::net::SocketAddr>()
+                    .map(|socket| socket.port() != 0)
+                    .map_err(|error| {
+                        MobError::WiringError(format!(
+                            "invalid mob supervisor bridge bind_address '{raw}': {error}"
+                        ))
+                    })
+            })
+            .transpose()?
+            .unwrap_or(false))
+    }
+
+    #[cfg(target_arch = "wasm32")]
+    fn has_fixed_supervisor_bind_port(
+        _endpoint_config: &SupervisorBridgeEndpointConfig,
+    ) -> Result<bool, MobError> {
+        Ok(false)
     }
 
     /// Supervisor bridge runtimes intentionally issue semantic peer
@@ -109,10 +180,27 @@ impl MobSupervisorBridge {
         &self,
         authority: SupervisorAuthorityRecord,
     ) -> Result<(), MobError> {
-        let runtime = Self::build_runtime(&self.participant_name, &authority)?;
+        let _request_guard = self.request_lock.lock().await;
+        self.replace_runtime_authority_locked(authority, true).await
+    }
+
+    async fn replace_runtime_authority_locked(
+        &self,
+        authority: SupervisorAuthorityRecord,
+        clear_buffered_candidates: bool,
+    ) -> Result<(), MobError> {
+        let mut runtime_guard = self.runtime.write().await;
+        #[cfg(not(target_arch = "wasm32"))]
+        if Self::has_fixed_supervisor_bind_port(&self.endpoint_config)? {
+            runtime_guard.stop_listeners_for_rebind().await;
+        }
+        let runtime =
+            Self::build_runtime(&self.participant_name, &authority, &self.endpoint_config).await?;
         *self.authority.write().await = authority;
-        *self.runtime.write().await = runtime;
-        self.buffered_candidates.lock().await.clear();
+        *runtime_guard = runtime;
+        if clear_buffered_candidates {
+            self.buffered_candidates.lock().await.clear();
+        }
         Ok(())
     }
 
@@ -130,12 +218,86 @@ impl MobSupervisorBridge {
 
     pub(crate) async fn supervisor_spec(&self) -> Result<TrustedPeerDescriptor, MobError> {
         let authority = self.authority().await;
+        self.supervisor_spec_with_address(&authority, format!("inproc://{}", self.participant_name))
+    }
+
+    pub(crate) async fn routable_supervisor_spec(&self) -> Result<TrustedPeerDescriptor, MobError> {
+        let authority = self.authority().await;
+        let runtime = self.runtime().await;
+        let address = self.supervisor_routable_address(runtime.as_ref())?;
+        self.supervisor_spec_with_address(&authority, address)
+    }
+
+    pub(crate) async fn supervisor_spec_for_recipient(
+        &self,
+        recipient: &TrustedPeerDescriptor,
+    ) -> Result<TrustedPeerDescriptor, MobError> {
+        self.supervisor_spec_for_authority_and_recipient(&self.authority().await, recipient)
+            .await
+    }
+
+    pub(crate) async fn supervisor_spec_for_authority_and_recipient(
+        &self,
+        authority: &SupervisorAuthorityRecord,
+        recipient: &TrustedPeerDescriptor,
+    ) -> Result<TrustedPeerDescriptor, MobError> {
+        if recipient.address.transport() == PeerTransport::Inproc {
+            self.supervisor_spec_with_address(
+                authority,
+                format!("inproc://{}", self.participant_name),
+            )
+        } else {
+            let runtime = self.runtime().await;
+            let address = self.supervisor_routable_address(runtime.as_ref())?;
+            self.supervisor_spec_with_address(authority, address)
+        }
+    }
+
+    fn supervisor_routable_address(
+        &self,
+        runtime: &meerkat_comms::CommsRuntime,
+    ) -> Result<String, MobError> {
+        if let Some(address) = self.endpoint_config.advertised_address.as_deref() {
+            let parsed = PeerAddress::parse(address).map_err(|error| {
+                MobError::WiringError(format!(
+                    "invalid mob supervisor bridge advertised_address '{address}': {error}"
+                ))
+            })?;
+            if parsed.transport() != PeerTransport::Tcp {
+                return Err(MobError::WiringError(format!(
+                    "mob supervisor bridge advertised_address must use tcp transport, got '{}'",
+                    parsed.transport()
+                )));
+            }
+            return Ok(address.to_string());
+        }
+        let address = CoreCommsRuntime::advertised_address(runtime)
+            .unwrap_or_else(|| format!("inproc://{}", self.participant_name));
+        if let Ok(parsed) = PeerAddress::parse(&address)
+            && parsed.transport() == PeerTransport::Tcp
+            && let Ok(socket) = parsed.endpoint().parse::<std::net::SocketAddr>()
+            && socket.ip().is_unspecified()
+        {
+            return Err(MobError::WiringError(
+                "mob supervisor bridge bind_address uses an unspecified interface; \
+                 backend.external.supervisor_bridge.advertised_address is required"
+                    .to_string(),
+            ));
+        }
+        Ok(address)
+    }
+
+    fn supervisor_spec_with_address(
+        &self,
+        authority: &SupervisorAuthorityRecord,
+        address: String,
+    ) -> Result<TrustedPeerDescriptor, MobError> {
         let public_key = authority.keypair().public_key();
         TrustedPeerDescriptor::unsigned_with_pubkey(
             self.participant_name.clone(),
-            authority.public_peer_id,
+            authority.public_peer_id.clone(),
             *public_key.as_bytes(),
-            format!("inproc://{}", self.participant_name),
+            address,
         )
         .map_err(|error| MobError::WiringError(format!("invalid supervisor spec: {error}")))
     }
@@ -164,12 +326,52 @@ impl MobSupervisorBridge {
         timeout: Duration,
     ) -> Result<serde_json::Value, MobError> {
         let _request_guard = self.request_lock.lock().await;
+        if Self::has_fixed_supervisor_bind_port(&self.endpoint_config)? {
+            let previous_authority = self.authority.read().await.clone();
+            let restore_after_send = previous_authority != *authority;
+            if restore_after_send {
+                self.replace_runtime_authority_locked(authority.clone(), false)
+                    .await?;
+            }
+            let send_result = async {
+                let runtime = self.runtime().await;
+                runtime
+                    .add_trusted_peer(recipient.clone())
+                    .await
+                    .map_err(MobError::from)?;
+                self.request_json_with_runtime(
+                    &runtime,
+                    recipient,
+                    super::bridge_protocol::SUPERVISOR_BRIDGE_INTENT,
+                    command,
+                    timeout,
+                )
+                .await
+            }
+            .await;
+            if restore_after_send {
+                if let Err(restore_error) = self
+                    .replace_runtime_authority_locked(previous_authority, false)
+                    .await
+                {
+                    return match send_result {
+                        Ok(_) => Err(restore_error),
+                        Err(send_error) => Err(MobError::Internal(format!(
+                            "alternate supervisor authority bridge request failed: {send_error}; \
+                             additionally failed to restore supervisor bridge authority: {restore_error}"
+                        ))),
+                    };
+                }
+            }
+            return send_result;
+        }
         let probe_participant_name = format!(
             "{}/pending-supervisor-probe/{}",
             self.participant_name,
             uuid::Uuid::new_v4()
         );
-        let runtime = Self::build_runtime(&probe_participant_name, authority)?;
+        let runtime =
+            Self::build_runtime(&probe_participant_name, authority, &self.endpoint_config).await?;
         runtime
             .add_trusted_peer(recipient.clone())
             .await

--- a/meerkat-mob/src/runtime/tests.rs
+++ b/meerkat-mob/src/runtime/tests.rs
@@ -3052,6 +3052,7 @@ fn sample_definition_with_external_backend() -> MobDefinition {
     let mut def = sample_definition();
     def.backend.external = Some(crate::definition::ExternalBackendConfig {
         address_base: "https://backend.example.invalid/mesh".to_string(),
+        supervisor_bridge: None,
     });
     def
 }
@@ -3505,6 +3506,7 @@ struct LiveExternalPeerHarness {
     delivered_inputs: Arc<RwLock<Vec<String>>>,
     hard_cancel_reasons: Arc<RwLock<Vec<String>>>,
     received_intents: Arc<RwLock<Vec<String>>>,
+    supervisor_addresses: Arc<RwLock<Vec<String>>>,
     supervisor_state: Arc<RwLock<Option<HarnessSupervisorState>>>,
     bind_peer_id_override: Arc<RwLock<Option<String>>>,
     fail_authorize_countdown: Arc<AtomicUsize>,
@@ -3567,6 +3569,10 @@ impl LiveExternalPeerHarness {
         self.received_intents.read().await.clone()
     }
 
+    async fn supervisor_addresses(&self) -> Vec<String> {
+        self.supervisor_addresses.read().await.clone()
+    }
+
     async fn authorized_supervisor_peer_id(&self) -> Option<String> {
         self.supervisor_state
             .read()
@@ -3623,11 +3629,35 @@ impl Drop for LiveExternalPeerHarness {
 }
 
 async fn spawn_live_external_peer(peer_name: &str) -> LiveExternalPeerHarness {
+    spawn_live_external_peer_with_transport(peer_name, false).await
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+async fn spawn_live_external_tcp_peer(peer_name: &str) -> LiveExternalPeerHarness {
+    spawn_live_external_peer_with_transport(peer_name, true).await
+}
+
+async fn spawn_live_external_peer_with_transport(
+    peer_name: &str,
+    listen_tcp: bool,
+) -> LiveExternalPeerHarness {
     let peer_name = peer_name.to_string();
-    let runtime = Arc::new(
-        meerkat_comms::CommsRuntime::inproc_only(&peer_name)
-            .expect("create live external peer runtime"),
-    );
+    let mut runtime = meerkat_comms::CommsRuntime::inproc_only(&peer_name)
+        .expect("create live external peer runtime");
+    #[cfg(not(target_arch = "wasm32"))]
+    if listen_tcp {
+        runtime
+            .set_listen_tcp_for_unstarted_runtime(std::net::SocketAddr::from(([127, 0, 0, 1], 0)))
+            .expect("configure live external peer TCP listener");
+        runtime
+            .start_listeners()
+            .await
+            .expect("start live external peer TCP listener");
+    }
+    #[cfg(target_arch = "wasm32")]
+    let _ = listen_tcp;
+    let runtime_address = runtime.advertised_address();
+    let runtime = Arc::new(runtime);
     install_ephemeral_peer_request_response_authority(
         &runtime,
         &format!("live-external-peer-{peer_name}"),
@@ -3636,7 +3666,7 @@ async fn spawn_live_external_peer(peer_name: &str) -> LiveExternalPeerHarness {
     let peer_pubkey = *runtime.public_key().as_bytes();
     let binding = crate::RuntimeBinding::External {
         peer_id: runtime.public_key().to_peer_id().to_string(),
-        address: format!("inproc://{peer_name}"),
+        address: runtime_address.clone(),
         bootstrap_token: Some(bootstrap_token.into()),
         pubkey: Some(peer_pubkey),
     };
@@ -3655,6 +3685,8 @@ async fn spawn_live_external_peer(peer_name: &str) -> LiveExternalPeerHarness {
     let responder_delivery_responses = delivery_responses.clone();
     let received_intents = Arc::new(RwLock::new(Vec::new()));
     let responder_received_intents = received_intents.clone();
+    let supervisor_addresses = Arc::new(RwLock::new(Vec::new()));
+    let responder_supervisor_addresses = supervisor_addresses.clone();
     let supervisor_state: Arc<RwLock<Option<HarnessSupervisorState>>> = Arc::new(RwLock::new(None));
     let responder_supervisor_state = supervisor_state.clone();
     let bind_peer_id_override: Arc<RwLock<Option<String>>> = Arc::new(RwLock::new(None));
@@ -3663,6 +3695,7 @@ async fn spawn_live_external_peer(peer_name: &str) -> LiveExternalPeerHarness {
     let responder_fail_authorize_countdown = fail_authorize_countdown.clone();
     let fail_next_bind = Arc::new(AtomicBool::new(false));
     let responder_fail_next_bind = fail_next_bind.clone();
+    let responder_runtime_address = runtime_address.clone();
     let task = tokio::spawn(async move {
         let mut state = super::bridge_protocol::BridgeMemberRuntimeState::Idle;
         let inbox_notify = responder_runtime.inbox_notify();
@@ -3814,6 +3847,10 @@ async fn spawn_live_external_peer(peer_name: &str) -> LiveExternalPeerHarness {
                                                             payload.supervisor.clone(),
                                                         )
                                                         .expect("valid supervisor spec");
+                                                    responder_supervisor_addresses
+                                                        .write()
+                                                        .await
+                                                        .push(supervisor_spec.address.to_string());
                                                     responder_runtime
                                                         .add_trusted_peer(supervisor_spec)
                                                         .await
@@ -3839,7 +3876,7 @@ async fn spawn_live_external_peer(peer_name: &str) -> LiveExternalPeerHarness {
                                                                     .to_peer_id()
                                                                     .to_string()
                                                             }),
-                                                        address: format!("inproc://{peer_name}"),
+                                                        address: responder_runtime_address.clone(),
                                                         capabilities:
                                                             super::bridge_protocol::BridgeCapabilities {
                                                                 deliver_member_input: true,
@@ -3940,6 +3977,10 @@ async fn spawn_live_external_peer(peer_name: &str) -> LiveExternalPeerHarness {
                                                         payload.supervisor.clone(),
                                                     )
                                                     .expect("valid supervisor spec");
+                                                responder_supervisor_addresses
+                                                    .write()
+                                                    .await
+                                                    .push(supervisor_spec.address.to_string());
                                                 responder_runtime
                                                     .add_trusted_peer(supervisor_spec)
                                                     .await
@@ -3964,6 +4005,10 @@ async fn spawn_live_external_peer(peer_name: &str) -> LiveExternalPeerHarness {
                                                     payload.supervisor.clone(),
                                                 )
                                                 .expect("valid supervisor spec");
+                                            responder_supervisor_addresses
+                                                .write()
+                                                .await
+                                                .push(supervisor_spec.address.to_string());
                                             responder_runtime
                                                 .add_trusted_peer(supervisor_spec)
                                                 .await
@@ -4231,6 +4276,7 @@ async fn spawn_live_external_peer(peer_name: &str) -> LiveExternalPeerHarness {
         delivered_inputs,
         hard_cancel_reasons,
         received_intents,
+        supervisor_addresses,
         supervisor_state,
         bind_peer_id_override,
         fail_authorize_countdown,
@@ -6894,7 +6940,8 @@ async fn test_rotate_supervisor_reauthorizes_live_remote_members_and_rejects_sta
         ),
     }
     .expect("peer spec");
-    let old_bridge = crate::runtime::MobSupervisorBridge::new(&mob_id, original.clone())
+    let old_bridge = crate::runtime::MobSupervisorBridge::new(&mob_id, original.clone(), None)
+        .await
         .expect("build old supervisor bridge");
     old_bridge
         .trust_recipient(&peer)
@@ -11595,6 +11642,7 @@ async fn test_spawn_member_tool_dispatches_backend_selection() {
     let mut definition = sample_definition_with_mob_tools();
     definition.backend.external = Some(crate::definition::ExternalBackendConfig {
         address_base: "https://backend.example.invalid/mesh".to_string(),
+        supervisor_bridge: None,
     });
     let (handle, service) = create_test_mob(definition).await;
     let sid_1 = handle
@@ -19146,6 +19194,7 @@ async fn test_external_backend_autonomous_flow_dispatch_normalizes_to_peer_only_
     );
     definition.backend.external = Some(crate::definition::ExternalBackendConfig {
         address_base: "https://backend.example.invalid/mesh".to_string(),
+        supervisor_bridge: None,
     });
     let mob_id = definition.id.clone();
     let (handle, service) = create_test_mob(definition).await;
@@ -29267,6 +29316,366 @@ async fn test_external_spawn_with_binding_uses_real_identity() {
         }
         other => panic!("expected BackendPeer member ref, got {other:?}"),
     }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+#[tokio::test]
+async fn test_external_tcp_bind_and_peer_turn_use_routable_supervisor_bridge() {
+    let _serial = REAL_COMMS_TEST_LOCK.lock().expect("real-comms test lock");
+    let definition = with_unique_mob_id(
+        sample_definition_with_external_backend(),
+        "external-tcp-bind-route",
+    );
+    let mob_id = definition.id.clone();
+    let (handle, service) = create_test_mob(definition).await;
+    let external_name = test_comms_name_for(&mob_id, "lead", "l-tcp");
+    let external = spawn_live_external_tcp_peer(&external_name).await;
+    let crate::RuntimeBinding::External { address, .. } = external.binding() else {
+        panic!("live external peer must produce external binding");
+    };
+    assert!(
+        address.starts_with("tcp://127.0.0.1:"),
+        "test harness must exercise TCP routing, got {address}"
+    );
+
+    let mut spec = SpawnMemberSpec::new("lead", "l-tcp");
+    spec.runtime_mode = Some(crate::MobRuntimeMode::TurnDriven);
+    spec.binding = Some(external.binding());
+    handle
+        .spawn_spec(spec)
+        .await
+        .expect("spawn TCP external member");
+
+    handle
+        .member(&AgentIdentity::from("l-tcp"))
+        .await
+        .expect("member handle")
+        .send("tcp external turn", HandlingMode::Queue)
+        .await
+        .expect("peer turn should route to TCP external runtime");
+
+    assert_eq!(
+        service.start_turn_call_count(),
+        0,
+        "peer-only TCP external dispatch must not fall back to local session start_turn"
+    );
+    assert_eq!(
+        external.delivered_input_ids().await.len(),
+        1,
+        "remote runtime must receive the post-bind peer turn"
+    );
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn unused_loopback_port() -> u16 {
+    std::net::TcpListener::bind(std::net::SocketAddr::from(([127, 0, 0, 1], 0)))
+        .expect("reserve loopback port")
+        .local_addr()
+        .expect("reserved listener local addr")
+        .port()
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+#[tokio::test]
+async fn test_external_tcp_bind_uses_configured_supervisor_advertised_address() {
+    let _serial = REAL_COMMS_TEST_LOCK.lock().expect("real-comms test lock");
+    let mut definition = with_unique_mob_id(
+        sample_definition_with_external_backend(),
+        "external-tcp-advertised-supervisor",
+    );
+    let mob_id = definition.id.clone();
+    let port = unused_loopback_port();
+    let advertised_address = format!("tcp://127.0.0.1:{port}");
+    definition
+        .backend
+        .external
+        .as_mut()
+        .expect("external backend")
+        .supervisor_bridge = Some(crate::definition::SupervisorBridgeEndpointConfig {
+        bind_address: Some(format!("0.0.0.0:{port}")),
+        advertised_address: Some(advertised_address.clone()),
+    });
+    let (handle, service) = create_test_mob(definition).await;
+    let external_name = test_comms_name_for(&mob_id, "lead", "l-tcp-advertised");
+    let external = spawn_live_external_tcp_peer(&external_name).await;
+
+    let mut spec = SpawnMemberSpec::new("lead", "l-tcp-advertised");
+    spec.runtime_mode = Some(crate::MobRuntimeMode::TurnDriven);
+    spec.binding = Some(external.binding());
+    handle
+        .spawn_spec(spec)
+        .await
+        .expect("spawn TCP external member");
+
+    assert_eq!(
+        external.supervisor_addresses().await,
+        vec![advertised_address.clone()],
+        "external runtime must be told to trust the configured supervisor bridge address"
+    );
+
+    handle
+        .member(&AgentIdentity::from("l-tcp-advertised"))
+        .await
+        .expect("member handle")
+        .send(
+            "tcp external turn through advertised supervisor",
+            HandlingMode::Queue,
+        )
+        .await
+        .expect("peer turn should route through configured advertised supervisor");
+
+    assert_eq!(
+        service.start_turn_call_count(),
+        0,
+        "configured peer-only TCP external dispatch must not fall back to local session start_turn"
+    );
+    assert_eq!(
+        external.delivered_input_ids().await.len(),
+        1,
+        "remote runtime must receive the post-bind peer turn"
+    );
+
+    handle
+        .rotate_supervisor()
+        .await
+        .expect("rotate configured supervisor bridge");
+    let supervisor_addresses = external.supervisor_addresses().await;
+    assert!(
+        supervisor_addresses.len() >= 2
+            && supervisor_addresses
+                .iter()
+                .all(|address| address == &advertised_address),
+        "rotation must preserve the configured routable supervisor address, got {supervisor_addresses:?}"
+    );
+
+    handle
+        .member(&AgentIdentity::from("l-tcp-advertised"))
+        .await
+        .expect("member handle")
+        .send(
+            "tcp external turn after advertised supervisor rotation",
+            HandlingMode::Queue,
+        )
+        .await
+        .expect("peer turn after rotation should route through configured advertised supervisor");
+
+    assert_eq!(
+        service.start_turn_call_count(),
+        0,
+        "configured peer-only TCP external dispatch after rotation must not fall back to local session start_turn"
+    );
+    assert_eq!(
+        external.delivered_input_ids().await.len(),
+        2,
+        "remote runtime must receive the post-rotation peer turn"
+    );
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+#[tokio::test]
+async fn test_external_tcp_fixed_supervisor_bridge_pending_rotation_retry_reuses_active_listener() {
+    let _serial = REAL_COMMS_TEST_LOCK.lock().expect("real-comms test lock");
+    let mut definition = with_unique_mob_id(
+        sample_definition_with_external_backend(),
+        "external-tcp-fixed-supervisor-pending-retry",
+    );
+    let mob_id = definition.id.clone();
+    let port = unused_loopback_port();
+    let advertised_address = format!("tcp://127.0.0.1:{port}");
+    definition
+        .backend
+        .external
+        .as_mut()
+        .expect("external backend")
+        .supervisor_bridge = Some(crate::definition::SupervisorBridgeEndpointConfig {
+        bind_address: Some(format!("0.0.0.0:{port}")),
+        advertised_address: Some(advertised_address.clone()),
+    });
+    definition
+        .profiles
+        .get_mut(&ProfileName::from("worker"))
+        .and_then(ProfileBinding::as_inline_mut)
+        .expect("worker profile exists")
+        .external_addressable = true;
+    let storage = MobStorage::in_memory();
+    let events = storage.events.clone();
+    let runtime_metadata = storage.runtime_metadata.clone();
+    let service = Arc::new(MockSessionService::new());
+    let _ = service.enable_runtime_adapter();
+    let handle = MobBuilder::new(definition, storage)
+        .with_session_service(service.clone())
+        .create()
+        .await
+        .expect("create mob");
+    let external_a =
+        spawn_live_external_tcp_peer(&test_comms_name_for(&mob_id, "worker", "w-a")).await;
+    let external_b =
+        spawn_live_external_tcp_peer(&test_comms_name_for(&mob_id, "worker", "w-b")).await;
+    handle
+        .spawn_with_binding(
+            ProfileName::from("worker"),
+            MeerkatId::from("w-a"),
+            None,
+            external_a.binding(),
+        )
+        .await
+        .expect("spawn first TCP external worker");
+    handle
+        .spawn_with_binding(
+            ProfileName::from("worker"),
+            MeerkatId::from("w-b"),
+            None,
+            external_b.binding(),
+        )
+        .await
+        .expect("spawn second TCP external worker");
+
+    let original = runtime_metadata
+        .load_supervisor_authority(&mob_id)
+        .await
+        .expect("load original authority")
+        .expect("original authority record");
+    external_b.fail_next_authorize();
+    let error = handle
+        .rotate_supervisor()
+        .await
+        .expect_err("partial rotation should leave pending supervisor authority");
+    let attempted_public_peer_id = match error {
+        MobError::SupervisorRotationIncomplete {
+            previous_epoch,
+            attempted_epoch,
+            attempted_public_peer_id,
+            rotated_peer_count,
+            pending_authority_recorded,
+            ..
+        } => {
+            assert_eq!(previous_epoch, original.epoch);
+            assert_eq!(attempted_epoch, original.epoch + 1);
+            assert_eq!(rotated_peer_count, 1);
+            assert!(
+                pending_authority_recorded,
+                "partial TCP rotation should persist pending authority for retry"
+            );
+            attempted_public_peer_id
+        }
+        other => panic!("expected typed incomplete supervisor rotation, got: {other:?}"),
+    };
+    assert_eq!(
+        external_a.authorized_supervisor_peer_id().await.as_deref(),
+        Some(attempted_public_peer_id.as_str()),
+        "first remote should accept the attempted authority before retry"
+    );
+
+    handle
+        .shutdown()
+        .await
+        .expect("shutdown original actor before retry");
+    let resumed = MobBuilder::for_resume(MobStorage::with_events_and_runtime_metadata(
+        events,
+        runtime_metadata.clone(),
+    ))
+    .with_session_service(service.clone())
+    .resume()
+    .await
+    .expect("resume mob with pending supervisor rotation");
+
+    let retry_report = resumed
+        .rotate_supervisor()
+        .await
+        .expect("fixed-port retry should reuse the active supervisor listener");
+    assert_eq!(retry_report.previous_epoch, original.epoch);
+    assert_eq!(retry_report.current_epoch, original.epoch + 1);
+    let retried = runtime_metadata
+        .load_supervisor_authority(&mob_id)
+        .await
+        .expect("load authority after retry")
+        .expect("authority after retry");
+    assert_eq!(retried.public_peer_id, retry_report.public_peer_id);
+    assert!(
+        retried.pending_rotation.is_none(),
+        "successful fixed-port retry must clear pending rotation metadata"
+    );
+    assert_eq!(
+        external_a.authorized_supervisor_peer_id().await.as_deref(),
+        Some(retried.public_peer_id.as_str()),
+        "retry should reconcile the already-accepted TCP remote"
+    );
+    assert_eq!(
+        external_b.authorized_supervisor_peer_id().await.as_deref(),
+        Some(retried.public_peer_id.as_str()),
+        "retry should rotate the TCP remote that rejected the first attempt"
+    );
+    let supervisor_addresses = external_a.supervisor_addresses().await;
+    assert!(
+        supervisor_addresses
+            .iter()
+            .all(|address| address == &advertised_address),
+        "retry must keep publishing the configured routable supervisor address, got {supervisor_addresses:?}"
+    );
+
+    resumed
+        .member(&AgentIdentity::from("w-a"))
+        .await
+        .expect("member handle")
+        .send("tcp fixed-port retry peer turn", HandlingMode::Queue)
+        .await
+        .expect("peer turn should route after fixed-port retry");
+    assert_eq!(
+        service.start_turn_call_count(),
+        0,
+        "peer-only TCP external dispatch after retry must not fall back to local session start_turn"
+    );
+    assert_eq!(
+        external_a.delivered_input_ids().await.len(),
+        1,
+        "remote runtime must receive the post-retry peer turn"
+    );
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+#[tokio::test]
+async fn test_external_tcp_peer_turn_routes_after_supervisor_rotation() {
+    let _serial = REAL_COMMS_TEST_LOCK.lock().expect("real-comms test lock");
+    let definition = with_unique_mob_id(
+        sample_definition_with_external_backend(),
+        "external-tcp-rotate-route",
+    );
+    let mob_id = definition.id.clone();
+    let (handle, service) = create_test_mob(definition).await;
+    let external_name = test_comms_name_for(&mob_id, "lead", "l-tcp-rotate");
+    let external = spawn_live_external_tcp_peer(&external_name).await;
+
+    let mut spec = SpawnMemberSpec::new("lead", "l-tcp-rotate");
+    spec.runtime_mode = Some(crate::MobRuntimeMode::TurnDriven);
+    spec.binding = Some(external.binding());
+    handle
+        .spawn_spec(spec)
+        .await
+        .expect("spawn TCP external member");
+
+    handle
+        .rotate_supervisor()
+        .await
+        .expect("rotate supervisor with TCP external member");
+
+    handle
+        .member(&AgentIdentity::from("l-tcp-rotate"))
+        .await
+        .expect("member handle")
+        .send("tcp external turn after rotation", HandlingMode::Queue)
+        .await
+        .expect("peer turn after rotation should route to TCP external runtime");
+
+    assert_eq!(
+        service.start_turn_call_count(),
+        0,
+        "rotated peer-only TCP external dispatch must not fall back to local session start_turn"
+    );
+    assert_eq!(
+        external.delivered_input_ids().await.len(),
+        1,
+        "remote runtime must receive the post-rotation peer turn"
+    );
 }
 
 #[tokio::test]

--- a/meerkat-mob/src/validate.rs
+++ b/meerkat-mob/src/validate.rs
@@ -250,7 +250,71 @@ pub fn validate_definition(def: &MobDefinition) -> Vec<Diagnostic> {
                     severity: DiagnosticSeverity::Error,
                 });
             }
-            Some(_) => {}
+            Some(external) => {
+                if let Some(supervisor_bridge) = &external.supervisor_bridge {
+                    let mut bind_socket = None;
+                    if let Some(bind_address) = supervisor_bridge.bind_address.as_deref() {
+                        match bind_address.parse::<std::net::SocketAddr>() {
+                            Ok(socket) => bind_socket = Some(socket),
+                            Err(error) => diagnostics.push(Diagnostic {
+                                code: DiagnosticCode::InvalidExternalBackendConfig,
+                                message: format!(
+                                    "backend.external.supervisor_bridge.bind_address must be a socket address: {error}"
+                                ),
+                                location: Some(
+                                    "backend.external.supervisor_bridge.bind_address".to_string(),
+                                ),
+                                severity: DiagnosticSeverity::Error,
+                            }),
+                        }
+                    }
+                    if bind_socket.is_some_and(|socket| socket.ip().is_unspecified())
+                        && supervisor_bridge.advertised_address.is_none()
+                    {
+                        diagnostics.push(Diagnostic {
+                            code: DiagnosticCode::InvalidExternalBackendConfig,
+                            message: "backend.external.supervisor_bridge.advertised_address is required when bind_address uses an unspecified interface".to_string(),
+                            location: Some(
+                                "backend.external.supervisor_bridge.advertised_address"
+                                    .to_string(),
+                            ),
+                            severity: DiagnosticSeverity::Error,
+                        });
+                    }
+                    if let Some(advertised_address) =
+                        supervisor_bridge.advertised_address.as_deref()
+                    {
+                        match meerkat_core::comms::PeerAddress::parse(advertised_address) {
+                            Ok(address)
+                                if address.transport()
+                                    == meerkat_core::comms::PeerTransport::Tcp => {}
+                            Ok(address) => diagnostics.push(Diagnostic {
+                                code: DiagnosticCode::InvalidExternalBackendConfig,
+                                message: format!(
+                                    "backend.external.supervisor_bridge.advertised_address must use tcp transport, got '{}'",
+                                    address.transport()
+                                ),
+                                location: Some(
+                                    "backend.external.supervisor_bridge.advertised_address"
+                                        .to_string(),
+                                ),
+                                severity: DiagnosticSeverity::Error,
+                            }),
+                            Err(error) => diagnostics.push(Diagnostic {
+                                code: DiagnosticCode::InvalidExternalBackendConfig,
+                                message: format!(
+                                    "backend.external.supervisor_bridge.advertised_address must be a typed peer address: {error}"
+                                ),
+                                location: Some(
+                                    "backend.external.supervisor_bridge.advertised_address"
+                                        .to_string(),
+                                ),
+                                severity: DiagnosticSeverity::Error,
+                            }),
+                        }
+                    }
+                }
+            }
         }
     }
 
@@ -538,12 +602,35 @@ mod tests {
             .backend = Some(MobBackendKind::External);
         def.backend.external = Some(crate::definition::ExternalBackendConfig {
             address_base: "   ".to_string(),
+            supervisor_bridge: None,
         });
         let diagnostics = validate_definition(&def);
         assert!(
             diagnostics
                 .iter()
                 .any(|d| d.code == DiagnosticCode::InvalidExternalBackendConfig)
+        );
+    }
+
+    #[test]
+    fn test_external_backend_requires_advertised_supervisor_address_for_unspecified_bind() {
+        let mut def = valid_definition();
+        def.backend.default = MobBackendKind::External;
+        def.backend.external = Some(crate::definition::ExternalBackendConfig {
+            address_base: "https://backend.example.invalid/mesh".to_string(),
+            supervisor_bridge: Some(crate::definition::SupervisorBridgeEndpointConfig {
+                bind_address: Some("0.0.0.0:42000".to_string()),
+                advertised_address: None,
+            }),
+        });
+        let diagnostics = validate_definition(&def);
+        assert!(
+            diagnostics.iter().any(|d| {
+                d.code == DiagnosticCode::InvalidExternalBackendConfig
+                    && d.location.as_deref()
+                        == Some("backend.external.supervisor_bridge.advertised_address")
+            }),
+            "unspecified bind address must not become advertised route truth"
         );
     }
 

--- a/sdks/python/meerkat/generated/types.py
+++ b/sdks/python/meerkat/generated/types.py
@@ -929,6 +929,7 @@ class MobEventRouterConfigInput:
 class MobExternalBackendConfigInput:
     """Request payload for MobExternalBackendConfigInput."""
     address_base: str
+    supervisor_bridge: Optional[Any] = None
 
 
 @dataclass

--- a/sdks/typescript/src/generated/types.ts
+++ b/sdks/typescript/src/generated/types.ts
@@ -676,6 +676,7 @@ export interface MobEventRouterConfigInput {
 
 export interface MobExternalBackendConfigInput {
   address_base: string;
+  supervisor_bridge?: unknown;
 }
 
 export interface MobFlowSpecInput {


### PR DESCRIPTION
## Summary
- give mob supervisor bridge runtimes a signed TCP listener while preserving in-process supervisor descriptors for local members
- use recipient-aware supervisor descriptors so TCP external members bind and reply through a routable supervisor address
- add a regression covering TCP external bind plus a subsequent peer turn on the remote runtime

## Validation
- ./scripts/repo-cargo test -p meerkat-mob test_external_tcp_bind_and_peer_turn_use_routable_supervisor_bridge -- --nocapture
- ./scripts/repo-cargo test -p meerkat-mob test_external_spawn_with_binding_uses_real_identity -- --nocapture
- ./scripts/repo-cargo test -p meerkat-mob test_supervisor_private_trust_preserves_send_resolution -- --nocapture
- make check
- make lint