### PR TITLE
[codex] Fix external bridge reply routing

### DIFF
--- a/meerkat-mob/src/runtime/actor.rs
+++ b/meerkat-mob/src/runtime/actor.rs
@@ -1143,12 +1143,11 @@ impl MobActor {
             }
             return Err(Self::bridge_rejection_error(rejection));
         }
-        let _ack: super::bridge_protocol::BridgeAck =
-            serde_json::from_value(value).map_err(|error| {
-                MobError::Internal(format!(
-                    "failed to decode authorize supervisor response: {error}"
-                ))
-            })?;
+        let _ack = super::bridge_protocol::decode_bridge_ack(
+            &command,
+            value,
+            "authorize supervisor response",
+        )?;
         Ok(peer.clone())
     }
 
@@ -1250,23 +1249,22 @@ impl MobActor {
         if let Some(rejection) = Self::bridge_rejection_reply(command.protocol_version(), &value) {
             return Err(Self::bridge_rejection_error(rejection));
         }
-        serde_json::from_value(value).map_err(|error| {
+        let payload =
+            super::bridge_protocol::decode_bridge_success_payload(command, value, "command")?;
+        serde_json::from_value(payload).map_err(|error| {
             MobError::Internal(format!("failed to decode bridge command response: {error}"))
         })
     }
 
     fn bridge_ack_from_value(
-        protocol_version: super::bridge_protocol::BridgeProtocolVersion,
+        command: &super::bridge_protocol::BridgeCommand,
         value: serde_json::Value,
         context: &str,
     ) -> Result<(), MobError> {
-        if let Some(rejection) = Self::bridge_rejection_reply(protocol_version, &value) {
+        if let Some(rejection) = Self::bridge_rejection_reply(command.protocol_version(), &value) {
             return Err(Self::bridge_rejection_error(rejection));
         }
-        let _ack: super::bridge_protocol::BridgeAck =
-            serde_json::from_value(value).map_err(|error| {
-                MobError::Internal(format!("failed to decode {context} response: {error}"))
-            })?;
+        let _ack = super::bridge_protocol::decode_bridge_ack(command, value, context)?;
         Ok(())
     }
 
@@ -10254,16 +10252,13 @@ impl MobActor {
                                                             retry_rejection.reason()
                                                         ),
                                                     ))
-                                                } else if let Err(error) = serde_json::from_value::<
-                                                    super::bridge_protocol::BridgeAck,
-                                                >(
-                                                    value
-                                                ) {
-                                                    Some(MobError::Internal(format!(
-                                                        "failed to decode rotate supervisor response after bind fallback: {error}"
-                                                    )))
                                                 } else {
-                                                    None
+                                                    super::bridge_protocol::decode_bridge_ack(
+                                                        &retry_next_command,
+                                                        value,
+                                                        "rotate supervisor response after bind fallback",
+                                                    )
+                                                    .err()
                                                 }
                                             }
                                             Err(error) => Some(error),
@@ -10282,14 +10277,13 @@ impl MobActor {
                             } else {
                                 Some(Self::bridge_rejection_error(rejection))
                             }
-                        } else if let Err(error) =
-                            serde_json::from_value::<super::bridge_protocol::BridgeAck>(value)
-                        {
-                            Some(MobError::Internal(format!(
-                                "failed to decode rotate supervisor response: {error}"
-                            )))
                         } else {
-                            None
+                            super::bridge_protocol::decode_bridge_ack(
+                                &next_command,
+                                value,
+                                "rotate supervisor response",
+                            )
+                            .err()
                         }
                     }
                     Err(error) => Some(error),
@@ -10565,12 +10559,11 @@ impl MobActor {
                 Some(_) | None => Err(Self::bridge_rejection_error(rejection)),
             };
         }
-        let _ack: super::bridge_protocol::BridgeAck =
-            serde_json::from_value(value).map_err(|error| {
-                MobError::Internal(format!(
-                    "failed to decode pending supervisor verification response: {error}"
-                ))
-            })?;
+        let _ack = super::bridge_protocol::decode_bridge_ack(
+            command,
+            value,
+            "pending supervisor verification response",
+        )?;
         Ok(true)
     }
 
@@ -10742,7 +10735,7 @@ impl MobActor {
                 .await
                 .and_then(|value| {
                     Self::bridge_ack_from_value(
-                        target_command.protocol_version(),
+                        &target_command,
                         value,
                         "supervisor reconciliation authorize",
                     )
@@ -10761,7 +10754,7 @@ impl MobActor {
                 .await
                 .and_then(|value| {
                     Self::bridge_ack_from_value(
-                        revoke_attempted_command.protocol_version(),
+                        &revoke_attempted_command,
                         value,
                         "supervisor reconciliation revoke",
                     )

--- a/meerkat-mob/src/runtime/bridge_protocol.rs
+++ b/meerkat-mob/src/runtime/bridge_protocol.rs
@@ -4,6 +4,8 @@
 //! This module provides convenience re-exports so mob-internal code can import
 //! from a single location.
 
+use crate::MobError;
+
 pub use meerkat_contracts::wire::supervisor_bridge::{
     BridgeAck, BridgeBindPayload, BridgeBindResponse, BridgeBootstrapToken, BridgeCapabilities,
     BridgeCommand, BridgeCommandDecodeError, BridgeDeliveryOutcome, BridgeDeliveryPayload,
@@ -20,3 +22,123 @@ pub use meerkat_contracts::wire::supervisor_bridge::{
     supervisor_bridge_default_protocol_version, supervisor_bridge_protocol_version_supported,
     supervisor_bridge_supported_protocol_versions,
 };
+
+pub(crate) fn decode_bridge_success_payload(
+    command: &BridgeCommand,
+    value: serde_json::Value,
+    context: &str,
+) -> Result<serde_json::Value, MobError> {
+    let reply: BridgeReply = serde_json::from_value(value).map_err(|error| {
+        MobError::Internal(format!("failed to decode {context} bridge reply: {error}"))
+    })?;
+    let expected = expected_reply_kind(command);
+    match reply {
+        BridgeReply::BindMember(payload) if expected == ExpectedBridgeReply::BindMember => {
+            serialize_success_payload(payload, context)
+        }
+        BridgeReply::Ack(payload) if expected == ExpectedBridgeReply::Ack => {
+            serialize_success_payload(payload, context)
+        }
+        BridgeReply::Observation(payload) if expected == ExpectedBridgeReply::Observation => {
+            serialize_success_payload(payload, context)
+        }
+        BridgeReply::Delivery(payload) if expected == ExpectedBridgeReply::Delivery => {
+            serialize_success_payload(payload, context)
+        }
+        BridgeReply::Retire(payload) if expected == ExpectedBridgeReply::Retire => {
+            serialize_success_payload(payload, context)
+        }
+        BridgeReply::Destroy(payload) if expected == ExpectedBridgeReply::Destroy => {
+            serialize_success_payload(payload, context)
+        }
+        BridgeReply::Rejected { cause, reason } => {
+            Err(MobError::from(BridgeRejectionReply::Typed {
+                cause,
+                reason,
+            }))
+        }
+        other => Err(MobError::Internal(format!(
+            "unexpected {context} bridge reply: expected {}, got {}",
+            expected.as_str(),
+            reply_kind(&other).as_str()
+        ))),
+    }
+}
+
+pub(crate) fn decode_bridge_ack(
+    command: &BridgeCommand,
+    value: serde_json::Value,
+    context: &str,
+) -> Result<BridgeAck, MobError> {
+    let payload = decode_bridge_success_payload(command, value, context)?;
+    serde_json::from_value(payload)
+        .map_err(|error| MobError::Internal(format!("failed to decode {context} ack: {error}")))
+}
+
+fn serialize_success_payload<T: serde::Serialize>(
+    payload: T,
+    context: &str,
+) -> Result<serde_json::Value, MobError> {
+    serde_json::to_value(payload).map_err(|error| {
+        MobError::Internal(format!(
+            "failed to normalize {context} bridge reply: {error}"
+        ))
+    })
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum ExpectedBridgeReply {
+    BindMember,
+    Ack,
+    Observation,
+    Delivery,
+    Retire,
+    Destroy,
+    Rejected,
+    Unknown,
+}
+
+impl ExpectedBridgeReply {
+    const fn as_str(self) -> &'static str {
+        match self {
+            Self::BindMember => "bind_member",
+            Self::Ack => "ack",
+            Self::Observation => "observation",
+            Self::Delivery => "delivery",
+            Self::Retire => "retire",
+            Self::Destroy => "destroy",
+            Self::Rejected => "rejected",
+            Self::Unknown => "unknown",
+        }
+    }
+}
+
+fn expected_reply_kind(command: &BridgeCommand) -> ExpectedBridgeReply {
+    match command {
+        BridgeCommand::BindMember(_) => ExpectedBridgeReply::BindMember,
+        BridgeCommand::AuthorizeSupervisor(_)
+        | BridgeCommand::RevokeSupervisor(_)
+        | BridgeCommand::InterruptMember(_)
+        | BridgeCommand::HardCancelMember(_)
+        | BridgeCommand::WireMember(_)
+        | BridgeCommand::UnwireMember(_) => ExpectedBridgeReply::Ack,
+        BridgeCommand::DeliverMemberInput(_) => ExpectedBridgeReply::Delivery,
+        BridgeCommand::ObserveMember(_) => ExpectedBridgeReply::Observation,
+        BridgeCommand::RetireMember(_) => ExpectedBridgeReply::Retire,
+        BridgeCommand::DestroyMember(_) => ExpectedBridgeReply::Destroy,
+        _ => ExpectedBridgeReply::Unknown,
+    }
+}
+
+fn reply_kind(reply: &BridgeReply) -> ExpectedBridgeReply {
+    match reply {
+        BridgeReply::BindMember(_) => ExpectedBridgeReply::BindMember,
+        BridgeReply::Ack(_) => ExpectedBridgeReply::Ack,
+        BridgeReply::Observation(_) => ExpectedBridgeReply::Observation,
+        BridgeReply::Delivery(_) => ExpectedBridgeReply::Delivery,
+        BridgeReply::Retire(_) => ExpectedBridgeReply::Retire,
+        BridgeReply::Destroy(_) => ExpectedBridgeReply::Destroy,
+        BridgeReply::Rejected { .. } => ExpectedBridgeReply::Rejected,
+        _ => ExpectedBridgeReply::Unknown,
+    }
+}

--- a/meerkat-mob/src/runtime/provisioner.rs
+++ b/meerkat-mob/src/runtime/provisioner.rs
@@ -2165,6 +2165,11 @@ impl MultiBackendProvisioner {
             }
             return Err(Self::bridge_rejection_error(rejection));
         }
+        let _ack = super::bridge_protocol::decode_bridge_ack(
+            &command,
+            value,
+            "authorize supervisor response",
+        )?;
         Ok(peer.clone())
     }
 
@@ -2241,7 +2246,9 @@ impl MultiBackendProvisioner {
         if let Some(rejection) = Self::bridge_rejection_reply(command.protocol_version(), &value) {
             return Err(Self::bridge_rejection_error(rejection));
         }
-        serde_json::from_value(value).map_err(|error| {
+        let payload =
+            super::bridge_protocol::decode_bridge_success_payload(command, value, "command")?;
+        serde_json::from_value(payload).map_err(|error| {
             MobError::Internal(format!("failed to decode bridge command response: {error}"))
         })
     }

--- a/meerkat-mob/src/runtime/tests.rs
+++ b/meerkat-mob/src/runtime/tests.rs
@@ -3865,7 +3865,8 @@ async fn spawn_live_external_peer_with_transport(
                                                     });
                                                 }
                                                 serde_json::to_value(
-                                                    super::bridge_protocol::BridgeBindResponse {
+                                                    super::bridge_protocol::BridgeReply::BindMember(
+                                                        super::bridge_protocol::BridgeBindResponse {
                                                         peer_id: responder_bind_peer_id_override
                                                             .write()
                                                             .await
@@ -3889,7 +3890,8 @@ async fn spawn_live_external_peer_with_transport(
                                                                 unwire_member: true,
                                                                 ..super::bridge_protocol::BridgeCapabilities::default()
                                                         },
-                                                    },
+                                                        },
+                                                    ),
                                                 )
                                                 .expect("bind response")
                                             }
@@ -3994,7 +3996,9 @@ async fn spawn_live_external_peer_with_transport(
                                                     epoch: payload.epoch,
                                                 });
                                                 serde_json::to_value(
-                                                    super::bridge_protocol::BridgeAck { ok: true },
+                                                    super::bridge_protocol::BridgeReply::Ack(
+                                                        super::bridge_protocol::BridgeAck { ok: true },
+                                                    ),
                                                 )
                                                 .expect("authorize ack")
                                             }
@@ -4034,16 +4038,16 @@ async fn spawn_live_external_peer_with_transport(
                                     remove_supervisors_after_response
                                         .push(meerkat_comms::PubKey::new(supervisor_spec.pubkey));
                                     *responder_supervisor_state.write().await = None;
-                                    serde_json::to_value(super::bridge_protocol::BridgeAck {
-                                        ok: true,
-                                    })
+                                    serde_json::to_value(super::bridge_protocol::BridgeReply::Ack(
+                                        super::bridge_protocol::BridgeAck { ok: true },
+                                    ))
                                     .expect("revoke ack")
                                 }
                                 super::bridge_protocol::BridgeCommand::InterruptMember(_) => {
                                     responder_interrupt_count.fetch_add(1, Ordering::Relaxed);
-                                    serde_json::to_value(super::bridge_protocol::BridgeAck {
-                                        ok: true,
-                                    })
+                                    serde_json::to_value(super::bridge_protocol::BridgeReply::Ack(
+                                        super::bridge_protocol::BridgeAck { ok: true },
+                                    ))
                                     .expect("interrupt ack")
                                 }
                                 super::bridge_protocol::BridgeCommand::HardCancelMember(
@@ -4053,9 +4057,9 @@ async fn spawn_live_external_peer_with_transport(
                                         .write()
                                         .await
                                         .push(payload.reason);
-                                    serde_json::to_value(super::bridge_protocol::BridgeAck {
-                                        ok: true,
-                                    })
+                                    serde_json::to_value(super::bridge_protocol::BridgeReply::Ack(
+                                        super::bridge_protocol::BridgeAck { ok: true },
+                                    ))
                                     .expect("hard-cancel ack")
                                 }
                                 super::bridge_protocol::BridgeCommand::DeliverMemberInput(
@@ -4096,8 +4100,10 @@ async fn spawn_live_external_peer_with_transport(
                                     if let Some(existing) =
                                         responses.get(&payload.input_id).cloned()
                                     {
-                                        serde_json::to_value(existing)
-                                            .expect("existing delivery response")
+                                        serde_json::to_value(
+                                            super::bridge_protocol::BridgeReply::Delivery(existing),
+                                        )
+                                        .expect("existing delivery response")
                                     } else {
                                         let supervisor_spec =
                                             meerkat_core::comms::TrustedPeerDescriptor::try_from(
@@ -4126,7 +4132,10 @@ async fn spawn_live_external_peer_with_transport(
                                         };
                                         responses
                                             .insert(payload.input_id.clone(), response.clone());
-                                        serde_json::to_value(response).expect("delivery response")
+                                        serde_json::to_value(
+                                            super::bridge_protocol::BridgeReply::Delivery(response),
+                                        )
+                                        .expect("delivery response")
                                     }
                                     }
                                 }
@@ -4140,9 +4149,9 @@ async fn spawn_live_external_peer_with_transport(
                                         .add_trusted_peer(peer_spec)
                                         .await
                                         .expect("wire trust");
-                                    serde_json::to_value(super::bridge_protocol::BridgeAck {
-                                        ok: true,
-                                    })
+                                    serde_json::to_value(super::bridge_protocol::BridgeReply::Ack(
+                                        super::bridge_protocol::BridgeAck { ok: true },
+                                    ))
                                     .expect("wire ack")
                                 }
                                 super::bridge_protocol::BridgeCommand::UnwireMember(payload) => {
@@ -4154,19 +4163,21 @@ async fn spawn_live_external_peer_with_transport(
                                     let _ = responder_runtime
                                         .remove_trusted_peer(&peer_spec.peer_id.to_string())
                                         .await;
-                                    serde_json::to_value(super::bridge_protocol::BridgeAck {
-                                        ok: true,
-                                    })
+                                    serde_json::to_value(super::bridge_protocol::BridgeReply::Ack(
+                                        super::bridge_protocol::BridgeAck { ok: true },
+                                    ))
                                     .expect("unwire ack")
                                 }
                                 super::bridge_protocol::BridgeCommand::RetireMember(_) => {
                                     state =
                                         super::bridge_protocol::BridgeMemberRuntimeState::Retired;
                                     serde_json::to_value(
-                                        super::bridge_protocol::BridgeRetireResponse {
+                                        super::bridge_protocol::BridgeReply::Retire(
+                                            super::bridge_protocol::BridgeRetireResponse {
                                             inputs_abandoned: 0,
                                             inputs_pending_drain: 0,
-                                        },
+                                            },
+                                        ),
                                     )
                                     .expect("retire response")
                                 }
@@ -4174,15 +4185,18 @@ async fn spawn_live_external_peer_with_transport(
                                     state =
                                         super::bridge_protocol::BridgeMemberRuntimeState::Destroyed;
                                     serde_json::to_value(
-                                        super::bridge_protocol::BridgeDestroyResponse {
+                                        super::bridge_protocol::BridgeReply::Destroy(
+                                            super::bridge_protocol::BridgeDestroyResponse {
                                             inputs_abandoned: 0,
-                                        },
+                                            },
+                                        ),
                                     )
                                     .expect("destroy response")
                                 }
                                 super::bridge_protocol::BridgeCommand::ObserveMember(_) => {
                                     serde_json::to_value(
-                                        super::bridge_protocol::BridgeObservationResponse::new(
+                                        super::bridge_protocol::BridgeReply::Observation(
+                                            super::bridge_protocol::BridgeObservationResponse::new(
                                             state,
                                             Some(matches!(
                                                 state,
@@ -4196,6 +4210,7 @@ async fn spawn_live_external_peer_with_transport(
                                             ),
                                             None,
                                             Utc::now().to_rfc3339(),
+                                            ),
                                         ),
                                     )
                                     .expect("observe response")

--- a/meerkat-mob/tests/smoke_mob_flow_runtime.rs
+++ b/meerkat-mob/tests/smoke_mob_flow_runtime.rs
@@ -12,16 +12,19 @@
 
 use indexmap::IndexMap;
 use meerkat::{AgentFactory, Config, FactoryAgentBuilder};
+use meerkat_core::HandlingMode;
+use meerkat_core::agent::CommsRuntime as _;
 use meerkat_mob::definition::{
     BackendConfig, CollectionPolicy, ConditionExpr, DependencyMode, DispatchMode, FlowNodeSpec,
     FlowSpec, FlowStepSpec, FrameSpec, FrameStepSpec, LimitsSpec, OrchestratorConfig,
     RepeatUntilSpec, WiringRules,
 };
 use meerkat_mob::{
-    AgentIdentity, FlowId, LoopId, MobBuilder, MobDefinition, MobHandle, MobId, MobRun,
-    MobRunStatus, MobRuntimeMode, MobSessionService, MobStorage, Profile, ProfileBinding,
-    ProfileName, SpawnMemberSpec, StepId, ToolConfig,
+    AgentIdentity, FlowId, LoopId, MobBackendKind, MobBuilder, MobDefinition, MobHandle, MobId,
+    MobRun, MobRunStatus, MobRuntimeMode, MobSessionService, MobStorage, Profile, ProfileBinding,
+    ProfileName, RuntimeBinding, SpawnMemberSpec, StepId, ToolConfig,
 };
+use meerkat_runtime::SessionServiceRuntimeExt;
 use meerkat_session::PersistentSessionService;
 use meerkat_store::{JsonlStore, MemoryBlobStore, StoreAdapter};
 use serde_json::Value;
@@ -2546,6 +2549,148 @@ async fn setup_flow_mob(
     (handle, mob_service, temp)
 }
 
+#[cfg(not(target_arch = "wasm32"))]
+struct ProductionExternalTcpTarget {
+    binding: RuntimeBinding,
+    adapter: Arc<meerkat_runtime::meerkat_machine::MeerkatMachine>,
+    session_id: meerkat_core::SessionId,
+    runtime: Arc<meerkat_comms::CommsRuntime>,
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+impl ProductionExternalTcpTarget {
+    async fn active_input_count(&self) -> usize {
+        self.adapter
+            .list_active_inputs(&self.session_id)
+            .await
+            .expect("target runtime should list active inputs")
+            .len()
+    }
+
+    async fn shutdown(&self) {
+        self.adapter.abort_comms_drain(&self.session_id).await;
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn unused_loopback_port() -> u16 {
+    std::net::TcpListener::bind(std::net::SocketAddr::from(([127, 0, 0, 1], 0)))
+        .expect("reserve loopback port")
+        .local_addr()
+        .expect("reserved listener local addr")
+        .port()
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn external_tcp_smoke_definition(
+    mob_id: MobId,
+    bind_address: String,
+    advertised_address: String,
+) -> MobDefinition {
+    let mut profiles = BTreeMap::new();
+    profiles.insert(
+        ProfileName::from("lead"),
+        ProfileBinding::Inline(Profile {
+            model: "claude-haiku-4-5-20251001".to_string(),
+            skills: vec![],
+            tools: ToolConfig {
+                comms: true,
+                mob: true,
+                ..ToolConfig::default()
+            },
+            peer_description: "External TCP smoke target".to_string(),
+            external_addressable: true,
+            backend: Some(MobBackendKind::External),
+            runtime_mode: MobRuntimeMode::TurnDriven,
+            max_inline_peer_notifications: None,
+            output_schema: None,
+            provider_params: None,
+        }),
+    );
+
+    let mut definition = MobDefinition::explicit(mob_id);
+    definition.orchestrator = Some(OrchestratorConfig {
+        profile: ProfileName::from("lead"),
+    });
+    definition.profiles = profiles;
+    definition.backend = BackendConfig {
+        default: MobBackendKind::External,
+        external: Some(meerkat_mob::definition::ExternalBackendConfig {
+            address_base: "tcp://127.0.0.1".to_string(),
+            supervisor_bridge: Some(meerkat_mob::definition::SupervisorBridgeEndpointConfig {
+                bind_address: Some(bind_address),
+                advertised_address: Some(advertised_address),
+            }),
+        }),
+    };
+    definition
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+async fn spawn_production_external_tcp_target(peer_name: &str) -> ProductionExternalTcpTarget {
+    let mut runtime =
+        meerkat_comms::CommsRuntime::inproc_only(peer_name).expect("create target comms runtime");
+    runtime
+        .set_listen_tcp_for_unstarted_runtime(std::net::SocketAddr::from(([127, 0, 0, 1], 0)))
+        .expect("configure target TCP listener");
+    runtime
+        .start_listeners()
+        .await
+        .expect("start target TCP listener");
+    let address = runtime.advertised_address();
+    let peer_id = runtime.public_key().to_peer_id().to_string();
+    let pubkey = *runtime.public_key().as_bytes();
+    let bootstrap_token = runtime.bridge_bootstrap_token().to_string();
+    let runtime = Arc::new(runtime);
+    let session_id = meerkat_core::SessionId::new();
+    let dsl = Arc::new(meerkat_runtime::HandleDslAuthority::ephemeral());
+    dsl.apply_signal(
+        meerkat_runtime::meerkat_machine::dsl::MeerkatMachineSignal::Initialize,
+        "external_tcp_smoke_target::initialize",
+    )
+    .expect("initialize target peer interaction authority");
+    dsl.apply_input(
+        meerkat_runtime::meerkat_machine::dsl::MeerkatMachineInput::RegisterSession {
+            session_id: meerkat_runtime::meerkat_machine::dsl::SessionId::from(
+                session_id.to_string(),
+            ),
+        },
+        "external_tcp_smoke_target::register",
+    )
+    .expect("register target peer interaction authority");
+    runtime.install_peer_request_response_authority(
+        meerkat_comms::PeerRequestResponseAuthority::new(
+            Arc::new(meerkat_runtime::handles::RuntimePeerInteractionHandle::new(
+                Arc::clone(&dsl),
+            )),
+            Arc::new(meerkat_runtime::handles::RuntimeInteractionStreamHandle::new(dsl)),
+        ),
+    );
+
+    let adapter = Arc::new(meerkat_runtime::meerkat_machine::MeerkatMachine::ephemeral());
+    adapter.register_session(session_id.clone()).await;
+    let spawned = adapter
+        .maybe_spawn_comms_drain(
+            &session_id,
+            true,
+            Some(runtime.clone() as Arc<dyn meerkat_core::agent::CommsRuntime>),
+        )
+        .await;
+    assert!(spawned, "target must run production comms_drain");
+
+    ProductionExternalTcpTarget {
+        binding: RuntimeBinding::External {
+            peer_id,
+            address,
+            bootstrap_token: Some(bootstrap_token.into()),
+            pubkey: Some(pubkey),
+        },
+        adapter,
+        session_id,
+        runtime,
+    }
+}
+
 async fn wait_for_run_terminal(handle: &MobHandle, run_id: &meerkat_mob::RunId) -> MobRun {
     let deadline = Instant::now() + Duration::from_secs(180);
     loop {
@@ -2622,6 +2767,88 @@ fn assert_completed_without_failures(run: &MobRun, label: &str) {
         run.failure_ledger.is_empty(),
         "{label} should not record failures: {run:?}"
     );
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+#[tokio::test]
+#[ignore = "lane:e2e-smoke"]
+async fn e2e_external_tcp_production_drain_bind_and_turn_smoke() {
+    let temp = TempDir::new().expect("temp dir");
+    let paths = FlowSmokePaths::new(temp.path());
+    let mob_id = MobId::from(format!(
+        "external-tcp-production-drain-smoke-{}",
+        uuid::Uuid::new_v4().simple()
+    ));
+    let supervisor_port = unused_loopback_port();
+    let supervisor_advertised_address = format!("tcp://127.0.0.1:{supervisor_port}");
+    let definition = external_tcp_smoke_definition(
+        mob_id.clone(),
+        format!("0.0.0.0:{supervisor_port}"),
+        supervisor_advertised_address.clone(),
+    );
+    let session_service = persistent_service(&paths);
+    let mob_service: Arc<dyn MobSessionService> = session_service.clone();
+    let runtime_adapter = mob_service
+        .runtime_adapter()
+        .expect("persistent smoke service should expose a runtime adapter");
+    let storage =
+        MobStorage::persistent(&paths.mob_db_path).expect("create persistent mob storage");
+    let handle = MobBuilder::new(definition, storage)
+        .with_session_service(mob_service.clone())
+        .with_runtime_adapter(runtime_adapter)
+        .create()
+        .await
+        .expect("create external TCP smoke mob");
+
+    let target_peer_name = format!("{mob_id}/lead/l-production-tcp");
+    let target = spawn_production_external_tcp_target(&target_peer_name).await;
+    let target_address = match &target.binding {
+        RuntimeBinding::External { address, .. } => address.clone(),
+        RuntimeBinding::Session => panic!("target binding must be external"),
+    };
+    assert!(
+        target_address.starts_with("tcp://127.0.0.1:"),
+        "test must exercise a real TCP external member, got {target_address}"
+    );
+
+    let mut spec = SpawnMemberSpec::new("lead", AgentIdentity::from("l-production-tcp"));
+    spec.runtime_mode = Some(MobRuntimeMode::TurnDriven);
+    spec.binding = Some(target.binding.clone());
+    handle
+        .spawn_spec(spec)
+        .await
+        .expect("BindMember should complete through production target comms_drain");
+
+    let trusted_peers = target.runtime.peers().await;
+    assert!(
+        trusted_peers
+            .iter()
+            .any(|peer| peer.address.to_string() == supervisor_advertised_address),
+        "target runtime must install the advertised supervisor bridge as sendable trust; peers={trusted_peers:?}"
+    );
+
+    handle
+        .member(&AgentIdentity::from("l-production-tcp"))
+        .await
+        .expect("member handle")
+        .send(
+            "production TCP external turn after bind",
+            HandlingMode::Queue,
+        )
+        .await
+        .expect("peer turn should deliver over TCP and return a bridge response");
+
+    assert_eq!(
+        target.active_input_count().await,
+        1,
+        "production target runtime must accept the delivered peer turn"
+    );
+
+    target.shutdown().await;
+    handle
+        .shutdown()
+        .await
+        .expect("shutdown external TCP smoke mob");
 }
 
 async fn run_smoke_flow_or_skip(test_name: &str, flow_id: &str, params: Value) -> Option<MobRun> {

--- a/meerkat-runtime/src/comms_drain.rs
+++ b/meerkat-runtime/src/comms_drain.rs
@@ -739,8 +739,10 @@ enum BindMemberGate {
     Bootstrap,
     /// A supervisor is already bound and the request exactly matches it
     /// (same peer id, same epoch, authenticated sender). Reply with the
-    /// same `BridgeBindResponse` we would have returned originally; do
-    /// not mutate `supervisor_state` or re-trust the peer.
+    /// same `BridgeBindResponse` we would have returned originally. The
+    /// DSL-owned `supervisor_state` is not mutated, but the runtime trust
+    /// projection may be repaired so the correlated reply has a sendable
+    /// route after restore.
     IdempotentAck,
 }
 
@@ -1083,6 +1085,34 @@ async fn try_handle_supervisor_bridge_command(
                         .await;
                         return true;
                     };
+                    let supervisor_spec =
+                        match TrustedPeerDescriptor::try_from(payload.supervisor.clone()) {
+                            Ok(spec) => spec,
+                            Err(error) => {
+                                send_bridge_failure(
+                                    comms_runtime,
+                                    candidate,
+                                    BridgeRejectionCause::InvalidSupervisorSpec,
+                                    format!(
+                                        "bind member failed: invalid supervisor peer spec: {error}"
+                                    ),
+                                )
+                                .await;
+                                return true;
+                            }
+                        };
+                    if let Err(error) = comms_runtime.add_trusted_peer(supervisor_spec).await {
+                        send_bridge_failure(
+                            comms_runtime,
+                            candidate,
+                            BridgeRejectionCause::Internal,
+                            format!(
+                                "bind member failed: trust repair failed before idempotent ack: {error}"
+                            ),
+                        )
+                        .await;
+                        return true;
+                    }
                     send_bridge_response(
                         comms_runtime,
                         candidate,
@@ -1942,6 +1972,32 @@ mod tests {
         .expect("valid non-zero trusted peer descriptor")
     }
 
+    fn trusted_tcp_peer_from_runtime(
+        name: &str,
+        runtime: &meerkat_comms::CommsRuntime,
+    ) -> TrustedPeerDescriptor {
+        let pubkey = runtime.public_key();
+        TrustedPeerDescriptor::unsigned_with_pubkey(
+            name,
+            pubkey.to_peer_id().as_str(),
+            *pubkey.as_bytes(),
+            runtime.advertised_address(),
+        )
+        .expect("valid non-zero TCP trusted peer descriptor")
+    }
+
+    fn install_test_peer_request_response_authority(
+        runtime: &Arc<meerkat_comms::CommsRuntime>,
+        peer_handle: Arc<CountingPeerInteractionHandle>,
+    ) {
+        runtime.install_peer_request_response_authority(
+            meerkat_comms::PeerRequestResponseAuthority::new(
+                peer_handle,
+                Arc::new(crate::handles::RuntimeInteractionStreamHandle::ephemeral()),
+            ),
+        );
+    }
+
     #[derive(Default)]
     struct CountingPeerInteractionHandle {
         inbound: std::sync::Mutex<HashSet<meerkat_core::PeerCorrelationId>>,
@@ -2775,6 +2831,170 @@ mod tests {
             1,
             "real CommsRuntime::send(PeerResponse) should pass the inbound-state guard"
         );
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    #[tokio::test]
+    async fn bind_member_idempotent_ack_repairs_tcp_supervisor_trust_before_reply() {
+        let suffix = Uuid::new_v4().simple().to_string();
+        let member_name = format!("tcp-bind-member-{suffix}");
+        let supervisor_name = format!("tcp-supervisor-{suffix}");
+
+        let mut member_runtime =
+            meerkat_comms::CommsRuntime::inproc_only(&member_name).expect("member runtime");
+        member_runtime
+            .set_listen_tcp_for_unstarted_runtime(std::net::SocketAddr::from(([127, 0, 0, 1], 0)))
+            .expect("configure member TCP listener");
+        member_runtime
+            .start_listeners()
+            .await
+            .expect("start member TCP listener");
+        let member_runtime = Arc::new(member_runtime);
+        let member_peer_handle = Arc::new(CountingPeerInteractionHandle::default());
+        install_test_peer_request_response_authority(&member_runtime, member_peer_handle.clone());
+
+        let mut supervisor_runtime =
+            meerkat_comms::CommsRuntime::inproc_only(&supervisor_name).expect("supervisor runtime");
+        supervisor_runtime
+            .set_listen_tcp_for_unstarted_runtime(std::net::SocketAddr::from(([127, 0, 0, 1], 0)))
+            .expect("configure supervisor TCP listener");
+        supervisor_runtime
+            .start_listeners()
+            .await
+            .expect("start supervisor TCP listener");
+        let supervisor_runtime = Arc::new(supervisor_runtime);
+        install_test_peer_request_response_authority(
+            &supervisor_runtime,
+            Arc::new(CountingPeerInteractionHandle::default()),
+        );
+
+        let member_spec = trusted_tcp_peer_from_runtime(&member_name, &member_runtime);
+        supervisor_runtime
+            .add_trusted_peer(member_spec.clone())
+            .await
+            .expect("supervisor trusts member target");
+        let supervisor_spec =
+            trusted_tcp_peer_from_runtime("mob/__mob_supervisor__", &supervisor_runtime);
+
+        let adapter = Arc::new(MeerkatMachine::ephemeral());
+        let session_id = SessionId::new();
+        adapter.register_session(session_id.clone()).await;
+        adapter
+            .stage_supervisor_bind(
+                &session_id,
+                supervisor_spec.name.to_string(),
+                supervisor_spec.peer_id.as_str(),
+                supervisor_spec.address.to_string(),
+                1,
+            )
+            .await
+            .expect("pre-bind supervisor in DSL state");
+        assert!(
+            member_runtime
+                .peers()
+                .await
+                .iter()
+                .all(|peer| peer.peer_id != supervisor_spec.peer_id),
+            "fixture must start with DSL supervisor binding but no sendable runtime trust entry"
+        );
+
+        let command = BridgeCommand::BindMember(
+            meerkat_contracts::wire::supervisor_bridge::BridgeBindPayload {
+                supervisor: BridgePeerSpec::from(supervisor_spec.clone()),
+                epoch: 1,
+                protocol_version: SUPERVISOR_BRIDGE_PROTOCOL_VERSION,
+                expected_peer_id: member_spec.peer_id.as_str(),
+                expected_address: member_spec.address.to_string(),
+                bootstrap_token: member_runtime.bridge_bootstrap_token().to_owned().into(),
+            },
+        );
+        let request_receipt = supervisor_runtime
+            .send(CommsCommand::PeerRequest {
+                to: PeerRoute::with_display_name(member_spec.peer_id, member_spec.name.clone()),
+                intent: SUPERVISOR_BRIDGE_INTENT.to_string(),
+                params: serde_json::to_value(&command).expect("serialize bridge command"),
+                blocks: None,
+                handling_mode: HandlingMode::Queue,
+                stream: meerkat_core::comms::InputStreamMode::None,
+            })
+            .await
+            .expect("supervisor sends idempotent BindMember over TCP");
+        let meerkat_core::SendReceipt::PeerRequestSent { interaction_id, .. } = request_receipt
+        else {
+            panic!("expected PeerRequestSent receipt, got {request_receipt:?}");
+        };
+
+        let candidate = drain_one_candidate(&member_runtime, "member BindMember request").await;
+        assert_eq!(
+            candidate.interaction.id, interaction_id,
+            "member must receive the correlated bridge request"
+        );
+        assert!(
+            try_handle_supervisor_bridge_command(
+                &adapter,
+                &session_id,
+                &(member_runtime.clone() as Arc<dyn CommsRuntime>),
+                &candidate,
+            )
+            .await,
+            "bridge handler must own BindMember"
+        );
+
+        let response =
+            drain_one_candidate(&supervisor_runtime, "supervisor BindMember response").await;
+        assert_eq!(
+            member_peer_handle.response_replied_count(),
+            1,
+            "target must send the terminal bridge response after repairing trust"
+        );
+        assert!(
+            member_runtime
+                .peers()
+                .await
+                .iter()
+                .any(|peer| peer.peer_id == supervisor_spec.peer_id),
+            "idempotent BindMember must repair the sendable supervisor trust projection"
+        );
+        let InteractionContent::Response {
+            in_reply_to,
+            status,
+            result,
+            ..
+        } = response.interaction.content
+        else {
+            panic!(
+                "expected bridge response, got {:?}",
+                response.interaction.content
+            );
+        };
+        assert_eq!(in_reply_to, interaction_id);
+        assert_eq!(status, meerkat_core::interaction::ResponseStatus::Completed);
+        let reply: BridgeReply = serde_json::from_value(result).expect("typed bridge reply");
+        let BridgeReply::BindMember(bind_response) = reply else {
+            panic!("expected BindMember reply, got {reply:?}");
+        };
+        assert_eq!(bind_response.peer_id, member_spec.peer_id.as_str());
+        assert_eq!(
+            bind_response.address,
+            canonicalize_bridge_address(&member_spec.address.to_string())
+        );
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    async fn drain_one_candidate(
+        runtime: &Arc<meerkat_comms::CommsRuntime>,
+        label: &str,
+    ) -> PeerInputCandidate {
+        for _ in 0..40 {
+            let candidates = runtime.drain_peer_input_candidates().await;
+            if let Some(candidate) = candidates.into_iter().next() {
+                return candidate;
+            }
+            let notify = runtime.inbox_notify();
+            let notified = notify.notified();
+            let _ = tokio::time::timeout(std::time::Duration::from_millis(25), notified).await;
+        }
+        panic!("timed out waiting for {label}");
     }
 
     #[test]

--- a/tests/integration/src/e2e_lanes.rs
+++ b/tests/integration/src/e2e_lanes.rs
@@ -208,6 +208,7 @@ macro_rules! e2e_smoke_lane_entries {
             suite(e2e_smoke_cli_background_job_active_turn, "cli-background-job-active-turn");
             suite(e2e_smoke_cli_background_job_idle_keepalive, "cli-background-job-idle-keepalive");
             suite(e2e_smoke_mob_live_smoke, "mob-live-smoke");
+            suite(e2e_smoke_mob_external_tcp_production_drain, "mob-external-tcp-production-drain");
             suite(e2e_smoke_mob_flow_runtime_suite, "mob-flow-runtime");
         }
     };
@@ -4888,6 +4889,25 @@ fn suite_spec(name: &str) -> Option<&'static Spec> {
                     "--nocapture",
                 ],
                 output_policy: OutputPolicy::CargoTest,
+            },
+        }),
+        "mob-external-tcp-production-drain" => Some(&Spec {
+            id: None,
+            lane: Lane::Smoke,
+            title: "Mob external TCP production drain smoke",
+            timeout_secs: 300,
+            required_env: &[],
+            required_bins: &["cargo"],
+            cwd: ".",
+            env: &[],
+            cargo_bin_env: &[],
+            pre_commands: &[],
+            command: CommandSpec::CargoTest {
+                package: "meerkat-mob",
+                test_target: "smoke_mob_flow_runtime",
+                test_name: "e2e_external_tcp_production_drain_bind_and_turn_smoke",
+                features: &["integration-real-tests"],
+                all_features: false,
             },
         }),
         _ => None,


### PR DESCRIPTION
## Summary

Fixes the production external TCP member-bind path where a remote target receives `BridgeCommand::BindMember` but cannot complete the supervisor round trip.

This PR addresses two production-path gaps:

- Repairs the target runtime trust projection before an idempotent `BindMember` ack is sent. Restored/bound supervisor DSL state can now re-publish the authenticated supervisor descriptor into the comms trust directory before replying.
- Makes the mob supervisor side decode the canonical `BridgeReply` envelope from production `comms_drain` instead of expecting bare helper-era success payloads. Existing helper tests now emit the same envelope shape as production.

## Why

The live MDM external-target path was timing out after the target accepted the bridge request. The target-side comms drain could reach reply construction, but the supervisor route/trust projection was not reliably sendable after restore/idempotent bind, and the mob-side decoder was not aligned with the contract envelope emitted by production `comms_drain`.

## Tests

- `./scripts/repo-cargo test -p meerkat-runtime bind_member_idempotent_ack_repairs_tcp_supervisor_trust_before_reply -- --nocapture`
- `./scripts/repo-cargo test -p meerkat-mob external_tcp -- --nocapture --test-threads=1`
- `./scripts/repo-cargo test -p meerkat-mob --features integration-real-tests --test smoke_mob_flow_runtime e2e_external_tcp_production_drain_bind_and_turn_smoke -- --ignored --nocapture`
- `SUITE=mob-external-tcp-production-drain make e2e-smoke`
- `make check`
- `make lint`
- push hook: changed-crates clippy, codegen freshness, bridge response-status guard, Bazel freshness, workspace deterministic gate
