### PR TITLE
[codex] Fix dogma ledger violations

### DIFF
--- a/examples/034-codemob-mcp/Cargo.lock
+++ b/examples/034-codemob-mcp/Cargo.lock
@@ -424,6 +424,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -761,6 +771,16 @@ checksum = "0f158e3ff0a1b334408dc9fb811cd99b446986f4d8b741bb08f9df1604085ae7"
 dependencies = [
  "lazy_static",
  "num",
+]
+
+[[package]]
+name = "fs4"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c29c30684418547d476f0b48e84f4821639119c483b1eccd566c8cd0cd05f521"
+dependencies = [
+ "rustix 0.38.44",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1346,6 +1366,55 @@ dependencies = [
 ]
 
 [[package]]
+name = "jni"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
+dependencies = [
+ "cfg-if",
+ "combine",
+ "jni-macros",
+ "jni-sys",
+ "log",
+ "simd_cesu8",
+ "thiserror 2.0.18",
+ "walkdir",
+ "windows-link",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1456,6 +1525,12 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+
+[[package]]
+name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
@@ -1513,13 +1588,14 @@ checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "meerkat"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "async-trait",
  "chrono",
  "futures",
  "inventory",
  "meerkat-anthropic",
+ "meerkat-capabilities",
  "meerkat-client",
  "meerkat-comms",
  "meerkat-contracts",
@@ -1537,7 +1613,9 @@ dependencies = [
  "meerkat-skills",
  "meerkat-store",
  "meerkat-tools",
+ "meerkat-workgraph",
  "parking_lot",
+ "serde",
  "serde_json",
  "thiserror 2.0.18",
  "tokio",
@@ -1548,7 +1626,7 @@ dependencies = [
 
 [[package]]
 name = "meerkat-anthropic"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -1558,6 +1636,7 @@ dependencies = [
  "meerkat-auth-core",
  "meerkat-core",
  "meerkat-llm-core",
+ "meerkat-models",
  "reqwest",
  "serde",
  "serde_json",
@@ -1569,7 +1648,7 @@ dependencies = [
 
 [[package]]
 name = "meerkat-auth-core"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "async-trait",
  "axum",
@@ -1587,16 +1666,30 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
+ "sha2",
  "thiserror 2.0.18",
  "tokio",
  "tokio_with_wasm",
  "tracing",
  "urlencoding",
+ "uuid",
+ "webbrowser",
+]
+
+[[package]]
+name = "meerkat-capabilities"
+version = "0.7.0"
+dependencies = [
+ "inventory",
+ "meerkat-core",
+ "schemars",
+ "serde",
+ "strum",
 ]
 
 [[package]]
 name = "meerkat-client"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "meerkat-anthropic",
  "meerkat-core",
@@ -1607,7 +1700,7 @@ dependencies = [
 
 [[package]]
 name = "meerkat-comms"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "async-trait",
  "base64",
@@ -1618,6 +1711,7 @@ dependencies = [
  "getrandom 0.2.17",
  "getrandom 0.3.4",
  "inventory",
+ "meerkat-capabilities",
  "meerkat-contracts",
  "meerkat-core",
  "meerkat-skills",
@@ -1640,13 +1734,14 @@ dependencies = [
 
 [[package]]
 name = "meerkat-contracts"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "base64",
  "chrono",
- "inventory",
+ "meerkat-capabilities",
  "meerkat-core",
  "meerkat-schedule",
+ "meerkat-workgraph",
  "schemars",
  "serde",
  "serde_json",
@@ -1656,9 +1751,10 @@ dependencies = [
 
 [[package]]
 name = "meerkat-core"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "async-trait",
+ "base64",
  "chrono",
  "dirs",
  "futures",
@@ -1671,6 +1767,7 @@ dependencies = [
  "schemars",
  "serde",
  "serde_json",
+ "sha2",
  "strum",
  "thiserror 2.0.18",
  "tokio",
@@ -1683,7 +1780,7 @@ dependencies = [
 
 [[package]]
 name = "meerkat-gemini"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -1699,17 +1796,19 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 2.0.18",
+ "tokio",
  "tokio_with_wasm",
 ]
 
 [[package]]
 name = "meerkat-hooks"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "async-trait",
  "chrono",
  "futures",
  "inventory",
+ "meerkat-capabilities",
  "meerkat-contracts",
  "meerkat-core",
  "meerkat-skills",
@@ -1723,7 +1822,7 @@ dependencies = [
 
 [[package]]
 name = "meerkat-llm-core"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -1747,7 +1846,7 @@ dependencies = [
 
 [[package]]
 name = "meerkat-machine-derive"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "quote",
  "syn",
@@ -1755,14 +1854,14 @@ dependencies = [
 
 [[package]]
 name = "meerkat-machine-dsl"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "meerkat-machine-dsl-core",
 ]
 
 [[package]]
 name = "meerkat-machine-dsl-core"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1771,7 +1870,7 @@ dependencies = [
 
 [[package]]
 name = "meerkat-machine-kernels"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "indexmap",
  "meerkat-core",
@@ -1782,7 +1881,7 @@ dependencies = [
 
 [[package]]
 name = "meerkat-machine-schema"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "indexmap",
  "meerkat-core",
@@ -1793,11 +1892,12 @@ dependencies = [
 
 [[package]]
 name = "meerkat-memory"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "async-trait",
  "hnsw_rs",
  "inventory",
+ "meerkat-capabilities",
  "meerkat-contracts",
  "meerkat-core",
  "meerkat-skills",
@@ -1811,7 +1911,7 @@ dependencies = [
 
 [[package]]
 name = "meerkat-mob"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1827,6 +1927,7 @@ dependencies = [
  "meerkat-machine-dsl",
  "meerkat-machine-kernels",
  "meerkat-machine-schema",
+ "meerkat-models",
  "meerkat-runtime",
  "meerkat-session",
  "notify",
@@ -1845,7 +1946,7 @@ dependencies = [
 
 [[package]]
 name = "meerkat-mob-mcp"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "async-trait",
  "futures",
@@ -1868,16 +1969,14 @@ dependencies = [
 
 [[package]]
 name = "meerkat-models"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "meerkat-core",
- "schemars",
- "serde_json",
 ]
 
 [[package]]
 name = "meerkat-openai"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -1890,6 +1989,7 @@ dependencies = [
  "meerkat-contracts",
  "meerkat-core",
  "meerkat-llm-core",
+ "meerkat-models",
  "reqwest",
  "serde",
  "serde_json",
@@ -1901,7 +2001,7 @@ dependencies = [
 
 [[package]]
 name = "meerkat-providers"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "meerkat-auth-core",
  "meerkat-llm-core",
@@ -1909,7 +2009,7 @@ dependencies = [
 
 [[package]]
 name = "meerkat-runtime"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1922,7 +2022,6 @@ dependencies = [
  "meerkat-machine-schema",
  "serde",
  "serde_json",
- "sha2",
  "thiserror 2.0.18",
  "tokio",
  "tokio_with_wasm",
@@ -1932,15 +2031,18 @@ dependencies = [
 
 [[package]]
 name = "meerkat-schedule"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "async-trait",
  "chrono",
  "chrono-tz",
  "futures",
  "indexmap",
+ "inventory",
+ "meerkat-capabilities",
  "meerkat-core",
  "meerkat-machine-schema",
+ "meerkat-skills",
  "schemars",
  "serde",
  "serde_json",
@@ -1952,14 +2054,16 @@ dependencies = [
 
 [[package]]
 name = "meerkat-session"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "async-trait",
  "futures",
  "indexmap",
  "inventory",
+ "meerkat-capabilities",
  "meerkat-contracts",
  "meerkat-core",
+ "meerkat-models",
  "meerkat-runtime",
  "meerkat-skills",
  "meerkat-store",
@@ -1974,12 +2078,12 @@ dependencies = [
 
 [[package]]
 name = "meerkat-skills"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "async-trait",
  "indexmap",
  "inventory",
- "meerkat-contracts",
+ "meerkat-capabilities",
  "meerkat-core",
  "regex",
  "reqwest",
@@ -1995,11 +2099,12 @@ dependencies = [
 
 [[package]]
 name = "meerkat-store"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "async-trait",
  "chrono",
  "dirs",
+ "fs4",
  "meerkat-core",
  "meerkat-schedule",
  "rusqlite",
@@ -2015,7 +2120,7 @@ dependencies = [
 
 [[package]]
 name = "meerkat-tools"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "async-trait",
  "base64",
@@ -2025,6 +2130,7 @@ dependencies = [
  "humantime",
  "inventory",
  "jsonschema",
+ "meerkat-capabilities",
  "meerkat-comms",
  "meerkat-contracts",
  "meerkat-core",
@@ -2044,6 +2150,30 @@ dependencies = [
  "tracing",
  "uuid",
  "which",
+]
+
+[[package]]
+name = "meerkat-workgraph"
+version = "0.7.0"
+dependencies = [
+ "async-trait",
+ "chrono",
+ "indexmap",
+ "inventory",
+ "meerkat-capabilities",
+ "meerkat-core",
+ "meerkat-machine-schema",
+ "meerkat-skills",
+ "rusqlite",
+ "schemars",
+ "serde",
+ "serde_json",
+ "sha2",
+ "strum",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio_with_wasm",
+ "uuid",
 ]
 
 [[package]]
@@ -2086,6 +2216,12 @@ dependencies = [
  "widestring",
  "windows",
 ]
+
+[[package]]
+name = "ndk-context"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
 
 [[package]]
 name = "nix"
@@ -2260,6 +2396,31 @@ dependencies = [
  "sha2",
  "thiserror 1.0.69",
  "url",
+]
+
+[[package]]
+name = "objc2"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a12a8ed07aefc768292f076dc3ac8c48f3781c8f2d5851dd3d98950e8c5a89f"
+dependencies = [
+ "objc2-encode",
+]
+
+[[package]]
+name = "objc2-encode"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
+
+[[package]]
+name = "objc2-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
+dependencies = [
+ "bitflags 2.11.0",
+ "objc2",
 ]
 
 [[package]]
@@ -2746,6 +2907,19 @@ dependencies = [
 
 [[package]]
 name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags 2.11.0",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
@@ -2753,7 +2927,7 @@ dependencies = [
  "bitflags 2.11.0",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.12.1",
  "windows-sys 0.61.2",
 ]
 
@@ -2928,11 +3102,11 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "0.6.9"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
 dependencies = [
- "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -3023,6 +3197,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "simd_cesu8"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
 name = "simple_asn1"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3054,9 +3244,9 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "socket2"
-version = "0.6.2"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
+checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
@@ -3080,18 +3270,18 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "strum"
-version = "0.27.2"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
+checksum = "9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd"
 dependencies = [
  "strum_macros",
 ]
 
 [[package]]
 name = "strum_macros"
-version = "0.27.2"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
+checksum = "ab85eea0270ee17587ed4156089e10b9e6880ee688791d45a905f5b1ca36f664"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -3159,7 +3349,7 @@ dependencies = [
  "fastrand",
  "getrandom 0.4.2",
  "once_cell",
- "rustix",
+ "rustix 1.1.4",
  "windows-sys 0.61.2",
 ]
 
@@ -3357,44 +3547,42 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.23"
+version = "0.9.12+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
 dependencies = [
- "serde",
+ "indexmap",
+ "serde_core",
  "serde_spanned",
  "toml_datetime",
- "toml_edit",
+ "toml_parser",
+ "toml_writer",
+ "winnow 0.7.15",
 ]
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.11"
+version = "0.7.5+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
 dependencies = [
- "serde",
+ "serde_core",
 ]
 
 [[package]]
-name = "toml_edit"
-version = "0.22.27"
+name = "toml_parser"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "indexmap",
- "serde",
- "serde_spanned",
- "toml_datetime",
- "toml_write",
- "winnow",
+ "winnow 1.0.3",
 ]
 
 [[package]]
-name = "toml_write"
-version = "0.1.2"
+name = "toml_writer"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
+checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "tower"
@@ -3809,6 +3997,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "webbrowser"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fc95580916af1e68ff6a7be07446fc5db73ebf71cf092de939bbf5f7e189f72"
+dependencies = [
+ "core-foundation",
+ "jni",
+ "log",
+ "ndk-context",
+ "objc2",
+ "objc2-foundation",
+ "url",
+ "web-sys",
+]
+
+[[package]]
 name = "webpki-roots"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3825,7 +4029,7 @@ checksum = "24d643ce3fd3e5b54854602a080f34fb10ab75e0b813ee32d00ca2b44fa74762"
 dependencies = [
  "either",
  "env_home",
- "rustix",
+ "rustix 1.1.4",
  "winsafe",
 ]
 
@@ -4161,9 +4365,12 @@ name = "winnow"
 version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
-dependencies = [
- "memchr",
-]
+
+[[package]]
+name = "winnow"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
 
 [[package]]
 name = "winsafe"
@@ -4263,7 +4470,7 @@ dependencies = [
 name = "writeable"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
 
 [[package]]
 name = "yoke"

--- a/examples/034-codemob-mcp/src/packs/advisor.rs
+++ b/examples/034-codemob-mcp/src/packs/advisor.rs
@@ -6,7 +6,6 @@
 use indexmap::IndexMap;
 use meerkat_mob::definition::*;
 use meerkat_mob::ids::*;
-use serde_json::Value;
 use std::collections::BTreeMap;
 
 use super::*;
@@ -32,7 +31,7 @@ impl Pack for AdvisorPack {
         task: &str,
         context: &str,
         overrides: &BTreeMap<String, String>,
-        pp: Option<&Value>,
+        pp: Option<&meerkat_core::ProviderParamsOverride>,
     ) -> MobDefinition {
         let ctx = format_context(context);
 

--- a/examples/034-codemob-mcp/src/packs/architect.rs
+++ b/examples/034-codemob-mcp/src/packs/architect.rs
@@ -7,7 +7,6 @@
 use indexmap::IndexMap;
 use meerkat_mob::definition::*;
 use meerkat_mob::ids::*;
-use serde_json::Value;
 use std::collections::BTreeMap;
 
 use super::*;
@@ -33,7 +32,7 @@ impl Pack for ArchitectPack {
         task: &str,
         context: &str,
         overrides: &BTreeMap<String, String>,
-        pp: Option<&Value>,
+        pp: Option<&meerkat_core::ProviderParamsOverride>,
     ) -> MobDefinition {
         let ctx = format_context(context);
 

--- a/examples/034-codemob-mcp/src/packs/brainstorm.rs
+++ b/examples/034-codemob-mcp/src/packs/brainstorm.rs
@@ -7,7 +7,6 @@
 use indexmap::IndexMap;
 use meerkat_mob::definition::*;
 use meerkat_mob::ids::*;
-use serde_json::Value;
 use std::collections::BTreeMap;
 
 use super::*;
@@ -33,7 +32,7 @@ impl Pack for BrainstormPack {
         task: &str,
         context: &str,
         overrides: &BTreeMap<String, String>,
-        pp: Option<&Value>,
+        pp: Option<&meerkat_core::ProviderParamsOverride>,
     ) -> MobDefinition {
         let ctx = format_context(context);
 

--- a/examples/034-codemob-mcp/src/packs/implement.rs
+++ b/examples/034-codemob-mcp/src/packs/implement.rs
@@ -1,23 +1,16 @@
-//! Implement pack — gated implementation with iterative review.
+//! Implement pack — gated implementation with reviewer synthesis.
 //!
-//! Two agents in a comms-based review loop:
-//! - **implementer**: receives the task, produces the solution
-//! - **reviewer**: quality gate — approves or sends feedback for revision
-//!
-//! The reviewer acts as orchestrator. It receives the task, forwards it to
-//! the implementer, reviews the output, and either approves (captured as
-//! the final result) or sends feedback for another iteration. Capped at
-//! 3 revision rounds by the reviewer's skill instructions.
+//! Two agents run in a `"main"` flow: the implementer produces the solution,
+//! then the reviewer emits the terminal gate verdict. Completion is resolved by
+//! `MobMachine` flow terminality.
 
+use indexmap::IndexMap;
 use std::collections::BTreeMap;
 
 use meerkat_mob::definition::*;
 use meerkat_mob::ids::*;
-use meerkat_mob::profile::{Profile, ProfileBinding, ToolConfig};
-use meerkat_mob::MobRuntimeMode;
-use serde_json::Value;
 
-use super::{resolve_model, Pack};
+use super::{flow_step, format_context, identity_spawn_policy, mob_definition, resolve_model, turn_driven_profile, Pack};
 
 pub struct ImplementPack;
 
@@ -26,60 +19,42 @@ impl Pack for ImplementPack {
         "implement"
     }
     fn description(&self) -> &str {
-        "Gated implementation: an implementer produces work, a reviewer approves or sends feedback. Iterates until the reviewer is satisfied (max 3 rounds)."
+        "Gated implementation: an implementer produces work, then a reviewer emits a gate verdict"
     }
     fn agent_count(&self) -> usize {
         2
     }
     fn flow_step_count(&self) -> usize {
-        0
-    } // comms-driven review loop
+        2
+    }
 
     fn definition(
         &self,
-        _task: &str,
-        _context: &str,
+        task: &str,
+        context: &str,
         overrides: &BTreeMap<String, String>,
-        pp: Option<&Value>,
+        pp: Option<&meerkat_core::ProviderParamsOverride>,
     ) -> MobDefinition {
-        let tools = ToolConfig {
-            builtins: true,
-            shell: true,
-            comms: true,
-            ..ToolConfig::default()
-        };
+        let ctx = format_context(context);
 
         let mut profiles = BTreeMap::new();
         profiles.insert(
             ProfileName::from("implementer"),
-            ProfileBinding::Inline(Box::new(Profile {
-                model: resolve_model(overrides, "implementer", "claude-sonnet-4-6"),
-                skills: vec!["implementer-skill".to_string()],
-                tools: tools.clone(),
-                peer_description: "Implementation agent — produces the solution".to_string(),
-                external_addressable: true,
-                backend: None,
-                runtime_mode: MobRuntimeMode::AutonomousHost,
-                max_inline_peer_notifications: None,
-                output_schema: None,
-                provider_params: pp.cloned(),
-            })),
+            turn_driven_profile(
+                resolve_model(overrides, "implementer", "claude-sonnet-4-6"),
+                "implementer-skill",
+                "Implementation agent — produces the solution",
+                pp,
+            ),
         );
         profiles.insert(
             ProfileName::from("reviewer"),
-            ProfileBinding::Inline(Box::new(Profile {
-                model: resolve_model(overrides, "reviewer", "gpt-5.5"),
-                skills: vec!["gate-reviewer-skill".to_string()],
-                tools: tools.clone(),
-                peer_description: "Quality gate reviewer — approves or requests revision"
-                    .to_string(),
-                external_addressable: true,
-                backend: None,
-                runtime_mode: MobRuntimeMode::AutonomousHost,
-                max_inline_peer_notifications: None,
-                output_schema: None,
-                provider_params: pp.cloned(),
-            })),
+            turn_driven_profile(
+                resolve_model(overrides, "reviewer", "gpt-5.5"),
+                "gate-reviewer-skill",
+                "Quality gate reviewer — approves or requests revision",
+                pp,
+            ),
         );
 
         let mut skills = BTreeMap::new();
@@ -96,22 +71,38 @@ impl Pack for ImplementPack {
             },
         );
 
-        let mut definition = MobDefinition::explicit(MobId::from(format!(
-            "codemob-implement-{}",
-            uuid::Uuid::new_v4().as_simple()
-        )));
-        definition.orchestrator = Some(OrchestratorConfig {
-            profile: ProfileName::from("reviewer"),
-        });
-        definition.profiles = profiles;
-        definition.wiring = WiringRules {
-            auto_wire_orchestrator: true,
-            role_wiring: vec![RoleWiringRule {
-                a: ProfileName::from("implementer"),
-                b: ProfileName::from("reviewer"),
-            }],
-        };
-        definition.skills = skills;
-        definition
+        let mut steps = IndexMap::new();
+        steps.insert(
+            StepId::from("implement"),
+            flow_step(
+                "implementer",
+                format!("Implement the requested change. Include the approach, changed files, and verification performed.\n\n{task}{ctx}"),
+                &[],
+                600_000,
+            ),
+        );
+        steps.insert(
+            StepId::from("review"),
+            flow_step(
+                "reviewer",
+                "Review the implementation below. Produce a final gate verdict: APPROVE or BLOCK, with blocking issues first and any follow-up recommendations.\n\n## Implementation\n{{ steps.implement }}".into(),
+                &["implement"],
+                300_000,
+            ),
+        );
+
+        let mut flows = BTreeMap::new();
+        flows.insert(
+            FlowId::from("main"),
+            FlowSpec::new(Some("Implementation followed by gate review".into()), steps, None),
+        );
+
+        mob_definition(
+            "implement",
+            profiles,
+            skills,
+            flows,
+            identity_spawn_policy(&["implementer", "reviewer"]),
+        )
     }
 }

--- a/examples/034-codemob-mcp/src/packs/mod.rs
+++ b/examples/034-codemob-mcp/src/packs/mod.rs
@@ -1,17 +1,10 @@
 //! Pack definitions — reusable team compositions for the `deliberate` tool.
 //!
 //! Each pack implements the [`Pack`] trait and builds a [`MobDefinition`] that
-//! the deliberate handler uses to create an ephemeral mob. Packs come in two
-//! execution modes:
-//!
-//! - **Flow-based** (`flow_step_count() > 0`): Structured step execution with
-//!   dependency tracking. The deliberate handler runs the `"main"` flow and
-//!   polls for completion. Prior step outputs are forwarded via `{{ steps.<id> }}`
-//!   template references.
-//!
-//! - **Comms-based** (`flow_step_count() == 0`): Autonomous agents communicate
-//!   freely via peer messaging. The deliberate handler injects the task via
-//!   `mob_member_send` and monitors the event stream for quiescence.
+//! the deliberate handler uses to create an ephemeral mob. Every pack must
+//! define a `"main"` flow: structured step execution gives `MobMachine` the
+//! terminal result, and prior step outputs are forwarded via
+//! `{{ steps.<id> }}` template references.
 
 pub mod advisor;
 pub mod architect;
@@ -29,7 +22,6 @@ use meerkat_mob::definition::*;
 use meerkat_mob::ids::*;
 use meerkat_mob::profile::{Profile, ProfileBinding, ToolConfig};
 use meerkat_mob::MobRuntimeMode;
-use serde_json::Value;
 
 // ── Pack trait ───────────────────────────────────────────────────────────────
 
@@ -41,7 +33,7 @@ pub trait Pack: Send + Sync {
     fn description(&self) -> &str;
     /// Number of agents this pack spawns.
     fn agent_count(&self) -> usize;
-    /// Number of flow steps (0 = comms-based, no flow).
+    /// Number of flow steps in the required `"main"` flow.
     fn flow_step_count(&self) -> usize;
     /// Build the [`MobDefinition`] with task/context interpolated and overrides applied.
     fn definition(
@@ -49,7 +41,7 @@ pub trait Pack: Send + Sync {
         task: &str,
         context: &str,
         model_overrides: &BTreeMap<String, String>,
-        provider_params: Option<&Value>,
+        provider_params: Option<&meerkat_core::ProviderParamsOverride>,
     ) -> MobDefinition;
 }
 
@@ -123,10 +115,15 @@ pub fn turn_driven_profile(
     model: String,
     skill: &str,
     desc: &str,
-    provider_params: Option<&Value>,
+    provider_params: Option<&meerkat_core::ProviderParamsOverride>,
 ) -> ProfileBinding {
     ProfileBinding::Inline(Box::new(Profile {
         model,
+        provider: None,
+        self_hosted_server_id: None,
+        image_generation_provider: None,
+        auto_compact_threshold: None,
+        resume_overrides: Vec::new(),
         skills: vec![skill.to_string()],
         tools: ToolConfig {
             builtins: true,
@@ -254,6 +251,25 @@ mod tests {
                     profile.model
                 );
             }
+        }
+    }
+
+    #[test]
+    fn built_in_packs_all_have_machine_owned_flows() {
+        let registry = PackRegistry::new();
+
+        for pack in registry.all() {
+            let definition = pack.definition("check flows", "", &BTreeMap::new(), None);
+            assert!(
+                pack.flow_step_count() > 0,
+                "pack '{}' must expose a machine-owned main flow",
+                pack.name()
+            );
+            assert!(
+                definition.flows.contains_key(&FlowId::from("main")),
+                "pack '{}' must define a main flow",
+                pack.name()
+            );
         }
     }
 }

--- a/examples/034-codemob-mcp/src/packs/panel.rs
+++ b/examples/034-codemob-mcp/src/packs/panel.rs
@@ -1,23 +1,16 @@
-//! Panel pack — free-form debate with 5 opinionated agents and a moderator.
+//! Panel pack — structured debate with opinionated agents and a moderator.
 //!
-//! Unlike flow-based packs, the panel uses **comms-based** execution:
-//! all agents are `autonomous_host` with full-mesh wiring. The moderator
-//! controls the floor, and all agents obey moderator instructions absolutely.
-//!
-//! The deliberate handler detects `flow_step_count() == 0` and routes to
-//! `run_comms()` instead of `run_flow()`. The task is injected via
-//! `mob_member_send` to the moderator (not baked into a flow step), which
-//! is why `_task` and `_context` are unused in `definition()`.
+//! The panel is a `"main"` flow: the moderator frames the task, the panelists
+//! respond in parallel, and the moderator synthesizes. Completion is therefore
+//! owned by `MobMachine`, not by event-stream quiescence heuristics.
 
+use indexmap::IndexMap;
 use std::collections::BTreeMap;
 
 use meerkat_mob::definition::*;
 use meerkat_mob::ids::*;
-use meerkat_mob::profile::{Profile, ProfileBinding, ToolConfig};
-use meerkat_mob::MobRuntimeMode;
-use serde_json::Value;
 
-use super::{resolve_model, Pack};
+use super::{flow_step, format_context, identity_spawn_policy, mob_definition, resolve_model, turn_driven_profile, Pack};
 
 pub struct PanelPack;
 
@@ -26,22 +19,24 @@ impl Pack for PanelPack {
         "panel"
     }
     fn description(&self) -> &str {
-        "Free-form review panel: 5 opinionated agents debate with a moderator keeping order. Full mesh comms, no flow script."
+        "Structured review panel: opinionated agents respond in parallel, then a moderator synthesizes"
     }
     fn agent_count(&self) -> usize {
         5
     }
     fn flow_step_count(&self) -> usize {
-        0
-    } // comms-driven, no flow
+        6
+    }
 
     fn definition(
         &self,
-        _task: &str,
-        _context: &str,
+        task: &str,
+        context: &str,
         overrides: &BTreeMap<String, String>,
-        pp: Option<&Value>,
+        pp: Option<&meerkat_core::ProviderParamsOverride>,
     ) -> MobDefinition {
+        let ctx = format_context(context);
+
         // Diverse models across providers for genuine perspective differences
         let agents: Vec<(&str, &str, &str, String)> = vec![
             (
@@ -76,29 +71,11 @@ impl Pack for PanelPack {
             ),
         ];
 
-        let tools = ToolConfig {
-            builtins: true,
-            shell: true,
-            comms: true,
-            ..ToolConfig::default()
-        };
-
         let mut profiles = BTreeMap::new();
         for (name, skill, desc, m) in &agents {
             profiles.insert(
                 ProfileName::from(*name),
-                ProfileBinding::Inline(Box::new(Profile {
-                    model: m.clone(),
-                    skills: vec![skill.to_string()],
-                    tools: tools.clone(),
-                    peer_description: desc.to_string(),
-                    external_addressable: true,
-                    backend: None,
-                    runtime_mode: MobRuntimeMode::AutonomousHost,
-                    max_inline_peer_notifications: None,
-                    output_schema: None,
-                    provider_params: pp.cloned(),
-                })),
+                turn_driven_profile(m.clone(), skill, desc, pp),
             );
         }
 
@@ -134,31 +111,76 @@ impl Pack for PanelPack {
             },
         );
 
-        // Full mesh: every pair wired (agents can message anyone)
-        let names: Vec<&str> = agents.iter().map(|(n, ..)| *n).collect();
-        let mut role_wiring = Vec::new();
-        for i in 0..names.len() {
-            for j in (i + 1)..names.len() {
-                role_wiring.push(RoleWiringRule {
-                    a: ProfileName::from(names[i]),
-                    b: ProfileName::from(names[j]),
-                });
-            }
-        }
+        let mut steps = IndexMap::new();
+        steps.insert(
+            StepId::from("moderator_brief"),
+            flow_step(
+                "moderator",
+                format!("Frame this panel discussion. Identify the key question, constraints, and what each panelist should pressure-test.\n\n{task}{ctx}"),
+                &[],
+                300_000,
+            ),
+        );
+        steps.insert(
+            StepId::from("purist_case"),
+            flow_step(
+                "purist",
+                "Respond as the architecture purist. Name clean-design risks, boundary violations, and the purest path forward.\n\n## Moderator Brief\n{{ steps.moderator_brief }}".into(),
+                &["moderator_brief"],
+                300_000,
+            ),
+        );
+        steps.insert(
+            StepId::from("pragmatist_case"),
+            flow_step(
+                "pragmatist",
+                "Respond as the pragmatist. Name the shortest shippable path, acceptable compromises, and what not to overbuild.\n\n## Moderator Brief\n{{ steps.moderator_brief }}".into(),
+                &["moderator_brief"],
+                300_000,
+            ),
+        );
+        steps.insert(
+            StepId::from("skeptic_case"),
+            flow_step(
+                "skeptic",
+                "Respond as the skeptic. Find edge cases, weak assumptions, failure modes, and missing evidence.\n\n## Moderator Brief\n{{ steps.moderator_brief }}".into(),
+                &["moderator_brief"],
+                300_000,
+            ),
+        );
+        steps.insert(
+            StepId::from("veteran_case"),
+            flow_step(
+                "veteran",
+                "Respond as the veteran. Bring operational lessons, maintainability concerns, and long-term cost trade-offs.\n\n## Moderator Brief\n{{ steps.moderator_brief }}".into(),
+                &["moderator_brief"],
+                300_000,
+            ),
+        );
+        steps.insert(
+            StepId::from("moderator_synthesis"),
+            flow_step(
+                "moderator",
+                "Synthesize the panel into a clear verdict. Include: core tension, strongest agreements, unresolved risks, and recommended next action.\n\n\
+                 ## Purist\n{{ steps.purist_case }}\n\n## Pragmatist\n{{ steps.pragmatist_case }}\n\n## Skeptic\n{{ steps.skeptic_case }}\n\n## Veteran\n{{ steps.veteran_case }}".into(),
+                &["purist_case", "pragmatist_case", "skeptic_case", "veteran_case"],
+                300_000,
+            ),
+        );
 
-        let mut definition = MobDefinition::explicit(MobId::from(format!(
-            "codemob-panel-{}",
-            uuid::Uuid::new_v4().as_simple()
-        )));
-        definition.orchestrator = Some(OrchestratorConfig {
-            profile: ProfileName::from("moderator"),
-        });
-        definition.profiles = profiles;
-        definition.wiring = WiringRules {
-            auto_wire_orchestrator: true,
-            role_wiring,
-        };
-        definition.skills = skills;
-        definition
+        let mut flows = BTreeMap::new();
+        flows.insert(
+            FlowId::from("main"),
+            FlowSpec::new(Some("Structured panel debate with moderator synthesis".into()), steps, None),
+        );
+
+        let names: Vec<&str> = agents.iter().map(|(n, ..)| *n).collect();
+        mob_definition(
+            "panel",
+            profiles,
+            skills,
+            flows,
+            identity_spawn_policy(&names),
+        )
     }
 }

--- a/examples/034-codemob-mcp/src/packs/rct.rs
+++ b/examples/034-codemob-mcp/src/packs/rct.rs
@@ -10,7 +10,6 @@ use meerkat_mob::definition::*;
 use meerkat_mob::ids::*;
 use meerkat_mob::profile::{Profile, ProfileBinding, ToolConfig};
 use meerkat_mob::MobRuntimeMode;
-use serde_json::Value;
 use std::collections::BTreeMap;
 
 use super::*;
@@ -36,7 +35,7 @@ impl Pack for RctPack {
         task: &str,
         context: &str,
         overrides: &BTreeMap<String, String>,
-        pp: Option<&Value>,
+        pp: Option<&meerkat_core::ProviderParamsOverride>,
     ) -> MobDefinition {
         let ctx = format_context(context);
 
@@ -104,6 +103,11 @@ impl Pack for RctPack {
                 ProfileName::from(*name),
                 ProfileBinding::Inline(Box::new(Profile {
                     model: resolve_model(overrides, name, default),
+                    provider: None,
+                    self_hosted_server_id: None,
+                    image_generation_provider: None,
+                    auto_compact_threshold: None,
+                    resume_overrides: Vec::new(),
                     skills: vec![skill.to_string()],
                     tools: tools.clone(),
                     peer_description: desc.to_string(),

--- a/examples/034-codemob-mcp/src/packs/red_team.rs
+++ b/examples/034-codemob-mcp/src/packs/red_team.rs
@@ -7,7 +7,6 @@
 use indexmap::IndexMap;
 use meerkat_mob::definition::*;
 use meerkat_mob::ids::*;
-use serde_json::Value;
 use std::collections::BTreeMap;
 
 use super::*;
@@ -33,7 +32,7 @@ impl Pack for RedTeamPack {
         task: &str,
         context: &str,
         overrides: &BTreeMap<String, String>,
-        pp: Option<&Value>,
+        pp: Option<&meerkat_core::ProviderParamsOverride>,
     ) -> MobDefinition {
         let ctx = format_context(context);
 

--- a/examples/034-codemob-mcp/src/packs/review.rs
+++ b/examples/034-codemob-mcp/src/packs/review.rs
@@ -7,7 +7,6 @@
 use indexmap::IndexMap;
 use meerkat_mob::definition::*;
 use meerkat_mob::ids::*;
-use serde_json::Value;
 use std::collections::BTreeMap;
 
 use super::*;
@@ -33,7 +32,7 @@ impl Pack for ReviewPack {
         task: &str,
         context: &str,
         overrides: &BTreeMap<String, String>,
-        pp: Option<&Value>,
+        pp: Option<&meerkat_core::ProviderParamsOverride>,
     ) -> MobDefinition {
         let ctx = format_context(context);
 

--- a/examples/034-codemob-mcp/src/tools/consult.rs
+++ b/examples/034-codemob-mcp/src/tools/consult.rs
@@ -117,6 +117,11 @@ pub async fn handle(
     let system_prompt = input
         .system_prompt
         .unwrap_or_else(|| DEFAULT_SYSTEM_PROMPT.to_string());
+    let provider_params = input
+        .provider_params
+        .map(serde_json::from_value::<meerkat_core::ProviderParamsOverride>)
+        .transpose()
+        .map_err(|e| ToolCallError::invalid_params(format!("Invalid provider_params: {e}")))?;
 
     let mut labels = BTreeMap::new();
     labels.insert("source".into(), "consult".into());
@@ -136,12 +141,12 @@ pub async fn handle(
         initial_turn_metadata: None,
         ..SessionBuildOptions::default()
     };
-    build.provider_params = input.provider_params;
+    build.provider_params = provider_params;
 
     let req = CreateSessionRequest {
         model,
         prompt: prompt.into(),
-        system_prompt: Some(system_prompt),
+        system_prompt: meerkat_core::SystemPromptOverride::Set(system_prompt),
         max_tokens: None,
         event_tx: None,
         initial_turn: InitialTurnPolicy::RunImmediately,

--- a/examples/034-codemob-mcp/src/tools/deliberate.rs
+++ b/examples/034-codemob-mcp/src/tools/deliberate.rs
@@ -10,7 +10,7 @@ use std::sync::{
 use std::time::Duration;
 
 use meerkat_mob::definition::FlowSpec;
-use meerkat_mob::ids::{AgentIdentity, FlowId, MobId};
+use meerkat_mob::ids::{FlowId, MobId};
 use meerkat_mob::{
     MobDefinition, MobFlowRunPublicResultClass, MobRun, MobRunStatus, SpawnMemberSpec,
     StepRunStatus, mob_machine_run_public_result_class, mob_machine_run_status_is_terminal,
@@ -47,9 +47,15 @@ pub async fn handle(
 
     let context = input.context.as_deref().unwrap_or("");
     let overrides = input.model_overrides.unwrap_or_default();
+    let provider_params = input
+        .provider_params
+        .as_ref()
+        .map(|value| serde_json::from_value::<meerkat_core::ProviderParamsOverride>(value.clone()))
+        .transpose()
+        .map_err(|e| ToolCallError::invalid_params(format!("Invalid provider_params: {e}")))?;
 
     // Borrow registry, extract what we need, then drop the borrow
-    let (total_steps, has_flows, definition) = {
+    let (total_steps, definition) = {
         let registry = state.pack_registry();
         let pack = registry.get(&input.pack).ok_or_else(|| {
             ToolCallError::invalid_params(format!(
@@ -59,14 +65,19 @@ pub async fn handle(
             ))
         })?;
         let total_steps = pack.flow_step_count();
-        let has_flows = total_steps > 0;
+        if total_steps == 0 {
+            return Err(ToolCallError::invalid_params(format!(
+                "Pack '{}' has no machine-owned flow; deliberate requires a 'main' flow so completion is resolved by MobMachine",
+                input.pack
+            )));
+        }
         let definition = pack.definition(
             &input.task,
             context,
             &overrides,
-            input.provider_params.as_ref(),
+            provider_params.as_ref(),
         );
-        (total_steps, has_flows, definition)
+        (total_steps, definition)
     };
 
     // If session_id is provided, attempt to reuse an existing mob.
@@ -121,21 +132,9 @@ pub async fn handle(
         }
     }
 
-    // Collect profile names and orchestrator before moving definition
+    // Collect profile names before moving definition.
     let profile_names: Vec<String> = definition.profiles.keys().map(|p| p.to_string()).collect();
-    let orchestrator_name = definition
-        .orchestrator
-        .as_ref()
-        .map(|o| o.profile.to_string())
-        .unwrap_or_else(|| "moderator".to_string());
-    let flow_timeout = if has_flows {
-        Some(derive_flow_watchdog_timeout(
-            &definition,
-            &FlowId::from("main"),
-        )?)
-    } else {
-        None
-    };
+    let flow_timeout = derive_flow_watchdog_timeout(&definition, &FlowId::from("main"))?;
 
     if !mob_exists {
         // Override the mob id when resuming with a new mob
@@ -206,11 +205,8 @@ pub async fn handle(
             )));
         }
 
-        // Wait for all autonomous kickoff turns to complete before subscribing
-        // to events. Without this barrier, the event subscription misses
-        // RunStarted events from kickoff turns (emitted during spawn) but sees
-        // their RunCompleted, causing the active_turns counter to go negative
-        // and triggering premature quiescence detection.
+        // Wait for autonomous kickoff turns to settle before the machine-owned
+        // flow starts dispatching steps to the same agents.
         if let Some(token) = progress_token.as_ref() {
             send_progress(
                 progress_notifier.as_ref(),
@@ -233,35 +229,16 @@ pub async fn handle(
         }
     }
 
-    // Route to flow-based or comms-based execution
-    let result = if has_flows {
-        run_flow(
-            state,
-            &mob_id,
-            total_steps,
-            progress_token.as_ref(),
-            progress_notifier.as_ref(),
-            request_context.as_ref(),
-            flow_timeout.expect("flow timeout computed when has_flows"),
-        )
-        .await
-    } else {
-        // Build the prompt with context
-        let prompt = if context.is_empty() {
-            input.task.clone()
-        } else {
-            format!("{}\n\n## Context\n\n{context}", input.task)
-        };
-        run_comms(
-            state,
-            &mob_id,
-            &orchestrator_name,
-            &prompt,
-            progress_token.as_ref(),
-            progress_notifier.as_ref(),
-        )
-        .await
-    };
+    let result = run_flow(
+        state,
+        &mob_id,
+        total_steps,
+        progress_token.as_ref(),
+        progress_notifier.as_ref(),
+        request_context.as_ref(),
+        flow_timeout,
+    )
+    .await;
 
     // Only destroy mob if not resuming (caller owns the lifecycle)
     if !resuming {
@@ -557,167 +534,6 @@ fn format_run_status(status: &MobRunStatus) -> &'static str {
         MobRunStatus::Failed => "failed",
         MobRunStatus::Canceled => "canceled",
     }
-}
-
-// ── Comms-based execution (autonomous panel) ────────────────────────────────
-
-async fn run_comms(
-    state: &ForceState,
-    mob_id: &MobId,
-    orchestrator: &str,
-    task: &str,
-    progress_token: Option<&Value>,
-    progress_notifier: Option<&ProgressNotifier>,
-) -> Result<Value, ToolCallError> {
-    use meerkat_core::event::AgentEvent;
-
-    if let Some(token) = progress_token {
-        send_progress(progress_notifier, token, 0, 1, "agents deliberating");
-    }
-
-    // Subscribe to mob-wide agent events (all members' streams merged)
-    let mut router_handle = state
-        .mob_state
-        .subscribe_mob_events(mob_id)
-        .await
-        .map_err(|e| ToolCallError::internal(format!("Event subscription failed: {e}")))?;
-
-    // Kick off the discussion by sending the task to the orchestrator
-    state
-        .mob_state
-        .mob_member_send(
-            mob_id,
-            AgentIdentity::from(orchestrator),
-            task.to_string().into(),
-            meerkat_core::types::HandlingMode::Queue,
-            None,
-        )
-        .await
-        .map_err(|e| ToolCallError::internal(format!("Failed to trigger {orchestrator}: {e}")))?;
-
-    // Drain events until all agents are idle.
-    //
-    // Track active turns via RunStarted/RunCompleted. When active_turns
-    // drops to 0 AND at least one turn has completed, the mob is done.
-    // A generous idle grace period handles the gap between one agent
-    // finishing and another being triggered by a comms message.
-    // Hard ceiling. Comms-based mobs can run iterative review loops where each
-    // agent turn involves full LLM calls, tool use, or even code execution —
-    // individual turns can take minutes. 1 hour accommodates long pipelines.
-    const MAX_WAIT: std::time::Duration = std::time::Duration::from_secs(3600);
-    // After all agents go idle, wait this long for a new turn to start (covers
-    // the gap between one agent finishing and a comms message triggering another).
-    const IDLE_GRACE: std::time::Duration = std::time::Duration::from_secs(120);
-
-    let deadline = tokio::time::Instant::now() + MAX_WAIT;
-    let mut last_orchestrator_text = String::new();
-    let mut total_events = 0u64;
-    let mut active_turns: i64 = 0;
-    let mut any_turn_completed = false;
-    let mut idle_since: Option<tokio::time::Instant> = None;
-
-    loop {
-        let poll_timeout = if active_turns <= 0 && any_turn_completed {
-            // All agents idle — wait grace period for a new turn to start
-            let remaining_grace = idle_since
-                .map(|t| IDLE_GRACE.saturating_sub(t.elapsed()))
-                .unwrap_or(IDLE_GRACE);
-            remaining_grace.min(deadline.saturating_duration_since(tokio::time::Instant::now()))
-        } else {
-            // Agents are working — just enforce the hard deadline
-            deadline.saturating_duration_since(tokio::time::Instant::now())
-        };
-
-        if poll_timeout.is_zero() {
-            if tokio::time::Instant::now() >= deadline {
-                tracing::warn!(total_events, active_turns, "hit max wait time");
-            } else {
-                tracing::info!(total_events, "all agents idle, grace period expired");
-            }
-            break;
-        }
-
-        match tokio::time::timeout(poll_timeout, router_handle.event_rx.recv()).await {
-            Ok(Some(attributed)) => {
-                total_events += 1;
-
-                match &attributed.envelope.payload {
-                    AgentEvent::RunStarted { .. } => {
-                        active_turns += 1;
-                        idle_since = None;
-                    }
-                    AgentEvent::RunCompleted { .. } => {
-                        active_turns -= 1;
-                        any_turn_completed = true;
-                        if active_turns <= 0 {
-                            idle_since = Some(tokio::time::Instant::now());
-                        }
-                    }
-                    _ => {}
-                }
-
-                // Capture the orchestrator's latest text output.
-                // Always update on RunCompleted (even empty) so we know the
-                // orchestrator ran. Prefer non-empty results; TextComplete
-                // overwrites if it carries content.
-                if attributed.source.identity.as_str() == orchestrator {
-                    match &attributed.envelope.payload {
-                        AgentEvent::RunCompleted { result, .. } => {
-                            if !result.is_empty() {
-                                last_orchestrator_text = result.clone();
-                            } else if last_orchestrator_text.is_empty() {
-                                last_orchestrator_text =
-                                    "[orchestrator completed a turn with tool-call-only output]"
-                                        .to_string();
-                            }
-                        }
-                        AgentEvent::TextComplete { content, .. } if !content.is_empty() => {
-                            last_orchestrator_text = content.clone();
-                        }
-                        _ => {}
-                    }
-                }
-
-                if total_events % 20 == 0 {
-                    if let Some(token) = progress_token {
-                        send_progress(
-                            progress_notifier,
-                            token,
-                            0,
-                            1,
-                            &format!("{total_events} events, {active_turns} active"),
-                        );
-                    }
-                }
-            }
-            Ok(None) => {
-                tracing::info!(total_events, "event channel closed");
-                break;
-            }
-            Err(_) => {
-                // Timeout expired — either grace period or deadline
-                if active_turns <= 0 && any_turn_completed {
-                    tracing::info!(total_events, "all agents idle, grace period expired");
-                    break;
-                }
-                if tokio::time::Instant::now() >= deadline {
-                    tracing::warn!(total_events, active_turns, "hit max wait time");
-                    break;
-                }
-            }
-        }
-    }
-
-    if let Some(token) = progress_token {
-        send_progress(progress_notifier, token, 1, 1, "complete");
-    }
-
-    if last_orchestrator_text.is_empty() {
-        last_orchestrator_text =
-            format!("Discussion completed but {orchestrator} output not captured.");
-    }
-
-    Ok(json!({"content": [{"type": "text", "text": last_orchestrator_text}]}))
 }
 
 // ── Progress notifications ──────────────────────────────────────────────────

--- a/examples/034-codemob-mcp/src/tools/mobs.rs
+++ b/examples/034-codemob-mcp/src/tools/mobs.rs
@@ -49,14 +49,16 @@ fn validate_name(name: &str) -> Result<(), ToolCallError> {
 pub struct UserMobConfig {
     pub name: String,
     pub description: String,
-    /// "comms" for autonomous loop, "flow" for structured steps.
+    /// "comms" is a legacy/default authoring shape that is normalized to a
+    /// machine-owned flow; "flow" uses caller-supplied structured steps.
     #[serde(default = "default_mode")]
     pub mode: String,
-    /// For comms mode: which agent's output is captured as the result.
-    /// Also receives the initial message.
+    /// For legacy comms mode: synthesis agent that receives peer flow outputs
+    /// and produces the final result.
     pub orchestrator: Option<String>,
     pub agents: BTreeMap<String, UserAgentConfig>,
-    /// Pairs of agent names to wire for comms. E.g. [["coder", "reviewer"]]
+    /// Pairs of agent names to wire for explicit flow-mode comms ingress/egress.
+    /// Ignored by legacy comms mode, which is normalized to strict flow edges.
     #[serde(default)]
     pub wiring: Vec<[String; 2]>,
     /// Flow definitions. Key is flow name (use "main").
@@ -101,20 +103,19 @@ impl UserMobConfig {
         task: &str,
         context: &str,
         model_overrides: &BTreeMap<String, String>,
-        provider_params: Option<&Value>,
+        provider_params: Option<&meerkat_core::ProviderParamsOverride>,
     ) -> MobDefinition {
         let ctx = format_context(context);
+        let is_comms = self.mode == "comms";
+        // `deliberate` no longer owns a local event-idle completion loop. Even
+        // user-authored comms mobs therefore run as a MobMachine-owned flow;
+        // the conversion is flow fan-in/synthesis, not peer-to-peer tool comms.
+        let runtime = MobRuntimeMode::TurnDriven;
         let tools = ToolConfig {
             builtins: true,
             shell: true,
-            comms: true,
+            comms: !is_comms,
             ..ToolConfig::default()
-        };
-        let is_comms = self.mode == "comms";
-        let runtime = if is_comms {
-            MobRuntimeMode::AutonomousHost
-        } else {
-            MobRuntimeMode::TurnDriven
         };
 
         let mut profiles = BTreeMap::new();
@@ -126,6 +127,11 @@ impl UserMobConfig {
                 ProfileName::from(name.as_str()),
                 ProfileBinding::Inline(Box::new(Profile {
                     model: resolve_model(model_overrides, name, &agent.model),
+                    provider: None,
+                    self_hosted_server_id: None,
+                    image_generation_provider: None,
+                    auto_compact_threshold: None,
+                    resume_overrides: Vec::new(),
                     skills: vec![skill_key.clone()],
                     tools: tools.clone(),
                     peer_description: if agent.peer_description.is_empty() {
@@ -149,14 +155,17 @@ impl UserMobConfig {
             );
         }
 
-        let role_wiring: Vec<RoleWiringRule> = self
-            .wiring
-            .iter()
-            .map(|pair| RoleWiringRule {
-                a: ProfileName::from(pair[0].as_str()),
-                b: ProfileName::from(pair[1].as_str()),
-            })
-            .collect();
+        let role_wiring: Vec<RoleWiringRule> = if is_comms {
+            Vec::new()
+        } else {
+            self.wiring
+                .iter()
+                .map(|pair| RoleWiringRule {
+                    a: ProfileName::from(pair[0].as_str()),
+                    b: ProfileName::from(pair[1].as_str()),
+                })
+                .collect()
+        };
 
         let has_orchestrator = self.orchestrator.is_some();
         let orchestrator = self.orchestrator.as_ref().map(|name| OrchestratorConfig {
@@ -164,7 +173,85 @@ impl UserMobConfig {
         });
 
         let mut flows = BTreeMap::new();
-        if !is_comms {
+        if is_comms {
+            if let Some(orchestrator_name) = self
+                .orchestrator
+                .as_deref()
+                .or_else(|| self.agents.keys().next().map(String::as_str))
+            {
+                let mut step_specs = indexmap::IndexMap::new();
+                let peer_steps: Vec<(String, StepId)> = self
+                    .agents
+                    .keys()
+                    .filter(|name| name.as_str() != orchestrator_name)
+                    .enumerate()
+                    .map(|(idx, name)| (name.clone(), StepId::from(format!("peer_{idx}"))))
+                    .collect();
+                for (agent_name, step_id) in &peer_steps {
+                    step_specs.insert(
+                        step_id.clone(),
+                        FlowStepSpec {
+                            role: ProfileName::from(agent_name.as_str()),
+                            message: ContentInput::from(format!(
+                                "Analyze the task independently. Return concise findings for the orchestrator to synthesize. Do not message peer agents directly.\n\n## Task\n{task}{ctx}"
+                            )),
+                            depends_on: Vec::new(),
+                            dispatch_mode: DispatchMode::default(),
+                            collection_policy: CollectionPolicy::default(),
+                            condition: None,
+                            timeout_ms: Some(default_timeout()),
+                            expected_schema_ref: None,
+                            branch: None,
+                            depends_on_mode: DependencyMode::default(),
+                            allowed_tools: None,
+                            blocked_tools: None,
+                            output_format: StepOutputFormat::Text,
+                        },
+                    );
+                }
+                let peer_outputs = peer_steps
+                    .iter()
+                    .map(|(agent_name, step_id)| {
+                        format!("### {agent_name}\n{{{{ steps.{step_id} }}}}")
+                    })
+                    .collect::<Vec<_>>()
+                    .join("\n\n");
+                let message = if peer_outputs.is_empty() {
+                    format!(
+                        "Return the final answer for this task.\n\n## Task\n{task}{ctx}"
+                    )
+                } else {
+                    format!(
+                        "Synthesize the peer flow outputs into the final answer. Do not message peer agents directly.\n\n## Task\n{task}{ctx}\n\n## Peer outputs\n{peer_outputs}"
+                    )
+                };
+                step_specs.insert(
+                    StepId::from("orchestrate"),
+                    FlowStepSpec {
+                        role: ProfileName::from(orchestrator_name),
+                        message: ContentInput::from(message),
+                        depends_on: peer_steps
+                            .iter()
+                            .map(|(_, step_id)| step_id.clone())
+                            .collect(),
+                        dispatch_mode: DispatchMode::default(),
+                        collection_policy: CollectionPolicy::default(),
+                        condition: None,
+                        timeout_ms: Some(default_timeout()),
+                        expected_schema_ref: None,
+                        branch: None,
+                        depends_on_mode: DependencyMode::default(),
+                        allowed_tools: None,
+                        blocked_tools: None,
+                        output_format: StepOutputFormat::Text,
+                    },
+                );
+                flows.insert(
+                    FlowId::from("main"),
+                    FlowSpec::new(Some("Comms-mode orchestrator flow".into()), step_specs, None),
+                );
+            }
+        } else {
             for (flow_name, steps) in &self.flows {
                 let mut step_specs = indexmap::IndexMap::new();
                 for step in steps {
@@ -243,8 +330,10 @@ impl Pack for UserPack {
     fn flow_step_count(&self) -> usize {
         if self.config.mode == "flow" {
             self.config.flows.values().map(|steps| steps.len()).sum()
-        } else {
+        } else if self.config.agents.is_empty() {
             0
+        } else {
+            self.config.agents.len()
         }
     }
     fn definition(
@@ -252,7 +341,7 @@ impl Pack for UserPack {
         task: &str,
         context: &str,
         model_overrides: &BTreeMap<String, String>,
-        provider_params: Option<&Value>,
+        provider_params: Option<&meerkat_core::ProviderParamsOverride>,
     ) -> MobDefinition {
         self.config
             .to_mob_definition(task, context, model_overrides, provider_params)
@@ -390,4 +479,77 @@ pub fn load_user_packs(dir: &Path) -> Vec<Box<dyn Pack>> {
         packs.push(Box::new(UserPack::new(config)));
     }
     packs
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_user_mob(mode: &str) -> UserMobConfig {
+        let mut agents = BTreeMap::new();
+        agents.insert(
+            "lead".to_string(),
+            UserAgentConfig {
+                model: "gpt-5.5".to_string(),
+                skill: "You lead the mob.".to_string(),
+                peer_description: "Lead".to_string(),
+            },
+        );
+        agents.insert(
+            "critic".to_string(),
+            UserAgentConfig {
+                model: "claude-sonnet-4-6".to_string(),
+                skill: "You critique plans.".to_string(),
+                peer_description: "Critic".to_string(),
+            },
+        );
+        UserMobConfig {
+            name: "custom".to_string(),
+            description: "Custom mob".to_string(),
+            mode: mode.to_string(),
+            orchestrator: Some("lead".to_string()),
+            agents,
+            wiring: vec![["lead".to_string(), "critic".to_string()]],
+            flows: BTreeMap::new(),
+        }
+    }
+
+    #[test]
+    fn comms_user_pack_synthesizes_machine_owned_main_flow() {
+        let pack = UserPack::new(sample_user_mob("comms"));
+
+        assert_eq!(pack.flow_step_count(), 2);
+
+        let definition = pack.definition("Ship it", "extra context", &BTreeMap::new(), None);
+        let main = definition
+            .flows
+            .get(&FlowId::from("main"))
+            .expect("comms user packs synthesize a main flow");
+        let peer = main
+            .steps
+            .get(&StepId::from("peer_0"))
+            .expect("synthetic peer analysis step");
+        let orchestrate = main
+            .steps
+            .get(&StepId::from("orchestrate"))
+            .expect("synthetic orchestrator step");
+
+        assert_eq!(peer.role, ProfileName::from("critic"));
+        assert!(peer.depends_on.is_empty());
+        assert_eq!(orchestrate.role, ProfileName::from("lead"));
+        assert_eq!(orchestrate.depends_on, vec![StepId::from("peer_0")]);
+        let text = orchestrate.message.text_content();
+        assert!(
+            text.contains("Ship it")
+                && text.contains("extra context")
+                && text.contains("{{ steps.peer_0 }}")
+                && text.contains("Do not message peer agents directly")
+        );
+        assert!(definition.wiring.role_wiring.is_empty());
+        for binding in definition.profiles.values() {
+            let profile = binding.as_inline().expect("inline user profile");
+            assert_eq!(profile.runtime_mode, MobRuntimeMode::TurnDriven);
+            assert!(!profile.tools.comms);
+        }
+    }
 }

--- a/examples/034-codemob-mcp/src/tools/mod.rs
+++ b/examples/034-codemob-mcp/src/tools/mod.rs
@@ -191,8 +191,8 @@ pub fn tools_list() -> Vec<Value> {
                         "properties": {
                             "name": { "type": "string", "description": "Unique mob name (alphanumeric, hyphens, underscores)" },
                             "description": { "type": "string", "description": "Human-readable description" },
-                            "mode": { "type": "string", "enum": ["comms", "flow"], "description": "comms=autonomous agents communicate freely (good for iterative loops), flow=structured DAG steps" },
-                            "orchestrator": { "type": "string", "description": "For comms mode: agent whose output is captured as the result and who receives the initial message" },
+                            "mode": { "type": "string", "enum": ["comms", "flow"], "description": "comms=legacy/default authoring shape normalized to a machine-owned analysis+synthesis flow, flow=structured DAG steps" },
+                            "orchestrator": { "type": "string", "description": "For comms mode: synthesis agent that receives peer flow outputs and produces the final result" },
                             "agents": {
                                 "type": "object",
                                 "description": "Map of agent_name → {model, skill, peer_description}",
@@ -208,7 +208,7 @@ pub fn tools_list() -> Vec<Value> {
                             },
                             "wiring": {
                                 "type": "array",
-                                "description": "Pairs of agent names to wire for communication, e.g. [[\"coder\", \"reviewer\"]]",
+                                "description": "Pairs of agent names to wire for explicit flow-mode communication ingress/egress, e.g. [[\"coder\", \"reviewer\"]]",
                                 "items": { "type": "array", "items": { "type": "string" }, "minItems": 2, "maxItems": 2 }
                             },
                             "flows": {

--- a/meerkat-cli/src/main.rs
+++ b/meerkat-cli/src/main.rs
@@ -3764,23 +3764,6 @@ async fn load_config(scope: &RuntimeScope) -> anyhow::Result<(Config, PathBuf)> 
     Ok((config, base_dir))
 }
 
-/// FROZEN historical snapshot of prior built-in CLI agent-model defaults.
-///
-/// This is intentionally NOT a mirror of the live model catalog. Its sole
-/// purpose is to detect a stale, previously-shipped default that a user still
-/// carries in their persisted `config.agent.model` and heal it by redirecting
-/// to the catalog-derived current default (see `resolve_cli_default_agent_model`
-/// → `meerkat::resolve_provider_catalog_default_model`, the canonical tiers-2/3
-/// ladder). Entries are prior *shipped CLI defaults*,
-/// not catalog membership claims: a listed model may still be a live catalog
-/// row (e.g. `claude-opus-4-7` remains a `Supported` Anthropic entry) — being
-/// here only means it was once the built-in default and should be healed when
-/// still persisted. Append the prior default here whenever the built-in default
-/// changes; never remove entries.
-///
-/// Covered by `test_resolve_cli_default_agent_model_heals_legacy_builtin_default`.
-const LEGACY_AGENT_MODEL_DEFAULTS: &[&str] = &["claude-opus-4-7"];
-
 fn model_provider(config: &Config, model: &str) -> Option<Provider> {
     config
         .model_registry(meerkat_models::canonical())
@@ -3802,21 +3785,6 @@ fn provider_default_model(config: &Config, provider: Provider) -> Option<String>
         return meerkat_models::default_model(provider.as_core()).map(str::to_string);
     }
     Some(model.clone())
-}
-
-fn resolve_cli_default_agent_model(config: &Config) -> String {
-    if LEGACY_AGENT_MODEL_DEFAULTS.contains(&config.agent.model.as_str()) {
-        // Known-stale operator default: resolve through the canonical
-        // provider-priority/catalog ladder (tiers 2-3 of the create-session
-        // seam), explicitly bypassing the stale `config.agent.model` knob.
-        // The CLI owns no parallel ladder.
-        return meerkat::resolve_provider_catalog_default_model(config);
-    }
-
-    // Canonical ladder: operator-set `config.agent.model` (tier 1), else the
-    // per-provider/catalog defaults. An unset agent model is the normal state
-    // (core embeds no provider data), not an error.
-    meerkat::resolve_create_session_default_model(config)
 }
 
 fn resolve_provider_constrained_default_model(config: &Config, provider: Provider) -> String {
@@ -3852,7 +3820,9 @@ fn resolve_cli_effective_model(
         return resolve_provider_constrained_default_model(config, provider);
     }
 
-    resolve_cli_default_agent_model(config)
+    // Canonical ladder: shared create-session default resolution owns operator
+    // defaults, stale built-in default healing, and provider/catalog fallback.
+    meerkat::resolve_create_session_default_model(config)
 }
 
 async fn handle_config_get(
@@ -20420,60 +20390,39 @@ capabilities = ["definitely_missing_capability"]
     }
 
     #[test]
-    fn test_resolve_cli_default_agent_model_heals_legacy_builtin_default() {
+    fn test_resolve_cli_effective_model_uses_shared_legacy_default_heal() {
         let mut config = Config::default();
         config.agent.model = "claude-opus-4-7".to_string();
-        // A legacy builtin default heals through the canonical ladder.
-        // Priority is owned by the catalog seam
-        // (`meerkat_models::provider_priority()` — anthropic first), so even
-        // with a customized OpenAI model the heal resolves to the configured
-        // anthropic override, not whichever provider happened to be set.
         config.models.anthropic = "custom-anthropic".to_string();
         config.models.openai = "gpt-5.5-custom".to_string();
 
-        assert_eq!(resolve_cli_default_agent_model(&config), "custom-anthropic");
-    }
-
-    #[test]
-    fn test_resolve_cli_default_agent_model_heals_to_global_default_without_overrides() {
-        // With no per-provider operator overrides (core leaves them empty),
-        // the heal terminates at the catalog-owned global default.
-        let mut config = Config::default();
-        config.agent.model = "claude-opus-4-7".to_string();
-
         assert_eq!(
-            resolve_cli_default_agent_model(&config),
-            meerkat_models::global_default_model()
+            resolve_cli_effective_model(&config, None, None, None),
+            meerkat::resolve_create_session_default_model(&config)
+        );
+        assert_eq!(
+            resolve_cli_effective_model(&config, None, None, None),
+            "custom-anthropic"
         );
     }
 
     #[test]
-    fn test_resolve_cli_default_agent_model_falls_back_by_best_available_priority() {
-        let mut config = Config::default();
-        config.agent.model = "claude-opus-4-7".to_string();
-        config.models.openai = "custom-openai".to_string();
-        config.models.gemini = "custom-gemini".to_string();
+    fn test_resolve_cli_effective_model_uses_shared_default_when_unset() {
+        let config = Config::default();
 
-        // anthropic unset: the next provider in catalog priority order wins.
-        assert_eq!(resolve_cli_default_agent_model(&config), "custom-openai");
-
-        config.models.openai.clear();
-        assert_eq!(resolve_cli_default_agent_model(&config), "custom-gemini");
-
-        config.models.gemini.clear();
         assert_eq!(
-            resolve_cli_default_agent_model(&config),
-            meerkat_models::global_default_model()
+            resolve_cli_effective_model(&config, None, None, None),
+            meerkat::resolve_create_session_default_model(&config)
         );
     }
 
     #[test]
-    fn test_resolve_cli_default_agent_model_preserves_custom_model() {
+    fn test_resolve_cli_effective_model_preserves_custom_model() {
         let mut config = Config::default();
         config.agent.model = "claude-sonnet-4-6".to_string();
 
         assert_eq!(
-            resolve_cli_default_agent_model(&config),
+            resolve_cli_effective_model(&config, None, None, None),
             "claude-sonnet-4-6"
         );
     }

--- a/meerkat-core/src/generated/session_document.rs
+++ b/meerkat-core/src/generated/session_document.rs
@@ -348,6 +348,7 @@ pub enum SessionDocumentInput {
         session_id: SessionDocumentKey,
         has_metadata: bool,
         has_build_state: bool,
+        runtime_projection_quarantined: bool,
     },
     ApplyPendingToolResults {
         session_id: SessionDocumentKey,
@@ -2529,16 +2530,24 @@ impl SessionDocumentMachineAuthority {
                 session_id,
                 has_metadata,
                 has_build_state,
+                runtime_projection_quarantined,
             } => {
                 let mut matches = Vec::new();
                 if (self.state.lifecycle_phase == SessionDocumentPhase::Ready)
-                    && (store_projection_can_recover_authority(has_metadata, has_build_state))
+                    && (store_projection_can_recover_authority(
+                        has_metadata,
+                        has_build_state,
+                        runtime_projection_quarantined,
+                    ))
                 {
                     matches.push(SessionDocumentTransition::RecoverSessionFromStoreAuthorized);
                 }
                 if (self.state.lifecycle_phase == SessionDocumentPhase::Ready)
-                    && (store_projection_can_recover_authority(has_metadata, has_build_state)
-                        == false)
+                    && (store_projection_can_recover_authority(
+                        has_metadata,
+                        has_build_state,
+                        runtime_projection_quarantined,
+                    ) == false)
                 {
                     matches.push(SessionDocumentTransition::RecoverSessionFromStoreUnrecoverable);
                 }
@@ -3106,11 +3115,13 @@ impl SessionDocumentMachineAuthority {
         session_id: SessionDocumentKey,
         has_metadata: bool,
         has_build_state: bool,
+        runtime_projection_quarantined: bool,
     ) -> Result<Vec<SessionDocumentEffect>, SessionDocumentError> {
         self.apply_input(SessionDocumentInput::RecoverSessionFromStore {
             session_id,
             has_metadata,
             has_build_state,
+            runtime_projection_quarantined,
         })
     }
 
@@ -3287,8 +3298,12 @@ fn resume_provider_recompute_from_model(
     (model_override_present) && (provider_override_present == false)
 }
 
-fn store_projection_can_recover_authority(has_metadata: bool, has_build_state: bool) -> bool {
-    (has_metadata) || (has_build_state)
+fn store_projection_can_recover_authority(
+    has_metadata: bool,
+    has_build_state: bool,
+    runtime_projection_quarantined: bool,
+) -> bool {
+    (has_metadata) || (has_build_state) || (runtime_projection_quarantined)
 }
 
 fn archive_should_retire_runtime(

--- a/meerkat-live/src/webrtc.rs
+++ b/meerkat-live/src/webrtc.rs
@@ -182,6 +182,12 @@ impl From<serde_json::Error> for LiveWebrtcError {
     }
 }
 
+#[derive(serde::Serialize)]
+struct WebrtcErrorFrame<'a> {
+    error: String,
+    reason: &'a str,
+}
+
 struct LiveWebrtcPeer {
     peer: Arc<RTCPeerConnection>,
     outgoing_audio: Arc<OutgoingAudioControl>,
@@ -358,6 +364,8 @@ impl LiveWebrtcState {
             Arc::clone(&self.host),
             channel_id.clone(),
             Arc::clone(&peer),
+            Arc::clone(&self.peers),
+            Arc::clone(&self.close_feedback),
             Arc::clone(&outgoing_audio_control),
         );
 
@@ -527,8 +535,18 @@ fn install_data_channel_handler(context: DataChannelPumpContext) {
                                     tracing::warn!(
                                         channel = %channel_id,
                                         error = %err,
-                                        "WebRTC data-channel send_input failed"
+                                        "WebRTC data-channel send_input failed; closing"
                                     );
+                                    send_webrtc_input_error_frame(&data_channel, &err).await;
+                                    reject_failed_input_handoff(
+                                        host.as_ref(),
+                                        close_feedback.as_ref(),
+                                        &peer_registry,
+                                        &channel_id,
+                                        &data_channel,
+                                        &peer,
+                                    )
+                                    .await;
                                 }
                             }
                             None => {
@@ -564,11 +582,17 @@ fn install_incoming_audio_handler(
     host: Arc<LiveAdapterHost>,
     channel_id: LiveChannelId,
     peer: Arc<RTCPeerConnection>,
+    peer_registry: LiveWebrtcPeerRegistry,
+    close_feedback: Arc<dyn LiveChannelCloseFeedback>,
     outgoing_audio_control: Arc<OutgoingAudioControl>,
 ) {
+    let peer_for_track = Arc::clone(&peer);
     peer.on_track(Box::new(move |track: Arc<TrackRemote>, _, _| {
         let host = Arc::clone(&host);
         let channel_id = channel_id.clone();
+        let peer_registry = Arc::clone(&peer_registry);
+        let close_feedback = Arc::clone(&close_feedback);
+        let peer = Arc::clone(&peer_for_track);
         let outgoing_audio_control = Arc::clone(&outgoing_audio_control);
         tokio::spawn(async move {
             let mut bridge = match WebrtcAudioBridge::new() {
@@ -625,8 +649,17 @@ fn install_incoming_audio_handler(
                     tracing::warn!(
                         channel = %channel_id,
                         error = %err,
-                        "WebRTC audio send_input failed"
+                        "WebRTC audio send_input failed; closing"
                     );
+                    reject_failed_audio_input_handoff(
+                        host.as_ref(),
+                        close_feedback.as_ref(),
+                        &peer_registry,
+                        &channel_id,
+                        peer.as_ref(),
+                    )
+                    .await;
+                    break;
                 }
             }
         });
@@ -938,12 +971,41 @@ async fn close_and_deregister_peer(
     data_channel: &RTCDataChannel,
     peer: &RTCPeerConnection,
 ) {
-    let registered_peer = peer_registry.lock().await.remove(channel_id);
     let _ = data_channel.close().await;
+    close_registered_peer(peer_registry, channel_id, peer).await;
+}
+
+async fn close_registered_peer(
+    peer_registry: &LiveWebrtcPeerRegistry,
+    channel_id: &LiveChannelId,
+    peer: &RTCPeerConnection,
+) {
+    let registered_peer = peer_registry.lock().await.remove(channel_id);
     if let Some(registered_peer) = registered_peer {
         let _ = registered_peer.peer.close().await;
     } else {
         let _ = peer.close().await;
+    }
+}
+
+fn webrtc_host_error_frame_json(err: &LiveAdapterHostError) -> String {
+    serde_json::to_string(&WebrtcErrorFrame {
+        error: err.to_string(),
+        reason: err.reason_code(),
+    })
+    .unwrap_or_default()
+}
+
+async fn send_webrtc_input_error_frame(data_channel: &RTCDataChannel, err: &LiveAdapterHostError) {
+    let frame = webrtc_host_error_frame_json(err);
+    if frame.is_empty() {
+        return;
+    }
+    if let Err(send_err) = data_channel.send_text(frame).await {
+        tracing::warn!(
+            error = %send_err,
+            "failed to send WebRTC input error frame"
+        );
     }
 }
 
@@ -967,6 +1029,32 @@ async fn reject_invalid_live_frame(
 ) {
     let _ = close_channel_with_generated_feedback(host, close_feedback, channel_id).await;
     close_and_deregister_peer(peer_registry, channel_id, data_channel, peer).await;
+}
+
+/// Terminalize a live channel after a parsed WebRTC input cannot be handed to
+/// the live host. This mirrors the malformed-frame path with one extra client
+/// error frame when the data channel is available.
+async fn reject_failed_input_handoff(
+    host: &LiveAdapterHost,
+    close_feedback: &dyn LiveChannelCloseFeedback,
+    peer_registry: &LiveWebrtcPeerRegistry,
+    channel_id: &LiveChannelId,
+    data_channel: &RTCDataChannel,
+    peer: &RTCPeerConnection,
+) {
+    let _ = close_channel_with_generated_feedback(host, close_feedback, channel_id).await;
+    close_and_deregister_peer(peer_registry, channel_id, data_channel, peer).await;
+}
+
+async fn reject_failed_audio_input_handoff(
+    host: &LiveAdapterHost,
+    close_feedback: &dyn LiveChannelCloseFeedback,
+    peer_registry: &LiveWebrtcPeerRegistry,
+    channel_id: &LiveChannelId,
+    peer: &RTCPeerConnection,
+) {
+    let _ = close_channel_with_generated_feedback(host, close_feedback, channel_id).await;
+    close_registered_peer(peer_registry, channel_id, peer).await;
 }
 
 fn spawn_outgoing_audio_track_pump(
@@ -1401,6 +1489,20 @@ mod tests {
                 "reason codes must be distinct: {expected}"
             );
         }
+    }
+
+    #[test]
+    fn webrtc_host_error_frame_carries_stable_reason_code() {
+        let err = LiveAdapterHostError::NoAdapter(LiveChannelId::new("ch-1"));
+        let frame: serde_json::Value =
+            serde_json::from_str(&webrtc_host_error_frame_json(&err)).expect("error frame JSON");
+
+        assert_eq!(frame["reason"], "no_adapter");
+        assert!(
+            frame["error"]
+                .as_str()
+                .is_some_and(|message| message.contains("no adapter attached"))
+        );
     }
 
     // -----------------------------------------------------------------

--- a/meerkat-machine-kernels/src/generated/session_document.rs
+++ b/meerkat-machine-kernels/src/generated/session_document.rs
@@ -1391,6 +1391,7 @@ pub mod inputs {
         pub session_id: SessionId,
         pub has_metadata: bool,
         pub has_build_state: bool,
+        pub runtime_projection_quarantined: bool,
     }
     #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
     pub struct ApplyPendingToolResults {

--- a/meerkat-machine-schema/src/catalog/dsl/session_document.rs
+++ b/meerkat-machine-schema/src/catalog/dsl/session_document.rs
@@ -649,18 +649,19 @@ machine! {
             // `runtime_backed_store_projection_can_recover_authority`). When
             // the runtime snapshot is absent, the session-store projection may
             // stand in as the authoritative read source iff it carries
-            // canonical session metadata or build state. The shell extracts the
-            // two typed presence observations and drives this input; THIS
+            // canonical session metadata, build state, or a generated runtime
+            // projection quarantine fact. The shell extracts the typed
+            // observations and drives this input; THIS
             // machine — not a handwritten shell `||` reducer — owns the
             // recoverable verdict. The shell mirrors `recoverable` onto its load
             // fallback (recoverable -> the projection is authoritative; not
-            // recoverable -> fall through to the quarantine check / `None`).
-            // Fails closed.
+            // recoverable -> `None`). Fails closed.
             // -----------------------------------------------------------
             RecoverSessionFromStore {
                 session_id: SessionId,
                 has_metadata: bool,
                 has_build_state: bool,
+                runtime_projection_quarantined: bool,
             },
 
             // -----------------------------------------------------------
@@ -1042,12 +1043,14 @@ machine! {
         // Recovery-source-projection predicate (port of the retired shell
         // `runtime_backed_store_projection_can_recover_authority`): a persisted
         // store projection is a valid authoritative read source iff it carries
-        // canonical session metadata OR build state.
+        // canonical session metadata, build state, OR a generated runtime
+        // projection quarantine fact.
         helper store_projection_can_recover_authority(
             has_metadata: bool,
-            has_build_state: bool
+            has_build_state: bool,
+            runtime_projection_quarantined: bool
         ) -> bool {
-            has_metadata || has_build_state
+            has_metadata || has_build_state || runtime_projection_quarantined
         }
 
         // Lifecycle-terminal realization helper: the runtime is retired iff
@@ -2979,7 +2982,7 @@ machine! {
 
         // ===============================================================
         // Recovery-source-projection region (KEYSTONE). Both transitions read
-        // the two typed presence observations and resolve the recoverable
+        // typed store/runtime observations and resolve the recoverable
         // verdict via `store_projection_can_recover_authority`. The verdict is
         // total over the boolean cube, so it is emitted on both branches; the
         // shell mirrors `recoverable` onto its load fallback and decides
@@ -2990,11 +2993,16 @@ machine! {
             on input RecoverSessionFromStore {
                 session_id,
                 has_metadata,
-                has_build_state
+                has_build_state,
+                runtime_projection_quarantined
             }
             guard {
                 self.lifecycle_phase == Phase::Ready
-                && store_projection_can_recover_authority(has_metadata, has_build_state)
+                && store_projection_can_recover_authority(
+                    has_metadata,
+                    has_build_state,
+                    runtime_projection_quarantined
+                )
             }
             update {}
             to Ready
@@ -3005,11 +3013,16 @@ machine! {
             on input RecoverSessionFromStore {
                 session_id,
                 has_metadata,
-                has_build_state
+                has_build_state,
+                runtime_projection_quarantined
             }
             guard {
                 self.lifecycle_phase == Phase::Ready
-                && store_projection_can_recover_authority(has_metadata, has_build_state) == false
+                && store_projection_can_recover_authority(
+                    has_metadata,
+                    has_build_state,
+                    runtime_projection_quarantined
+                ) == false
             }
             update {}
             to Ready

--- a/meerkat-session/src/persistent.rs
+++ b/meerkat-session/src/persistent.rs
@@ -1729,23 +1729,20 @@ impl<B: SessionAgentBuilder + 'static> PersistentSessionService<B> {
                         // Recovery-source eligibility (whether a store-only
                         // projection may stand in as authoritative when the
                         // runtime snapshot is absent) is owned by the canonical
-                        // SessionDocumentMachine. The shell extracts only the two
-                        // pure presence observations and mirrors the verdict; the
-                        // separate quarantine fallback OR-term remains shell-side
-                        // (a distinct runtime fact). Fails closed: a machine drive
-                        // error makes the projection ineligible (the quarantine
-                        // fallback cannot rescue an unresolved verdict).
+                        // SessionDocumentMachine. The shell extracts only typed
+                        // store/runtime observations and mirrors the verdict.
+                        // Fails closed: a machine drive error makes the
+                        // projection ineligible.
                         match store_projection {
                             Some(session) => {
-                                match self.store_projection_recovery_source_resolved(id, &session) {
+                                let runtime_projection_quarantined =
+                                    self.runtime_projection_fallback_quarantined(id).await;
+                                match self.store_projection_recovery_source_resolved(
+                                    id,
+                                    &session,
+                                    runtime_projection_quarantined,
+                                ) {
                                     Ok(true) => Some(session),
-                                    Ok(false)
-                                        if self
-                                            .runtime_projection_fallback_quarantined(id)
-                                            .await =>
-                                    {
-                                        Some(session)
-                                    }
                                     Ok(false) | Err(_) => None,
                                 }
                             }
@@ -2315,13 +2312,15 @@ impl<B: SessionAgentBuilder + 'static> PersistentSessionService<B> {
 
     /// Whether a SessionStore projection may stand in as the authoritative read
     /// source when the runtime snapshot is absent. The shell extracts only the
-    /// two pure presence observations (canonical metadata / build state) and
-    /// mirrors the canonical SessionDocumentMachine recovery-source verdict; it
-    /// decides nothing. Fails closed if the machine emits no verdict.
+    /// store/runtime observations (canonical metadata / build state / runtime
+    /// projection quarantine) and mirrors the canonical SessionDocumentMachine
+    /// recovery-source verdict; it decides nothing. Fails closed if the machine
+    /// emits no verdict.
     fn store_projection_recovery_source_resolved(
         &self,
         id: &SessionId,
         session: &Session,
+        runtime_projection_quarantined: bool,
     ) -> Result<bool, SessionError> {
         let mut authority = SessionDocumentMachineAuthority::new();
         let effects = authority
@@ -2329,6 +2328,7 @@ impl<B: SessionAgentBuilder + 'static> PersistentSessionService<B> {
                 SessionDocumentKey::new(id.to_string()),
                 session.session_metadata().is_some(),
                 session.build_state().is_some(),
+                runtime_projection_quarantined,
             )
             .map_err(|err| {
                 SessionError::Agent(AgentError::InternalError(format!(

--- a/meerkat/src/factory.rs
+++ b/meerkat/src/factory.rs
@@ -1012,9 +1012,9 @@ fn provider_tool_defaults_for(
 /// resolve `None` to the *same* default instead of each hand-coding a ladder or
 /// literal. Resolution order:
 ///
-/// 1. The configured global agent default (`config.agent.model`) when set —
-///    this is the operator's explicit "default model" knob and outranks the
-///    per-provider entries.
+/// 1. The configured global agent default (`config.agent.model`) when set and
+///    not a frozen legacy built-in default — this is the operator's explicit
+///    "default model" knob and outranks the per-provider entries.
 /// 2. The configured per-provider default (`config.models.{provider}`) walked
 ///    in the catalog-owned [`provider_priority`] order — the first non-empty
 ///    entry wins. Core's [`ModelDefaults::default`] leaves these empty
@@ -1028,9 +1028,24 @@ fn provider_tool_defaults_for(
 #[must_use]
 pub fn resolve_create_session_default_model(config: &Config) -> String {
     if !config.agent.model.is_empty() {
+        if legacy_agent_model_defaults().contains(&config.agent.model.as_str()) {
+            return resolve_provider_catalog_default_model(config);
+        }
         return config.agent.model.clone();
     }
     resolve_provider_catalog_default_model(config)
+}
+
+/// FROZEN historical snapshot of prior built-in create-session defaults.
+///
+/// This is intentionally not a mirror of the live model catalog. It detects
+/// stale defaults that users may still carry in persisted `config.agent.model`
+/// and heals them through the shared catalog/provider ladder. Entries are prior
+/// shipped defaults, not catalog membership claims: a listed model may still be
+/// a supported catalog row.
+#[must_use]
+fn legacy_agent_model_defaults() -> &'static [&'static str] {
+    &["claude-opus-4-7"]
 }
 
 /// Tiers 2–3 of [`resolve_create_session_default_model`]: the configured
@@ -1038,10 +1053,10 @@ pub fn resolve_create_session_default_model(config: &Config) -> String {
 /// catalog [`global_default_model`] terminal fallback — *without* consulting
 /// `config.agent.model`.
 ///
-/// This is the seam for callers that must resolve a default while explicitly
-/// overriding the operator's global knob (e.g. the CLI's legacy-default
-/// detection, which replaces a known-stale `config.agent.model` value). Every
-/// other caller should use [`resolve_create_session_default_model`].
+/// This is the seam for code that already decided to bypass the global knob,
+/// including the legacy-default heal owned by
+/// [`resolve_create_session_default_model`]. Create-session callers should use
+/// [`resolve_create_session_default_model`].
 ///
 /// [`provider_priority`]: meerkat_models::provider_priority
 /// [`global_default_model`]: meerkat_models::global_default_model
@@ -5688,7 +5703,7 @@ mod tests {
         // A default config pins no model anywhere (core embeds no provider
         // data), so the resolver must terminate at the catalog-owned global
         // default — the SAME value every surface gets. An operator-set
-        // `config.agent.model` outranks it (tier 1).
+        // non-legacy `config.agent.model` outranks it (tier 1).
         let config = Config::default();
         assert!(config.agent.model.is_empty());
         assert_eq!(
@@ -5701,6 +5716,60 @@ mod tests {
         assert_eq!(
             resolve_create_session_default_model(&pinned),
             "operator-pinned-model",
+        );
+    }
+
+    #[test]
+    fn create_session_default_model_heals_legacy_builtin_default() {
+        let mut config = Config::default();
+        config.agent.model = "claude-opus-4-7".to_string();
+        // A legacy builtin default heals through the canonical ladder. Priority
+        // is owned by the catalog seam (`meerkat_models::provider_priority()`),
+        // so even with a customized OpenAI model the heal resolves to the
+        // configured Anthropic override.
+        config.models.anthropic = "custom-anthropic".to_string();
+        config.models.openai = "gpt-5.5-custom".to_string();
+
+        assert_eq!(
+            resolve_create_session_default_model(&config),
+            "custom-anthropic"
+        );
+    }
+
+    #[test]
+    fn create_session_default_model_heals_legacy_default_to_global_without_overrides() {
+        let mut config = Config::default();
+        config.agent.model = "claude-opus-4-7".to_string();
+
+        assert_eq!(
+            resolve_create_session_default_model(&config),
+            meerkat_models::global_default_model()
+        );
+    }
+
+    #[test]
+    fn create_session_default_model_heals_legacy_default_by_provider_priority() {
+        let mut config = Config::default();
+        config.agent.model = "claude-opus-4-7".to_string();
+        config.models.openai = "custom-openai".to_string();
+        config.models.gemini = "custom-gemini".to_string();
+
+        // Anthropic unset: the next provider in catalog priority order wins.
+        assert_eq!(
+            resolve_create_session_default_model(&config),
+            "custom-openai"
+        );
+
+        config.models.openai.clear();
+        assert_eq!(
+            resolve_create_session_default_model(&config),
+            "custom-gemini"
+        );
+
+        config.models.gemini.clear();
+        assert_eq!(
+            resolve_create_session_default_model(&config),
+            meerkat_models::global_default_model()
         );
     }
 

--- a/specs/machines/session_document/contract.md
+++ b/specs/machines/session_document/contract.md
@@ -42,7 +42,7 @@ _Generated from the Rust machine catalog. Do not edit by hand._
 - `ResolvePendingContinuation`(session_tail: ObservedSessionTailKind, staged_tool_result_count: u64)
 - `AuthorizeSessionResumeOverrides`(provider_override_present: Bool, model_override_present: Bool, has_build_only_overrides: Bool, first_turn_phase: SessionFirstTurnPhase)
 - `ClassifyLiveSessionAuthority`(stored_transcript_diverged: Bool, live_has_uncommitted_transcript: Bool, runtime_system_context_diverged: Bool, stored_is_archived: Bool)
-- `RecoverSessionFromStore`(session_id: SessionId, has_metadata: Bool, has_build_state: Bool)
+- `RecoverSessionFromStore`(session_id: SessionId, has_metadata: Bool, has_build_state: Bool, runtime_projection_quarantined: Bool)
 - `ApplyPendingToolResults`(session_id: SessionId, result_count: u64)
 - `TranscriptEdit`(session_id: SessionId, fork_or_rewrite_directive: TranscriptEditKind)
 - `RecoverSessionLifecycleTerminal`(session_id: SessionId, terminal: SessionDocumentLifecycle)
@@ -100,7 +100,7 @@ _Generated from the Rust machine catalog. Do not edit by hand._
 - `resume_reject_build_only_after_first_turn`(has_build_only_overrides: Bool, first_turn_phase: SessionFirstTurnPhase) -> `Bool`
 - `resume_overrides_admissible`(provider_override_present: Bool, model_override_present: Bool, has_build_only_overrides: Bool, first_turn_phase: SessionFirstTurnPhase) -> `Bool`
 - `resume_provider_recompute_from_model`(model_override_present: Bool, provider_override_present: Bool) -> `Bool`
-- `store_projection_can_recover_authority`(has_metadata: Bool, has_build_state: Bool) -> `Bool`
+- `store_projection_can_recover_authority`(has_metadata: Bool, has_build_state: Bool, runtime_projection_quarantined: Bool) -> `Bool`
 - `archive_should_retire_runtime`(runtime_backed: Bool, durable_snapshot_present: Bool, runtime_session_registered: Bool) -> `Bool`
 
 ## Invariants
@@ -680,7 +680,7 @@ _Generated from the Rust machine catalog. Do not edit by hand._
 
 ### `RecoverSessionFromStoreAuthorized`
 - From: `Ready`
-- On: `RecoverSessionFromStore`(session_id, has_metadata, has_build_state)
+- On: `RecoverSessionFromStore`(session_id, has_metadata, has_build_state, runtime_projection_quarantined)
 - Guards:
   - ``
 - Emits: `SessionStoreRecoverySourceResolved`
@@ -688,7 +688,7 @@ _Generated from the Rust machine catalog. Do not edit by hand._
 
 ### `RecoverSessionFromStoreUnrecoverable`
 - From: `Ready`
-- On: `RecoverSessionFromStore`(session_id, has_metadata, has_build_state)
+- On: `RecoverSessionFromStore`(session_id, has_metadata, has_build_state, runtime_projection_quarantined)
 - Guards:
   - ``
 - Emits: `SessionStoreRecoverySourceResolved`

--- a/specs/machines/session_document/model.tla
+++ b/specs/machines/session_document/model.tla
@@ -31,7 +31,7 @@ VARIABLES phase, model_step_count, session_first_turn_phase, session_pending_ini
 vars == << phase, model_step_count, session_first_turn_phase, session_pending_initial_prompt_present, session_pending_tool_results_count, session_lifecycle_terminal >>
 
 archive_should_retire_runtime(runtime_backed, durable_snapshot_present, runtime_session_registered) == (runtime_backed /\ (IF durable_snapshot_present THEN TRUE ELSE runtime_session_registered))
-store_projection_can_recover_authority(has_metadata, has_build_state) == (IF has_metadata THEN TRUE ELSE has_build_state)
+store_projection_can_recover_authority(has_metadata, has_build_state, runtime_projection_quarantined) == (IF has_metadata THEN TRUE ELSE (IF has_build_state THEN TRUE ELSE runtime_projection_quarantined))
 resume_provider_recompute_from_model(model_override_present, provider_override_present) == (model_override_present /\ (provider_override_present = FALSE))
 resume_reject_provider_requires_model(provider_override_present, model_override_present) == (provider_override_present /\ (model_override_present = FALSE))
 tail_has_pending_boundary(session_tail) == (IF (session_tail = "User") THEN TRUE ELSE (session_tail = "ToolResults"))
@@ -654,17 +654,17 @@ ClassifyLiveSessionAuthorityDurableRevision(stored_transcript_diverged, live_has
     /\ UNCHANGED << session_first_turn_phase, session_pending_initial_prompt_present, session_pending_tool_results_count, session_lifecycle_terminal >>
 
 
-RecoverSessionFromStoreAuthorized(session_id, has_metadata, has_build_state) ==
+RecoverSessionFromStoreAuthorized(session_id, has_metadata, has_build_state, runtime_projection_quarantined) ==
     /\ phase = "Ready"
-    /\ store_projection_can_recover_authority(has_metadata, has_build_state)
+    /\ store_projection_can_recover_authority(has_metadata, has_build_state, runtime_projection_quarantined)
     /\ phase' = "Ready"
     /\ model_step_count' = model_step_count + 1
     /\ UNCHANGED << session_first_turn_phase, session_pending_initial_prompt_present, session_pending_tool_results_count, session_lifecycle_terminal >>
 
 
-RecoverSessionFromStoreUnrecoverable(session_id, has_metadata, has_build_state) ==
+RecoverSessionFromStoreUnrecoverable(session_id, has_metadata, has_build_state, runtime_projection_quarantined) ==
     /\ phase = "Ready"
-    /\ (store_projection_can_recover_authority(has_metadata, has_build_state) = FALSE)
+    /\ (store_projection_can_recover_authority(has_metadata, has_build_state, runtime_projection_quarantined) = FALSE)
     /\ phase' = "Ready"
     /\ model_step_count' = model_step_count + 1
     /\ UNCHANGED << session_first_turn_phase, session_pending_initial_prompt_present, session_pending_tool_results_count, session_lifecycle_terminal >>
@@ -792,8 +792,8 @@ Next ==
     \/ \E stored_transcript_diverged \in BOOLEAN : \E live_has_uncommitted_transcript \in BOOLEAN : \E runtime_system_context_diverged \in BOOLEAN : \E stored_is_archived \in BOOLEAN : ClassifyLiveSessionAuthorityDurableUncommitted(stored_transcript_diverged, live_has_uncommitted_transcript, runtime_system_context_diverged, stored_is_archived)
     \/ \E stored_transcript_diverged \in BOOLEAN : \E live_has_uncommitted_transcript \in BOOLEAN : \E runtime_system_context_diverged \in BOOLEAN : \E stored_is_archived \in BOOLEAN : ClassifyLiveSessionAuthorityDurableSystemContext(stored_transcript_diverged, live_has_uncommitted_transcript, runtime_system_context_diverged, stored_is_archived)
     \/ \E stored_transcript_diverged \in BOOLEAN : \E live_has_uncommitted_transcript \in BOOLEAN : \E runtime_system_context_diverged \in BOOLEAN : \E stored_is_archived \in BOOLEAN : ClassifyLiveSessionAuthorityDurableRevision(stored_transcript_diverged, live_has_uncommitted_transcript, runtime_system_context_diverged, stored_is_archived)
-    \/ \E session_id \in SessionIdValues : \E has_metadata \in BOOLEAN : \E has_build_state \in BOOLEAN : RecoverSessionFromStoreAuthorized(session_id, has_metadata, has_build_state)
-    \/ \E session_id \in SessionIdValues : \E has_metadata \in BOOLEAN : \E has_build_state \in BOOLEAN : RecoverSessionFromStoreUnrecoverable(session_id, has_metadata, has_build_state)
+    \/ \E session_id \in SessionIdValues : \E has_metadata \in BOOLEAN : \E has_build_state \in BOOLEAN : \E runtime_projection_quarantined \in BOOLEAN : RecoverSessionFromStoreAuthorized(session_id, has_metadata, has_build_state, runtime_projection_quarantined)
+    \/ \E session_id \in SessionIdValues : \E has_metadata \in BOOLEAN : \E has_build_state \in BOOLEAN : \E runtime_projection_quarantined \in BOOLEAN : RecoverSessionFromStoreUnrecoverable(session_id, has_metadata, has_build_state, runtime_projection_quarantined)
     \/ \E session_id \in SessionIdValues : \E result_count \in 0..2 : ApplyPendingToolResults(session_id, result_count)
     \/ \E session_id \in SessionIdValues : \E fork_or_rewrite_directive \in TranscriptEditKindValues : TranscriptEditFork(session_id, fork_or_rewrite_directive)
     \/ \E session_id \in SessionIdValues : \E fork_or_rewrite_directive \in TranscriptEditKindValues : TranscriptEditRewrite(session_id, fork_or_rewrite_directive)

--- a/xtask/src/lib.rs
+++ b/xtask/src/lib.rs
@@ -89,7 +89,9 @@ pub fn run() -> Result<()> {
             run_machine_authority_task(move || machines::machine_check_drift(args))
         }
         Commands::SeamInventory(args) => seam_inventory::run_seam_inventory(args),
-        Commands::ProtocolCodegen => protocol_codegen::run_protocol_codegen(),
+        Commands::ProtocolCodegen => {
+            run_machine_authority_task(protocol_codegen::run_protocol_codegen)
+        }
         Commands::RmatAudit(args) => rmat_audit::rmat_audit(args),
         Commands::EffectAuthority => effect_authority::run_effect_authority(),
         Commands::BridgeClassifier => bridge_classifier::run_bridge_classifier(),


### PR DESCRIPTION
## Summary
- fold runtime projection quarantine into the generated SessionDocument recovery verdict instead of a shell-side fallback override
- move legacy CLI default-model healing into the shared create-session resolver, preserving the #254 user-facing behavior while deleting the CLI-local ladder
- terminalize WebRTC input handoff failures with typed client error frames and generated close authority
- remove Codemob local comms completion by requiring machine-owned `main` flows and converting remaining built-in packs
- preserve user-created/default `mode: "comms"` mob definitions as a schema/storage compatibility path by normalizing them to strict machine-owned analysis+synthesis flow; comms tools and wiring stay disabled
- retain the `meerkat_mob_seam` TLC skip on current main because the recorded CI time/memory budget rationale still applies; this PR does not claim that row fixed until a bounded config lands

## Review-sensitive notes
- Theme 2 now makes the shared resolver the superset: non-empty operator model still wins except the frozen legacy built-in default list, which heals through provider/catalog fallback from `meerkat::resolve_create_session_default_model`.
- Theme 5 was backed out during the rebase onto `origin/main`; generated code drift is verified, but the broad mob-seam TLC run remains skipped pending a bounded CI composition config.
- The comms-mode user mob compatibility path is load/authoring compatibility only. It does not preserve free peer communication; legacy/default comms definitions are compiled into flow edges with peer outputs fed to the orchestrator.

## Validation
- `make fmt`
- `make check`
- `make machine-codegen`
- `make machine-check-drift`
- `./scripts/repo-cargo test --manifest-path examples/034-codemob-mcp/Cargo.toml comms_user_pack_synthesizes_machine_owned_main_flow`
- `./scripts/repo-cargo test --manifest-path examples/034-codemob-mcp/Cargo.toml built_in_packs_all_have_machine_owned_flows`
- `./scripts/repo-cargo test -p rkat test_resolve_cli_effective_model`
- `./scripts/repo-cargo test -p meerkat create_session_default_model`
- `git diff --check`
- pre-push hook: format, changed-crate clippy, machine codegen + verify, generated-header audit, bridge audit, Bazel freshness, deterministic workspace gate

Not run: full workspace nextest; full `meerkat_mob_seam` TLC sweep, intentionally still skipped until bounded CI config exists.