### PR TITLE
fix(dogma): enforce Terminality and Faults Are Explicit (Rule 8) across provider seams, ops barrier, and surfaces

### DIFF
--- a/docs/architecture/dogma-audits/split-commit-atomicity-gaps.md
+++ b/docs/architecture/dogma-audits/split-commit-atomicity-gaps.md
@@ -1,0 +1,138 @@
+---
+title: "Dogma Audit — Split Commit / Atomicity Gaps"
+description: "Workspace audit for multi-step semantic commits with crash/rejection/cancel windows (Rules 1/2/8)."
+icon: "magnifying-glass"
+---
+
+# Dogma Audit: Split Commit / Atomicity Gaps (Rules 1 / 2 / 8)
+
+**Audit target:** detached `origin/main` @ `a1ec8de86` (includes merged R4/R6/R7 fixes)
+**Date:** 2026-06-06
+**Dogma:** cross-cuts Rule 1 (Authority Is Singular), Rule 2 (no semantic effects outside the owning transition),
+Rule 8 (cancellation is a transition; state-mutating async must be cancel-safe / rollback-guarded / wrapped in
+explicit transition state). Reference-correct pattern: the supervisor bridge rotation that **fails closed on partial
+remote failure** (retains pending rotation metadata, commits only after every remote confirms).
+**Test:** authority / persistence / side effects / events / trust / token writes / public replies must not happen in
+separate steps with a crash, rejection, cancellation, or concurrent-interleave window that leaves **durable
+inconsistency** or a **false caller-belief**. Smells: "persist first, publish machine later", "send reply before
+local authority accepts", "trust before authorization terminality".
+
+## Method
+
+Two agent workflows (same harness). (1) A 10-agent locus map inventoried **97 sites** (51 suspect; schedule and the
+agent loop over-flagged at 11/12 and 10/11). (2) A 54-candidate verify pass: each candidate got an independent
+classifier that **re-traced both the split steps AND the recovery path**; suspects faced a 3-lens adversarial panel
+(atomic-or-protected / ordering-correct / recovery-closes-window). Crucially the synthesis **independently
+re-verified the full pool**, and I then **hand-verified the load-bearing claims** (mob wire rollback, schedule CAS,
+auth token ordering, hook spawn).
+
+**Result:** 54 candidates → **0 confirmed, 0 contested, 54 legitimate at stage 1.** But the per-candidate classifiers
+were **lenient** (they waved in-memory/bounded gaps through as "no durable inconsistency"); the synthesis re-verify +
+hand-check surfaced **2–3 genuine but bounded Low residuals.** **SYSTEMIC: false.**
+
+## Bottom line
+
+- **Widespread?** **No — the cleanest of the seven aspects audited.** ~50 of 54 candidates are legitimate
+  event-sourcing / atomic-transaction / in-memory-crash-symmetric / single-lock-CAS / fail-closed-rollback patterns.
+  Several candidates were factually **stale**.
+- **Systemic?** **No.** There is no recurring split-commit root shape and no cross-crate transaction redesign needed.
+  The codebase's durable-commit discipline is strong (see below).
+- **Durable gaps?** **None found.** No two-durable-writes-without-a-transaction, no token-write-split, no
+  reply-before-accept with persisted consequence. Every genuine residual is **in-memory or best-effort-by-design**.
+- **Complexity?** **Low.** 2–3 localized hardening edits; no durable schema work, no new authorities.
+
+## What makes it clean (the dominant legitimate patterns — verified)
+
+- **Event-sourcing.** AgentEvents are non-blocking observer notifications; canonical truth is the event-sourced
+  projector/checkpointer (`.rkat/sessions/` are derived projections). A crash between an event/effect and the save
+  loses no canonical state — the in-memory `Session` is a CoW projection rebuilt from the durable log; `JsonlStore`
+  reconciles on `open_index`; `projector::resume()` is idempotent. This refuted the entire `event_before_state`
+  cluster (core loop + store/projector + schedule receipts).
+- **Atomic transactions.** The schedule store runs claim/transition inside one `begin_immediate_transaction` (SQLite)
+  or one `state.write().await` (in-memory) — a true CAS on `attempt_count`+`claim_token` with no await between
+  read-check-write; stale completions fail closed. Refuted the `read_modify_write_race` cluster.
+- **Fail-closed compensation rollback.** Auth token refresh (`meerkat-auth-core/src/resolver.rs:843`) does AuthMachine
+  accept → `store.save`, and on save failure **releases the lease, restores the token-lifecycle snapshot, restores
+  the token store**, returning a typed Err. **Verified — the highest-stakes concern (token-write-split / credential
+  bleed) is properly handled.**
+- **In-memory authority rebuilt from the durable owner.** `StagedSessionRegistry` / `staged_capacity_admissions`
+  (RwLock/Mutex `HashMap`, crash-symmetric, error path rolls back via abandon+cleanup); the comms trust store
+  (projection of the generated trust authority); the `AuthMachine` lease (rebuilt from the durable token store each
+  call); HNSW `next_id` (re-derived `SELECT MAX(point_id)` on every open). Refuted the bulk of
+  `persist_before_authority` / `trust_before_terminality`.
+- **Fail-closed two-phase.** The supervisor bridge rotation (pending metadata + per-remote confirm + retry) is the
+  reference, and it holds.
+
+## Genuine residuals (all Low, in-memory / best-effort)
+
+### R1 — Multi-peer mob WIRE rollback is best-effort, weaker than the rotation reference
+**`no_rollback_on_midfail` / `effect_before_commit` · Low · meerkat-mob · members 0,1**
+
+`apply_wire_members_idempotent` / `wire_members_peer_only` (`meerkat-mob/src/runtime/actor.rs:9748-9830`, batch
+`:10272-10385`) mutate the in-memory `dsl_authority` and in-memory comms trust per peer. On a later peer's
+trust/wire failure, the rollback unwires the DSL edge and prior trust — but **the rollback's own error is discarded**
+(`let _ = self.apply_trusted_peer_remove(...)`, ~`:9830`, **verified**), and the DSL unwire can itself be rejected
+with no recovery, leaving an orphaned in-memory edge+trust. In-memory only (a live-actor restart rebuilds from the
+durable authority), so no durable inconsistency — but it's weaker than `handle_rotate_supervisor`'s pending-metadata
+fail-closed pattern. **Repair:** fold per-edge wire+trust into the existing `WireMembersWithTrust` single transition
+(no inter-peer window), or surface the rollback errors and record pending-unwire metadata for the next reconcile.
+*(The stage-1 classifier missed this as "in-memory, legit"; the synthesis + hand-check caught it.)*
+
+### R2 — Background hook patch publish dropped on cancellation (Rule 8 leaked task)
+**`effect_before_commit` / `cancel_window` · Low · meerkat-hooks · member 50**
+
+`meerkat-hooks/src/lib.rs:814-854` fires background hooks via detached `tokio::spawn`; on session
+cancellation/shutdown the task can be killed after `execute_one()` but before `publish_patches()`, silently dropping
+patches (`tracing::warn` only). Best-effort by design and the caller never relies on it — but it's an unmodeled
+leaked-task fault. **Repair:** track in-flight background-hook tasks against the session lifecycle (a `JoinSet` /
+tracked registry) so cancellation drains pending `publish_patches` or records an explicit "patches dropped" signal.
+
+### R3 — Schedule materialization-before-advance idempotency contract (recovery-protected)
+**`effect_before_commit` · Low · meerkat-schedule · members 20-30**
+
+Dispatch materializes a session (effect) before the occurrence advances, but the cluster is overwhelmingly
+legitimate: `ClassifyDue` emits `LeaseExpired` to reclaim crashed/stuck occurrences with a new
+`claim_token`+incremented `attempt_count` (covered by `driver_reclaims_expired_*` tests), so recovery re-drives. The
+only residual is making the delivery adapter **contractually idempotent** on an already-bound
+`materialized_session_id` (reuse, never re-create) — defensive, recovery already mostly present.
+
+## Systemic read & clean path
+
+There is **no systemic split-commit shape.** The durable-commit disciplines (event-sourcing replay, SQLite IMMEDIATE
+transactions, single-lock CAS, fail-closed compensation rollback, the two-phase rotation reference) are applied
+consistently across the subsystems that hold durable or cross-host state. What remains are a handful of **in-memory,
+live-actor, best-effort** edges that don't rise to durable inconsistency.
+
+**Ordered plan (residuals only):**
+1. **R1 (mob wire, Low→med-ish):** fold per-edge wire+trust into `WireMembersWithTrust`, or surface rollback errors +
+   pending-unwire metadata (mirror `handle_rotate_supervisor`).
+2. **R2 (hooks, Low):** session-scoped tracked task set for background hooks tied to the cancellation token.
+3. **R3 (schedule, Low):** delivery-adapter idempotency contract on bound `materialized_session_id`.
+
+**Overall: Low.** Everything else is verified-correct and needs no change.
+
+## Methodology note
+
+This audit's 0-confirmed stage-1 result was **slightly optimistic** — the per-candidate classifiers, applying the
+(correct) "in-memory rebuilt-from-authority = legitimate" carve-out, waved through R1 and R2, which are genuine (if
+bounded) gaps. The synthesis's independent re-verification of the full pool, plus hand-verification of the
+load-bearing claims (mob `let _ = apply_trusted_peer_remove`, schedule `begin_immediate_transaction`, auth
+fail-closed rollback, hook detached spawn), corrected this. The lesson for this dogma specifically: "in-memory" is
+not automatically "safe" — a cancellation/rejection window in a live-actor multi-step mutation can still orphan
+in-memory authority, even without durable inconsistency.
+
+## The seven audits, summarized
+
+| Aspect | Rule | Verdict | High |
+|---|---|---|---|
+| Projection Promotion | R3 | not systemic — 3 live Medium | 0 |
+| String/JSON/Option Folklore | R4 | widespread + systemic; **FIXED** | 2 |
+| Surface-Owned Truth | R6 | narrow, SDK last-mile; **FIXED** | 0 |
+| Generated-Artifact Theater | R9 | systemic in un-gated catalogs | 2 (live) |
+| Provider/Auth Policy Escapes | R7 | cleanest surfaces-only; **FIXED** | 0 |
+| Terminal Truth Laundering | R8 | not widespread after filter; systemic shape | 2 |
+| **Split Commit / Atomicity Gaps** | **R1/R2/R8** | **cleanest — no durable gaps, 2-3 Low in-memory residuals** | **0** |
+
+The through-line across all seven: the **durable/typed/authoritative core is well-governed**; residual violations are
+leaves that drop a fault, re-derive a fact, or skip a window the surrounding system already models — and the strongest
+durable invariant of all (atomicity) is the one the codebase protects most consistently.

--- a/docs/architecture/dogma-audits/terminal-truth-laundering.md
+++ b/docs/architecture/dogma-audits/terminal-truth-laundering.md
@@ -1,0 +1,129 @@
+---
+title: "Dogma Audit — Terminal Truth Laundering"
+description: "Workspace audit for Rule 8 (Terminality and Faults Are Explicit) / Split Terminality."
+icon: "magnifying-glass"
+---
+
+# Dogma Audit: Terminal Truth Laundering (Rule 8 / Split Terminality)
+
+**Audit target:** PR #756 head `worktree-third-dogma` @ `688f56442`
+**Date:** 2026-06-05
+**Dogma:** Rule 8 — *Terminality and Faults Are Explicit*; pattern *Split Terminality*.
+**Test:** a failure / timeout / cancellation / dropped delivery / malformed data / partial execution / unknown
+state must not be converted into a benign terminal class (success, empty, None, not-found, destroyed, default,
+generic string error) that loses the typed fault. *"One condition, one ending. Success must prove itself. A logged
+fault is not a handled fault. Cancellation is a transition, not an interruption."* A site is a real violation only
+when the typed fault is **lost**, the caller **cannot distinguish** it from genuine success/absence, **and** the
+lost fact has semantic consequence.
+
+## Method
+
+Two agent workflows (same harness as the prior audits). (1) A 10-agent locus map inventoried **197 sites** — and
+**over-flagged badly** (142 marked suspect, 72%; one agent flagged 29/29). (2) A 142-candidate verify pass: each
+candidate got an independent classifier that **re-traced what the caller receives on failure and whether the
+authoritative outcome is preserved elsewhere**; every suspect faced a 3-lens adversarial refuter panel
+(fault-preserved / single-meaning / canonical-terminal), confirmed at ≥2 non-refutes; a synthesis agent clustered
+survivors. Load-bearing claims (both High + the config cluster + a key *cleared* item) were hand-verified.
+
+**Result:** 142 candidates → **16 confirmed, 7 contested, 119 legitimate**. **11 root clusters, 2 High.** The
+adversarial panels did the heavy lifting: **119/142 refuted**, including the entire `let _ = tap_emit(...)`
+event-tap "dropped-delivery" cluster (35 sites the map flagged) — correctly cleared as best-effort observability
+whose authoritative terminal truth is carried by the return value / machine state / persisted event.
+
+## Bottom line
+
+- **Widespread?** **No — once adversarially filtered.** The raw suspect count was huge, but the codebase's typed-error
+  discipline (`?` propagation, typed `ToolError`/`SessionError`/`LlmError` with `error_code()`) holds in the vast
+  majority. Only **~16 genuine** violations remain, and ~6 of those are bounded/Low. The map's 142 was 88% noise.
+- **Systemic?** **Yes — one shape.** A fault is dropped at a leaf (`.ok()?` / `unwrap_or_default()` / `let _ =` /
+  swallow-to-`tracing::error!`+return) instead of propagating the typed fault — **and the same condition is handled
+  correctly by a sibling** (Anthropic `StreamParseError` vs OpenAI silent drop; `config/get` vs `capabilities/get`;
+  the service re-persist vs the loop's best-effort save). The dogma-correct pattern almost always already exists nearby.
+- **Live impact?** Mostly latent (requires a corrupt config, a malformed provider chunk, or an authority-invariant
+  breach to bite) — but **two are High** because they corrupt the agent turn outcome and the ops barrier.
+- **Complexity?** **Medium**, most clusters small/mechanical (copy the sibling's typed propagation). No new authorities.
+
+## High-severity clusters (hand-verified)
+
+### H1 — Provider streaming seam drops malformed/truncated output into synthetic Success
+**`malformed_to_default` + `split_terminality` · High · anthropic/openai/llm-core · members 43,46,50**
+
+The **same condition terminates two ways across provider parsers** — the canonical Rule-8 violation:
+- **id 50:** `ToolCallBuffer::try_complete()` returns `Option`, and `serde_json::from_str(&self.args_json).ok()?`
+  (`meerkat-llm-core/src/types.rs:445`) silently drops malformed tool-args after `finish_reason == tool_calls` → the
+  intended tool call **vanishes** and the turn emits `Done{Success}`. Anthropic, for the identical corruption,
+  returns typed `LlmError::StreamParseError` (`meerkat-anthropic/src/client.rs:1638`).
+- **id 46:** Anthropic clean-EOF-without `message_stop` synthesizes `Done{Success{EndTurn}}` (`client.rs:1423-1432`),
+  pre-empting `ensure_terminal_done`'s `IncompleteResponse` and dropping any in-flight `tool_use`; OpenAI/Gemini don't.
+- **id 43:** `parse_sse_line` `.ok()`-drops a malformed real `data:` event → content truncation laundered to Success.
+
+**Repair:** one canonical terminal for malformed/truncated output, matching Anthropic's `StreamParseError`: make
+`try_complete -> Result<ToolCall, LlmError>` (map serde failure to `StreamParseError`, carve out empty/no-name);
+give `parse_sse_line` a typed parse-failure distinction; delete the synthetic-Success branch and let
+`ensure_terminal_done` classify EOF as `IncompleteResponse`. *Medium — typed faults already exist; streaming code is test-heavy.*
+
+### H2 — ops_lifecycle authority faults swallowed (op reported complete + waiter hangs)
+**`split_terminality` · High · meerkat-runtime · members 97,101**
+
+- **id 101:** `maybe_satisfy_wait(&mut self)` (returns nothing) swallows `try_satisfy_wait_all_authority()` errors —
+  an `OpsLifecycleError::Internal` (authority-invariant corruption) — into `tracing::error! + return`
+  (`ops_lifecycle.rs:1762-1768`). Its caller `finalize_terminal` returns `Ok(())`, so `complete/fail/cancel_operation`
+  report the op **fully terminal** while the wait-all barrier's oneshot never fires → the waiting consumer **hangs**.
+- **id 97:** completion-cursor poison laundered to `None` (`ops_lifecycle.rs:3149`).
+
+**Repair:** `maybe_satisfy_wait -> Result<(), OpsLifecycleError>`, `?`-propagate from `finalize_terminal`, and route
+the barrier-satisfaction failure to a typed terminal for the op + the waiter (don't report complete on authority
+corruption). *Medium — local to one file with a prevailing propagation convention.*
+
+## Medium / Low clusters
+
+| Cluster | Sig | Cx | Evidence |
+|---|---|---|---|
+| **Config-read handlers launder `ConfigError` → `Config::default()`** (114-117) | malformed_to_default | small | `config_store.get().await.unwrap_or_default()` at REST `lib.rs:3253` (`/capabilities`, returns bare `Json` — can't even propagate), `:3315` (`/models`), RPC `router.rs:1706` (`capabilities/get`), `:1734` (`models/catalog`). Benign absence is already `Ok(default)` inside the store, so every `Err` is a TRUE fault → success payload with phantom capabilities/empty catalog. Correct sibling exists: `handlers/config.rs:165` `match … Ok/Err`. **Verified.** |
+| **In-loop durable-projection writes swallow `Err` then emit success** (17,12) | split_terminality | medium | `publish_committed_visible_set`'s typed `AgentError` dropped to `warn!`, then `AgentEvent::ToolConfigChanged{boundary_applied}` + "change applied" notice emitted; durable tool-visibility projection (recovery source) diverges from in-memory authority. |
+| **Realm lease reader launders corrupt-but-live lease to absent — and deletes the evidence** (110,111) | malformed_to_default | small | `inspect_realm_leases_in` has no unparseable channel; a lease `*.json` failing serde lands in neither `active` nor `stale`, and under `cleanup_stale=true` (every prune/delete caller) is **auto-deleted** — defeating the `delete_realm` "active leases block destructive prune" safety guard. **Safety consequence.** |
+| **Cleanup/rotation drops typed `Err` with `let _ =`** (2,78) | error_swallowed_to_success | small | `rotate_auth_lease_auth_binding`'s `let _ = handle.release_lease(&previous_key)` drops the release outcome during LLM hot-swap while the acquire branch maps to `AgentError` (asymmetric); stale lease may conflict with the new bind. |
+| **Broadcast subscription silently drops `Lagged` events to pure observers** (122) | dropped_observation | medium | `subscribe_pending_session_events` on `RecvError::Lagged(n)` `continue`s, dropping n `AgentEvent`s (incl. `RunCompleted`/`RunFailed`) with no record; asymmetric with the existing `NotificationQueueOverflow` modeling. Pure observers can't reconstruct terminal truth. |
+| **Python SDK post-connect tool registration laundered to success** (133) | error_swallowed_to_success | small | `_register_tool_with_server` wraps `tools/register` in `except Exception: pass` — catches protocol errors / server rejection, not just shutdown; tool silently never registered. |
+| **RPC success envelope fabricates `result:null` on serialization failure** (120) | error_swallowed_to_success | trivial | `RpcResponse::success`'s outer `to_raw_value` failure fabricates `{result: "null", error: None}` — a valid JSON-RPC **success** carrying null, on the authoritative reply channel. |
+| **Store enumeration drops faults to empty/none** (107,108,104,105) | error_to_empty | small/Low | `read_all_metadata_sidecars` drops a malformed `.meta` to warn+continue → incomplete `list()` (bounded: canonical `<id>.jsonl` still read directly). 104/105 (`SessionIndex` trait) verified **dead** (zero callers) → delete. |
+
+## Contested / cleared (validates panel quality)
+
+The map's two most prominent agent-loop flags were **correctly refuted**: **id 1** `save_session_best_effort`
+(`meerkat-core/src/agent/state.rs:255`) swallows the store save — but it's a redundant optimization: the persistent
+service re-persists with `?`-propagation (`persist_full_session_or_discard_live`) and `RunResult` never claims
+persistence (**verified**). The **entire 35-site `let _ = tap_emit(...)` event-tap cluster** was refuted — best-effort
+observability whose authoritative terminal outcome is the return value / machine state / persisted event, not the
+dropped event. (Worth keeping an eye on: this is only legitimate *because* observers don't reconstruct terminal truth
+from those events — cluster 122 is the one place that assumption breaks.)
+
+## Systemic read & clean path
+
+The recurring shape: **a leaf drops a typed fault** (`.ok()?` / `unwrap_or_default()` / `let _ =` /
+`tracing::error!`+`return`) **into a benign terminal**, while a sibling handles the same condition correctly. The fix
+is uniform: **propagate the typed fault that already exists, matching the sibling.** Because the typed faults and the
+correct conventions are already present, no new authorities are needed.
+
+**Ordered plan:**
+1. **H1 provider seam** (highest blast — corrupts the agent turn): `try_complete -> Result`, typed `parse_sse_line`
+   skip, delete the synthetic-Success branch. Unifies malformed-output terminality across all three providers.
+2. **H2 ops_lifecycle**: `maybe_satisfy_wait -> Result`, `?`-propagate; don't report op-complete on authority corruption.
+3. **Config handlers (114-117)**: replace `unwrap_or_default()` with the `handlers/config.rs` propagate-or-error
+   pattern; make `/capabilities` return `Result<_, ApiError>`. *(small, mechanical)*
+4. **Realm lease (110,111)**: add an `unparseable` channel; never auto-delete a corrupt-but-live lease (safety).
+5. **The small set**: RPC envelope typed-error (120), cleanup `let _ =` → `?` (2,78), SDK `except: pass` → propagate
+   (133), `Lagged` → typed gap observation (122), delete dead `SessionIndex` (104,105).
+
+**Overall: medium**, front-loaded on the two Highs; the long tail is mechanical "copy the sibling's typed propagation."
+
+## Cross-audit note
+
+This is the fifth and final-style aspect, and it confirms the through-line of all five: **the typed/authoritative
+core is well-governed; residual violations are leaves that drop a fault the surrounding system already models.** The
+strongest evidence is *split terminality itself* — the violations are precisely where one path (Anthropic
+`StreamParseError`, `config/get`, the persistent service) does it right and a twin (OpenAI `.ok()?`,
+`capabilities/get`, the loop best-effort save) launders. Three audits now converge on consolidation targets: one
+default-model owner (R6/R7/R9), one backend-kind owner (R4/R7), and here **one canonical terminal per condition**
+across the provider parsers. The biggest *structural* lever remains R9's: the missing rerun-and-diff/parity gates
+that would catch this class of drift before it lands.

--- a/examples/035-mdm-tux-rs/src/bin/target.rs
+++ b/examples/035-mdm-tux-rs/src/bin/target.rs
@@ -264,10 +264,13 @@ impl SurfaceScheduleSessionHost for TargetScheduleSessionHost {
 
     async fn materialize_session(
         &self,
+        occurrence: &meerkat::Occurrence,
         create: &meerkat::SessionMaterializationSpec,
         prompt_system_prompt: Option<&str>,
     ) -> Result<SessionId, meerkat::ScheduleDomainError> {
-        let session = Session::new();
+        // Deterministic per-occurrence id so a reclaim/redrive reuses the same
+        // session instead of orphaning a fresh random one.
+        let session = Session::with_id(occurrence.materialized_session_id());
         let session_id = session.id().clone();
         let bindings = self
             .runtime_adapter

--- a/meerkat-anthropic/src/client.rs
+++ b/meerkat-anthropic/src/client.rs
@@ -875,13 +875,21 @@ impl AnthropicClient {
             .is_some_and(|authorizer| authorizer.label() == CLAUDE_AI_OAUTH_AUTHORIZER_LABEL)
     }
 
-    /// Parse an SSE event from the response
-    fn parse_sse_line(line: &str) -> Option<AnthropicEvent> {
-        if let Some(data) = Self::strip_data_prefix(line) {
-            serde_json::from_str(data).ok()
-        } else {
-            None
-        }
+    /// Parse an SSE event from the response.
+    ///
+    /// Returns `Ok(None)` when the line is not a `data:` event, and
+    /// `Err(LlmError::StreamParseError)` when it IS a `data:` event whose JSON
+    /// fails to parse — a malformed-but-present data event is a typed fault, not
+    /// a silently skippable non-event.
+    fn parse_sse_line(line: &str) -> Result<Option<AnthropicEvent>, LlmError> {
+        let Some(data) = Self::strip_data_prefix(line) else {
+            return Ok(None);
+        };
+        serde_json::from_str(data)
+            .map(Some)
+            .map_err(|error| LlmError::StreamParseError {
+                message: format!("invalid Anthropic SSE data event JSON: {error}"),
+            })
     }
 
     fn strip_data_prefix(line: &str) -> Option<&str> {
@@ -1088,7 +1096,6 @@ impl LlmClient for AnthropicClient {
             let mut last_stop_reason: Option<StopReason> = None;
             let mut usage = Usage::default();
             let mut saw_done = false;
-            let mut saw_event = false;
 
             macro_rules! handle_event {
                 ($event:expr) => {
@@ -1098,27 +1105,23 @@ impl LlmClient for AnthropicClient {
                                 match delta.delta_type.as_str() {
                                     "text_delta" => {
                                         if let Some(text) = delta.text {
-                                            saw_event = true;
                                             yield LlmEvent::TextDelta { delta: text, meta: None };
                                         }
                                     }
                                     "thinking_delta" => {
                                         // Emit incremental thinking content
                                         if let Some(text) = delta.thinking {
-                                            saw_event = true;
                                             yield LlmEvent::ReasoningDelta { delta: text };
                                         }
                                     }
                                     "signature_delta" => {
                                         // Signature arrives as separate delta before content_block_stop
                                         if let Some(sig) = delta.signature {
-                                            saw_event = true;
                                             current_thinking_signature = Some(sig);
                                         }
                                     }
                                     "input_json_delta" => {
                                         if let Some(partial_json) = delta.partial_json {
-                                            saw_event = true;
                                             if current_block_type.as_deref() == Some("server_tool_use") {
                                                 accumulated_server_tool_input.push_str(&partial_json);
                                             } else {
@@ -1134,7 +1137,6 @@ impl LlmClient for AnthropicClient {
                                     "compaction_delta" => {
                                         // Compaction summary arrives as single delta — emit as Reasoning with compaction meta
                                         if let Some(content) = delta.content {
-                                            saw_event = true;
                                             yield LlmEvent::ReasoningComplete {
                                                 text: String::new(),
                                                 meta: Some(Box::new(meerkat_core::ProviderMeta::AnthropicCompaction { content })),
@@ -1151,7 +1153,6 @@ impl LlmClient for AnthropicClient {
                                 match content_block.block_type.as_str() {
                                     "text" => {
                                         if let Some(citations) = content_block.extra.get("citations") {
-                                            saw_event = true;
                                             yield LlmEvent::ServerToolContent {
                                                 id: None,
                                                 name: "web_search_citations".to_string(),
@@ -1171,7 +1172,6 @@ impl LlmClient for AnthropicClient {
                                     "redacted_thinking" => {
                                         // Redacted by safety systems — emit as Reasoning with redacted meta
                                         if let Some(data) = content_block.data {
-                                            saw_event = true;
                                             yield LlmEvent::ReasoningComplete {
                                                 text: String::new(),
                                                 meta: Some(Box::new(meerkat_core::ProviderMeta::AnthropicRedacted { data })),
@@ -1186,7 +1186,6 @@ impl LlmClient for AnthropicClient {
                                         current_tool_id = Some(id.clone());
                                         current_tool_name = content_block.name.clone();
                                         accumulated_tool_args.clear();
-                                        saw_event = true;
                                         yield LlmEvent::ToolCallDelta {
                                             id,
                                             name: content_block.name,
@@ -1199,7 +1198,6 @@ impl LlmClient for AnthropicClient {
                                         accumulated_server_tool_input.clear();
                                     }
                                     "web_search_tool_result" => {
-                                        saw_event = true;
                                         yield LlmEvent::ServerToolContent {
                                             id: content_block.tool_use_id.clone(),
                                             name: "web_search".to_string(),
@@ -1240,7 +1238,6 @@ impl LlmClient for AnthropicClient {
                                             tool_id,
                                         ) {
                                             Ok(args_val) => {
-                                                saw_event = true;
                                                 yield LlmEvent::ToolCallComplete {
                                                     id: tool_id.clone(),
                                                     name: current_tool_name.take().unwrap_or_default(),
@@ -1249,7 +1246,6 @@ impl LlmClient for AnthropicClient {
                                                 };
                                             }
                                             Err(error) => {
-                                                saw_event = true;
                                                 if !saw_done {
                                                     yield LlmEvent::Done {
                                                         outcome: LlmDoneOutcome::Error { error },
@@ -1276,7 +1272,6 @@ impl LlmClient for AnthropicClient {
                                         .take()
                                         .unwrap_or_else(|| "server_tool".to_string());
                                     accumulated_server_tool_input.clear();
-                                    saw_event = true;
                                     yield LlmEvent::ServerToolContent {
                                         id,
                                         name,
@@ -1294,7 +1289,6 @@ impl LlmClient for AnthropicClient {
                         "message_delta" => {
                             if let Some(usage_update) = $event.usage {
                                 merge_usage(&mut usage, &usage_update);
-                                saw_event = true;
                                 yield LlmEvent::UsageUpdate {
                                     usage: usage.clone(),
                                 };
@@ -1303,7 +1297,6 @@ impl LlmClient for AnthropicClient {
                                 let reason = Self::map_stop_reason(finish_reason.as_str());
                                 last_stop_reason = Some(reason);
                                 if !saw_done {
-                                    saw_event = true;
                                     yield LlmEvent::Done {
                                         outcome: LlmDoneOutcome::Success { stop_reason: reason },
                                     };
@@ -1314,7 +1307,6 @@ impl LlmClient for AnthropicClient {
                         "message_start" => {
                             if let Some(usage_update) = $event.message.and_then(|m| m.usage) {
                                 merge_usage(&mut usage, &usage_update);
-                                saw_event = true;
                                 yield LlmEvent::UsageUpdate {
                                     usage: usage.clone(),
                                 };
@@ -1329,7 +1321,6 @@ impl LlmClient for AnthropicClient {
                                     .or(last_stop_reason)
                                     .unwrap_or(StopReason::EndTurn);
                                 last_stop_reason = Some(reason);
-                                saw_event = true;
                                 yield LlmEvent::Done {
                                     outcome: LlmDoneOutcome::Success { stop_reason: reason },
                                 };
@@ -1368,7 +1359,6 @@ impl LlmClient for AnthropicClient {
                             };
 
                             if !saw_done {
-                                saw_event = true;
                                 yield LlmEvent::Done {
                                     outcome: LlmDoneOutcome::Error { error },
                                 };
@@ -1388,14 +1378,24 @@ impl LlmClient for AnthropicClient {
                                 if !saw_done {
                                     let reason =
                                         last_stop_reason.unwrap_or(StopReason::EndTurn);
-                                    saw_event = true;
                                     yield LlmEvent::Done {
                                         outcome: LlmDoneOutcome::Success { stop_reason: reason },
                                     };
                                     saw_done = true;
                                 }
-                            } else if let Some(event) = Self::parse_sse_line($line) {
-                                handle_event!(event);
+                            } else {
+                                match Self::parse_sse_line($line) {
+                                    Ok(Some(event)) => { handle_event!(event); }
+                                    Ok(None) => {}
+                                    Err(error) => {
+                                        if !saw_done {
+                                            yield LlmEvent::Done {
+                                                outcome: LlmDoneOutcome::Error { error },
+                                            };
+                                        }
+                                        return;
+                                    }
+                                }
                             }
                         }
                     }
@@ -1420,16 +1420,6 @@ impl LlmClient for AnthropicClient {
                 }
             }
 
-            if !saw_done && saw_event {
-                tracing::warn!(
-                    model = %request.model,
-                    "Anthropic stream ended without terminal event; emitting synthetic Done"
-                );
-                let reason = last_stop_reason.unwrap_or(StopReason::EndTurn);
-                yield LlmEvent::Done {
-                    outcome: LlmDoneOutcome::Success { stop_reason: reason },
-                };
-            }
         });
 
         streaming::ensure_terminal_done(inner)
@@ -2317,18 +2307,27 @@ mod tests {
     #[test]
     fn test_parse_sse_line() {
         let line = r#"data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hello"}}"#;
-        let event = AnthropicClient::parse_sse_line(line);
-        assert!(event.is_some());
-        assert_eq!(event.unwrap().event_type, "content_block_delta");
+        let event = AnthropicClient::parse_sse_line(line)
+            .expect("well-formed data event parses")
+            .expect("event present");
+        assert_eq!(event.event_type, "content_block_delta");
 
-        let done = AnthropicClient::parse_sse_line("data: [DONE]");
-        assert!(done.is_none());
-
+        // Non-`data:` lines are legitimate non-events -> Ok(None).
         let comment = AnthropicClient::parse_sse_line(": comment");
-        assert!(comment.is_none());
+        assert!(matches!(comment, Ok(None)));
 
         let event_line = AnthropicClient::parse_sse_line("event: message_start");
-        assert!(event_line.is_none());
+        assert!(matches!(event_line, Ok(None)));
+
+        // A `data:` line whose JSON fails to parse is a typed fault, not a
+        // silently-dropped non-event. (`[DONE]` is a sentinel handled by the
+        // caller before parse_sse_line is reached, so it is treated here as the
+        // non-JSON data payload it is.)
+        let done = AnthropicClient::parse_sse_line("data: [DONE]");
+        assert!(matches!(done, Err(LlmError::StreamParseError { .. })));
+
+        let malformed = AnthropicClient::parse_sse_line(r#"data: {"type": "content_block"#);
+        assert!(matches!(malformed, Err(LlmError::StreamParseError { .. })));
     }
 
     #[test]
@@ -3131,6 +3130,51 @@ mod tests {
                 .contains("invalid Anthropic tool call arguments JSON"),
             "error should name invalid Anthropic tool args: {error}"
         );
+    }
+
+    /// A clean EOF without any terminal event (no message_stop, message_delta,
+    /// or [DONE]) must NOT be laundered into a synthetic Done{Success}. It must
+    /// fall through to ensure_terminal_done and surface Done{Error{IncompleteResponse}},
+    /// matching the OpenAI/Gemini fall-through behavior.
+    #[tokio::test]
+    async fn test_stream_eof_without_terminal_fails_incomplete() {
+        let payload = [
+            r#"data: {"type":"message_start","message":{"usage":{"input_tokens":10,"output_tokens":0}}}"#,
+            r#"data: {"type":"content_block_start","content_block":{"type":"text","text":""}}"#,
+            r#"data: {"type":"content_block_delta","delta":{"type":"text_delta","text":"partial"}}"#,
+            // Stream ends here WITHOUT content_block_stop / message_delta /
+            // message_stop / [DONE] (truncated mid-turn).
+            "",
+        ]
+        .join("\n");
+        let (base_url, server) = spawn_anthropic_stub_server(payload).await;
+        let client = AnthropicClient::builder("test-key".to_string())
+            .base_url(base_url)
+            .build()
+            .unwrap();
+        let request = LlmRequest::new(
+            "claude-sonnet-4-5",
+            vec![Message::User(UserMessage::text("hello".to_string()))],
+        );
+
+        let mut stream = client.stream(&request);
+        let mut terminal = None;
+        while let Some(event) = stream.next().await {
+            if let LlmEvent::Done { outcome } =
+                event.expect("stream wrapper should convert errors to Done")
+            {
+                terminal = Some(outcome);
+                break;
+            }
+        }
+        server.abort();
+
+        match terminal.expect("expected a terminal Done event") {
+            LlmDoneOutcome::Error {
+                error: LlmError::IncompleteResponse { .. },
+            } => {}
+            other => panic!("expected Done{{Error{{IncompleteResponse}}}}, got {other:?}"),
+        }
     }
 
     /// Normal stream with message_stop should still work (baseline).

--- a/meerkat-cli/src/main.rs
+++ b/meerkat-cli/src/main.rs
@@ -10155,10 +10155,14 @@ impl SurfaceScheduleSessionHost for CliScheduleSessionHost {
 
     async fn materialize_session(
         &self,
+        occurrence: &meerkat::Occurrence,
         create: &meerkat::SessionMaterializationSpec,
         prompt_system_prompt: Option<&str>,
     ) -> Result<SessionId, meerkat::ScheduleDomainError> {
-        let session = Session::new();
+        // Deterministic per-occurrence id so a reclaim/redrive reuses the same
+        // session instead of orphaning a fresh random one in the
+        // materialize->bind crash window.
+        let session = Session::with_id(occurrence.materialized_session_id());
         let session_id = session.id().clone();
         let bindings = self
             .runtime_adapter

--- a/meerkat-cli/src/main.rs
+++ b/meerkat-cli/src/main.rs
@@ -6951,11 +6951,12 @@ async fn delete_realm(
     let lease_status = meerkat_store::inspect_realm_leases_in(state_root, realm_id, true)
         .await
         .map_err(|e| anyhow::anyhow!("Failed to inspect realm leases: {e}"))?;
-    if !lease_status.active.is_empty() && !force {
+    if lease_status.blocks_destructive_prune() && !force {
         return Err(anyhow::anyhow!(
-            "Realm '{}' appears active ({} live lease(s)). Use --force to override.",
+            "Realm '{}' appears active ({} live lease(s), {} unreadable lease file(s)). Use --force to override.",
             realm_id,
-            lease_status.active.len()
+            lease_status.active.len(),
+            lease_status.unparseable.len()
         ));
     }
 
@@ -7073,7 +7074,7 @@ async fn prune_realms_inner(
             meerkat_store::inspect_realm_leases_in(state_root, manifest.realm.as_str(), true)
                 .await
                 .map_err(|e| anyhow::anyhow!("Failed to inspect realm leases: {e}"))?;
-        if !lease_status.active.is_empty() && !force {
+        if lease_status.blocks_destructive_prune() && !force {
             outcome.skipped_active += 1;
             continue;
         }
@@ -20123,6 +20124,48 @@ supports_reasoning = true
         lease.shutdown().await;
     }
 
+    #[tokio::test]
+    async fn test_delete_realm_blocks_when_lease_unreadable_without_force() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let state_root = temp.path().join("realms");
+        let realm_id = "corrupt-lease-realm";
+
+        let _manifest = meerkat_store::ensure_realm_manifest_in(
+            &state_root,
+            realm_id,
+            Some(meerkat_store::RealmBackend::Sqlite),
+            Some(meerkat_store::RealmOrigin::Generated),
+        )
+        .await
+        .expect("create manifest");
+
+        // A corrupt-but-present lease file is an unknown-state datum: it may
+        // belong to a still-live instance whose heartbeat was caught mid-write.
+        let paths = meerkat_store::realm_paths_in(&state_root, realm_id);
+        let lease_dir = meerkat_store::realm_lease_dir(&paths);
+        tokio::fs::create_dir_all(&lease_dir)
+            .await
+            .expect("create lease dir");
+        let corrupt_path = lease_dir.join("corrupt-instance.json");
+        tokio::fs::write(&corrupt_path, b"{ not json")
+            .await
+            .expect("write corrupt lease");
+
+        let blocked = delete_realm(&state_root, realm_id, false).await;
+        assert!(
+            blocked.is_err(),
+            "delete must block while a lease is unreadable (unknown liveness)"
+        );
+        // The inspect call must NOT have deleted the corrupt evidence.
+        assert!(
+            tokio::fs::try_exists(&corrupt_path).await.unwrap(),
+            "corrupt lease must not be auto-deleted by the inspect call"
+        );
+
+        let forced = delete_realm(&state_root, realm_id, true).await;
+        assert!(forced.is_ok(), "delete --force should proceed");
+    }
+
     #[cfg(unix)]
     #[tokio::test]
     async fn test_prune_inner_reports_leftovers_on_partial_failure() {
@@ -20152,6 +20195,48 @@ supports_reasoning = true
 
         let restore = std::fs::Permissions::from_mode(0o755);
         let _ = std::fs::set_permissions(&state_root, restore);
+    }
+
+    #[tokio::test]
+    async fn test_prune_inner_skips_realm_with_unreadable_lease() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let state_root = temp.path().join("realms");
+        let realm_id = "corrupt-lease-prune";
+
+        let _manifest = meerkat_store::ensure_realm_manifest_in(
+            &state_root,
+            realm_id,
+            Some(meerkat_store::RealmBackend::Sqlite),
+            Some(meerkat_store::RealmOrigin::Generated),
+        )
+        .await
+        .expect("create manifest");
+
+        // A corrupt-but-present lease must be treated as possibly-live: the
+        // realm must be skipped, not pruned, and the realm root must survive.
+        let paths = meerkat_store::realm_paths_in(&state_root, realm_id);
+        let lease_dir = meerkat_store::realm_lease_dir(&paths);
+        tokio::fs::create_dir_all(&lease_dir)
+            .await
+            .expect("create lease dir");
+        let corrupt_path = lease_dir.join("corrupt-instance.json");
+        tokio::fs::write(&corrupt_path, b"{ not json")
+            .await
+            .expect("write corrupt lease");
+
+        let outcome = prune_realms_inner(&state_root, true, 0, false)
+            .await
+            .expect("prune outcome");
+        assert_eq!(outcome.skipped_active, 1);
+        assert_eq!(outcome.removed, 0);
+        assert!(
+            tokio::fs::try_exists(&paths.root).await.unwrap(),
+            "realm root must survive when a lease is unreadable"
+        );
+        assert!(
+            tokio::fs::try_exists(&corrupt_path).await.unwrap(),
+            "corrupt lease must not be auto-deleted by the inspect call"
+        );
     }
 
     #[test]

--- a/meerkat-client/tests/live_client_provider_matrix.rs
+++ b/meerkat-client/tests/live_client_provider_matrix.rs
@@ -656,8 +656,14 @@ async fn test_anthropic_message_stop_without_space_prefix_yields_done()
     Ok(())
 }
 
+/// Rule 8 (Terminal Truth Laundering): a stream that emits content but ends
+/// WITHOUT a terminal event (no `message_stop` / `message_delta` / `[DONE]`) is
+/// truncated, not successful. It must terminalize as a typed
+/// `LlmError::IncompleteResponse` (supplied by `ensure_terminal_done` once the
+/// former synthetic-`Done{Success}`-on-clean-EOF branch was removed) — never a
+/// laundered `Done{Success{EndTurn}}` that hides the truncation.
 #[tokio::test]
-async fn test_anthropic_stream_end_without_done_yields_success()
+async fn test_anthropic_stream_end_without_done_yields_incomplete()
 -> Result<(), Box<dyn std::error::Error>> {
     const SSE_BODY: &str = concat!(
         "data: {\"type\":\"content_block_delta\",\"delta\":{\"type\":\"text_delta\",\"text\":\"Hello\"}}\n",
@@ -680,8 +686,7 @@ async fn test_anthropic_stream_end_without_done_yields_success()
 
     let mut stream = client.stream(&request);
     let mut got_text = false;
-    let mut got_done = false;
-    let mut stop_reason = None;
+    let mut got_incomplete = false;
 
     while let Some(result) = stream.next().await {
         match result {
@@ -691,26 +696,33 @@ async fn test_anthropic_stream_end_without_done_yields_success()
                 }
             }
             Ok(LlmEvent::Done {
-                outcome:
-                    LlmDoneOutcome::Success {
-                        stop_reason: reason,
-                    },
+                outcome: LlmDoneOutcome::Success { stop_reason },
             }) => {
-                got_done = true;
-                stop_reason = Some(reason);
-                break;
+                return Err(format!(
+                    "truncated stream must not launder into Done{{Success}}; got stop_reason {stop_reason:?}"
+                )
+                .into());
             }
             Ok(LlmEvent::Done {
                 outcome: LlmDoneOutcome::Error { error },
-            }) => return Err(format!("Unexpected error: {error:?}").into()),
+            }) => {
+                assert!(
+                    matches!(error, LlmError::IncompleteResponse { .. }),
+                    "expected IncompleteResponse on truncated stream, got {error:?}"
+                );
+                got_incomplete = true;
+                break;
+            }
             Ok(_) => {}
-            Err(e) => return Err(format!("Unexpected error: {e:?}").into()),
+            Err(e) => return Err(format!("Unexpected stream error: {e:?}").into()),
         }
     }
 
-    assert!(got_text);
-    assert!(got_done);
-    assert_eq!(stop_reason, Some(StopReason::EndTurn));
+    assert!(got_text, "the content_block_delta text should still arrive");
+    assert!(
+        got_incomplete,
+        "stream-end-without-terminal must yield Done{{Error{{IncompleteResponse}}}}"
+    );
     Ok(())
 }
 

--- a/meerkat-core/src/agent/builder.rs
+++ b/meerkat-core/src/agent/builder.rs
@@ -109,6 +109,8 @@ pub enum AgentBuildPolicyError {
     ToolVisibilityCatalog { message: String },
     #[error("failed to persist canonical tool visibility state during restore: {message}")]
     ToolVisibilityPersist { message: String },
+    #[error("failed to seed agent completion cursor from generated ops authority: {message}")]
+    OpsCursorSeed { message: String },
 }
 
 #[cfg(not(target_arch = "wasm32"))]
@@ -535,6 +537,20 @@ impl AgentBuilder {
         };
         let compaction_cadence = crate::agent::compact::load_compaction_cadence(&session);
 
+        // Seed only from generated cursor authority. A completion feed without
+        // ops-lifecycle authority is read-only storage, not cursor truth for
+        // async completion delivery. A poisoned/corrupt cursor authority must
+        // fail the build loud rather than launder into a silent zero seed.
+        let applied_cursor = match self.ops_lifecycle.as_ref() {
+            Some(registry) => registry
+                .completion_cursor(crate::ops_lifecycle::CompletionCursorConsumer::AgentApplied)
+                .map_err(|err| AgentBuildPolicyError::OpsCursorSeed {
+                    message: err.to_string(),
+                })?
+                .unwrap_or(0),
+            None => 0,
+        };
+
         let mut agent = Agent {
             config: self.config,
             client,
@@ -565,18 +581,7 @@ impl AgentBuilder {
                 .unwrap_or_else(crate::event_tap::new_event_tap),
             system_context_state,
             default_event_tx: self.default_event_tx,
-            // Seed only from generated cursor authority. A completion feed
-            // without ops-lifecycle authority is read-only storage, not cursor
-            // truth for async completion delivery.
-            applied_cursor: self
-                .ops_lifecycle
-                .as_ref()
-                .and_then(|registry| {
-                    registry.completion_cursor(
-                        crate::ops_lifecycle::CompletionCursorConsumer::AgentApplied,
-                    )
-                })
-                .unwrap_or(0),
+            applied_cursor,
             ops_lifecycle: self.ops_lifecycle,
             completion_feed: self.completion_feed,
             epoch_cursor_state: self.epoch_cursor_state,

--- a/meerkat-core/src/agent/runner.rs
+++ b/meerkat-core/src/agent/runner.rs
@@ -229,13 +229,21 @@ where
         let handle = self.tool_scope.handle();
         let revision = handle.stage_external_filter(filter)?;
         let _ = handle.staged_revision();
-        if let Ok(visibility_state) = self.tool_scope.authorized_visibility_state() {
-            if let Err(err) = self.session.set_tool_visibility_state(visibility_state) {
-                tracing::warn!(
-                    error = %err,
-                    "failed to persist staged canonical tool visibility state"
-                );
-            }
+        if self.tool_scope.owns_durable_visibility_projection() {
+            let visibility_state =
+                self.tool_scope
+                    .authorized_visibility_state()
+                    .map_err(|err| ToolScopeStageError::Owner {
+                        message: err.to_string(),
+                    })?;
+            self.session
+                .set_tool_visibility_state(visibility_state)
+                .map_err(|err| ToolScopeStageError::DurableProjectionPersist {
+                    message: err.to_string(),
+                })?;
+            // Only remove the legacy fallback AFTER the canonical write
+            // committed — a failed canonical persist must never destroy the
+            // legacy recovery source (which would leave both sources gone).
             self.session
                 .remove_metadata(EXTERNAL_TOOL_FILTER_METADATA_KEY);
         }

--- a/meerkat-core/src/agent/runner.rs
+++ b/meerkat-core/src/agent/runner.rs
@@ -431,7 +431,11 @@ where
         }
         if let Some(previous) = previous {
             let previous_key = crate::handles::LeaseKey::from_auth_binding(previous);
-            let _ = handle.release_lease(&previous_key);
+            handle.release_lease(&previous_key).map_err(|err| {
+                AgentError::ConfigError(format!(
+                    "failed to release previous auth lease {previous_key} during rotation: {err}"
+                ))
+            })?;
         }
         if let Some(target) = target {
             let target_key = crate::handles::LeaseKey::from_auth_binding(target);
@@ -461,7 +465,17 @@ where
     /// Persist the currently committed visible tool set into canonical session metadata.
     pub(crate) fn publish_committed_visible_set(&mut self) -> Result<(), AgentError> {
         // Session metadata is a durable projection/export of the canonical
-        // visibility owner state so checkpoint/recovery stays aligned.
+        // visibility owner state so checkpoint/recovery stays aligned. The
+        // projection only exists when a generated MeerkatMachine authority owns
+        // it; standalone builds use a read-only local projection with nothing to
+        // persist, so this is a no-op there (not a durable-write fault). When
+        // the projection IS owned, a write failure is a genuine fault that must
+        // propagate — never be swallowed while a boundary-applied success is
+        // reported, which would diverge the recovery source from in-memory
+        // authority.
+        if !self.tool_scope.owns_durable_visibility_projection() {
+            return Ok(());
+        }
         let authorized_visibility_state =
             self.tool_scope
                 .authorized_visibility_state()

--- a/meerkat-core/src/agent/state.rs
+++ b/meerkat-core/src/agent/state.rs
@@ -6230,6 +6230,99 @@ mod tests {
         );
     }
 
+    /// Dispatcher whose tool catalog carries callback provenance so that
+    /// filter staging through a generated visibility owner can mint valid
+    /// identity witnesses (the generated owner requires filter witnesses).
+    struct ProvenancedToolDispatcher {
+        tools: Arc<[Arc<ToolDef>]>,
+    }
+
+    impl ProvenancedToolDispatcher {
+        fn new(tool_names: &[&str]) -> Self {
+            let tools = tool_names
+                .iter()
+                .map(|name| {
+                    Arc::new(ToolDef {
+                        name: (*name).into(),
+                        description: format!("{name} tool"),
+                        input_schema: serde_json::json!({ "type": "object" }),
+                        provenance: Some(crate::ToolProvenance {
+                            kind: crate::ToolSourceKind::Callback,
+                            source_id: (*name).into(),
+                        }),
+                    })
+                })
+                .collect::<Vec<_>>()
+                .into();
+            Self { tools }
+        }
+    }
+
+    #[async_trait]
+    impl AgentToolDispatcher for ProvenancedToolDispatcher {
+        fn tools(&self) -> Arc<[Arc<ToolDef>]> {
+            Arc::clone(&self.tools)
+        }
+
+        async fn dispatch(
+            &self,
+            call: ToolCallView<'_>,
+        ) -> Result<crate::ops::ToolDispatchOutcome, ToolError> {
+            Ok(ToolResult::new(
+                call.id.to_string(),
+                format!("dispatched {}", call.name),
+                false,
+            )
+            .into())
+        }
+    }
+
+    #[tokio::test]
+    async fn generated_authority_stage_persists_projection_and_clears_legacy_only_on_success() {
+        let client = Arc::new(VisibilityRecordingLlmClient::new());
+        let tools = Arc::new(ProvenancedToolDispatcher::new(&["visible", "secret"]));
+        let visibility_owner: Arc<dyn crate::tool_scope::ToolVisibilityOwner> =
+            Arc::new(crate::tool_scope::GeneratedTestToolVisibilityOwner::new());
+        let mut agent = with_test_turn_state_handle(AgentBuilder::new())
+            .with_tool_visibility_owner(
+                crate::tool_scope::generated_test_tool_visibility_owner_from(visibility_owner),
+            )
+            .build_standalone(client, tools, Arc::new(NoopStore))
+            .await;
+
+        // Seed the legacy fallback recovery source. The canonical persist must
+        // remove it ONLY after the durable projection write commits.
+        agent.session_mut().set_metadata(
+            EXTERNAL_TOOL_FILTER_METADATA_KEY,
+            serde_json::to_value(ToolFilter::Deny(
+                ["secret".to_string()].into_iter().collect(),
+            ))
+            .expect("legacy filter should serialize"),
+        );
+
+        agent
+            .stage_external_tool_filter(ToolFilter::Deny(
+                ["secret".to_string()].into_iter().collect(),
+            ))
+            .expect("generated authority staging must persist canonical visibility");
+
+        assert!(
+            agent
+                .session()
+                .tool_visibility_state()
+                .expect("visibility state should decode")
+                .is_some(),
+            "successful generated-authority staging must persist the canonical visibility projection"
+        );
+        assert!(
+            !agent
+                .session()
+                .metadata()
+                .contains_key(EXTERNAL_TOOL_FILTER_METADATA_KEY),
+            "successful canonical persist must clear the legacy fallback source"
+        );
+    }
+
     #[tokio::test]
     async fn run_loop_fails_closed_on_tool_scope_boundary_failure() {
         let client = Arc::new(SingleTurnVisibilityClient::new());

--- a/meerkat-core/src/agent/state.rs
+++ b/meerkat-core/src/agent/state.rs
@@ -1525,12 +1525,11 @@ where
                         };
                         match apply_result {
                             Ok(applied) => {
-                                if let Err(err) = self.publish_committed_visible_set() {
-                                    tracing::warn!(
-                                        error = %err,
-                                        "failed to persist canonical tool visibility state after boundary apply"
-                                    );
-                                }
+                                self.publish_committed_visible_set().map_err(|err| {
+                                    AgentError::InternalError(format!(
+                                        "failed to persist canonical tool visibility state after boundary apply: {err}"
+                                    ))
+                                })?;
                                 if applied.changed() {
                                     let status_info = ToolConfigChangeStatus::boundary_applied(
                                         applied.base_changed(),

--- a/meerkat-core/src/ops_lifecycle.rs
+++ b/meerkat-core/src/ops_lifecycle.rs
@@ -526,12 +526,15 @@ pub trait OpsLifecycleRegistry: Send + Sync {
 
     /// Read the generated completion-consumer cursor for this registry.
     ///
-    /// Implementations without generated cursor authority return `None`.
+    /// `Ok(None)` means this registry has no generated cursor authority.
+    /// `Err(OpsLifecycleError::Internal(_))` means the cursor authority is
+    /// corrupt (e.g. a poisoned registry lock) and must not be laundered into
+    /// the `None`/no-authority meaning by callers.
     fn completion_cursor(
         &self,
         _consumer: CompletionCursorConsumer,
-    ) -> Option<crate::completion_feed::CompletionSeq> {
-        None
+    ) -> Result<Option<crate::completion_feed::CompletionSeq>, OpsLifecycleError> {
+        Ok(None)
     }
 
     /// Advance a completion-consumer cursor through generated authority.

--- a/meerkat-core/src/tool_scope.rs
+++ b/meerkat-core/src/tool_scope.rs
@@ -1468,6 +1468,17 @@ impl ToolScope {
         }
     }
 
+    /// Whether this scope owns a durable (generated-MeerkatMachine) tool
+    /// visibility projection that must be persisted on boundary apply.
+    ///
+    /// Standalone builds use a read-only local projection
+    /// ([`ToolVisibilityAuthorityKind::LocalReadOnlyProjection`]) with no
+    /// durable session-metadata projection to write, so publishing the
+    /// committed visible set there is a legitimate no-op rather than a fault.
+    pub(crate) fn owns_durable_visibility_projection(&self) -> bool {
+        self.visibility_authority == ToolVisibilityAuthorityKind::GeneratedMachine
+    }
+
     /// Returns the currently visible tools using base + active external filter composition.
     pub fn visible_tools(&self) -> Arc<[Arc<ToolDef>]> {
         match self.visible_tools_result() {

--- a/meerkat-core/src/tool_scope.rs
+++ b/meerkat-core/src/tool_scope.rs
@@ -196,6 +196,8 @@ pub enum ToolScopeStageError {
     LockPoisoned,
     #[error("Tool visibility owner error: {message}")]
     Owner { message: String },
+    #[error("failed to persist durable tool visibility projection: {message}")]
+    DurableProjectionPersist { message: String },
 }
 
 #[derive(Debug, Clone, thiserror::Error, PartialEq, Eq)]

--- a/meerkat-gemini/src/client.rs
+++ b/meerkat-gemini/src/client.rs
@@ -707,34 +707,54 @@ impl GeminiClient {
         }
     }
 
-    /// Parse streaming response line
-    fn parse_stream_line(line: &str) -> Option<GenerateContentResponse> {
-        serde_json::from_str(line).ok()
+    /// Parse a streaming response line.
+    ///
+    /// Returns `Ok(None)` when the line is blank (not a data event), and
+    /// `Err(LlmError::StreamParseError)` when a non-empty line fails to parse —
+    /// a malformed-but-present data event is a typed fault, not a silently
+    /// skippable non-event.
+    fn parse_stream_line(line: &str) -> Result<Option<GenerateContentResponse>, LlmError> {
+        if line.trim().is_empty() {
+            return Ok(None);
+        }
+        serde_json::from_str(line)
+            .map(Some)
+            .map_err(|error| LlmError::StreamParseError {
+                message: format!("invalid Gemini SSE data event JSON: {error}"),
+            })
     }
 
-    fn parse_stream_line_for_wire(&self, line: &str) -> Option<GenerateContentResponse> {
+    fn parse_stream_line_for_wire(
+        &self,
+        line: &str,
+    ) -> Result<Option<GenerateContentResponse>, LlmError> {
         match self.wire_mode {
             GeminiWireMode::PublicGenerateContent => Self::parse_stream_line(line),
             GeminiWireMode::CodeAssist => {
-                let wrapper: Option<CodeAssistGenerateContentResponse> =
-                    serde_json::from_str(line).ok();
-                wrapper
-                    .map(|wrapper| {
-                        if let Some(mut response) = wrapper.response {
-                            if response.response_id.is_none() {
-                                response.response_id = wrapper.trace_id;
-                            }
-                            response
-                        } else {
-                            GenerateContentResponse {
-                                candidates: Some(Vec::new()),
-                                usage_metadata: None,
-                                response_id: wrapper.trace_id,
-                                prompt_feedback: None,
-                            }
+                if line.trim().is_empty() {
+                    return Ok(None);
+                }
+                // CodeAssist responses are wrapped; fall back to the bare wire
+                // shape only when the wrapper does not match. A line that parses
+                // as neither is a typed fault.
+                if let Ok(wrapper) = serde_json::from_str::<CodeAssistGenerateContentResponse>(line)
+                {
+                    let response = if let Some(mut response) = wrapper.response {
+                        if response.response_id.is_none() {
+                            response.response_id = wrapper.trace_id;
                         }
-                    })
-                    .or_else(|| Self::parse_stream_line(line))
+                        response
+                    } else {
+                        GenerateContentResponse {
+                            candidates: Some(Vec::new()),
+                            usage_metadata: None,
+                            response_id: wrapper.trace_id,
+                            prompt_feedback: None,
+                        }
+                    };
+                    return Ok(Some(response));
+                }
+                Self::parse_stream_line(line)
             }
         }
     }
@@ -1572,7 +1592,7 @@ impl LlmClient for GeminiClient {
                     let line = buffer[..newline_pos].trim();
                     let data = line.strip_prefix("data: ");
                     let parsed_response = if let Some(d) = data {
-                        self.parse_stream_line_for_wire(d)
+                        self.parse_stream_line_for_wire(d)?
                     } else {
                         None
                     };
@@ -2613,9 +2633,7 @@ mod tests {
     fn test_parse_stream_line_valid_response() -> Result<(), Box<dyn std::error::Error>> {
         let line =
             r#"{"candidates":[{"content":{"parts":[{"text":"Hello"}]},"finishReason":"STOP"}]}"#;
-        let response = GeminiClient::parse_stream_line(line);
-        assert!(response.is_some());
-        let response = response.ok_or("missing response")?;
+        let response = GeminiClient::parse_stream_line(line)?.ok_or("missing response")?;
         assert!(response.candidates.is_some());
         let candidates = response.candidates.ok_or("missing candidates")?;
         assert_eq!(candidates.len(), 1);
@@ -2625,9 +2643,7 @@ mod tests {
     #[test]
     fn test_parse_stream_line_with_usage() -> Result<(), Box<dyn std::error::Error>> {
         let line = r#"{"usageMetadata":{"promptTokenCount":10,"candidatesTokenCount":5}}"#;
-        let response = GeminiClient::parse_stream_line(line);
-        assert!(response.is_some());
-        let response = response.ok_or("missing response")?;
+        let response = GeminiClient::parse_stream_line(line)?.ok_or("missing response")?;
         assert!(response.usage_metadata.is_some());
         let usage = response.usage_metadata.ok_or("missing usage")?;
         assert_eq!(usage.prompt_token_count, Some(10));
@@ -2637,9 +2653,7 @@ mod tests {
     #[test]
     fn test_parse_stream_line_function_call() -> Result<(), Box<dyn std::error::Error>> {
         let line = r#"{"candidates":[{"content":{"parts":[{"functionCall":{"name":"get_weather","args":{"city":"Tokyo"}}}]}}]}"#;
-        let response = GeminiClient::parse_stream_line(line);
-        assert!(response.is_some());
-        let response = response.ok_or("missing response")?;
+        let response = GeminiClient::parse_stream_line(line)?.ok_or("missing response")?;
         let candidates = response.candidates.as_ref().ok_or("missing candidates")?;
         let parts = candidates[0]
             .content
@@ -2656,16 +2670,18 @@ mod tests {
 
     #[test]
     fn test_parse_stream_line_empty() {
+        // A blank line is legitimately "not a data event" -> Ok(None).
         let line = "";
         let response = GeminiClient::parse_stream_line(line);
-        assert!(response.is_none());
+        assert!(matches!(response, Ok(None)));
     }
 
     #[test]
     fn test_parse_stream_line_invalid_json() {
+        // A non-empty but unparseable line is a typed fault, not a dropped event.
         let line = "{invalid}";
         let response = GeminiClient::parse_stream_line(line);
-        assert!(response.is_none());
+        assert!(matches!(response, Err(LlmError::StreamParseError { .. })));
     }
 
     /// Regression: Gemini tool-call finish reasons must map to ToolUse.
@@ -3612,7 +3628,7 @@ mod tests {
     #[test]
     fn test_parse_function_call_with_thought_signature() -> Result<(), Box<dyn std::error::Error>> {
         let line = r#"{"candidates":[{"content":{"parts":[{"functionCall":{"name":"get_weather","args":{"city":"Tokyo"}},"thoughtSignature":"sig_abc123"}]}}]}"#;
-        let response = GeminiClient::parse_stream_line(line).ok_or("missing response")?;
+        let response = GeminiClient::parse_stream_line(line)?.ok_or("missing response")?;
         let candidates = response.candidates.as_ref().ok_or("missing candidates")?;
         let parts = candidates[0]
             .content
@@ -3638,7 +3654,7 @@ mod tests {
     #[test]
     fn test_parse_text_with_thought_signature() -> Result<(), Box<dyn std::error::Error>> {
         let line = r#"{"candidates":[{"content":{"parts":[{"text":"Hello world","thoughtSignature":"sig_text_456"}]}}]}"#;
-        let response = GeminiClient::parse_stream_line(line).ok_or("missing response")?;
+        let response = GeminiClient::parse_stream_line(line)?.ok_or("missing response")?;
         let candidates = response.candidates.as_ref().ok_or("missing candidates")?;
         let parts = candidates[0]
             .content
@@ -3661,7 +3677,7 @@ mod tests {
     fn test_parse_text_with_thought_flag() -> Result<(), Box<dyn std::error::Error>> {
         let line =
             r#"{"candidates":[{"content":{"parts":[{"text":"thinking...","thought":true}]}}]}"#;
-        let response = GeminiClient::parse_stream_line(line).ok_or("missing response")?;
+        let response = GeminiClient::parse_stream_line(line)?.ok_or("missing response")?;
         let candidates = response.candidates.as_ref().ok_or("missing candidates")?;
         let parts = candidates[0]
             .content
@@ -3686,7 +3702,7 @@ mod tests {
             {"functionCall":{"name":"get_population","args":{"city":"Tokyo"}}}
         ]}}]}"#;
 
-        let response = GeminiClient::parse_stream_line(line).ok_or("missing response")?;
+        let response = GeminiClient::parse_stream_line(line)?.ok_or("missing response")?;
         let candidates = response.candidates.ok_or("missing candidates")?;
         let parts = candidates[0]
             .content

--- a/meerkat-hooks/src/lib.rs
+++ b/meerkat-hooks/src/lib.rs
@@ -181,6 +181,16 @@ pub struct DefaultHookEngine {
         Arc<std::sync::RwLock<HashMap<InProcessHookHandlerId, InProcessHookHandler>>>,
     background_patch_delivery: LocalHookPatchDelivery,
     background_slots: Arc<Semaphore>,
+    /// In-flight background hook tasks owned by the engine lifecycle.
+    ///
+    /// On non-wasm targets the previously-detached background `tokio::spawn`
+    /// is tracked here so (a) dropping the engine aborts the `JoinSet` instead
+    /// of leaking a zombie task that races a freed delivery queue, and (b) the
+    /// consumer seam (`drain_published_patches_for_session`) reaps finished
+    /// publishers before reading. Wasm has no detached-task-teardown hazard, so
+    /// the field is gated out and the wasm path keeps the existing spawn.
+    #[cfg(not(target_arch = "wasm32"))]
+    inflight_background: Arc<Mutex<tokio::task::JoinSet<()>>>,
     revision: Arc<AtomicU64>,
 }
 
@@ -201,6 +211,8 @@ impl DefaultHookEngine {
             in_process_handlers: Arc::new(std::sync::RwLock::new(HashMap::new())),
             background_patch_delivery: LocalHookPatchDelivery::new(),
             background_slots: Arc::new(Semaphore::new(background_max_concurrency)),
+            #[cfg(not(target_arch = "wasm32"))]
+            inflight_background: Arc::new(Mutex::new(tokio::task::JoinSet::new())),
             revision: Arc::new(AtomicU64::new(1)),
         }
     }
@@ -317,6 +329,19 @@ impl DefaultHookEngine {
         &self,
         session_id: &SessionId,
     ) -> Vec<HookPatchEnvelope> {
+        // Reap any background publishers that have already finished before
+        // reading the queue. We use the non-blocking `try_join_next` (not
+        // `join_next().await`) deliberately: it reaps completed tasks — whose
+        // publishes have already committed to the delivery queue — without
+        // blocking on still-running tasks, so it cannot deadlock against a
+        // background hook that is itself awaiting this same engine. Finished
+        // tasks are removed from the `JoinSet` here, so the set stays bounded
+        // and engine drop only has to abort genuinely-in-flight work.
+        #[cfg(not(target_arch = "wasm32"))]
+        {
+            let mut set = self.inflight_background.lock().await;
+            while set.try_join_next().is_some() {}
+        }
         let target = HookPatchDeliveryTarget::for_session(session_id.clone());
         self.background_patch_delivery.drain(&target).await
     }
@@ -821,7 +846,7 @@ impl HookEngine for DefaultHookEngine {
                 };
                 let engine = self.clone();
                 let invocation_cloned = invocation.clone();
-                tokio::spawn(async move {
+                let task = async move {
                     let _permit = permit;
                     let delivery_target =
                         HookPatchDeliveryTarget::for_session(invocation_cloned.session_id.clone());
@@ -851,7 +876,15 @@ impl HookEngine for DefaultHookEngine {
                             .publish_patches(delivery_target, outcome.published_patches)
                             .await;
                     }
-                });
+                };
+                // Non-wasm: bind the task to the engine lifecycle via the owned
+                // `JoinSet` so engine drop aborts it and the consumer seam can
+                // reap finished publishers. Wasm: keep the existing detached
+                // spawn (no detached-task-teardown hazard there).
+                #[cfg(not(target_arch = "wasm32"))]
+                self.inflight_background.lock().await.spawn(task);
+                #[cfg(target_arch = "wasm32")]
+                tokio::spawn(task);
             }
         }
 
@@ -1049,6 +1082,94 @@ mod tests {
                 .await
                 .unwrap()
                 .is_empty()
+        );
+    }
+
+    #[tokio::test]
+    async fn background_post_hook_task_is_tracked_and_reaped_not_leaked() {
+        // R2 regression: the background post-hook task used to be a detached
+        // `tokio::spawn` tied to nothing, so on engine/runtime teardown a task
+        // parked between `execute_one` and `publish_patches` would vanish with
+        // no signal. The task is now owned by the engine's `JoinSet`, so it is
+        // (a) observable as in-flight after `execute()` and (b) reaped at the
+        // consumer seam (`drain_published_patches`) once it completes.
+        let mut config = HooksConfig::default();
+        config.entries = vec![HookEntryConfig {
+            id: HookId::new("tracked-post-bg"),
+            point: HookPoint::PostToolExecution,
+            mode: HookExecutionMode::Background,
+            capability: HookCapability::Observe,
+            runtime: runtime_in_process("tracked-post-bg"),
+            ..Default::default()
+        }];
+
+        let engine = DefaultHookEngine::new(config);
+        // A handler with a short delay so the spawned task is genuinely
+        // in-flight when we observe the JoinSet immediately after `execute()`.
+        engine
+            .register_in_process_handler(
+                "tracked-post-bg",
+                delayed_handler(
+                    20,
+                    RuntimeHookResponse {
+                        decision: None,
+                        patches: Vec::new(),
+                    },
+                ),
+            )
+            .await;
+
+        let session_id = SessionId::new();
+        let report = engine
+            .execute(
+                HookInvocation {
+                    point: HookPoint::PostToolExecution,
+                    session_id: session_id.clone(),
+                    turn_number: Some(1),
+                    prompt_input: None,
+                    prompt: None,
+                    error_report: None,
+                    error_class: None,
+                    error: None,
+                    llm_request: None,
+                    llm_response: None,
+                    tool_call: None,
+                    tool_result: None,
+                },
+                None,
+            )
+            .await
+            .unwrap();
+        assert!(report.published_patches.is_empty());
+
+        // The background publisher is owned by the engine's JoinSet, not
+        // detached: it is tracked as in-flight right after `execute()` returns.
+        assert_eq!(
+            engine.inflight_background.lock().await.len(),
+            1,
+            "background post-hook task must be tracked in the engine JoinSet, not detached"
+        );
+
+        // The consumer seam reaps the finished publisher (non-blocking
+        // `try_join_next`). Drain repeatedly until the task has run and been
+        // reaped, proving the task is reaped (lifecycle-bound) rather than
+        // leaked. `HookPatch` is uninhabited, so no envelope can ever be
+        // published; the observable contract here is the reaped, empty JoinSet.
+        let mut drained = Vec::new();
+        for _ in 0..200 {
+            drained = engine.drain_published_patches(&session_id).await.unwrap();
+            if engine.inflight_background.lock().await.is_empty() {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(5)).await;
+        }
+        assert!(
+            engine.inflight_background.lock().await.is_empty(),
+            "finished background publisher must be reaped from the engine JoinSet, not leaked"
+        );
+        assert!(
+            drained.is_empty(),
+            "uninhabited HookPatch means no envelope is ever published"
         );
     }
 

--- a/meerkat-llm-core/src/types.rs
+++ b/meerkat-llm-core/src/types.rs
@@ -433,23 +433,33 @@ impl ToolCallBuffer {
         self.args_json.push_str(delta);
     }
 
-    /// Try to complete the tool call (parse JSON args)
-    pub fn try_complete(&self) -> Option<meerkat_core::ToolCall> {
-        let name = self.name.as_ref()?;
+    /// Try to complete the tool call (parse JSON args).
+    ///
+    /// Returns `Ok(None)` for the legitimate benign "not a complete tool call"
+    /// states (no name yet, or empty args treated as an empty object). Returns
+    /// `Err(LlmError::StreamParseError)` only when non-empty accumulated args
+    /// fail to parse as JSON — a malformed/truncated tool call must surface as a
+    /// typed fault rather than silently vanishing.
+    pub fn try_complete(&self) -> Result<Option<meerkat_core::ToolCall>, LlmError> {
+        let Some(name) = self.name.as_ref() else {
+            return Ok(None);
+        };
 
         // Try to parse the accumulated JSON
         // Handle empty args (tools with no parameters) by treating as empty object
         let args: Value = if self.args_json.is_empty() {
             serde_json::json!({})
         } else {
-            serde_json::from_str(&self.args_json).ok()?
+            serde_json::from_str(&self.args_json).map_err(|error| LlmError::StreamParseError {
+                message: format!("invalid tool call arguments JSON for {}: {error}", self.id),
+            })?
         };
 
-        Some(meerkat_core::ToolCall::new(
+        Ok(Some(meerkat_core::ToolCall::new(
             self.id.clone(),
             name.clone(),
             args,
-        ))
+        )))
     }
 }
 
@@ -516,7 +526,7 @@ mod tests {
         buffer.name = Some("test_tool".to_string());
         buffer.args_json = r#"{"key": "value"}"#.to_string();
 
-        let completed = buffer.try_complete().ok_or("incomplete")?;
+        let completed = buffer.try_complete()?.ok_or("incomplete")?;
         assert_eq!(completed.id, "tc_1");
         assert_eq!(completed.name, "test_tool");
         assert_eq!(completed.args["key"], "value");
@@ -525,13 +535,18 @@ mod tests {
 
     #[test]
     fn test_tool_call_buffer_incomplete() {
+        // No name yet: legitimate benign "not a complete tool call" -> Ok(None).
         let buffer = ToolCallBuffer::new("tc_1".to_string());
-        assert!(buffer.try_complete().is_none());
+        assert!(matches!(buffer.try_complete(), Ok(None)));
 
+        // Name present but malformed/truncated args: typed StreamParseError fault.
         let mut buffer = ToolCallBuffer::new("tc_1".to_string());
         buffer.name = Some("test".to_string());
         buffer.args_json = r#"{"incomplete"#.to_string();
-        assert!(buffer.try_complete().is_none());
+        assert!(matches!(
+            buffer.try_complete(),
+            Err(LlmError::StreamParseError { .. })
+        ));
     }
 
     #[test]
@@ -540,7 +555,7 @@ mod tests {
         buffer.name = Some("get_todays_activities".to_string());
         buffer.args_json = String::new();
 
-        let completed = buffer.try_complete().ok_or("incomplete")?;
+        let completed = buffer.try_complete()?.ok_or("incomplete")?;
         assert_eq!(completed.id, "tc_1");
         assert_eq!(completed.name, "get_todays_activities");
         assert_eq!(completed.args, serde_json::json!({}));
@@ -614,7 +629,7 @@ mod tests {
         buffer.push_args(r#"{"key""#);
         buffer.push_args(r#": "value"}"#);
 
-        let completed = buffer.try_complete().ok_or("incomplete")?;
+        let completed = buffer.try_complete()?.ok_or("incomplete")?;
         assert_eq!(completed.args["key"], "value");
         Ok(())
     }
@@ -654,8 +669,8 @@ mod tests {
 
         let tool_calls: Vec<_> = buffers
             .into_values()
-            .filter_map(|b| b.try_complete())
-            .collect();
+            .filter_map(|b| b.try_complete().transpose())
+            .collect::<Result<Vec<_>, _>>()?;
 
         assert_eq!(tool_calls.len(), 1);
         assert_eq!(tool_calls[0].name, "read_file");

--- a/meerkat-mcp-server/src/schedule_host.rs
+++ b/meerkat-mcp-server/src/schedule_host.rs
@@ -3,14 +3,13 @@ use std::sync::Arc;
 use async_trait::async_trait;
 #[cfg(not(feature = "mob"))]
 use meerkat::surface::NoopScheduleMobHost;
-use meerkat::surface::prepare_surface_session;
 use meerkat::surface::{
     ScheduledPromptDispatch, SharedScheduleTargetAdapter, SurfaceScheduleMobHost,
     SurfaceScheduleSessionHost, schedule_host_supported, spawn_schedule_host,
 };
 use meerkat::{
-    DeliveryDispatch, Occurrence, ScheduleDomainError, SessionMaterializationSpec, SessionService,
-    SessionTargetBinding, TargetProbeOutcome,
+    DeliveryDispatch, Occurrence, ScheduleDomainError, Session, SessionMaterializationSpec,
+    SessionService, SessionTargetBinding, TargetProbeOutcome,
 };
 use meerkat_core::agent::AgentToolDispatcher;
 use meerkat_core::handles::ExternalToolSurfaceHandle;
@@ -143,6 +142,7 @@ impl McpScheduleContext {
 
     async fn materialize_scheduled_session(
         &self,
+        occurrence: &Occurrence,
         create: &SessionMaterializationSpec,
         prompt_system_prompt: Option<&str>,
     ) -> Result<SessionId, ScheduleDomainError> {
@@ -151,12 +151,24 @@ impl McpScheduleContext {
             .reserve_create_session_admission()
             .await
             .map_err(|error| ScheduleDomainError::Internal(error.to_string()))?;
-        let prepared = prepare_surface_session(&self.runtime_adapter)
+        // Layer A: derive the materialized SessionId deterministically from the
+        // occurrence identity (NOT attempt_count) so a redrive of the same
+        // occurrence reuses the existing session (via the `resume_session`
+        // create-or-reuse recovery path) instead of minting a second orphan if
+        // a prior attempt died inside the materialize->bind window.
+        // `prepare_bindings` is idempotent on an already-registered session, so
+        // a second materialize for the same id is a no-op reuse.
+        let session = Session::with_id(occurrence.materialized_session_id());
+        let session_id = session.id().clone();
+        let runtime_bindings = self
+            .runtime_adapter
+            .prepare_bindings(session_id.clone())
             .await
-            .map_err(ScheduleDomainError::Internal)?;
-        let session = prepared.session;
-        let session_id = prepared.session_id;
-        let runtime_bindings = prepared.bindings;
+            .map_err(|error| {
+                ScheduleDomainError::Internal(format!(
+                    "failed to prepare bindings for scheduled session {session_id}: {error}"
+                ))
+            })?;
 
         let output_schema = create.output_schema.clone();
 
@@ -407,11 +419,12 @@ impl SurfaceScheduleSessionHost for McpScheduleTargetAdapter {
 
     async fn materialize_session(
         &self,
+        occurrence: &Occurrence,
         create: &SessionMaterializationSpec,
         prompt_system_prompt: Option<&str>,
     ) -> Result<SessionId, ScheduleDomainError> {
         self.context
-            .materialize_scheduled_session(create, prompt_system_prompt)
+            .materialize_scheduled_session(occurrence, create, prompt_system_prompt)
             .await
     }
 

--- a/meerkat-mob/src/runtime/actor.rs
+++ b/meerkat-mob/src/runtime/actor.rs
@@ -9478,18 +9478,14 @@ impl MobActor {
                         .await
                     {
                         if local_trust_created {
-                            let rollback_handoff = self.authorize_member_trust_unwiring(
+                            self.rollback_peer_only_trust(
                                 &edge,
+                                local_comms.as_ref(),
+                                &peer_meerkat_id,
+                                &peer_key,
                                 "wire_members_repair_rollback_trust_authority",
-                            )?;
-                            let _ = self
-                                .apply_trusted_peer_remove(
-                                    local_comms.as_ref(),
-                                    peer_key.clone(),
-                                    rollback_handoff
-                                        .unwiring_authority_for(&peer_meerkat_id, &peer_key)?,
-                                )
-                                .await;
+                            )
+                            .await;
                         }
                         return Err(MobError::from(error));
                     }
@@ -9579,18 +9575,14 @@ impl MobActor {
                         .await
                     {
                         if local_trust_created {
-                            let rollback_handoff = self.authorize_member_trust_unwiring(
+                            self.rollback_peer_only_trust(
                                 &edge,
+                                local_comms.as_ref(),
+                                &peer_meerkat_id,
+                                &peer_key,
                                 "wire_members_peer_only_repair_rollback_trust_authority",
-                            )?;
-                            let _ = self
-                                .apply_trusted_peer_remove(
-                                    local_comms.as_ref(),
-                                    peer_key.clone(),
-                                    rollback_handoff
-                                        .unwiring_authority_for(&peer_meerkat_id, &peer_key)?,
-                                )
-                                .await;
+                            )
+                            .await;
                         }
                         return Err(error);
                     }
@@ -9633,17 +9625,14 @@ impl MobActor {
                         .await
                     {
                         if peer_trust_created {
-                            let rollback_handoff = self.authorize_member_trust_unwiring(
+                            self.rollback_peer_only_trust(
                                 &edge,
+                                peer_comms.as_ref(),
+                                &local,
+                                &local_key,
                                 "wire_members_peer_only_repair_rollback_trust_authority",
-                            )?;
-                            let _ = self
-                                .apply_trusted_peer_remove(
-                                    peer_comms.as_ref(),
-                                    local_key.clone(),
-                                    rollback_handoff.unwiring_authority_for(&local, &local_key)?,
-                                )
-                                .await;
+                            )
+                            .await;
                         }
                         return Err(error);
                     }
@@ -9787,17 +9776,14 @@ impl MobActor {
                 .await
             {
                 if local_trust_created {
-                    let rollback_handoff = self.authorize_member_trust_unwiring(
+                    self.rollback_peer_only_trust(
                         &edge,
+                        local_comms.as_ref(),
+                        &peer_meerkat_id,
+                        &peer_key,
                         "wire_members_peer_only_rollback_trust_authority",
-                    )?;
-                    let _ = self
-                        .apply_trusted_peer_remove(
-                            local_comms.as_ref(),
-                            peer_key.clone(),
-                            rollback_handoff.unwiring_authority_for(&peer_meerkat_id, &peer_key)?,
-                        )
-                        .await;
+                    )
+                    .await;
                 }
                 self.rollback_peer_only_wire(
                     &edge,
@@ -9823,18 +9809,14 @@ impl MobActor {
                 Ok(stored) => stored,
                 Err(error) => {
                     if local_trust_created {
-                        let rollback_handoff = self.authorize_member_trust_unwiring(
+                        self.rollback_peer_only_trust(
                             &edge,
+                            local_comms.as_ref(),
+                            &peer_meerkat_id,
+                            &peer_key,
                             "wire_members_peer_only_event_rollback_trust_authority",
-                        )?;
-                        let _ = self
-                            .apply_trusted_peer_remove(
-                                local_comms.as_ref(),
-                                peer_key.clone(),
-                                rollback_handoff
-                                    .unwiring_authority_for(&peer_meerkat_id, &peer_key)?,
-                            )
-                            .await;
+                        )
+                        .await;
                     }
                     self.rollback_peer_only_wire(
                         &edge,
@@ -9902,17 +9884,14 @@ impl MobActor {
                 .await
             {
                 if peer_trust_created {
-                    let rollback_handoff = self.authorize_member_trust_unwiring(
+                    self.rollback_peer_only_trust(
                         &edge,
+                        peer_comms.as_ref(),
+                        &local,
+                        &local_key,
                         "wire_members_peer_only_rollback_trust_authority",
-                    )?;
-                    let _ = self
-                        .apply_trusted_peer_remove(
-                            peer_comms.as_ref(),
-                            local_key.clone(),
-                            rollback_handoff.unwiring_authority_for(&local, &local_key)?,
-                        )
-                        .await;
+                    )
+                    .await;
                 }
                 self.rollback_peer_only_wire(
                     &edge,
@@ -9938,17 +9917,14 @@ impl MobActor {
                 Ok(stored) => stored,
                 Err(error) => {
                     if peer_trust_created {
-                        let rollback_handoff = self.authorize_member_trust_unwiring(
+                        self.rollback_peer_only_trust(
                             &edge,
+                            peer_comms.as_ref(),
+                            &local,
+                            &local_key,
                             "wire_members_peer_only_event_rollback_trust_authority",
-                        )?;
-                        let _ = self
-                            .apply_trusted_peer_remove(
-                                peer_comms.as_ref(),
-                                local_key.clone(),
-                                rollback_handoff.unwiring_authority_for(&local, &local_key)?,
-                            )
-                            .await;
+                        )
+                        .await;
                     }
                     self.rollback_peer_only_wire(
                         &edge,
@@ -10632,6 +10608,56 @@ impl MobActor {
                     "wire_members_batch failed to rollback previously installed trust after trust failure"
                 );
             }
+        }
+    }
+
+    /// Compensate the comms-trust half of a failed peer-only wire.
+    ///
+    /// Mirrors [`Self::rollback_wire_side_effects`] for the peer-only paths:
+    /// the rollback-authority derivation never `?`-propagates (a derivation
+    /// failure must not abort the caller before its DSL `UnwireMembers` runs),
+    /// and every compensation fault is warn-logged rather than dropped via
+    /// `let _ =`. Callers invoke this strictly before `rollback_peer_only_wire`
+    /// so the DSL edge is always unwound regardless of the trust outcome.
+    async fn rollback_peer_only_trust(
+        &mut self,
+        edge: &mob_dsl::WiringEdge,
+        comms: &(dyn CoreCommsRuntime + '_),
+        identity: &AgentIdentity,
+        removal_key: &str,
+        context: &str,
+    ) {
+        let rollback_handoff = match self.authorize_member_trust_unwiring(edge, context) {
+            Ok(handoff) => handoff,
+            Err(err) => {
+                tracing::warn!(
+                    mob_id = %self.definition.id,
+                    %err,
+                    "peer-only wire rollback: failed to obtain generated trust removal authority"
+                );
+                return;
+            }
+        };
+        let authority = match rollback_handoff.unwiring_authority_for(identity, removal_key) {
+            Ok(authority) => authority,
+            Err(err) => {
+                tracing::warn!(
+                    mob_id = %self.definition.id,
+                    %err,
+                    "peer-only wire rollback: failed to build generated trust removal authority"
+                );
+                return;
+            }
+        };
+        if let Err(err) = self
+            .apply_trusted_peer_remove(comms, removal_key.to_string(), authority)
+            .await
+        {
+            tracing::warn!(
+                mob_id = %self.definition.id,
+                %err,
+                "peer-only wire rollback: failed to remove trust"
+            );
         }
     }
 

--- a/meerkat-mob/src/runtime/tests.rs
+++ b/meerkat-mob/src/runtime/tests.rs
@@ -4701,12 +4701,16 @@ async fn spawn_live_external_peer_with_transport(
                         // `trust_candidate_sender_for_reply` records trust for the
                         // requester, but the registration of that peer in the
                         // send path propagates asynchronously. Under slow
-                        // scheduling (notably the Linux CI executors) it can lag
-                        // this reply, surfacing a transient `PeerNotFound`. Wait
-                        // for the registration to land rather than racing it; any
-                        // other send error still fails immediately (no masking).
+                        // scheduling (notably the high-parallelism Linux RBE
+                        // executors) it can lag this reply well past a few
+                        // seconds, surfacing a transient `PeerNotFound`. Wait
+                        // generously for the registration to land rather than
+                        // racing it; any other send error still fails immediately
+                        // (no masking). The deadline only bounds the failure-lag
+                        // path -- the happy path returns as soon as the peer is
+                        // registered.
                         let send_deadline =
-                            tokio::time::Instant::now() + std::time::Duration::from_secs(10);
+                            tokio::time::Instant::now() + std::time::Duration::from_secs(60);
                         loop {
                             match responder_runtime
                                 .send(CommsCommand::PeerResponse {

--- a/meerkat-openai/src/client.rs
+++ b/meerkat-openai/src/client.rs
@@ -864,19 +864,27 @@ impl OpenAiClient {
         Ok((items, instructions))
     }
 
-    /// Parse an SSE event from the Responses API stream
-    fn parse_responses_sse_line(line: &str) -> Option<ResponsesStreamEvent> {
-        if let Some(data) = line
+    /// Parse an SSE event from the Responses API stream.
+    ///
+    /// Returns `Ok(None)` when the line is not a `data:` event or is the
+    /// `[DONE]` sentinel, and `Err(LlmError::StreamParseError)` when it IS a
+    /// real `data:` event whose JSON fails to parse — a malformed-but-present
+    /// event is a typed fault, not a silently skippable non-event.
+    fn parse_responses_sse_line(line: &str) -> Result<Option<ResponsesStreamEvent>, LlmError> {
+        let Some(data) = line
             .strip_prefix("data: ")
             .or_else(|| line.strip_prefix("data:"))
-        {
-            if data == "[DONE]" {
-                return None;
-            }
-            serde_json::from_str(data).ok()
-        } else {
-            None
+        else {
+            return Ok(None);
+        };
+        if data == "[DONE]" {
+            return Ok(None);
         }
+        serde_json::from_str(data)
+            .map(Some)
+            .map_err(|error| LlmError::StreamParseError {
+                message: format!("invalid OpenAI Responses SSE data event JSON: {error}"),
+            })
     }
 
     fn image_prompt(request: &ProviderImageGenerationRequest) -> String {
@@ -1337,7 +1345,7 @@ impl OpenAiClient {
                 let line = buffer[..newline_pos].trim();
                 let should_process = !line.is_empty() && !line.starts_with(':');
                 let parsed_event = if should_process {
-                    Self::parse_responses_sse_line(line)
+                    Self::parse_responses_sse_line(line)?
                 } else {
                     None
                 };
@@ -1602,7 +1610,7 @@ impl LlmClient for OpenAiClient {
                     }
                     let should_process = !line.is_empty() && !line.starts_with(':');
                     let parsed_event = if should_process {
-                        Self::parse_responses_sse_line(line)
+                        Self::parse_responses_sse_line(line)?
                     } else {
                         None
                     };
@@ -4321,9 +4329,9 @@ mod tests {
     #[test]
     fn test_parse_responses_sse_line_text_delta() {
         let line = r#"data: {"type":"response.output_text.delta","delta":"Hello"}"#;
-        let event = OpenAiClient::parse_responses_sse_line(line);
-        assert!(event.is_some());
-        let event = event.unwrap();
+        let event = OpenAiClient::parse_responses_sse_line(line)
+            .expect("well-formed data event parses")
+            .expect("event present");
         assert_eq!(event.event_type, "response.output_text.delta");
         assert_eq!(event.delta, Some("Hello".to_string()));
     }
@@ -4332,9 +4340,9 @@ mod tests {
     fn test_parse_responses_sse_line_reasoning_delta() {
         let line =
             r#"data: {"type":"response.reasoning_summary_text.delta","delta":"thinking..."}"#;
-        let event = OpenAiClient::parse_responses_sse_line(line);
-        assert!(event.is_some());
-        let event = event.unwrap();
+        let event = OpenAiClient::parse_responses_sse_line(line)
+            .expect("well-formed data event parses")
+            .expect("event present");
         assert_eq!(event.event_type, "response.reasoning_summary_text.delta");
         assert_eq!(event.delta, Some("thinking...".to_string()));
     }
@@ -4342,9 +4350,9 @@ mod tests {
     #[test]
     fn test_parse_responses_sse_line_function_call_done() {
         let line = r#"data: {"type":"response.function_call_arguments.done","call_id":"call_123","name":"get_weather","arguments":"{\"location\":\"Tokyo\"}"}"#;
-        let event = OpenAiClient::parse_responses_sse_line(line);
-        assert!(event.is_some());
-        let event = event.unwrap();
+        let event = OpenAiClient::parse_responses_sse_line(line)
+            .expect("well-formed data event parses")
+            .expect("event present");
         assert_eq!(event.event_type, "response.function_call_arguments.done");
         assert_eq!(event.call_id, Some("call_123".to_string()));
         assert_eq!(event.name, Some("get_weather".to_string()));
@@ -4354,12 +4362,11 @@ mod tests {
     #[test]
     fn test_parse_responses_sse_line_response_done() {
         let line = r#"data: {"type":"response.done","response":{"status":"completed","output":[{"type":"message","content":[{"type":"output_text","text":"Hi"}]}],"usage":{"input_tokens":10,"output_tokens":5}}}"#;
-        let event = OpenAiClient::parse_responses_sse_line(line);
-        assert!(event.is_some());
-        let event = event.unwrap();
+        let event = OpenAiClient::parse_responses_sse_line(line)
+            .expect("well-formed data event parses")
+            .expect("event present");
         assert_eq!(event.event_type, "response.done");
-        assert!(event.response.is_some());
-        let response = event.response.unwrap();
+        let response = event.response.expect("response present");
         assert_eq!(response["status"], "completed");
     }
 
@@ -4367,29 +4374,38 @@ mod tests {
     fn test_parse_responses_sse_line_done_marker() {
         let line = "data: [DONE]";
         let event = OpenAiClient::parse_responses_sse_line(line);
-        assert!(event.is_none());
+        assert!(matches!(event, Ok(None)));
     }
 
     #[test]
     fn test_parse_responses_sse_line_without_trailing_space() {
         let line = r#"data:{"type":"response.output_text.delta","delta":"hello"}"#;
         let event = OpenAiClient::parse_responses_sse_line(line);
-        assert!(event.is_some());
+        assert!(matches!(event, Ok(Some(_))));
     }
 
     #[test]
     fn test_parse_responses_sse_line_non_data_line() {
         let line = "event: message";
         let event = OpenAiClient::parse_responses_sse_line(line);
-        assert!(event.is_none());
+        assert!(matches!(event, Ok(None)));
+    }
+
+    #[test]
+    fn test_parse_responses_sse_line_malformed_data_event_is_typed_error() {
+        // A real `data:` line whose JSON is truncated is a typed fault, not a
+        // silently-dropped non-event.
+        let line = r#"data: {"type":"response.output_text.delta""#;
+        let event = OpenAiClient::parse_responses_sse_line(line);
+        assert!(matches!(event, Err(LlmError::StreamParseError { .. })));
     }
 
     #[test]
     fn test_parse_responses_sse_line_reasoning_item_with_encrypted() {
         let line = r#"data: {"type":"response.reasoning.done","item":{"id":"rs_abc123","summary":[{"type":"summary_text","text":"I need to think"}],"encrypted_content":"enc_xyz"}}"#;
-        let event = OpenAiClient::parse_responses_sse_line(line);
-        assert!(event.is_some());
-        let event = event.unwrap();
+        let event = OpenAiClient::parse_responses_sse_line(line)
+            .expect("well-formed data event parses")
+            .expect("event present");
         assert_eq!(event.event_type, "response.reasoning.done");
         let item = event.item.expect("should have item");
         assert_eq!(item["id"], "rs_abc123");

--- a/meerkat-openai/src/client_compatible.rs
+++ b/meerkat-openai/src/client_compatible.rs
@@ -573,7 +573,7 @@ impl LlmClient for OpenAiCompatibleClient {
                                         };
                                         if matches!(stop_reason, StopReason::ToolUse) {
                                             for buffer in tool_buffers.values() {
-                                                if let Some(tool_call) = buffer.try_complete() {
+                                                if let Some(tool_call) = buffer.try_complete()? {
                                                     yield LlmEvent::ToolCallComplete {
                                                         id: tool_call.id,
                                                         name: tool_call.name,
@@ -891,6 +891,64 @@ mod tests {
         }
         assert!(saw_complete);
         assert!(saw_done);
+        handle.abort();
+    }
+
+    #[tokio::test]
+    async fn chat_completions_stream_malformed_tool_args_fail_closed() {
+        // A tool call whose accumulated argument JSON is truncated must NOT be
+        // silently dropped and laundered into Done{Success}. It must surface as
+        // a terminal Done{Error{StreamParseError}}.
+        let payload = concat!(
+            "data: {\"choices\":[{\"delta\":{\"tool_calls\":[{\"index\":0,\"id\":\"call_1\",\"function\":{\"name\":\"read_file\",\"arguments\":\"{\\\"path\\\":\"}}]}}]}\n\n",
+            "data: {\"choices\":[{\"finish_reason\":\"tool_calls\"}],\"usage\":{\"prompt_tokens\":10,\"completion_tokens\":4}}\n\n",
+            "data: [DONE]\n\n"
+        )
+        .to_string();
+        let (base_url, handle) = spawn_chat_stub_server(payload).await;
+        let client = OpenAiCompatibleClient::new(
+            OpenAiCompatibleMode::ChatCompletions,
+            "remote-model".to_string(),
+            base_url,
+            None,
+            true,
+            false,
+            false,
+        );
+        let request = LlmRequest::new(
+            "gemma-4-31b",
+            vec![Message::User(UserMessage::text("hello".to_string()))],
+        );
+
+        let events: Vec<_> = client.stream(&request).collect().await;
+        let mut saw_complete = false;
+        let mut saw_success_done = false;
+        let mut terminal_error = None;
+        for event in events {
+            match event {
+                Ok(LlmEvent::ToolCallComplete { .. }) => saw_complete = true,
+                Ok(LlmEvent::Done {
+                    outcome: LlmDoneOutcome::Error { error },
+                }) => terminal_error = Some(error),
+                Ok(LlmEvent::Done {
+                    outcome: LlmDoneOutcome::Success { .. },
+                }) => saw_success_done = true,
+                Err(error) => terminal_error = Some(error),
+                _ => {}
+            }
+        }
+        assert!(
+            !saw_complete,
+            "malformed tool args must not produce a ToolCallComplete"
+        );
+        assert!(
+            !saw_success_done,
+            "malformed tool args must not be laundered into a successful Done"
+        );
+        assert!(
+            matches!(terminal_error, Some(LlmError::StreamParseError { .. })),
+            "expected terminal StreamParseError, got {terminal_error:?}"
+        );
         handle.abort();
     }
 

--- a/meerkat-rest/src/lib.rs
+++ b/meerkat-rest/src/lib.rs
@@ -3249,9 +3249,13 @@ fn skill_entry(
 /// Get runtime capabilities with status resolved against config.
 async fn get_capabilities(
     State(state): State<AppState>,
-) -> Json<meerkat_contracts::CapabilitiesResponse> {
-    let config = state.config_store.get().await.unwrap_or_default();
-    Json(meerkat::surface::build_capabilities_response(&config))
+) -> Result<Json<meerkat_contracts::CapabilitiesResponse>, ApiError> {
+    let config = state
+        .config_store
+        .get()
+        .await
+        .map_err(|e| ApiError::Configuration(e.to_string()))?;
+    Ok(Json(meerkat::surface::build_capabilities_response(&config)))
 }
 
 fn rest_runtime_host_surface_options(
@@ -3312,7 +3316,11 @@ async fn get_runtime_health() -> Json<meerkat_contracts::RuntimeHostHealth> {
 async fn get_models_catalog(
     State(state): State<AppState>,
 ) -> Result<Json<meerkat_contracts::ModelsCatalogResponse>, ApiError> {
-    let config = state.config_store.get().await.unwrap_or_default();
+    let config = state
+        .config_store
+        .get()
+        .await
+        .map_err(|e| ApiError::Configuration(e.to_string()))?;
     let response = meerkat::surface::build_models_catalog_response(&config)
         .map_err(|e| ApiError::Configuration(e.to_string()))?;
     Ok(Json(response))
@@ -12533,6 +12541,76 @@ mod tests {
             let response = app.oneshot(request).await.unwrap();
             // Should be 405 Method Not Allowed (route doesn't exist for POST).
             assert_ne!(response.status(), StatusCode::OK);
+        }
+    }
+
+    /// Verify config-read endpoints propagate a typed `ConfigError` instead of
+    /// laundering it into `Config::default()` and returning a 200 with phantom
+    /// content.
+    mod config_fault_propagation_tests {
+        use super::*;
+        use axum::body::Body;
+        use http_body_util::BodyExt;
+        use tower::ServiceExt;
+
+        /// Config store whose `get()` always returns a typed fault.
+        struct FailingConfigStore;
+
+        #[async_trait]
+        impl ConfigStore for FailingConfigStore {
+            async fn get(&self) -> Result<Config, meerkat_core::ConfigError> {
+                Err(meerkat_core::ConfigError::Validation("boom".to_string()))
+            }
+
+            async fn set(&self, _config: Config) -> Result<(), meerkat_core::ConfigError> {
+                Err(meerkat_core::ConfigError::Validation("boom".to_string()))
+            }
+
+            async fn patch(
+                &self,
+                _delta: ConfigDelta,
+            ) -> Result<Config, meerkat_core::ConfigError> {
+                Err(meerkat_core::ConfigError::Validation("boom".to_string()))
+            }
+        }
+
+        async fn assert_config_fault_endpoint(uri: &str) {
+            let temp = TempDir::new().unwrap();
+            let mut state = AppState::load_from(temp.path().to_path_buf())
+                .await
+                .unwrap();
+            state.config_store = Arc::new(FailingConfigStore);
+            let app = router(state);
+
+            let request = axum::http::Request::builder()
+                .method("GET")
+                .uri(uri)
+                .body(Body::empty())
+                .unwrap();
+            let response = app.oneshot(request).await.unwrap();
+            let status = response.status();
+            let body = response.into_body().collect().await.unwrap().to_bytes();
+            assert_eq!(
+                status,
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "{uri} must return 500 on a config fault, got body: {}",
+                String::from_utf8_lossy(&body)
+            );
+            let payload: Value = serde_json::from_slice(&body).unwrap();
+            assert_eq!(
+                payload["code"], "CONFIGURATION_ERROR",
+                "{uri} must surface CONFIGURATION_ERROR on a config fault: {payload}"
+            );
+        }
+
+        #[tokio::test]
+        async fn capabilities_endpoint_propagates_config_fault() {
+            assert_config_fault_endpoint("/capabilities").await;
+        }
+
+        #[tokio::test]
+        async fn models_catalog_endpoint_propagates_config_fault() {
+            assert_config_fault_endpoint("/models/catalog").await;
         }
     }
 }

--- a/meerkat-rest/src/schedule_host.rs
+++ b/meerkat-rest/src/schedule_host.rs
@@ -258,9 +258,13 @@ impl SurfaceScheduleSessionHost for RestScheduleTargetAdapter {
 
     async fn materialize_session(
         &self,
+        _occurrence: &Occurrence,
         create: &SessionMaterializationSpec,
         prompt_system_prompt: Option<&str>,
     ) -> Result<SessionId, ScheduleDomainError> {
+        // Idempotent reuse of an already-bound materialized session is enforced
+        // by `SharedScheduleTargetAdapter::resolve_session` (Layer B) before
+        // this is reached, so this surface need not re-derive a deterministic id.
         self.context
             .materialize_scheduled_session(create, prompt_system_prompt)
             .await

--- a/meerkat-rpc/src/protocol.rs
+++ b/meerkat-rpc/src/protocol.rs
@@ -74,23 +74,27 @@ pub enum RpcMessage {
 
 impl RpcResponse {
     /// Construct a success response with the given result.
+    ///
+    /// If the result payload fails to serialize, this does NOT fabricate a
+    /// success-with-null reply: it surfaces the typed serialization fault as a
+    /// JSON-RPC internal error on the same id, preserving the contract that a
+    /// request gets either a result or an error, never a fabricated success.
     pub fn success(id: Option<RpcId>, result: impl Serialize) -> Self {
-        // Serialize the result to a RawValue. If serialization fails,
-        // fall back to a JSON null.
-        let raw = serde_json::value::to_raw_value(&result).unwrap_or_else(|_| {
-            // This is extremely unlikely to fail since we're serializing
-            // a type that impl Serialize, but we avoid unwrap in library code.
-            serde_json::value::to_raw_value(&serde_json::Value::Null).unwrap_or_else(|_| {
-                // Serializing null to RawValue cannot realistically fail.
-                // We use a const approach as last resort.
-                RawValue::from_string("null".to_string()).unwrap_or_default()
-            })
-        });
-        Self {
-            jsonrpc: "2.0".to_string(),
-            id,
-            result: Some(raw),
-            error: None,
+        match serde_json::value::to_raw_value(&result) {
+            Ok(raw) => Self {
+                jsonrpc: "2.0".to_string(),
+                id,
+                result: Some(raw),
+                error: None,
+            },
+            // Serializing the result payload failed. Surface the typed fault as
+            // a JSON-RPC internal error on the same id so the client sees the
+            // real terminal instead of an authoritative success carrying null.
+            Err(e) => Self::error(
+                id,
+                crate::error::INTERNAL_ERROR,
+                format!("failed to serialize RPC result: {e}"),
+            ),
         }
     }
 
@@ -199,6 +203,29 @@ mod tests {
         // Verify result content
         let parsed: serde_json::Value = serde_json::from_str(&serialized).unwrap();
         assert_eq!(parsed["result"]["status"], "ok");
+    }
+
+    #[test]
+    fn success_serialization_failure_yields_internal_error() {
+        // A payload whose Serialize impl always fails must NOT be laundered
+        // into a success-with-null envelope; it must become an error envelope.
+        struct AlwaysFails;
+        impl Serialize for AlwaysFails {
+            fn serialize<S: serde::Serializer>(&self, _s: S) -> Result<S::Ok, S::Error> {
+                Err(serde::ser::Error::custom("boom"))
+            }
+        }
+
+        let resp = RpcResponse::success(Some(RpcId::Num(1)), AlwaysFails);
+        assert_eq!(resp.id, Some(RpcId::Num(1)));
+        assert!(resp.result.is_none());
+        let err = resp.error.as_ref().unwrap();
+        assert_eq!(err.code, error::INTERNAL_ERROR);
+
+        // On the wire it is an error envelope, never a fabricated success.
+        let serialized = serde_json::to_string(&resp).unwrap();
+        assert!(serialized.contains("\"error\""));
+        assert!(!serialized.contains("\"result\""));
     }
 
     #[test]

--- a/meerkat-rpc/src/router.rs
+++ b/meerkat-rpc/src/router.rs
@@ -1702,10 +1702,10 @@ impl MethodRouter {
                     "skills/inspect is no longer served; resolve skills through the typed registry surface".to_string(),
                 )
             }
-            "capabilities/get" => {
-                let config = self.config_store.get().await.unwrap_or_default();
-                handlers::capabilities::handle_get(id, &config)
-            }
+            "capabilities/get" => match self.config_store.get().await {
+                Ok(config) => handlers::capabilities::handle_get(id, &config),
+                Err(e) => RpcResponse::error(id, error::INTERNAL_ERROR, e.to_string()),
+            },
             "runtime/host_info" => handlers::runtime_host::handle_info(
                 id,
                 &self.runtime,
@@ -1730,10 +1730,10 @@ impl MethodRouter {
             "approval/decide" => {
                 handlers::approval::handle_decide(id, params, self.runtime.clone()).await
             }
-            "models/catalog" => {
-                let config = self.config_store.get().await.unwrap_or_default();
-                handlers::models::handle_catalog(id, &config)
-            }
+            "models/catalog" => match self.config_store.get().await {
+                Ok(config) => handlers::models::handle_catalog(id, &config),
+                Err(e) => RpcResponse::error(id, error::INTERNAL_ERROR, e.to_string()),
+            },
             // Auth + realm methods (Phase 4d).
             "auth/profile/list" => {
                 handlers::auth::handle_auth_profile_list(id, params, &self.runtime).await
@@ -3636,7 +3636,36 @@ mod tests {
         meerkat::PersistenceBundle::new(store, Some(runtime_store), memory_blob_store())
     }
 
+    /// Config store whose `get()` always returns a typed fault, used to prove
+    /// that config-read handlers propagate `ConfigError` instead of laundering
+    /// it into `Config::default()`.
+    struct FailingConfigStore;
+
+    #[async_trait]
+    impl ConfigStore for FailingConfigStore {
+        async fn get(&self) -> Result<Config, meerkat_core::ConfigError> {
+            Err(meerkat_core::ConfigError::Validation("boom".to_string()))
+        }
+
+        async fn set(&self, _config: Config) -> Result<(), meerkat_core::ConfigError> {
+            Err(meerkat_core::ConfigError::Validation("boom".to_string()))
+        }
+
+        async fn patch(
+            &self,
+            _delta: meerkat_core::ConfigDelta,
+        ) -> Result<Config, meerkat_core::ConfigError> {
+            Err(meerkat_core::ConfigError::Validation("boom".to_string()))
+        }
+    }
+
     async fn test_router() -> (MethodRouter, mpsc::Receiver<RpcNotification>) {
+        test_router_with_config_store(Arc::new(MemoryConfigStore::new(Config::default()))).await
+    }
+
+    async fn test_router_with_config_store(
+        config_store: Arc<dyn ConfigStore>,
+    ) -> (MethodRouter, mpsc::Receiver<RpcNotification>) {
         let temp = tempfile::tempdir().unwrap();
         let factory = AgentFactory::new(temp.path().join("sessions"));
         let config = Config::default();
@@ -3648,8 +3677,6 @@ mod tests {
             runtime_backed_persistence(store),
             NotificationSink::noop(),
         );
-        let config_store: Arc<dyn ConfigStore> =
-            Arc::new(MemoryConfigStore::new(Config::default()));
         runtime.set_default_llm_client(Some(Arc::new(MockLlmClient)));
         runtime.set_config_runtime(Arc::new(ConfigRuntime::new(
             Arc::clone(&config_store),
@@ -3692,6 +3719,54 @@ mod tests {
         let sink = NotificationSink::new(notif_tx);
         let router = MethodRouter::new(runtime, config_store, sink);
         (router, notif_rx)
+    }
+
+    #[tokio::test]
+    async fn capabilities_get_propagates_config_fault() {
+        let (router, _rx) = test_router_with_config_store(Arc::new(FailingConfigStore)).await;
+        let response = router
+            .dispatch(RpcRequest {
+                jsonrpc: "2.0".to_string(),
+                method: "capabilities/get".to_string(),
+                params: None,
+                id: Some(RpcId::Num(1)),
+            })
+            .await
+            .expect("response");
+        let value = serde_json::to_value(response).expect("response serializes");
+        assert!(
+            value["result"].is_null(),
+            "capabilities/get must not return a success payload on a config fault: {value}"
+        );
+        assert_eq!(
+            value["error"]["code"],
+            error::INTERNAL_ERROR,
+            "capabilities/get must surface INTERNAL_ERROR on a config fault: {value}"
+        );
+    }
+
+    #[tokio::test]
+    async fn models_catalog_propagates_config_fault() {
+        let (router, _rx) = test_router_with_config_store(Arc::new(FailingConfigStore)).await;
+        let response = router
+            .dispatch(RpcRequest {
+                jsonrpc: "2.0".to_string(),
+                method: "models/catalog".to_string(),
+                params: None,
+                id: Some(RpcId::Num(1)),
+            })
+            .await
+            .expect("response");
+        let value = serde_json::to_value(response).expect("response serializes");
+        assert!(
+            value["result"].is_null(),
+            "models/catalog must not return a success payload on a config fault: {value}"
+        );
+        assert_eq!(
+            value["error"]["code"],
+            error::INTERNAL_ERROR,
+            "models/catalog must surface INTERNAL_ERROR on a config fault: {value}"
+        );
     }
 
     #[tokio::test]

--- a/meerkat-rpc/src/session_runtime.rs
+++ b/meerkat-rpc/src/session_runtime.rs
@@ -7307,14 +7307,28 @@ impl SessionRuntime {
             receiver_dropped: Arc::clone(&sender.receiver_dropped),
         };
         Ok(Box::pin(futures::stream::unfold(
-            (rx, drop_guard),
-            |(mut rx, drop_guard)| async move {
-                loop {
-                    match rx.recv().await {
-                        Ok(event) => return Some((event, (rx, drop_guard))),
-                        Err(broadcast::error::RecvError::Lagged(_)) => continue,
-                        Err(broadcast::error::RecvError::Closed) => return None,
+            (rx, drop_guard, session_id.clone()),
+            |(mut rx, drop_guard, stream_session_id)| async move {
+                // Every arm resolves the next stream item, so this is a single
+                // `recv` per poll (the `unfold` re-invokes us with the threaded
+                // receiver). A `Lagged` gap yields a typed `StreamTruncated`
+                // marker instead of being silently dropped.
+                match rx.recv().await {
+                    Ok(event) => Some((event, (rx, drop_guard, stream_session_id))),
+                    Err(broadcast::error::RecvError::Lagged(dropped)) => {
+                        let marker = meerkat_core::EventEnvelope::new_session(
+                            stream_session_id.clone(),
+                            0,
+                            None,
+                            meerkat_core::event::AgentEvent::StreamTruncated {
+                                reason: format!(
+                                    "pending session event stream lagged; {dropped} events dropped (terminal event remains authoritative)"
+                                ),
+                            },
+                        );
+                        Some((marker, (rx, drop_guard, stream_session_id)))
                     }
+                    Err(broadcast::error::RecvError::Closed) => None,
                 }
             },
         )))
@@ -19259,6 +19273,69 @@ mod tests {
         })
         .await
         .expect("pending stream entry should be removed after listener close");
+    }
+
+    /// A pure observer that lags behind the pending broadcast sees a typed
+    /// `StreamTruncated` marker recording the gap instead of silently losing
+    /// the dropped events. This asserts the Rule-8 fix: backpressure-induced
+    /// drops are observable, mirroring `event_tap::tap_try_send`.
+    #[tokio::test]
+    async fn pending_session_stream_yields_stream_truncated_marker_on_lag() {
+        let temp = tempfile::tempdir().unwrap();
+        let runtime = make_runtime(temp_factory(&temp), 10);
+
+        let session_id = runtime
+            .create_session(mock_build_config(), None, None)
+            .await
+            .unwrap();
+
+        // Subscribe to the pending (pre-materialization) broadcast but do NOT
+        // poll it, so the receiver falls behind the 128-slot ring buffer.
+        let mut stream = runtime
+            .subscribe_session_events(&session_id)
+            .await
+            .expect("subscribe pending session events");
+
+        let pending_streams = runtime
+            .pending_session_event_stream_state(&session_id)
+            .await
+            .expect("pending stream entry should exist before materialization");
+
+        // Force the non-polled receiver to lag by overflowing the broadcast
+        // ring (> PENDING_SESSION_EVENT_CHANNEL_CAPACITY sends).
+        for i in 0..(PENDING_SESSION_EVENT_CHANNEL_CAPACITY * 2) {
+            let envelope = EventEnvelope::new_session(
+                session_id.clone(),
+                0,
+                None,
+                AgentEvent::TextDelta {
+                    delta: format!("event-{i}"),
+                },
+            );
+            let _ = pending_streams.events.send(envelope);
+        }
+
+        // The first yielded item must be the synthetic StreamTruncated marker
+        // recording the gap, before any live (non-lagged) events resume.
+        let first = tokio::time::timeout(std::time::Duration::from_secs(2), stream.next())
+            .await
+            .expect("pending stream lag marker timeout")
+            .expect("pending stream should yield a lag marker");
+
+        match &first.payload {
+            AgentEvent::StreamTruncated { reason } => {
+                assert!(
+                    reason.contains("lagged"),
+                    "StreamTruncated reason should describe the lag: {reason}"
+                );
+            }
+            other => panic!("expected StreamTruncated marker on lag, got {other:?}"),
+        }
+        assert_eq!(
+            first.source_session_id(),
+            Some(&session_id),
+            "lag marker should be session-scoped to the subscribed session"
+        );
     }
 
     /// turn/start with keep_alive override on a materialized session is not rejected.

--- a/meerkat-rpc/src/session_runtime/schedule_host.rs
+++ b/meerkat-rpc/src/session_runtime/schedule_host.rs
@@ -137,9 +137,13 @@ impl SurfaceScheduleSessionHost for RpcScheduleTargetAdapter {
 
     async fn materialize_session(
         &self,
+        _occurrence: &Occurrence,
         create: &SessionMaterializationSpec,
         prompt_system_prompt: Option<&str>,
     ) -> Result<SessionId, ScheduleDomainError> {
+        // Idempotent reuse of an already-bound materialized session is enforced
+        // by `SharedScheduleTargetAdapter::resolve_session` (Layer B) before
+        // this is reached, so this surface need not re-derive a deterministic id.
         let runtime = self.upgrade_runtime()?;
         Box::pin(runtime.materialize_scheduled_session(create, prompt_system_prompt)).await
     }

--- a/meerkat-runtime/src/ops_lifecycle.rs
+++ b/meerkat-runtime/src/ops_lifecycle.rs
@@ -1116,8 +1116,11 @@ impl ShellState {
             }
         }
 
-        // Satisfy a pending wait request if all its ops are now terminal.
-        self.maybe_satisfy_wait();
+        // Satisfy a pending wait request if all its ops are now terminal. On
+        // authority-invariant corruption this propagates the typed fault (and
+        // drops the barrier oneshot so the waiter resolves to Err) instead of
+        // reporting the op terminal with a silently-hung barrier.
+        self.maybe_satisfy_wait()?;
         Ok(())
     }
 
@@ -1755,17 +1758,29 @@ impl ShellState {
     /// `wait_request_id` is the shell-owned oneshot correlation id that
     /// selects which sender to notify; when the DSL barrier satisfies
     /// without a live correlation (post-recovery, or duplicate resolution),
-    /// the oneshot simply remains pending.
-    fn maybe_satisfy_wait(&mut self) {
+    /// the oneshot simply remains pending. That benign no-correlation case is
+    /// the only path that leaves the oneshot pending: on authority-invariant
+    /// corruption the pending sender is dropped so the waiter's
+    /// `WaitAllFuture` resolves to `Err` and the typed
+    /// [`OpsLifecycleError`] propagates to the terminal transition caller
+    /// instead of reporting the op complete with a silently-hung barrier.
+    fn maybe_satisfy_wait(&mut self) -> Result<(), OpsLifecycleError> {
         let satisfied = match self.try_satisfy_wait_all_authority() {
             Ok(Some(satisfied)) => satisfied,
-            Ok(None) => return,
+            Ok(None) => return Ok(()),
             Err(err) => {
-                tracing::error!(
-                    error = %err,
-                    "generated wait_all authority rejected satisfaction unexpectedly"
-                );
-                return;
+                // Authority-invariant corruption: do NOT report the op complete
+                // with a silently-pending barrier oneshot. Drop the sender so
+                // the waiter's `WaitAllFuture` resolves to `Err` via its
+                // `Poll::Ready(Err(_))` arm (the same mechanism
+                // `cancel_wait_all_internal` uses), then propagate the typed
+                // fault. The invariant is already broken, so we do not attempt
+                // a `CancelWaitAll` rollback on the corrupt machine.
+                if let Some(pending) = self.pending_wait.take() {
+                    drop(pending.sender);
+                }
+                self.wait_request_id = None;
+                return Err(err);
             }
         };
         let shell_wait_id = self.wait_request_id.take();
@@ -1791,6 +1806,7 @@ impl ShellState {
                 );
             }
         }
+        Ok(())
     }
 
     /// Persist a terminal snapshot if a persistence channel is wired.
@@ -3145,9 +3161,12 @@ impl OpsLifecycleRegistry for RuntimeOpsLifecycleRegistry {
         Some(self.completion_feed_handle())
     }
 
-    fn completion_cursor(&self, consumer: CompletionCursorConsumer) -> Option<CompletionSeq> {
-        let state = self.read_state().ok()?;
-        Some(state.completion_cursor(consumer))
+    fn completion_cursor(
+        &self,
+        consumer: CompletionCursorConsumer,
+    ) -> Result<Option<CompletionSeq>, OpsLifecycleError> {
+        let state = self.read_state()?;
+        Ok(Some(state.completion_cursor(consumer)))
     }
 
     fn advance_completion_cursor(
@@ -3668,6 +3687,105 @@ mod tests {
         assert!(state.wait_request_id.is_none());
         assert!(state.wait_operation_ids().unwrap().is_empty());
         assert!(!state.wait_active());
+    }
+
+    /// id 101: an authority-invariant corruption surfaced during a terminal
+    /// transition must NOT report the op terminal with a silently-hung barrier.
+    /// The terminal call must return the typed `Internal` fault, AND the awaited
+    /// `wait_all` future must resolve to `Err` (via the dropped-sender arm)
+    /// instead of hanging forever.
+    #[tokio::test]
+    async fn satisfy_wait_authority_fault_fails_terminal_and_unblocks_waiter() {
+        let registry = RuntimeOpsLifecycleRegistry::new();
+        let run_id = test_run_id();
+
+        let spec = background_spec("corrupt-barrier");
+        let op_id = spec.id.clone();
+        registry.register_operation(spec).unwrap();
+        registry.provisioning_succeeded(&op_id).unwrap();
+
+        // Activate a barrier whose waiter is still pending.
+        let wait_fut = registry.wait_all(&run_id, std::slice::from_ref(&op_id));
+        tokio::pin!(wait_fut);
+        assert!(
+            tokio::time::timeout(std::time::Duration::from_millis(10), &mut wait_fut)
+                .await
+                .is_err(),
+            "barrier waiter must still be pending before corruption"
+        );
+        assert!(registry.read_state().unwrap().wait_request_id.is_some());
+
+        // Corrupt the generated wait authority: an active wait_request_id with
+        // no wait_run_id forces `try_satisfy_wait_all_authority` down its
+        // non-GuardRejected `Internal` arm during the terminal transition.
+        {
+            let mut state = registry.write_state().unwrap();
+            let mut machine_state = state.dsl.0.state().clone();
+            machine_state.wait_run_id = None;
+            state.dsl = DslAuthority(Box::new(
+                mm_dsl::MeerkatMachineAuthority::recover_from_state(machine_state).unwrap(),
+            ));
+        }
+
+        // The terminal transition must FAIL with the typed authority fault, not
+        // report the op complete.
+        let err = registry
+            .complete_operation(
+                &op_id,
+                OperationResult {
+                    id: op_id.clone(),
+                    content: "done".into(),
+                    is_error: false,
+                    duration_ms: 1,
+                    tokens_used: 0,
+                },
+            )
+            .expect_err("corrupt wait authority must fail the terminal transition");
+        assert!(
+            matches!(&err, OpsLifecycleError::Internal(message) if message.contains("active wait without run id")),
+            "unexpected terminal error: {err:?}"
+        );
+
+        // The waiter must resolve to Err (dropped sender), not hang.
+        let waiter_result = tokio::time::timeout(std::time::Duration::from_secs(1), &mut wait_fut)
+            .await
+            .expect("waiter must resolve, not hang, after authority corruption");
+        match waiter_result {
+            Err(OpsLifecycleError::Internal(message)) => assert!(
+                message.contains("wait_all completion channel dropped"),
+                "unexpected waiter error message: {message}"
+            ),
+            other => panic!("expected dropped-channel Internal error, got {other:?}"),
+        }
+    }
+
+    /// id 97: a poisoned registry lock must surface as a typed `Internal` fault
+    /// from `completion_cursor`, NOT laundered into `Ok(None)` (which means "no
+    /// generated cursor authority") or a bare `None`.
+    #[test]
+    fn completion_cursor_propagates_poison_not_none() {
+        let registry = std::sync::Arc::new(RuntimeOpsLifecycleRegistry::new());
+
+        // Poison the registry RwLock by panicking while holding the write guard.
+        let poison_registry = std::sync::Arc::clone(&registry);
+        let join = std::thread::spawn(move || {
+            let _guard = poison_registry.write_state().unwrap();
+            panic!("intentional panic to poison ops lifecycle registry lock");
+        });
+        assert!(
+            join.join().is_err(),
+            "poisoning thread must have panicked while holding the write guard"
+        );
+
+        let trait_ref: &dyn OpsLifecycleRegistry = registry.as_ref();
+        let result = trait_ref.completion_cursor(CompletionCursorConsumer::AgentApplied);
+        match result {
+            Err(OpsLifecycleError::Internal(message)) => assert!(
+                message.contains("ops lifecycle registry poisoned"),
+                "unexpected cursor error message: {message}"
+            ),
+            other => panic!("poisoned registry must surface typed Internal fault, got {other:?}"),
+        }
     }
 
     #[test]

--- a/meerkat-runtime/src/runtime_loop.rs
+++ b/meerkat-runtime/src/runtime_loop.rs
@@ -826,28 +826,60 @@ pub(crate) fn spawn_runtime_loop_with_completions(
         // all-zero runtime-owned cursor must win over the feed watermark so a
         // fresh runtime loop cannot silently skip background completions that
         // land before the task reaches its first select iteration.
-        let initial_watermark = ops_lifecycle
-            .as_ref()
-            .and_then(|registry| {
-                let obs = registry.completion_cursor(
+        let initial_watermark = match ops_lifecycle.as_ref() {
+            Some(registry) => {
+                let obs = match registry.completion_cursor(
                     meerkat_core::ops_lifecycle::CompletionCursorConsumer::RuntimeObserved,
-                )?;
-                let inj = registry.completion_cursor(
+                ) {
+                    Ok(value) => value,
+                    Err(err) => {
+                        tracing::error!(
+                            session_id = %authority_binding.session_id,
+                            error = %err,
+                            "runtime loop refused to seed idle-wake watermark from poisoned ops cursor authority"
+                        );
+                        return;
+                    }
+                };
+                let inj = match registry.completion_cursor(
                     meerkat_core::ops_lifecycle::CompletionCursorConsumer::RuntimeInjected,
-                )?;
-                Some(obs.max(inj))
-            })
-            .unwrap_or(0);
+                ) {
+                    Ok(value) => value,
+                    Err(err) => {
+                        tracing::error!(
+                            session_id = %authority_binding.session_id,
+                            error = %err,
+                            "runtime loop refused to seed idle-wake watermark from poisoned ops cursor authority"
+                        );
+                        return;
+                    }
+                };
+                // `Ok(None)` from either consumer means no generated cursor
+                // authority for that consumer; treat the missing value as 0 so
+                // the watermark falls back to the legitimate no-authority floor.
+                obs.unwrap_or(0).max(inj.unwrap_or(0))
+            }
+            None => 0,
+        };
         let mut observed_seq: meerkat_core::completion_feed::CompletionSeq = initial_watermark;
-        let mut last_injected_seq: meerkat_core::completion_feed::CompletionSeq = ops_lifecycle
-            .as_ref()
-            .and_then(|registry| {
-                registry.completion_cursor(
+        let mut last_injected_seq: meerkat_core::completion_feed::CompletionSeq =
+            match ops_lifecycle.as_ref() {
+                Some(registry) => match registry.completion_cursor(
                     meerkat_core::ops_lifecycle::CompletionCursorConsumer::RuntimeInjected,
-                )
-            })
-            .filter(|&v| v > 0)
-            .unwrap_or(initial_watermark);
+                ) {
+                    Ok(Some(value)) if value > 0 => value,
+                    Ok(_) => initial_watermark,
+                    Err(err) => {
+                        tracing::error!(
+                            session_id = %authority_binding.session_id,
+                            error = %err,
+                            "runtime loop refused to seed idle-wake watermark from poisoned ops cursor authority"
+                        );
+                        return;
+                    }
+                },
+                None => initial_watermark,
+            };
 
         loop {
             // Build a future for the idle wake. Backed by the completion feed

--- a/meerkat-schedule/src/types.rs
+++ b/meerkat-schedule/src/types.rs
@@ -2431,6 +2431,18 @@ impl Occurrence {
         validate_occurrence_machine_projection(self)
     }
 
+    /// The deterministic `SessionId` an on-demand materialization must use for
+    /// this occurrence.
+    ///
+    /// Derived solely from the stable `occurrence_id` (NOT `attempt_count`), so
+    /// a reclaim/redrive of the SAME occurrence re-materializes to the SAME
+    /// session id and is reused rather than orphaning a fresh random session in
+    /// the materialize→bind crash window. Distinct occurrences get distinct ids
+    /// because `occurrence_id` is unique.
+    pub fn materialized_session_id(&self) -> SessionId {
+        SessionId::from_uuid(self.occurrence_id.0)
+    }
+
     pub fn due_misfire_detail_at(&self, now_utc: DateTime<Utc>) -> String {
         self.misfire_policy.misfire_detail(self.due_at_utc, now_utc)
     }

--- a/meerkat-store/src/index.rs
+++ b/meerkat-store/src/index.rs
@@ -40,7 +40,7 @@ fn open_connection(path: &Path) -> Result<Connection, StoreError> {
     Ok(conn)
 }
 
-/// SQLite-backed [`SessionIndex`] implementation.
+/// SQLite-backed session index implementation.
 pub struct SqliteSessionIndex {
     path: PathBuf,
 }
@@ -153,41 +153,5 @@ impl SqliteSessionIndex {
             metas.push(serde_json::from_slice(&bytes).map_err(StoreError::Serialization)?);
         }
         Ok(metas)
-    }
-}
-
-pub trait SessionIndex: Send + Sync {
-    fn lookup(&self, id: &SessionId) -> Option<SessionMeta>;
-
-    fn insert(&self, meta: SessionMeta);
-
-    fn list(&self, filter: SessionFilter) -> Vec<SessionMeta>;
-}
-
-impl SessionIndex for SqliteSessionIndex {
-    fn lookup(&self, id: &SessionId) -> Option<SessionMeta> {
-        match self.lookup_meta(id) {
-            Ok(meta) => meta,
-            Err(err) => {
-                tracing::warn!("session index lookup failed: {err}");
-                None
-            }
-        }
-    }
-
-    fn insert(&self, meta: SessionMeta) {
-        if let Err(err) = self.insert_meta(meta) {
-            tracing::warn!("session index insert failed: {err}");
-        }
-    }
-
-    fn list(&self, filter: SessionFilter) -> Vec<SessionMeta> {
-        match self.list_meta(filter) {
-            Ok(metas) => metas,
-            Err(err) => {
-                tracing::warn!("session index list failed: {err}");
-                Vec::new()
-            }
-        }
     }
 }

--- a/meerkat-store/src/jsonl.rs
+++ b/meerkat-store/src/jsonl.rs
@@ -109,17 +109,12 @@ impl JsonlStore {
 
             let contents = match fs::read_to_string(&path).await {
                 Ok(contents) => contents,
-                Err(err) => {
-                    tracing::warn!("failed to read session metadata sidecar: {path:?}: {err}");
-                    continue;
-                }
+                Err(err) => return Err(StoreError::Io(err)),
             };
 
             match serde_json::from_str::<SessionMeta>(&contents) {
                 Ok(meta) => sessions.push(meta),
-                Err(err) => {
-                    tracing::warn!("failed to parse session metadata sidecar: {path:?}: {err}");
-                }
+                Err(err) => return Err(StoreError::Serialization(err)),
             }
         }
 
@@ -683,6 +678,40 @@ mod tests {
         let sessions = store.list(SessionFilter::default()).await?;
         assert_eq!(sessions.len(), 1);
         assert_eq!(sessions[0].id, id);
+        Ok(())
+    }
+
+    /// A corrupt `.meta` sidecar must surface as a typed `SessionStoreError`
+    /// rather than being silently dropped (laundered) from the reconciliation
+    /// set, which would otherwise yield an incomplete `list()` with no fault.
+    #[tokio::test]
+    async fn test_jsonl_store_list_surfaces_corrupt_metadata_sidecar()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let temp_dir = tempfile::tempdir()?;
+        let store_path = temp_dir.path().to_path_buf();
+
+        let id = {
+            let store = JsonlStore::new(store_path.clone());
+            let mut session = Session::new();
+            session.push(Message::User(UserMessage::text("Hello".to_string())));
+            let id = session.id().clone();
+            store.save(&session).await?;
+            id
+        };
+
+        // Corrupt the metadata sidecar so reconciliation can no longer parse it.
+        let meta_path = store_path.join(format!("{}.meta", id.0));
+        fs::write(&meta_path, b"{ this is not valid SessionMeta json").await?;
+
+        // A fresh store forces index reconciliation, which scans sidecars.
+        // The corrupt sidecar must propagate as a typed serialization error
+        // instead of an incomplete `Ok(short Vec)`.
+        let store = JsonlStore::new(store_path);
+        let result = store.list(SessionFilter::default()).await;
+        assert!(
+            matches!(result, Err(SessionStoreError::Serialization(_))),
+            "corrupt .meta must surface as SessionStoreError::Serialization, got {result:?}"
+        );
         Ok(())
     }
 

--- a/meerkat-store/src/lib.rs
+++ b/meerkat-store/src/lib.rs
@@ -48,8 +48,6 @@ pub use artifact::FsArtifactStore;
 #[cfg(not(target_arch = "wasm32"))]
 pub use blob::FsBlobStore;
 #[cfg(not(target_arch = "wasm32"))]
-pub use index::SessionIndex;
-#[cfg(not(target_arch = "wasm32"))]
 pub use realm::{
     REALM_LEASE_HEARTBEAT_SECS, REALM_LEASE_STALE_TTL_SECS, RealmBackend, RealmLeaseGuard,
     RealmLeaseRecord, RealmLeaseStatus, RealmManifest, RealmManifestEntry, RealmOrigin, RealmPaths,

--- a/meerkat-store/src/realm.rs
+++ b/meerkat-store/src/realm.rs
@@ -113,6 +113,20 @@ pub struct RealmLeaseRecord {
 pub struct RealmLeaseStatus {
     pub active: Vec<RealmLeaseRecord>,
     pub stale: Vec<RealmLeaseRecord>,
+    /// Corrupt-but-present lease files that failed to parse. Their liveness
+    /// cannot be ruled out, so they are recorded here and NEVER auto-deleted.
+    pub unparseable: Vec<PathBuf>,
+}
+
+impl RealmLeaseStatus {
+    /// True when any lease is live OR cannot be ruled out as live.
+    ///
+    /// A corrupt lease is an unknown-state datum (e.g. a still-live instance's
+    /// heartbeat caught mid-write), not proof of absence, so its presence must
+    /// block destructive prune just like a live lease does.
+    pub fn blocks_destructive_prune(&self) -> bool {
+        !self.active.is_empty() || !self.unparseable.is_empty()
+    }
 }
 
 pub struct RealmLeaseGuard {
@@ -424,10 +438,13 @@ pub async fn inspect_realm_leases_in(
                         }
                     }
                 }
+                // A lease that fails serde parse is malformed/unknown-state, not
+                // proof of absence. It may be a still-live instance's heartbeat
+                // caught mid-write. Record it as unparseable and NEVER delete it,
+                // even under cleanup_stale -- a corrupt lease must block
+                // destructive prune, not silently vanish.
                 Err(_) => {
-                    if cleanup_stale {
-                        let _ = tokio::fs::remove_file(&path).await;
-                    }
+                    status.unparseable.push(path.clone());
                 }
             },
             Err(err) if err.kind() == std::io::ErrorKind::NotFound => {}
@@ -1030,7 +1047,49 @@ mod tests {
             .unwrap();
         assert!(status.active.is_empty());
         assert_eq!(status.stale.len(), 1);
+        assert!(status.unparseable.is_empty());
         assert!(!tokio::fs::try_exists(&stale_path).await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn lease_unparseable_is_recorded_and_not_deleted() {
+        let temp = tempfile::tempdir().unwrap();
+        let realms_root = temp.path().join("realms");
+        let realm_id = "lease-corrupt";
+        let paths = realm_paths_in(&realms_root, realm_id);
+        let lease_dir = realm_lease_dir(&paths);
+        tokio::fs::create_dir_all(&lease_dir).await.unwrap();
+
+        // A corrupt lease (e.g. a heartbeat write caught mid-rename) is an
+        // unknown-state datum -- not proof of absence.
+        let corrupt_path = lease_dir.join("corrupt-instance.json");
+        tokio::fs::write(&corrupt_path, b"{ not json")
+            .await
+            .unwrap();
+
+        // cleanup_stale=true is what every destructive/listing caller passes.
+        let status = inspect_realm_leases_in(&realms_root, realm_id, true)
+            .await
+            .unwrap();
+        assert!(status.active.is_empty());
+        assert!(status.stale.is_empty());
+        assert_eq!(status.unparseable.len(), 1);
+        // The corrupt file must NOT be auto-deleted even under cleanup_stale=true.
+        assert!(tokio::fs::try_exists(&corrupt_path).await.unwrap());
+        assert!(status.blocks_destructive_prune());
+    }
+
+    #[test]
+    fn blocks_destructive_prune_true_when_only_unparseable() {
+        let status = RealmLeaseStatus {
+            active: Vec::new(),
+            stale: Vec::new(),
+            unparseable: vec![PathBuf::from("/tmp/corrupt.json")],
+        };
+        assert!(status.blocks_destructive_prune());
+
+        let empty = RealmLeaseStatus::default();
+        assert!(!empty.blocks_destructive_prune());
     }
 
     #[tokio::test]

--- a/meerkat/src/surface/runtime_schedule_host.rs
+++ b/meerkat/src/surface/runtime_schedule_host.rs
@@ -317,15 +317,23 @@ impl SurfaceScheduleSessionHost for RuntimeBackedScheduleSessionHost {
 
     async fn materialize_session(
         &self,
+        occurrence: &crate::Occurrence,
         create: &SessionMaterializationSpec,
         prompt_system_prompt: Option<&str>,
     ) -> Result<SessionId, ScheduleDomainError> {
         let request = self.build_materialized_request(create, prompt_system_prompt)?;
         let keep_alive = request.build.as_ref().is_some_and(|build| build.keep_alive);
+        // Layer A: derive the materialized SessionId deterministically from the
+        // occurrence identity (NOT attempt_count) so a redrive reuses the same
+        // durable session via the create-or-reuse `resume_session` recovery
+        // path in `materialize_session`, instead of minting a fresh random id
+        // that would orphan the prior session on a crash/lease-expiry/cancel
+        // landing inside the materialize->bind window.
+        let session = Session::with_id(occurrence.materialized_session_id());
         let result = Box::pin(materialize_session(
             &self.service,
             &self.runtime_adapter,
-            Session::new(),
+            session,
             request,
             {
                 let service = Arc::clone(&self.service);
@@ -505,5 +513,70 @@ mod tests {
             .expect("valid realm slug");
 
         assert_eq!(build.preload_skills, Some(vec![key]));
+    }
+
+    fn sample_occurrence() -> crate::Occurrence {
+        let schedule = meerkat_schedule::Schedule::new(meerkat_schedule::CreateScheduleRequest {
+            name: Some("runtime-schedule-host-test".to_string()),
+            description: None,
+            trigger: meerkat_schedule::TriggerSpec::Interval(
+                meerkat_schedule::IntervalTriggerSpec {
+                    start_at_utc: chrono::Utc::now(),
+                    every_seconds: 60,
+                    end_at_utc: None,
+                },
+            ),
+            target: crate::TargetBinding::session(SessionTargetBinding::ExactSession {
+                session_id: SessionId::new(),
+                action: meerkat_schedule::ScheduledSessionAction::Prompt {
+                    prompt: ContentInput::Text("hello".to_string()),
+                    system_prompt: None,
+                    render_metadata: None,
+                    skill_refs: Vec::new(),
+                    additional_instructions: Vec::new(),
+                },
+            }),
+            misfire_policy: meerkat_schedule::MisfirePolicy::Skip,
+            overlap_policy: meerkat_schedule::OverlapPolicy::SkipIfRunning,
+            missing_target_policy: meerkat_schedule::MissingTargetPolicy::Skip,
+            labels: Default::default(),
+            planning_horizon_days: None,
+            planning_horizon_occurrences: None,
+        })
+        .expect("sample schedule creation should pass generated authority");
+        meerkat_schedule::Occurrence::planned_from_schedule(
+            &schedule,
+            meerkat_schedule::OccurrenceOrdinal(0),
+            chrono::Utc::now(),
+        )
+        .expect("sample occurrence planning should pass generated authority")
+    }
+
+    #[test]
+    fn materialized_session_id_is_deterministic_per_occurrence_and_attempt_invariant() {
+        let mut occurrence = sample_occurrence();
+        occurrence.attempt_count = 1;
+        let first = occurrence.materialized_session_id();
+
+        // Same occurrence id, a later reclaim attempt: the derived session id
+        // MUST collapse to the same value so a redrive reuses, not orphans.
+        occurrence.attempt_count = 7;
+        let after_reclaim = occurrence.materialized_session_id();
+        assert_eq!(
+            first, after_reclaim,
+            "materialized session id must be invariant across attempt_count"
+        );
+
+        // A distinct occurrence must derive a distinct session id.
+        let other = sample_occurrence();
+        assert_ne!(
+            occurrence.occurrence_id, other.occurrence_id,
+            "fixture occurrences must have distinct ids"
+        );
+        assert_ne!(
+            occurrence.materialized_session_id(),
+            other.materialized_session_id(),
+            "distinct occurrences must derive distinct session ids"
+        );
     }
 }

--- a/meerkat/src/surface/schedule_host.rs
+++ b/meerkat/src/surface/schedule_host.rs
@@ -93,8 +93,17 @@ pub trait SurfaceScheduleSessionHost: Send + Sync {
         binding: &SessionTargetBinding,
     ) -> Result<TargetProbeOutcome, ScheduleDomainError>;
 
+    /// Materialize the on-demand session for `occurrence`.
+    ///
+    /// The session id MUST be derived deterministically from the occurrence
+    /// identity (via [`Occurrence::materialized_session_id`]) so a redrive of
+    /// the same occurrence reuses the existing session instead of minting a
+    /// second orphan. Implementations are required to be create-or-reuse: a
+    /// second materialize for an occurrence whose deterministic session id
+    /// already exists is a no-op reuse, never a duplicate and never an error.
     async fn materialize_session(
         &self,
+        occurrence: &Occurrence,
         create: &SessionMaterializationSpec,
         prompt_system_prompt: Option<&str>,
     ) -> Result<SessionId, ScheduleDomainError>;
@@ -215,6 +224,20 @@ impl SharedScheduleTargetAdapter {
                 action,
                 bound_session_id: None,
             } => {
+                // Layer B: defensive contractual reuse guard. The in-flight
+                // occurrence snapshot can be stale — a prior attempt may have
+                // committed the bound id to the authoritative schedule target
+                // (and pending occurrences) after this snapshot was claimed.
+                // Re-read the authoritative binding for THIS occurrence before
+                // materializing; if a session is already bound, reuse it and
+                // never mint a second one.
+                if let Some(bound) = self.authoritative_bound_session_id(occurrence).await {
+                    return Ok(ResolvedScheduledSession {
+                        session_id: bound.clone(),
+                        materialized_session_id: Some(bound),
+                        allow_system_prompt_override: false,
+                    });
+                }
                 let prompt_system_prompt = match action {
                     ScheduledSessionAction::Prompt { system_prompt, .. } => {
                         system_prompt.as_deref()
@@ -223,7 +246,7 @@ impl SharedScheduleTargetAdapter {
                 };
                 match self
                     .session_host
-                    .materialize_session(create, prompt_system_prompt)
+                    .materialize_session(occurrence, create, prompt_system_prompt)
                     .await
                 {
                     Ok(session_id) => {
@@ -256,6 +279,39 @@ impl SharedScheduleTargetAdapter {
                 }
             }
         }
+    }
+
+    /// Re-read the authoritative bound session id for `occurrence`.
+    ///
+    /// `bind_materialized_session_for_occurrence` commits the materialized id
+    /// to the schedule target (and pending occurrences). After a prior attempt
+    /// committed that bind but died before the in-flight snapshot was synced,
+    /// the occurrence handed to `resolve_session` can still report
+    /// `bound_session_id: None`. This consults the freshest authoritative
+    /// state — the re-read occurrence first, then the schedule target — so the
+    /// adapter never materializes a second session for an already-bound
+    /// occurrence. A read failure is treated as "no authoritative binding
+    /// known": the caller falls through to deterministic-id materialization,
+    /// which is itself create-or-reuse, so no orphan can result.
+    async fn authoritative_bound_session_id(&self, occurrence: &Occurrence) -> Option<SessionId> {
+        let store = self.schedule_service.store();
+
+        if let Ok(Some(current)) = store.get_occurrence(&occurrence.occurrence_id).await
+            && let TargetBinding::Session(binding) = &current.target_snapshot
+            && let Some(session_id) = binding.resolved_session_id()
+        {
+            return Some(session_id.clone());
+        }
+
+        if let Ok(Some(schedule)) = store.get_schedule(&occurrence.schedule_id).await
+            && schedule.revision == occurrence.schedule_revision
+            && let TargetBinding::Session(binding) = &schedule.target
+            && let Some(session_id) = binding.resolved_session_id()
+        {
+            return Some(session_id.clone());
+        }
+
+        None
     }
 }
 
@@ -633,6 +689,8 @@ pub fn schedule_attempt_idempotency_key(occurrence: &Occurrence) -> String {
 mod tests {
     use super::*;
 
+    use async_trait::async_trait;
+    use meerkat_schedule::ScheduleStore;
     use std::collections::BTreeMap;
 
     fn sample_occurrence() -> Occurrence {
@@ -770,5 +828,172 @@ mod tests {
             }
             other => panic!("unexpected completion error: {other}"),
         }
+    }
+
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    /// A session host that must never be asked to materialize. Any
+    /// `materialize_session` call records a hit and returns an error so the
+    /// Layer B reuse guard regression is caught as a test failure rather than
+    /// a silent duplicate session.
+    struct PanicOnMaterializeHost {
+        materialize_calls: Arc<AtomicUsize>,
+    }
+
+    #[async_trait]
+    impl SurfaceScheduleSessionHost for PanicOnMaterializeHost {
+        async fn probe_session_target(
+            &self,
+            _binding: &SessionTargetBinding,
+        ) -> Result<TargetProbeOutcome, ScheduleDomainError> {
+            Ok(TargetProbeOutcome::Ready)
+        }
+
+        async fn materialize_session(
+            &self,
+            _occurrence: &Occurrence,
+            _create: &SessionMaterializationSpec,
+            _prompt_system_prompt: Option<&str>,
+        ) -> Result<SessionId, ScheduleDomainError> {
+            self.materialize_calls.fetch_add(1, Ordering::SeqCst);
+            Err(ScheduleDomainError::Internal(
+                "Layer B reuse guard must reuse the bound session, never materialize".to_string(),
+            ))
+        }
+
+        async fn deliver_prompt(
+            &self,
+            _session_id: &SessionId,
+            occurrence: &Occurrence,
+            _dispatch: ScheduledPromptDispatch,
+        ) -> Result<DeliveryDispatch, ScheduleDomainError> {
+            Ok(immediate_completed_dispatch(occurrence, None))
+        }
+
+        async fn deliver_event(
+            &self,
+            _session_id: &SessionId,
+            occurrence: &Occurrence,
+            _event_type: String,
+            _payload: serde_json::Value,
+            _render_metadata: Option<RenderMetadata>,
+            _materialized_session_id: Option<SessionId>,
+        ) -> Result<DeliveryDispatch, ScheduleDomainError> {
+            Ok(immediate_completed_dispatch(occurrence, None))
+        }
+    }
+
+    fn materialize_on_demand_target() -> TargetBinding {
+        TargetBinding::session(SessionTargetBinding::materialize_on_demand(
+            SessionMaterializationSpec {
+                model: "claude-sonnet-4-6".to_string(),
+                system_prompt: None,
+                max_tokens: None,
+                provider: None,
+                output_schema: None,
+                structured_output_retries: None,
+                provider_params: None,
+                comms_name: None,
+                peer_meta: None,
+                labels: BTreeMap::new(),
+                preload_skills: Vec::new(),
+                additional_instructions: Vec::new(),
+                realm_id: None,
+                instance_id: None,
+                backend: None,
+                config_generation: None,
+                keep_alive: false,
+                app_context: None,
+            },
+            ScheduledSessionAction::Prompt {
+                prompt: ContentInput::Text("scheduled prompt".to_string()),
+                system_prompt: None,
+                render_metadata: None,
+                skill_refs: Vec::new(),
+                additional_instructions: Vec::new(),
+            },
+        ))
+    }
+
+    #[tokio::test]
+    async fn resolve_session_reuses_authoritative_bound_id_without_materializing_on_stale_snapshot()
+    {
+        let store =
+            Arc::new(meerkat_schedule::MemoryScheduleStore::new()) as Arc<dyn ScheduleStore>;
+        let service = ScheduleService::new(store.clone());
+        let schedule = service
+            .create(meerkat_schedule::CreateScheduleRequest {
+                name: Some("layer-b-reuse".to_string()),
+                description: None,
+                trigger: meerkat_schedule::TriggerSpec::Once {
+                    due_at_utc: chrono::Utc::now() - ChronoDuration::seconds(1),
+                },
+                target: materialize_on_demand_target(),
+                misfire_policy: meerkat_schedule::MisfirePolicy::Skip,
+                overlap_policy: meerkat_schedule::OverlapPolicy::AllowConcurrent,
+                missing_target_policy: meerkat_schedule::MissingTargetPolicy::Skip,
+                labels: BTreeMap::new(),
+                planning_horizon_days: Some(1),
+                planning_horizon_occurrences: Some(1),
+            })
+            .await
+            .expect("schedule create should plan one occurrence");
+
+        let occurrence = service
+            .list_occurrences(&schedule.schedule_id)
+            .await
+            .expect("list occurrences")
+            .into_iter()
+            .next()
+            .expect("schedule should have planned one occurrence");
+
+        // A prior attempt materialized and committed the bound id to the
+        // authoritative schedule target (and pending occurrences).
+        let bound_id = SessionId::new();
+        service
+            .bind_materialized_session_for_occurrence(&occurrence, &bound_id)
+            .await
+            .expect("bind should commit the materialized session id");
+
+        // The in-flight occurrence snapshot is STALE: it still reports
+        // `bound_session_id: None`, exactly the window the residual described.
+        let mut stale = occurrence.clone();
+        stale.target_snapshot = materialize_on_demand_target();
+        let TargetBinding::Session(binding) = &stale.target_snapshot else {
+            panic!("expected a session target binding");
+        };
+        assert!(
+            binding.resolved_session_id().is_none(),
+            "stale snapshot must start unbound to exercise the reuse guard"
+        );
+
+        let materialize_calls = Arc::new(AtomicUsize::new(0));
+        let session_host: Arc<dyn SurfaceScheduleSessionHost> = Arc::new(PanicOnMaterializeHost {
+            materialize_calls: Arc::clone(&materialize_calls),
+        });
+        let mob_host: Arc<dyn SurfaceScheduleMobHost> = Arc::new(NoopScheduleMobHost::new(
+            "mob targets unsupported in this test",
+        ));
+        let adapter = SharedScheduleTargetAdapter::new(service, session_host, mob_host);
+
+        let TargetBinding::Session(stale_binding) = &stale.target_snapshot else {
+            panic!("expected a session target binding");
+        };
+        let resolved = adapter
+            .resolve_session(&stale, stale_binding)
+            .await
+            .expect("reuse guard should resolve without a delivery failure");
+
+        assert_eq!(resolved.session_id, bound_id);
+        assert_eq!(resolved.materialized_session_id, Some(bound_id));
+        assert!(
+            !resolved.allow_system_prompt_override,
+            "reused session must not allow a fresh system-prompt override"
+        );
+        assert_eq!(
+            materialize_calls.load(Ordering::SeqCst),
+            0,
+            "Layer B guard must reuse the bound id, never call materialize_session"
+        );
     }
 }

--- a/sdks/python/meerkat/client.py
+++ b/sdks/python/meerkat/client.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 import asyncio
 from dataclasses import asdict, is_dataclass
 import json
+import logging
 import os
 import platform
 import shutil
@@ -147,6 +148,8 @@ from .types import (
     WorkItem,
     WorkItemListResult,
 )
+
+_logger = logging.getLogger(__name__)
 
 _MEERKAT_REPO = ("lukacf", "meerkat")
 _MEERKAT_BINARY = "rkat-rpc"
@@ -409,15 +412,32 @@ class MeerkatClient:
         description: str,
         input_schema: dict[str, Any] | None,
     ) -> None:
-        """Best-effort registration of a single tool with the server."""
+        """Register a single tool with the server post-connect.
+
+        Benign shutdown/disconnect faults return quietly (the local registry
+        still holds the definition and the next ``connect()`` re-sends it);
+        genuine server rejection / protocol faults are logged and re-raised.
+        """
         try:
             await self._request(
                 "tools/register",
                 {"tools": [{"name": name, "description": description or f"Tool: {name}",
                              "input_schema": input_schema or {"type": "object"}}]},
             )
-        except Exception:
-            pass  # Best-effort — server may be shutting down.
+        except MeerkatError as exc:
+            # Clean shutdown / disconnect is genuinely benign — the registry
+            # already holds the definition and a future connect() will re-send it.
+            if exc.code in ("CLIENT_CLOSED", "CONNECTION_CLOSED", "NOT_CONNECTED"):
+                return
+            # Server rejection / protocol error is a real fault. We are on a
+            # detached task (asyncio.ensure_future), so re-raising is invisible:
+            # surface it via logging so the silent-never-registers failure is
+            # observable.
+            _logger.error(
+                "post-connect tool registration failed for %r: [%s] %s",
+                name, exc.code, exc.message,
+            )
+            raise
 
     # -- Async context manager ---------------------------------------------
 

--- a/sdks/python/meerkat/client.py
+++ b/sdks/python/meerkat/client.py
@@ -378,6 +378,7 @@ class MeerkatClient:
         self._methods: set[str] = set()
         self._dispatcher: _StdoutDispatcher | None = None
         self._tool_registry = ToolRegistry()
+        self._tool_registration_errors: dict[str, MeerkatError] = {}
 
     # -- Tool registration -------------------------------------------------
 
@@ -416,7 +417,8 @@ class MeerkatClient:
 
         Benign shutdown/disconnect faults return quietly (the local registry
         still holds the definition and the next ``connect()`` re-sends it);
-        genuine server rejection / protocol faults are logged and re-raised.
+        genuine server rejection / protocol faults are logged, recorded as
+        programmatically-distinguishable state, and re-raised.
         """
         try:
             await self._request(
@@ -430,14 +432,19 @@ class MeerkatClient:
             if exc.code in ("CLIENT_CLOSED", "CONNECTION_CLOSED", "NOT_CONNECTED"):
                 return
             # Server rejection / protocol error is a real fault. We are on a
-            # detached task (asyncio.ensure_future), so re-raising is invisible:
-            # surface it via logging so the silent-never-registers failure is
-            # observable.
+            # detached task (asyncio.ensure_future), so re-raising is invisible
+            # to the sync decorator caller. Record the typed fault as
+            # caller-inspectable state so the silent-never-registers failure is
+            # programmatically distinguishable, then log and re-raise.
+            self._tool_registration_errors[name] = exc
             _logger.error(
                 "post-connect tool registration failed for %r: [%s] %s",
                 name, exc.code, exc.message,
             )
             raise
+        # Success: clear any stale fault recorded by a prior failed attempt so a
+        # later re-registration that succeeds no longer reports an error.
+        self._tool_registration_errors.pop(name, None)
 
     # -- Async context manager ---------------------------------------------
 

--- a/sdks/python/tests/test_tool_registration.py
+++ b/sdks/python/tests/test_tool_registration.py
@@ -30,6 +30,23 @@ async def test_register_tool_propagates_server_rejection() -> None:
 
 
 @pytest.mark.asyncio
+async def test_register_tool_records_server_rejection_as_state() -> None:
+    """A server rejection is recorded as caller-inspectable state, keyed by
+    tool name, in addition to being re-raised."""
+    client = MeerkatClient()
+
+    async def reject(_method: str, _params: object) -> object:
+        raise MeerkatError("TOOL_REJECTED", "server rejected tools/register")
+
+    client._request = reject  # type: ignore[assignment]
+
+    with pytest.raises(MeerkatError):
+        await client._register_tool_with_server("t", "", None)
+
+    assert client._tool_registration_errors["t"].code == "TOOL_REJECTED"
+
+
+@pytest.mark.asyncio
 async def test_register_tool_swallows_benign_disconnect() -> None:
     """Clean shutdown / disconnect codes return None without raising."""
     client = MeerkatClient()

--- a/sdks/python/tests/test_tool_registration.py
+++ b/sdks/python/tests/test_tool_registration.py
@@ -1,0 +1,44 @@
+"""Tests for post-connect tool registration fault handling.
+
+`MeerkatClient._register_tool_with_server` runs on a detached
+`asyncio.ensure_future` task launched from the synchronous `@client.tool`
+decorator. A genuine server rejection of `tools/register` is a real fault and
+must NOT be laundered into a silent success: it is logged and re-raised. Only
+the truly-benign shutdown/disconnect codes return quietly.
+"""
+
+import pytest
+
+from meerkat.client import MeerkatClient
+from meerkat.errors import MeerkatError
+
+
+@pytest.mark.asyncio
+async def test_register_tool_propagates_server_rejection() -> None:
+    """A server rejection MeerkatError is re-raised, not swallowed."""
+    client = MeerkatClient()
+
+    async def reject(_method: str, _params: object) -> object:
+        raise MeerkatError("TOOL_REJECTED", "server rejected tools/register")
+
+    client._request = reject  # type: ignore[assignment]
+
+    with pytest.raises(MeerkatError) as excinfo:
+        await client._register_tool_with_server("t", "", None)
+
+    assert excinfo.value.code == "TOOL_REJECTED"
+
+
+@pytest.mark.asyncio
+async def test_register_tool_swallows_benign_disconnect() -> None:
+    """Clean shutdown / disconnect codes return None without raising."""
+    client = MeerkatClient()
+
+    for benign_code in ("CLIENT_CLOSED", "CONNECTION_CLOSED", "NOT_CONNECTED"):
+        async def disconnect(_method: str, _params: object, _code: str = benign_code) -> object:
+            raise MeerkatError(_code, "transport closed")
+
+        client._request = disconnect  # type: ignore[assignment]
+
+        result = await client._register_tool_with_server("t", "", None)
+        assert result is None


### PR DESCRIPTION
## Terminal Truth Laundering (Rule 8 / Split Terminality)

Closes the violations in `docs/architecture/dogma-audits/terminal-truth-laundering.md`. **Rule 8 — Terminality and Faults Are Explicit:** a failure / timeout / cancellation / dropped delivery / malformed data / partial execution must not be converted into a benign terminal class (success, empty, `None`, default) that loses the typed fault. Every fix here **propagates the typed fault a sibling path already uses** — no new authorities.

### High
- **Provider streaming seam** (`meerkat-llm-core`, `meerkat-anthropic`, `meerkat-openai`, `meerkat-gemini`)
  - `ToolCallBuffer::try_complete -> Result<Option<ToolCall>, LlmError>`: malformed tool-call args fail closed to `LlmError::StreamParseError` instead of silently vanishing into `Done{Success}`.
  - The three SSE line parsers (`parse_sse_line`, `parse_responses_sse_line`, `parse_stream_line`/`_for_wire`) → `Result<Option<_>, LlmError>`: an unparseable real `data:` event is a typed `StreamParseError`, not a silent skip.
  - Deleted the Anthropic synthetic-`Done{Success}`-on-clean-EOF branch → a truncated stream classifies as `IncompleteResponse` via `ensure_terminal_done`, matching OpenAI/Gemini.
- **ops_lifecycle barrier** (`meerkat-runtime`)
  - `maybe_satisfy_wait -> Result`: on authority-invariant corruption it drops the wait-all oneshot (the waiter resolves to `Err` instead of hanging forever) and `?`-propagates from `finalize_terminal` — terminal transitions no longer report the op complete while the barrier consumer hangs.
  - `completion_cursor` trait → `Result<Option<CompletionSeq>, OpsLifecycleError>`: RwLock poison propagates instead of laundering to `None` (which silently reset the idle-wake watermark to 0).

### Medium / Low
- **Config-read handlers**: REST `/capabilities` + `/models/catalog`, RPC `capabilities/get` + `models/catalog` propagate `ConfigError` (`ApiError::Configuration` / `INTERNAL_ERROR`) instead of `unwrap_or_default()` returning success with phantom default capabilities.
- **Boundary tool-visibility publish** (`meerkat-core`): a real durable-projection write fault propagates before any `boundary_applied` success event/notice is emitted. Standalone read-only builds remain a correct no-op via `ToolScope::owns_durable_visibility_projection()` (the durable projection only exists under `GeneratedMachine` authority).
- **Realm lease inspection** (`meerkat-store`, `meerkat-cli`): a corrupt-but-present lease is recorded in a new `RealmLeaseStatus.unparseable` channel and **never auto-deleted**; `delete_realm` and `prune_realms_inner` block on it. **Safety:** a corrupt-but-live lease can no longer let a realm be destroyed.
- **Auth-lease rotation** (`meerkat-core`): the previous-lease release `map_err`s to `AgentError::ConfigError` and `?`-propagates instead of `let _ =` dropping it (symmetric with the acquire branch).
- **Pending session event stream** (`meerkat-rpc`): broadcast `Lagged(n)` yields a typed `AgentEvent::StreamTruncated` gap marker instead of silently dropping events.
- **Python SDK** (`sdks/python`): post-connect tool registration no longer `except Exception: pass`; benign disconnect codes return quietly, genuine rejections log + raise.
- **`RpcResponse::success`** (`meerkat-rpc`): result serialization failure returns an `INTERNAL_ERROR` envelope instead of fabricating `{result: null}`.
- **Session store** (`meerkat-store`): `read_all_metadata_sidecars` propagates `StoreError` instead of `warn+continue` dropping a session from `list()`; deleted the dead `SessionIndex` trait (Option/()/Vec laundering wrappers, zero callers).

### Verification
- `nextest --workspace --all-features` — **8010 passed, 0 failed**.
- `clippy --workspace --all-features --all-targets -- -D warnings` — clean.
- `e2e-fast` — green (3/3).
- Added fail-closed tests for each propagating path; **inverted** the `meerkat-client` test that codified the old synthetic-success (now `test_anthropic_stream_end_without_done_yields_incomplete`).
- Adversarial per-cluster Rule-8 review + completeness critic: no broken verdicts; the critic verified every cluster against the final code.

### Scoped out (documented, not regressions)
- **Adjacent best-effort siblings** `runner.rs::stage_external_tool_filter` / `session_with_system_context_state`: same swallow shape, but they re-persist authoritatively at the now-fixed boundary commit (the audit's *cleared* best-effort pattern). Left as a noted follow-up rather than making best-effort staging fail-closed or cascading a `Session`-getter signature.
- **GeneratedMachine boundary-publish fault** and **auth-lease rotation-release** behavioral tests need the runtime `MeerkatMachine` / `RuntimeAuthLeaseHandle` harness (`cfg(not(test))`-gated constructors); verified by inspection + sibling parity, with the standalone paths covered by the green suite.
- **Python registration** is log-only-observable (fire-and-forget `ensure_future` task) — a material improvement over silent `pass`, the best achievable at that surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
