### PR TITLE
Fix external bridge response routing

### DIFF
--- a/meerkat-runtime/src/comms_drain.rs
+++ b/meerkat-runtime/src/comms_drain.rs
@@ -1986,7 +1986,11 @@ async fn try_handle_supervisor_bridge_command(
             };
             let endpoint = crate::meerkat_machine::dsl::PeerEndpoint::from(&peer_spec);
             match adapter
-                .stage_add_direct_peer_endpoint(session_id, endpoint, Arc::clone(comms_runtime))
+                .stage_add_direct_peer_endpoint(
+                    session_id,
+                    endpoint.clone(),
+                    Arc::clone(comms_runtime),
+                )
                 .await
             {
                 Ok(()) => {
@@ -1999,13 +2003,33 @@ async fn try_handle_supervisor_bridge_command(
                     .await;
                 }
                 Err(error) => {
-                    send_bridge_failure(
-                        comms_runtime,
-                        candidate,
-                        BridgeRejectionCause::Internal,
-                        format!("wire member failed: {error}"),
-                    )
-                    .await;
+                    if matches!(
+                        error,
+                        crate::meerkat_machine::PeerEndpointStageError::Dsl(
+                            crate::meerkat_machine::dsl::MeerkatMachineTransitionError::GuardRejected {
+                                ..
+                            }
+                        )
+                    ) && adapter
+                        .direct_peer_endpoint_contains(session_id, &endpoint)
+                        .await
+                    {
+                        send_bridge_response(
+                            comms_runtime,
+                            candidate,
+                            meerkat_core::interaction::ResponseStatus::Completed,
+                            BridgeReply::Ack(BridgeAck { ok: true }),
+                        )
+                        .await;
+                    } else {
+                        send_bridge_failure(
+                            comms_runtime,
+                            candidate,
+                            BridgeRejectionCause::Internal,
+                            format!("wire member failed: {error}"),
+                        )
+                        .await;
+                    }
                 }
             }
             true
@@ -2051,7 +2075,11 @@ async fn try_handle_supervisor_bridge_command(
             };
             let endpoint = crate::meerkat_machine::dsl::PeerEndpoint::from(&peer_spec);
             match adapter
-                .stage_remove_direct_peer_endpoint(session_id, endpoint, Arc::clone(comms_runtime))
+                .stage_remove_direct_peer_endpoint(
+                    session_id,
+                    endpoint.clone(),
+                    Arc::clone(comms_runtime),
+                )
                 .await
             {
                 Ok(()) => {
@@ -2064,13 +2092,33 @@ async fn try_handle_supervisor_bridge_command(
                     .await;
                 }
                 Err(error) => {
-                    send_bridge_failure(
-                        comms_runtime,
-                        candidate,
-                        BridgeRejectionCause::Internal,
-                        format!("unwire member failed: {error}"),
-                    )
-                    .await;
+                    if matches!(
+                        error,
+                        crate::meerkat_machine::PeerEndpointStageError::Dsl(
+                            crate::meerkat_machine::dsl::MeerkatMachineTransitionError::GuardRejected {
+                                ..
+                            }
+                        )
+                    ) && !adapter
+                        .direct_peer_endpoint_contains(session_id, &endpoint)
+                        .await
+                    {
+                        send_bridge_response(
+                            comms_runtime,
+                            candidate,
+                            meerkat_core::interaction::ResponseStatus::Completed,
+                            BridgeReply::Ack(BridgeAck { ok: true }),
+                        )
+                        .await;
+                    } else {
+                        send_bridge_failure(
+                            comms_runtime,
+                            candidate,
+                            BridgeRejectionCause::Internal,
+                            format!("unwire member failed: {error}"),
+                        )
+                        .await;
+                    }
                 }
             }
             true
@@ -2208,6 +2256,10 @@ mod tests {
         )
     }
 
+    fn pubkey_sender_for_bridge_spec(spec: &BridgePeerSpec) -> String {
+        meerkat_comms::PubKey::new(spec.pubkey).to_pubkey_string()
+    }
+
     fn old_supervisor_bridge_spec() -> BridgePeerSpec {
         bridge_peer_spec_with_seed(
             "mob/__mob_supervisor__",
@@ -2237,6 +2289,38 @@ mod tests {
             format!("inproc://{name}"),
         )
         .expect("valid non-zero trusted peer descriptor")
+    }
+
+    async fn recorded_bridge_replies(
+        sent_commands: &Arc<tokio::sync::Mutex<Vec<CommsCommand>>>,
+    ) -> Vec<(meerkat_core::interaction::ResponseStatus, BridgeReply)> {
+        sent_commands
+            .lock()
+            .await
+            .iter()
+            .filter_map(|cmd| match cmd {
+                CommsCommand::PeerResponse { status, result, .. } => Some((
+                    *status,
+                    serde_json::from_value::<BridgeReply>(result.clone())
+                        .expect("recorded bridge response is typed"),
+                )),
+                _ => None,
+            })
+            .collect()
+    }
+
+    fn assert_completed_bridge_ack(
+        reply: &(meerkat_core::interaction::ResponseStatus, BridgeReply),
+    ) {
+        assert_eq!(
+            reply.0,
+            meerkat_core::interaction::ResponseStatus::Completed
+        );
+        assert!(
+            matches!(reply.1, BridgeReply::Ack(BridgeAck { ok: true })),
+            "expected completed bridge ack, got {:?}",
+            reply.1
+        );
     }
 
     fn trusted_tcp_peer_from_runtime(
@@ -3724,6 +3808,8 @@ mod tests {
         add_trusted_peer_errors: HashMap<String, String>,
         remove_trusted_peer_errors: HashMap<String, String>,
         trusted_peer_ids: Arc<tokio::sync::Mutex<HashSet<String>>>,
+        trusted_peers: Arc<tokio::sync::Mutex<HashMap<String, TrustedPeerDescriptor>>>,
+        sent_commands: Arc<tokio::sync::Mutex<Vec<CommsCommand>>>,
         peer_handle: Option<Arc<dyn meerkat_core::handles::PeerInteractionHandle>>,
         peer_request_response_handle: Option<Arc<dyn meerkat_core::handles::PeerInteractionHandle>>,
         completed_count: Arc<std::sync::atomic::AtomicUsize>,
@@ -3773,15 +3859,61 @@ mod tests {
             if let Some(message) = self.add_trusted_peer_errors.get(&peer_id_str) {
                 return Err(SendError::Internal(message.clone()));
             }
-            self.trusted_peer_ids.lock().await.insert(peer_id_str);
+            self.trusted_peer_ids
+                .lock()
+                .await
+                .insert(peer_id_str.clone());
+            self.trusted_peers.lock().await.insert(peer_id_str, peer);
             Ok(())
         }
 
         async fn remove_trusted_peer(&self, peer_id: &str) -> Result<bool, SendError> {
             match self.remove_trusted_peer_errors.get(peer_id) {
                 Some(message) => Err(SendError::Internal(message.clone())),
-                None => Ok(self.trusted_peer_ids.lock().await.remove(peer_id)),
+                None => {
+                    let removed_id = self.trusted_peer_ids.lock().await.remove(peer_id);
+                    let removed_descriptor =
+                        self.trusted_peers.lock().await.remove(peer_id).is_some();
+                    Ok(removed_id || removed_descriptor)
+                }
             }
+        }
+
+        async fn send(&self, cmd: CommsCommand) -> Result<meerkat_core::SendReceipt, SendError> {
+            let receipt = match &cmd {
+                CommsCommand::PeerResponse { in_reply_to, .. } => {
+                    meerkat_core::SendReceipt::PeerResponseSent {
+                        envelope_id: Uuid::new_v4(),
+                        in_reply_to: *in_reply_to,
+                    }
+                }
+                other => {
+                    return Err(SendError::Unsupported(format!(
+                        "BootstrapRuntime only records peer responses, got {}",
+                        other.command_kind()
+                    )));
+                }
+            };
+            self.sent_commands.lock().await.push(cmd);
+            Ok(receipt)
+        }
+
+        async fn peer_ingress_runtime_snapshot(
+            &self,
+        ) -> Result<
+            meerkat_core::interaction::PeerIngressRuntimeSnapshot,
+            meerkat_core::CommsCapabilityError,
+        > {
+            Ok(meerkat_core::interaction::PeerIngressRuntimeSnapshot {
+                self_peer_id: self
+                    .peer_id()
+                    .unwrap_or_else(|| PeerId::parse(PEER_ID_RECEIVER).expect("valid peer id")),
+                auth_required: true,
+                authority_phase: meerkat_core::interaction::PeerIngressAuthorityPhase::Received,
+                trusted_peers: self.trusted_peers.lock().await.values().cloned().collect(),
+                submission_queue_len: 0,
+                queue: meerkat_core::interaction::PeerIngressQueueSnapshot::default(),
+            })
         }
     }
 
@@ -3800,6 +3932,8 @@ mod tests {
             add_trusted_peer_errors: HashMap::new(),
             remove_trusted_peer_errors: HashMap::new(),
             trusted_peer_ids: Arc::new(tokio::sync::Mutex::new(HashSet::new())),
+            trusted_peers: Arc::new(tokio::sync::Mutex::new(HashMap::new())),
+            sent_commands: Arc::new(tokio::sync::Mutex::new(Vec::new())),
             peer_handle: Some(peer_handle.clone()),
             peer_request_response_handle: Some(peer_handle),
             completed_count: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
@@ -5821,6 +5955,147 @@ mod tests {
             peers.iter().all(|entry| !entry.name.as_str().is_empty()),
             "invalid wire peer specs must not be materialized in comms trust"
         );
+    }
+
+    #[tokio::test]
+    async fn wire_member_duplicate_direct_endpoint_idempotently_acks() {
+        let runtime_impl = bootstrap_runtime(PEER_ID_RECEIVER, "inproc://receiver", None);
+        let sent_commands = runtime_impl.sent_commands.clone();
+        let runtime: Arc<dyn CommsRuntime> = Arc::new(runtime_impl);
+        let adapter = Arc::new(MeerkatMachine::ephemeral());
+        let session_id = SessionId::new();
+        adapter.register_session(session_id.clone()).await;
+
+        let supervisor = current_supervisor_bridge_spec();
+        adapter
+            .stage_supervisor_bind(
+                &session_id,
+                supervisor.name.clone(),
+                supervisor.peer_id.clone(),
+                supervisor.address.clone(),
+                1,
+            )
+            .await
+            .expect("pre-bind supervisor");
+
+        let peer_spec = bridge_peer_spec_with_seed("peer-a", 0xa1, "inproc://peer-a");
+        let command = BridgeCommand::WireMember(BridgePeerWiringPayload {
+            supervisor: supervisor.clone(),
+            epoch: 1,
+            protocol_version: SUPERVISOR_BRIDGE_PROTOCOL_VERSION,
+            peer_spec: peer_spec.clone(),
+        });
+        let sender = pubkey_sender_for_bridge_spec(&supervisor);
+
+        assert!(
+            try_handle_supervisor_bridge_command(
+                &adapter,
+                &session_id,
+                &runtime,
+                &bridge_candidate(&sender, &command),
+            )
+            .await,
+            "initial wire command should be handled"
+        );
+        assert!(
+            try_handle_supervisor_bridge_command(
+                &adapter,
+                &session_id,
+                &runtime,
+                &bridge_candidate(&sender, &command),
+            )
+            .await,
+            "duplicate wire command should be handled"
+        );
+
+        let endpoint = crate::meerkat_machine::dsl::PeerEndpoint::from(
+            &TrustedPeerDescriptor::try_from(peer_spec).expect("valid peer spec"),
+        );
+        assert!(
+            adapter
+                .direct_peer_endpoint_contains(&session_id, &endpoint)
+                .await,
+            "duplicate wire must leave the direct endpoint installed"
+        );
+        let replies = recorded_bridge_replies(&sent_commands).await;
+        assert_eq!(replies.len(), 2, "both wire attempts must reply");
+        assert_completed_bridge_ack(&replies[0]);
+        assert_completed_bridge_ack(&replies[1]);
+    }
+
+    #[tokio::test]
+    async fn unwire_member_absent_direct_endpoint_idempotently_acks() {
+        let runtime_impl = bootstrap_runtime(PEER_ID_RECEIVER, "inproc://receiver", None);
+        let sent_commands = runtime_impl.sent_commands.clone();
+        let runtime: Arc<dyn CommsRuntime> = Arc::new(runtime_impl);
+        let adapter = Arc::new(MeerkatMachine::ephemeral());
+        let session_id = SessionId::new();
+        adapter.register_session(session_id.clone()).await;
+
+        let supervisor = current_supervisor_bridge_spec();
+        adapter
+            .stage_supervisor_bind(
+                &session_id,
+                supervisor.name.clone(),
+                supervisor.peer_id.clone(),
+                supervisor.address.clone(),
+                1,
+            )
+            .await
+            .expect("pre-bind supervisor");
+
+        let peer_spec = bridge_peer_spec_with_seed("peer-b", 0xb1, "inproc://peer-b");
+        let peer_descriptor =
+            TrustedPeerDescriptor::try_from(peer_spec.clone()).expect("valid peer spec");
+        adapter
+            .stage_add_direct_peer_endpoint(
+                &session_id,
+                crate::meerkat_machine::dsl::PeerEndpoint::from(&peer_descriptor),
+                runtime.clone(),
+            )
+            .await
+            .expect("pre-wire peer");
+
+        let command = BridgeCommand::UnwireMember(BridgePeerWiringPayload {
+            supervisor: supervisor.clone(),
+            epoch: 1,
+            protocol_version: SUPERVISOR_BRIDGE_PROTOCOL_VERSION,
+            peer_spec,
+        });
+        let sender = pubkey_sender_for_bridge_spec(&supervisor);
+
+        assert!(
+            try_handle_supervisor_bridge_command(
+                &adapter,
+                &session_id,
+                &runtime,
+                &bridge_candidate(&sender, &command),
+            )
+            .await,
+            "initial unwire command should be handled"
+        );
+        assert!(
+            try_handle_supervisor_bridge_command(
+                &adapter,
+                &session_id,
+                &runtime,
+                &bridge_candidate(&sender, &command),
+            )
+            .await,
+            "duplicate unwire command should be handled"
+        );
+
+        let endpoint = crate::meerkat_machine::dsl::PeerEndpoint::from(&peer_descriptor);
+        assert!(
+            !adapter
+                .direct_peer_endpoint_contains(&session_id, &endpoint)
+                .await,
+            "duplicate unwire must leave the direct endpoint absent"
+        );
+        let replies = recorded_bridge_replies(&sent_commands).await;
+        assert_eq!(replies.len(), 2, "both unwire attempts must reply");
+        assert_completed_bridge_ack(&replies[0]);
+        assert_completed_bridge_ack(&replies[1]);
     }
 }
 

--- a/meerkat-runtime/src/comms_drain.rs
+++ b/meerkat-runtime/src/comms_drain.rs
@@ -928,14 +928,6 @@ async fn resolve_peer_route(
         .map(|entry| PeerRoute::with_display_name(entry.peer_id, entry.name.clone()))
 }
 
-async fn bridge_peer_is_trusted(comms_runtime: &Arc<dyn CommsRuntime>, peer_id: PeerId) -> bool {
-    comms_runtime
-        .peers()
-        .await
-        .iter()
-        .any(|peer| peer.peer_id == peer_id)
-}
-
 fn record_bridge_inbound_peer_request(
     comms_runtime: &Arc<dyn CommsRuntime>,
     candidate: &PeerInputCandidate,
@@ -1031,7 +1023,14 @@ async fn require_authorized_supervisor_with_response_route(
     context: &str,
 ) -> Result<BridgePeerIdentity, (BridgeRejectionCause, String)> {
     let supervisor = require_authorized_supervisor(sender, payload, current)?;
-    ensure_bridge_response_route_for_supervisor(comms_runtime, &supervisor, context).await?;
+    let binding = BoundSupervisorState::from_binding(current).ok_or_else(|| {
+        (
+            BridgeRejectionCause::Internal,
+            format!("{context}: missing bound supervisor response state"),
+        )
+    })?;
+    let response_peer = bound_supervisor_response_descriptor(sender, &binding, context)?;
+    ensure_bridge_response_route_for_descriptor(comms_runtime, response_peer, context).await?;
     Ok(supervisor)
 }
 
@@ -1088,17 +1087,36 @@ async fn send_bridge_response_with_temporary_supervisor_route(
     context: &str,
 ) {
     let removal_key = response_peer.peer_id.as_str();
-    let had_existing_route = comms_runtime
-        .peers()
+    let add_result = match comms_runtime
+        .add_private_trusted_peer(response_peer.clone())
         .await
-        .iter()
-        .any(|peer| peer.peer_id == response_peer.peer_id);
-    match ensure_bridge_response_route_for_descriptor(comms_runtime, response_peer, context).await {
-        Ok(()) => {
+    {
+        Ok(()) => Ok(true),
+        Err(SendError::Unsupported(_)) => comms_runtime
+            .add_trusted_peer(response_peer)
+            .await
+            .map(|()| false)
+            .map_err(|error| {
+                (
+                    BridgeRejectionCause::Internal,
+                    format!("{context}: failed to install supervisor response route: {error}"),
+                )
+            }),
+        Err(error) => Err((
+            BridgeRejectionCause::Internal,
+            format!("{context}: failed to install supervisor response route: {error}"),
+        )),
+    };
+    match add_result {
+        Ok(used_private_route) => {
             send_bridge_response(comms_runtime, candidate, status, reply).await;
-            if !had_existing_route
-                && let Err(error) = comms_runtime.remove_trusted_peer(&removal_key).await
-            {
+            if let Err(error) = if used_private_route {
+                comms_runtime
+                    .remove_private_trusted_peer(&removal_key)
+                    .await
+            } else {
+                comms_runtime.remove_trusted_peer(&removal_key).await
+            } {
                 tracing::warn!(
                     error = %error,
                     peer_id = %removal_key,
@@ -1116,32 +1134,6 @@ async fn send_bridge_response_with_temporary_supervisor_route(
             comms_runtime.mark_interaction_complete(&candidate.interaction.id);
         }
     }
-}
-
-async fn send_bind_failure_with_response_route(
-    comms_runtime: &Arc<dyn CommsRuntime>,
-    candidate: &PeerInputCandidate,
-    sender: &PeerIngressFact,
-    payload: &meerkat_contracts::wire::supervisor_bridge::BridgeBindPayload,
-    cause: BridgeRejectionCause,
-    reason: String,
-) {
-    let supervisor = match bridge_peer_identity(&payload.supervisor, "bind member failed") {
-        Ok(supervisor) if sender_matches_bridge_peer(sender, &supervisor) => supervisor,
-        _ => {
-            send_bridge_failure(comms_runtime, candidate, cause, reason).await;
-            return;
-        }
-    };
-    send_bridge_response_with_temporary_supervisor_route(
-        comms_runtime,
-        candidate,
-        meerkat_core::interaction::ResponseStatus::Failed,
-        BridgeReply::Rejected { cause, reason },
-        supervisor.into_trusted_peer_descriptor(),
-        "bind member failed",
-    )
-    .await;
 }
 
 /// Try to handle a supervisor bridge command from an incoming comms request.
@@ -1302,15 +1294,7 @@ async fn try_handle_supervisor_bridge_command(
                 match validate_bind_request(comms_runtime, sender, &payload) {
                     Ok(binding) => binding,
                     Err((cause, reason)) => {
-                        send_bind_failure_with_response_route(
-                            comms_runtime,
-                            candidate,
-                            sender,
-                            &payload,
-                            cause,
-                            reason,
-                        )
-                        .await;
+                        send_bridge_failure(comms_runtime, candidate, cause, reason).await;
                         return true;
                     }
                 };
@@ -1964,7 +1948,7 @@ async fn try_handle_supervisor_bridge_command(
                 epoch: payload.epoch,
                 protocol_version: payload.protocol_version,
             };
-            let authorized_supervisor = match require_authorized_supervisor_with_response_route(
+            match require_authorized_supervisor_with_response_route(
                 comms_runtime,
                 sender,
                 &sup_payload,
@@ -1973,13 +1957,12 @@ async fn try_handle_supervisor_bridge_command(
             )
             .await
             {
-                Ok(supervisor) => supervisor,
+                Ok(_) => {}
                 Err((cause, reason)) => {
                     send_bridge_failure(comms_runtime, candidate, cause, reason).await;
                     return true;
                 }
-            };
-            let supervisor_response_peer = authorized_supervisor.into_trusted_peer_descriptor();
+            }
             // D-track-b: route WireMember through the DSL authority's
             // peer-projection state. The stager helper applies
             // `AddDirectPeerEndpoint`, emits
@@ -2007,35 +1990,15 @@ async fn try_handle_supervisor_bridge_command(
                 .await
             {
                 Ok(()) => {
-                    send_bridge_response_with_temporary_supervisor_route(
+                    send_bridge_response(
                         comms_runtime,
                         candidate,
                         meerkat_core::interaction::ResponseStatus::Completed,
                         BridgeReply::Ack(BridgeAck { ok: true }),
-                        supervisor_response_peer.clone(),
-                        "wire member failed",
                     )
                     .await;
                 }
                 Err(error) => {
-                    if bridge_peer_is_trusted(comms_runtime, peer_spec.peer_id).await {
-                        tracing::debug!(
-                            %session_id,
-                            peer_id = %peer_spec.peer_id,
-                            error = %error,
-                            "wire member peer projection rejected after trust was already present; treating as idempotent ack"
-                        );
-                        send_bridge_response_with_temporary_supervisor_route(
-                            comms_runtime,
-                            candidate,
-                            meerkat_core::interaction::ResponseStatus::Completed,
-                            BridgeReply::Ack(BridgeAck { ok: true }),
-                            supervisor_response_peer,
-                            "wire member idempotent ack failed",
-                        )
-                        .await;
-                        return true;
-                    }
                     send_bridge_failure(
                         comms_runtime,
                         candidate,
@@ -2053,7 +2016,7 @@ async fn try_handle_supervisor_bridge_command(
                 epoch: payload.epoch,
                 protocol_version: payload.protocol_version,
             };
-            let authorized_supervisor = match require_authorized_supervisor_with_response_route(
+            match require_authorized_supervisor_with_response_route(
                 comms_runtime,
                 sender,
                 &sup_payload,
@@ -2062,13 +2025,12 @@ async fn try_handle_supervisor_bridge_command(
             )
             .await
             {
-                Ok(supervisor) => supervisor,
+                Ok(_) => {}
                 Err((cause, reason)) => {
                     send_bridge_failure(comms_runtime, candidate, cause, reason).await;
                     return true;
                 }
-            };
-            let supervisor_response_peer = authorized_supervisor.into_trusted_peer_descriptor();
+            }
             // D-track-b: mirror of WireMember — route UnwireMember
             // through `RemoveDirectPeerEndpoint`. The DSL authority's
             // peer-projection state is the source of truth; the trust
@@ -2093,35 +2055,15 @@ async fn try_handle_supervisor_bridge_command(
                 .await
             {
                 Ok(()) => {
-                    send_bridge_response_with_temporary_supervisor_route(
+                    send_bridge_response(
                         comms_runtime,
                         candidate,
                         meerkat_core::interaction::ResponseStatus::Completed,
                         BridgeReply::Ack(BridgeAck { ok: true }),
-                        supervisor_response_peer.clone(),
-                        "unwire member failed",
                     )
                     .await;
                 }
                 Err(error) => {
-                    if !bridge_peer_is_trusted(comms_runtime, peer_spec.peer_id).await {
-                        tracing::debug!(
-                            %session_id,
-                            peer_id = %peer_spec.peer_id,
-                            error = %error,
-                            "unwire member peer projection rejected after trust was already absent; treating as idempotent ack"
-                        );
-                        send_bridge_response_with_temporary_supervisor_route(
-                            comms_runtime,
-                            candidate,
-                            meerkat_core::interaction::ResponseStatus::Completed,
-                            BridgeReply::Ack(BridgeAck { ok: true }),
-                            supervisor_response_peer,
-                            "unwire member idempotent ack failed",
-                        )
-                        .await;
-                        return true;
-                    }
                     send_bridge_failure(
                         comms_runtime,
                         candidate,
@@ -3302,135 +3244,6 @@ mod tests {
         assert_eq!(
             bind_response.address,
             canonicalize_bridge_address(&member_spec.address.to_string())
-        );
-    }
-
-    #[cfg(not(target_arch = "wasm32"))]
-    #[tokio::test]
-    async fn bind_member_validation_failure_routes_tcp_rejection_before_trust_is_bound() {
-        let suffix = Uuid::new_v4().simple().to_string();
-        let member_name = format!("tcp-bind-reject-member-{suffix}");
-        let supervisor_name = format!("tcp-bind-reject-supervisor-{suffix}");
-
-        let mut member_runtime =
-            meerkat_comms::CommsRuntime::inproc_only(&member_name).expect("member runtime");
-        member_runtime
-            .set_listen_tcp_for_unstarted_runtime(std::net::SocketAddr::from(([127, 0, 0, 1], 0)))
-            .expect("configure member TCP listener");
-        member_runtime
-            .start_listeners()
-            .await
-            .expect("start member TCP listener");
-        let member_runtime = Arc::new(member_runtime);
-        let member_peer_handle = Arc::new(CountingPeerInteractionHandle::default());
-        install_test_peer_request_response_authority(&member_runtime, member_peer_handle.clone());
-
-        let mut supervisor_runtime =
-            meerkat_comms::CommsRuntime::inproc_only(&supervisor_name).expect("supervisor runtime");
-        supervisor_runtime
-            .set_listen_tcp_for_unstarted_runtime(std::net::SocketAddr::from(([127, 0, 0, 1], 0)))
-            .expect("configure supervisor TCP listener");
-        supervisor_runtime
-            .start_listeners()
-            .await
-            .expect("start supervisor TCP listener");
-        let supervisor_runtime = Arc::new(supervisor_runtime);
-        install_test_peer_request_response_authority(
-            &supervisor_runtime,
-            Arc::new(CountingPeerInteractionHandle::default()),
-        );
-
-        let member_spec = trusted_tcp_peer_from_runtime(&member_name, &member_runtime);
-        supervisor_runtime
-            .add_trusted_peer(member_spec.clone())
-            .await
-            .expect("supervisor trusts member target");
-        let supervisor_spec =
-            trusted_tcp_peer_from_runtime("mob/__mob_supervisor__", &supervisor_runtime);
-
-        let adapter = Arc::new(MeerkatMachine::ephemeral());
-        let session_id = SessionId::new();
-        adapter.register_session(session_id.clone()).await;
-        assert!(
-            member_runtime.peers().await.is_empty(),
-            "fixture starts before bind, so the target must not already trust the supervisor"
-        );
-
-        let command = BridgeCommand::BindMember(
-            meerkat_contracts::wire::supervisor_bridge::BridgeBindPayload {
-                supervisor: BridgePeerSpec::from(supervisor_spec.clone()),
-                epoch: 1,
-                protocol_version: SUPERVISOR_BRIDGE_PROTOCOL_VERSION,
-                expected_peer_id: member_spec.peer_id.as_str(),
-                expected_address: "tcp://127.0.0.1:1".to_string(),
-                bootstrap_token: member_runtime.bridge_bootstrap_token().to_owned().into(),
-            },
-        );
-        let request_receipt = supervisor_runtime
-            .send(CommsCommand::PeerRequest {
-                to: PeerRoute::with_display_name(member_spec.peer_id, member_spec.name.clone()),
-                intent: SUPERVISOR_BRIDGE_INTENT.to_string(),
-                params: serde_json::to_value(&command).expect("serialize bridge command"),
-                blocks: None,
-                handling_mode: HandlingMode::Queue,
-                stream: meerkat_core::comms::InputStreamMode::None,
-            })
-            .await
-            .expect("supervisor sends BindMember over TCP");
-        let meerkat_core::SendReceipt::PeerRequestSent { interaction_id, .. } = request_receipt
-        else {
-            panic!("expected PeerRequestSent receipt, got {request_receipt:?}");
-        };
-
-        let candidate = drain_one_candidate(&member_runtime, "member BindMember request").await;
-        assert_eq!(
-            candidate.interaction.id, interaction_id,
-            "member must receive the correlated bridge request"
-        );
-        assert!(
-            try_handle_supervisor_bridge_command(
-                &adapter,
-                &session_id,
-                &(member_runtime.clone() as Arc<dyn CommsRuntime>),
-                &candidate,
-            )
-            .await,
-            "bridge handler must own BindMember"
-        );
-
-        let response =
-            drain_one_candidate(&supervisor_runtime, "supervisor BindMember rejection").await;
-        assert_eq!(
-            member_peer_handle.response_replied_count(),
-            1,
-            "target must send a terminal bridge rejection instead of timing out on PeerNotFound"
-        );
-        assert!(
-            member_runtime.peers().await.is_empty(),
-            "temporary bind rejection route must not leave the supervisor trusted before bind"
-        );
-        let InteractionContent::Response {
-            in_reply_to,
-            status,
-            result,
-            ..
-        } = response.interaction.content
-        else {
-            panic!(
-                "expected bridge rejection response, got {:?}",
-                response.interaction.content
-            );
-        };
-        assert_eq!(in_reply_to, interaction_id);
-        assert_eq!(status, meerkat_core::interaction::ResponseStatus::Failed);
-        let reply: BridgeReply = serde_json::from_value(result).expect("typed bridge reply");
-        let BridgeReply::Rejected { cause, reason } = reply else {
-            panic!("expected Rejected reply, got {reply:?}");
-        };
-        assert_eq!(cause, BridgeRejectionCause::AddressMismatch);
-        assert!(
-            reason.contains("bind address mismatch"),
-            "rejection should preserve the real bind failure reason, got: {reason}"
         );
     }
 
@@ -5436,6 +5249,39 @@ mod tests {
         assert!(
             trusted_peer_ids.lock().await.is_empty(),
             "failed trust publication must not leave the supervisor trusted"
+        );
+    }
+
+    #[tokio::test]
+    async fn bind_member_invalid_bootstrap_does_not_publish_response_route() {
+        let mut payload = sample_bind_payload();
+        payload.bootstrap_token = "wrong-token".into();
+        let sender = payload.supervisor.peer_id.clone();
+        let runtime_impl = bootstrap_runtime(
+            PEER_ID_RECEIVER,
+            "inproc://receiver",
+            Some("expected-token"),
+        );
+        let trusted_peer_ids = runtime_impl.trusted_peer_ids.clone();
+        let runtime: Arc<dyn CommsRuntime> = Arc::new(runtime_impl);
+        let adapter = Arc::new(MeerkatMachine::ephemeral());
+        let session_id = SessionId::new();
+        adapter.register_session(session_id.clone()).await;
+        let candidate = bridge_candidate(&sender, &BridgeCommand::BindMember(payload));
+
+        assert!(
+            try_handle_supervisor_bridge_command(&adapter, &session_id, &runtime, &candidate).await
+        );
+        assert!(
+            matches!(
+                adapter.supervisor_binding(&session_id).await,
+                SupervisorBinding::Unbound
+            ),
+            "invalid bootstrap must not bind supervisor authority"
+        );
+        assert!(
+            trusted_peer_ids.lock().await.is_empty(),
+            "invalid bootstrap must not temporarily publish supervisor trust just to route rejection"
         );
     }
 

--- a/meerkat-runtime/src/comms_drain.rs
+++ b/meerkat-runtime/src/comms_drain.rs
@@ -928,6 +928,14 @@ async fn resolve_peer_route(
         .map(|entry| PeerRoute::with_display_name(entry.peer_id, entry.name.clone()))
 }
 
+async fn bridge_peer_is_trusted(comms_runtime: &Arc<dyn CommsRuntime>, peer_id: PeerId) -> bool {
+    comms_runtime
+        .peers()
+        .await
+        .iter()
+        .any(|peer| peer.peer_id == peer_id)
+}
+
 fn record_bridge_inbound_peer_request(
     comms_runtime: &Arc<dyn CommsRuntime>,
     candidate: &PeerInputCandidate,
@@ -1060,11 +1068,37 @@ async fn send_bridge_response_after_removed_supervisor_route(
     response_peer: TrustedPeerDescriptor,
     context: &str,
 ) {
+    send_bridge_response_with_temporary_supervisor_route(
+        comms_runtime,
+        candidate,
+        status,
+        reply,
+        response_peer,
+        context,
+    )
+    .await;
+}
+
+async fn send_bridge_response_with_temporary_supervisor_route(
+    comms_runtime: &Arc<dyn CommsRuntime>,
+    candidate: &PeerInputCandidate,
+    status: meerkat_core::interaction::ResponseStatus,
+    reply: BridgeReply,
+    response_peer: TrustedPeerDescriptor,
+    context: &str,
+) {
     let removal_key = response_peer.peer_id.as_str();
+    let had_existing_route = comms_runtime
+        .peers()
+        .await
+        .iter()
+        .any(|peer| peer.peer_id == response_peer.peer_id);
     match ensure_bridge_response_route_for_descriptor(comms_runtime, response_peer, context).await {
         Ok(()) => {
             send_bridge_response(comms_runtime, candidate, status, reply).await;
-            if let Err(error) = comms_runtime.remove_trusted_peer(&removal_key).await {
+            if !had_existing_route
+                && let Err(error) = comms_runtime.remove_trusted_peer(&removal_key).await
+            {
                 tracing::warn!(
                     error = %error,
                     peer_id = %removal_key,
@@ -1082,6 +1116,32 @@ async fn send_bridge_response_after_removed_supervisor_route(
             comms_runtime.mark_interaction_complete(&candidate.interaction.id);
         }
     }
+}
+
+async fn send_bind_failure_with_response_route(
+    comms_runtime: &Arc<dyn CommsRuntime>,
+    candidate: &PeerInputCandidate,
+    sender: &PeerIngressFact,
+    payload: &meerkat_contracts::wire::supervisor_bridge::BridgeBindPayload,
+    cause: BridgeRejectionCause,
+    reason: String,
+) {
+    let supervisor = match bridge_peer_identity(&payload.supervisor, "bind member failed") {
+        Ok(supervisor) if sender_matches_bridge_peer(sender, &supervisor) => supervisor,
+        _ => {
+            send_bridge_failure(comms_runtime, candidate, cause, reason).await;
+            return;
+        }
+    };
+    send_bridge_response_with_temporary_supervisor_route(
+        comms_runtime,
+        candidate,
+        meerkat_core::interaction::ResponseStatus::Failed,
+        BridgeReply::Rejected { cause, reason },
+        supervisor.into_trusted_peer_descriptor(),
+        "bind member failed",
+    )
+    .await;
 }
 
 /// Try to handle a supervisor bridge command from an incoming comms request.
@@ -1242,7 +1302,15 @@ async fn try_handle_supervisor_bridge_command(
                 match validate_bind_request(comms_runtime, sender, &payload) {
                     Ok(binding) => binding,
                     Err((cause, reason)) => {
-                        send_bridge_failure(comms_runtime, candidate, cause, reason).await;
+                        send_bind_failure_with_response_route(
+                            comms_runtime,
+                            candidate,
+                            sender,
+                            &payload,
+                            cause,
+                            reason,
+                        )
+                        .await;
                         return true;
                     }
                 };
@@ -1896,7 +1964,7 @@ async fn try_handle_supervisor_bridge_command(
                 epoch: payload.epoch,
                 protocol_version: payload.protocol_version,
             };
-            if let Err((cause, reason)) = require_authorized_supervisor_with_response_route(
+            let authorized_supervisor = match require_authorized_supervisor_with_response_route(
                 comms_runtime,
                 sender,
                 &sup_payload,
@@ -1905,9 +1973,13 @@ async fn try_handle_supervisor_bridge_command(
             )
             .await
             {
-                send_bridge_failure(comms_runtime, candidate, cause, reason).await;
-                return true;
-            }
+                Ok(supervisor) => supervisor,
+                Err((cause, reason)) => {
+                    send_bridge_failure(comms_runtime, candidate, cause, reason).await;
+                    return true;
+                }
+            };
+            let supervisor_response_peer = authorized_supervisor.into_trusted_peer_descriptor();
             // D-track-b: route WireMember through the DSL authority's
             // peer-projection state. The stager helper applies
             // `AddDirectPeerEndpoint`, emits
@@ -1935,15 +2007,35 @@ async fn try_handle_supervisor_bridge_command(
                 .await
             {
                 Ok(()) => {
-                    send_bridge_response(
+                    send_bridge_response_with_temporary_supervisor_route(
                         comms_runtime,
                         candidate,
                         meerkat_core::interaction::ResponseStatus::Completed,
                         BridgeReply::Ack(BridgeAck { ok: true }),
+                        supervisor_response_peer.clone(),
+                        "wire member failed",
                     )
                     .await;
                 }
                 Err(error) => {
+                    if bridge_peer_is_trusted(comms_runtime, peer_spec.peer_id).await {
+                        tracing::debug!(
+                            %session_id,
+                            peer_id = %peer_spec.peer_id,
+                            error = %error,
+                            "wire member peer projection rejected after trust was already present; treating as idempotent ack"
+                        );
+                        send_bridge_response_with_temporary_supervisor_route(
+                            comms_runtime,
+                            candidate,
+                            meerkat_core::interaction::ResponseStatus::Completed,
+                            BridgeReply::Ack(BridgeAck { ok: true }),
+                            supervisor_response_peer,
+                            "wire member idempotent ack failed",
+                        )
+                        .await;
+                        return true;
+                    }
                     send_bridge_failure(
                         comms_runtime,
                         candidate,
@@ -1961,7 +2053,7 @@ async fn try_handle_supervisor_bridge_command(
                 epoch: payload.epoch,
                 protocol_version: payload.protocol_version,
             };
-            if let Err((cause, reason)) = require_authorized_supervisor_with_response_route(
+            let authorized_supervisor = match require_authorized_supervisor_with_response_route(
                 comms_runtime,
                 sender,
                 &sup_payload,
@@ -1970,9 +2062,13 @@ async fn try_handle_supervisor_bridge_command(
             )
             .await
             {
-                send_bridge_failure(comms_runtime, candidate, cause, reason).await;
-                return true;
-            }
+                Ok(supervisor) => supervisor,
+                Err((cause, reason)) => {
+                    send_bridge_failure(comms_runtime, candidate, cause, reason).await;
+                    return true;
+                }
+            };
+            let supervisor_response_peer = authorized_supervisor.into_trusted_peer_descriptor();
             // D-track-b: mirror of WireMember — route UnwireMember
             // through `RemoveDirectPeerEndpoint`. The DSL authority's
             // peer-projection state is the source of truth; the trust
@@ -1997,15 +2093,35 @@ async fn try_handle_supervisor_bridge_command(
                 .await
             {
                 Ok(()) => {
-                    send_bridge_response(
+                    send_bridge_response_with_temporary_supervisor_route(
                         comms_runtime,
                         candidate,
                         meerkat_core::interaction::ResponseStatus::Completed,
                         BridgeReply::Ack(BridgeAck { ok: true }),
+                        supervisor_response_peer.clone(),
+                        "unwire member failed",
                     )
                     .await;
                 }
                 Err(error) => {
+                    if !bridge_peer_is_trusted(comms_runtime, peer_spec.peer_id).await {
+                        tracing::debug!(
+                            %session_id,
+                            peer_id = %peer_spec.peer_id,
+                            error = %error,
+                            "unwire member peer projection rejected after trust was already absent; treating as idempotent ack"
+                        );
+                        send_bridge_response_with_temporary_supervisor_route(
+                            comms_runtime,
+                            candidate,
+                            meerkat_core::interaction::ResponseStatus::Completed,
+                            BridgeReply::Ack(BridgeAck { ok: true }),
+                            supervisor_response_peer,
+                            "unwire member idempotent ack failed",
+                        )
+                        .await;
+                        return true;
+                    }
                     send_bridge_failure(
                         comms_runtime,
                         candidate,
@@ -3186,6 +3302,135 @@ mod tests {
         assert_eq!(
             bind_response.address,
             canonicalize_bridge_address(&member_spec.address.to_string())
+        );
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    #[tokio::test]
+    async fn bind_member_validation_failure_routes_tcp_rejection_before_trust_is_bound() {
+        let suffix = Uuid::new_v4().simple().to_string();
+        let member_name = format!("tcp-bind-reject-member-{suffix}");
+        let supervisor_name = format!("tcp-bind-reject-supervisor-{suffix}");
+
+        let mut member_runtime =
+            meerkat_comms::CommsRuntime::inproc_only(&member_name).expect("member runtime");
+        member_runtime
+            .set_listen_tcp_for_unstarted_runtime(std::net::SocketAddr::from(([127, 0, 0, 1], 0)))
+            .expect("configure member TCP listener");
+        member_runtime
+            .start_listeners()
+            .await
+            .expect("start member TCP listener");
+        let member_runtime = Arc::new(member_runtime);
+        let member_peer_handle = Arc::new(CountingPeerInteractionHandle::default());
+        install_test_peer_request_response_authority(&member_runtime, member_peer_handle.clone());
+
+        let mut supervisor_runtime =
+            meerkat_comms::CommsRuntime::inproc_only(&supervisor_name).expect("supervisor runtime");
+        supervisor_runtime
+            .set_listen_tcp_for_unstarted_runtime(std::net::SocketAddr::from(([127, 0, 0, 1], 0)))
+            .expect("configure supervisor TCP listener");
+        supervisor_runtime
+            .start_listeners()
+            .await
+            .expect("start supervisor TCP listener");
+        let supervisor_runtime = Arc::new(supervisor_runtime);
+        install_test_peer_request_response_authority(
+            &supervisor_runtime,
+            Arc::new(CountingPeerInteractionHandle::default()),
+        );
+
+        let member_spec = trusted_tcp_peer_from_runtime(&member_name, &member_runtime);
+        supervisor_runtime
+            .add_trusted_peer(member_spec.clone())
+            .await
+            .expect("supervisor trusts member target");
+        let supervisor_spec =
+            trusted_tcp_peer_from_runtime("mob/__mob_supervisor__", &supervisor_runtime);
+
+        let adapter = Arc::new(MeerkatMachine::ephemeral());
+        let session_id = SessionId::new();
+        adapter.register_session(session_id.clone()).await;
+        assert!(
+            member_runtime.peers().await.is_empty(),
+            "fixture starts before bind, so the target must not already trust the supervisor"
+        );
+
+        let command = BridgeCommand::BindMember(
+            meerkat_contracts::wire::supervisor_bridge::BridgeBindPayload {
+                supervisor: BridgePeerSpec::from(supervisor_spec.clone()),
+                epoch: 1,
+                protocol_version: SUPERVISOR_BRIDGE_PROTOCOL_VERSION,
+                expected_peer_id: member_spec.peer_id.as_str(),
+                expected_address: "tcp://127.0.0.1:1".to_string(),
+                bootstrap_token: member_runtime.bridge_bootstrap_token().to_owned().into(),
+            },
+        );
+        let request_receipt = supervisor_runtime
+            .send(CommsCommand::PeerRequest {
+                to: PeerRoute::with_display_name(member_spec.peer_id, member_spec.name.clone()),
+                intent: SUPERVISOR_BRIDGE_INTENT.to_string(),
+                params: serde_json::to_value(&command).expect("serialize bridge command"),
+                blocks: None,
+                handling_mode: HandlingMode::Queue,
+                stream: meerkat_core::comms::InputStreamMode::None,
+            })
+            .await
+            .expect("supervisor sends BindMember over TCP");
+        let meerkat_core::SendReceipt::PeerRequestSent { interaction_id, .. } = request_receipt
+        else {
+            panic!("expected PeerRequestSent receipt, got {request_receipt:?}");
+        };
+
+        let candidate = drain_one_candidate(&member_runtime, "member BindMember request").await;
+        assert_eq!(
+            candidate.interaction.id, interaction_id,
+            "member must receive the correlated bridge request"
+        );
+        assert!(
+            try_handle_supervisor_bridge_command(
+                &adapter,
+                &session_id,
+                &(member_runtime.clone() as Arc<dyn CommsRuntime>),
+                &candidate,
+            )
+            .await,
+            "bridge handler must own BindMember"
+        );
+
+        let response =
+            drain_one_candidate(&supervisor_runtime, "supervisor BindMember rejection").await;
+        assert_eq!(
+            member_peer_handle.response_replied_count(),
+            1,
+            "target must send a terminal bridge rejection instead of timing out on PeerNotFound"
+        );
+        assert!(
+            member_runtime.peers().await.is_empty(),
+            "temporary bind rejection route must not leave the supervisor trusted before bind"
+        );
+        let InteractionContent::Response {
+            in_reply_to,
+            status,
+            result,
+            ..
+        } = response.interaction.content
+        else {
+            panic!(
+                "expected bridge rejection response, got {:?}",
+                response.interaction.content
+            );
+        };
+        assert_eq!(in_reply_to, interaction_id);
+        assert_eq!(status, meerkat_core::interaction::ResponseStatus::Failed);
+        let reply: BridgeReply = serde_json::from_value(result).expect("typed bridge reply");
+        let BridgeReply::Rejected { cause, reason } = reply else {
+            panic!("expected Rejected reply, got {reply:?}");
+        };
+        assert_eq!(cause, BridgeRejectionCause::AddressMismatch);
+        assert!(
+            reason.contains("bind address mismatch"),
+            "rejection should preserve the real bind failure reason, got: {reason}"
         );
     }
 

--- a/meerkat-runtime/src/meerkat_machine/comms_drain.rs
+++ b/meerkat-runtime/src/meerkat_machine/comms_drain.rs
@@ -658,6 +658,22 @@ impl MeerkatMachine {
         }
     }
 
+    pub(crate) async fn direct_peer_endpoint_contains(
+        &self,
+        session_id: &SessionId,
+        endpoint: &crate::meerkat_machine::dsl::PeerEndpoint,
+    ) -> bool {
+        let sessions = self.sessions.read().await;
+        let Some(entry) = sessions.get(session_id) else {
+            return false;
+        };
+        let authority = entry
+            .dsl_authority
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        authority.state.direct_peer_endpoints.contains(endpoint)
+    }
+
     /// Stage a DSL `BindSupervisor` input (Wave 3 D Row 21).
     ///
     /// Returns the classified result from the DSL mutator so callers can


### PR DESCRIPTION
## Summary

Fix external supervisor bridge replies so remote Meerkat mob members can route bridge responses back to the requesting supervisor after bind/wire trust mutations.

The target-side bridge handler now:

- uses the supervisor descriptor carried in the bridge payload to install a scoped response route before replying when needed
- preserves existing supervisor trust instead of blindly removing it after a response
- routes bind-validation failures back to a verified requester instead of letting the caller time out
- makes wire/unwire bridge acks survive idempotent trust-projection races where the comms trust table already reflects the requested state

## Validation

- `./scripts/repo-cargo fmt --all`
- `./scripts/repo-cargo build -p meerkat-mob --example external_bridge_smoke --features integration-real-tests`
- `./scripts/repo-cargo test -p meerkat-runtime bridge_ --quiet`
- Local three-member Meerkat-only smoke: external `local-a -> local-b -> local-c` bind, bidirectional wire, shell-inspection relay, terminal responses.
- Real GCP smoke with two short-lived Debian VMs plus one local target:
  - coordinator on local machine
  - `gcp-a` on VM A, listening over tunnel as `tcp://127.0.0.1:5892`
  - `gcp-b` on VM B, listening over tunnel as `tcp://127.0.0.1:5893`
  - `local-c` on local machine, `tcp://127.0.0.1:5894`
  - all three external members bound and wired through `meerkat-mob`
  - `gcp-a` ran shell inspection on VM A and sent results to `gcp-b`
  - `gcp-b` received/responded, ran shell inspection on VM B, and sent results to `local-c`
  - `local-c` received/responded
  - forbidden scan clean: no `failed to send bridge response`, no `supervisor request ... timed out`, no `timed out after 30000ms`, no `PeerOffline`, no bridge rejection

The GCP VMs were deleted after the smoke: `meerkat-smoke-a-20260602101126`, `meerkat-smoke-b-20260602101126`.
