### PR TITLE
Fix Meerkat 0.7 resume and retry regressions

### DIFF
--- a/meerkat-core/src/provider.rs
+++ b/meerkat-core/src/provider.rs
@@ -19,8 +19,9 @@ pub enum Provider {
     // diverges from the canonical `as_str()` name `"openai"` that every other
     // seam (and durable data) uses. Pin the canonical wire/schema name on the
     // variant so the derived `Serialize`/`Deserialize` and the generated
-    // `schemars` schema all agree on `"openai"` — one representation, no shim.
-    #[serde(rename = "openai")]
+    // `schemars` schema all agree on `"openai"`. The alias is read-only for
+    // durable pre-0.7 session metadata; serialization remains canonical.
+    #[serde(rename = "openai", alias = "open_a_i")]
     OpenAI,
     Gemini,
     SelfHosted,
@@ -125,5 +126,13 @@ mod tests {
             Some(Provider::Anthropic)
         );
         assert_eq!(Provider::parse_strict("openai"), Some(Provider::OpenAI));
+    }
+
+    #[test]
+    fn provider_deserializes_legacy_openai_tag() -> Result<(), serde_json::Error> {
+        let provider: Provider = serde_json::from_str("\"open_a_i\"")?;
+        assert_eq!(provider, Provider::OpenAI);
+        assert_eq!(serde_json::to_string(&provider)?, "\"openai\"");
+        Ok(())
     }
 }

--- a/meerkat-core/src/types.rs
+++ b/meerkat-core/src/types.rs
@@ -678,6 +678,32 @@ impl ServerToolKind {
             ServerToolKind::ProviderNative { name } => name,
         }
     }
+
+    pub fn from_provider_name(name: impl Into<String>) -> Self {
+        let name = name.into();
+        match name.as_str() {
+            "web_search" => ServerToolKind::WebSearch,
+            "google_search" => ServerToolKind::GoogleSearch,
+            _ => ServerToolKind::ProviderNative { name },
+        }
+    }
+}
+
+fn deserialize_server_tool_kind<'de, D>(deserializer: D) -> Result<ServerToolKind, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    #[derive(Deserialize)]
+    #[serde(untagged)]
+    enum ServerToolKindCompat {
+        Current(ServerToolKind),
+        LegacyName(String),
+    }
+
+    match ServerToolKindCompat::deserialize(deserializer)? {
+        ServerToolKindCompat::Current(kind) => Ok(kind),
+        ServerToolKindCompat::LegacyName(name) => Ok(ServerToolKind::from_provider_name(name)),
+    }
 }
 
 impl fmt::Display for ServerToolKind {
@@ -747,6 +773,7 @@ pub enum AssistantBlock {
         #[serde(skip_serializing_if = "Option::is_none")]
         id: Option<String>,
         /// Typed semantic tool kind, parsed once at the provider adapter.
+        #[serde(alias = "name", deserialize_with = "deserialize_server_tool_kind")]
         kind: ServerToolKind,
         /// Provider-native JSON payload, preserved for citations and grounding evidence.
         content: Value,

--- a/meerkat-core/src/types/tests.rs
+++ b/meerkat-core/src/types/tests.rs
@@ -1121,6 +1121,34 @@ mod ordered_transcript_types {
         }
     }
 
+    #[test]
+    fn test_assistant_block_server_tool_content_reads_legacy_name_shape() {
+        let value = serde_json::json!({
+            "block_type": "server_tool_content",
+            "data": {
+                "id": "tool-1",
+                "name": "web_search",
+                "content": { "query": "meerkat" }
+            }
+        });
+
+        let parsed: AssistantBlock = serde_json::from_value(value).unwrap();
+        match parsed {
+            AssistantBlock::ServerToolContent {
+                id,
+                kind,
+                content,
+                meta,
+            } => {
+                assert_eq!(id.as_deref(), Some("tool-1"));
+                assert_eq!(kind, ServerToolKind::WebSearch);
+                assert_eq!(content["query"], "meerkat");
+                assert!(meta.is_none());
+            }
+            other => panic!("Expected ServerToolContent, got {other:?}"),
+        }
+    }
+
     // -----------------------------------------------------------------------
     // AssistantBlock::Transcript variant
     // -----------------------------------------------------------------------

--- a/meerkat-mob/src/build.rs
+++ b/meerkat-mob/src/build.rs
@@ -358,17 +358,19 @@ fn apply_resumed_session_metadata(
     config: &mut AgentBuildConfig,
     metadata: &SessionMetadata,
 ) -> Result<(), MobError> {
-    let current_comms_name = config.comms_name.clone();
+    let Some(current_comms_name) = config.comms_name.clone() else {
+        return Err(MobError::Internal(
+            "missing current comms_name for resumed mob member".to_string(),
+        ));
+    };
     let Some(stored_comms_name) = metadata.comms_name.clone() else {
         return Err(MobError::Internal(
             "missing durable comms_name for resumed mob member".to_string(),
         ));
     };
-    if current_comms_name.as_deref() != Some(stored_comms_name.as_str()) {
+    if !resumed_comms_name_matches_current_or_legacy(&current_comms_name, &stored_comms_name) {
         return Err(MobError::Internal(format!(
-            "persisted comms_name '{}' does not match current mob identity '{}'",
-            stored_comms_name,
-            current_comms_name.unwrap_or_else(|| "<none>".to_string())
+            "persisted comms_name '{stored_comms_name}' does not match current mob identity '{current_comms_name}'"
         )));
     }
 
@@ -403,9 +405,43 @@ fn apply_resumed_session_metadata(
     config.preload_skills = metadata.tooling.active_skills.clone();
     // keep_alive is NOT restored from metadata — mob runtime owns it
     // (determined by runtime_mode == AutonomousHost). §1: one owner.
-    config.comms_name = Some(stored_comms_name);
+    config.comms_name = Some(current_comms_name);
     config.peer_meta = metadata.peer_meta.clone();
     Ok(())
+}
+
+pub(crate) fn resumed_comms_name_matches_current_or_legacy(current: &str, stored: &str) -> bool {
+    if current == stored {
+        return true;
+    }
+    legacy_raw_alias_comms_name(current).is_some_and(|legacy| stored == legacy)
+}
+
+pub(crate) fn legacy_raw_alias_comms_name(current: &str) -> Option<String> {
+    let mut parts = current.split('/');
+    let (Some(mob_id), Some(role), Some(member), None) =
+        (parts.next(), parts.next(), parts.next(), parts.next())
+    else {
+        return None;
+    };
+    let legacy_member = member
+        .strip_prefix("mk--")
+        .map(decode_legacy_member_alias_segment)?;
+    Some(format!("{mob_id}/{role}/{legacy_member}"))
+}
+
+fn decode_legacy_member_alias_segment(encoded: &str) -> String {
+    let mut decoded = String::with_capacity(encoded.len());
+    let mut chars = encoded.chars().peekable();
+    while let Some(ch) = chars.next() {
+        if ch == '_' && chars.peek() == Some(&'c') {
+            chars.next();
+            decoded.push(':');
+        } else {
+            decoded.push(ch);
+        }
+    }
+    decoded
 }
 
 /// Bridge an [`AgentBuildConfig`] to a [`CreateSessionRequest`].
@@ -2362,6 +2398,39 @@ mod tests {
         apply_resumed_session_metadata(&mut config, &metadata).expect("metadata applies");
         assert_eq!(config.model, "gpt-5.4");
         assert_eq!(config.provider, Some(meerkat_core::Provider::OpenAI));
+    }
+
+    #[test]
+    fn test_resumed_metadata_accepts_legacy_raw_alias_comms_name() {
+        let mut config = AgentBuildConfig::new("gpt-5.4");
+        config.comms_name = Some("ob3/review/mk--rt_creview_csingleton_c0".to_string());
+
+        let metadata = SessionMetadata {
+            schema_version: meerkat_core::SESSION_METADATA_SCHEMA_VERSION,
+            model: "gpt-5.4".to_string(),
+            max_tokens: 4096,
+            structured_output_retries: 2,
+            provider: meerkat_core::Provider::OpenAI,
+            self_hosted_server_id: None,
+            provider_params: None,
+            tooling: Default::default(),
+            keep_alive: false,
+            comms_name: Some("ob3/review/rt:review:singleton:0".to_string()),
+            peer_meta: None,
+            realm_id: None,
+            instance_id: None,
+            backend: None,
+            config_generation: None,
+            auth_binding: None,
+            mob_member_binding: None,
+        };
+
+        apply_resumed_session_metadata(&mut config, &metadata).expect("legacy metadata applies");
+        assert_eq!(
+            config.comms_name.as_deref(),
+            Some("ob3/review/mk--rt_creview_csingleton_c0"),
+            "resume should rehydrate to the canonical encoded comms name"
+        );
     }
 
     #[tokio::test]

--- a/meerkat-mob/src/event.rs
+++ b/meerkat-mob/src/event.rs
@@ -324,6 +324,14 @@ pub enum MobEventKind {
         agent_runtime_id: AgentRuntimeId,
     },
 
+    /// A session-backed member's durable bridge-session binding was recovered.
+    ///
+    /// Replay feeds this through `MobMachineSignal::RecoverMemberSessionBinding`
+    /// and updates the roster read model. The MobMachine remains the behavior
+    /// authority; this event is the crash-recovery fact that preserves a
+    /// machine-authorized rebind across the next process restart.
+    MemberSessionBindingRecovered(MemberSessionBindingRecoveredEvent),
+
     /// Kickoff state for an existing member changed.
     MemberKickoffUpdated {
         /// Member whose kickoff state changed.
@@ -571,6 +579,40 @@ impl MemberSpawnedEvent {
     }
 }
 
+/// Public identity-native payload for a recovered session binding.
+///
+/// The bridge session id is kept as crate-internal replay metadata only;
+/// it is intentionally not serialized on the public event surface.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct MemberSessionBindingRecoveredEvent {
+    /// Stable member identity whose bridge binding was recovered.
+    pub agent_identity: AgentIdentity,
+    /// Runtime incarnation the recovered binding belongs to.
+    pub agent_runtime_id: AgentRuntimeId,
+    /// Recovered bridge session id for the member.
+    /// Not part of the public identity-native contract.
+    #[serde(skip, default)]
+    pub(crate) bridge_session_id: Option<SessionId>,
+}
+
+impl MemberSessionBindingRecoveredEvent {
+    pub(crate) fn new(
+        agent_identity: AgentIdentity,
+        agent_runtime_id: AgentRuntimeId,
+        bridge_session_id: SessionId,
+    ) -> Self {
+        Self {
+            agent_identity,
+            agent_runtime_id,
+            bridge_session_id: Some(bridge_session_id),
+        }
+    }
+
+    pub(crate) fn bridge_session_id(&self) -> Option<&SessionId> {
+        self.bridge_session_id.as_ref()
+    }
+}
+
 fn is_ephemeral_continuity(intent: &crate::runtime::SpawnContinuityIntent) -> bool {
     matches!(intent, crate::runtime::SpawnContinuityIntent::Ephemeral)
 }
@@ -590,6 +632,24 @@ impl MobEventKind {
             _ => None,
         }
     }
+
+    pub(crate) fn member_session_binding_recovered(
+        &self,
+    ) -> Option<&MemberSessionBindingRecoveredEvent> {
+        match self {
+            Self::MemberSessionBindingRecovered(event) => Some(event),
+            _ => None,
+        }
+    }
+
+    pub(crate) fn member_session_binding_recovered_mut(
+        &mut self,
+    ) -> Option<&mut MemberSessionBindingRecoveredEvent> {
+        match self {
+            Self::MemberSessionBindingRecovered(event) => Some(event),
+            _ => None,
+        }
+    }
 }
 
 /// Encode a stored mob event, preserving internal replay-only fields that are
@@ -604,6 +664,15 @@ pub(crate) fn encode_stored_mob_event(event: &MobEvent) -> Result<Vec<u8>, serde
         kind.insert(
             "bridge_member_ref".to_string(),
             serde_json::to_value(bridge_member_ref)?,
+        );
+    }
+    if let Some(recovered) = event.kind.member_session_binding_recovered()
+        && let Some(bridge_session_id) = recovered.bridge_session_id()
+        && let Some(kind) = value.get_mut("kind").and_then(Value::as_object_mut)
+    {
+        kind.insert(
+            "bridge_session_id".to_string(),
+            serde_json::to_value(bridge_session_id)?,
         );
     }
     serde_json::to_vec(&serde_json::json!({
@@ -642,11 +711,29 @@ pub(crate) fn decode_stored_mob_event(bytes: &[u8]) -> Result<MobEvent, serde_js
         .and_then(|kind| kind.remove("bridge_member_ref"))
         .map(serde_json::from_value)
         .transpose()?;
+    let recovered_bridge_session_id = value
+        .get_mut("kind")
+        .and_then(Value::as_object_mut)
+        .and_then(|kind| {
+            if kind.get("type").and_then(Value::as_str) == Some("member_session_binding_recovered")
+            {
+                kind.remove("bridge_session_id")
+            } else {
+                None
+            }
+        })
+        .map(serde_json::from_value)
+        .transpose()?;
     let mut event: MobEvent = serde_json::from_value(value)?;
     if let Some(bridge_member_ref) = bridge_member_ref
         && let Some(member_spawned) = event.kind.member_spawned_mut()
     {
         member_spawned.bridge_member_ref = Some(bridge_member_ref);
+    }
+    if let Some(bridge_session_id) = recovered_bridge_session_id
+        && let Some(recovered) = event.kind.member_session_binding_recovered_mut()
+    {
+        recovered.bridge_session_id = Some(bridge_session_id);
     }
     Ok(event)
 }
@@ -705,6 +792,37 @@ mod tests {
             destroy_on_owner_archive: true,
             implicit_delegation_mob: true,
         });
+    }
+
+    #[test]
+    fn test_stored_mob_event_roundtrip_preserves_owner_bridge_session_bound() {
+        let sid = SessionId::from_uuid(Uuid::nil());
+        let event = MobEvent {
+            cursor: 1,
+            timestamp: Utc::now(),
+            mob_id: MobId::from("test-mob"),
+            kind: MobEventKind::MobOwnerBridgeSessionBound {
+                bridge_session_id: sid.clone(),
+                destroy_on_owner_archive: true,
+                implicit_delegation_mob: true,
+            },
+        };
+
+        let encoded = encode_stored_mob_event(&event).unwrap();
+        let decoded = decode_stored_mob_event(&encoded).unwrap();
+
+        match decoded.kind {
+            MobEventKind::MobOwnerBridgeSessionBound {
+                bridge_session_id,
+                destroy_on_owner_archive,
+                implicit_delegation_mob,
+            } => {
+                assert_eq!(bridge_session_id, sid);
+                assert!(destroy_on_owner_archive);
+                assert!(implicit_delegation_mob);
+            }
+            other => panic!("expected MobOwnerBridgeSessionBound, got {other:?}"),
+        }
     }
 
     #[test]
@@ -1009,6 +1127,34 @@ mod tests {
         }
     }
 
+    #[test]
+    fn test_stored_mob_event_roundtrip_preserves_recovered_member_session_binding() {
+        let sid = SessionId::from_uuid(Uuid::nil());
+        let identity = AgentIdentity::from("researcher");
+        let event = MobEvent {
+            cursor: 1,
+            timestamp: Utc::now(),
+            mob_id: MobId::from("test-mob"),
+            kind: MobEventKind::MemberSessionBindingRecovered(
+                MemberSessionBindingRecoveredEvent::new(
+                    identity.clone(),
+                    AgentRuntimeId::initial(identity),
+                    sid.clone(),
+                ),
+            ),
+        };
+
+        let encoded = encode_stored_mob_event(&event).unwrap();
+        let decoded = decode_stored_mob_event(&encoded).unwrap();
+
+        match decoded.kind {
+            MobEventKind::MemberSessionBindingRecovered(recovered) => {
+                assert_eq!(recovered.bridge_session_id(), Some(&sid));
+            }
+            other => panic!("expected MemberSessionBindingRecovered, got {other:?}"),
+        }
+    }
+
     /// DELETE_ME A6 regression: `MemberSpawned(MemberSpawnedEvent)` uses
     /// a named struct variant while every other `Member*` variant uses
     /// inline fields. The reason is load-bearing: `bridge_member_ref` is
@@ -1055,6 +1201,29 @@ mod tests {
         assert!(
             payload_object.contains_key("agent_identity") || serialized.contains("agent_identity"),
             "public MemberSpawned must carry agent_identity: {serialized}",
+        );
+    }
+
+    #[test]
+    fn member_session_binding_recovered_public_wire_shape_excludes_bridge_session_id() {
+        let identity = AgentIdentity::from("researcher");
+        let sid = SessionId::from_uuid(Uuid::nil());
+        let kind =
+            MobEventKind::MemberSessionBindingRecovered(MemberSessionBindingRecoveredEvent::new(
+                identity.clone(),
+                AgentRuntimeId::initial(identity),
+                sid,
+            ));
+
+        let value = serde_json::to_value(&kind).expect("serialize mob event kind");
+        let serialized = serde_json::to_string(&value).unwrap();
+        assert!(
+            !serialized.contains("bridge_session_id"),
+            "public MemberSessionBindingRecovered must not expose bridge_session_id: {serialized}",
+        );
+        assert!(
+            serialized.contains("agent_identity"),
+            "public MemberSessionBindingRecovered must carry agent_identity: {serialized}",
         );
     }
 

--- a/meerkat-mob/src/roster.rs
+++ b/meerkat-mob/src/roster.rs
@@ -205,6 +205,14 @@ impl Roster {
                     entry.agent_runtime_id = agent_runtime_id.clone();
                 }
             }
+            MobEventKind::MemberSessionBindingRecovered(recovered) => {
+                if let Some(bridge_session_id) = recovered.bridge_session_id() {
+                    self.set_bridge_session_id(
+                        &recovered.agent_identity,
+                        bridge_session_id.clone(),
+                    );
+                }
+            }
             MobEventKind::MemberKickoffUpdated { member, kickoff } => {
                 self.set_kickoff_by_identity(member, Some(kickoff.clone()));
             }

--- a/meerkat-mob/src/runtime/actor.rs
+++ b/meerkat-mob/src/runtime/actor.rs
@@ -1520,28 +1520,14 @@ impl MobActor {
     ) -> Result<SupervisorPrivateTrustInstall, SupervisorPrivateTrustInstallError> {
         let authority = self.supervisor_bridge.authority().await;
         let spec = Self::supervisor_spec_for_authority(&self.definition.id, &authority)?;
-        #[cfg(target_arch = "wasm32")]
-        {
-            Box::pin(self.install_supervisor_private_trust_for_session_authority(
-                session_id,
-                comms,
-                &authority,
-                spec,
-                previous_private_trust_removal_key,
-            ))
-            .await
-        }
-        #[cfg(not(target_arch = "wasm32"))]
-        {
-            self.install_supervisor_private_trust_for_session_authority(
-                session_id,
-                comms,
-                &authority,
-                spec,
-                previous_private_trust_removal_key,
-            )
-            .await
-        }
+        Box::pin(self.install_supervisor_private_trust_for_session_authority(
+            session_id,
+            comms,
+            &authority,
+            spec,
+            previous_private_trust_removal_key,
+        ))
+        .await
     }
 
     async fn install_supervisor_private_trust_for_session_authority(

--- a/meerkat-mob/src/runtime/builder.rs
+++ b/meerkat-mob/src/runtime/builder.rs
@@ -862,6 +862,77 @@ fn apply_seeded_member_session_binding(
     )
 }
 
+async fn latest_persisted_session_for_member(
+    session_service: &dyn MobSessionService,
+    listed_sessions: &[meerkat_core::service::SessionSummary],
+    missing_session_id: &meerkat_core::types::SessionId,
+    mob_id: &crate::ids::MobId,
+    role: &crate::ids::ProfileName,
+    agent_identity: &crate::ids::AgentIdentity,
+) -> Result<Option<(meerkat_core::types::SessionId, meerkat_core::Session)>, MobError> {
+    let canonical_comms_name = super::actor::render_member_comms_name(
+        mob_id.as_str(),
+        role.as_str(),
+        agent_identity.as_str(),
+    )?;
+    let mut best: Option<(
+        meerkat_core::time_compat::SystemTime,
+        meerkat_core::types::SessionId,
+        meerkat_core::Session,
+    )> = None;
+
+    for summary in listed_sessions {
+        if &summary.session_id == missing_session_id {
+            continue;
+        }
+        let Some(session) = session_service
+            .load_persisted_session(&summary.session_id)
+            .await?
+        else {
+            continue;
+        };
+        if !persisted_session_matches_member(
+            &session,
+            mob_id,
+            role,
+            agent_identity,
+            &canonical_comms_name,
+        ) {
+            continue;
+        }
+        let replace = best
+            .as_ref()
+            .is_none_or(|(updated_at, _, _)| summary.updated_at > *updated_at);
+        if replace {
+            best = Some((summary.updated_at, summary.session_id.clone(), session));
+        }
+    }
+
+    Ok(best.map(|(_, session_id, session)| (session_id, session)))
+}
+
+fn persisted_session_matches_member(
+    session: &meerkat_core::Session,
+    mob_id: &crate::ids::MobId,
+    role: &crate::ids::ProfileName,
+    agent_identity: &crate::ids::AgentIdentity,
+    canonical_comms_name: &str,
+) -> bool {
+    let Some(metadata) = session.session_metadata() else {
+        return false;
+    };
+    if metadata.mob_member_binding.as_ref().is_some_and(|binding| {
+        binding.mob_id == mob_id.as_str()
+            && binding.role == role.as_str()
+            && binding.member == agent_identity.as_str()
+    }) {
+        return true;
+    }
+    metadata.comms_name.as_deref().is_some_and(|comms_name| {
+        crate::build::resumed_comms_name_matches_current_or_legacy(canonical_comms_name, comms_name)
+    })
+}
+
 fn authorize_seeded_session_provision_operation_owner(
     authority: &mut crate::machines::mob_machine::MobMachineAuthority,
     agent_identity: &crate::ids::AgentIdentity,
@@ -1324,6 +1395,21 @@ fn seed_mob_authority_sync_from_events(
                         generation: mob_dsl::Generation::from_domain(agent_runtime_id.generation),
                     },
                     "recover_member_reset",
+                )?;
+            }
+            MobEventKind::MemberSessionBindingRecovered(recovered) => {
+                let Some(bridge_session_id) = recovered.bridge_session_id() else {
+                    return Err(MobError::Internal(format!(
+                        "stored member-session binding recovery event for '{}' is missing bridge_session_id",
+                        recovered.agent_identity
+                    )));
+                };
+                apply_seeded_member_session_binding(
+                    authority,
+                    &recovered.agent_identity,
+                    &recovered.agent_runtime_id,
+                    bridge_session_id,
+                    "recover_member_session_binding_recovered",
                 )?;
             }
             MobEventKind::MemberRetired {
@@ -2583,7 +2669,7 @@ impl MobBuilder {
         for entry in &roster_entries {
             let dsl_identity =
                 crate::machines::mob_machine::AgentIdentity::from_domain(&entry.agent_identity);
-            let Some(bridge_session_id) = dsl_authority
+            let Some(mut bridge_session_id) = dsl_authority
                 .state()
                 .member_session_bindings
                 .get(&dsl_identity)
@@ -2594,11 +2680,12 @@ impl MobBuilder {
             if active_ids.contains(&bridge_session_id) {
                 continue;
             }
-            let record_restore_failure = |reason: String| async {
+            let record_restore_failure = |bridge_session_id: meerkat_core::types::SessionId,
+                                          reason: String| async {
                 tool_handle.restore_diagnostics.write().await.insert(
                     entry.agent_identity.clone(),
                     super::handle::RestoreFailureDiagnostic {
-                        bridge_session_id: Some(bridge_session_id.clone()),
+                        bridge_session_id: Some(bridge_session_id),
                         reason,
                     },
                 );
@@ -2643,15 +2730,64 @@ impl MobBuilder {
             if matches!(entry.member_ref, MemberRef::Session { .. })
                 && session_service.supports_persistent_sessions()
             {
-                let Some(stored_session) = session_service
+                let stored_session = match session_service
                     .load_persisted_session(&bridge_session_id)
                     .await?
-                else {
-                    record_restore_failure(format!(
-                        "missing durable session snapshot for '{bridge_session_id}'"
-                    ))
-                    .await;
-                    continue;
+                {
+                    Some(stored_session) => stored_session,
+                    None => {
+                        if let Some((replacement_session_id, replacement_session)) =
+                            latest_persisted_session_for_member(
+                                session_service.as_ref(),
+                                &listed_sessions,
+                                &bridge_session_id,
+                                &definition.id,
+                                &entry.role,
+                                &entry.agent_identity,
+                            )
+                            .await?
+                        {
+                            apply_seeded_member_session_binding(
+                                dsl_authority,
+                                &entry.agent_identity,
+                                &entry.agent_runtime_id,
+                                &replacement_session_id,
+                                "resume_repoint_missing_member_session_binding",
+                            )?;
+                            tool_handle
+                                .events
+                                .append(crate::event::NewMobEvent {
+                                    mob_id: definition.id.clone(),
+                                    timestamp: None,
+                                    kind: MobEventKind::MemberSessionBindingRecovered(
+                                        crate::event::MemberSessionBindingRecoveredEvent::new(
+                                            entry.agent_identity.clone(),
+                                            entry.agent_runtime_id.clone(),
+                                            replacement_session_id.clone(),
+                                        ),
+                                    ),
+                                })
+                                .await?;
+                            bridge_session_id = replacement_session_id;
+                            let _ = roster.set_bridge_session_id(
+                                &entry.agent_identity,
+                                bridge_session_id.clone(),
+                            );
+                            if active_ids.contains(&bridge_session_id) {
+                                continue;
+                            }
+                            replacement_session
+                        } else {
+                            record_restore_failure(
+                                bridge_session_id.clone(),
+                                format!(
+                                    "missing durable session snapshot for '{bridge_session_id}'"
+                                ),
+                            )
+                            .await;
+                            continue;
+                        }
+                    }
                 };
                 // Prefer customizer/roster effective_profile_override on restore for lifecycle safety.
                 let mut profile = if let Some(ref p) = restore_profile_override {
@@ -2706,7 +2842,7 @@ impl MobBuilder {
                 let mut resumed_config = match resumed_config {
                     Ok(config) => config,
                     Err(error) => {
-                        record_restore_failure(error.to_string()).await;
+                        record_restore_failure(bridge_session_id.clone(), error.to_string()).await;
                         continue;
                     }
                 };
@@ -2731,10 +2867,13 @@ impl MobBuilder {
                 ) {
                     Ok(name) => name,
                     Err(error) => {
-                        record_restore_failure(format!(
-                            "failed to render comms name for resumed member '{}': {error}",
-                            entry.agent_identity
-                        ))
+                        record_restore_failure(
+                            bridge_session_id.clone(),
+                            format!(
+                                "failed to render comms name for resumed member '{}': {error}",
+                                entry.agent_identity
+                            ),
+                        )
                         .await;
                         continue;
                     }
@@ -2745,7 +2884,7 @@ impl MobBuilder {
                     ) {
                         Ok(authority) => authority,
                         Err(error) => {
-                            record_restore_failure(format!(
+                            record_restore_failure(bridge_session_id.clone(), format!(
                                 "failed to recover MobMachine authority for session provision owner '{}': {error}",
                                 entry.agent_identity
                             ))
@@ -2763,7 +2902,7 @@ impl MobBuilder {
                     ) {
                         Ok(owner) => owner,
                         Err(error) => {
-                            record_restore_failure(format!(
+                            record_restore_failure(bridge_session_id.clone(), format!(
                                 "failed to authorize recovered session provision owner '{}': {error}",
                                 entry.agent_identity
                             ))
@@ -2806,7 +2945,7 @@ impl MobBuilder {
                             profile.external_addressable,
                             "resume_recovered_member_addressability",
                         ) {
-                            record_restore_failure(format!(
+                            record_restore_failure(bridge_session_id.clone(), format!(
                                 "MobMachine rejected recovered member addressability for '{}': {error}",
                                 entry.agent_identity
                             ))
@@ -2820,7 +2959,7 @@ impl MobBuilder {
                             &created_bridge_session_id,
                             "resume_recovered_member_session_binding",
                         ) {
-                            record_restore_failure(format!(
+                            record_restore_failure(bridge_session_id.clone(), format!(
                                 "MobMachine rejected recovered bridge session '{created_bridge_session_id}': {error}"
                             ))
                             .await;
@@ -2837,9 +2976,12 @@ impl MobBuilder {
                             .remove(&entry.agent_identity);
                     }
                     Err(error) => {
-                        record_restore_failure(format!(
-                            "failed to restore durable session '{bridge_session_id}': {error}"
-                        ))
+                        record_restore_failure(
+                            bridge_session_id.clone(),
+                            format!(
+                                "failed to restore durable session '{bridge_session_id}': {error}"
+                            ),
+                        )
                         .await;
                     }
                 }

--- a/meerkat-mob/src/runtime/tests.rs
+++ b/meerkat-mob/src/runtime/tests.rs
@@ -2603,6 +2603,7 @@ impl FaultInjectedMobEventStore {
             MobEventKind::MemberSpawned(..) => "MemberSpawned",
             MobEventKind::MemberRetired { .. } => "MemberRetired",
             MobEventKind::MemberReset { .. } => "MemberReset",
+            MobEventKind::MemberSessionBindingRecovered(..) => "MemberSessionBindingRecovered",
             MobEventKind::MemberKickoffUpdated { .. } => "MemberKickoffUpdated",
             MobEventKind::MembersWired { .. } => "MembersWired",
             MobEventKind::MembersWiredBatch { .. } => "MembersWiredBatch",
@@ -14012,6 +14013,134 @@ async fn test_resume_marks_missing_persisted_session_as_broken() {
         crate::runtime::handle::MobMemberStatus::Broken
     );
     assert!(broken_including_retiring.is_final);
+}
+
+#[tokio::test]
+async fn test_resume_repoints_snapshotless_member_head_to_latest_persisted_session() {
+    let service = Arc::new(MockSessionService::new());
+    let _ = service.enable_runtime_adapter();
+    let storage = MobStorage::in_memory();
+    let events = storage.events.clone();
+    let runtime_metadata = storage.runtime_metadata.clone();
+    let identity = AgentIdentity::from("mk--rt_creview_csingleton_c0");
+    let handle = MobBuilder::new(sample_definition(), storage)
+        .with_session_service(service.clone())
+        .create()
+        .await
+        .expect("create mob");
+    handle
+        .spawn(ProfileName::from("worker"), identity.clone(), None)
+        .await
+        .expect("spawn");
+    handle.stop().await.expect("stop");
+
+    let old_sid = handle
+        .get_member(&identity)
+        .await
+        .unwrap()
+        .expect("roster entry")
+        .bridge_session_id()
+        .cloned()
+        .expect("session-backed member");
+    MobSessionService::discard_live_session(service.as_ref(), &old_sid)
+        .await
+        .expect("discard old live session");
+    service.delete_persisted_session(&old_sid).await;
+
+    let replacement = service
+        .create_session(CreateSessionRequest {
+            model: "claude-sonnet-4-5".to_string(),
+            prompt: "replacement".to_string().into(),
+            system_prompt: meerkat_core::SystemPromptOverride::Inherit,
+            max_tokens: None,
+            event_tx: None,
+            build: Some(meerkat_core::service::SessionBuildOptions {
+                comms_name: Some("test-mob/worker/rt:review:singleton:0".to_string()),
+                mob_member_binding: None,
+                ..Default::default()
+            }),
+            initial_turn: meerkat_core::service::InitialTurnPolicy::RunImmediately,
+            deferred_prompt_policy: meerkat_core::service::DeferredPromptPolicy::Discard,
+            labels: None,
+        })
+        .await
+        .expect("create replacement");
+    service
+        .session_comms_names
+        .write()
+        .await
+        .remove(&replacement.session_id);
+
+    let resumed = MobBuilder::for_resume(MobStorage::with_events_and_runtime_metadata(
+        events.clone(),
+        runtime_metadata.clone(),
+    ))
+    .with_session_service(service.clone())
+    .resume()
+    .await
+    .expect("resume should self-heal snapshotless head");
+
+    let snapshot = resumed
+        .member_status(&identity)
+        .await
+        .expect("member status");
+    assert_eq!(
+        snapshot.status,
+        crate::runtime::handle::MobMemberStatus::Active
+    );
+    assert_eq!(
+        snapshot.current_session_id,
+        Some(replacement.session_id.clone())
+    );
+
+    let machine_state = resumed
+        .query_machine_state()
+        .await
+        .expect("query MobMachine state after self-heal");
+    let dsl_identity = crate::machines::mob_machine::AgentIdentity::from_domain(&identity);
+    let dsl_session_id =
+        crate::machines::mob_machine::SessionId::from_domain(&replacement.session_id);
+    assert_eq!(
+        machine_state.member_session_bindings.get(&dsl_identity),
+        Some(&dsl_session_id),
+        "snapshotless continuity heads should be repointed through MobMachine recovery"
+    );
+
+    let resumed_again = MobBuilder::for_resume(MobStorage::with_events_and_runtime_metadata(
+        events.clone(),
+        runtime_metadata,
+    ))
+    .with_session_service(service.clone())
+    .resume()
+    .await
+    .expect("repeat resume should replay durable self-heal");
+    let repeated_snapshot = resumed_again
+        .member_status(&identity)
+        .await
+        .expect("repeat member status");
+    assert_eq!(
+        repeated_snapshot.current_session_id,
+        Some(replacement.session_id.clone()),
+        "durable self-heal should survive the next restart without fresh-spawn churn"
+    );
+
+    let stored_events = events.replay_all().await.expect("replay events");
+    assert_eq!(
+        stored_events
+            .iter()
+            .filter(|event| matches!(event.kind, MobEventKind::MemberSessionBindingRecovered(..)))
+            .count(),
+        1,
+        "self-heal should persist exactly one recovered binding event"
+    );
+    assert_eq!(
+        stored_events
+            .iter()
+            .filter(|event| matches!(event.kind, MobEventKind::MemberSpawned(..)))
+            .count(),
+        1,
+        "repeat resume should not fresh-spawn a replacement member"
+    );
 }
 
 #[tokio::test]
@@ -26262,6 +26391,10 @@ fn test_supervisor_private_trust_realizes_generated_publish_obligation() {
     assert!(
         body.contains("protocol_supervisor_trust_publish::extract_obligations"),
         "supervisor private trust publication must realize the generated supervisor_trust_publish handoff obligation"
+    );
+    assert!(
+        body.contains("Box::pin(self.install_supervisor_private_trust_for_session_authority"),
+        "the supervisor private-trust authority future must be boxed before awaiting so the spawn finalization chain does not live on the worker stack"
     );
     assert!(
         body.contains("stage_supervisor_trust_publish_request"),

--- a/meerkat/src/factory.rs
+++ b/meerkat/src/factory.rs
@@ -5083,6 +5083,10 @@ impl AgentFactory {
             .max_tokens_per_turn(max_tokens)
             .budget(budget_limits)
             .structured_output_retries(resolved_structured_output_retries)
+            .retry_policy(meerkat_core::retry::RetryPolicy {
+                call_timeout: None,
+                ..config.retry.clone().into()
+            })
             .with_hook_run_overrides(build_config.hooks_override)
             .with_model_defaults_resolver(Arc::new(RegistryBackedDefaultsResolver {
                 registry: Arc::new(registry.clone()),

--- a/meerkat/tests/factory_build_agent.rs
+++ b/meerkat/tests/factory_build_agent.rs
@@ -775,6 +775,36 @@ async fn build_agent_sets_session_metadata() {
     assert!(metadata.comms_name.is_none());
 }
 
+#[tokio::test]
+async fn build_agent_applies_configured_retry_schedule_without_call_timeout() {
+    let temp = tempfile::tempdir().unwrap();
+    let factory = temp_factory(&temp);
+    let mut config = Config::default();
+    config.retry.max_retries = 8;
+    config.retry.initial_delay = std::time::Duration::from_millis(750);
+    config.retry.max_delay = std::time::Duration::from_secs(120);
+    config.retry.multiplier = 2.5;
+    config.retry.call_timeout_override =
+        meerkat_core::CallTimeoutOverride::Value(std::time::Duration::from_secs(90));
+
+    let build_config = AgentBuildConfig {
+        llm_client_override: Some(Arc::new(MockLlmClient)),
+        ..AgentBuildConfig::new("claude-sonnet-4-5")
+    };
+
+    let agent = factory.build_agent(build_config, &config).await.unwrap();
+    let retry = agent.retry_policy();
+
+    assert_eq!(retry.max_retries, 8);
+    assert_eq!(retry.initial_delay, std::time::Duration::from_millis(750));
+    assert_eq!(retry.max_delay, std::time::Duration::from_secs(120));
+    assert_eq!(retry.multiplier, 2.5);
+    assert_eq!(
+        retry.call_timeout, None,
+        "factory retry schedule wiring must not steal call-timeout ownership from call_timeout_override"
+    );
+}
+
 /// 4b. Configured self-hosted aliases resolve as first-class model IDs.
 #[tokio::test]
 async fn build_agent_resolves_self_hosted_alias_from_registry() {


### PR DESCRIPTION
## Summary
- wire `Config.retry` into factory-built agents while leaving call timeout owned by `call_timeout_override`
- add read-side 0.6 durable compatibility for legacy OpenAI provider tags, legacy `ServerToolContent.name`, and raw-alias mob `comms_name`
- box the supervisor private-trust future used during spawn finalization
- self-heal snapshotless continuity heads by selecting the latest matching persisted session, persisting a MobMachine-authorized recovered binding event, and replaying it without leaking bridge session ids on the public event surface

## Verification
- repeated adversarial 2-subagent review: initial blockers fixed; final pass from both reviewers found no blockers
- `./scripts/repo-cargo fmt --all --check`
- `./scripts/repo-cargo test -p meerkat-core legacy --lib`
- `./scripts/repo-cargo test -p meerkat-mob recovered_member_session_binding --lib`
- `./scripts/repo-cargo test -p meerkat-mob member_session_binding_recovered_public_wire_shape_excludes_bridge_session_id --lib`
- `./scripts/repo-cargo test -p meerkat-mob test_resume_repoints_snapshotless_member_head_to_latest_persisted_session --lib`
- `./scripts/repo-cargo test -p meerkat-mob test_resumed_metadata_accepts_legacy_raw_alias_comms_name --lib`
- `./scripts/repo-cargo test -p meerkat-mob test_supervisor_private_trust_realizes_generated_publish_obligation --lib`
- `./scripts/repo-cargo test -p meerkat build_agent_applies_configured_retry_schedule_without_call_timeout --test factory_build_agent`
- `make check`
- `make test` (8482 nextest tests passed, 73 skipped; follow-on session tests passed)
- `make lint`
