### PR TITLE
[codex] add model fallback chain

### DIFF
--- a/.claude/skills/meerkat-architecture/references/agent-construction.md
+++ b/.claude/skills/meerkat-architecture/references/agent-construction.md
@@ -25,6 +25,40 @@ The factory validates `bindings.session_id == session.id()` for `SessionOwned` b
 
 **Dynamic tooling gotcha:** if a child dispatcher can change between turns (callback tools, agent mob tools), compose with `DynamicToolComposite` rather than a gateway that snapshots tool definitions once at construction.
 
+## Model Fallback Chain
+
+The fallback chain is an agent-facing LLM client decorator assembled by
+`AgentFactory`, but it is not an authority for recovery semantics. Keep these
+ownership boundaries intact:
+
+- `meerkat` facade resolves concrete fallback identities from `[model_fallback]`
+  and the effective `ModelRegistry`; `meerkat-core` remains provider-data-free.
+- `ProviderRuntimeRegistry` is still the only credential path for every
+  fallback target. Catalog-default candidates inherit the selected non-env realm
+  when possible and skip providers unavailable in that realm; explicit chains
+  may carry typed `auth_binding`, including same-model/provider credential
+  failover targets.
+- The generated turn recovery authority classifies whether an LLM failure is
+  recoverable. The fallback client only selects the next prebuilt candidate; it
+  must not shadow-classify provider errors or make provider calls while
+  preparing a switch.
+- `Agent::apply_model_fallback_switch()` owns applying the switch: rotate auth
+  lease binding, apply request policy, persist `SessionLlmIdentity`, recompute
+  provider params, clamp max output tokens, filter tools by the target model's
+  capability base filter, and append the hidden `model_fallback` system notice.
+- The retry is allowed only when core decides it is pre-stream safe. Do not add
+  hidden retry paths for network/call timeouts or after user-visible
+  text/reasoning stream output escaped.
+- Extraction fallback must merge the target request policy with the current
+  extraction overrides: reapply structured output for the new provider and keep
+  provider-native web search disabled.
+- Tool visibility projections must use the active model's
+  `active_capability_base_filter()` on every call and visible-tool snapshot, so
+  later sticky fallback turns and control-plane reads agree.
+- Context-overflow fallback must not downgrade to a target whose catalog
+  context window is smaller than the requested size; report skipped targets in
+  the notice payload.
+
 ## Multimodal Content
 
 - `ContentBlock` (meerkat-core): `Text { text }`, `Image { media_type, ... }`, or `Video { media_type, duration_ms, ... }`

--- a/.claude/skills/meerkat-architecture/references/gotchas.md
+++ b/.claude/skills/meerkat-architecture/references/gotchas.md
@@ -39,6 +39,7 @@ Load this reference as the first review lens when touching runtime, mob, comms, 
 33. **Trust is PeerId-keyed.** `TrustStore` (meerkat-comms/src/trust.rs) keys entries on `PeerId` and rejects duplicates with a typed error. Recipient-side wiring trust is a MobMachine obligation (`pending_recipient_trust: Set<PeerId>`), not fire-and-forget shell work.
 34. **Member revival is machine-authorized.** Post-discard revival flows observe → classify → realize through MobMachine (`member_revival_pending`, `MemberLiveMaterializationClassified`, `ResolveMemberRevival*`). `Broken` is terminal — the `not_broken` guard refuses retry and `member()` returns typed `MobError::MemberRestoreFailed`. Do not add shell-side retry loops.
 35. **Image-gen routing follows session identity.** The planner resolves the image target from `SessionModelRoutingStatus.session_provider` (typed session provider identity); model-name inference (`infer_from_model`) was deleted from the planner path. Do not reintroduce provider-prefix sniffing in image routing.
+36. **Model fallback is a core-applied switch, not a hidden client retry.** Generated recovery authority classifies the LLM failure; core decides pre-stream retry safety and applies identity, auth lease, request policy, token limits, and tool visibility before retry. The fallback client only selects a prebuilt candidate from the factory-resolved chain.
 
 ## Gotchas to check on every non-trivial change
 

--- a/.claude/skills/meerkat-platform/SKILL.md
+++ b/.claude/skills/meerkat-platform/SKILL.md
@@ -554,6 +554,51 @@ The model catalog (canonical data: `meerkat-models`; `meerkat_core::model_profil
 
 `rkat models` prints pretty JSON by default and has no `--json` flag. It returns the effective runtime model registry for the active realm: built-in catalog entries plus configured `self_hosted` aliases, providers, default models, and per-model profiles.
 
+### Model fallback chain
+
+Factory-built agents support runtime model fallback through `[model_fallback]`
+in realm config. Defaults are enabled with an empty `chain`, which means
+"build the catalog-owned default backup order" from provider defaults plus the
+global catalog default. A non-empty `[[model_fallback.chain]]` is a user-owned
+ordered policy:
+
+```toml
+[model_fallback]
+enabled = true
+
+[[model_fallback.chain]]
+model = "claude-opus-4-8"
+provider = "anthropic"
+
+[[model_fallback.chain]]
+model = "gpt-5.5"
+provider = "openai"
+auth_binding = { realm = "dev", binding = "openai_oauth" }
+```
+
+Operational rules to remember:
+
+- `enabled = false` disables failover; `use_catalog_default_chain = true`
+  restores the built-in chain over an inherited disabled/custom policy.
+- Fallback is only for machine-classified recoverable LLM failures and core
+  pre-stream-safe retries. Network/call timeouts do not trigger model fallback,
+  and any user-visible text/reasoning stream output suppresses cross-model
+  fallback for that failed call.
+- Fallback target identity includes `auth_binding`; same model/provider with a
+  different configured binding is a valid credential-failover target.
+- The switch updates session LLM identity, request policy, auth lease, provider
+  params, max-output clamp, and capability-based tool filtering before retry.
+- Structured-output extraction fallback must reapply the extraction schema for
+  the new provider and keep provider-native web search disabled.
+- The active agent receives a hidden `model_fallback` system notice explaining
+  the source model, fallback model, reason, skipped targets, limits, and hidden
+  tools.
+- A smaller-context backup target is skipped for a context-overflow failure
+  when its catalog context window cannot satisfy the requested size.
+- Catalog-default candidates stay in the selected non-env auth realm when that
+  realm has a provider binding. Explicit chains may set `auth_binding`; missing
+  explicit targets fail configuration instead of being silently skipped.
+
 ### Mid-session model hot-swap
 
 Model and provider can be changed on a running session without rebuilding the agent:

--- a/docs/cli/configuration.mdx
+++ b/docs/cli/configuration.mdx
@@ -143,6 +143,46 @@ the connection itself are owned by a realm binding for
 run time. See [Self-hosting models](/guides/self-hosting-models) for the
 realm binding shape.
 
+## Model fallback config
+
+Model fallback is enabled by default for factory-built agents. If the active
+model fails at a recoverable LLM boundary, Meerkat can move through an ordered
+backup chain and retry with the next viable model:
+
+```toml
+[model_fallback]
+enabled = true
+
+[[model_fallback.chain]]
+model = "claude-opus-4-8"
+provider = "anthropic"
+
+[[model_fallback.chain]]
+model = "gpt-5.5"
+provider = "openai"
+auth_binding = { realm = "dev", binding = "openai_oauth" }
+```
+
+Omit `chain` to use the catalog default chain. Set `enabled = false` to fail
+closed on the original model error. Set `use_catalog_default_chain = true` in a
+higher-precedence config layer when you need to undo an inherited disabled or
+custom policy.
+
+Fallback targets include the auth binding identity. Use `auth_binding` on an
+explicit target to retry the same model/provider through a different configured
+credential. The catalog default chain only uses provider bindings available in
+the selected non-env realm.
+
+Fallback can change the effective model surface. Smaller backup models can
+reduce max output tokens, hide tools gated by model capabilities, and be skipped
+for context overflow if their context window is too small. The agent receives a
+hidden system notice when a switch happens, including the reason and any hidden
+tools.
+
+Fallback is only attempted before user-visible stream output has been emitted.
+Structured-output extraction retries keep their schema and provider-native web
+search remains disabled after a fallback switch.
+
 ## Session storage layout
 
 CLI realm storage lives under the active state root. By default, that is

--- a/docs/concepts/configuration.mdx
+++ b/docs/concepts/configuration.mdx
@@ -111,6 +111,44 @@ min_turns_between_compactions = 3
 
 When `session-compaction` is enabled, `AgentFactory` maps these values into the runtime `CompactionConfig`.
 
+## Model fallback settings
+
+The model fallback chain is realm-scoped configuration. Empty `chain` means
+"use the catalog default chain"; a non-empty chain is an explicit ordered
+operator policy:
+
+```toml
+[model_fallback]
+enabled = true
+
+[[model_fallback.chain]]
+model = "claude-opus-4-8"
+provider = "anthropic"
+
+[[model_fallback.chain]]
+model = "gpt-5.5"
+provider = "openai"
+auth_binding = { realm = "dev", binding = "openai_oauth" }
+```
+
+A fallback target is identified by model, provider, self-hosted server, and
+`auth_binding`. This means an explicit custom chain can retry the same
+model/provider through a different credential binding. Catalog-default chains
+stay inside the selected non-env auth realm and skip providers that are not
+registered there.
+
+Use `enabled = false` to disable runtime model failover. If a lower-precedence
+layer disabled fallback or supplied a custom chain, set
+`use_catalog_default_chain = true` in a higher-precedence layer to restore the
+built-in catalog chain.
+
+Fallback activation is still runtime-governed: the generated recovery
+authority must classify the LLM failure as recoverable, and the core run loop
+must decide the retry is pre-stream safe. Network/call timeouts never trigger
+model fallback, and cross-model fallback is suppressed after user-visible text
+or reasoning stream output has been emitted. On activation, Meerkat recomputes
+the active model's tool capability filter and token limits before retrying.
+
 ## See also
 
 - [Realms](/concepts/realms)

--- a/docs/concepts/providers.mdx
+++ b/docs/concepts/providers.mdx
@@ -218,6 +218,68 @@ match, so it works without `--provider`.
 
 You can still override this with `--provider` on the CLI or `provider` in API requests.
 
+## Model fallback chain
+
+Factory-built agents can use an ordered model fallback chain when the active
+model reaches a typed, recoverable LLM failure boundary. This protects long
+sessions from provider-side disruptions such as removed models, rate limits,
+provider overload, auth failures, and context-window overflow.
+
+Fallback is enabled by default. With no explicit chain, Meerkat builds a
+catalog-owned backup order from the configured provider defaults and the global
+catalog default, excluding the active model and duplicate targets. You can
+replace that order in realm config:
+
+```toml config.toml
+[model_fallback]
+enabled = true
+
+[[model_fallback.chain]]
+model = "claude-opus-4-8"
+provider = "anthropic"
+
+[[model_fallback.chain]]
+model = "gpt-5.5"
+provider = "openai"
+auth_binding = { realm = "dev", binding = "openai_oauth" }
+
+[[model_fallback.chain]]
+model = "gemma-4-31b"
+provider = "self_hosted"
+auth_binding = { realm = "lab", binding = "ollama" }
+```
+
+`provider` is optional when the model exists in the effective registry.
+`auth_binding` is optional; when omitted, the target resolves through the same
+provider-runtime registry used for normal session creation. The same
+model/provider with a different `auth_binding` is a distinct fallback target,
+so custom chains can fail over to another credential realm. For the catalog
+default chain, Meerkat keeps candidates inside the selected non-env realm when
+that realm has a matching provider binding; unavailable catalog-default
+candidates are skipped rather than silently bleeding into another realm. For an
+explicit custom chain, an unavailable target is a configuration error.
+
+When a switch is applied, Meerkat updates the session LLM identity, request
+policy, auth lease, provider parameters, output-token ceiling, and capability
+base filter before retrying. The agent receives a hidden system notice with the
+source model, fallback model, failure reason, skipped targets, active model
+limits, and any tools hidden by the fallback model's capabilities.
+
+For structured-output extraction turns, fallback keeps the extraction request
+deterministic: Meerkat reapplies the output schema for the new provider and
+keeps provider-native web search/grounding disabled on the retry.
+
+Capability changes are expected. For example, falling back from a 1M-context
+vision model to a 128K local model can clamp output tokens, hide image-result
+tools, and skip the local target entirely if the failure was a context overflow
+larger than that target's context window. Later turns remain sticky to the
+active fallback model until the session is explicitly hot-swapped or rebuilt.
+
+Meerkat does not fallback on call/network timeouts, and it suppresses
+cross-model fallback for any retryable error after user-visible text or
+reasoning stream output has been emitted. Ordinary same-model retry policy can
+still apply when the recovery authority permits it.
+
 ## See also
 
 - [Auth & bindings](/concepts/auth-and-bindings)

--- a/meerkat-core/src/agent.rs
+++ b/meerkat-core/src/agent.rs
@@ -86,6 +86,54 @@ pub trait AgentLlmClient: Send + Sync {
     /// after hot-swap.
     fn model(&self) -> &str;
 
+    /// Prepare the next prebuilt fallback model after the generated turn
+    /// authority has classified the LLM failure as recoverable.
+    ///
+    /// This method does not classify failures and must not call the provider.
+    /// It only selects an already-constructed candidate and returns the typed
+    /// state the agent loop must apply before the retry attempt.
+    fn prepare_model_fallback(&self, _failure: &AgentError) -> Option<AgentLlmFallbackSwitch> {
+        None
+    }
+
+    /// Commit a prepared fallback after the agent loop has applied the paired
+    /// request policy, identity, and tool-visibility state.
+    fn commit_model_fallback(&self, _identity: &crate::SessionLlmIdentity) {}
+
+    /// Capability base filter for the current active model.
+    ///
+    /// The agent loop composes this with the already-authorized tool set before
+    /// every provider call so sticky fallback models keep their downgraded tool
+    /// surface on later turns too.
+    fn active_capability_base_filter(&self) -> crate::ToolFilter {
+        crate::ToolFilter::All
+    }
+
+    /// Output-token ceiling for the current active model, if the catalog knows
+    /// one. Used on every provider call so a sticky fallback keeps respecting
+    /// the backup model's smaller output limit after the failover turn.
+    fn active_max_output_tokens(&self) -> Option<u32> {
+        None
+    }
+
+    /// Reset per-call observation of user-visible streaming output.
+    ///
+    /// Adapters that emit display/reasoning deltas before returning the final
+    /// stream result use this to let the retry loop distinguish a pre-stream
+    /// failure from a post-partial-output failure. The default is no-op for
+    /// clients that do not stream visible events outside the returned blocks.
+    fn begin_stream_output_observation(&self) {}
+
+    /// Whether the current LLM call has emitted user-visible streaming output.
+    ///
+    /// A `true` value suppresses model fallback for the failed call: retrying
+    /// against a different model after users already saw partial output can
+    /// produce duplicate assistant answers. Ordinary same-model retry policy is
+    /// still governed by the generated turn recovery authority.
+    fn stream_output_observed(&self) -> bool {
+        false
+    }
+
     /// Compile an output schema for this provider.
     ///
     /// Default implementation normalizes the schema without provider-specific lowering.
@@ -107,6 +155,29 @@ pub trait AgentLlmClient: Send + Sync {
 /// registry hooks.
 pub type AgentLlmClientDecorator =
     Arc<dyn Fn(Arc<dyn AgentLlmClient>) -> Arc<dyn AgentLlmClient> + Send + Sync + 'static>;
+
+/// One fallback target skipped while selecting a viable backup model.
+#[derive(Debug, Clone)]
+pub struct AgentLlmFallbackSkippedTarget {
+    pub identity: crate::SessionLlmIdentity,
+    pub reason: String,
+}
+
+/// Typed state produced when an agent-facing LLM client activates a fallback.
+///
+/// The client owns only prebuilt candidate selection. The agent loop owns
+/// applying request policy, durable identity metadata, and tool visibility
+/// before issuing the machine-authorized retry.
+#[derive(Debug, Clone)]
+pub struct AgentLlmFallbackSwitch {
+    pub previous_identity: crate::SessionLlmIdentity,
+    pub new_identity: crate::SessionLlmIdentity,
+    pub request_policy: crate::SessionLlmRequestPolicy,
+    pub capability_base_filter: crate::ToolFilter,
+    pub context_window: Option<u32>,
+    pub max_output_tokens: Option<u32>,
+    pub skipped_targets: Vec<AgentLlmFallbackSkippedTarget>,
+}
 
 /// Result of streaming from the LLM
 pub struct LlmStreamResult {

--- a/meerkat-core/src/agent/runner.rs
+++ b/meerkat-core/src/agent/runner.rs
@@ -705,7 +705,26 @@ where
 
     /// Snapshot the agent's live tool-scope state for diagnostics and mapping.
     pub fn tool_scope_snapshot(&self) -> Option<crate::ToolScopeSnapshot> {
-        self.tool_scope.snapshot()
+        let mut snapshot = self.tool_scope.snapshot()?;
+        let capability_filter =
+            crate::ToolScope::compose(&[self.client.active_capability_base_filter()]);
+        snapshot
+            .visible_names
+            .retain(|name| capability_filter.allows(name.as_str()));
+        snapshot.capability_base_filter = self.client.active_capability_base_filter();
+        Some(snapshot)
+    }
+
+    /// Snapshot the provider-visible tool definitions for the active LLM model.
+    pub fn visible_tool_defs(&self) -> Vec<crate::ToolDef> {
+        let capability_filter =
+            crate::ToolScope::compose(&[self.client.active_capability_base_filter()]);
+        self.tool_scope
+            .visible_tools()
+            .iter()
+            .filter(|tool| capability_filter.allows(tool.name.as_str()))
+            .map(|tool| tool.as_ref().clone())
+            .collect()
     }
 
     /// Snapshot the live external tool-surface state, if supported by the dispatcher chain.

--- a/meerkat-core/src/agent/state.rs
+++ b/meerkat-core/src/agent/state.rs
@@ -1,7 +1,7 @@
 //! Agent state machine internals.
 
 use crate::budget::{BudgetDimension, BudgetExceeded};
-use crate::error::{AgentError, ToolError};
+use crate::error::{AgentError, LlmFailureReason, ToolError};
 use crate::event::{
     AgentEvent, BackgroundJobTerminalStatus, BudgetType, DeferredCatalogDelta, ToolCallArguments,
     ToolCallArgumentsError, ToolConfigChangeDomain, ToolConfigChangeOperation,
@@ -16,7 +16,7 @@ use crate::hooks::{
 };
 use crate::image_content::{MissingBlobBehavior, hydrate_messages_for_execution};
 use crate::lifecycle::RunId;
-use crate::lifecycle::run_primitive::ProviderParamsOverride;
+use crate::lifecycle::run_primitive::{ProviderParamsCarrier, ProviderParamsOverride};
 use crate::ops_lifecycle::OperationCompletionWakeClass;
 use crate::session::TranscriptRewriteReason;
 #[cfg(target_arch = "wasm32")]
@@ -38,8 +38,8 @@ use std::sync::Arc;
 use tokio::sync::mpsc;
 
 use super::{
-    Agent, AgentLlmClient, AgentSessionStore, AgentToolDispatcher, LlmStreamResult,
-    select_tool_catalog_mode,
+    Agent, AgentLlmClient, AgentLlmFallbackSwitch, AgentSessionStore, AgentToolDispatcher,
+    LlmStreamResult, select_tool_catalog_mode,
 };
 
 /// Pre-selected timeout source — determined before the LLM await, not inferred after.
@@ -62,8 +62,16 @@ struct LlmRetryRequest<'a> {
     max_tokens: u32,
     temperature: Option<f32>,
     provider_params: Option<&'a ProviderParamsOverride>,
+    extraction_output_schema: Option<crate::types::OutputSchema>,
     allow_empty_success: bool,
 }
+
+type AppliedModelFallbackSwitch = (
+    Arc<[Arc<ToolDef>]>,
+    Option<ProviderParamsOverride>,
+    u32,
+    Message,
+);
 
 fn turn_input_failure_source(input: &TurnExecutionInput) -> Option<&TurnFailureSource> {
     match input {
@@ -142,6 +150,22 @@ fn synthetic_notice_block_message(
 ) -> Message {
     let body = body.into();
     Message::SystemNotice(SystemNoticeMessage::with_block(kind, Some(body), block))
+}
+
+fn fallback_activation_is_pre_stream_safe(
+    error: &AgentError,
+    stream_output_observed: bool,
+) -> bool {
+    if stream_output_observed {
+        return false;
+    }
+    match error {
+        AgentError::Llm { reason, .. } => !matches!(
+            reason,
+            LlmFailureReason::NetworkTimeout { .. } | LlmFailureReason::CallTimeout { .. }
+        ),
+        _ => false,
+    }
 }
 
 /// Test-only predicate; production notice refresh goes through the atomic
@@ -242,6 +266,140 @@ where
         if let Err(e) = self.store.save(&self.session).await {
             tracing::warn!("Failed to save session: {}", e);
         }
+    }
+
+    fn apply_model_fallback_switch(
+        &mut self,
+        switch: AgentLlmFallbackSwitch,
+        failure: &AgentError,
+        previous_tools: &[Arc<ToolDef>],
+    ) -> Result<AppliedModelFallbackSwitch, AgentError> {
+        self.rotate_auth_lease_auth_binding(
+            switch.previous_identity.auth_binding.as_ref(),
+            switch.new_identity.auth_binding.as_ref(),
+        )?;
+        self.apply_llm_request_policy(switch.request_policy.clone());
+
+        if let Some(mut metadata) = self.session.session_metadata() {
+            metadata.apply_llm_identity(&switch.new_identity);
+            self.session.set_session_metadata(metadata).map_err(|err| {
+                AgentError::ConfigError(format!("failed to persist fallback LLM identity: {err}"))
+            })?;
+        }
+
+        let capability_filter = crate::tool_scope::ToolScope::compose(std::slice::from_ref(
+            &switch.capability_base_filter,
+        ));
+        let next_tools: Arc<[Arc<ToolDef>]> = previous_tools
+            .iter()
+            .filter(|tool| capability_filter.allows(tool.name.as_str()))
+            .cloned()
+            .collect::<Vec<_>>()
+            .into();
+        let next_names = next_tools
+            .iter()
+            .map(|tool| tool.name.clone())
+            .collect::<BTreeSet<_>>();
+        let hidden_tools = previous_tools
+            .iter()
+            .filter(|tool| !next_names.contains(&tool.name))
+            .map(|tool| tool.name.to_string())
+            .collect::<Vec<_>>();
+
+        let carrier = ProviderParamsCarrier {
+            params: switch
+                .request_policy
+                .provider_params
+                .clone()
+                .unwrap_or_default(),
+            tool_defaults: switch.request_policy.provider_tool_defaults.clone(),
+        };
+        let provider_params = carrier
+            .effective_params()
+            .map_err(|err| AgentError::ConfigError(err.to_string()))?;
+        let provider_params = (!provider_params.is_empty()).then_some(provider_params);
+        let max_tokens = switch
+            .max_output_tokens
+            .map(|limit| self.config.max_tokens_per_turn.min(limit))
+            .unwrap_or(self.config.max_tokens_per_turn);
+
+        let skipped_targets = switch
+            .skipped_targets
+            .iter()
+            .map(|target| {
+                serde_json::json!({
+                    "model": target.identity.model,
+                    "provider": target.identity.provider.as_str(),
+                    "reason": target.reason,
+                })
+            })
+            .collect::<Vec<_>>();
+        let hidden_detail = if hidden_tools.is_empty() {
+            String::new()
+        } else {
+            format!(
+                " Hidden tools for the fallback model: {}.",
+                hidden_tools.join(", ")
+            )
+        };
+        let body = format!(
+            "The runtime switched from model '{}' ({}) to fallback model '{}' ({}) after an LLM failure: {}. Active model limits are context_window={:?}, max_output_tokens={:?}.{} Adapt to the active model and visible tools.",
+            switch.previous_identity.model,
+            switch.previous_identity.provider.as_str(),
+            switch.new_identity.model,
+            switch.new_identity.provider.as_str(),
+            failure,
+            switch.context_window,
+            switch.max_output_tokens,
+            hidden_detail,
+        );
+        let payload = serde_json::json!({
+            "event": "model_fallback",
+            "from": {
+                "model": switch.previous_identity.model,
+                "provider": switch.previous_identity.provider.as_str(),
+            },
+            "to": {
+                "model": switch.new_identity.model,
+                "provider": switch.new_identity.provider.as_str(),
+                "context_window": switch.context_window,
+                "max_output_tokens": switch.max_output_tokens,
+            },
+            "hidden_tools": hidden_tools,
+            "skipped_targets": skipped_targets,
+            "reason": failure.to_string(),
+        });
+        let notice = Message::SystemNotice(SystemNoticeMessage::with_block(
+            SystemNoticeKind::Generic,
+            Some(body),
+            crate::types::SystemNoticeBlock::RuntimeNotice {
+                category: "model_fallback".to_string(),
+                detail: Some(
+                    "active LLM model changed after recoverable provider failure".to_string(),
+                ),
+                payload: Some(payload),
+            },
+        ));
+        self.session.push(notice.clone());
+
+        Ok((next_tools, provider_params, max_tokens, notice))
+    }
+
+    fn apply_extraction_request_overrides(
+        provider: crate::Provider,
+        mut provider_params: Option<ProviderParamsOverride>,
+        output_schema: Option<&crate::types::OutputSchema>,
+    ) -> Result<Option<ProviderParamsOverride>, AgentError> {
+        let Some(output_schema) = output_schema.cloned() else {
+            return Ok(provider_params);
+        };
+
+        let mut effective = provider_params.take().unwrap_or_default();
+        effective
+            .set_structured_output(provider, output_schema)
+            .map_err(|error| AgentError::ConfigError(error.to_string()))?;
+        effective.clear_web_search();
+        Ok((!effective.is_empty()).then_some(effective))
     }
 
     /// Snapshot the runtime-backed turn-state authority.
@@ -399,6 +557,7 @@ where
             max_tokens,
             temperature,
             provider_params,
+            extraction_output_schema,
             allow_empty_success,
         } = request;
 
@@ -426,7 +585,21 @@ where
         } else {
             None
         };
-        let messages = hydrated_messages.as_deref().unwrap_or(messages);
+        let mut current_messages = hydrated_messages.unwrap_or_else(|| messages.to_vec());
+        let active_capability_filter =
+            crate::tool_scope::ToolScope::compose(&[self.client.active_capability_base_filter()]);
+        let mut current_tools: Arc<[Arc<ToolDef>]> = tools
+            .iter()
+            .filter(|tool| active_capability_filter.allows(tool.name.as_str()))
+            .cloned()
+            .collect::<Vec<_>>()
+            .into();
+        let mut current_max_tokens = self
+            .client
+            .active_max_output_tokens()
+            .map(|limit| max_tokens.min(limit))
+            .unwrap_or(max_tokens);
+        let mut current_provider_params = provider_params.cloned();
         let mut attempt = 0u32;
 
         loop {
@@ -447,11 +620,18 @@ where
             }
 
             // 4. Determine whether to wrap the call and select timeout source
+            self.client.begin_stream_output_observation();
             let call_result = match (effective_call_timeout, remaining_turn) {
                 (None, None) => {
                     // No timeout wrapper needed
                     self.client
-                        .stream_response(messages, tools, max_tokens, temperature, provider_params)
+                        .stream_response(
+                            &current_messages,
+                            &current_tools,
+                            current_max_tokens,
+                            temperature,
+                            current_provider_params.as_ref(),
+                        )
                         .await
                 }
                 (call_to, turn_remaining) => {
@@ -472,11 +652,11 @@ where
                     match tokio::time::timeout(
                         effective_timeout,
                         self.client.stream_response(
-                            messages,
-                            tools,
-                            max_tokens,
+                            &current_messages,
+                            &current_tools,
+                            current_max_tokens,
                             temperature,
-                            provider_params,
+                            current_provider_params.as_ref(),
                         ),
                     )
                     .await
@@ -540,6 +720,29 @@ where
                             self.retry_policy.max_retries,
                         )?;
                         if let LlmFailureRecoveryKind::Recover = recovery {
+                            if fallback_activation_is_pre_stream_safe(
+                                &error,
+                                self.client.stream_output_observed(),
+                            ) && let Some(switch) = self.client.prepare_model_fallback(&error)
+                            {
+                                let new_identity = switch.new_identity.clone();
+                                let (next_tools, next_params, next_max_tokens, notice) = self
+                                    .apply_model_fallback_switch(
+                                        switch,
+                                        &error,
+                                        current_tools.as_ref(),
+                                    )?;
+                                let next_params = Self::apply_extraction_request_overrides(
+                                    new_identity.provider,
+                                    next_params,
+                                    extraction_output_schema.as_ref(),
+                                )?;
+                                self.client.commit_model_fallback(&new_identity);
+                                current_tools = next_tools;
+                                current_provider_params = next_params;
+                                current_max_tokens = next_max_tokens;
+                                current_messages.push(notice);
+                            }
                             let retry_schedule = self
                                 .retry_policy
                                 .schedule_retry(&error, attempt, self.budget.remaining_duration())
@@ -599,6 +802,25 @@ where
                         self.retry_policy.max_retries,
                     )?;
                     if let LlmFailureRecoveryKind::Recover = recovery {
+                        if fallback_activation_is_pre_stream_safe(
+                            &e,
+                            self.client.stream_output_observed(),
+                        ) && let Some(switch) = self.client.prepare_model_fallback(&e)
+                        {
+                            let new_identity = switch.new_identity.clone();
+                            let (next_tools, next_params, next_max_tokens, notice) = self
+                                .apply_model_fallback_switch(switch, &e, current_tools.as_ref())?;
+                            let next_params = Self::apply_extraction_request_overrides(
+                                new_identity.provider,
+                                next_params,
+                                extraction_output_schema.as_ref(),
+                            )?;
+                            self.client.commit_model_fallback(&new_identity);
+                            current_tools = next_tools;
+                            current_provider_params = next_params;
+                            current_max_tokens = next_max_tokens;
+                            current_messages.push(notice);
+                        }
                         let retry_schedule = self
                             .retry_policy
                             .schedule_retry(&e, attempt, self.budget.remaining_duration())
@@ -1959,6 +2181,11 @@ where
                             max_tokens: effective_max_tokens,
                             temperature: effective_temperature,
                             provider_params: typed_provider_params.as_ref(),
+                            extraction_output_schema: if in_extraction {
+                                self.config.output_schema.clone()
+                            } else {
+                                None
+                            },
                             allow_empty_success: run_has_visible_or_actionable_output,
                         })
                         .await
@@ -3194,6 +3421,12 @@ mod tests {
             .with_runtime_execution_kind_for_test(
                 crate::lifecycle::RuntimeExecutionKind::ContentTurn,
             )
+    }
+
+    fn explicit_test_visibility_owner() -> crate::GeneratedToolVisibilityOwner {
+        let owner: Arc<dyn crate::ToolVisibilityOwner> =
+            Arc::new(crate::tool_scope::GeneratedTestToolVisibilityOwner::new());
+        crate::tool_scope::generated_test_tool_visibility_owner_from(owner)
     }
 
     struct StaticLlmClient;
@@ -8499,6 +8732,300 @@ mod tests {
         }
     }
 
+    struct FallbackActivatingClient {
+        active: std::sync::atomic::AtomicUsize,
+        seen_tools: Mutex<Vec<Vec<String>>>,
+        seen_notice_bodies: Mutex<Vec<Vec<String>>>,
+        seen_max_tokens: Mutex<Vec<u32>>,
+        seen_provider_params:
+            Mutex<Vec<Option<crate::lifecycle::run_primitive::ProviderParamsOverride>>>,
+    }
+
+    impl FallbackActivatingClient {
+        fn new() -> Self {
+            Self {
+                active: std::sync::atomic::AtomicUsize::new(0),
+                seen_tools: Mutex::new(Vec::new()),
+                seen_notice_bodies: Mutex::new(Vec::new()),
+                seen_max_tokens: Mutex::new(Vec::new()),
+                seen_provider_params: Mutex::new(Vec::new()),
+            }
+        }
+
+        fn seen_tools(&self) -> Vec<Vec<String>> {
+            self.seen_tools.lock().unwrap().clone()
+        }
+
+        fn seen_notice_bodies(&self) -> Vec<Vec<String>> {
+            self.seen_notice_bodies.lock().unwrap().clone()
+        }
+
+        fn seen_max_tokens(&self) -> Vec<u32> {
+            self.seen_max_tokens.lock().unwrap().clone()
+        }
+
+        fn seen_provider_params(
+            &self,
+        ) -> Vec<Option<crate::lifecycle::run_primitive::ProviderParamsOverride>> {
+            self.seen_provider_params.lock().unwrap().clone()
+        }
+    }
+
+    #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+    #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+    impl AgentLlmClient for FallbackActivatingClient {
+        async fn stream_response(
+            &self,
+            messages: &[Message],
+            tools: &[Arc<ToolDef>],
+            max_tokens: u32,
+            _temperature: Option<f32>,
+            provider_params: Option<&crate::lifecycle::run_primitive::ProviderParamsOverride>,
+        ) -> Result<super::LlmStreamResult, AgentError> {
+            self.seen_max_tokens.lock().unwrap().push(max_tokens);
+            self.seen_provider_params
+                .lock()
+                .unwrap()
+                .push(provider_params.cloned());
+            self.seen_tools.lock().unwrap().push(
+                tools
+                    .iter()
+                    .map(|tool| tool.name.to_string())
+                    .collect::<Vec<_>>(),
+            );
+            self.seen_notice_bodies.lock().unwrap().push(
+                messages
+                    .iter()
+                    .filter_map(|message| match message {
+                        Message::SystemNotice(notice) => notice.body.clone(),
+                        _ => None,
+                    })
+                    .collect::<Vec<_>>(),
+            );
+
+            if self.active.load(std::sync::atomic::Ordering::SeqCst) == 0 {
+                return Err(AgentError::llm(
+                    "mock",
+                    crate::error::LlmFailureReason::ProviderError(
+                        crate::error::LlmProviderError::retryable(
+                            crate::error::LlmProviderErrorKind::ServerOverloaded,
+                            serde_json::json!({"message": "busy"}),
+                        ),
+                    ),
+                    "mock overloaded",
+                ));
+            }
+
+            Ok(super::LlmStreamResult::new(
+                vec![AssistantBlock::Text {
+                    text: "ok after fallback".to_string(),
+                    meta: None,
+                }],
+                StopReason::EndTurn,
+                Usage::default(),
+            ))
+        }
+
+        fn provider(&self) -> crate::provider::Provider {
+            crate::provider::Provider::Other
+        }
+
+        fn model(&self) -> &'static str {
+            if self.active.load(std::sync::atomic::Ordering::SeqCst) == 0 {
+                "primary"
+            } else {
+                "backup"
+            }
+        }
+
+        fn prepare_model_fallback(
+            &self,
+            _failure: &AgentError,
+        ) -> Option<crate::AgentLlmFallbackSwitch> {
+            if self.active.load(std::sync::atomic::Ordering::SeqCst) != 0 {
+                return None;
+            }
+            Some(crate::AgentLlmFallbackSwitch {
+                previous_identity: crate::SessionLlmIdentity {
+                    model: "primary".to_string(),
+                    provider: crate::provider::Provider::Other,
+                    self_hosted_server_id: None,
+                    provider_params: None,
+                    auth_binding: None,
+                },
+                new_identity: crate::SessionLlmIdentity {
+                    model: "backup".to_string(),
+                    provider: crate::provider::Provider::Other,
+                    self_hosted_server_id: None,
+                    provider_params: None,
+                    auth_binding: None,
+                },
+                request_policy: crate::SessionLlmRequestPolicy {
+                    model: "backup".to_string(),
+                    provider_params: Some(
+                        crate::lifecycle::run_primitive::ProviderParamsOverride {
+                            temperature: Some(0.37),
+                            max_output_tokens: Some(777),
+                            ..Default::default()
+                        },
+                    ),
+                    provider_tool_defaults: None,
+                },
+                capability_base_filter: ToolFilter::Deny(
+                    [crate::VIEW_IMAGE_TOOL_NAME.to_string()]
+                        .into_iter()
+                        .collect(),
+                ),
+                context_window: Some(128_000),
+                max_output_tokens: Some(2048),
+                skipped_targets: Vec::new(),
+            })
+        }
+
+        fn commit_model_fallback(&self, identity: &crate::SessionLlmIdentity) {
+            if identity.model == "backup" {
+                self.active.store(1, std::sync::atomic::Ordering::SeqCst);
+            }
+        }
+
+        fn active_capability_base_filter(&self) -> ToolFilter {
+            if self.active.load(std::sync::atomic::Ordering::SeqCst) == 0 {
+                ToolFilter::All
+            } else {
+                ToolFilter::Deny(
+                    [crate::VIEW_IMAGE_TOOL_NAME.to_string()]
+                        .into_iter()
+                        .collect(),
+                )
+            }
+        }
+
+        fn active_max_output_tokens(&self) -> Option<u32> {
+            (self.active.load(std::sync::atomic::Ordering::SeqCst) != 0).then_some(2048)
+        }
+    }
+
+    struct PartialOutputThenRecoverClient {
+        calls: std::sync::atomic::AtomicUsize,
+        stream_output_observed: std::sync::atomic::AtomicBool,
+        fallback_committed: std::sync::atomic::AtomicBool,
+    }
+
+    impl PartialOutputThenRecoverClient {
+        fn new() -> Self {
+            Self {
+                calls: std::sync::atomic::AtomicUsize::new(0),
+                stream_output_observed: std::sync::atomic::AtomicBool::new(false),
+                fallback_committed: std::sync::atomic::AtomicBool::new(false),
+            }
+        }
+
+        fn calls(&self) -> usize {
+            self.calls.load(std::sync::atomic::Ordering::SeqCst)
+        }
+
+        fn fallback_committed(&self) -> bool {
+            self.fallback_committed
+                .load(std::sync::atomic::Ordering::SeqCst)
+        }
+    }
+
+    #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+    #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+    impl AgentLlmClient for PartialOutputThenRecoverClient {
+        async fn stream_response(
+            &self,
+            _messages: &[Message],
+            _tools: &[Arc<ToolDef>],
+            _max_tokens: u32,
+            _temperature: Option<f32>,
+            _provider_params: Option<&crate::lifecycle::run_primitive::ProviderParamsOverride>,
+        ) -> Result<super::LlmStreamResult, AgentError> {
+            let call = self.calls.fetch_add(1, std::sync::atomic::Ordering::SeqCst) + 1;
+            if call == 1 {
+                self.stream_output_observed
+                    .store(true, std::sync::atomic::Ordering::SeqCst);
+                return Err(AgentError::llm(
+                    "mock",
+                    crate::error::LlmFailureReason::ProviderError(
+                        crate::error::LlmProviderError::retryable(
+                            crate::error::LlmProviderErrorKind::ServerOverloaded,
+                            serde_json::json!({"message": "late stream error"}),
+                        ),
+                    ),
+                    "late stream error",
+                ));
+            }
+
+            Ok(super::LlmStreamResult::new(
+                vec![AssistantBlock::Text {
+                    text: "ok after same-model retry".to_string(),
+                    meta: None,
+                }],
+                StopReason::EndTurn,
+                Usage::default(),
+            ))
+        }
+
+        fn provider(&self) -> crate::provider::Provider {
+            crate::provider::Provider::Other
+        }
+
+        fn model(&self) -> &'static str {
+            if self.fallback_committed() {
+                "backup"
+            } else {
+                "primary"
+            }
+        }
+
+        fn prepare_model_fallback(
+            &self,
+            _failure: &AgentError,
+        ) -> Option<crate::AgentLlmFallbackSwitch> {
+            Some(crate::AgentLlmFallbackSwitch {
+                previous_identity: crate::SessionLlmIdentity {
+                    model: "primary".to_string(),
+                    provider: crate::provider::Provider::Other,
+                    self_hosted_server_id: None,
+                    provider_params: None,
+                    auth_binding: None,
+                },
+                new_identity: crate::SessionLlmIdentity {
+                    model: "backup".to_string(),
+                    provider: crate::provider::Provider::Other,
+                    self_hosted_server_id: None,
+                    provider_params: None,
+                    auth_binding: None,
+                },
+                request_policy: crate::SessionLlmRequestPolicy {
+                    model: "backup".to_string(),
+                    provider_params: None,
+                    provider_tool_defaults: None,
+                },
+                capability_base_filter: ToolFilter::All,
+                context_window: None,
+                max_output_tokens: None,
+                skipped_targets: Vec::new(),
+            })
+        }
+
+        fn commit_model_fallback(&self, _identity: &crate::SessionLlmIdentity) {
+            self.fallback_committed
+                .store(true, std::sync::atomic::Ordering::SeqCst);
+        }
+
+        fn begin_stream_output_observation(&self) {
+            self.stream_output_observed
+                .store(false, std::sync::atomic::Ordering::SeqCst);
+        }
+
+        fn stream_output_observed(&self) -> bool {
+            self.stream_output_observed
+                .load(std::sync::atomic::Ordering::SeqCst)
+        }
+    }
+
     #[tokio::test]
     async fn retry_exhaustion_surfaces_typed_terminal_failure() {
         use crate::retry::RetryPolicy;
@@ -8572,6 +9099,182 @@ mod tests {
             actual_delay >= hint,
             "retry delay ({actual_delay:?}) must be at least the server hint ({hint:?})",
         );
+    }
+
+    #[tokio::test]
+    async fn model_fallback_activation_filters_tools_before_retry() {
+        use crate::retry::RetryPolicy;
+
+        let client = Arc::new(FallbackActivatingClient::new());
+        let tools = Arc::new(FullToolDispatcher::new(&[
+            crate::VIEW_IMAGE_TOOL_NAME,
+            "shell",
+        ]));
+        let mut agent = with_test_turn_state_handle(AgentBuilder::new())
+            .with_tool_visibility_owner(explicit_test_visibility_owner())
+            .retry_policy(RetryPolicy {
+                max_retries: 1,
+                initial_delay: Duration::from_millis(1),
+                max_delay: Duration::from_millis(1),
+                multiplier: 1.0,
+                call_timeout: None,
+            })
+            .build_standalone(client.clone(), tools, Arc::new(NoopStore))
+            .await;
+
+        let result = agent
+            .run("trigger fallback".to_string().into())
+            .await
+            .expect("fallback retry should succeed");
+
+        assert_eq!(result.text, "ok after fallback");
+        let seen_tools = client.seen_tools();
+        assert_eq!(seen_tools.len(), 2);
+        assert!(
+            seen_tools[0].contains(&crate::VIEW_IMAGE_TOOL_NAME.to_string()),
+            "primary should see the initial visible tool set"
+        );
+        assert!(
+            !seen_tools[1].contains(&crate::VIEW_IMAGE_TOOL_NAME.to_string()),
+            "fallback retry should hide view_image for a downgraded model"
+        );
+        assert!(
+            seen_tools[1].contains(&"shell".to_string()),
+            "non-filtered tools should remain visible"
+        );
+        let notices = client.seen_notice_bodies();
+        assert!(
+            notices.get(1).is_some_and(|bodies| {
+                bodies.iter().any(|body| {
+                    body.contains("switched from model")
+                        && body.contains("Hidden tools for the fallback model: view_image")
+                })
+            }),
+            "fallback retry should inform the active model about the switch and hidden tool"
+        );
+        let seen_max_tokens = client.seen_max_tokens();
+        assert_eq!(seen_max_tokens.len(), 2);
+        assert_eq!(seen_max_tokens[1], 2048);
+        assert!(
+            seen_max_tokens[0] >= seen_max_tokens[1],
+            "fallback retry should clamp max tokens to the backup model limit"
+        );
+        let seen_provider_params = client.seen_provider_params();
+        assert_eq!(seen_provider_params.len(), 2);
+        assert_eq!(seen_provider_params[0], None);
+        assert_eq!(
+            seen_provider_params[1]
+                .as_ref()
+                .and_then(|params| params.temperature),
+            Some(0.37)
+        );
+        assert_eq!(
+            seen_provider_params[1]
+                .as_ref()
+                .and_then(|params| params.max_output_tokens),
+            Some(777)
+        );
+        let snapshot = agent
+            .tool_scope_snapshot()
+            .expect("effective tool scope snapshot");
+        assert!(
+            !snapshot
+                .visible_names
+                .iter()
+                .any(|name| name.as_str() == crate::VIEW_IMAGE_TOOL_NAME),
+            "reported live tool scope should match active fallback model visibility"
+        );
+        assert_eq!(
+            snapshot.capability_base_filter,
+            ToolFilter::Deny(
+                [crate::VIEW_IMAGE_TOOL_NAME.to_string()]
+                    .into_iter()
+                    .collect()
+            )
+        );
+
+        let second = agent
+            .run("sticky fallback".to_string().into())
+            .await
+            .expect("subsequent turn should keep using fallback model");
+        assert_eq!(second.text, "ok after fallback");
+        let seen_tools = client.seen_tools();
+        assert_eq!(seen_tools.len(), 3);
+        assert!(
+            !seen_tools[2].contains(&crate::VIEW_IMAGE_TOOL_NAME.to_string()),
+            "subsequent fallback turn should keep the downgraded tool surface"
+        );
+        let seen_max_tokens = client.seen_max_tokens();
+        assert_eq!(seen_max_tokens.len(), 3);
+        assert_eq!(
+            seen_max_tokens[2], 2048,
+            "subsequent fallback turn should keep the backup model max-token clamp"
+        );
+    }
+
+    #[tokio::test]
+    async fn model_fallback_does_not_switch_after_visible_stream_output() {
+        use crate::retry::RetryPolicy;
+
+        let client = Arc::new(PartialOutputThenRecoverClient::new());
+        let mut agent = with_test_turn_state_handle(AgentBuilder::new())
+            .retry_policy(RetryPolicy {
+                max_retries: 1,
+                initial_delay: Duration::ZERO,
+                max_delay: Duration::ZERO,
+                multiplier: 1.0,
+                call_timeout: None,
+            })
+            .build_standalone(client.clone(), Arc::new(NoTools), Arc::new(NoopStore))
+            .await;
+
+        let result = agent
+            .run("partial stream then late error".to_string().into())
+            .await
+            .expect("same-model retry should recover after post-stream error");
+
+        assert_eq!(result.text, "ok after same-model retry");
+        assert_eq!(client.calls(), 2);
+        assert!(
+            !client.fallback_committed(),
+            "fallback must not activate after user-visible stream output escaped"
+        );
+    }
+
+    #[test]
+    fn model_fallback_safety_gate_rejects_timeout_failures() {
+        assert!(!super::fallback_activation_is_pre_stream_safe(
+            &AgentError::llm(
+                "mock",
+                LlmFailureReason::CallTimeout { duration_ms: 1000 },
+                "call timed out",
+            ),
+            false,
+        ));
+        assert!(!super::fallback_activation_is_pre_stream_safe(
+            &AgentError::llm(
+                "mock",
+                LlmFailureReason::NetworkTimeout { duration_ms: 1000 },
+                "network timed out",
+            ),
+            false,
+        ));
+        assert!(super::fallback_activation_is_pre_stream_safe(
+            &AgentError::llm(
+                "mock",
+                LlmFailureReason::InvalidModel("removed".to_string()),
+                "model removed",
+            ),
+            false,
+        ));
+        assert!(!super::fallback_activation_is_pre_stream_safe(
+            &AgentError::llm(
+                "mock",
+                LlmFailureReason::InvalidModel("removed".to_string()),
+                "model removed after partial output",
+            ),
+            true,
+        ));
     }
 
     /// Integration test: rate-limited error WITHOUT a hint uses the 30s floor,
@@ -8823,6 +9526,147 @@ mod tests {
         }
     }
 
+    struct ExtractionFallbackOverrideClient {
+        active_fallback: std::sync::atomic::AtomicBool,
+        call_count: std::sync::atomic::AtomicUsize,
+        seen_provider_params:
+            Mutex<Vec<Option<crate::lifecycle::run_primitive::ProviderParamsOverride>>>,
+    }
+
+    impl ExtractionFallbackOverrideClient {
+        fn new() -> Self {
+            Self {
+                active_fallback: std::sync::atomic::AtomicBool::new(false),
+                call_count: std::sync::atomic::AtomicUsize::new(0),
+                seen_provider_params: Mutex::new(Vec::new()),
+            }
+        }
+
+        fn seen_provider_params(
+            &self,
+        ) -> Vec<Option<crate::lifecycle::run_primitive::ProviderParamsOverride>> {
+            self.seen_provider_params.lock().unwrap().clone()
+        }
+    }
+
+    #[async_trait]
+    impl AgentLlmClient for ExtractionFallbackOverrideClient {
+        async fn stream_response(
+            &self,
+            _messages: &[Message],
+            _tools: &[Arc<ToolDef>],
+            _max_tokens: u32,
+            _temperature: Option<f32>,
+            provider_params: Option<&crate::lifecycle::run_primitive::ProviderParamsOverride>,
+        ) -> Result<super::LlmStreamResult, AgentError> {
+            self.seen_provider_params
+                .lock()
+                .unwrap()
+                .push(provider_params.cloned());
+            let call = self
+                .call_count
+                .fetch_add(1, std::sync::atomic::Ordering::SeqCst)
+                + 1;
+
+            match call {
+                1 => Ok(text_response("main answer")),
+                2 => Err(AgentError::llm(
+                    "openai",
+                    crate::error::LlmFailureReason::ProviderError(
+                        crate::error::LlmProviderError::retryable(
+                            crate::error::LlmProviderErrorKind::ServerOverloaded,
+                            serde_json::json!({"message": "extraction retryable failure"}),
+                        ),
+                    ),
+                    "extraction retryable failure",
+                )),
+                3 => Ok(text_response(r#"{"answer": "42"}"#)),
+                _ => Err(AgentError::InternalError(
+                    "ExtractionFallbackOverrideClient: unexpected extra call".to_string(),
+                )),
+            }
+        }
+
+        fn provider(&self) -> crate::provider::Provider {
+            if self
+                .active_fallback
+                .load(std::sync::atomic::Ordering::SeqCst)
+            {
+                crate::provider::Provider::Anthropic
+            } else {
+                crate::provider::Provider::OpenAI
+            }
+        }
+
+        fn model(&self) -> &'static str {
+            if self
+                .active_fallback
+                .load(std::sync::atomic::Ordering::SeqCst)
+            {
+                "claude-backup"
+            } else {
+                "gpt-primary"
+            }
+        }
+
+        fn prepare_model_fallback(
+            &self,
+            _failure: &AgentError,
+        ) -> Option<crate::AgentLlmFallbackSwitch> {
+            use crate::lifecycle::run_primitive::{
+                AnthropicProviderTag, OpaqueProviderBody, ProviderParamsOverride, ProviderTag,
+            };
+
+            if self
+                .active_fallback
+                .load(std::sync::atomic::Ordering::SeqCst)
+            {
+                return None;
+            }
+
+            Some(crate::AgentLlmFallbackSwitch {
+                previous_identity: crate::SessionLlmIdentity {
+                    model: "gpt-primary".to_string(),
+                    provider: crate::provider::Provider::OpenAI,
+                    self_hosted_server_id: None,
+                    provider_params: None,
+                    auth_binding: None,
+                },
+                new_identity: crate::SessionLlmIdentity {
+                    model: "claude-backup".to_string(),
+                    provider: crate::provider::Provider::Anthropic,
+                    self_hosted_server_id: None,
+                    provider_params: None,
+                    auth_binding: None,
+                },
+                request_policy: crate::SessionLlmRequestPolicy {
+                    model: "claude-backup".to_string(),
+                    provider_params: Some(ProviderParamsOverride {
+                        provider_tag: Some(ProviderTag::Anthropic(AnthropicProviderTag {
+                            web_search: Some(OpaqueProviderBody::from_value(
+                                &serde_json::json!({"type": "web_search"}),
+                            )),
+                            ..Default::default()
+                        })),
+                        ..Default::default()
+                    }),
+                    provider_tool_defaults: None,
+                },
+                capability_base_filter: ToolFilter::All,
+                context_window: Some(128_000),
+                max_output_tokens: Some(4096),
+                skipped_targets: Vec::new(),
+            })
+        }
+
+        fn commit_model_fallback(&self, identity: &crate::SessionLlmIdentity) {
+            if identity.provider == crate::provider::Provider::Anthropic {
+                self.active_fallback
+                    .store(true, std::sync::atomic::Ordering::SeqCst);
+            }
+        }
+    }
+
     fn text_response(text: &str) -> super::LlmStreamResult {
         super::LlmStreamResult::new(
             vec![AssistantBlock::Text {
@@ -8885,6 +9729,79 @@ mod tests {
             2,
             "expect 1 agentic + 1 extraction call"
         );
+    }
+
+    #[tokio::test]
+    async fn extraction_fallback_reapplies_structured_output_and_clears_native_search() {
+        use crate::lifecycle::run_primitive::ProviderTag;
+        use crate::retry::RetryPolicy;
+
+        let schema = crate::types::OutputSchema::new(serde_json::json!({
+            "type": "object",
+            "properties": {
+                "answer": { "type": "string" }
+            },
+            "required": ["answer"]
+        }))
+        .unwrap();
+
+        let client = Arc::new(ExtractionFallbackOverrideClient::new());
+        let mut agent = with_test_turn_state_handle(AgentBuilder::new())
+            .output_schema(schema)
+            .retry_policy(RetryPolicy {
+                max_retries: 1,
+                initial_delay: Duration::ZERO,
+                max_delay: Duration::ZERO,
+                multiplier: 1.0,
+                call_timeout: None,
+            })
+            .build_standalone(client.clone(), Arc::new(NoTools), Arc::new(NoopStore))
+            .await;
+
+        let result = agent
+            .run("extract after fallback".to_string().into())
+            .await
+            .expect("extraction fallback should retry and validate structured output");
+
+        assert_eq!(result.structured_output.unwrap()["answer"], "42");
+        let seen_params = client.seen_provider_params();
+        assert_eq!(
+            seen_params.len(),
+            3,
+            "expected main call, failed extraction call, and fallback extraction retry"
+        );
+        match seen_params[1]
+            .as_ref()
+            .and_then(|params| params.provider_tag.as_ref())
+        {
+            Some(ProviderTag::OpenAi(tag)) => {
+                assert!(
+                    tag.structured_output.is_some(),
+                    "primary extraction call should carry structured output"
+                );
+                assert_eq!(
+                    tag.web_search, None,
+                    "primary extraction call must disable provider-native web search"
+                );
+            }
+            other => panic!("expected OpenAI extraction params, got {other:?}"),
+        }
+        match seen_params[2]
+            .as_ref()
+            .and_then(|params| params.provider_tag.as_ref())
+        {
+            Some(ProviderTag::Anthropic(tag)) => {
+                assert!(
+                    tag.structured_output.is_some(),
+                    "fallback extraction retry should carry structured output for the new provider"
+                );
+                assert_eq!(
+                    tag.web_search, None,
+                    "fallback extraction retry must not re-enable provider-native web search"
+                );
+            }
+            other => panic!("expected Anthropic fallback extraction params, got {other:?}"),
+        }
     }
 
     #[tokio::test]

--- a/meerkat-core/src/config.rs
+++ b/meerkat-core/src/config.rs
@@ -46,6 +46,7 @@ pub struct Config {
     pub skills: crate::skills_config::SkillsConfig,
     pub self_hosted: SelfHostedConfig,
     pub provider_tools: ProviderToolsConfig,
+    pub model_fallback: ModelFallbackConfig,
     pub presentation: PresentationConfig,
     /// Realm-scoped connection sets (backend profiles, auth profiles,
     /// bindings). TOML keys use the singular `[realm.<id>.*]` namespace
@@ -82,6 +83,7 @@ impl Default for Config {
             skills: crate::skills_config::SkillsConfig::default(),
             self_hosted: SelfHostedConfig::default(),
             provider_tools: ProviderToolsConfig::default(),
+            model_fallback: ModelFallbackConfig::default(),
             presentation: PresentationConfig::default(),
             realm: BTreeMap::new(),
         }
@@ -346,6 +348,11 @@ impl Config {
                 self.hooks.background_max_concurrency = other.hooks.background_max_concurrency;
             }
             self.hooks.entries.extend(other.hooks.entries);
+        }
+        if other.model_fallback.use_catalog_default_chain {
+            self.model_fallback = ModelFallbackConfig::default();
+        } else if other.model_fallback != ModelFallbackConfig::default() {
+            self.model_fallback = other.model_fallback;
         }
     }
 
@@ -1192,6 +1199,54 @@ pub struct ProviderToolsConfig {
     pub anthropic: AnthropicProviderToolsConfig,
     pub openai: OpenAiProviderToolsConfig,
     pub gemini: GeminiProviderToolsConfig,
+}
+
+/// Ordered model failover policy used when a turn reaches a recoverable LLM
+/// failure boundary.
+///
+/// Empty `chain` means "use the catalog-owned default fallback chain" at the
+/// factory seam. Core keeps this provider-data-free; the `meerkat` facade
+/// resolves catalog defaults and builds concrete clients.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(default)]
+pub struct ModelFallbackConfig {
+    /// Enables runtime model failover for factory-built agents.
+    pub enabled: bool,
+    /// When true in a higher-precedence layer, restore the catalog-owned
+    /// default chain (`enabled = true`, empty `chain`) over an inherited
+    /// disabled/custom fallback policy.
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub use_catalog_default_chain: bool,
+    /// Ordered operator-provided backup targets.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub chain: Vec<ModelFallbackTarget>,
+}
+
+impl Default for ModelFallbackConfig {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            use_catalog_default_chain: false,
+            chain: Vec::new(),
+        }
+    }
+}
+
+/// One configured model fallback target.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct ModelFallbackTarget {
+    /// Model id, resolved through the effective [`crate::ModelRegistry`].
+    pub model: String,
+    /// Optional typed provider override. When omitted, registry ownership of
+    /// `model` supplies the provider.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub provider: Option<crate::Provider>,
+    /// Optional realm-scoped auth binding for this target. When omitted, the
+    /// provider's default binding is resolved by the existing provider-runtime
+    /// registry.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub auth_binding: Option<crate::AuthBindingRef>,
 }
 
 /// Anthropic provider-native tool defaults.
@@ -2043,6 +2098,10 @@ pub struct CommandRuntimeConfig {
 
 fn default_http_method() -> String {
     "POST".to_string()
+}
+
+fn is_false(value: &bool) -> bool {
+    !*value
 }
 
 /// Typed payload for a [`HookRuntimeKind::Http`] adapter.
@@ -3272,6 +3331,70 @@ call_timeout = "30s"
         let toml_str = toml::to_string(&config.provider_tools).unwrap();
         let parsed: ProviderToolsConfig = toml::from_str(&toml_str).unwrap();
         assert_eq!(parsed, config.provider_tools);
+    }
+
+    #[test]
+    fn test_model_fallback_defaults_enabled_with_catalog_chain() {
+        let config = Config::default();
+        assert!(config.model_fallback.enabled);
+        assert!(config.model_fallback.chain.is_empty());
+    }
+
+    #[test]
+    fn test_model_fallback_chain_parses_typed_targets() {
+        let config: Config = toml::from_str(
+            r#"
+[model_fallback]
+enabled = true
+
+[[model_fallback.chain]]
+model = "backup-openai"
+provider = "openai"
+
+[[model_fallback.chain]]
+model = "backup-anthropic"
+provider = "anthropic"
+"#,
+        )
+        .unwrap();
+
+        assert!(config.model_fallback.enabled);
+        assert_eq!(config.model_fallback.chain.len(), 2);
+        assert_eq!(config.model_fallback.chain[0].model, "backup-openai");
+        assert_eq!(
+            config.model_fallback.chain[0].provider,
+            Some(crate::Provider::OpenAI)
+        );
+        assert_eq!(
+            config.model_fallback.chain[1].provider,
+            Some(crate::Provider::Anthropic)
+        );
+    }
+
+    #[test]
+    fn test_model_fallback_catalog_default_reset_overrides_custom_layer() {
+        let mut config: Config = toml::from_str(
+            r#"
+[model_fallback]
+enabled = false
+
+[[model_fallback.chain]]
+model = "backup-openai"
+provider = "openai"
+"#,
+        )
+        .unwrap();
+        let reset: Config = toml::from_str(
+            r"
+[model_fallback]
+use_catalog_default_chain = true
+",
+        )
+        .unwrap();
+
+        config.merge(reset);
+
+        assert_eq!(config.model_fallback, ModelFallbackConfig::default());
     }
 
     #[test]

--- a/meerkat-core/src/config_template.toml
+++ b/meerkat-core/src/config_template.toml
@@ -56,6 +56,19 @@ web_search = true
 [provider_tools.gemini]
 google_search = true
 
+[model_fallback]
+# When enabled, factory-built agents try an ordered backup model after typed
+# recoverable LLM failures such as rate limits, missing models, provider
+# overload, auth failures, and context overflow. Omit `chain` to use the
+# catalog-owned provider default chain.
+enabled = true
+# Set `use_catalog_default_chain = true` in a higher-precedence config layer to
+# restore the built-in catalog chain over an inherited disabled/custom policy.
+# [[model_fallback.chain]]
+# model = "claude-opus-4-8"
+# provider = "anthropic"
+# auth_binding = { realm = "anthropic", binding = "default" }
+
 [presentation.html]
 # Used by `rkat run --html` / `--browser` unless overridden per run.
 default_template = "polished"

--- a/meerkat-core/src/lib.rs
+++ b/meerkat-core/src/lib.rs
@@ -87,12 +87,12 @@ pub mod web_search;
 // Re-export main types at crate root
 pub use agent::{
     Agent, AgentBuildPolicyError, AgentBuilder, AgentExecutionSnapshot, AgentLlmClient,
-    AgentLlmClientDecorator, AgentRunner, AgentSessionStore, AgentToolDispatcher, BindOutcome,
-    CancelAfterBoundaryCommand, CancelAfterBoundarySender, CommsCapabilityError, CommsRuntime,
-    CurrentTurnContent, CurrentTurnImageRef, DefaultSystemPromptPolicy, DispatcherCapabilities,
-    ExternalToolUpdate, FilteredToolDispatcher, LlmStreamResult, SnapshotProjectionError,
-    SystemContextStateError, ToolDispatchContext, select_tool_catalog_mode,
-    should_compose_tool_catalog_control_plane,
+    AgentLlmClientDecorator, AgentLlmFallbackSkippedTarget, AgentLlmFallbackSwitch, AgentRunner,
+    AgentSessionStore, AgentToolDispatcher, BindOutcome, CancelAfterBoundaryCommand,
+    CancelAfterBoundarySender, CommsCapabilityError, CommsRuntime, CurrentTurnContent,
+    CurrentTurnImageRef, DefaultSystemPromptPolicy, DispatcherCapabilities, ExternalToolUpdate,
+    FilteredToolDispatcher, LlmStreamResult, SnapshotProjectionError, SystemContextStateError,
+    ToolDispatchContext, select_tool_catalog_mode, should_compose_tool_catalog_control_plane,
 };
 pub use approval::{
     ApprovalActionKind, ApprovalDecision, ApprovalDecisionRecord, ApprovalError, ApprovalId,

--- a/meerkat-llm-core/src/adapter.rs
+++ b/meerkat-llm-core/src/adapter.rs
@@ -11,6 +11,7 @@ use meerkat_core::{
     ToolDef, Usage,
 };
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 use tokio::sync::mpsc;
 
 use crate::block_assembler::BlockAssembler;
@@ -29,6 +30,10 @@ pub struct LlmClientAdapter {
     provider_params: Option<ProviderTag>,
     /// Per-interaction event tap for streaming events to subscribers.
     event_tap: meerkat_core::EventTap,
+    /// True after this adapter emitted user-visible streaming output for the
+    /// current call. The agent retry loop reads this to avoid cross-model
+    /// fallback after partial output has escaped.
+    stream_output_observed: Arc<AtomicBool>,
 }
 
 impl LlmClientAdapter {
@@ -39,6 +44,7 @@ impl LlmClientAdapter {
             event_tx: None,
             provider_params: None,
             event_tap: meerkat_core::new_event_tap(),
+            stream_output_observed: Arc::new(AtomicBool::new(false)),
         }
     }
 
@@ -54,6 +60,13 @@ impl LlmClientAdapter {
             event_tx: Some(event_tx),
             provider_params: None,
             event_tap: meerkat_core::new_event_tap(),
+            stream_output_observed: Arc::new(AtomicBool::new(false)),
+        }
+    }
+
+    fn mark_visible_stream_output(&self, text: &str) {
+        if !text.trim().is_empty() {
+            self.stream_output_observed.store(true, Ordering::SeqCst);
         }
     }
 
@@ -227,6 +240,7 @@ impl AgentLlmClient for LlmClientAdapter {
                 Ok(event) => match event {
                     LlmEvent::TextDelta { delta, meta } => {
                         assembler.on_text_delta(&delta, meta);
+                        self.mark_visible_stream_output(&delta);
                         meerkat_core::tap_try_send(
                             &self.event_tap,
                             &AgentEvent::TextDelta {
@@ -242,6 +256,7 @@ impl AgentLlmClient for LlmClientAdapter {
                             reasoning_started = true;
                             assembler.on_reasoning_start();
                         }
+                        self.mark_visible_stream_output(&delta);
                         if let Err(e) = assembler.on_reasoning_delta(&delta) {
                             tracing::warn!(?e, "orphaned reasoning delta");
                         }
@@ -256,6 +271,7 @@ impl AgentLlmClient for LlmClientAdapter {
                         }
                     }
                     LlmEvent::ReasoningComplete { text, meta } => {
+                        self.mark_visible_stream_output(&text);
                         if !reasoning_started {
                             assembler.on_reasoning_start();
                             let _ = assembler.on_reasoning_delta(&text);
@@ -266,6 +282,7 @@ impl AgentLlmClient for LlmClientAdapter {
                         let reasoning_text = assembler.current_reasoning_text();
                         assembler.on_reasoning_complete(meta);
                         reasoning_started = false;
+                        self.mark_visible_stream_output(&reasoning_text);
                         meerkat_core::tap_try_send(
                             &self.event_tap,
                             &AgentEvent::ReasoningComplete {
@@ -365,6 +382,7 @@ impl AgentLlmClient for LlmClientAdapter {
         if reasoning_started {
             let reasoning_text = assembler.current_reasoning_text();
             assembler.on_reasoning_complete(None);
+            self.mark_visible_stream_output(&reasoning_text);
             meerkat_core::tap_try_send(
                 &self.event_tap,
                 &AgentEvent::ReasoningComplete {
@@ -392,6 +410,14 @@ impl AgentLlmClient for LlmClientAdapter {
 
     fn model(&self) -> &str {
         &self.model
+    }
+
+    fn begin_stream_output_observation(&self) {
+        self.stream_output_observed.store(false, Ordering::SeqCst);
+    }
+
+    fn stream_output_observed(&self) -> bool {
+        self.stream_output_observed.load(Ordering::SeqCst)
     }
 
     fn compile_schema(&self, output_schema: &OutputSchema) -> Result<CompiledSchema, SchemaError> {
@@ -584,6 +610,48 @@ mod tests {
         assert!(
             meerkat_core::assistant_blocks_have_visible_or_actionable_output(result.blocks()),
             "non-empty reasoning delta should survive to the core commit predicate"
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn adapter_marks_visible_stream_output_before_done_error() -> Result<(), String> {
+        let adapter = LlmClientAdapter::new(
+            Arc::new(ScriptedClient {
+                events: vec![
+                    Ok(LlmEvent::TextDelta {
+                        delta: "partial answer".to_string(),
+                        meta: None,
+                    }),
+                    Ok(LlmEvent::Done {
+                        outcome: LlmDoneOutcome::Error {
+                            error: LlmError::ServerOverloaded,
+                        },
+                    }),
+                ],
+            }),
+            "scripted-model".to_string(),
+        );
+
+        adapter.begin_stream_output_observation();
+        let err = match adapter
+            .stream_response(
+                &[Message::User(UserMessage::text("stream then fail"))],
+                &[],
+                1024,
+                None,
+                None,
+            )
+            .await
+        {
+            Ok(_) => return Err("late done error should surface".to_string()),
+            Err(err) => err,
+        };
+
+        assert!(matches!(err, AgentError::Llm { .. }));
+        assert!(
+            adapter.stream_output_observed(),
+            "partial text delta should suppress cross-model fallback on the failed call"
         );
         Ok(())
     }

--- a/meerkat/src/factory.rs
+++ b/meerkat/src/factory.rs
@@ -87,6 +87,8 @@ use tokio_with_wasm::alias::sync::RwLock;
 #[cfg(target_arch = "wasm32")]
 use tokio_with_wasm::alias::sync::mpsc;
 
+use crate::model_fallback::{ModelFallbackCandidate, ModelFallbackClient};
+
 #[cfg(feature = "comms")]
 use crate::compose_tools_with_comms;
 #[cfg(not(target_arch = "wasm32"))]
@@ -3028,6 +3030,145 @@ impl AgentFactory {
         })
     }
 
+    fn model_fallback_identities(
+        &self,
+        config: &Config,
+        registry: &ModelRegistry,
+        current: &SessionLlmIdentity,
+    ) -> Result<Vec<SessionLlmIdentity>, BuildAgentError> {
+        if !config.model_fallback.enabled {
+            return Ok(Vec::new());
+        }
+
+        let catalog_default_chain = config.model_fallback.chain.is_empty();
+        let preferred_realm = current
+            .auth_binding
+            .as_ref()
+            .filter(|auth_binding| !auth_binding.is_env_default())
+            .map(|auth_binding| auth_binding.realm.clone());
+        let mut targets: Vec<(String, Option<Provider>, Option<AuthBindingRef>)> =
+            if catalog_default_chain {
+                let mut defaults = Vec::new();
+                for provider in meerkat_models::provider_priority() {
+                    let model = match provider {
+                        Provider::Anthropic => config.models.anthropic.clone(),
+                        Provider::OpenAI => config.models.openai.clone(),
+                        Provider::Gemini => config.models.gemini.clone(),
+                        _ => String::new(),
+                    };
+                    let model = if model.is_empty() {
+                        meerkat_models::default_model(*provider)
+                            .map(str::to_string)
+                            .unwrap_or_default()
+                    } else {
+                        model
+                    };
+                    if !model.is_empty() {
+                        defaults.push((model, Some(*provider), None));
+                    }
+                }
+                defaults.push((
+                    meerkat_models::global_default_model().to_string(),
+                    None,
+                    None,
+                ));
+                defaults
+            } else {
+                config
+                    .model_fallback
+                    .chain
+                    .iter()
+                    .map(|target| {
+                        (
+                            target.model.clone(),
+                            target.provider,
+                            target.auth_binding.clone(),
+                        )
+                    })
+                    .collect()
+            };
+
+        let mut identities = Vec::new();
+        for (model, provider_override, auth_binding) in targets.drain(..) {
+            let provider = if let Some(provider) = provider_override {
+                if let Some(reason) = registry.provider_override_mismatch_reason(provider, &model) {
+                    return Err(BuildAgentError::Config(reason));
+                }
+                provider
+            } else {
+                registry
+                    .entry(&model)
+                    .map(|entry| entry.provider)
+                    .ok_or_else(|| BuildAgentError::UnknownProvider {
+                        model: model.clone(),
+                    })?
+            };
+            let self_hosted_server_id = if matches!(provider, Provider::SelfHosted) {
+                registry
+                    .entry_for_provider(Provider::SelfHosted, &model)
+                    .and_then(|entry| entry.self_hosted.as_ref())
+                    .map(|server| server.server_id.clone())
+            } else {
+                None
+            };
+            let auth_binding = match (auth_binding, preferred_realm.as_ref()) {
+                (Some(auth_binding), _) => Some(auth_binding),
+                (None, Some(realm)) => {
+                    let resolved = Self::resolve_realm_binding_candidates_for_provider(
+                        config,
+                        provider,
+                        None,
+                        Some(realm),
+                    )
+                    .ok()
+                    .and_then(|candidates| {
+                        candidates
+                            .into_iter()
+                            .find(|target| {
+                                if catalog_default_chain {
+                                    target.auth_binding.realm == *realm
+                                        && !target.auth_binding.is_env_default()
+                                } else {
+                                    true
+                                }
+                            })
+                            .map(|target| target.auth_binding)
+                    });
+                    if catalog_default_chain && resolved.is_none() {
+                        continue;
+                    }
+                    resolved
+                }
+                (None, None) => None,
+            };
+            let identity = SessionLlmIdentity {
+                model,
+                provider,
+                self_hosted_server_id,
+                provider_params: None,
+                auth_binding,
+            };
+            if identity.model == current.model
+                && identity.provider == current.provider
+                && identity.self_hosted_server_id == current.self_hosted_server_id
+                && identity.auth_binding == current.auth_binding
+            {
+                continue;
+            }
+            if identities.iter().any(|seen: &SessionLlmIdentity| {
+                seen.model == identity.model
+                    && seen.provider == identity.provider
+                    && seen.self_hosted_server_id == identity.self_hosted_server_id
+                    && seen.auth_binding == identity.auth_binding
+            }) {
+                continue;
+            }
+            identities.push(identity);
+        }
+
+        Ok(identities)
+    }
+
     #[cfg(feature = "openai")]
     fn self_hosted_client_spec_for_identity(
         &self,
@@ -4032,6 +4173,8 @@ impl AgentFactory {
                 })?;
         }
         let event_tap = meerkat_core::new_event_tap();
+        let agent_llm_client_was_overridden = build_config.agent_llm_client_override.is_some();
+        let raw_llm_client_was_overridden = build_config.llm_client_override.is_some();
         let llm_adapter: Arc<dyn AgentLlmClient> =
             if let Some(agent_client) = build_config.agent_llm_client_override.take() {
                 agent_client
@@ -4062,6 +4205,103 @@ impl AgentFactory {
             llm_adapter,
             build_config.agent_llm_client_decorator.as_ref(),
         );
+        let llm_adapter = if !agent_llm_client_was_overridden
+            && !raw_llm_client_was_overridden
+            && config.model_fallback.enabled
+        {
+            let explicit_fallback_chain = !config.model_fallback.chain.is_empty();
+            let primary_request_policy = self.request_policy_for_llm_identity(
+                config,
+                &resolved_llm_identity,
+                build_config.override_web_search,
+            )?;
+            let mut candidates = vec![ModelFallbackCandidate {
+                identity: resolved_llm_identity.clone(),
+                request_policy: primary_request_policy,
+                client: Arc::clone(&llm_adapter),
+                capability_base_filter: capability_base_filter_override
+                    .clone()
+                    .unwrap_or(ToolFilter::All),
+                context_window: registry
+                    .entry(&model)
+                    .and_then(|entry| entry.context_window),
+                max_output_tokens: registry
+                    .entry(&model)
+                    .and_then(|entry| entry.max_output_tokens),
+            }];
+            let auth_lease_handle = match &build_config.runtime_build_mode {
+                RuntimeBuildMode::SessionOwned(bindings) => Some(bindings.auth_lease().clone()),
+                RuntimeBuildMode::StandaloneEphemeral => None,
+            };
+            for identity in
+                self.model_fallback_identities(config, &registry, &resolved_llm_identity)?
+            {
+                let raw_client = match self
+                    .build_llm_client_for_identity_with_auth_lease(
+                        config,
+                        &identity,
+                        auth_lease_handle.clone(),
+                    )
+                    .await
+                {
+                    Ok(client) => client,
+                    Err(error) if explicit_fallback_chain => {
+                        return Err(BuildAgentError::LlmClient(error));
+                    }
+                    Err(error) => {
+                        tracing::debug!(
+                            model = %identity.model,
+                            provider = %identity.provider.as_str(),
+                            error = %error,
+                            "skipping unavailable catalog-default model fallback candidate"
+                        );
+                        continue;
+                    }
+                };
+                let mut adapter = match build_config.event_tx.clone() {
+                    Some(tx) => {
+                        LlmClientAdapter::with_event_channel(raw_client, identity.model.clone(), tx)
+                    }
+                    None => LlmClientAdapter::new(raw_client, identity.model.clone()),
+                };
+                adapter = adapter.with_event_tap(event_tap.clone());
+                let decorated = Self::decorate_agent_llm_client(
+                    Arc::new(adapter),
+                    build_config.agent_llm_client_decorator.as_ref(),
+                );
+                let capability_base_filter = registry
+                    .profile_for_provider(identity.provider, &identity.model)
+                    .map(|profile| {
+                        meerkat_core::capability_base_filter_for_image_tool_results(
+                            profile.image_tool_results,
+                        )
+                    })
+                    .unwrap_or(ToolFilter::All);
+                let request_policy = self.request_policy_for_llm_identity(
+                    config,
+                    &identity,
+                    build_config.override_web_search,
+                )?;
+                candidates.push(ModelFallbackCandidate {
+                    context_window: registry
+                        .entry_for_provider(identity.provider, &identity.model)
+                        .and_then(|entry| entry.context_window),
+                    max_output_tokens: registry
+                        .entry_for_provider(identity.provider, &identity.model)
+                        .and_then(|entry| entry.max_output_tokens),
+                    capability_base_filter,
+                    request_policy,
+                    identity,
+                    client: decorated,
+                });
+            }
+            match ModelFallbackClient::new(candidates) {
+                Some(client) => Arc::new(client) as Arc<dyn AgentLlmClient>,
+                None => llm_adapter,
+            }
+        } else {
+            llm_adapter
+        };
 
         // 5. Resolve max_tokens
         let max_tokens = build_config.max_tokens.unwrap_or(config.max_tokens);
@@ -5379,6 +5619,7 @@ impl AgentFactory {
 mod tests {
     use super::*;
     use async_trait::async_trait;
+    use meerkat_core::config::ModelFallbackTarget;
     #[cfg(feature = "skills")]
     use meerkat_core::skills::{
         SkillDocument, SkillKey, SkillKeyRemap, SkillName, SkillRuntime, SourceIdentityLineage,
@@ -6080,6 +6321,231 @@ mod tests {
 
     fn inline_realm_section(entries: &[(&str, &str)]) -> RealmConfigSection {
         RealmConfigSection::from_inline_api_keys(entries)
+    }
+
+    fn configured_auth_binding(realm: &str, binding: &str) -> AuthBindingRef {
+        AuthBindingRef {
+            realm: RealmId::parse(realm).expect("valid realm"),
+            binding: BindingId::parse(binding).expect("valid binding"),
+            profile: None,
+            origin: meerkat_core::BindingOrigin::Configured,
+        }
+    }
+
+    fn openai_realm_with_bindings(bindings: &[(&str, &str)]) -> RealmConfigSection {
+        let mut section = RealmConfigSection::default();
+        section.backend.insert(
+            "openai_api".to_string(),
+            BackendProfileConfig {
+                provider: "openai".to_string(),
+                backend_kind: "openai_api".to_string(),
+                base_url: None,
+                options: serde_json::Value::Null,
+            },
+        );
+        for (binding_id, secret) in bindings {
+            let auth_id = format!("{binding_id}_auth");
+            section.auth.insert(
+                auth_id.clone(),
+                meerkat_core::AuthProfileConfig {
+                    provider: "openai".to_string(),
+                    auth_method: "api_key".to_string(),
+                    source: CredentialSourceSpec::InlineSecret {
+                        secret: (*secret).to_string(),
+                    },
+                    constraints: Default::default(),
+                    metadata_defaults: Default::default(),
+                },
+            );
+            section.binding.insert(
+                (*binding_id).to_string(),
+                ProviderBindingConfig {
+                    backend_profile: "openai_api".to_string(),
+                    auth_profile: auth_id,
+                    default_model: None,
+                    policy: Default::default(),
+                    provider_default: false,
+                },
+            );
+        }
+        section
+    }
+
+    #[test]
+    fn model_fallback_keeps_same_model_provider_with_different_auth_binding() {
+        let factory = AgentFactory::new(std::env::temp_dir().join("meerkat-test-sessions"));
+        let mut config = Config::default();
+        let primary = configured_auth_binding("dev", "primary_openai");
+        let secondary = configured_auth_binding("dev", "secondary_openai");
+        config.model_fallback.chain = vec![ModelFallbackTarget {
+            model: "gpt-5.5".to_string(),
+            provider: Some(Provider::OpenAI),
+            auth_binding: Some(secondary.clone()),
+        }];
+        let registry = factory.model_registry(&config).expect("model registry");
+        let current = SessionLlmIdentity {
+            model: "gpt-5.5".to_string(),
+            provider: Provider::OpenAI,
+            self_hosted_server_id: None,
+            provider_params: None,
+            auth_binding: Some(primary),
+        };
+
+        let identities = factory
+            .model_fallback_identities(&config, &registry, &current)
+            .expect("fallback identities");
+
+        assert_eq!(identities.len(), 1);
+        assert_eq!(identities[0].model, "gpt-5.5");
+        assert_eq!(identities[0].provider, Provider::OpenAI);
+        assert_eq!(identities[0].auth_binding, Some(secondary));
+    }
+
+    #[test]
+    fn catalog_model_fallback_uses_only_available_bindings_in_selected_realm() {
+        let factory = AgentFactory::new(std::env::temp_dir().join("meerkat-test-sessions"));
+        let mut config = Config::default();
+        config.realm.insert(
+            "team".to_string(),
+            inline_realm_section(&[("openai", "sk-test-openai"), ("anthropic", "sk-ant-test")]),
+        );
+        let registry = factory.model_registry(&config).expect("model registry");
+        let current = SessionLlmIdentity {
+            model: meerkat_models::default_model(Provider::OpenAI)
+                .expect("OpenAI catalog default")
+                .to_string(),
+            provider: Provider::OpenAI,
+            self_hosted_server_id: None,
+            provider_params: None,
+            auth_binding: Some(configured_auth_binding("team", "default_openai")),
+        };
+
+        let identities = factory
+            .model_fallback_identities(&config, &registry, &current)
+            .expect("catalog fallback identities");
+
+        assert!(
+            identities.iter().any(|identity| {
+                identity.provider == Provider::Anthropic
+                    && identity.auth_binding
+                        == Some(configured_auth_binding("team", "default_anthropic"))
+            }),
+            "catalog fallback should include providers registered in the selected realm: {identities:#?}"
+        );
+        assert!(
+            identities.iter().all(|identity| {
+                identity
+                    .auth_binding
+                    .as_ref()
+                    .is_some_and(|auth_binding| auth_binding.realm.as_str() == "team")
+            }),
+            "catalog fallback must not bleed into env/default realms when selected realm auth is in use"
+        );
+        assert!(
+            identities
+                .iter()
+                .all(|identity| identity.provider != Provider::Gemini),
+            "providers not registered in the selected realm should be skipped for the catalog chain"
+        );
+    }
+
+    #[cfg(all(feature = "openai", not(target_arch = "wasm32")))]
+    struct RecordingOpenAiRuntime {
+        calls: Arc<std::sync::Mutex<Vec<AuthBindingRef>>>,
+    }
+
+    #[cfg(all(feature = "openai", not(target_arch = "wasm32")))]
+    #[async_trait::async_trait]
+    impl meerkat_llm_core::provider_runtime::ProviderRuntime for RecordingOpenAiRuntime {
+        fn provider_id(&self) -> Provider {
+            Provider::OpenAI
+        }
+
+        async fn resolve_binding(
+            &self,
+            binding: &meerkat_llm_core::provider_runtime::ValidatedBinding,
+            _env: &meerkat_llm_core::provider_runtime::ResolverEnvironment,
+        ) -> Result<
+            meerkat_llm_core::provider_runtime::ResolvedConnection,
+            meerkat_llm_core::provider_runtime::ProviderAuthError,
+        > {
+            self.calls
+                .lock()
+                .unwrap()
+                .push(binding.auth_binding_ref().clone());
+            Ok(meerkat_llm_core::provider_runtime::ResolvedConnection {
+                provider: Provider::OpenAI,
+                backend: binding.backend(),
+                backend_profile: Arc::clone(binding.backend_profile()),
+                auth_lease: Arc::new(
+                    meerkat_llm_core::provider_runtime::StaticLease::inline_secret(
+                        "sk-test-openai".to_string(),
+                        meerkat_core::AuthMetadata::default(),
+                        None,
+                        "test-openai",
+                    ),
+                ),
+            })
+        }
+
+        fn build_client(
+            &self,
+            _connection: meerkat_llm_core::provider_runtime::ResolvedConnection,
+        ) -> Result<Arc<dyn LlmClient>, meerkat_llm_core::provider_runtime::ProviderClientError>
+        {
+            Ok(Arc::new(meerkat_client::TestClient::default()))
+        }
+    }
+
+    #[cfg(all(feature = "openai", not(target_arch = "wasm32")))]
+    #[tokio::test]
+    async fn explicit_model_fallback_resolves_secondary_auth_binding_for_same_model() {
+        let temp = tempfile::tempdir().unwrap();
+        let calls = Arc::new(std::sync::Mutex::new(Vec::new()));
+        let mut factory = AgentFactory::new(temp.path().join("sessions")).builtins(false);
+        factory.provider_registry = Arc::new(
+            meerkat_llm_core::provider_runtime::ProviderRuntimeRegistry::empty().with_runtime(
+                Arc::new(RecordingOpenAiRuntime {
+                    calls: Arc::clone(&calls),
+                }),
+            ),
+        );
+
+        let primary = configured_auth_binding("dev", "primary_openai");
+        let secondary = configured_auth_binding("dev", "secondary_openai");
+        let mut config = Config::default();
+        config.realm.insert(
+            "dev".to_string(),
+            openai_realm_with_bindings(&[
+                ("primary_openai", "sk-primary"),
+                ("secondary_openai", "sk-secondary"),
+            ]),
+        );
+        config.model_fallback.chain = vec![ModelFallbackTarget {
+            model: "gpt-5.5".to_string(),
+            provider: Some(Provider::OpenAI),
+            auth_binding: Some(secondary.clone()),
+        }];
+
+        let mut build = AgentBuildConfig::new("gpt-5.5");
+        build.provider = Some(Provider::OpenAI);
+        build.auth_binding = Some(primary.clone());
+        build.override_builtins = ToolCategoryOverride::Disable;
+
+        let _agent = factory
+            .build_agent(build, &config)
+            .await
+            .expect("agent should build primary plus fallback clients");
+
+        let calls = calls.lock().unwrap().clone();
+        assert!(
+            calls.contains(&primary),
+            "primary binding should be resolved for the active client"
+        );
+        assert!(
+            calls.contains(&secondary),
+            "same model/provider fallback must still resolve the secondary auth binding"
+        );
     }
 
     #[test]

--- a/meerkat/src/lib.rs
+++ b/meerkat/src/lib.rs
@@ -227,6 +227,7 @@ pub use meerkat_workgraph::{
 
 // AgentFactory and build_agent types
 mod factory;
+mod model_fallback;
 pub use factory::{
     AgentBuildConfig, AgentFactory, BuildAgentError, DynAgent,
     decode_llm_client_override_from_service, encode_llm_client_override_for_service, provider_key,

--- a/meerkat/src/model_fallback.rs
+++ b/meerkat/src/model_fallback.rs
@@ -1,0 +1,335 @@
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use async_trait::async_trait;
+use meerkat_core::error::{AgentError, LlmFailureReason};
+use meerkat_core::lifecycle::run_primitive::ProviderParamsOverride;
+use meerkat_core::schema::{CompiledSchema, SchemaError};
+use meerkat_core::{
+    AgentLlmClient, AgentLlmFallbackSkippedTarget, AgentLlmFallbackSwitch, LlmStreamResult,
+    Provider, SessionLlmIdentity, SessionLlmRequestPolicy, ToolDef, ToolFilter,
+};
+
+pub struct ModelFallbackCandidate {
+    pub identity: SessionLlmIdentity,
+    pub request_policy: SessionLlmRequestPolicy,
+    pub client: Arc<dyn AgentLlmClient>,
+    pub capability_base_filter: ToolFilter,
+    pub context_window: Option<u32>,
+    pub max_output_tokens: Option<u32>,
+}
+
+pub struct ModelFallbackClient {
+    candidates: Vec<ModelFallbackCandidate>,
+    active: AtomicUsize,
+}
+
+impl ModelFallbackClient {
+    pub fn new(candidates: Vec<ModelFallbackCandidate>) -> Option<Self> {
+        (candidates.len() > 1).then_some(Self {
+            candidates,
+            active: AtomicUsize::new(0),
+        })
+    }
+
+    fn active_index(&self) -> usize {
+        self.active
+            .load(Ordering::SeqCst)
+            .min(self.candidates.len().saturating_sub(1))
+    }
+
+    fn context_downgrade_skip_reason(
+        failure: &AgentError,
+        _failed: &ModelFallbackCandidate,
+        next: &ModelFallbackCandidate,
+    ) -> Option<String> {
+        let requested = match failure {
+            AgentError::Llm {
+                reason: LlmFailureReason::ContextExceeded { requested, .. },
+                ..
+            } => *requested,
+            _ => return None,
+        };
+
+        let next_window = next.context_window?;
+        (next_window < requested).then(|| {
+            format!(
+                "context overflow requested {requested} tokens; {next_window}-token fallback cannot recover it"
+            )
+        })
+    }
+}
+
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+impl AgentLlmClient for ModelFallbackClient {
+    async fn stream_response(
+        &self,
+        messages: &[meerkat_core::Message],
+        tools: &[Arc<ToolDef>],
+        max_tokens: u32,
+        temperature: Option<f32>,
+        provider_params: Option<&ProviderParamsOverride>,
+    ) -> Result<LlmStreamResult, AgentError> {
+        let candidate = &self.candidates[self.active_index()];
+        candidate
+            .client
+            .stream_response(messages, tools, max_tokens, temperature, provider_params)
+            .await
+    }
+
+    fn provider(&self) -> Provider {
+        self.candidates[self.active_index()].identity.provider
+    }
+
+    fn model(&self) -> &str {
+        &self.candidates[self.active_index()].identity.model
+    }
+
+    fn prepare_model_fallback(&self, failure: &AgentError) -> Option<AgentLlmFallbackSwitch> {
+        let current_idx = self.active_index();
+        let current = &self.candidates[current_idx];
+        let mut skipped_targets = Vec::new();
+
+        for next_idx in current_idx + 1..self.candidates.len() {
+            let next = &self.candidates[next_idx];
+            if let Some(reason) = Self::context_downgrade_skip_reason(failure, current, next) {
+                skipped_targets.push(AgentLlmFallbackSkippedTarget {
+                    identity: next.identity.clone(),
+                    reason,
+                });
+                continue;
+            }
+            return Some(AgentLlmFallbackSwitch {
+                previous_identity: current.identity.clone(),
+                new_identity: next.identity.clone(),
+                request_policy: next.request_policy.clone(),
+                capability_base_filter: next.capability_base_filter.clone(),
+                context_window: next.context_window,
+                max_output_tokens: next.max_output_tokens,
+                skipped_targets,
+            });
+        }
+
+        None
+    }
+
+    fn commit_model_fallback(&self, identity: &SessionLlmIdentity) {
+        if let Some(idx) = self.candidates.iter().position(|candidate| {
+            candidate.identity.model == identity.model
+                && candidate.identity.provider == identity.provider
+                && candidate.identity.auth_binding == identity.auth_binding
+        }) {
+            self.active.store(idx, Ordering::SeqCst);
+        }
+    }
+
+    fn active_capability_base_filter(&self) -> ToolFilter {
+        self.candidates[self.active_index()]
+            .capability_base_filter
+            .clone()
+    }
+
+    fn active_max_output_tokens(&self) -> Option<u32> {
+        self.candidates[self.active_index()].max_output_tokens
+    }
+
+    fn begin_stream_output_observation(&self) {
+        self.candidates[self.active_index()]
+            .client
+            .begin_stream_output_observation();
+    }
+
+    fn stream_output_observed(&self) -> bool {
+        self.candidates[self.active_index()]
+            .client
+            .stream_output_observed()
+    }
+
+    fn compile_schema(
+        &self,
+        output_schema: &meerkat_core::OutputSchema,
+    ) -> Result<CompiledSchema, SchemaError> {
+        self.candidates[self.active_index()]
+            .client
+            .compile_schema(output_schema)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use meerkat_core::error::{LlmProviderError, LlmProviderErrorKind};
+    use meerkat_core::{AssistantBlock, StopReason, Usage};
+    use tokio::sync::Mutex;
+
+    struct ScriptedClient {
+        provider: Provider,
+        model: String,
+        seen_tools: Arc<Mutex<Vec<Vec<String>>>>,
+    }
+
+    #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+    #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+    impl AgentLlmClient for ScriptedClient {
+        async fn stream_response(
+            &self,
+            _messages: &[meerkat_core::Message],
+            tools: &[Arc<ToolDef>],
+            _max_tokens: u32,
+            _temperature: Option<f32>,
+            _provider_params: Option<&ProviderParamsOverride>,
+        ) -> Result<LlmStreamResult, AgentError> {
+            self.seen_tools.lock().await.push(
+                tools
+                    .iter()
+                    .map(|tool| tool.name.to_string())
+                    .collect::<Vec<_>>(),
+            );
+            Ok(LlmStreamResult::new(
+                vec![AssistantBlock::Text {
+                    text: "ok".to_string(),
+                    meta: None,
+                }],
+                StopReason::EndTurn,
+                Usage::default(),
+            ))
+        }
+
+        fn provider(&self) -> Provider {
+            self.provider
+        }
+
+        fn model(&self) -> &str {
+            &self.model
+        }
+    }
+
+    fn candidate(
+        provider: Provider,
+        model: &str,
+        capability_base_filter: ToolFilter,
+        context_window: Option<u32>,
+        max_output_tokens: Option<u32>,
+        seen_tools: Arc<Mutex<Vec<Vec<String>>>>,
+    ) -> ModelFallbackCandidate {
+        let identity = SessionLlmIdentity {
+            model: model.to_string(),
+            provider,
+            self_hosted_server_id: None,
+            provider_params: None,
+            auth_binding: None,
+        };
+        ModelFallbackCandidate {
+            request_policy: SessionLlmRequestPolicy {
+                model: model.to_string(),
+                provider_params: None,
+                provider_tool_defaults: None,
+            },
+            identity,
+            client: Arc::new(ScriptedClient {
+                provider,
+                model: model.to_string(),
+                seen_tools,
+            }),
+            capability_base_filter,
+            context_window,
+            max_output_tokens,
+        }
+    }
+
+    fn retryable_error(provider: Provider) -> AgentError {
+        AgentError::llm(
+            provider.as_str(),
+            LlmFailureReason::ProviderError(LlmProviderError::retryable(
+                LlmProviderErrorKind::ServerOverloaded,
+                serde_json::json!({"message": "busy"}),
+            )),
+            "busy",
+        )
+    }
+
+    #[test]
+    fn prepare_model_fallback_moves_to_next_candidate_after_commit() {
+        let seen_tools = Arc::new(Mutex::new(Vec::new()));
+        let client = ModelFallbackClient::new(vec![
+            candidate(
+                Provider::OpenAI,
+                "primary",
+                ToolFilter::All,
+                Some(200_000),
+                Some(4096),
+                Arc::clone(&seen_tools),
+            ),
+            candidate(
+                Provider::Anthropic,
+                "backup",
+                ToolFilter::Deny(["view_image".to_string()].into_iter().collect()),
+                Some(200_000),
+                Some(2048),
+                Arc::clone(&seen_tools),
+            ),
+        ])
+        .expect("chain with backup");
+
+        let switch = client
+            .prepare_model_fallback(&retryable_error(Provider::OpenAI))
+            .expect("backup switch");
+
+        assert_eq!(switch.previous_identity.model, "primary");
+        assert_eq!(switch.new_identity.model, "backup");
+        assert_eq!(switch.max_output_tokens, Some(2048));
+        assert_eq!(client.provider(), Provider::OpenAI);
+        assert_eq!(client.model(), "primary");
+        client.commit_model_fallback(&switch.new_identity);
+        assert_eq!(client.provider(), Provider::Anthropic);
+        assert_eq!(client.model(), "backup");
+    }
+
+    #[test]
+    fn prepare_model_fallback_skips_smaller_context_after_context_overflow() {
+        let seen_tools = Arc::new(Mutex::new(Vec::new()));
+        let client = ModelFallbackClient::new(vec![
+            candidate(
+                Provider::OpenAI,
+                "large",
+                ToolFilter::All,
+                Some(1_000_000),
+                None,
+                Arc::clone(&seen_tools),
+            ),
+            candidate(
+                Provider::SelfHosted,
+                "small",
+                ToolFilter::All,
+                Some(128_000),
+                None,
+                Arc::clone(&seen_tools),
+            ),
+            candidate(
+                Provider::Anthropic,
+                "large-backup",
+                ToolFilter::All,
+                Some(1_200_000),
+                None,
+                Arc::clone(&seen_tools),
+            ),
+        ])
+        .expect("chain with backups");
+
+        let switch = client
+            .prepare_model_fallback(&AgentError::llm(
+                Provider::OpenAI.as_str(),
+                LlmFailureReason::ContextExceeded {
+                    max: 1_000_000,
+                    requested: 1_100_000,
+                },
+                "context exceeded",
+            ))
+            .expect("larger viable backup");
+
+        assert_eq!(switch.new_identity.model, "large-backup");
+        assert_eq!(switch.skipped_targets.len(), 1);
+        assert_eq!(switch.skipped_targets[0].identity.model, "small");
+    }
+}

--- a/meerkat/src/service_factory.rs
+++ b/meerkat/src/service_factory.rs
@@ -426,12 +426,7 @@ impl SessionAgent for FactoryAgent {
     }
 
     fn visible_tool_defs(&self) -> Vec<meerkat_core::ToolDef> {
-        self.agent
-            .tool_scope()
-            .visible_tools()
-            .iter()
-            .map(|tool| tool.as_ref().clone())
-            .collect()
+        self.agent.visible_tool_defs()
     }
 
     fn external_tool_surface_snapshot(&self) -> Option<meerkat_core::ExternalToolSurfaceSnapshot> {

--- a/meerkat/tests/factory_build_agent.rs
+++ b/meerkat/tests/factory_build_agent.rs
@@ -553,6 +553,7 @@ async fn agent_llm_client_decorator_wraps_registry_resolved_provider_client() {
         "default".to_string(),
         meerkat_core::RealmConfigSection::from_inline_api_keys(&[("openai", "test-openai-key")]),
     );
+    config.model_fallback.enabled = false;
     let constructions = Arc::new(AtomicUsize::new(0));
     let stream_calls = Arc::new(AtomicUsize::new(0));
 


### PR DESCRIPTION
## Summary
- add typed `model_fallback` config with a catalog-default chain, explicit user chain, and reset-to-default support
- build pre-authorized fallback LLM candidates in the facade with request policy, auth binding, capability filter, context window, and max-token metadata
- activate fallback only after the generated turn authority classifies an LLM failure as recoverable, then inform the model, clamp max tokens, apply effective tool filtering, and keep the downgraded tool surface sticky for later turns

## Dogma notes
- failure recoverability remains owned by the generated turn authority; the fallback client only selects the next candidate when core asks it
- provider/model/auth details are resolved at the factory/catalog seam, not in core
- effective live tool snapshots and visible tool definitions use the same active fallback capability filter as provider calls, so the control plane and model-facing surface stay aligned
- agent-loop call/network timeouts do not trigger fallback because a cancelled stream may already have emitted partial deltas

## Validation
- `./scripts/repo-cargo test -p meerkat-core model_fallback --no-fail-fast`
- `./scripts/repo-cargo test -p meerkat model_fallback --no-fail-fast`
- `./scripts/repo-cargo check -p meerkat`
- `make check`
- `./scripts/repo-cargo clippy -p meerkat-core -p meerkat --all-targets -- -D warnings`
- repeated adversarial two-agent review: final round returned NO BLOCK from both reviewers
