### PR TITLE
[codex] Promote Homebrew install docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,21 +46,23 @@ The library still comes first; surfaces come second. Pick the entry point that f
 | **Automation** | Durable once/interval/calendar schedules for sessions and mobs | External cron/scheduler required |
 | **Multi-agent** | Session-backed mob members, peer comms, profile-driven teams, flows, and realm-scoped WorkGraph commitments | Single agent or ad hoc delegation |
 | **Portable deployment** | Signed `.mobpack` artifacts with `pack`, `inspect`, `validate`, `deploy`, and `mob web build` | No equivalent portable team artifact flow |
-| **Distribution** | Release binaries, Homebrew tap, SDK auto-runtime, crates, PyPI, npm | Runtime plus dependencies |
+| **Distribution** | Homebrew tap for macOS/Linux, release binaries, SDK auto-runtime, crates, PyPI, npm | Runtime plus dependencies |
 
 Those tools excel at interactive development with rich terminal UIs. Meerkat is for automated pipelines, embedded agents, multi-agent systems, browser-delivered agents, and applications that need programmatic control over lifecycle, credentials, tools, and runtime events.
 
 ## Quick Start
 
 ```bash
-cargo install rkat
+brew install lukacf/meerkat/rkat
 export RKAT_OPENAI_API_KEY=sk-...
 ```
 
-`RKAT_OPENAI_API_KEY`, `RKAT_ANTHROPIC_API_KEY`, and `RKAT_GEMINI_API_KEY` take precedence over the provider-native names (`OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `GEMINI_API_KEY`, `GOOGLE_API_KEY`). Azure OpenAI uses `RKAT_AZURE_OPENAI_API_KEY` plus `RKAT_AZURE_OPENAI_ENDPOINT` (or the unprefixed Azure names). You can also install from the Homebrew tap, use release binaries, or let the Python and TypeScript SDKs auto-resolve `rkat-rpc`:
+The Homebrew tap supports macOS and Linux. On Linux, install Homebrew first from the [Homebrew on Linux](https://docs.brew.sh/Homebrew-on-Linux) instructions, then use the same tap command.
+
+`RKAT_OPENAI_API_KEY`, `RKAT_ANTHROPIC_API_KEY`, and `RKAT_GEMINI_API_KEY` take precedence over the provider-native names (`OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `GEMINI_API_KEY`, `GOOGLE_API_KEY`). Azure OpenAI uses `RKAT_AZURE_OPENAI_API_KEY` plus `RKAT_AZURE_OPENAI_ENDPOINT` (or the unprefixed Azure names). You can also install from release binaries, build from crates.io, or let the Python and TypeScript SDKs auto-resolve `rkat-rpc`:
 
 ```bash
-brew install lukacf/meerkat/rkat
+cargo install rkat
 pip install meerkat-sdk
 npm install @rkat/sdk
 npm install @rkat/web

--- a/docs/guides/cd-and-distribution.md
+++ b/docs/guides/cd-and-distribution.md
@@ -9,7 +9,7 @@ Meerkat publishes one source project across several consumer surfaces:
 | Artifact | Audience | Published as |
 |----------|----------|--------------|
 | Rust crates | Rust library users and surface binaries | crates.io |
-| `rkat` | CLI users | GitHub Release binary, Rust crate binary |
+| `rkat` | CLI users | Homebrew tap for macOS/Linux, GitHub Release binary, Rust crate binary |
 | `rkat-rpc` | SDK backends and JSON-RPC hosts | GitHub Release binary |
 | `rkat-rest` | HTTP/SSE service hosts | GitHub Release binary |
 | `rkat-mcp` | MCP host integrations | GitHub Release binary |
@@ -56,6 +56,25 @@ Release assets include platform archives plus a checksum manifest:
 - `checksums.sha256`
 - `index.json`
 
+## Homebrew Tap
+
+The featured CLI install path is the Homebrew tap:
+
+```bash
+brew install lukacf/meerkat/rkat
+```
+
+The generated formula supports both macOS and Linux release assets. Linux users
+should install Homebrew from the official
+[Homebrew on Linux](https://docs.brew.sh/Homebrew-on-Linux) instructions before
+using the same tap command.
+
+The formula installs `rkat` plus the companion binaries:
+
+- `rkat-rpc`
+- `rkat-rest`
+- `rkat-mcp`
+
 Reduced distributions are source builds of the same crates with a narrower
 feature set, not separate public binaries.
 
@@ -76,9 +95,10 @@ embedding a separate runtime implementation.
 1. Validate the release candidate.
 2. Build platform binaries.
 3. Create the GitHub release and upload binary assets.
-4. Publish Rust crates.
-5. Publish Python and TypeScript packages.
-6. Run install smoke checks for at least one platform.
+4. Update the Homebrew tap formula.
+5. Publish Rust crates.
+6. Publish Python and TypeScript packages.
+7. Run install smoke checks for at least one platform.
 
 Manual release dispatch supports dry-run registry validation. Locally, use:
 
@@ -106,6 +126,7 @@ Registry credentials are independent:
 
 | Registry | Credential |
 |----------|------------|
+| Homebrew tap | `HOMEBREW_TAP_TOKEN` |
 | crates.io | Cargo publish token |
 | PyPI | `PYPI_API_TOKEN` |
 | npm | `NPM_TOKEN` |

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -7,14 +7,13 @@ icon: "bolt"
 ## Install
 
 <Tabs>
-  <Tab title="Rust crate">
-    ```toml Cargo.toml
-    [dependencies]
-    meerkat = { version = "0.6.23", features = ["anthropic", "jsonl-store"] }
-    meerkat-store = "0.6.23"
-    meerkat-tools = "0.6.23"
-    tokio = { version = "1", features = ["full"] }
+  <Tab title="CLI">
+    ```bash
+    brew install lukacf/meerkat/rkat
     ```
+    <Note>
+    The Homebrew tap supports macOS and Linux. On Linux, install Homebrew first from the [Homebrew on Linux](https://docs.brew.sh/Homebrew-on-Linux) instructions, then use the same tap command.
+    </Note>
   </Tab>
   <Tab title="Python">
     ```bash
@@ -32,7 +31,16 @@ icon: "bolt"
     The SDK resolves `rkat-rpc` automatically by default and downloads it when needed. Install the standalone binary only if you want to manage it yourself.
     </Note>
   </Tab>
-  <Tab title="CLI">
+  <Tab title="Rust crate">
+    ```toml Cargo.toml
+    [dependencies]
+    meerkat = { version = "0.6.23", features = ["anthropic", "jsonl-store"] }
+    meerkat-store = "0.6.23"
+    meerkat-tools = "0.6.23"
+    tokio = { version = "1", features = ["full"] }
+    ```
+  </Tab>
+  <Tab title="Cargo">
     ```bash
     cargo install rkat
     ```


### PR DESCRIPTION
## Summary

- Promote `brew install lukacf/meerkat/rkat` as the featured CLI install path in the README and quickstart.
- Document that the Homebrew tap supports both macOS and Linux, with a link to the official Homebrew on Linux setup instructions.
- Add Homebrew tap coverage to the distribution guide, including the companion binaries installed by the formula and the tap token in release credentials.

## Validation

- `git diff --check -- README.md docs/quickstart.mdx docs/guides/cd-and-distribution.md`
- Pre-push hooks passed during `git push -u origin codex/linuxbrew-docs`.
