### PR TITLE
fix: 0.7.2 follow-up — mob-teardown regressions + e2e-system + immediate dogma fixes

### DIFF
--- a/meerkat-cli/src/main.rs
+++ b/meerkat-cli/src/main.rs
@@ -4408,16 +4408,17 @@ async fn refresh_auth_profile(
         .get(profile_id)
         .ok_or_else(|| anyhow::anyhow!("Auth profile '{realm}:{profile_id}' not found"))?;
 
-    // No-op fast paths: refresh is meaningless for non-OAuth methods.
-    // Dogma §5: typed truth — we branch on auth_method, not folklore.
-    let is_refreshable = matches!(
-        profile.auth_method.as_str(),
-        "managed_chatgpt_oauth"
-            | "claude_ai_oauth"
-            | "oauth_to_api_key"
-            | "google_oauth"
-            | "code_assist_oauth"
-    );
+    // No-op fast path: refresh is meaningless for methods whose persisted
+    // credential is not an OAuth-login-lifecycle secret. Dogma §5: branch on
+    // the typed owner — the per-provider auth matrix's persisted-mode mapping —
+    // not a hand-maintained raw-string allowlist. The old `matches!` set omitted
+    // the real `external_chatgpt_tokens` OAuth-login mode (so `auth refresh`
+    // wrongly no-op'd it with a false "credentials don't expire" message) and
+    // carried the dead `code_assist_oauth` string that parses nowhere in the
+    // matrix.
+    let is_refreshable = meerkat_providers::NormalizedAuthMethod::from_auth_profile(profile)
+        .and_then(meerkat_providers::NormalizedAuthMethod::persisted_auth_mode)
+        .is_some_and(meerkat_core::auth::persisted_auth_mode_uses_oauth_login_lifecycle);
     if !is_refreshable {
         println!(
             "profile:       {realm}:{profile_id}\n\

--- a/meerkat-runtime/src/meerkat_machine/session_management.rs
+++ b/meerkat-runtime/src/meerkat_machine/session_management.rs
@@ -1560,15 +1560,37 @@ impl MeerkatMachine {
                 }
             }
         }
-        if let Some(drain_handle) = drain_handle
-            && let Err(join_error) = drain_handle.await
-            && !join_error.is_cancelled()
-        {
-            tracing::warn!(
-                %session_id,
-                error = %join_error,
-                "comms drain task ended abnormally during unregister drain"
-            );
+        if let Some(drain_handle) = drain_handle {
+            // The comms drain task was already aborted via
+            // `abort_keeping_handle()` above; await its quiescence, but BOUND
+            // the wait exactly like the runtime-loop handle. An external member
+            // (e.g. a TCP transport drain) whose task is parked in an operation
+            // that does not observe the cooperative abort promptly would
+            // otherwise wedge teardown forever on an unbounded `.await`
+            // (regression: `external_tcp_production_drain` hung past 900s). The
+            // grace is far above any realistic cancel latency; on elapse we
+            // abort the handle and proceed — the task is already aborted and
+            // will unwind, and teardown must not stall on it.
+            const COMMS_DRAIN_GRACE: std::time::Duration = std::time::Duration::from_secs(2);
+            let drain_abort = drain_handle.abort_handle();
+            match crate::tokio::time::timeout(COMMS_DRAIN_GRACE, drain_handle).await {
+                Ok(Ok(())) => {}
+                Ok(Err(join_error)) if join_error.is_cancelled() => {}
+                Ok(Err(join_error)) => {
+                    tracing::warn!(
+                        %session_id,
+                        error = %join_error,
+                        "comms drain task ended abnormally during unregister drain"
+                    );
+                }
+                Err(_elapsed) => {
+                    drain_abort.abort();
+                    tracing::warn!(
+                        %session_id,
+                        "comms drain task did not quiesce within the unregister drain grace window; abandoning the already-aborted drain task so teardown cannot stall"
+                    );
+                }
+            }
         }
 
         // Phase 5: re-acquire the gate. If the session vanished while the gate

--- a/meerkat-runtime/src/meerkat_machine_tests.rs
+++ b/meerkat-runtime/src/meerkat_machine_tests.rs
@@ -2375,6 +2375,73 @@ async fn unregister_session_aborts_and_removes_drain_slot() {
     );
 }
 
+/// Regression (0.7.2): `unregister_session` must BOUND its comms-drain await.
+///
+/// The two-phase drain aborts the comms-drain task and awaits its quiescence.
+/// The runtime-loop handle is bounded (grace + abort), but the comms-drain
+/// handle was awaited UNBOUNDED — so an external member (e.g. a TCP transport
+/// drain) whose task does not observe the cooperative abort promptly wedged
+/// teardown forever (the `external_tcp_production_drain` smoke hung past 900s).
+/// This is a regular (non-live, CI-gated) guard: a drain task that blocks its
+/// worker and ignores abort must NOT stall `unregister_session`.
+#[tokio::test(flavor = "multi_thread")]
+async fn unregister_session_bounds_an_unquiescing_comms_drain() {
+    let adapter = Arc::new(MeerkatMachine::ephemeral());
+    let session_id = SessionId::new();
+    let comms_runtime: Arc<dyn CommsRuntime> = Arc::new(FakeDrainRuntime::idle());
+
+    adapter
+        .register_session(session_id.clone())
+        .await
+        .expect("register session");
+
+    // A drain task that blocks its worker thread and does NOT honor tokio's
+    // cooperative abort, modelling a transport drain parked in a non-yielding
+    // operation. It auto-releases well above the teardown grace so that a
+    // regressed (unbounded) await terminates the test rather than hanging
+    // runtime shutdown.
+    let (release_tx, release_rx) = std::sync::mpsc::channel::<()>();
+    let stuck = tokio::spawn(async move {
+        tokio::task::block_in_place(move || {
+            let _ = release_rx.recv_timeout(Duration::from_secs(10));
+        });
+    });
+    {
+        let mut sessions = adapter.sessions.write().await;
+        let entry = sessions
+            .get_mut(&session_id)
+            .expect("register_session must have created the entry");
+        {
+            let mut authority = entry
+                .dsl_authority
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            crate::meerkat_machine::dsl::MeerkatMachineMutator::apply(
+                &mut *authority,
+                crate::meerkat_machine::dsl::MeerkatMachineInput::SpawnDrain {
+                    mode: crate::meerkat_machine::dsl::DrainMode::from(
+                        CommsDrainMode::PersistentHost,
+                    ),
+                },
+            )
+            .expect("test drain spawn authority should accept");
+        }
+        entry.drain_slot.install_task(comms_runtime, stuck);
+    }
+
+    // `COMMS_DRAIN_GRACE` (~2s) must bound teardown; pre-fix this awaited the
+    // stuck handle unbounded (~10s) and the 5s outer bound would elapse.
+    crate::tokio::time::timeout(
+        Duration::from_secs(5),
+        adapter.unregister_session(&session_id),
+    )
+    .await
+    .expect("unregister_session must not hang on an unquiescing comms drain");
+
+    // Release the modelled-stuck worker so the test does not leak it.
+    let _ = release_tx.send(());
+}
+
 #[tokio::test]
 async fn unregister_session_deletes_persisted_ops_lifecycle_epoch() {
     let store = Arc::new(crate::store::InMemoryRuntimeStore::new());

--- a/meerkat-session/src/ephemeral.rs
+++ b/meerkat-session/src/ephemeral.rs
@@ -1464,11 +1464,20 @@ impl<B: SessionAgentBuilder + 'static> EphemeralSessionService<B> {
     /// This is used when a runtime-backed turn mutates the in-memory session
     /// but fails to durably commit its boundary. Discarding the live handle
     /// forces subsequent access to recover from the last persisted snapshot.
+    ///
+    /// Idempotent: "the live handle is not present" is the desired end state,
+    /// so discarding an already-discarded (or never-materialized) session is a
+    /// success, not a `NotFound`. The runtime loop's `StopRuntimeExecutor`
+    /// clean exit discards the live handle as it quiesces, so a teardown drain
+    /// (`unregister_session`) that awaits that quiescence can race an explicit
+    /// caller-side discard; both must converge on `Ok(())`. Every production
+    /// caller already encodes this (`Ok(()) | Err(NotFound) => Ok(())`); this
+    /// makes the contract itself idempotent.
     pub async fn discard_live_session(&self, id: &SessionId) -> Result<(), SessionError> {
         let mut sessions = self.sessions.write().await;
-        let handle = sessions
-            .swap_remove(id)
-            .ok_or_else(|| SessionError::NotFound { id: id.clone() })?;
+        let Some(handle) = sessions.swap_remove(id) else {
+            return Ok(());
+        };
         drop(sessions);
         // Clear the singular typed materialization record. For a staged
         // session the registry-held capacity permit drops with it, so the
@@ -7088,6 +7097,47 @@ mod archive_shutdown_drain_tests {
             matches!(result, Err(SessionError::NotFound { .. })),
             "post-archive context application must be a typed NotFound, got {result:?}"
         );
+    }
+
+    /// Regression (0.7.2): `discard_live_session` must be idempotent.
+    ///
+    /// The runtime-loop drain in `unregister_session` (D1) quiesces the loop,
+    /// whose `StopRuntimeExecutor` clean exit discards the live handle. A caller
+    /// that then explicitly discards the same session (e.g. same-process mob
+    /// restart in `smoke_mob_resume`) raced that teardown and got `NotFound`,
+    /// which `.expect()` turned into a panic. "Not live" is the desired end
+    /// state, so a redundant discard must be `Ok(())`. This is a regular
+    /// (non-live, CI-gated) guard for the behavior the smoke lane caught.
+    #[tokio::test]
+    async fn discard_live_session_is_idempotent() {
+        let hooks = DrainProbeHooks::new();
+        let service = EphemeralSessionService::new(DrainProbeBuilder { hooks }, 1);
+        let created = service
+            .create_session(create_request())
+            .await
+            .expect("create session");
+        let session_id = created.session_id.clone();
+
+        // First discard removes the live handle.
+        service
+            .discard_live_session(&session_id)
+            .await
+            .expect("first discard removes the live handle");
+
+        // Second discard of the now-absent handle must be a benign no-op, NOT
+        // `NotFound` — this is the exact interleaving the teardown drain
+        // produces against an explicit caller discard.
+        service
+            .discard_live_session(&session_id)
+            .await
+            .expect("second discard is idempotent, not NotFound");
+
+        // A never-materialized session is likewise `Ok(())`.
+        let never_live = SessionId::new();
+        service
+            .discard_live_session(&never_live)
+            .await
+            .expect("discarding a never-materialized session is idempotent");
     }
 
     /// D1: archive teardown is only complete once the machine-owned drain

--- a/sdks/web/src/mob.ts
+++ b/sdks/web/src/mob.ts
@@ -1099,7 +1099,11 @@ export class Mob {
         JSON.stringify({
           prompt,
           agent_identity: options.agentIdentity,
-          profile_name: options.profileName,
+          // Canonical wire field is `role_name` (the WASM helper structs +
+          // TS/Python SDKs all consume `role_name`); serializing `profile_name`
+          // here was silently dropped by the WASM deserializer, so the helper
+          // was built with the default profile.
+          role_name: options.profileName,
           auth_binding: options.authBinding,
           runtime_mode: options.runtimeMode,
           backend: options.backend,
@@ -1135,7 +1139,11 @@ export class Mob {
           source_member_id: sourceMemberId,
           prompt,
           agent_identity: options.agentIdentity,
-          profile_name: options.profileName,
+          // Canonical wire field is `role_name` (the WASM helper structs +
+          // TS/Python SDKs all consume `role_name`); serializing `profile_name`
+          // here was silently dropped by the WASM deserializer, so the helper
+          // was built with the default profile.
+          role_name: options.profileName,
           auth_binding: options.authBinding,
           fork_context: options.forkContext,
           runtime_mode: options.runtimeMode,

--- a/sdks/web/tests/mob_payload.unit.mjs
+++ b/sdks/web/tests/mob_payload.unit.mjs
@@ -1233,3 +1233,31 @@ test('Session.destroy re-throws non-already-gone typed errors', () => {
   );
   assert.throws(() => session.destroy(), /SESSION_BUSY/);
 });
+
+// Regression: the WASM helper deserializers (MobSpawnHelperOptions /
+// MobForkHelperOptions) consume `role_name`, matching the canonical wire
+// contract and the TS/Python SDKs. The web SDK previously serialized
+// `profile_name`, which the WASM boundary silently dropped, so
+// `spawnHelper`/`forkHelper` built helpers with the DEFAULT profile.
+test('Mob.spawnHelper / forkHelper serialize canonical role_name (not profile_name)', async () => {
+  let spawnCaptured;
+  let forkCaptured;
+  const mob = new Mob('mob-web-unit', {
+    async mob_spawn_helper(_mobId, json) {
+      spawnCaptured = JSON.parse(json);
+      return JSON.stringify({ agent_identity: 'h-1', member_ref: 'ref-h-1', tokens_used: 0 });
+    },
+    async mob_fork_helper(_mobId, json) {
+      forkCaptured = JSON.parse(json);
+      return JSON.stringify({ agent_identity: 'h-2', member_ref: 'ref-h-2', tokens_used: 0 });
+    },
+  });
+
+  await mob.spawnHelper('do it', { agentIdentity: 'h-1', profileName: 'reviewer' });
+  await mob.forkHelper('src-1', 'do it', { agentIdentity: 'h-2', profileName: 'reviewer' });
+
+  assert.equal(spawnCaptured.role_name, 'reviewer');
+  assert.equal(spawnCaptured.profile_name, undefined);
+  assert.equal(forkCaptured.role_name, 'reviewer');
+  assert.equal(forkCaptured.profile_name, undefined);
+});

--- a/tests/integration/src/e2e_lanes.rs
+++ b/tests/integration/src/e2e_lanes.rs
@@ -4271,7 +4271,12 @@ fn suite_spec(name: &str) -> Option<&'static Spec> {
                 package: "rkat",
                 test_target: "system_cli_resume",
                 test_name: "integration_real_cli_resume_tools",
-                features: &["integration-real-tests"],
+                // yolo's Full preset enables `memory` only when the build
+                // supports it (`cfg!(feature = "memory-store-session")`), so the
+                // scenario must build rkat with memory or the
+                // `memory should be recorded for yolo` assertion degrades to
+                // Disable and fails.
+                features: &["integration-real-tests", "memory-store-session"],
                 all_features: false,
             },
         }),


### PR DESCRIPTION
0.7.2 follow-up fixes found during post-release e2e verification + the dogma audit.

## Mob-teardown regressions (introduced in 0.7.2, caught by the e2e-smoke mob lane — not in CI)
1. **Unbounded comms-drain teardown await** → external-TCP members whose drain task ignores cooperative abort wedged teardown (`external_tcp_production_drain` hung >900s). Now bounded by `COMMS_DRAIN_GRACE` + abort, matching the runtime-loop handle.
2. **`discard_live_session` raced the teardown drain → `NotFound`**, breaking same-process mob restart. `discard_live_session` is now idempotent (codifies the existing `Ok(()) | Err(NotFound) => Ok(())` caller idiom).

Both bisected against pre-0.7.2 (`37a0b9461`, where the smoke test passes) and now covered by **regular CI-gated tests**: `unregister_session_bounds_an_unquiescing_comms_drain`, `discard_live_session_is_idempotent`.

## e2e-system fix (pre-existing)
`cli-resume-tools` built rkat without `memory-store-session`, so yolo's `memory` tool degraded to Disable and the assertion failed. Now builds that scenario with the memory feature. (e2e-system: 11/11 green.)

## Immediate dogma fixes (post-0.7.2 audit)
- **`rkat auth refresh`** derived refreshability from a raw-string allowlist that omitted `external_chatgpt_tokens` (a real OAuth-login mode) → false "credentials don't expire" no-op, token never refreshed. Now uses the typed projection (`NormalizedAuthMethod` → persisted mode → `uses_oauth_login_lifecycle`); dead `code_assist_oauth` dropped.
- **@rkat/web `spawnHelper`/`forkHelper`** serialized `profile_name`, silently dropped by the WASM `role_name` deserializer → helpers built with the default profile. Now serializes canonical `role_name` (+ payload regression test).

The 9 remaining confirmed/partial dogma rows have **no immediate operational effect** and are deferred to #769.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
