### PR TITLE
dogma(provider-auth): close Provider/Auth Policy Escapes (Rule 7)

### DIFF
--- a/meerkat-auth-core/src/mcp_oauth.rs
+++ b/meerkat-auth-core/src/mcp_oauth.rs
@@ -21,12 +21,16 @@ use crate::auth_oauth::{
     oauth_refresh_observation,
 };
 use crate::auth_store::{PersistedAuthMode, PersistedTokens, TokenKey, TokenStore};
+use meerkat_core::connection::{BindingId, RealmId};
+use meerkat_core::handles::{
+    AUTH_LEASE_TTL_REFRESH_WINDOW_SECS, CredentialUseDisposition, GeneratedAuthLeaseHandle,
+    LeaseKey, OAuthLoginCredentialFacts,
+};
 
 const MCP_TOKEN_REALM: &str = "mcp-oauth";
 const CALLBACK_PATH: &str = "/mcp/oauth/callback";
 const CLIENT_NAME: &str = "Meerkat rkat";
 pub const MCP_INTERACTIVE_LOGIN_TIMEOUT: Duration = Duration::from_secs(300);
-const REFRESH_SKEW_SECS: i64 = 60;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum McpAuthMode {
@@ -61,6 +65,27 @@ impl McpAuthTarget {
                 reason: error.to_string(),
             },
         )
+    }
+
+    /// The per-binding `AuthMachine` lease key for this MCP server, structurally
+    /// identical to [`token_key`](Self::token_key) (realm `mcp-oauth` + the
+    /// `<slug>-<digest>` binding slug). The credential-freshness / reauth
+    /// decision for MCP-OAuth bearer tokens is owned by the `AuthMachine` keyed
+    /// on this lease — the authority never re-derives expiry policy.
+    pub fn lease_key(&self) -> Result<LeaseKey, McpOAuthError> {
+        let mut hasher = Sha256::new();
+        hasher.update(self.server_name.as_bytes());
+        hasher.update(b"\0");
+        hasher.update(self.server_url.as_bytes());
+        let digest = URL_SAFE_NO_PAD.encode(hasher.finalize());
+        let name_slug = slug_component(&self.server_name);
+        let to_err = |error: meerkat_core::connection::IdentityError| McpOAuthError::TokenKey {
+            server_name: self.server_name.clone(),
+            reason: error.to_string(),
+        };
+        let realm = RealmId::parse(MCP_TOKEN_REALM).map_err(to_err)?;
+        let binding = BindingId::parse(format!("{name_slug}-{}", &digest[..16])).map_err(to_err)?;
+        Ok(LeaseKey::new(realm, binding, None))
     }
 }
 
@@ -128,6 +153,8 @@ pub enum McpOAuthError {
     MissingStoredMetadata { server_name: String },
     #[error("MCP OAuth stored credentials for '{server_name}' require reauth")]
     ReauthRequired { server_name: String },
+    #[error("MCP OAuth credential lifecycle error for '{server_name}': {reason}")]
+    AuthLifecycle { server_name: String, reason: String },
 }
 
 #[derive(Clone)]
@@ -136,15 +163,26 @@ pub struct McpOAuthAuthority {
     token_store: Arc<dyn TokenStore>,
     browser: Arc<dyn BrowserOpener>,
     login_timeout: Duration,
+    /// Generated `AuthMachine` lease handle that owns the credential
+    /// freshness/refresh/reauth decision for the `mcp-oauth` realm. Injected by
+    /// the surface that owns the runtime (the CLI) — `meerkat-auth-core` sits
+    /// below `meerkat-runtime` in the dep graph and cannot mint a certified
+    /// handle itself.
+    auth_lease: GeneratedAuthLeaseHandle,
 }
 
 impl McpOAuthAuthority {
-    pub fn new(token_store: Arc<dyn TokenStore>, browser: Arc<dyn BrowserOpener>) -> Self {
+    pub fn new(
+        token_store: Arc<dyn TokenStore>,
+        browser: Arc<dyn BrowserOpener>,
+        auth_lease: GeneratedAuthLeaseHandle,
+    ) -> Self {
         Self {
             http: Client::new(),
             token_store,
             browser,
             login_timeout: MCP_INTERACTIVE_LOGIN_TIMEOUT,
+            auth_lease,
         }
     }
 
@@ -152,12 +190,14 @@ impl McpOAuthAuthority {
         token_store: Arc<dyn TokenStore>,
         browser: Arc<dyn BrowserOpener>,
         http: Client,
+        auth_lease: GeneratedAuthLeaseHandle,
     ) -> Self {
         Self {
             http,
             token_store,
             browser,
             login_timeout: MCP_INTERACTIVE_LOGIN_TIMEOUT,
+            auth_lease,
         }
     }
 
@@ -167,12 +207,14 @@ impl McpOAuthAuthority {
         browser: Arc<dyn BrowserOpener>,
         http: Client,
         login_timeout: Duration,
+        auth_lease: GeneratedAuthLeaseHandle,
     ) -> Self {
         Self {
             http,
             token_store,
             browser,
             login_timeout,
+            auth_lease,
         }
     }
 
@@ -281,51 +323,101 @@ impl McpOAuthAuthority {
         let Some(expires_at) = tokens.expires_at else {
             return Ok(tokens);
         };
-        if expires_at > Utc::now() + chrono::Duration::seconds(REFRESH_SKEW_SECS) {
-            return Ok(tokens);
-        }
-        let Some(refresh_token) = tokens.refresh_token.clone() else {
-            return Err(McpOAuthError::ReauthRequired {
+
+        // Route the cached-vs-refresh-vs-reauth decision through the injected
+        // per-binding `AuthMachine` lease for the `mcp-oauth` realm. The machine
+        // owns the freshness policy (observed expiry vs the canonical refresh
+        // window); this authority only feeds it the expiry and the pure
+        // OAuth-login facts, then mirrors the verdict. No local skew comparison.
+        let auth_lease = &self.auth_lease;
+        let lease_key = target.lease_key()?;
+        let now_secs = epoch_secs(Utc::now());
+        let lifecycle_err =
+            |error: meerkat_core::handles::DslTransitionError| McpOAuthError::AuthLifecycle {
                 server_name: target.server_name.clone(),
-            });
+                reason: error.to_string(),
+            };
+        // The handle is shared across calls and servers; reset this key's prior
+        // lease state, then record the current credential's expiry so the
+        // freshness verdict reflects THIS token. Release is best-effort: an
+        // untracked key has nothing to clear.
+        let _ = auth_lease.release_lease(&lease_key);
+        auth_lease
+            .acquire_lease(&lease_key, epoch_secs(expires_at))
+            .map_err(lifecycle_err)?;
+        auth_lease
+            .observe_credential_freshness(&lease_key, now_secs, AUTH_LEASE_TTL_REFRESH_WINDOW_SECS)
+            .map_err(lifecycle_err)?;
+        let facts = OAuthLoginCredentialFacts {
+            credential_present: tokens.primary_secret.is_some(),
+            force_refresh: false,
+            refresh_allowed: tokens.refresh_token.is_some(),
         };
-        let endpoints = OAuthEndpoints {
-            client_id: metadata.client.client_id.clone(),
-            authorize_url: metadata.discovery.authorization_endpoint.clone(),
-            token_url: metadata.discovery.token_endpoint.clone(),
-            device_code_url: None,
-            redirect_uri: metadata.client.redirect_uri.clone(),
-            scopes: metadata.discovery.scopes.clone(),
-            extra_authorize_params: Vec::new(),
-            token_request_format: OAuthTokenRequestFormat::FormUrlEncoded,
-            include_state_in_token_exchange: false,
-            extra_token_params: vec![("resource".to_string(), metadata.discovery.resource.clone())],
-            refresh_scopes: metadata.discovery.scopes.clone(),
-            extra_headers: Vec::new(),
-        };
-        let refreshed = exchange_refresh_token(
-            &self.http,
-            &endpoints,
-            &refresh_token,
-            metadata.client.client_secret.as_deref(),
-        )
-        .await
-        .map_err(|error| map_refresh_error(target, error))?;
-        let mut persisted = persisted_tokens_from_result(
-            &refreshed,
-            &metadata.discovery,
-            &metadata.client,
-            target,
-            Utc::now(),
-        )?;
-        if persisted.refresh_token.is_none() {
-            persisted.refresh_token = Some(refresh_token);
+        let disposition = auth_lease
+            .resolve_oauth_login_credential_disposition(&lease_key, facts)
+            .map_err(lifecycle_err)?;
+        match disposition {
+            // The machine authorizes the cached credential as fresh.
+            CredentialUseDisposition::Authorized => Ok(tokens),
+            // The machine asks for a refresh: run the OAuth refresh exchange.
+            CredentialUseDisposition::RefreshRequired => {
+                let Some(refresh_token) = tokens.refresh_token.clone() else {
+                    return Err(McpOAuthError::ReauthRequired {
+                        server_name: target.server_name.clone(),
+                    });
+                };
+                let endpoints = OAuthEndpoints {
+                    client_id: metadata.client.client_id.clone(),
+                    authorize_url: metadata.discovery.authorization_endpoint.clone(),
+                    token_url: metadata.discovery.token_endpoint.clone(),
+                    device_code_url: None,
+                    redirect_uri: metadata.client.redirect_uri.clone(),
+                    scopes: metadata.discovery.scopes.clone(),
+                    extra_authorize_params: Vec::new(),
+                    token_request_format: OAuthTokenRequestFormat::FormUrlEncoded,
+                    include_state_in_token_exchange: false,
+                    extra_token_params: vec![(
+                        "resource".to_string(),
+                        metadata.discovery.resource.clone(),
+                    )],
+                    refresh_scopes: metadata.discovery.scopes.clone(),
+                    extra_headers: Vec::new(),
+                };
+                let refreshed = exchange_refresh_token(
+                    &self.http,
+                    &endpoints,
+                    &refresh_token,
+                    metadata.client.client_secret.as_deref(),
+                )
+                .await
+                .map_err(|error| map_refresh_error(target, error))?;
+                let mut persisted = persisted_tokens_from_result(
+                    &refreshed,
+                    &metadata.discovery,
+                    &metadata.client,
+                    target,
+                    Utc::now(),
+                )?;
+                if persisted.refresh_token.is_none() {
+                    persisted.refresh_token = Some(refresh_token);
+                }
+                self.token_store
+                    .save(key, &persisted)
+                    .await
+                    .map_err(|error| McpOAuthError::TokenStore(error.to_string()))?;
+                Ok(persisted)
+            }
+            // Refresh is not permitted or the credential is otherwise unusable:
+            // the user must reauthenticate. (`LeaseAbsent`/`AlreadyRefreshing`
+            // cannot arise for a freshly acquired single-shot lease, but are
+            // handled exhaustively and fail closed to reauth.)
+            CredentialUseDisposition::RefreshDisallowed
+            | CredentialUseDisposition::ReauthRequired
+            | CredentialUseDisposition::LeaseAbsent
+            | CredentialUseDisposition::AlreadyRefreshing => Err(McpOAuthError::ReauthRequired {
+                server_name: target.server_name.clone(),
+            }),
         }
-        self.token_store
-            .save(key, &persisted)
-            .await
-            .map_err(|error| McpOAuthError::TokenStore(error.to_string()))?;
-        Ok(persisted)
     }
 
     async fn discover(
@@ -616,6 +708,12 @@ fn map_refresh_error(target: &McpAuthTarget, error: OAuthError) -> McpOAuthError
     }
 }
 
+/// Whole seconds since the Unix epoch, clamped to a non-negative `u64` for the
+/// `AuthMachine` lease lifecycle inputs.
+fn epoch_secs(time: DateTime<Utc>) -> u64 {
+    time.timestamp().max(0) as u64
+}
+
 fn resource_metadata_from_header(header: &str) -> Option<String> {
     auth_param(header, "resource_metadata")
 }
@@ -792,6 +890,17 @@ mod tests {
     use serde_json::Value;
     use std::collections::HashMap;
     use tokio::net::TcpListener;
+
+    /// A certified `AuthMachine` lease handle for tests. `meerkat-runtime` is a
+    /// dev-dependency, so tests can mint the same generated lease the CLI
+    /// injects in production (the lib cannot, to avoid a dep cycle).
+    fn test_auth_lease() -> GeneratedAuthLeaseHandle {
+        let handle = Arc::new(meerkat_runtime::RuntimeAuthLeaseHandle::new());
+        meerkat_runtime::protocol_auth_lease_lifecycle_publication::generated_auth_lease_handle(
+            handle,
+        )
+        .expect("test auth lease must be certified by generated AuthMachine authority")
+    }
 
     #[derive(Debug, Clone, Copy, Default)]
     enum AuthorizeOutcome {
@@ -1072,7 +1181,8 @@ mod tests {
         let (base, state) = spawn_oauth_fixture().await;
         let store = Arc::new(EphemeralTokenStore::new());
         let browser = recording_browser(Arc::clone(&state));
-        let authority = McpOAuthAuthority::with_http(store.clone(), browser, Client::new());
+        let authority =
+            McpOAuthAuthority::with_http(store.clone(), browser, Client::new(), test_auth_lease());
         let target = McpAuthTarget::new("glean", format!("{base}/mcp"));
         let token = authority
             .interactive_login(
@@ -1138,7 +1248,8 @@ mod tests {
         let (base, state) = spawn_oauth_fixture().await;
         let store = Arc::new(EphemeralTokenStore::new());
         let browser = recording_browser(Arc::clone(&state));
-        let authority = McpOAuthAuthority::with_http(store.clone(), browser, Client::new());
+        let authority =
+            McpOAuthAuthority::with_http(store.clone(), browser, Client::new(), test_auth_lease());
         let target = McpAuthTarget::new("glean", format!("{base}/mcp"));
 
         let token = authority
@@ -1163,7 +1274,8 @@ mod tests {
         let (base, state) = spawn_oauth_fixture().await;
         let store = Arc::new(EphemeralTokenStore::new());
         let browser = recording_browser(Arc::clone(&state));
-        let authority = McpOAuthAuthority::with_http(store.clone(), browser, Client::new());
+        let authority =
+            McpOAuthAuthority::with_http(store.clone(), browser, Client::new(), test_auth_lease());
         let target = McpAuthTarget::new("glean", format!("{base}/mcp"));
 
         authority
@@ -1195,7 +1307,8 @@ mod tests {
         let (base, state) = spawn_oauth_fixture().await;
         let store = Arc::new(EphemeralTokenStore::new());
         let browser = recording_browser(Arc::clone(&state));
-        let authority = McpOAuthAuthority::with_http(store.clone(), browser, Client::new());
+        let authority =
+            McpOAuthAuthority::with_http(store.clone(), browser, Client::new(), test_auth_lease());
         let original = McpAuthTarget::new("glean", format!("{base}/mcp"));
         let other = McpAuthTarget::new("glean", format!("{base}/other-mcp"));
 
@@ -1227,7 +1340,8 @@ mod tests {
         *state.include_registration_endpoint.lock() = false;
         let store = Arc::new(EphemeralTokenStore::new());
         let browser = recording_browser(Arc::clone(&state));
-        let authority = McpOAuthAuthority::with_http(store.clone(), browser, Client::new());
+        let authority =
+            McpOAuthAuthority::with_http(store.clone(), browser, Client::new(), test_auth_lease());
         let target = McpAuthTarget::new("glean", format!("{base}/mcp"));
 
         let result = authority.interactive_login(&target, None).await;
@@ -1252,7 +1366,8 @@ mod tests {
         *state.omit_token_endpoint_auth_method.lock() = true;
         let store = Arc::new(EphemeralTokenStore::new());
         let browser = recording_browser(Arc::clone(&state));
-        let authority = McpOAuthAuthority::with_http(store.clone(), browser, Client::new());
+        let authority =
+            McpOAuthAuthority::with_http(store.clone(), browser, Client::new(), test_auth_lease());
         let target = McpAuthTarget::new("glean", format!("{base}/mcp"));
 
         let result = authority.interactive_login(&target, None).await;
@@ -1277,7 +1392,8 @@ mod tests {
         *state.resource_override.lock() = Some(format!("{base}/other-mcp"));
         let store = Arc::new(EphemeralTokenStore::new());
         let browser = recording_browser(Arc::clone(&state));
-        let authority = McpOAuthAuthority::with_http(store.clone(), browser, Client::new());
+        let authority =
+            McpOAuthAuthority::with_http(store.clone(), browser, Client::new(), test_auth_lease());
         let target = McpAuthTarget::new("glean", format!("{base}/mcp"));
 
         let result = authority.interactive_login(&target, None).await;
@@ -1302,7 +1418,8 @@ mod tests {
         *state.resource_override.lock() = Some("/mcp".to_string());
         let store = Arc::new(EphemeralTokenStore::new());
         let browser = recording_browser(Arc::clone(&state));
-        let authority = McpOAuthAuthority::with_http(store.clone(), browser, Client::new());
+        let authority =
+            McpOAuthAuthority::with_http(store.clone(), browser, Client::new(), test_auth_lease());
         let target = McpAuthTarget::new("glean", format!("{base}/mcp"));
 
         let result = authority.interactive_login(&target, None).await;
@@ -1322,7 +1439,8 @@ mod tests {
         let (_base, state) = spawn_oauth_fixture().await;
         let store = Arc::new(EphemeralTokenStore::new());
         let browser = recording_browser(Arc::clone(&state));
-        let authority = McpOAuthAuthority::with_http(store.clone(), browser, Client::new());
+        let authority =
+            McpOAuthAuthority::with_http(store.clone(), browser, Client::new(), test_auth_lease());
         let target = McpAuthTarget::new("glean", "http://mcp.example.test/mcp");
 
         let result = authority.interactive_login(&target, None).await;
@@ -1347,7 +1465,8 @@ mod tests {
         *state.issuer_override.lock() = Some("https://issuer.example.invalid".to_string());
         let store = Arc::new(EphemeralTokenStore::new());
         let browser = recording_browser(Arc::clone(&state));
-        let authority = McpOAuthAuthority::with_http(store.clone(), browser, Client::new());
+        let authority =
+            McpOAuthAuthority::with_http(store.clone(), browser, Client::new(), test_auth_lease());
         let target = McpAuthTarget::new("glean", format!("{base}/mcp"));
 
         let result = authority.interactive_login(&target, None).await;
@@ -1372,7 +1491,8 @@ mod tests {
         *state.issuer_override.lock() = Some(format!("{base}/"));
         let store = Arc::new(EphemeralTokenStore::new());
         let browser = recording_browser(Arc::clone(&state));
-        let authority = McpOAuthAuthority::with_http(store.clone(), browser, Client::new());
+        let authority =
+            McpOAuthAuthority::with_http(store.clone(), browser, Client::new(), test_auth_lease());
         let target = McpAuthTarget::new("glean", format!("{base}/mcp"));
 
         let result = authority.interactive_login(&target, None).await;
@@ -1418,7 +1538,8 @@ mod tests {
         *state.token_fails.lock() = true;
         let store = Arc::new(EphemeralTokenStore::new());
         let browser = recording_browser(Arc::clone(&state));
-        let authority = McpOAuthAuthority::with_http(store.clone(), browser, Client::new());
+        let authority =
+            McpOAuthAuthority::with_http(store.clone(), browser, Client::new(), test_auth_lease());
         let target = McpAuthTarget::new("glean", format!("{base}/mcp"));
 
         let result = authority.interactive_login(&target, None).await;
@@ -1433,7 +1554,8 @@ mod tests {
         *state.authorize_outcome.lock() = AuthorizeOutcome::StateMismatch;
         let store = Arc::new(EphemeralTokenStore::new());
         let browser = recording_browser(Arc::clone(&state));
-        let authority = McpOAuthAuthority::with_http(store.clone(), browser, Client::new());
+        let authority =
+            McpOAuthAuthority::with_http(store.clone(), browser, Client::new(), test_auth_lease());
         let target = McpAuthTarget::new("glean", format!("{base}/mcp"));
 
         let result = authority.interactive_login(&target, None).await;
@@ -1448,7 +1570,8 @@ mod tests {
         *state.authorize_outcome.lock() = AuthorizeOutcome::Denied;
         let store = Arc::new(EphemeralTokenStore::new());
         let browser = recording_browser(Arc::clone(&state));
-        let authority = McpOAuthAuthority::with_http(store.clone(), browser, Client::new());
+        let authority =
+            McpOAuthAuthority::with_http(store.clone(), browser, Client::new(), test_auth_lease());
         let target = McpAuthTarget::new("glean", format!("{base}/mcp"));
 
         let result = authority.interactive_login(&target, None).await;
@@ -1469,6 +1592,7 @@ mod tests {
             browser,
             Client::new(),
             Duration::from_millis(10),
+            test_auth_lease(),
         );
         let target = McpAuthTarget::new("glean", format!("{base}/mcp"));
 

--- a/meerkat-cli/src/main.rs
+++ b/meerkat-cli/src/main.rs
@@ -3085,11 +3085,6 @@ async fn handle_run_command(
     match (duration, provider_params, provider_params_json) {
         (Ok(dur), Ok(parsed_params), Ok(parsed_params_json)) => {
             let merged_provider_params = merge_provider_params(parsed_params, parsed_params_json)?;
-            let merged_provider_params = apply_no_web_search_provider_param(
-                resolved_provider,
-                merged_provider_params,
-                no_web_search,
-            )?;
             let mut limits = config.budget_limits();
             if let Some(max_duration) = dur {
                 limits.max_duration = Some(max_duration);
@@ -3111,6 +3106,7 @@ async fn handle_run_command(
                 stream,
                 stream_policy.clone(),
                 merged_provider_params,
+                no_web_search,
                 parsed_output_schema,
                 None,
                 comms_overrides,
@@ -3206,60 +3202,6 @@ fn merge_provider_params(
             "provider params must be JSON objects after parsing"
         )),
     }
-}
-
-fn provider_web_search_param_key(provider: Provider) -> Option<&'static str> {
-    match provider {
-        Provider::Anthropic | Provider::Openai => Some("web_search"),
-        Provider::Gemini => Some("google_search"),
-        Provider::SelfHosted => None,
-    }
-}
-
-fn apply_no_web_search_provider_param(
-    provider: Provider,
-    provider_params: Option<serde_json::Value>,
-    no_web_search: bool,
-) -> anyhow::Result<Option<serde_json::Value>> {
-    if !no_web_search {
-        return Ok(provider_params);
-    }
-
-    let Some(key) = provider_web_search_param_key(provider) else {
-        return Ok(provider_params);
-    };
-
-    let mut opt_out = serde_json::Map::new();
-    opt_out.insert(key.to_string(), serde_json::Value::Null);
-    let opt_out = Some(serde_json::Value::Object(opt_out));
-    merge_provider_params(opt_out, provider_params)
-}
-
-fn apply_no_web_search_resume_provider_params(
-    provider: Option<Provider>,
-    model_override_provider: Option<Provider>,
-    stored_provider: meerkat_core::Provider,
-    stored_provider_params: Option<&serde_json::Value>,
-    merged_provider_params: &mut Option<serde_json::Value>,
-    no_web_search: bool,
-) -> anyhow::Result<()> {
-    if !no_web_search {
-        return Ok(());
-    }
-
-    let Some(web_search_provider) = provider
-        .or(model_override_provider)
-        .or_else(|| Provider::from_core(stored_provider))
-    else {
-        return Ok(());
-    };
-
-    let base_params = merged_provider_params
-        .take()
-        .or_else(|| stored_provider_params.cloned());
-    *merged_provider_params =
-        apply_no_web_search_provider_param(web_search_provider, base_params, true)?;
-    Ok(())
 }
 
 fn looks_like_path(raw: &str) -> bool {
@@ -3727,11 +3669,12 @@ async fn load_config(scope: &RuntimeScope) -> anyhow::Result<(Config, PathBuf)> 
 /// purpose is to detect a stale, previously-shipped default that a user still
 /// carries in their persisted `config.agent.model` and heal it by redirecting
 /// to the catalog-derived current default (see `resolve_cli_default_agent_model`
-/// → `best_available_default_model`). Because it must match what *older* CLI
-/// builds wrote, it deliberately retains retired model IDs that no longer exist
-/// in the catalog, so it cannot — and must not — be catalog-bound. Append the
-/// prior default here whenever the built-in default changes; never remove
-/// entries.
+/// → `best_available_default_model`). Entries are prior *shipped CLI defaults*,
+/// not catalog membership claims: a listed model may still be a live catalog
+/// row (e.g. `claude-opus-4-7` remains a `Supported` Anthropic entry) — being
+/// here only means it was once the built-in default and should be healed when
+/// still persisted. Append the prior default here whenever the built-in default
+/// changes; never remove entries.
 ///
 /// Covered by `test_resolve_cli_default_agent_model_heals_legacy_builtin_default`.
 const LEGACY_AGENT_MODEL_DEFAULTS: &[&str] = &["claude-opus-4-7"];
@@ -3755,8 +3698,9 @@ fn provider_default_model(config: &Config, provider: Provider) -> Option<String>
 }
 
 fn best_available_default_model(config: &Config) -> String {
-    [Provider::Openai, Provider::Anthropic, Provider::Gemini]
-        .into_iter()
+    meerkat_core::model_profile::catalog::provider_priority()
+        .iter()
+        .filter_map(|core_p| Provider::from_core(*core_p))
         .find_map(|provider| provider_default_model(config, provider))
         .unwrap_or_else(|| config.agent.model.clone())
 }
@@ -4582,12 +4526,20 @@ impl LoginProvider {
         }
     }
 
-    fn oauth_auth_method(self) -> &'static str {
+    fn normalized_auth_method(self) -> meerkat_providers::NormalizedAuthMethod {
+        use meerkat_core::provider_matrix::anthropic::AnthropicAuthMethod;
+        use meerkat_core::provider_matrix::google::GoogleAuthMethod;
+        use meerkat_core::provider_matrix::openai::OpenAiAuthMethod;
+        use meerkat_providers::NormalizedAuthMethod;
         match self {
-            Self::Anthropic => "claude_ai_oauth",
-            Self::OpenAi => "managed_chatgpt_oauth",
-            Self::Google => "google_oauth",
+            Self::Anthropic => NormalizedAuthMethod::Anthropic(AnthropicAuthMethod::ClaudeAiOauth),
+            Self::OpenAi => NormalizedAuthMethod::OpenAi(OpenAiAuthMethod::ManagedChatGptOauth),
+            Self::Google => NormalizedAuthMethod::Google(GoogleAuthMethod::GoogleOauth),
         }
+    }
+
+    fn oauth_auth_method(self) -> &'static str {
+        self.normalized_auth_method().as_str()
     }
 
     fn oauth_alias(self) -> &'static str {
@@ -5304,14 +5256,23 @@ async fn noninteractive_login(
         );
     }
 
-    let backend =
-        backend_hint
-            .map(ToString::to_string)
-            .unwrap_or_else(|| match provider_lc.as_str() {
-                "anthropic" => "anthropic_api".to_string(),
-                "openai" => "openai_api".to_string(),
-                _ => "google_genai".to_string(),
-            });
+    let backend = match backend_hint {
+        Some(hint) => hint.to_string(),
+        None => {
+            let provider_enum =
+                meerkat_core::Provider::parse_strict(&provider_lc).ok_or_else(|| {
+                    anyhow::anyhow!(
+                        "unknown provider '{provider}' — expected anthropic / openai / gemini"
+                    )
+                })?;
+            meerkat_providers::NormalizedBackendKind::default_for_provider(provider_enum)
+                .ok_or_else(|| {
+                    anyhow::anyhow!("provider '{provider}' has no default backend kind")
+                })?
+                .as_str()
+                .to_string()
+        }
+    };
 
     let secret_value = match secret {
         Some(s) if !s.trim().is_empty() => s.trim().to_string(),
@@ -8506,6 +8467,7 @@ async fn run_agent(
     stream: bool,
     stream_policy: Option<stream_renderer::StreamRenderPolicy>,
     provider_params: Option<serde_json::Value>,
+    no_web_search: bool,
     output_schema: Option<OutputSchema>,
     structured_output_retries: Option<u32>,
     comms_overrides: CommsOverrides,
@@ -8548,6 +8510,7 @@ async fn run_agent(
             stream,
             stream_policy,
             provider_params,
+            no_web_search,
             output_schema,
             structured_output_retries,
             comms_overrides,
@@ -8781,7 +8744,11 @@ async fn run_agent(
             ),
             override_mob: meerkat_core::ToolCategoryOverride::Inherit,
             override_image_generation: meerkat_core::ToolCategoryOverride::Inherit,
-            override_web_search: meerkat_core::ToolCategoryOverride::Inherit,
+            override_web_search: if no_web_search {
+                meerkat_core::ToolCategoryOverride::Disable
+            } else {
+                meerkat_core::ToolCategoryOverride::Inherit
+            },
             schedule_tools: None,
             workgraph_tools: None,
             mob_tool_authority_context: None,
@@ -9214,7 +9181,7 @@ async fn resume_session_with_llm_override(
         let stream = resolve_stream_enabled(stream, no_stream, output.format.streams_by_default())?;
         let parsed_params = parse_provider_params(&params)?;
         let parsed_params_json = parse_provider_params_json(provider_params_json)?;
-        let mut merged_provider_params = merge_provider_params(parsed_params, parsed_params_json)?;
+        let merged_provider_params = merge_provider_params(parsed_params, parsed_params_json)?;
         let parsed_output_schema = output_schema
             .as_ref()
             .map(|s| parse_output_schema(s))
@@ -9271,24 +9238,6 @@ async fn resume_session_with_llm_override(
         } else {
             model
         };
-        let model_override_provider = if provider.is_none() {
-            model_override
-                .as_deref()
-                .map(|model_override| resolve_cli_provider(&config, model_override, None))
-                .transpose()?
-        } else {
-            None
-        };
-
-        apply_no_web_search_resume_provider_params(
-            provider,
-            model_override_provider,
-            stored_metadata.provider,
-            stored_metadata.provider_params.as_ref(),
-            &mut merged_provider_params,
-            no_web_search,
-        )?;
-
         let mut limits = build_state
             .budget_limits
             .clone()
@@ -9468,6 +9417,7 @@ async fn resume_session_with_llm_override(
             override_memory: explicit_tooling.map(|resolved| resolved.memory),
             override_workgraph: explicit_tooling.map(|resolved| resolved.workgraph),
             override_mob: explicit_tooling.map(|resolved| resolved.mob),
+            override_web_search: if no_web_search { Some(true) } else { None },
             preload_skills: resumed_preload_skills,
             app_context: parsed_app_context,
             ..Default::default()
@@ -18368,102 +18318,6 @@ capabilities = ["definitely_missing_capability"]
         Ok(())
     }
 
-    #[test]
-    fn test_no_web_search_provider_param_uses_provider_native_key()
-    -> Result<(), Box<dyn std::error::Error>> {
-        let openai = apply_no_web_search_provider_param(
-            Provider::Openai,
-            Some(serde_json::json!({
-                "reasoning_effort": "high",
-                "web_search": {"type": "web_search"}
-            })),
-            true,
-        )?
-        .expect("OpenAI opt-out params");
-        assert_eq!(openai["reasoning_effort"], "high");
-        assert!(
-            openai
-                .get("web_search")
-                .is_some_and(serde_json::Value::is_null)
-        );
-
-        let gemini = apply_no_web_search_provider_param(Provider::Gemini, None, true)?
-            .expect("Gemini opt-out params");
-        assert!(
-            gemini
-                .get("google_search")
-                .is_some_and(serde_json::Value::is_null)
-        );
-        assert!(gemini.get("web_search").is_none());
-
-        let self_hosted = apply_no_web_search_provider_param(Provider::SelfHosted, None, true)?;
-        assert!(self_hosted.is_none());
-        Ok(())
-    }
-
-    #[test]
-    fn test_no_web_search_resume_params_preserve_resume_precedence()
-    -> Result<(), Box<dyn std::error::Error>> {
-        let stored = serde_json::json!({
-            "temperature": 0.1,
-            "web_search": {"type": "web_search"}
-        });
-        let mut inherited = None;
-        apply_no_web_search_resume_provider_params(
-            None,
-            None,
-            meerkat_core::Provider::OpenAI,
-            Some(&stored),
-            &mut inherited,
-            true,
-        )?;
-        let inherited = inherited.expect("stored params plus opt-out");
-        assert_eq!(inherited["temperature"], 0.1);
-        assert!(
-            inherited
-                .get("web_search")
-                .is_some_and(serde_json::Value::is_null)
-        );
-
-        let mut explicit = Some(serde_json::json!({"reasoning_effort": "high"}));
-        apply_no_web_search_resume_provider_params(
-            None,
-            None,
-            meerkat_core::Provider::OpenAI,
-            Some(&stored),
-            &mut explicit,
-            true,
-        )?;
-        let explicit = explicit.expect("explicit params plus opt-out");
-        assert_eq!(explicit["reasoning_effort"], "high");
-        assert!(explicit.get("temperature").is_none());
-        assert!(
-            explicit
-                .get("web_search")
-                .is_some_and(serde_json::Value::is_null)
-        );
-
-        let mut model_override = Some(serde_json::json!({"top_p": 0.8}));
-        apply_no_web_search_resume_provider_params(
-            None,
-            Some(Provider::Gemini),
-            meerkat_core::Provider::OpenAI,
-            Some(&stored),
-            &mut model_override,
-            true,
-        )?;
-        let model_override = model_override.expect("model override params plus opt-out");
-        assert_eq!(model_override["top_p"], 0.8);
-        assert!(model_override.get("web_search").is_none());
-        assert!(
-            model_override
-                .get("google_search")
-                .is_some_and(serde_json::Value::is_null)
-        );
-
-        Ok(())
-    }
-
     fn create_mobpack_fixture_dir(base: &std::path::Path) -> PathBuf {
         let mob_dir = base.join("fixture-mob");
         std::fs::create_dir_all(mob_dir.join("skills")).expect("create skills dir");
@@ -19703,9 +19557,17 @@ capabilities = ["definitely_missing_capability"]
     fn test_resolve_cli_default_agent_model_heals_legacy_builtin_default() {
         let mut config = Config::default();
         config.agent.model = "claude-opus-4-7".to_string();
+        // A legacy builtin default heals to the highest-priority available
+        // provider's configured model. Priority is owned by the catalog seam
+        // (`meerkat_core::model_profile::catalog::provider_priority()` —
+        // anthropic first), so even with a customized OpenAI model the heal
+        // resolves to anthropic, not whichever provider happened to be set.
         config.models.openai = "gpt-5.5-custom".to_string();
 
-        assert_eq!(resolve_cli_default_agent_model(&config), "gpt-5.5-custom");
+        assert_eq!(
+            resolve_cli_default_agent_model(&config),
+            config.models.anthropic
+        );
     }
 
     #[test]

--- a/meerkat-cli/src/main.rs
+++ b/meerkat-cli/src/main.rs
@@ -7114,6 +7114,23 @@ fn open_mcp_auth_resolver(
     Ok(Some(Arc::new(open_mcp_oauth_authority(mode)?)))
 }
 
+/// Mint a certified `AuthMachine` lease handle for the `mcp-oauth` realm.
+///
+/// `meerkat-auth-core` sits below `meerkat-runtime` in the dep graph, so the
+/// MCP-OAuth authority cannot mint its own generated lease — the CLI (which
+/// owns the runtime) injects one, exactly as the provider-auth path does via
+/// `new_cli_auth_lease`. The lease realm is independent of the LLM provider
+/// auth bindings.
+#[cfg(feature = "mcp")]
+fn new_cli_mcp_oauth_auth_lease() -> anyhow::Result<meerkat_core::handles::GeneratedAuthLeaseHandle>
+{
+    let auth_lease = Arc::new(meerkat_runtime::RuntimeAuthLeaseHandle::new());
+    meerkat_runtime::protocol_auth_lease_lifecycle_publication::generated_auth_lease_handle(
+        auth_lease,
+    )
+    .map_err(|reason| anyhow::anyhow!("MCP-OAuth auth lease certification failed: {reason}"))
+}
+
 #[cfg(feature = "mcp")]
 fn open_mcp_oauth_authority(
     mode: CliMcpAuthMode,
@@ -7123,7 +7140,10 @@ fn open_mcp_oauth_authority(
         .open()
         .map_err(|error| anyhow::anyhow!("Cannot open MCP OAuth TokenStore: {error}"))?;
     let browser: Arc<dyn meerkat_auth_core::BrowserOpener> = Arc::new(CliMcpBrowserOpener { mode });
-    Ok(meerkat_auth_core::McpOAuthAuthority::new(store, browser))
+    let auth_lease = new_cli_mcp_oauth_auth_lease()?;
+    Ok(meerkat_auth_core::McpOAuthAuthority::new(
+        store, browser, auth_lease,
+    ))
 }
 
 #[cfg(feature = "mcp")]

--- a/meerkat-core/src/agent/state.rs
+++ b/meerkat-core/src/agent/state.rs
@@ -1786,12 +1786,14 @@ where
                         {
                             obj.insert("structured_output".to_string(), output_schema.to_value());
                         }
-                        // Strip provider-native tool keys — extraction is deterministic, no tools.
-                        if let Some(obj) = params.as_object_mut() {
-                            obj.remove("web_search");
-                            obj.remove("google_search");
-                        }
-                        effective_provider_params = Some(params);
+                        // Strip the provider-native web-search/grounding body via the typed
+                        // ProviderTag owner — extraction is deterministic and tool-free.
+                        let mut typed = ProviderParamsOverride::from_legacy_provider_value(
+                            self.client.provider(),
+                            &params,
+                        );
+                        typed.clear_web_search();
+                        effective_provider_params = Some(typed.to_legacy_provider_value());
                     }
 
                     // No tools for extraction turn (empty slice)

--- a/meerkat-core/src/lifecycle/run_primitive.rs
+++ b/meerkat-core/src/lifecycle/run_primitive.rs
@@ -1021,6 +1021,18 @@ impl ProviderParamsOverride {
         }
         serde_json::Value::Object(object)
     }
+
+    /// Clear any provider-native web-search / grounding tool body from this
+    /// override. Used when an extraction (deterministic, tool-free) turn must
+    /// suppress web search without re-deriving provider-native key names.
+    pub fn clear_web_search(&mut self) {
+        match self.provider_tag.as_mut() {
+            Some(ProviderTag::Anthropic(t)) => t.web_search = None,
+            Some(ProviderTag::OpenAi(t)) => t.web_search = None,
+            Some(ProviderTag::Gemini(t)) => t.google_search = None,
+            _ => {}
+        }
+    }
 }
 
 fn parse_reasoning_mode(value: &str) -> Option<ReasoningMode> {

--- a/meerkat-core/src/model_profile/catalog.rs
+++ b/meerkat-core/src/model_profile/catalog.rs
@@ -374,6 +374,25 @@ pub fn image_generation_provider_defaults() -> &'static [ImageGenerationProvider
     })
 }
 
+/// The platform-wide default model when no provider/model is otherwise
+/// specified. The single global default owned by the catalog seam — surfaces
+/// must read this instead of hardcoding a model literal.
+pub fn global_default_model() -> &'static str {
+    DEFAULT_ANTHROPIC
+}
+
+/// Canonical cross-provider priority order, owned by the catalog seam. A
+/// surface that must pick "the best available provider" (e.g. when several
+/// API keys are present) consults this order instead of hand-coding its own.
+pub fn provider_priority() -> &'static [crate::Provider] {
+    const PRIORITY: &[crate::Provider] = &[
+        crate::Provider::Anthropic,
+        crate::Provider::OpenAI,
+        crate::Provider::Gemini,
+    ];
+    PRIORITY
+}
+
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
@@ -553,6 +572,31 @@ mod tests {
             image_generation_provider_for_model("gemini-3.5-flash"),
             None,
             "Gemini text catalog rows are not image-generation model authority"
+        );
+    }
+
+    #[test]
+    fn global_default_and_provider_priority_are_catalog_owned() {
+        assert_eq!(global_default_model(), DEFAULT_ANTHROPIC);
+
+        let priority = provider_priority();
+        assert_eq!(
+            priority.len(),
+            3,
+            "provider priority must cover three providers"
+        );
+        assert_eq!(
+            priority.first(),
+            Some(&Provider::Anthropic),
+            "Anthropic must be the highest-priority provider"
+        );
+        assert!(
+            priority.contains(&Provider::OpenAI),
+            "provider priority must contain OpenAI"
+        );
+        assert!(
+            priority.contains(&Provider::Gemini),
+            "provider priority must contain Gemini"
         );
     }
 

--- a/meerkat-gemini/src/client.rs
+++ b/meerkat-gemini/src/client.rs
@@ -23,7 +23,10 @@ use serde::Deserialize;
 use serde_json::{Map, Value, json};
 use std::collections::{HashMap, HashSet};
 
-use crate::image_generation::{GeminiImageOutputOptions, GeminiImageTurnPlan};
+use crate::image_generation::{
+    GeminiImageGenerationProfile, GeminiImageOutputOptions, GeminiImageTurnPlan,
+};
+use meerkat_core::image_generation::ImageGenerationProviderProfile;
 
 /// Extract the typed Gemini provider tag from a request.
 fn gemini_tag(request: &LlmRequest) -> Option<&GeminiProviderTag> {
@@ -1007,7 +1010,7 @@ impl ImageGenerationExecutor for GeminiClient {
         request: ProviderImageGenerationRequest,
     ) -> Result<ProviderImageGenerationOutput, LlmError> {
         match request.execution_plan.clone() {
-            plan if plan.provider.0 == "gemini" || plan.provider.0 == "google" => {
+            plan if GeminiImageGenerationProfile.matches_provider_id(&plan.provider.0) => {
                 if plan.backend != meerkat_core::ImageGenerationBackendKind::NativeModel {
                     return Err(LlmError::InvalidRequest {
                         message: format!(

--- a/meerkat-llm-core/src/provider_runtime/binding.rs
+++ b/meerkat-llm-core/src/provider_runtime/binding.rs
@@ -46,6 +46,21 @@ impl NormalizedBackendKind {
             Self::SelfHosted(kind) => kind.as_str(),
         }
     }
+
+    /// The default API-key backend kind for a provider — the canonical backend
+    /// used when no explicit backend hint is given (e.g. non-interactive API-key
+    /// login). Total over Provider; `Other` has no default. Owned here (the typed
+    /// matrix) so surfaces never hand-map a provider->backend-kind string with a
+    /// fail-open arm.
+    pub fn default_for_provider(provider: Provider) -> Option<Self> {
+        match provider {
+            Provider::Anthropic => Some(Self::Anthropic(AnthropicBackendKind::AnthropicApi)),
+            Provider::OpenAI => Some(Self::OpenAi(OpenAiBackendKind::OpenAiApi)),
+            Provider::Gemini => Some(Self::Google(GoogleBackendKind::GoogleGenAi)),
+            Provider::SelfHosted => Some(Self::SelfHosted(SelfHostedBackendKind::SelfHosted)),
+            Provider::Other => None,
+        }
+    }
 }
 
 /// Provider-tagged normalized auth method.
@@ -72,6 +87,17 @@ impl NormalizedAuthMethod {
             Self::Anthropic(method) => method.persisted_auth_mode(),
             Self::Google(method) => method.persisted_auth_mode(),
             Self::SelfHosted(method) => method.persisted_auth_mode(),
+        }
+    }
+
+    /// The canonical wire string for this auth method, delegating to the
+    /// per-provider matrix enum's as_str (the matrix owns the literal).
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::OpenAi(m) => m.as_str(),
+            Self::Anthropic(m) => m.as_str(),
+            Self::Google(m) => m.as_str(),
+            Self::SelfHosted(m) => m.as_str(),
         }
     }
 }
@@ -369,5 +395,43 @@ mod tests {
         ));
 
         assert_eq!(lease.expires_at(), Some(expires_at));
+    }
+
+    #[test]
+    fn default_backend_kind_per_provider_is_typed() {
+        assert_eq!(
+            NormalizedBackendKind::default_for_provider(Provider::Anthropic),
+            Some(NormalizedBackendKind::Anthropic(
+                AnthropicBackendKind::AnthropicApi
+            ))
+        );
+        assert_eq!(
+            NormalizedBackendKind::default_for_provider(Provider::OpenAI),
+            Some(NormalizedBackendKind::OpenAi(OpenAiBackendKind::OpenAiApi))
+        );
+        assert_eq!(
+            NormalizedBackendKind::default_for_provider(Provider::Gemini),
+            Some(NormalizedBackendKind::Google(
+                GoogleBackendKind::GoogleGenAi
+            ))
+        );
+        assert_eq!(
+            NormalizedBackendKind::default_for_provider(Provider::SelfHosted),
+            Some(NormalizedBackendKind::SelfHosted(
+                SelfHostedBackendKind::SelfHosted
+            ))
+        );
+        assert_eq!(
+            NormalizedBackendKind::default_for_provider(Provider::Other),
+            None
+        );
+    }
+
+    #[test]
+    fn auth_method_as_str_delegates_to_matrix() {
+        assert_eq!(
+            NormalizedAuthMethod::Anthropic(AnthropicAuthMethod::ClaudeAiOauth).as_str(),
+            "claude_ai_oauth"
+        );
     }
 }

--- a/meerkat-openai/src/client.rs
+++ b/meerkat-openai/src/client.rs
@@ -29,9 +29,11 @@ use serde_json::value::RawValue;
 use std::collections::{HashMap, HashSet};
 
 use crate::image_generation::{
-    OpenAiImageOutputOptions, OpenAiImageProviderParams, OpenAiImagesApiEndpoint,
-    OpenAiImagesApiPlan, OpenAiImagesApiRequestShape, OpenAiResponsesImagePlan,
+    OpenAiImageGenerationProfile, OpenAiImageOutputOptions, OpenAiImageProviderParams,
+    OpenAiImagesApiEndpoint, OpenAiImagesApiPlan, OpenAiImagesApiRequestShape,
+    OpenAiResponsesImagePlan,
 };
+use meerkat_core::image_generation::ImageGenerationProviderProfile;
 
 /// Extract the typed OpenAI provider tag from a request.
 pub(crate) fn openai_tag(request: &LlmRequest) -> Option<&OpenAiProviderTag> {
@@ -1462,31 +1464,33 @@ impl ImageGenerationExecutor for OpenAiClient {
         request: ProviderImageGenerationRequest,
     ) -> Result<ProviderImageGenerationOutput, LlmError> {
         match request.execution_plan.clone() {
-            plan if plan.provider.0 == "openai" => match plan.backend {
-                meerkat_core::ImageGenerationBackendKind::HostedTool => {
-                    let provider_plan: OpenAiResponsesImagePlan =
-                        serde_json::from_value(plan.provider_plan).map_err(|err| {
-                            LlmError::InvalidRequest {
-                                message: format!("invalid OpenAI hosted image plan: {err}"),
-                            }
-                        })?;
-                    self.execute_hosted_responses_image(request, provider_plan)
-                        .await
+            plan if OpenAiImageGenerationProfile.matches_provider_id(&plan.provider.0) => {
+                match plan.backend {
+                    meerkat_core::ImageGenerationBackendKind::HostedTool => {
+                        let provider_plan: OpenAiResponsesImagePlan =
+                            serde_json::from_value(plan.provider_plan).map_err(|err| {
+                                LlmError::InvalidRequest {
+                                    message: format!("invalid OpenAI hosted image plan: {err}"),
+                                }
+                            })?;
+                        self.execute_hosted_responses_image(request, provider_plan)
+                            .await
+                    }
+                    meerkat_core::ImageGenerationBackendKind::ProviderApi => {
+                        let provider_plan: OpenAiImagesApiPlan =
+                            serde_json::from_value(plan.provider_plan).map_err(|err| {
+                                LlmError::InvalidRequest {
+                                    message: format!("invalid OpenAI Images API plan: {err}"),
+                                }
+                            })?;
+                        let model = request.model.clone();
+                        self.execute_images_api(request, model, provider_plan).await
+                    }
+                    other => Err(LlmError::InvalidRequest {
+                        message: format!("OpenAI image executor cannot run backend {other:?}"),
+                    }),
                 }
-                meerkat_core::ImageGenerationBackendKind::ProviderApi => {
-                    let provider_plan: OpenAiImagesApiPlan =
-                        serde_json::from_value(plan.provider_plan).map_err(|err| {
-                            LlmError::InvalidRequest {
-                                message: format!("invalid OpenAI Images API plan: {err}"),
-                            }
-                        })?;
-                    let model = request.model.clone();
-                    self.execute_images_api(request, model, provider_plan).await
-                }
-                other => Err(LlmError::InvalidRequest {
-                    message: format!("OpenAI image executor cannot run backend {other:?}"),
-                }),
-            },
+            }
             other => Err(LlmError::InvalidRequest {
                 message: format!("OpenAI image executor cannot run plan {other:?}"),
             }),

--- a/meerkat-web-runtime/src/lib.rs
+++ b/meerkat-web-runtime/src/lib.rs
@@ -212,11 +212,7 @@ struct Credentials {
 }
 
 fn default_model() -> Option<String> {
-    Some(
-        meerkat_models::default_model("anthropic")
-            .unwrap_or("claude-sonnet-4-5")
-            .to_string(),
-    )
+    Some(meerkat_models::catalog::global_default_model().to_string())
 }
 
 #[derive(Debug, Deserialize)]
@@ -295,14 +291,23 @@ fn populate_realm_from_api_keys(
         .iter()
         .map(|(k, v)| (k.as_str(), v.as_str()))
         .collect();
-    // Deterministic order: anthropic first (historical default), then
-    // openai, gemini, everything else alphabetically.
-    entries.sort_by_key(|(k, _)| match *k {
-        "anthropic" => 0,
-        "openai" => 1,
-        "gemini" | "google" => 2,
-        _ => 3,
-    });
+    // Deterministic cross-provider order owned by the model catalog
+    // (`provider_priority()` == [Anthropic, OpenAI, Gemini]). Each provider's
+    // sort index is its position in that list; providers absent from the list
+    // (and unrecognized strings) sort last. The `google` alias normalizes to
+    // the Gemini identity before lookup.
+    let priority = meerkat_models::catalog::provider_priority();
+    let provider_rank = |key: &str| -> usize {
+        let canonical = if key == "google" { "gemini" } else { key };
+        match meerkat_core::Provider::parse_strict(canonical) {
+            Some(provider) => priority
+                .iter()
+                .position(|p| *p == provider)
+                .unwrap_or(priority.len()),
+            None => priority.len(),
+        }
+    };
+    entries.sort_by_key(|(k, _)| provider_rank(k));
 
     let mut section = meerkat_core::RealmConfigSection::from_inline_api_keys(&entries);
     if let Some(urls) = base_urls {
@@ -1091,7 +1096,7 @@ fn build_wasm_tool_dispatcher() -> Result<Arc<dyn meerkat_core::AgentToolDispatc
 /// Primary bootstrap: parse a mobpack and create service infrastructure.
 ///
 /// `mobpack_bytes`: tar.gz mobpack archive.
-/// `credentials_json`: `{ "anthropic_api_key"?: "...", "openai_api_key"?: "...", "gemini_api_key"?: "...", "model"?: "claude-sonnet-4-5" }`
+/// `credentials_json`: `{ "anthropic_api_key"?: "...", "openai_api_key"?: "...", "gemini_api_key"?: "...", "model"?: "<catalog default>" }`
 ///
 /// Stores an `EphemeralSessionService<FactoryAgentBuilder>` and a `MobMcpState`
 /// in a `thread_local! RuntimeState` for subsequent mob/comms calls.
@@ -1109,11 +1114,9 @@ pub fn init_runtime(mobpack_bytes: &[u8], credentials_json: &str) -> Result<JsVa
         creds.gemini_api_key.as_deref(),
     )?;
 
-    let model = creds.model.unwrap_or_else(|| {
-        meerkat_models::default_model("anthropic")
-            .unwrap_or("claude-sonnet-4-5")
-            .to_string()
-    });
+    let model = creds
+        .model
+        .unwrap_or_else(|| meerkat_models::catalog::global_default_model().to_string());
 
     let providers: Vec<String> = api_keys.keys().cloned().collect();
     let base_urls = build_provider_base_urls(
@@ -1150,7 +1153,7 @@ pub fn init_runtime(mobpack_bytes: &[u8], credentials_json: &str) -> Result<JsVa
 
 /// Advanced bare-bones bootstrap without a mobpack.
 ///
-/// `config_json`: `{ "anthropic_api_key"?: "...", "openai_api_key"?: "...", "gemini_api_key"?: "...", "model"?: "claude-sonnet-4-5", "max_sessions"?: 100000 }`
+/// `config_json`: `{ "anthropic_api_key"?: "...", "openai_api_key"?: "...", "gemini_api_key"?: "...", "model"?: "<catalog default>", "max_sessions"?: 100000 }`
 #[wasm_bindgen]
 pub fn init_runtime_from_config(config_json: &str) -> Result<JsValue, JsValue> {
     init_tracing();
@@ -1164,11 +1167,9 @@ pub fn init_runtime_from_config(config_json: &str) -> Result<JsValue, JsValue> {
         rt_config.gemini_api_key.as_deref(),
     )?;
 
-    let model = rt_config.model.unwrap_or_else(|| {
-        meerkat_models::default_model("anthropic")
-            .unwrap_or("claude-sonnet-4-5")
-            .to_string()
-    });
+    let model = rt_config
+        .model
+        .unwrap_or_else(|| meerkat_models::catalog::global_default_model().to_string());
     let max_sessions = rt_config.max_sessions;
 
     let providers: Vec<String> = api_keys.keys().cloned().collect();

--- a/meerkat/src/factory.rs
+++ b/meerkat/src/factory.rs
@@ -896,7 +896,11 @@ fn provider_tool_defaults_for(
     provider: Provider,
     config: &Config,
     model_profile: Option<&meerkat_core::model_profile::ModelProfile>,
+    web_search_override: ToolCategoryOverride,
 ) -> Option<serde_json::Value> {
+    if matches!(web_search_override, ToolCategoryOverride::Disable) {
+        return None;
+    }
     if !model_profile.is_some_and(|profile| profile.supports_web_search) {
         return None;
     }
@@ -2550,10 +2554,17 @@ impl AgentFactory {
             .map_err(|e| FactoryError::ClientCreationFailed(e.to_string()))
     }
 
+    /// Build the per-request LLM policy for a (re)configured identity.
+    ///
+    /// `web_search` carries the session's persisted web-search disable intent
+    /// (`SessionMetadata.tooling.web_search`). It MUST be threaded through so a
+    /// model/provider hot-swap preserves a session's `--no-web-search` disable
+    /// instead of silently re-enabling the provider-native web-search body.
     pub fn request_policy_for_llm_identity(
         &self,
         config: &Config,
         identity: &SessionLlmIdentity,
+        web_search: ToolCategoryOverride,
     ) -> Result<meerkat_core::SessionLlmRequestPolicy, FactoryError> {
         let registry = config
             .model_registry()
@@ -2566,6 +2577,7 @@ impl AgentFactory {
                 identity.provider,
                 config,
                 model_profile.as_ref(),
+                web_search,
             ),
         })
     }
@@ -4746,8 +4758,12 @@ impl AgentFactory {
             }))
             .with_call_timeout_override(effective_call_timeout_override);
 
-        if let Some(defaults) = provider_tool_defaults_for(provider, config, model_profile.as_ref())
-        {
+        if let Some(defaults) = provider_tool_defaults_for(
+            provider,
+            config,
+            model_profile.as_ref(),
+            build_config.override_web_search,
+        ) {
             builder = builder.provider_tool_defaults(defaults);
         }
         if let Some(params) = build_config.provider_params.clone() {
@@ -5370,7 +5386,11 @@ mod tests {
         };
 
         let openai_policy = factory
-            .request_policy_for_llm_identity(&config, &openai_identity)
+            .request_policy_for_llm_identity(
+                &config,
+                &openai_identity,
+                ToolCategoryOverride::Inherit,
+            )
             .expect("OpenAI request policy");
         assert_eq!(
             openai_policy.provider_tool_defaults,
@@ -5379,11 +5399,77 @@ mod tests {
         );
 
         let mismatched_policy = factory
-            .request_policy_for_llm_identity(&config, &mismatched_identity)
+            .request_policy_for_llm_identity(
+                &config,
+                &mismatched_identity,
+                ToolCategoryOverride::Inherit,
+            )
             .expect("mismatched request policy should fail closed, not error");
         assert!(
             mismatched_policy.provider_tool_defaults.is_none(),
             "Anthropic policy must not reuse OpenAI model defaults from model id alone"
+        );
+
+        // A session that persisted a web-search disable intent must keep it
+        // across a model reconfigure: the provider-native body is suppressed
+        // even though the model profile would otherwise advertise it.
+        let disabled_policy = factory
+            .request_policy_for_llm_identity(
+                &config,
+                &openai_identity,
+                ToolCategoryOverride::Disable,
+            )
+            .expect("OpenAI request policy with web-search disabled");
+        assert!(
+            disabled_policy.provider_tool_defaults.is_none(),
+            "persisted web-search Disable must survive reconfigure and suppress the native body"
+        );
+    }
+
+    #[test]
+    fn provider_tool_defaults_suppressed_on_web_search_disable() {
+        let config = Config::default();
+        // Profile advertises web-search support and config enables the provider
+        // tool — without the override this would resolve the native body.
+        let profile = meerkat_core::model_profile::ModelProfile {
+            provider: Provider::OpenAI.as_str().to_string(),
+            model_family: "gpt-5".to_string(),
+            supports_temperature: false,
+            supports_thinking: false,
+            supports_reasoning: false,
+            inline_video: false,
+            vision: false,
+            image_input: false,
+            image_tool_results: false,
+            realtime: false,
+            supports_web_search: true,
+            image_generation: false,
+            params_schema: serde_json::json!({}),
+            beta_headers: Vec::new(),
+            call_timeout_secs: None,
+        };
+
+        let enabled = provider_tool_defaults_for(
+            Provider::OpenAI,
+            &config,
+            Some(&profile),
+            ToolCategoryOverride::Inherit,
+        );
+        assert_eq!(
+            enabled,
+            Some(serde_json::json!({"web_search": {"type": "web_search"}})),
+            "Inherit must leave owned web-search defaults intact"
+        );
+
+        let disabled = provider_tool_defaults_for(
+            Provider::OpenAI,
+            &config,
+            Some(&profile),
+            ToolCategoryOverride::Disable,
+        );
+        assert!(
+            disabled.is_none(),
+            "Disable must suppress the native web-search body even when profile+config would enable it"
         );
     }
 

--- a/meerkat/src/session_runtime/llm_reconfigure.rs
+++ b/meerkat/src/session_runtime/llm_reconfigure.rs
@@ -247,8 +247,21 @@ impl SessionRuntimeLlmReconfigureHost {
         identity: &SessionLlmIdentity,
     ) -> Result<meerkat_core::SessionLlmRequestPolicy, RuntimeDriverError> {
         let config = self.load_config_for_hot_swap().await?;
+        // The session's persisted web-search disable intent
+        // (`SessionMetadata.tooling.web_search`) must survive a model hot-swap —
+        // otherwise reconfigure would silently re-enable the provider-native
+        // web-search body that `--no-web-search` suppressed. Read it from the
+        // live session metadata; fail closed to `Inherit` only when the metadata
+        // is genuinely unavailable.
+        let web_search = match self.service.export_live_session(session_id).await {
+            Ok(session) => session
+                .session_metadata()
+                .map(|metadata| metadata.tooling.web_search)
+                .unwrap_or(meerkat_core::ToolCategoryOverride::Inherit),
+            Err(_) => meerkat_core::ToolCategoryOverride::Inherit,
+        };
         self.factory
-            .request_policy_for_llm_identity(&config, identity)
+            .request_policy_for_llm_identity(&config, identity, web_search)
             .map_err(|e| {
                 RuntimeDriverError::Internal(format!(
                     "Failed to build LLM request policy for session {session_id} identity hot-swap: {e}"

--- a/sdks/web/src/runtime.ts
+++ b/sdks/web/src/runtime.ts
@@ -21,13 +21,11 @@ const EXPECTED_VERSION = '0.7.0-alpha.0';
  */
 function toWasmConfig(config: RuntimeConfig): Record<string, unknown> {
   return {
-    api_key: config.apiKey,
     anthropic_api_key: config.anthropicApiKey,
     openai_api_key: config.openaiApiKey,
     gemini_api_key: config.geminiApiKey,
     model: config.model,
     max_sessions: config.maxSessions,
-    base_url: config.baseUrl,
     anthropic_base_url: config.anthropicBaseUrl,
     openai_base_url: config.openaiBaseUrl,
     gemini_base_url: config.geminiBaseUrl,

--- a/sdks/web/src/types.ts
+++ b/sdks/web/src/types.ts
@@ -6,8 +6,6 @@ import type { WireMobMemberStatus } from './generated/mob.js';
 
 /** Configuration for {@link MeerkatRuntime.init}. */
 export interface RuntimeConfig {
-  /** Backward-compat single API key (treated as Anthropic fallback). */
-  apiKey?: string;
   /** Anthropic API key. */
   anthropicApiKey?: string;
   /** OpenAI API key. */
@@ -18,8 +16,6 @@ export interface RuntimeConfig {
   model?: string;
   /** Maximum concurrent sessions. Default: 64. */
   maxSessions?: number;
-  /** Backward-compat single base URL (mapped to default model's provider). */
-  baseUrl?: string;
   /** Anthropic base URL (e.g. for proxy deployments). */
   anthropicBaseUrl?: string;
   /** OpenAI base URL. */

--- a/sdks/web/tests/types.test.ts
+++ b/sdks/web/tests/types.test.ts
@@ -52,13 +52,11 @@ const minimalConfig: RuntimeConfig = {
 };
 
 const fullConfig: RuntimeConfig = {
-  apiKey: 'sk-fallback',
   anthropicApiKey: 'sk-ant',
   openaiApiKey: 'sk-oai',
   geminiApiKey: 'sk-gem',
   model: 'claude-sonnet-4-5',
   maxSessions: 16,
-  baseUrl: 'https://proxy.example.com',
   anthropicBaseUrl: 'https://proxy.example.com/anthropic',
   openaiBaseUrl: 'https://proxy.example.com/openai',
   geminiBaseUrl: 'https://proxy.example.com/gemini',


### PR DESCRIPTION
Closes the **Provider/Auth Policy Escapes** audit (Rule 7 — *Providers and Policy Stay Behind Their Owning Seams*; patterns *Provider Leakage* + *Policy Drift*). Every escape was a **surface re-deriving a provider/auth/capability/policy fact that an owning seam already holds typed**. The fix moves each decision into its seam and has the surface read the typed owner — no new authorities except binding MCP-OAuth to a per-binding `AuthMachine` lease.

All 7 confirmed root sites across the 6 audit clusters are closed:

### C1 — CLI `--no-web-search` → typed disable intent *(cli + facade + core)*
- CLI sets `override_web_search = ToolCategoryOverride::Disable` (build) / `SurfaceSessionRecoveryOverrides.override_web_search` (resume) instead of injecting raw `{web_search: null}` provider params; deletes `provider_web_search_param_key` / `apply_no_web_search_provider_param[_resume]` and their surface tests.
- Facade `provider_tool_defaults_for` now suppresses the provider-native web-search body on `Disable` (gated on `ModelProfile.supports_web_search`) at **both** the build and reconfigure (`request_policy_for_llm_identity`) call sites; the reconfigure path threads the session's persisted `tooling.web_search` so the intent survives a model hot-swap.
- `meerkat-core` clears the native web-search/grounding body via a typed `ProviderParamsOverride::clear_web_search()` instead of raw `obj.remove("web_search"/"google_search")` in the extraction turn.

### C2 — default-model selection owned by the catalog seam *(cli + web-runtime)*
- Adds `meerkat_core::model_profile::catalog::{global_default_model, provider_priority}`; the CLI's `best_available_default_model` and web-runtime's `default_model` / realm population read them. The hardcoded cross-provider order and the dead `claude-sonnet-4-5` web-runtime fallback + stale docstrings are gone. Canonical priority is **anthropic-first** (matches the global default and the web-runtime realm order). Fixes the inaccurate `LEGACY_AGENT_MODEL_DEFAULTS` comment (`claude-opus-4-7` is a live catalog row).

### C3 — MCP-server OAuth freshness bound to the `AuthMachine` *(auth-core; largest fix)*
- `McpOAuthAuthority::refresh_if_needed` no longer decides freshness itself (`expires_at` vs a local `REFRESH_SKEW_SECS`) or raises `ReauthRequired` on its own. It routes the cached-vs-refresh-vs-reauth decision through a per-binding `AuthMachine` lease for the `mcp-oauth` realm (`acquire_lease` → `observe_credential_freshness` → `resolve_oauth_login_credential_disposition` → dispatch), mirroring the provider path. The lease is a **mandatory** injected `GeneratedAuthLeaseHandle` (no `Option` fail-open); since `meerkat-auth-core` sits below `meerkat-runtime` in the dep graph, the CLI injects it and tests mint one via the dev-dependency. Window (60s) equals the old skew, so behavior is preserved.

### C4 — OAuth backend/auth-method via the typed provider matrix *(llm-core + cli)*
- Adds `NormalizedBackendKind::default_for_provider` (total over `Provider`, no fail-open) and `NormalizedAuthMethod::as_str`. `noninteractive_login` routes the backend default through the typed matrix (removing the fail-open `_ => "google_genai"` arm); `LoginProvider::oauth_auth_method` delegates to a typed `normalized_auth_method`. The distinct OAuth-login backend taxonomy (`LoginProvider::normalized_backend_kind`, ChatGpt/CodeAssist) is deliberately untouched.

### C5 — image-gen adapters dispatch via the owning profile *(gemini + openai)*
- Replaces inline `plan.provider.0 == "gemini"/"google"/"openai"` re-checks with `ImageGenerationProviderProfile::matches_provider_id`.

### C6 — `@rkat/web` drops the dead bare `apiKey`/`baseUrl` convention *(web SDK)*
- Removes the `RuntimeConfig.apiKey`/`baseUrl` fields + their `toWasmConfig` mappings; only the typed per-provider keys remain (matching the WASM realm-config bootstrap, which already rejects bare keys).

## Verification
- `cargo clippy --workspace --all-features -- -D warnings`: clean
- `cargo nextest run --workspace`: **7904 passed, 0 failed**, 181 skipped
- `@rkat/web` `tsc` typecheck: clean for the changed types
- Adversarial dogma re-review (per cluster): old violation patterns confirmed gone, no shadow copies, no fail-open arms, no production model literals (remaining `claude-sonnet-4-5` are test fixtures only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)