### PR TITLE
[codex] Fix compaction retry loop and OpenAI done fallback

### DIFF
--- a/meerkat-core/src/agent/compact.rs
+++ b/meerkat-core/src/agent/compact.rs
@@ -157,6 +157,7 @@ pub fn load_compaction_cadence(session: &Session) -> SessionCompactionCadence {
         .unwrap_or_else(|| SessionCompactionCadence {
             session_boundary_index: infer_session_boundary_index(session.messages()),
             last_compaction_boundary_index: None,
+            last_compaction_attempt_boundary_index: None,
         })
 }
 
@@ -341,6 +342,7 @@ mod tests {
         let cadence = SessionCompactionCadence {
             session_boundary_index: 7,
             last_compaction_boundary_index: Some(4),
+            last_compaction_attempt_boundary_index: Some(6),
         };
         persist_compaction_cadence(&mut session, &cadence).unwrap();
 

--- a/meerkat-core/src/agent/state.rs
+++ b/meerkat-core/src/agent/state.rs
@@ -940,13 +940,23 @@ where
             if let TurnExecutionEffect::CheckCompaction = effect {
                 let current_boundary_index = self.compaction_cadence.session_boundary_index;
                 if let Some(ref compactor) = self.compactor {
+                    let last_guarded_boundary = [
+                        self.compaction_cadence.last_compaction_boundary_index,
+                        self.compaction_cadence
+                            .last_compaction_attempt_boundary_index,
+                    ]
+                    .into_iter()
+                    .flatten()
+                    .max();
                     let ctx = crate::agent::compact::build_compaction_context(
                         self.session.messages(),
                         self.last_input_tokens,
-                        self.compaction_cadence.last_compaction_boundary_index,
+                        last_guarded_boundary,
                         current_boundary_index,
                     );
                     if compactor.should_compact(&ctx) {
+                        self.compaction_cadence
+                            .last_compaction_attempt_boundary_index = Some(current_boundary_index);
                         let outcome = crate::agent::compact::run_compaction(
                             self.client.as_ref(),
                             compactor,
@@ -2918,7 +2928,9 @@ mod tests {
     use crate::blob::{BlobId, BlobPayload, BlobRef, BlobStore, BlobStoreError};
     use crate::budget::{Budget, BudgetLimits};
     use crate::compact::{CompactionContext, CompactionResult, Compactor};
-    use crate::error::{AgentError, ToolError};
+    use crate::error::{
+        AgentError, LlmFailureReason, LlmProviderError, LlmProviderErrorKind, ToolError,
+    };
     use crate::event::AgentErrorClass;
     use crate::lifecycle::RunId;
     use crate::memory::{
@@ -3403,6 +3415,126 @@ mod tests {
                 messages: messages.to_vec(),
                 discarded: Vec::new(),
             }
+        }
+    }
+
+    struct CadenceAwareFailingCompactor {
+        seen_contexts: Mutex<Vec<CompactionContext>>,
+    }
+
+    impl CadenceAwareFailingCompactor {
+        fn new() -> Self {
+            Self {
+                seen_contexts: Mutex::new(Vec::new()),
+            }
+        }
+
+        fn seen_contexts(&self) -> Vec<CompactionContext> {
+            self.seen_contexts.lock().unwrap().clone()
+        }
+    }
+
+    impl Compactor for CadenceAwareFailingCompactor {
+        fn should_compact(&self, ctx: &CompactionContext) -> bool {
+            self.seen_contexts.lock().unwrap().push(ctx.clone());
+            if ctx.session_boundary_index == 0 {
+                return false;
+            }
+            if let Some(last) = ctx.last_compaction_boundary_index
+                && ctx.session_boundary_index.saturating_sub(last) < 3
+            {
+                return false;
+            }
+            true
+        }
+
+        fn compaction_prompt(&self) -> &'static str {
+            "COMPACT NOW"
+        }
+
+        fn max_summary_tokens(&self) -> u32 {
+            32
+        }
+
+        fn rebuild_history(&self, messages: &[Message], _summary: &str) -> CompactionResult {
+            CompactionResult {
+                messages: messages.to_vec(),
+                discarded: Vec::new(),
+            }
+        }
+    }
+
+    struct FailingCompactionLlmClient {
+        last_user_messages: Mutex<Vec<String>>,
+    }
+
+    impl FailingCompactionLlmClient {
+        fn new() -> Self {
+            Self {
+                last_user_messages: Mutex::new(Vec::new()),
+            }
+        }
+
+        fn seen_last_user_messages(&self) -> Vec<String> {
+            self.last_user_messages.lock().unwrap().clone()
+        }
+    }
+
+    #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+    #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+    impl AgentLlmClient for FailingCompactionLlmClient {
+        async fn stream_response(
+            &self,
+            messages: &[Message],
+            _tools: &[Arc<ToolDef>],
+            _max_tokens: u32,
+            _temperature: Option<f32>,
+            _provider_params: Option<&crate::lifecycle::run_primitive::ProviderParamsOverride>,
+        ) -> Result<super::LlmStreamResult, AgentError> {
+            let last_user = messages
+                .iter()
+                .rev()
+                .find_map(|message| match message {
+                    Message::User(user) => Some(user.text_content()),
+                    _ => None,
+                })
+                .unwrap_or_default();
+            self.last_user_messages
+                .lock()
+                .unwrap()
+                .push(last_user.clone());
+
+            if last_user == "COMPACT NOW" {
+                return Err(AgentError::Llm {
+                    provider: "mock",
+                    reason: LlmFailureReason::ProviderError(LlmProviderError::retryable(
+                        LlmProviderErrorKind::IncompleteResponse,
+                        serde_json::json!({"message": "stream ended before done"}),
+                    )),
+                    message: "stream ended before done".to_string(),
+                });
+            }
+
+            Ok(super::LlmStreamResult::new(
+                vec![AssistantBlock::Text {
+                    text: "ok".to_string(),
+                    meta: None,
+                }],
+                StopReason::EndTurn,
+                Usage {
+                    input_tokens: 200_000,
+                    output_tokens: 5,
+                    ..Usage::default()
+                },
+            ))
+        }
+
+        fn provider(&self) -> &'static str {
+            "mock"
+        }
+
+        fn model(&self) -> &'static str {
+            "mock-model"
         }
     }
 
@@ -4436,6 +4568,69 @@ mod tests {
                 "second".to_string()
             ]
         );
+    }
+
+    #[tokio::test]
+    async fn failed_compaction_attempt_uses_cadence_guard_before_retry() {
+        let client = Arc::new(FailingCompactionLlmClient::new());
+        let compactor = Arc::new(CadenceAwareFailingCompactor::new());
+        let mut agent = with_test_turn_state_handle(AgentBuilder::new())
+            .compactor(compactor.clone())
+            .build_standalone(client.clone(), Arc::new(NoTools), Arc::new(NoopStore))
+            .await;
+
+        agent.run("first".into()).await.unwrap();
+
+        let (tx, mut rx) = mpsc::channel::<crate::event::AgentEvent>(128);
+        agent
+            .run_with_events("second".into(), tx)
+            .await
+            .expect("compaction failure should preserve history and continue the turn");
+
+        let mut saw_compaction_failure = false;
+        while let Ok(event) = rx.try_recv() {
+            if let crate::event::AgentEvent::CompactionFailed { error } = event {
+                assert!(
+                    error.contains("stream ended before done"),
+                    "unexpected compaction failure: {error}"
+                );
+                saw_compaction_failure = true;
+            }
+        }
+        assert!(
+            saw_compaction_failure,
+            "failed compaction attempt should be surfaced"
+        );
+
+        agent.run("third".into()).await.unwrap();
+
+        let contexts = compactor.seen_contexts();
+        assert_eq!(
+            contexts
+                .iter()
+                .map(|ctx| (
+                    ctx.session_boundary_index,
+                    ctx.last_compaction_boundary_index
+                ))
+                .collect::<Vec<_>>(),
+            vec![(0, None), (1, None), (2, Some(1))],
+            "failed attempt boundary should feed the cadence guard on the next run"
+        );
+        assert_eq!(
+            client.seen_last_user_messages(),
+            vec![
+                "first".to_string(),
+                "COMPACT NOW".to_string(),
+                "second".to_string(),
+                "third".to_string(),
+            ],
+            "the next boundary after a failed compaction should not immediately retry compaction"
+        );
+
+        let cadence = crate::agent::compact::load_compaction_cadence(agent.session());
+        assert_eq!(cadence.session_boundary_index, 3);
+        assert_eq!(cadence.last_compaction_boundary_index, None);
+        assert_eq!(cadence.last_compaction_attempt_boundary_index, Some(1));
     }
 
     #[tokio::test]

--- a/meerkat-core/src/compact.rs
+++ b/meerkat-core/src/compact.rs
@@ -19,6 +19,9 @@ pub struct SessionCompactionCadence {
     /// Boundary index where compaction last completed successfully.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub last_compaction_boundary_index: Option<u64>,
+    /// Boundary index where compaction was last attempted, successful or not.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_compaction_attempt_boundary_index: Option<u64>,
 }
 
 /// Context provided to `Compactor::should_compact` for trigger decisions.
@@ -30,7 +33,10 @@ pub struct CompactionContext {
     pub message_count: usize,
     /// Estimated history tokens (JSON bytes / 4).
     pub estimated_history_tokens: u64,
-    /// Session-scoped pre-LLM boundary index where compaction last occurred, if ever.
+    /// Session-scoped pre-LLM boundary index used by the cadence guard.
+    ///
+    /// This is the latest successful compaction boundary or failed compaction
+    /// attempt boundary, whichever is newer.
     pub last_compaction_boundary_index: Option<u64>,
     /// Current session-scoped pre-LLM boundary index.
     pub session_boundary_index: u64,

--- a/meerkat-openai/src/client.rs
+++ b/meerkat-openai/src/client.rs
@@ -1587,6 +1587,7 @@ impl LlmClient for OpenAiClient {
                 HashMap::with_capacity(4);
             let mut streamed_reasoning_ids: HashSet<String> = HashSet::with_capacity(2);
             let mut done_emitted = false;
+            let mut saw_terminal_fallback_output = false;
 
             while let Some(chunk) = stream.next().await {
                 let chunk = chunk.map_err(|_| LlmError::ConnectionReset)?;
@@ -1594,6 +1595,21 @@ impl LlmClient for OpenAiClient {
 
                 while let Some(newline_pos) = buffer.find('\n') {
                     let line = buffer[..newline_pos].trim();
+                    if line == "data: [DONE]" {
+                        buffer.drain(..=newline_pos);
+                        if !done_emitted && saw_terminal_fallback_output {
+                            done_emitted = true;
+                            let stop_reason = if streamed_tool_ids.is_empty() {
+                                StopReason::EndTurn
+                            } else {
+                                StopReason::ToolUse
+                            };
+                            yield LlmEvent::Done {
+                                outcome: LlmDoneOutcome::Success { stop_reason },
+                            };
+                        }
+                        continue;
+                    }
                     let should_process = !line.is_empty() && !line.starts_with(':');
                     let parsed_event = if should_process {
                         Self::parse_responses_sse_line(line)
@@ -1639,6 +1655,7 @@ impl LlmClient for OpenAiClient {
                                                                         if let Some(text) = part.get("text").and_then(|t| t.as_str())
                                                                             && !saw_stream_text_delta
                                                                         {
+                                                                            saw_terminal_fallback_output = true;
                                                                             assembler.on_text_delta(text, None);
                                                                             yield LlmEvent::TextDelta { delta: text.to_string(), meta: None };
                                                                         }
@@ -1647,6 +1664,7 @@ impl LlmClient for OpenAiClient {
                                                                         if let Some(refusal) = part.get("refusal").and_then(|r| r.as_str())
                                                                             && !saw_stream_text_delta
                                                                         {
+                                                                            saw_terminal_fallback_output = true;
                                                                             assembler.on_text_delta(refusal, None);
                                                                             yield LlmEvent::TextDelta { delta: refusal.to_string(), meta: None };
                                                                         }
@@ -1698,6 +1716,7 @@ impl LlmClient for OpenAiClient {
 
                                                     assembler.on_reasoning_start();
                                                     if !summary_text.is_empty() {
+                                                        saw_terminal_fallback_output = true;
                                                         let _ = assembler.on_reasoning_delta(&summary_text);
                                                     }
                                                     assembler.on_reasoning_complete(meta.clone());
@@ -1747,6 +1766,7 @@ impl LlmClient for OpenAiClient {
                                                         args: args_value,
                                                         meta: None,
                                                     };
+                                                    saw_terminal_fallback_output = true;
                                                 }
                                                 "web_search_call" | "web_search_result" => {
                                                     let id = item.get("id")
@@ -1826,12 +1846,16 @@ impl LlmClient for OpenAiClient {
                         else if event.event_type == "response.output_text.delta" {
                             if let Some(delta) = &event.delta {
                                 saw_stream_text_delta = true;
+                                saw_terminal_fallback_output = true;
                                 assembler.on_text_delta(delta, None);
                                 yield LlmEvent::TextDelta { delta: delta.clone(), meta: None };
                             }
                         }
                         else if event.event_type == "response.reasoning_summary_text.delta" {
                             if let Some(delta) = &event.delta {
+                                if !delta.trim().is_empty() {
+                                    saw_terminal_fallback_output = true;
+                                }
                                 yield LlmEvent::ReasoningDelta { delta: delta.clone() };
                             }
                         }
@@ -1889,6 +1913,7 @@ impl LlmClient for OpenAiClient {
                                 );
 
                                 streamed_tool_ids.insert(call_id.clone());
+                                saw_terminal_fallback_output = true;
                                 yield LlmEvent::ToolCallComplete {
                                     id: call_id.clone(),
                                     name,
@@ -1932,6 +1957,7 @@ impl LlmClient for OpenAiClient {
                                 );
 
                                 streamed_tool_ids.insert(call_id.to_string());
+                                saw_terminal_fallback_output = true;
                                 yield LlmEvent::ToolCallComplete {
                                     id: call_id.to_string(),
                                     name: name.to_string(),
@@ -1976,11 +2002,15 @@ impl LlmClient for OpenAiClient {
 
                                 assembler.on_reasoning_start();
                                 if !summary_text.is_empty() {
+                                    saw_terminal_fallback_output = true;
                                     let _ = assembler.on_reasoning_delta(&summary_text);
                                 }
                                 assembler.on_reasoning_complete(meta.clone());
 
                                 streamed_reasoning_ids.insert(reasoning_id.to_string());
+                                if !summary_text.trim().is_empty() || meta.is_some() {
+                                    saw_terminal_fallback_output = true;
+                                }
                                 yield LlmEvent::ReasoningComplete {
                                     text: summary_text,
                                     meta,
@@ -4386,6 +4416,167 @@ mod tests {
         server.abort();
 
         assert_eq!(deltas, vec!["Hello"]);
+    }
+
+    #[tokio::test]
+    async fn test_stream_done_marker_after_delta_yields_success() {
+        let payload = [
+            r#"data: {"type":"response.output_text.delta","delta":"Hello"}"#,
+            "data: [DONE]",
+            "",
+        ]
+        .join("\n");
+        let (base_url, server) = spawn_openai_stub_server(payload).await;
+        let client = OpenAiClient::new_with_base_url("test-key".to_string(), base_url);
+        let request = LlmRequest::new(
+            "gpt-5-mini",
+            vec![Message::User(UserMessage::text("hello".to_string()))],
+        );
+
+        let mut stream = client.stream(&request);
+        let mut deltas = Vec::new();
+        let mut saw_success_done = false;
+        while let Some(event) = stream.next().await {
+            match event.expect("stream event") {
+                LlmEvent::TextDelta { delta, .. } => deltas.push(delta),
+                LlmEvent::Done {
+                    outcome: LlmDoneOutcome::Success { stop_reason },
+                } => {
+                    assert_eq!(stop_reason, StopReason::EndTurn);
+                    saw_success_done = true;
+                    break;
+                }
+                other => panic!("unexpected event: {other:?}"),
+            }
+        }
+        server.abort();
+
+        assert_eq!(deltas, vec!["Hello"]);
+        assert!(
+            saw_success_done,
+            "[DONE] after streamed output should be accepted as a terminal fallback"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_stream_done_marker_after_reasoning_delta_yields_success() {
+        let payload = [
+            r#"data: {"type":"response.reasoning_summary_text.delta","delta":"thinking"}"#,
+            "data: [DONE]",
+            "",
+        ]
+        .join("\n");
+        let (base_url, server) = spawn_openai_stub_server(payload).await;
+        let client = OpenAiClient::new_with_base_url("test-key".to_string(), base_url);
+        let request = LlmRequest::new(
+            "gpt-5-mini",
+            vec![Message::User(UserMessage::text("hello".to_string()))],
+        );
+
+        let mut stream = client.stream(&request);
+        let mut reasoning_deltas = Vec::new();
+        let mut saw_success_done = false;
+        while let Some(event) = stream.next().await {
+            match event.expect("stream event") {
+                LlmEvent::ReasoningDelta { delta } => reasoning_deltas.push(delta),
+                LlmEvent::Done {
+                    outcome: LlmDoneOutcome::Success { stop_reason },
+                } => {
+                    assert_eq!(stop_reason, StopReason::EndTurn);
+                    saw_success_done = true;
+                    break;
+                }
+                other => panic!("unexpected event: {other:?}"),
+            }
+        }
+        server.abort();
+
+        assert_eq!(reasoning_deltas, vec!["thinking"]);
+        assert!(
+            saw_success_done,
+            "[DONE] after streamed reasoning should be accepted as a terminal fallback"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_stream_done_marker_after_reasoning_meta_yields_success() {
+        let payload = [
+            r#"data: {"type":"response.reasoning.done","item":{"id":"rs_meta","summary":[],"encrypted_content":"enc_meta"}}"#,
+            "data: [DONE]",
+            "",
+        ]
+        .join("\n");
+        let (base_url, server) = spawn_openai_stub_server(payload).await;
+        let client = OpenAiClient::new_with_base_url("test-key".to_string(), base_url);
+        let request = LlmRequest::new(
+            "gpt-5-mini",
+            vec![Message::User(UserMessage::text("hello".to_string()))],
+        );
+
+        let mut stream = client.stream(&request);
+        let mut saw_reasoning_meta = false;
+        let mut saw_success_done = false;
+        while let Some(event) = stream.next().await {
+            match event.expect("stream event") {
+                LlmEvent::ReasoningComplete { text, meta } => {
+                    assert_eq!(text, "");
+                    assert!(matches!(
+                        meta.as_deref(),
+                        Some(ProviderMeta::OpenAi {
+                            id,
+                            encrypted_content: Some(encrypted),
+                            ..
+                        }) if id == "rs_meta" && encrypted == "enc_meta"
+                    ));
+                    saw_reasoning_meta = true;
+                }
+                LlmEvent::Done {
+                    outcome: LlmDoneOutcome::Success { stop_reason },
+                } => {
+                    assert_eq!(stop_reason, StopReason::EndTurn);
+                    saw_success_done = true;
+                    break;
+                }
+                other => panic!("unexpected event: {other:?}"),
+            }
+        }
+        server.abort();
+
+        assert!(saw_reasoning_meta);
+        assert!(
+            saw_success_done,
+            "[DONE] after reasoning metadata should be accepted as a terminal fallback"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_stream_done_marker_without_output_still_fails_incomplete() {
+        let payload = ["data: [DONE]", ""].join("\n");
+        let (base_url, server) = spawn_openai_stub_server(payload).await;
+        let client = OpenAiClient::new_with_base_url("test-key".to_string(), base_url);
+        let request = LlmRequest::new(
+            "gpt-5-mini",
+            vec![Message::User(UserMessage::text("hello".to_string()))],
+        );
+
+        let mut stream = client.stream(&request);
+        let mut saw_incomplete_done = false;
+        while let Some(event) = stream.next().await {
+            if let LlmEvent::Done {
+                outcome: LlmDoneOutcome::Error { error },
+            } = event.expect("stream event")
+            {
+                assert!(matches!(error, LlmError::IncompleteResponse { .. }));
+                saw_incomplete_done = true;
+                break;
+            }
+        }
+        server.abort();
+
+        assert!(
+            saw_incomplete_done,
+            "empty [DONE] streams should remain fail-closed"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- Treat OpenAI `data: [DONE]` as a terminal fallback only after actual streamed output/tool/reasoning content has been observed.
- Persist failed compaction attempt boundaries and feed them into the compaction cadence guard.
- Add regression coverage for failed compaction attempts so the next over-threshold turn does not immediately retry the same failing compaction path.

## Root Cause

A compaction failure was non-fatal, but it did not advance any cadence marker. Sessions that remained above the compaction threshold could therefore attempt compaction again on every pre-LLM boundary. Separately, OpenAI streams that emitted output and then closed with `[DONE]` but without a provider `response.done` event were reported as incomplete.

## Validation

- `./scripts/repo-cargo test -p meerkat-openai test_stream_done_marker --lib`
- `./scripts/repo-cargo test -p meerkat-core failed_compaction_attempt_uses_cadence_guard_before_retry --lib`
- `./scripts/repo-cargo test -p meerkat-core persisted_compaction_cadence_round_trips_through_session_metadata --lib`
- `./scripts/repo-cargo check -p meerkat-core -p meerkat-openai`
- `./scripts/repo-cargo fmt --check`
- `git diff --check`
- Pre-push hooks: secrets, whitespace, fmt, changed-crates clippy, machine codegen/verify, generated headers audit, bridge status guard, Bazel freshness, workspace deterministic gate
