### PR TITLE
[codex] fix compacted session retire stranding

### DIFF
--- a/meerkat-mob/src/runtime/actor.rs
+++ b/meerkat-mob/src/runtime/actor.rs
@@ -8685,9 +8685,12 @@ impl MobActor {
                     }
                 }
                 crate::RuntimeBinding::Session => {
-                    return Err(MobRespawnError::PreviousMemberCleanupAmbiguous {
-                        report: cleanup_report,
-                    });
+                    tracing::warn!(
+                        mob_id = %self.definition.id,
+                        agent_identity = %agent_identity,
+                        retire_error = %error,
+                        "respawn proceeding after session-bound retire removed the stale roster anchor"
+                    );
                 }
             }
         }
@@ -9016,20 +9019,21 @@ impl MobActor {
                 Some((DisposalStep::ArchiveSession, _))
             );
 
-        // Finally: edge-lock cleanup is unconditional, but roster removal is
-        // gated on critical archive success so retry has a concrete member
-        // anchor to operate on.
+        // Finally: edge-lock cleanup and roster removal are unconditional for
+        // normal disposal. ArchiveSession errors are still returned to the
+        // caller, but retaining a session-backed member after archive failure
+        // can leave the roster pointing at a runtime that retire already
+        // terminally drained.
         self.dispose_prune_edge_locks(ctx).await;
         if archive_failed {
             tracing::warn!(
                 mob_id = %self.definition.id,
                 agent_identity = %ctx.agent_identity,
-                "retaining retiring roster entry after ArchiveSession failure for retry"
+                "removing retiring roster entry after ArchiveSession failure to avoid a dead runtime anchor"
             );
-        } else {
-            self.dispose_remove_from_roster(ctx).await;
-            report.roster_removed = true;
         }
+        self.dispose_remove_from_roster(ctx).await;
+        report.roster_removed = true;
         report
     }
 
@@ -11060,6 +11064,19 @@ impl MobActor {
         for id in ids {
             let result = self.retire_one(id).await;
             if let Err((id, error)) = result {
+                let roster_still_contains_member = {
+                    let roster = self.roster.read().await;
+                    roster.get(&id).is_some()
+                };
+                if !roster_still_contains_member {
+                    tracing::warn!(
+                        mob_id = %self.definition.id,
+                        agent_identity = %id,
+                        error = %error,
+                        "{context}: retire reported cleanup failure after removing member; continuing"
+                    );
+                    continue;
+                }
                 tracing::warn!(
                     mob_id = %self.definition.id,
                     agent_identity = %id,

--- a/meerkat-mob/src/runtime/tests.rs
+++ b/meerkat-mob/src/runtime/tests.rs
@@ -10895,7 +10895,7 @@ async fn test_respawn_ignores_machine_local_edge_to_retired_peer() {
 }
 
 #[tokio::test]
-async fn test_respawn_archive_failure_retains_retry_anchor_and_can_retry() {
+async fn test_respawn_archive_failure_removes_stale_anchor_and_respawns() {
     let (handle, service) = create_test_mob(sample_definition()).await;
     let member_id = MeerkatId::from("respawn-ambiguous");
     let member_ref = handle
@@ -10913,43 +10913,11 @@ async fn test_respawn_archive_failure_retains_retry_anchor_and_can_retry() {
 
     service.set_archive_failure(&old_session_id).await;
 
-    let error = handle
+    let receipt = handle
         .respawn(AgentIdentity::from(member_id.as_str()), None)
         .await
-        .expect_err("respawn should surface cleanup failure when archive fails");
+        .expect("respawn should remove the stale cleanup anchor and spawn replacement");
 
-    assert!(
-        matches!(
-            error,
-            crate::runtime::handle::MobRespawnError::Mob(MobError::Internal(ref message))
-                if message.contains("ArchiveSession")
-        ),
-        "session-bound respawn should retain the cleanup anchor and return the archive failure directly: {error:?}"
-    );
-    let retained = handle
-        .get_member(&AgentIdentity::from(member_id.as_str()))
-        .await
-        .expect("archive failure should retain retiring member for retry");
-    assert_eq!(
-        retained.agent_runtime_id,
-        original_snapshot.agent_runtime_id
-    );
-    assert_eq!(retained.fence_token, original_snapshot.fence_token);
-    assert_eq!(retained.state, crate::roster::MemberState::Retiring);
-    assert_eq!(
-        handle.list_members_including_retiring().await.len(),
-        1,
-        "failed cleanup must leave exactly the retained retiring member, not a replacement"
-    );
-
-    service.clear_archive_failure(&old_session_id).await;
-    let receipt = handle
-        .respawn(
-            AgentIdentity::from(member_id.as_str()),
-            Some("retry replacement".into()),
-        )
-        .await
-        .expect("respawn retry should clean up the old session and spawn replacement");
     assert_eq!(receipt.identity, AgentIdentity::from(member_id.as_str()));
     let replacement = handle
         .member_status(&AgentIdentity::from(member_id.as_str()))
@@ -14982,19 +14950,19 @@ async fn test_retire_archive_failure_is_not_silent() {
         "retire must return Err when ArchiveSession fails"
     );
 
-    // Critical archive failure retains the retiring roster entry so cleanup can
-    // be retried without losing the member/session anchor.
-    let retained = handle
-        .get_member(&AgentIdentity::from("w-1"))
-        .await
-        .expect("archive failure should retain retry anchor");
-    assert_eq!(retained.state, crate::roster::MemberState::Retiring);
+    assert!(
+        handle
+            .get_member(&AgentIdentity::from("w-1"))
+            .await
+            .is_none(),
+        "archive failure must remove the stale roster anchor"
+    );
     let events = handle.events().replay_all().await.expect("replay");
     assert!(
         events
             .iter()
             .any(|e| matches!(e.kind, MobEventKind::MemberRetired { .. })),
-        "retire event should be persisted before archive so cleanup remains retryable"
+        "retire event should be persisted before archive so cleanup remains auditable"
     );
 }
 
@@ -17717,8 +17685,8 @@ async fn test_fault_injected_lifecycle_operations_preserve_transactional_invaria
         "spawn rollback should remove leaked trust edges"
     );
 
-    // Retire cleanup invariants: archive failure is surfaced and retains the
-    // retiring roster entry so the cleanup can be retried.
+    // Retire cleanup invariants: archive failure is surfaced, but the retiring
+    // roster entry is removed so callers cannot keep addressing a drained runtime.
     let (retire_handle, retire_service) = create_test_mob(sample_definition()).await;
     let sid_r1 = retire_handle
         .spawn(ProfileName::from("worker"), MeerkatId::from("r-1"), None)
@@ -17741,23 +17709,12 @@ async fn test_fault_injected_lifecycle_operations_preserve_transactional_invaria
         retire_result.is_err(),
         "retire must return Err when ArchiveSession fails"
     );
-    let retained = retire_handle
-        .get_member(&AgentIdentity::from("r-1"))
-        .await
-        .expect("retire must retain roster entry when archive fails");
-    assert_eq!(retained.state, crate::roster::MemberState::Retiring);
-
-    retire_service.clear_archive_failure(&sid_r1).await;
-    retire_handle
-        .retire(AgentIdentity::from("r-1"))
-        .await
-        .expect("retire retry should complete archive cleanup");
     assert!(
         retire_handle
             .get_member(&AgentIdentity::from("r-1"))
             .await
             .is_none(),
-        "successful retry must remove roster entry"
+        "archive failure must remove roster entry"
     );
     let r2 = retire_handle
         .get_member(&AgentIdentity::from("r-2"))
@@ -27894,10 +27851,10 @@ async fn test_retire_sends_required_peer_retired_notifications() {
 // Disposal pipeline integration tests
 // -----------------------------------------------------------------------
 
-/// Verifies that critical archive failure retains the retry anchor even when
-/// best-effort peer cleanup also fails.
+/// Verifies that critical archive failure is surfaced while the stale roster
+/// anchor is removed even when best-effort peer cleanup also fails.
 #[tokio::test]
-async fn test_dispose_member_retains_roster_when_archive_fails() {
+async fn test_dispose_member_removes_roster_when_archive_fails() {
     let (handle, service) = create_test_mob(sample_definition()).await;
     // Configure w-1's comms to fail both send and trust removal.
     service
@@ -27942,23 +27899,12 @@ async fn test_dispose_member_retains_roster_when_archive_fails() {
         "retire must return Err when ArchiveSession fails, regardless of other step failures"
     );
 
-    let retained = handle
-        .get_member(&AgentIdentity::from("w-1"))
-        .await
-        .expect("critical archive failure must retain member for cleanup retry");
-    assert_eq!(retained.state, crate::roster::MemberState::Retiring);
-
-    service.clear_archive_failure(&sid_w1).await;
-    handle
-        .retire(AgentIdentity::from("w-1"))
-        .await
-        .expect("retry should finish archive cleanup");
     assert!(
         handle
             .get_member(&AgentIdentity::from("w-1"))
             .await
             .is_none(),
-        "successful retry should remove the roster entry"
+        "archive failure must remove member to avoid a stale runtime anchor"
     );
 }
 
@@ -28052,6 +27998,29 @@ async fn test_reset_clears_roster_events_and_returns_to_running() {
     assert!(
         roster.list().next().is_none(),
         "roster projection should be empty after reset epoch"
+    );
+}
+
+#[tokio::test]
+async fn test_reset_continues_after_archive_failure_removed_stale_member() {
+    let (handle, service) = create_test_mob(sample_definition()).await;
+    let session_id = handle
+        .spawn(ProfileName::from("worker"), MeerkatId::from("w-1"), None)
+        .await
+        .expect("spawn w-1")
+        .bridge_session_id()
+        .expect("session-backed")
+        .clone();
+    service.set_archive_failure(&session_id).await;
+
+    handle
+        .reset()
+        .await
+        .expect("reset should continue once failed retire removed stale member");
+    assert_eq!(handle.status().await.unwrap(), MobState::Running);
+    assert!(
+        handle.list_members_including_retiring().await.is_empty(),
+        "reset must not leave a retiring ghost member"
     );
 }
 
@@ -28819,11 +28788,13 @@ async fn test_retire_returns_err_when_archive_fails() {
         "retire must return Err when ArchiveSession fails — got Ok"
     );
 
-    let retained = handle
-        .get_member(&AgentIdentity::from("w-1"))
-        .await
-        .expect("archive failure should retain retry anchor");
-    assert_eq!(retained.state, crate::roster::MemberState::Retiring);
+    assert!(
+        handle
+            .get_member(&AgentIdentity::from("w-1"))
+            .await
+            .is_none(),
+        "archive failure must remove the stale roster anchor"
+    );
 
     // Retire event was persisted before disposal (event-first).
     let events = handle.events().replay_all().await.expect("replay");

--- a/meerkat-session/src/persistent.rs
+++ b/meerkat-session/src/persistent.rs
@@ -870,7 +870,8 @@ async fn save_session_projection_with_storage_normalization_bridge(
         Ok(()) => Ok(()),
         Err(
             error @ (SessionStoreError::TranscriptContinuityViolation { .. }
-            | SessionStoreError::InvalidTranscriptRewrite { .. }),
+            | SessionStoreError::InvalidTranscriptRewrite { .. }
+            | SessionStoreError::MonotonicityViolation { .. }),
         ) => {
             let Some(previous) = store.load(session.id()).await? else {
                 return Err(error);
@@ -6467,6 +6468,91 @@ mod tests {
         }
     }
 
+    struct MonotonicityOnceStore {
+        inner: MemoryStore,
+        fail_next_save: AtomicBool,
+    }
+
+    impl MonotonicityOnceStore {
+        fn new() -> Self {
+            Self {
+                inner: MemoryStore::new(),
+                fail_next_save: AtomicBool::new(false),
+            }
+        }
+
+        fn fail_next_save_with_monotonicity(&self) {
+            self.fail_next_save.store(true, Ordering::Release);
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl SessionStore for MonotonicityOnceStore {
+        async fn save(&self, session: &Session) -> Result<(), SessionStoreError> {
+            if self.fail_next_save.swap(false, Ordering::AcqRel) {
+                return Err(SessionStoreError::MonotonicityViolation {
+                    id: session.id().clone(),
+                    prev_len: session.messages().len() + 1,
+                    new_len: session.messages().len(),
+                });
+            }
+            self.inner.save(session).await
+        }
+
+        async fn save_transcript_rewrite(
+            &self,
+            session: &Session,
+            commit: &meerkat_core::TranscriptRewriteCommit,
+        ) -> Result<(), SessionStoreError> {
+            self.inner.save_transcript_rewrite(session, commit).await
+        }
+
+        async fn save_authoritative_projection(
+            &self,
+            session: &Session,
+        ) -> Result<(), SessionStoreError> {
+            self.inner.save_authoritative_projection(session).await
+        }
+
+        async fn save_authoritative_projection_if_current_revision(
+            &self,
+            session: &Session,
+            expected_current_revision: Option<String>,
+        ) -> Result<(), SessionStoreError> {
+            self.inner
+                .save_authoritative_projection_if_current_revision(
+                    session,
+                    expected_current_revision,
+                )
+                .await
+        }
+
+        async fn load(&self, id: &SessionId) -> Result<Option<Session>, SessionStoreError> {
+            self.inner.load(id).await
+        }
+
+        async fn list(
+            &self,
+            filter: meerkat_store::SessionFilter,
+        ) -> Result<Vec<meerkat_core::SessionMeta>, SessionStoreError> {
+            self.inner.list(filter).await
+        }
+
+        async fn delete(&self, id: &SessionId) -> Result<(), SessionStoreError> {
+            self.inner.delete(id).await
+        }
+
+        async fn delete_if_current_revision(
+            &self,
+            id: &SessionId,
+            expected_current_revision: &str,
+        ) -> Result<bool, SessionStoreError> {
+            self.inner
+                .delete_if_current_revision(id, expected_current_revision)
+                .await
+        }
+    }
+
     struct BlockingArchiveSaveStore {
         inner: MemoryStore,
         block_archived_saves: AtomicBool,
@@ -9060,6 +9146,71 @@ mod tests {
         assert_eq!(
             saved.transcript_revision().expect("saved revision"),
             incoming_revision
+        );
+    }
+
+    #[tokio::test]
+    async fn test_projection_bridge_recovers_monotonicity_with_verified_projection() {
+        let store = MonotonicityOnceStore::new();
+        let blob_store = memory_blob_store();
+
+        let mut previous = Session::new();
+        previous.push(Message::User(UserMessage::text(
+            "persisted prompt before compaction".to_string(),
+        )));
+        previous.push(Message::Assistant(meerkat_core::AssistantMessage {
+            content: "persisted answer before compaction".to_string(),
+            tool_calls: Vec::new(),
+            stop_reason: StopReason::EndTurn,
+            usage: Usage::default(),
+            created_at: meerkat_core::types::message_timestamp_now(),
+        }));
+        store
+            .save(&previous)
+            .await
+            .expect("seed previous projection");
+        let parent_revision = previous.transcript_revision().expect("parent revision");
+
+        let mut compacted = previous.clone();
+        let commit = compacted
+            .commit_transcript_rewrite(
+                TranscriptRewriteSelection::MessageRange {
+                    start: 0,
+                    end: previous.messages().len(),
+                },
+                vec![Message::User(UserMessage::text(
+                    "[Context compacted] persisted summary".to_string(),
+                ))],
+                TranscriptRewriteReason::new("compaction"),
+                Some("meerkat-core".to_string()),
+                Some(parent_revision),
+            )
+            .expect("compaction rewrite should commit");
+        store
+            .save_transcript_rewrite(&compacted, &commit)
+            .await
+            .expect("seed audited compacted projection");
+        let compacted_revision = compacted
+            .transcript_revision()
+            .expect("compacted revision should digest");
+
+        store.fail_next_save_with_monotonicity();
+        save_session_projection_with_storage_normalization_bridge(
+            &store,
+            blob_store.as_ref(),
+            &compacted,
+        )
+        .await
+        .expect("verified projection bridge should recover monotonicity rejection");
+
+        let saved = store
+            .load(compacted.id())
+            .await
+            .expect("load saved projection")
+            .expect("projection should remain persisted");
+        assert_eq!(
+            saved.transcript_revision().expect("saved revision"),
+            compacted_revision
         );
     }
 


### PR DESCRIPTION
## Summary

Fixes a compacted singleton retire/disposal stranding path where archive projection saves could reject an already-compacted transcript with `MonotonicityViolation`, leaving the mob roster pointing at a member whose runtime had already been retired.

## What changed

- Route `MonotonicityViolation` through the existing verified storage-normalization projection bridge so legitimately compacted projections can recover via the CAS-checked authoritative projection path.
- Remove normal-disposal roster entries even when `ArchiveSession` fails, while still surfacing the archive error to the caller.
- Let session-backed respawn proceed after retire removed the stale cleanup anchor.
- Let reset continue when a retire error happened after the member was removed, avoiding a retained retiring ghost.
- Update/add regression tests for projection recovery, retire, respawn, and reset behavior.

## Validation

- `./scripts/repo-cargo fmt --check`
- `./scripts/repo-cargo test -p meerkat-session --features session-store persistent::tests::test_projection_bridge_recovers_monotonicity_with_verified_projection -- --exact --nocapture`
- `./scripts/repo-cargo check -p meerkat-session --features session-store`
- `./scripts/repo-cargo test -p meerkat-mob test_dispose_member_removes_roster_when_archive_fails`
- `./scripts/repo-cargo test -p meerkat-mob test_respawn_archive_failure_removes_stale_anchor_and_respawns`
- `./scripts/repo-cargo test -p meerkat-mob test_reset_continues_after_archive_failure_removed_stale_member`
- `./scripts/repo-cargo check -p meerkat-mob`
- Pre-push hooks, including changed-crate clippy, codegen verification, and deterministic workspace gate
