### PR TITLE
fix: compacted singleton retire stranding (MonotonicityViolation at archive)

### DIFF
--- a/meerkat-mob/src/runtime/actor.rs
+++ b/meerkat-mob/src/runtime/actor.rs
@@ -8685,9 +8685,12 @@ impl MobActor {
                     }
                 }
                 crate::RuntimeBinding::Session => {
-                    return Err(MobRespawnError::PreviousMemberCleanupAmbiguous {
-                        report: cleanup_report,
-                    });
+                    tracing::warn!(
+                        mob_id = %self.definition.id,
+                        agent_identity = %agent_identity,
+                        retire_error = %error,
+                        "respawn proceeding after session-bound retire removed the stale roster anchor"
+                    );
                 }
             }
         }
@@ -9016,20 +9019,21 @@ impl MobActor {
                 Some((DisposalStep::ArchiveSession, _))
             );
 
-        // Finally: edge-lock cleanup is unconditional, but roster removal is
-        // gated on critical archive success so retry has a concrete member
-        // anchor to operate on.
+        // Finally: edge-lock cleanup and roster removal are unconditional for
+        // normal disposal. ArchiveSession errors are still returned to the
+        // caller, but retaining a session-backed member after archive failure
+        // would leave the roster pointing at a runtime that retire already
+        // terminally drained — an unreachable ghost that blocks respawn/reset.
         self.dispose_prune_edge_locks(ctx).await;
         if archive_failed {
             tracing::warn!(
                 mob_id = %self.definition.id,
                 agent_identity = %ctx.agent_identity,
-                "retaining retiring roster entry after ArchiveSession failure for retry"
+                "removing retiring roster entry after ArchiveSession failure to avoid a dead runtime anchor"
             );
-        } else {
-            self.dispose_remove_from_roster(ctx).await;
-            report.roster_removed = true;
         }
+        self.dispose_remove_from_roster(ctx).await;
+        report.roster_removed = true;
         report
     }
 
@@ -11060,6 +11064,19 @@ impl MobActor {
         for id in ids {
             let result = self.retire_one(id).await;
             if let Err((id, error)) = result {
+                let roster_still_contains_member = {
+                    let roster = self.roster.read().await;
+                    roster.get(&id).is_some()
+                };
+                if !roster_still_contains_member {
+                    tracing::warn!(
+                        mob_id = %self.definition.id,
+                        agent_identity = %id,
+                        error = %error,
+                        "{context}: retire reported cleanup failure after removing member; continuing"
+                    );
+                    continue;
+                }
                 tracing::warn!(
                     mob_id = %self.definition.id,
                     agent_identity = %id,

--- a/meerkat-mob/src/runtime/tests.rs
+++ b/meerkat-mob/src/runtime/tests.rs
@@ -10895,7 +10895,7 @@ async fn test_respawn_ignores_machine_local_edge_to_retired_peer() {
 }
 
 #[tokio::test]
-async fn test_respawn_archive_failure_retains_retry_anchor_and_can_retry() {
+async fn test_respawn_archive_failure_removes_stale_anchor_and_respawns() {
     let (handle, service) = create_test_mob(sample_definition()).await;
     let member_id = MeerkatId::from("respawn-ambiguous");
     let member_ref = handle
@@ -10913,43 +10913,11 @@ async fn test_respawn_archive_failure_retains_retry_anchor_and_can_retry() {
 
     service.set_archive_failure(&old_session_id).await;
 
-    let error = handle
+    let receipt = handle
         .respawn(AgentIdentity::from(member_id.as_str()), None)
         .await
-        .expect_err("respawn should surface cleanup failure when archive fails");
+        .expect("respawn should remove the stale cleanup anchor and spawn replacement");
 
-    assert!(
-        matches!(
-            error,
-            crate::runtime::handle::MobRespawnError::Mob(MobError::Internal(ref message))
-                if message.contains("ArchiveSession")
-        ),
-        "session-bound respawn should retain the cleanup anchor and return the archive failure directly: {error:?}"
-    );
-    let retained = handle
-        .get_member(&AgentIdentity::from(member_id.as_str()))
-        .await
-        .expect("archive failure should retain retiring member for retry");
-    assert_eq!(
-        retained.agent_runtime_id,
-        original_snapshot.agent_runtime_id
-    );
-    assert_eq!(retained.fence_token, original_snapshot.fence_token);
-    assert_eq!(retained.state, crate::roster::MemberState::Retiring);
-    assert_eq!(
-        handle.list_members_including_retiring().await.len(),
-        1,
-        "failed cleanup must leave exactly the retained retiring member, not a replacement"
-    );
-
-    service.clear_archive_failure(&old_session_id).await;
-    let receipt = handle
-        .respawn(
-            AgentIdentity::from(member_id.as_str()),
-            Some("retry replacement".into()),
-        )
-        .await
-        .expect("respawn retry should clean up the old session and spawn replacement");
     assert_eq!(receipt.identity, AgentIdentity::from(member_id.as_str()));
     let replacement = handle
         .member_status(&AgentIdentity::from(member_id.as_str()))
@@ -14982,19 +14950,21 @@ async fn test_retire_archive_failure_is_not_silent() {
         "retire must return Err when ArchiveSession fails"
     );
 
-    // Critical archive failure retains the retiring roster entry so cleanup can
-    // be retried without losing the member/session anchor.
-    let retained = handle
-        .get_member(&AgentIdentity::from("w-1"))
-        .await
-        .expect("archive failure should retain retry anchor");
-    assert_eq!(retained.state, crate::roster::MemberState::Retiring);
+    // Critical archive failure is surfaced, but the stale roster anchor is
+    // removed so callers cannot keep addressing a runtime retire already drained.
+    assert!(
+        handle
+            .get_member(&AgentIdentity::from("w-1"))
+            .await
+            .is_none(),
+        "archive failure must remove the stale roster anchor"
+    );
     let events = handle.events().replay_all().await.expect("replay");
     assert!(
         events
             .iter()
             .any(|e| matches!(e.kind, MobEventKind::MemberRetired { .. })),
-        "retire event should be persisted before archive so cleanup remains retryable"
+        "retire event should be persisted before archive so cleanup remains auditable"
     );
 }
 
@@ -17717,8 +17687,8 @@ async fn test_fault_injected_lifecycle_operations_preserve_transactional_invaria
         "spawn rollback should remove leaked trust edges"
     );
 
-    // Retire cleanup invariants: archive failure is surfaced and retains the
-    // retiring roster entry so the cleanup can be retried.
+    // Retire cleanup invariants: archive failure is surfaced, but the retiring
+    // roster entry is removed so callers cannot keep addressing a drained runtime.
     let (retire_handle, retire_service) = create_test_mob(sample_definition()).await;
     let sid_r1 = retire_handle
         .spawn(ProfileName::from("worker"), MeerkatId::from("r-1"), None)
@@ -17741,23 +17711,12 @@ async fn test_fault_injected_lifecycle_operations_preserve_transactional_invaria
         retire_result.is_err(),
         "retire must return Err when ArchiveSession fails"
     );
-    let retained = retire_handle
-        .get_member(&AgentIdentity::from("r-1"))
-        .await
-        .expect("retire must retain roster entry when archive fails");
-    assert_eq!(retained.state, crate::roster::MemberState::Retiring);
-
-    retire_service.clear_archive_failure(&sid_r1).await;
-    retire_handle
-        .retire(AgentIdentity::from("r-1"))
-        .await
-        .expect("retire retry should complete archive cleanup");
     assert!(
         retire_handle
             .get_member(&AgentIdentity::from("r-1"))
             .await
             .is_none(),
-        "successful retry must remove roster entry"
+        "archive failure must remove roster entry"
     );
     let r2 = retire_handle
         .get_member(&AgentIdentity::from("r-2"))
@@ -27894,8 +27853,8 @@ async fn test_retire_sends_required_peer_retired_notifications() {
 // Disposal pipeline integration tests
 // -----------------------------------------------------------------------
 
-/// Verifies that critical archive failure retains the retry anchor even when
-/// best-effort peer cleanup also fails.
+/// Verifies that critical archive failure is surfaced while the stale roster
+/// anchor is removed even when best-effort peer cleanup also fails.
 #[tokio::test]
 async fn test_dispose_member_retains_roster_when_archive_fails() {
     let (handle, service) = create_test_mob(sample_definition()).await;
@@ -27942,23 +27901,12 @@ async fn test_dispose_member_retains_roster_when_archive_fails() {
         "retire must return Err when ArchiveSession fails, regardless of other step failures"
     );
 
-    let retained = handle
-        .get_member(&AgentIdentity::from("w-1"))
-        .await
-        .expect("critical archive failure must retain member for cleanup retry");
-    assert_eq!(retained.state, crate::roster::MemberState::Retiring);
-
-    service.clear_archive_failure(&sid_w1).await;
-    handle
-        .retire(AgentIdentity::from("w-1"))
-        .await
-        .expect("retry should finish archive cleanup");
     assert!(
         handle
             .get_member(&AgentIdentity::from("w-1"))
             .await
             .is_none(),
-        "successful retry should remove the roster entry"
+        "critical archive failure must still remove the stale roster anchor"
     );
 }
 
@@ -28819,11 +28767,13 @@ async fn test_retire_returns_err_when_archive_fails() {
         "retire must return Err when ArchiveSession fails — got Ok"
     );
 
-    let retained = handle
-        .get_member(&AgentIdentity::from("w-1"))
-        .await
-        .expect("archive failure should retain retry anchor");
-    assert_eq!(retained.state, crate::roster::MemberState::Retiring);
+    assert!(
+        handle
+            .get_member(&AgentIdentity::from("w-1"))
+            .await
+            .is_none(),
+        "archive failure must still remove the stale roster anchor (unconditional finally block)"
+    );
 
     // Retire event was persisted before disposal (event-first).
     let events = handle.events().replay_all().await.expect("replay");

--- a/meerkat-rpc/src/session_runtime.rs
+++ b/meerkat-rpc/src/session_runtime.rs
@@ -11531,11 +11531,12 @@ mod tests {
             self.fail_after_saves
                 .store(usize::MAX, AtomicOrdering::Release);
         }
-    }
 
-    #[async_trait]
-    impl meerkat::SessionStore for ToggleFailSaveStore {
-        async fn save(&self, session: &Session) -> Result<(), meerkat_store::SessionStoreError> {
+        // Shared injection check so the runtime-backed projection write
+        // (`save_authoritative_projection_if_current_revision`) honors the same
+        // forced/countdown failures as `save`. Each durable projection write
+        // consumes one countdown tick regardless of which path performs it.
+        fn check_injected_failure(&self) -> Result<(), meerkat_store::SessionStoreError> {
             if self.fail_save.load(AtomicOrdering::Acquire) {
                 return Err(meerkat_store::SessionStoreError::Internal(
                     "forced save failure".to_string(),
@@ -11564,7 +11565,29 @@ mod tests {
                     break;
                 }
             }
+            Ok(())
+        }
+    }
+
+    #[async_trait]
+    impl meerkat::SessionStore for ToggleFailSaveStore {
+        async fn save(&self, session: &Session) -> Result<(), meerkat_store::SessionStoreError> {
+            self.check_injected_failure()?;
             self.inner.save(session).await
+        }
+
+        async fn save_authoritative_projection_if_current_revision(
+            &self,
+            session: &Session,
+            expected_current_revision: Option<String>,
+        ) -> Result<(), meerkat_store::SessionStoreError> {
+            self.check_injected_failure()?;
+            self.inner
+                .save_authoritative_projection_if_current_revision(
+                    session,
+                    expected_current_revision,
+                )
+                .await
         }
 
         async fn load(

--- a/meerkat-session/src/persistent.rs
+++ b/meerkat-session/src/persistent.rs
@@ -3556,17 +3556,32 @@ impl<B: SessionAgentBuilder + 'static> PersistentSessionService<B> {
                 .await;
         }
         if let Some(runtime_store) = self.runtime_store.as_ref() {
-            if let Err(error) = verify_authoritative_projection_persisted_continuity(
-                self.store.as_ref(),
-                self.blob_store.as_ref(),
-                &session,
-            )
-            .await
-            {
-                return Err(self
-                    .fail_closed_runtime_projection_preflight(session.id(), error)
-                    .await);
-            }
+            // The preflight validates continuity against the durable projection
+            // head using the rewrite-aware `run_boundary_snapshot_save_guard`, so
+            // a core-owned shrink (e.g. compaction) whose `TranscriptRewriteCommit`
+            // anchors to that head is accepted here. Capture the validated CAS
+            // token: once the runtime authority commits below, the durable row is
+            // an explicitly rebuildable projection, so the projection write must
+            // be a CAS-guarded authoritative-projection save keyed on that token
+            // — not a plain append-guarded `store.save`, whose rewrite-blind
+            // `append_only_save_guard` would reject the very shrink the preflight
+            // just proved legal (the source of the archive-time
+            // `MonotonicityViolation` that strands compacted singletons).
+            let expected_current_revision =
+                match verify_authoritative_projection_persisted_continuity(
+                    self.store.as_ref(),
+                    self.blob_store.as_ref(),
+                    &session,
+                )
+                .await
+                {
+                    Ok(expected_current_revision) => expected_current_revision,
+                    Err(error) => {
+                        return Err(self
+                            .fail_closed_runtime_projection_preflight(session.id(), error)
+                            .await);
+                    }
+                };
             let session_snapshot = serde_json::to_vec(&session).map_err(|err| {
                 SessionError::Agent(meerkat_core::error::AgentError::InternalError(format!(
                     "failed to serialize session snapshot for runtime persistence: {err}"
@@ -3585,12 +3600,13 @@ impl<B: SessionAgentBuilder + 'static> PersistentSessionService<B> {
                         "runtime snapshot persistence failed: {err}"
                     )))
                 })?;
-            if let Err(error) = save_session_projection_with_storage_normalization_bridge(
-                self.store.as_ref(),
-                self.blob_store.as_ref(),
-                &session,
-            )
-            .await
+            if let Err(error) = self
+                .store
+                .save_authoritative_projection_if_current_revision(
+                    &session,
+                    expected_current_revision,
+                )
+                .await
             {
                 return Err(self
                     .fail_closed_runtime_projection_update(
@@ -6352,6 +6368,27 @@ mod tests {
                 ));
             }
             self.inner.save(session).await
+        }
+
+        async fn save_authoritative_projection_if_current_revision(
+            &self,
+            session: &Session,
+            expected_current_revision: Option<String>,
+        ) -> Result<(), SessionStoreError> {
+            // Runtime-backed projection writes flow through this CAS path, so it
+            // honors the same injected failure as `save` to keep modelling a
+            // projection-write failure for the discards-live-state tests.
+            if self.fail_save.load(Ordering::Acquire) {
+                return Err(SessionStoreError::Internal(
+                    "forced save failure".to_string(),
+                ));
+            }
+            self.inner
+                .save_authoritative_projection_if_current_revision(
+                    session,
+                    expected_current_revision,
+                )
+                .await
         }
 
         async fn load(&self, id: &SessionId) -> Result<Option<Session>, SessionStoreError> {
@@ -11136,6 +11173,250 @@ mod tests {
                 .await
                 .expect("live-session status should succeed"),
             "archive() should discard the stale live session"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_compacted_session_persists_when_durable_projection_lagged_across_compaction() {
+        // Regression: a long-lived runtime-backed singleton whose durable
+        // `SessionStore` projection lagged behind the `runtime_store` across a
+        // compaction boundary must still persist (and therefore archive)
+        // without a `MonotonicityViolation`.
+        //
+        // The divergence reproduced here: the durable store is stuck at the
+        // pre-compaction ("parent") revision while the runtime_store already
+        // holds the compacted revision, whose `TranscriptRewriteCommit` anchors
+        // to the parent head. `save_normalized_session` loads `previous` from
+        // the runtime_store (== incoming), so the rewrite chain is empty and it
+        // falls to the runtime-store projection branch. The preflight accepts
+        // the shrink via the rewrite-aware `run_boundary_snapshot_save_guard`
+        // against the lagged durable head, but a plain `store.save` then rejects
+        // the same snapshot via the rewrite-blind `append_only_save_guard`.
+        let store: Arc<dyn SessionStore> = Arc::new(MemoryStore::new());
+        let runtime_store: Arc<dyn RuntimeStore> = Arc::new(InMemoryRuntimeStore::new());
+        let service = PersistentSessionService::new(
+            DummyBuilder,
+            4,
+            Arc::clone(&store),
+            Some(Arc::clone(&runtime_store)),
+            memory_blob_store(),
+        );
+
+        let created = service
+            .create_session(create_request("seed", InitialTurnPolicy::Defer))
+            .await
+            .expect("create_session should succeed");
+
+        // Build the pre-compaction "parent" transcript and pin it as the lagged
+        // durable head.
+        let seed = store
+            .load(&created.session_id)
+            .await
+            .expect("load should succeed")
+            .unwrap_or_else(|| Session::with_id(created.session_id.clone()));
+        let mut parent = seed.clone();
+        for turn in 0..2 {
+            parent.push(Message::User(UserMessage::text(format!(
+                "turn-{turn} question"
+            ))));
+            parent.push(Message::Assistant(meerkat_core::AssistantMessage {
+                content: format!("turn-{turn} answer"),
+                tool_calls: Vec::new(),
+                stop_reason: StopReason::EndTurn,
+                usage: Usage::default(),
+                created_at: meerkat_core::types::message_timestamp_now(),
+            }));
+        }
+        let parent_revision = parent.transcript_revision().expect("parent revision");
+        store
+            .save(&parent)
+            .await
+            .expect("durable store should accept the pre-compaction append");
+
+        // Compact the parent transcript, recording a compaction rewrite commit
+        // that anchors to the parent head.
+        let mut compacted = parent.clone();
+        let replacement = vec![
+            parent.messages()[0].clone(),
+            Message::User(UserMessage::text(
+                "[Context compacted] singleton summary".to_string(),
+            )),
+        ];
+        compacted
+            .commit_transcript_rewrite(
+                TranscriptRewriteSelection::MessageRange {
+                    start: 0,
+                    end: parent.messages().len(),
+                },
+                replacement,
+                TranscriptRewriteReason::new("compaction"),
+                Some("meerkat-core".to_string()),
+                Some(parent_revision),
+            )
+            .expect("compaction rewrite should commit");
+        let compacted_revision = compacted.transcript_revision().expect("compacted revision");
+        assert!(
+            compacted.messages().len() < parent.messages().len(),
+            "compaction must shrink the transcript to exercise the monotonicity guard"
+        );
+
+        // Advance only the runtime_store to the compacted revision so the
+        // durable projection lags behind it across the compaction boundary.
+        let runtime_id =
+            PersistentSessionService::<DummyBuilder>::runtime_id_for_session(&created.session_id);
+        runtime_store
+            .commit_session_snapshot(
+                &runtime_id,
+                SessionDelta {
+                    session_snapshot: serde_json::to_vec(&compacted)
+                        .expect("serialize compacted runtime snapshot"),
+                },
+            )
+            .await
+            .expect("seed runtime_store at the compacted revision");
+
+        // Persist the compacted snapshot. Before the fix this fails with a
+        // MonotonicityViolation because the durable projection catch-up is not
+        // rewrite-aware.
+        service
+            .save_normalized_session(compacted)
+            .await
+            .expect("compacted snapshot must persist even when the durable projection lagged");
+
+        let saved = store
+            .load(&created.session_id)
+            .await
+            .expect("load should succeed")
+            .expect("compacted projection should exist");
+        assert_eq!(
+            saved.transcript_revision().expect("saved revision"),
+            compacted_revision,
+            "durable projection must catch up to the compacted revision"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_archive_succeeds_for_compacted_session_with_lagging_durable_projection() {
+        // End-to-end regression for the reported symptom: archiving a compacted
+        // runtime-backed singleton whose durable projection lagged across the
+        // compaction boundary must succeed (it previously failed at
+        // DisposalStep::ArchiveSession with a MonotonicityViolation, stranding
+        // the member). Drives the full `archive_with_machine_protocol` path with
+        // the durable store stuck at the pre-compaction revision and the runtime
+        // authority holding the compacted revision.
+        let store: Arc<dyn SessionStore> = Arc::new(MemoryStore::new());
+        let runtime_store: Arc<dyn RuntimeStore> = Arc::new(InMemoryRuntimeStore::new());
+        let service = PersistentSessionService::new(
+            DummyBuilder,
+            4,
+            Arc::clone(&store),
+            Some(Arc::clone(&runtime_store)),
+            memory_blob_store(),
+        );
+        let machine = MeerkatMachine::persistent(Arc::clone(&runtime_store), memory_blob_store());
+
+        let created = service
+            .create_session(create_request("seed", InitialTurnPolicy::Defer))
+            .await
+            .expect("create_session should succeed");
+
+        let seed = store
+            .load(&created.session_id)
+            .await
+            .expect("load should succeed")
+            .unwrap_or_else(|| Session::with_id(created.session_id.clone()));
+        let mut parent = seed.clone();
+        for turn in 0..2 {
+            parent.push(Message::User(UserMessage::text(format!(
+                "turn-{turn} question"
+            ))));
+            parent.push(Message::Assistant(meerkat_core::AssistantMessage {
+                content: format!("turn-{turn} answer"),
+                tool_calls: Vec::new(),
+                stop_reason: StopReason::EndTurn,
+                usage: Usage::default(),
+                created_at: meerkat_core::types::message_timestamp_now(),
+            }));
+        }
+        let parent_revision = parent.transcript_revision().expect("parent revision");
+        store
+            .save(&parent)
+            .await
+            .expect("durable store should accept the pre-compaction append");
+
+        let mut compacted = parent.clone();
+        let replacement = vec![
+            parent.messages()[0].clone(),
+            Message::User(UserMessage::text(
+                "[Context compacted] singleton summary".to_string(),
+            )),
+        ];
+        compacted
+            .commit_transcript_rewrite(
+                TranscriptRewriteSelection::MessageRange {
+                    start: 0,
+                    end: parent.messages().len(),
+                },
+                replacement,
+                TranscriptRewriteReason::new("compaction"),
+                Some("meerkat-core".to_string()),
+                Some(parent_revision),
+            )
+            .expect("compaction rewrite should commit");
+        let compacted_revision = compacted.transcript_revision().expect("compacted revision");
+
+        let runtime_id =
+            PersistentSessionService::<DummyBuilder>::runtime_id_for_session(&created.session_id);
+        runtime_store
+            .commit_session_snapshot(
+                &runtime_id,
+                SessionDelta {
+                    session_snapshot: serde_json::to_vec(&compacted)
+                        .expect("serialize compacted runtime snapshot"),
+                },
+            )
+            .await
+            .expect("seed runtime_store at the compacted revision");
+
+        // Drop the live handle so the archive snapshot is sourced from runtime
+        // authority (the compacted revision), exercising the lagged-projection
+        // catch-up rather than the still-seeded live transcript.
+        match service.discard_live_session(&created.session_id).await {
+            Ok(()) | Err(SessionError::NotFound { .. }) => {}
+            Err(error) => panic!("discard_live_session should succeed: {error}"),
+        }
+
+        service
+            .archive_with_machine_protocol(
+                &created.session_id,
+                MachineSessionArchiveProtocol::from_machine(&machine),
+            )
+            .await
+            .expect(
+                "archive must succeed for a compacted session with a lagged durable projection",
+            );
+
+        let archived = service
+            .load_authoritative_session(&created.session_id)
+            .await
+            .expect("archive authority should load")
+            .expect("archive should persist the durable snapshot");
+        assert_eq!(
+            archived.transcript_revision().expect("archived revision"),
+            compacted_revision,
+            "archive must persist the compacted revision as durable truth"
+        );
+        assert!(
+            metadata_marks_archived(archived.metadata()),
+            "archive should mirror the retired lifecycle into the projection"
+        );
+        assert_eq!(
+            runtime_store
+                .load_runtime_state(&runtime_id)
+                .await
+                .expect("runtime state load should succeed"),
+            Some(RuntimeState::Retired),
+            "archive must persist machine-owned retired lifecycle"
         );
     }
 


### PR DESCRIPTION
## Summary

Fixes the reported bug where a long-lived runtime-backed **singleton** whose session had been compacted at least once becomes **permanently stranded on retire**: `DisposalStep::ArchiveSession` fails with `MonotonicityViolation`, the runtime is already retired, and the roster entry is retained — leaving an unreachable ghost that neither respawn nor reset recovers (only a process restart did).

Two layers, both fail-closed and dogma-aligned:

### 1. Persistence (root cause) — `meerkat-session/src/persistent.rs`

When the durable `SessionStore` projection lags behind the `runtime_store` across a **compaction boundary** (rt advanced to the compacted revision; a transient durable-projection failure or read-after-write lag left the store at the pre-compaction revision), `save_normalized_session` loads `previous` from the runtime_store (== incoming) → empty rewrite chain → the runtime-store projection branch.

That branch ran a **rewrite-aware** continuity preflight (`verify_authoritative_projection_persisted_continuity` → `run_boundary_snapshot_save_guard`) that *correctly accepted* the compacted shrink (its `TranscriptRewriteCommit` anchors to the lagged durable head) — then **discarded the validated token** and wrote the projection with a plain, **rewrite-blind** `store.save` (`append_only_save_guard`), which rejected the same shrink with `MonotonicityViolation`.

**Fix:** flow the preflight-validated CAS token into `save_authoritative_projection_if_current_revision` — the documented primitive for runtime-backed services, where the runtime snapshot has already committed authority and the store row is an explicitly rebuildable projection. This accepts a legitimately-compacted shrink and still rejects an illegitimate one (CAS/continuity), introducing **no new audit commits** at the projection layer, and removes the discarded-return-value smell.

### 2. Disposal hardening (defense-in-depth) — `meerkat-mob/src/runtime/actor.rs`

So a member is **never** permanently stranded even if archive fails for an unrelated reason:

- `dispose_member` removes the roster entry **unconditionally** (ArchiveSession errors are still surfaced to the caller, but the dead anchor — whose runtime retire already drained — is not retained).
- `handle_respawn` proceeds for session-bound members once retire removed the stale anchor, instead of returning `PreviousMemberCleanupAmbiguous`.
- `retire_all_members` (reset) continues past a retire error when the member was already removed.
- The `destroy` path's intentional retain-for-retry is untouched.

## Tests

- `test_compacted_session_persists_when_durable_projection_lagged_across_compaction` — reproduces the exact `MonotonicityViolation { prev_len: 4, new_len: 2 }` at `save_normalized_session`; green under the fix.
- `test_archive_succeeds_for_compacted_session_with_lagging_durable_projection` — drives the full `archive_with_machine_protocol` path end-to-end.
- Updated retire/respawn/reset/disposal-pipeline tests in `meerkat-mob` to assert roster removal on archive failure.

## Validation

- `make lint` (clippy `--workspace --all-features -D warnings`): clean
- `meerkat-session` lib suite: 222 passed
- `meerkat-mob` suite: 931 passed
- Pre-push gate (changed-crate clippy + machine codegen verify + workspace deterministic gate incl. unit + e2e-fast): passed

## Relationship to #745

Same bug. This PR carries a **stronger persistence fix** than #745: #745 adds `MonotonicityViolation` to the projection bridge's recovery arm, but that arm's `save_verified_transcript_history_projection` requires the rewrite commits to be *preserved/equal*, so it does **not** recover the genuine durable-lag case (longer persisted row + a fresh compaction commit) — `test_compacted_session_persists_when_durable_projection_lagged_across_compaction` here would fail under #745's persistence change. This PR also adopts #745's disposal hardening so both layers are covered.