### PR TITLE
Harden machine-owned execution control

### DIFF
--- a/meerkat-machine-kernels/src/generated/meerkat.rs
+++ b/meerkat-machine-kernels/src/generated/meerkat.rs
@@ -10316,7 +10316,7 @@ pub struct State {
     pub input_abandon_attempt_count: std::collections::BTreeMap<String, u64>,
     pub input_attempt_counts: std::collections::BTreeMap<String, u64>,
     pub max_stage_attempts: u64,
-    pub input_run_associations: std::collections::BTreeMap<String, String>,
+    pub input_run_associations: std::collections::BTreeMap<String, RunId>,
     pub input_boundary_sequences: std::collections::BTreeMap<String, u64>,
     pub live_boundary_context_sequence_by_run: std::collections::BTreeMap<RunId, u64>,
     pub next_admission_seq: u64,
@@ -11014,7 +11014,7 @@ pub mod inputs {
         pub abandon_reason: Option<InputAbandonReason>,
         pub abandon_attempt_count: u64,
         pub attempt_count: u64,
-        pub run_id: Option<String>,
+        pub run_id: Option<RunId>,
         pub boundary_sequence: Option<u64>,
         pub admission_sequence: Option<u64>,
         pub recovery_lane: Option<InputLane>,
@@ -11234,7 +11234,7 @@ pub mod inputs {
         pub abandon_reason: Option<InputAbandonReason>,
         pub abandon_attempt_count: u64,
         pub attempt_count: u64,
-        pub run_id: Option<String>,
+        pub run_id: Option<RunId>,
         pub boundary_sequence: Option<u64>,
         pub admission_sequence: Option<u64>,
         pub admission_sequence_recovery: Option<RecoveredInputNormalizationReasonKind>,
@@ -11265,7 +11265,7 @@ pub mod inputs {
     #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
     pub struct StageForRun {
         pub input_id: String,
-        pub run_id: String,
+        pub run_id: RunId,
     }
     #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
     pub struct IncrementAttemptCount {

--- a/meerkat-machine-schema/src/catalog/dsl/meerkat_machine.rs
+++ b/meerkat-machine-schema/src/catalog/dsl/meerkat_machine.rs
@@ -37,6 +37,16 @@ pub struct RuntimeEpochId(pub String);
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 pub struct RunId(pub String);
 
+impl RunId {
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    pub fn get(&self, _key: &str) -> String {
+        self.0.clone()
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 pub struct InputId(pub String);
 
@@ -2610,7 +2620,7 @@ macro_rules! meerkat_catalog_machine_dsl {
             input_abandon_attempt_count: Map<String, u64>,
             input_attempt_counts: Map<String, u64>,
             max_stage_attempts: u64,
-            input_run_associations: Map<String, String>,
+            input_run_associations: Map<String, RunId>,
             input_boundary_sequences: Map<String, u64>,
             live_boundary_context_sequence_by_run: Map<RunId, u64>,
             next_admission_seq: u64,
@@ -3594,7 +3604,7 @@ macro_rules! meerkat_catalog_machine_dsl {
                 abandon_reason: Option<Enum<InputAbandonReason>>,
                 abandon_attempt_count: u64,
                 attempt_count: u64,
-                run_id: Option<String>,
+                run_id: Option<RunId>,
                 boundary_sequence: Option<u64>,
                 admission_sequence: Option<u64>,
                 recovery_lane: Option<Enum<InputLane>>,
@@ -3700,7 +3710,7 @@ macro_rules! meerkat_catalog_machine_dsl {
                 abandon_reason: Option<Enum<InputAbandonReason>>,
                 abandon_attempt_count: u64,
                 attempt_count: u64,
-                run_id: Option<String>,
+                run_id: Option<RunId>,
                 boundary_sequence: Option<u64>,
                 admission_sequence: Option<u64>,
                 admission_sequence_recovery: Option<Enum<RecoveredInputNormalizationReasonKind>>,
@@ -3712,7 +3722,7 @@ macro_rules! meerkat_catalog_machine_dsl {
             ChangeLane { input_id: String, new_lane: Enum<InputLane> },
             PrioritizeInput { input_id: String },
             DeferInputBehindBacklog { input_id: String },
-            StageForRun { input_id: String, run_id: String },
+            StageForRun { input_id: String, run_id: RunId },
             IncrementAttemptCount { input_id: String },
             RollbackStaged { input_id: String, lane: Enum<InputLane> },
             ResolveStagedRollback { input_id: String, lane: Enum<InputLane> },
@@ -5459,6 +5469,18 @@ macro_rules! meerkat_catalog_machine_dsl {
         invariant current_run_has_pre_run_phase {
             (self.current_run_id == None && self.pre_run_phase == None)
             || (self.current_run_id != None && self.pre_run_phase != None)
+        }
+
+        invariant staged_inputs_are_not_queued {
+            for_all(input_id in self.input_phases.keys(),
+                self.input_phases.get(input_id).get("value") != InputPhase::Staged
+                || !self.input_lane.contains_key(input_id))
+        }
+
+        invariant staged_inputs_have_run_association {
+            for_all(input_id in self.input_phases.keys(),
+                self.input_phases.get(input_id).get("value") != InputPhase::Staged
+                || self.input_run_associations.contains_key(input_id))
         }
 
         invariant staged_surface_ops_are_known_and_sequenced {
@@ -15534,11 +15556,23 @@ macro_rules! meerkat_catalog_machine_dsl {
         transition StageForRun {
             per_phase [Idle, Attached, Running, Retired, Stopped]
             on input StageForRun { input_id, run_id }
-            guard "input_tracked" { self.input_phases.contains_key(input_id) }
+            guard "input_queued" {
+                self.input_phases.contains_key(input_id)
+                && self.input_phases.get(input_id).get("value") == InputPhase::Queued
+            }
+            guard "input_lane_bound" { self.input_lane.contains_key(input_id) }
+            guard "input_sequence_bound" { self.input_admission_seq.contains_key(input_id) }
+            guard "input_recovery_lane_bound" { self.input_recovery_lanes.contains_key(input_id) }
+            guard "input_not_run_associated" { !self.input_run_associations.contains_key(input_id) }
+            guard "current_run_matches" {
+                self.current_run_id != None
+                && self.current_run_id.get("value") == run_id
+            }
             update {
                 self.input_phases.insert(input_id, InputPhase::Staged);
                 self.input_run_associations.insert(input_id, run_id);
                 self.input_lane.remove(input_id);
+                self.input_attempt_counts.increment(input_id, 1);
             }
             to Idle
             emit RecordRunAssociation

--- a/meerkat-runtime/BUILD.bazel
+++ b/meerkat-runtime/BUILD.bazel
@@ -607,6 +607,7 @@ rust_test(
         "//:workspace_cargo_manifests",
         "//:workspace_metadata",
         "//meerkat-core:package_runfiles",
+        "//meerkat-machine-schema:package_runfiles",
         "//meerkat-mcp-server:package_runfiles",
         "//meerkat:package_runfiles",
     ],

--- a/meerkat-runtime/src/accept.rs
+++ b/meerkat-runtime/src/accept.rs
@@ -119,10 +119,69 @@ impl MachineAdmissionAuthority {
     }
 }
 
+/// Runtime-local proof that generated admission authority authorized execution
+/// of the accepted input's semantic admission plan.
+#[must_use = "runtime ingress execution capability must be consumed by accept_resolved_input"]
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) struct RuntimeIngressExecutionCapability {
+    input_id: String,
+    lane: mm_dsl::InputLane,
+    plan: mm_dsl::AdmissionPlanKind,
+}
+
+impl RuntimeIngressExecutionCapability {
+    fn from_admission_resolved_effect(
+        input_id: String,
+        lane: mm_dsl::InputLane,
+        plan: mm_dsl::AdmissionPlanKind,
+    ) -> Self {
+        Self {
+            input_id,
+            lane,
+            plan,
+        }
+    }
+
+    fn validate_for(
+        self,
+        input_id: &InputId,
+        handling_mode: HandlingMode,
+        admission_plan: &AdmissionPlan,
+    ) -> Result<(), String> {
+        if self.input_id != input_id.to_string() {
+            return Err(format!(
+                "runtime ingress capability id '{}' did not match accepted input '{input_id}'",
+                self.input_id
+            ));
+        }
+
+        let expected_lane = mm_dsl::InputLane::from(handling_mode);
+        if self.lane != expected_lane {
+            return Err(format!(
+                "runtime ingress capability lane {:?} did not match accepted input lane {expected_lane:?}",
+                self.lane
+            ));
+        }
+
+        let expected_plan = match admission_plan {
+            AdmissionPlan::ConsumedOnAccept => mm_dsl::AdmissionPlanKind::ConsumedOnAccept,
+            AdmissionPlan::Queued { .. } => mm_dsl::AdmissionPlanKind::Queued,
+        };
+        if self.plan != expected_plan {
+            return Err(format!(
+                "runtime ingress capability plan {:?} did not match accepted input plan {expected_plan:?}",
+                self.plan
+            ));
+        }
+
+        Ok(())
+    }
+}
+
 /// Machine-owned resolution of an accepted input's semantic admission path.
 // Cannot derive `Eq`: `RuntimeInputProjection` carries a typed
 // `peer_response_terminal` fact whose render payload is a `serde_json::Value`.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, PartialEq)]
 pub struct ResolvedAdmission {
     policy: PolicyDecision,
     handling_mode: HandlingMode,
@@ -132,6 +191,7 @@ pub struct ResolvedAdmission {
     coarse_flags: CoarseAdmissionFlags,
     requires_active_pre_admission: bool,
     authority: MachineAdmissionAuthority,
+    execution_capability: Option<RuntimeIngressExecutionCapability>,
 }
 
 impl ResolvedAdmission {
@@ -145,6 +205,7 @@ impl ResolvedAdmission {
         coarse_flags: CoarseAdmissionFlags,
         requires_active_pre_admission: bool,
         authority: MachineAdmissionAuthority,
+        execution_capability: Option<(String, mm_dsl::InputLane, mm_dsl::AdmissionPlanKind)>,
     ) -> Self {
         Self {
             policy,
@@ -155,6 +216,11 @@ impl ResolvedAdmission {
             coarse_flags,
             requires_active_pre_admission,
             authority,
+            execution_capability: execution_capability.map(|(input_id, lane, plan)| {
+                RuntimeIngressExecutionCapability::from_admission_resolved_effect(
+                    input_id, lane, plan,
+                )
+            }),
         }
     }
 
@@ -166,6 +232,11 @@ impl ResolvedAdmission {
         self.requires_active_pre_admission
     }
 
+    #[cfg(test)]
+    pub(crate) fn policy(&self) -> &PolicyDecision {
+        &self.policy
+    }
+
     pub(crate) fn stages_run_boundary(&self) -> bool {
         self.policy.apply_mode == crate::policy::ApplyMode::StageRunBoundary
     }
@@ -174,22 +245,51 @@ impl ResolvedAdmission {
         &self.authority
     }
 
-    pub(crate) fn into_parts(
+    pub(crate) fn semantically_equivalent_to(&self, other: &Self) -> bool {
+        self.policy == other.policy
+            && self.handling_mode == other.handling_mode
+            && self.runtime_semantics == other.runtime_semantics
+            && self.primitive_projection == other.primitive_projection
+            && self.admission_plan == other.admission_plan
+            && self.coarse_flags == other.coarse_flags
+            && self.requires_active_pre_admission == other.requires_active_pre_admission
+            && self.authority == other.authority
+    }
+
+    pub(crate) fn consume_execution_capability(
         self,
-    ) -> (
-        PolicyDecision,
-        HandlingMode,
-        crate::ingress_types::RuntimeInputSemantics,
-        crate::ingress_types::RuntimeInputProjection,
-        AdmissionPlan,
-    ) {
+        input_id: &InputId,
+    ) -> Result<
         (
-            self.policy,
-            self.handling_mode,
-            self.runtime_semantics,
-            self.primitive_projection,
-            self.admission_plan,
-        )
+            PolicyDecision,
+            HandlingMode,
+            crate::ingress_types::RuntimeInputSemantics,
+            crate::ingress_types::RuntimeInputProjection,
+            AdmissionPlan,
+        ),
+        String,
+    > {
+        let Self {
+            policy,
+            handling_mode,
+            runtime_semantics,
+            primitive_projection,
+            admission_plan,
+            execution_capability,
+            ..
+        } = self;
+        let execution_capability = execution_capability.ok_or_else(|| {
+            "runtime ingress execution capability was not minted for this admission resolution"
+                .to_string()
+        })?;
+        execution_capability.validate_for(input_id, handling_mode, &admission_plan)?;
+        Ok((
+            policy,
+            handling_mode,
+            runtime_semantics,
+            primitive_projection,
+            admission_plan,
+        ))
     }
 }
 

--- a/meerkat-runtime/src/completion.rs
+++ b/meerkat-runtime/src/completion.rs
@@ -15,6 +15,7 @@ use std::future::Future;
 use meerkat_core::lifecycle::InputId;
 #[cfg(test)]
 use meerkat_core::lifecycle::RunId;
+use meerkat_core::lifecycle::core_executor::CoreApplyTerminal;
 use meerkat_core::types::{RunResult, SessionId};
 use meerkat_core::{TurnErrorMetadata, TurnTerminalCauseKind, TurnTerminalOutcome};
 use serde_json::Value;
@@ -507,6 +508,21 @@ impl CompletionRegistry {
         }
     }
 
+    #[cfg(test)]
+    fn fail_inputs_authority_mismatch<I>(
+        &mut self,
+        input_ids: I,
+        authority: &RuntimeCompletionResultAuthority,
+        expected: RuntimeCompletionResultClass,
+    ) where
+        I: IntoIterator<Item = InputId>,
+    {
+        self.fail_inputs(
+            input_ids,
+            Self::authority_mismatch_error(authority, expected),
+        );
+    }
+
     /// Register a waiter for an input. Returns the handle the caller will await.
     ///
     /// Multiple waiters can be registered for the same InputId — all will be
@@ -533,6 +549,7 @@ impl CompletionRegistry {
         }
     }
 
+    #[cfg(test)]
     pub(crate) fn resolve_completed_authorized(
         &mut self,
         input_id: &InputId,
@@ -549,6 +566,180 @@ impl CompletionRegistry {
             result,
             CompletionCleanupObservation::from_authority(authority),
         );
+    }
+
+    pub(crate) fn resolve_runtime_completion_authorized<I>(
+        &mut self,
+        input_ids: I,
+        terminal: Option<&CoreApplyTerminal>,
+        authority: RuntimeCompletionResultAuthority,
+        finalization_error: Option<TurnErrorMetadata>,
+    ) where
+        I: IntoIterator<Item = InputId>,
+    {
+        let input_ids: Vec<InputId> = input_ids.into_iter().collect();
+        match authority.class() {
+            RuntimeCompletionResultClass::Completed => {
+                let Some(CoreApplyTerminal::RunResult(result)) = terminal else {
+                    self.fail_inputs(
+                        input_ids,
+                        CompletionWaitError::AuthorityUnavailable(
+                            "runtime completion authority resolved Completed without result payload"
+                                .to_string(),
+                        ),
+                    );
+                    return;
+                };
+                let cleanup_observation = CompletionCleanupObservation::from_authority(authority);
+                for input_id in input_ids {
+                    self.resolve_completed(
+                        &input_id,
+                        result.as_ref().clone(),
+                        cleanup_observation.clone(),
+                    );
+                }
+            }
+            RuntimeCompletionResultClass::CompletedWithoutResult => {
+                if !matches!(terminal, Some(CoreApplyTerminal::NoPendingBoundary) | None) {
+                    self.fail_inputs(
+                        input_ids,
+                        CompletionWaitError::AuthorityUnavailable(
+                            "runtime completion authority resolved CompletedWithoutResult with terminal payload"
+                                .to_string(),
+                        ),
+                    );
+                    return;
+                }
+                let cleanup_observation = CompletionCleanupObservation::from_authority(authority);
+                for input_id in input_ids {
+                    self.resolve_without_result(&input_id, cleanup_observation.clone());
+                }
+            }
+            RuntimeCompletionResultClass::CallbackPending => {
+                let Some(CoreApplyTerminal::CallbackPending { tool_name, args }) = terminal else {
+                    self.fail_inputs(
+                        input_ids,
+                        CompletionWaitError::AuthorityUnavailable(
+                            "runtime completion authority resolved CallbackPending without callback payload"
+                                .to_string(),
+                        ),
+                    );
+                    return;
+                };
+                let cleanup_observation = CompletionCleanupObservation::from_authority(authority);
+                for input_id in input_ids {
+                    self.resolve_callback_pending(
+                        &input_id,
+                        tool_name.clone(),
+                        args.clone(),
+                        cleanup_observation.clone(),
+                    );
+                }
+            }
+            RuntimeCompletionResultClass::Cancelled => {
+                if terminal.is_some() || finalization_error.is_some() {
+                    self.fail_inputs(
+                        input_ids,
+                        CompletionWaitError::AuthorityUnavailable(
+                            "runtime completion authority resolved Cancelled with payload"
+                                .to_string(),
+                        ),
+                    );
+                    return;
+                }
+                let cleanup_observation = CompletionCleanupObservation::from_authority(authority);
+                for input_id in input_ids {
+                    self.resolve_cancelled(&input_id, cleanup_observation.clone());
+                }
+            }
+            RuntimeCompletionResultClass::AbandonedWithError => {
+                if matches!(terminal, Some(CoreApplyTerminal::RunResult(_))) {
+                    self.fail_inputs(
+                        input_ids,
+                        CompletionWaitError::AuthorityUnavailable(
+                            "runtime completion authority resolved AbandonedWithError with result payload"
+                                .to_string(),
+                        ),
+                    );
+                    return;
+                }
+                let Some(error) = finalization_error else {
+                    self.fail_inputs(
+                        input_ids,
+                        CompletionWaitError::AuthorityUnavailable(
+                            "runtime completion authority resolved AbandonedWithError without typed error"
+                                .to_string(),
+                        ),
+                    );
+                    return;
+                };
+                let reason = error
+                    .detail
+                    .clone()
+                    .unwrap_or_else(|| "runtime finalization failed".to_string());
+                let cleanup_observation = CompletionCleanupObservation::from_authority(authority);
+                for input_id in input_ids {
+                    self.resolve_abandoned_with_error(
+                        &input_id,
+                        reason.clone(),
+                        error.clone(),
+                        cleanup_observation.clone(),
+                    );
+                }
+            }
+            RuntimeCompletionResultClass::CompletedWithFinalizationFailure => {
+                let Some(CoreApplyTerminal::RunResult(_result)) = terminal else {
+                    self.fail_inputs(
+                        input_ids,
+                        CompletionWaitError::AuthorityUnavailable(
+                            "runtime completion authority resolved CompletedWithFinalizationFailure without result payload"
+                                .to_string(),
+                        ),
+                    );
+                    return;
+                };
+                let Some(error) = finalization_error else {
+                    self.fail_inputs(
+                        input_ids,
+                        CompletionWaitError::AuthorityUnavailable(
+                            "runtime completion authority resolved finalization failure without typed error"
+                                .to_string(),
+                        ),
+                    );
+                    return;
+                };
+                let cleanup_observation = CompletionCleanupObservation::from_authority(authority);
+                for input_id in input_ids {
+                    self.resolve_completed_with_finalization_failure(
+                        &input_id,
+                        error.clone(),
+                        cleanup_observation.clone(),
+                    );
+                }
+            }
+            RuntimeCompletionResultClass::RuntimeTerminated => {
+                if terminal.is_some() || finalization_error.is_some() {
+                    self.fail_inputs(
+                        input_ids,
+                        CompletionWaitError::AuthorityUnavailable(
+                            "runtime completion authority resolved RuntimeTerminated with payload"
+                                .to_string(),
+                        ),
+                    );
+                    return;
+                }
+                let cleanup_observation = CompletionCleanupObservation::from_authority(authority);
+                for input_id in input_ids {
+                    if let Some(senders) = self.take_waiters(&input_id) {
+                        Self::send_outcome(
+                            senders,
+                            CompletionOutcome::runtime_terminated("runtime terminated"),
+                            cleanup_observation.clone(),
+                        );
+                    }
+                }
+            }
+        }
     }
 
     /// Resolve all waiters for an input that completed without producing a RunResult.
@@ -599,6 +790,7 @@ impl CompletionRegistry {
         }
     }
 
+    #[cfg(test)]
     pub(crate) fn resolve_callback_pending_authorized(
         &mut self,
         input_id: &InputId,
@@ -630,6 +822,7 @@ impl CompletionRegistry {
         }
     }
 
+    #[cfg(test)]
     pub(crate) fn resolve_cancelled_authorized(
         &mut self,
         input_id: &InputId,
@@ -663,6 +856,7 @@ impl CompletionRegistry {
         }
     }
 
+    #[cfg(test)]
     pub(crate) fn resolve_abandoned_with_error_authorized(
         &mut self,
         input_id: &InputId,
@@ -700,6 +894,7 @@ impl CompletionRegistry {
         }
     }
 
+    #[cfg(test)]
     pub(crate) fn resolve_completed_with_finalization_failure_authorized(
         &mut self,
         input_id: &InputId,
@@ -744,6 +939,7 @@ impl CompletionRegistry {
         }
     }
 
+    #[cfg(test)]
     pub(crate) fn resolve_inputs_runtime_terminated<I>(
         &mut self,
         input_ids: I,
@@ -755,8 +951,7 @@ impl CompletionRegistry {
         let input_ids: Vec<InputId> = input_ids.into_iter().collect();
         let expected = RuntimeCompletionResultClass::RuntimeTerminated;
         if !authority.allows(expected) {
-            let error = Self::authority_mismatch_error(&authority, expected);
-            self.fail_inputs(input_ids, error);
+            self.fail_inputs_authority_mismatch(input_ids, &authority, expected);
             return;
         }
         let cleanup_observation = CompletionCleanupObservation::from_authority(authority);

--- a/meerkat-runtime/src/driver/ephemeral.rs
+++ b/meerkat-runtime/src/driver/ephemeral.rs
@@ -597,7 +597,7 @@ impl EphemeralRuntimeDriver {
     pub fn input_last_run_id(&self, input_id: &InputId) -> Option<RunId> {
         let key = Self::dsl_key(input_id);
         let raw = self.with_dsl_state(|state| state.input_run_associations.get(&key).cloned())?;
-        raw.parse::<uuid::Uuid>().ok().map(RunId::from_uuid)
+        raw.0.parse::<uuid::Uuid>().ok().map(RunId::from_uuid)
     }
 
     /// Read the committed boundary sequence for an input, from the DSL.
@@ -1074,7 +1074,7 @@ impl EphemeralRuntimeDriver {
                 run_id: recovered_seed
                     .last_run_id
                     .as_ref()
-                    .map(std::string::ToString::to_string),
+                    .map(mm_dsl::RunId::from_domain),
                 boundary_sequence: recovered_seed.last_boundary_sequence,
                 admission_sequence: recovered_seed.admission_sequence,
                 admission_sequence_recovery,
@@ -1853,28 +1853,29 @@ impl EphemeralRuntimeDriver {
         Some((queued.input_id, queued.input))
     }
 
-    /// Dequeue a specific input by ID from whichever queue contains it.
-    pub fn dequeue_by_id(&mut self, input_id: &InputId) -> Option<(InputId, Input)> {
-        self.steer_queue
-            .dequeue_by_id(input_id)
-            .or_else(|| self.queue.dequeue_by_id(input_id))
-    }
-
-    pub fn stage_input(
+    pub(crate) fn dequeue_batch_exact(
         &mut self,
-        input_id: &InputId,
-        run_id: &RunId,
-    ) -> Result<(), RuntimeDriverError> {
-        self.stage_batch(std::slice::from_ref(input_id), run_id)
-    }
+        batch: &crate::meerkat_machine::driver::AuthorizedRuntimeLoopBatch,
+    ) -> Result<Vec<(InputId, Input)>, RuntimeDriverError> {
+        let mut staged_steer_queue = self.steer_queue.clone();
+        let mut staged_queue = self.queue.clone();
+        let mut dequeued = Vec::with_capacity(batch.input_ids().len());
 
-    /// Stage a batch of inputs via DSL `StageForRun` transitions.
-    pub fn stage_batch(
-        &mut self,
-        input_ids: &[InputId],
-        run_id: &RunId,
-    ) -> Result<(), RuntimeDriverError> {
-        self.machine_realize_stage_batch(input_ids, run_id)
+        for input_id in batch.input_ids() {
+            let Some(input) = staged_steer_queue
+                .dequeue_by_id(input_id)
+                .or_else(|| staged_queue.dequeue_by_id(input_id))
+            else {
+                return Err(RuntimeDriverError::Internal(format!(
+                    "authorized runtime batch member {input_id} was missing from physical queue projection"
+                )));
+            };
+            dequeued.push(input);
+        }
+
+        self.steer_queue = staged_steer_queue;
+        self.queue = staged_queue;
+        Ok(dequeued)
     }
 
     /// Machine-owned realization for a validated staged contributor batch.
@@ -1892,15 +1893,9 @@ impl EphemeralRuntimeDriver {
             self.dsl_apply(
                 mm_dsl::MeerkatMachineInput::StageForRun {
                     input_id: key,
-                    run_id: run_id.to_string(),
+                    run_id: mm_dsl::RunId(run_id.to_string()),
                 },
                 "StageForRun",
-            )?;
-            self.dsl_apply(
-                mm_dsl::MeerkatMachineInput::IncrementAttemptCount {
-                    input_id: Self::dsl_key(input_id),
-                },
-                "IncrementAttemptCount",
             )?;
 
             let now = Utc::now();
@@ -2599,6 +2594,7 @@ impl EphemeralRuntimeDriver {
         input: &Input,
         authority: MachineAdmissionAuthority,
         effects: Vec<mm_dsl::MeerkatMachineEffect>,
+        mint_execution_capability: bool,
     ) -> Result<ResolvedAdmission, RuntimeDriverError> {
         let Some(effect) = effects.into_iter().find_map(|effect| match effect {
             mm_dsl::MeerkatMachineEffect::AdmissionResolved {
@@ -2735,6 +2731,7 @@ impl EphemeralRuntimeDriver {
             },
             requires_active_pre_admission,
             authority,
+            mint_execution_capability.then_some((input_id, lane, plan)),
         ))
     }
 
@@ -2760,7 +2757,7 @@ impl EphemeralRuntimeDriver {
             Self::resolve_admission_plan_input(&authority),
             "ResolveAdmissionPlan",
         )?;
-        self.resolved_admission_from_machine_effects(input, authority, effects)
+        self.resolved_admission_from_machine_effects(input, authority, effects, false)
     }
 
     pub(crate) fn resolve_admission(
@@ -2919,9 +2916,17 @@ impl EphemeralRuntimeDriver {
             Self::resolve_admission_plan_input(&authority),
             "ResolveAdmissionPlan",
         )?;
-        let resolved = self.resolved_admission_from_machine_effects(&input, authority, effects)?;
+        let committed_resolved =
+            self.resolved_admission_from_machine_effects(&input, authority, effects, true)?;
+        if !resolved.semantically_equivalent_to(&committed_resolved) {
+            return Err(RuntimeDriverError::Internal(format!(
+                "committed admission resolution diverged from preview: preview={resolved:?}, committed={committed_resolved:?}"
+            )));
+        }
         let (policy, handling_mode, runtime_semantics, primitive_projection, admission_plan) =
-            resolved.into_parts();
+            committed_resolved
+                .consume_execution_capability(&input_id)
+                .map_err(RuntimeDriverError::Internal)?;
 
         let content_shape = ContentShape::from_kind(input.kind());
         let is_prompt = matches!(input, Input::Prompt(_));
@@ -3025,10 +3030,21 @@ impl EphemeralRuntimeDriver {
     pub(crate) async fn preview_accept_resolved_input(
         &self,
         input: Input,
-        resolved: crate::accept::ResolvedAdmission,
+        resolved: &crate::accept::ResolvedAdmission,
     ) -> Result<AcceptOutcome, RuntimeDriverError> {
         let mut staged = self.clone_with_isolated_dsl_authority();
         staged.ensure_contract_session_authority()?;
+        let resolved = if resolved.authority().without_wake() {
+            staged.resolve_admission_without_wake_with_active_turn_boundary(
+                &input,
+                resolved.authority().active_turn_boundary_available(),
+            )?
+        } else {
+            staged.resolve_admission_with_active_turn_boundary(
+                &input,
+                resolved.authority().active_turn_boundary_available(),
+            )?
+        };
         staged.accept_resolved_input(input, resolved).await
     }
 
@@ -3889,9 +3905,15 @@ mod tests {
         let input_id = input.id().clone();
         driver.accept_input(input).await.unwrap();
 
+        let run_id = RunId::new();
+        driver
+            .contract_begin_run_authority(run_id.clone())
+            .expect("runtime run authority should begin through generated DSL");
+
         for attempt in 1..3 {
-            let run_id = RunId::new();
-            driver.stage_input(&input_id, &run_id).unwrap();
+            driver
+                .machine_realize_stage_batch(std::slice::from_ref(&input_id), &run_id)
+                .unwrap();
             assert_eq!(driver.input_attempt_count(&input_id), attempt);
 
             driver
@@ -3905,8 +3927,9 @@ mod tests {
             assert_eq!(driver.input_terminal_outcome(&input_id), None);
         }
 
-        let final_run_id = RunId::new();
-        driver.stage_input(&input_id, &final_run_id).unwrap();
+        driver
+            .machine_realize_stage_batch(std::slice::from_ref(&input_id), &run_id)
+            .unwrap();
         assert_eq!(driver.input_attempt_count(&input_id), 3);
         driver
             .rollback_staged(std::slice::from_ref(&input_id))
@@ -3923,6 +3946,47 @@ mod tests {
             })
         );
         assert!(!driver.has_queued_input(&input_id));
+    }
+
+    #[tokio::test]
+    async fn stage_input_keeps_queue_projection_aligned() {
+        let mut driver = EphemeralRuntimeDriver::new(LogicalRuntimeId::new("stage-projection"));
+        let input = prompt_input("stage me");
+        let input_id = input.id().clone();
+        driver.accept_input(input).await.unwrap();
+
+        let run_id = RunId::new();
+        driver.contract_begin_run_authority(run_id.clone()).unwrap();
+        driver
+            .machine_realize_stage_batch(std::slice::from_ref(&input_id), &run_id)
+            .unwrap();
+
+        assert!(driver.queue().is_empty());
+        driver.debug_assert_queue_projection_alignment();
+    }
+
+    #[tokio::test]
+    async fn recovery_applied_stays_applied() {
+        let mut driver = EphemeralRuntimeDriver::new(LogicalRuntimeId::new("recovery-applied"));
+
+        let input = prompt_input("hello");
+        let input_id = input.id().clone();
+        driver.accept_input(input).await.unwrap();
+
+        let run_id = RunId::new();
+        driver.contract_begin_run_authority(run_id.clone()).unwrap();
+        driver
+            .machine_realize_stage_batch(std::slice::from_ref(&input_id), &run_id)
+            .unwrap();
+        driver.apply_input(&input_id, &run_id).unwrap();
+
+        let report = driver.recover_ephemeral().unwrap();
+        assert_eq!(report.inputs_recovered, 1);
+        assert_eq!(
+            driver.input_phase(&input_id),
+            Some(InputLifecycleState::AppliedPendingConsumption)
+        );
+        driver.debug_assert_queue_projection_alignment();
     }
 
     #[tokio::test]
@@ -3953,7 +4017,7 @@ mod tests {
         );
 
         let err = driver
-            .stage_input(&input_id, &RunId::new())
+            .machine_realize_stage_batch(std::slice::from_ref(&input_id), &RunId::new())
             .expect_err("staging must not synthesize a queued phase without machine authority");
         assert!(
             matches!(&err, RuntimeDriverError::Internal(message) if message.contains("generated input lifecycle phase missing before staging")),
@@ -4158,8 +4222,7 @@ mod tests {
         let projected = driver.resolve_admission(&input).unwrap();
         assert!(projected.requires_active_runtime_pre_admission());
         let flags = projected.coarse_flags();
-        let (policy, _, _, _, _) = projected.into_parts();
-        assert_eq!(policy.wake_mode, WakeMode::WakeIfIdle);
+        assert_eq!(projected.policy().wake_mode, WakeMode::WakeIfIdle);
         assert!(!flags.interrupt_yielding);
         assert!(!flags.request_immediate_processing);
     }

--- a/meerkat-runtime/src/driver/persistent.rs
+++ b/meerkat-runtime/src/driver/persistent.rs
@@ -335,9 +335,11 @@ impl PersistentRuntimeDriver {
         self.inner.dequeue_next()
     }
 
-    /// Dequeue a specific input by ID (delegates to inner).
-    pub fn dequeue_by_id(&mut self, input_id: &InputId) -> Option<(InputId, Input)> {
-        self.inner.dequeue_by_id(input_id)
+    pub(crate) fn dequeue_batch_exact(
+        &mut self,
+        batch: &crate::meerkat_machine::driver::AuthorizedRuntimeLoopBatch,
+    ) -> Result<Vec<(InputId, Input)>, RuntimeDriverError> {
+        self.inner.dequeue_batch_exact(batch)
     }
 
     pub fn has_queued_input_outside(&self, excluded: &[InputId]) -> bool {
@@ -391,11 +393,27 @@ impl PersistentRuntimeDriver {
         input: Input,
         resolved: crate::accept::ResolvedAdmission,
     ) -> Result<AcceptOutcome, RuntimeDriverError> {
-        let flags = resolved.coarse_flags();
         let mut staged = self.inner.clone_with_isolated_dsl_authority();
         staged.ensure_contract_session_authority()?;
+        let staged_resolved = if resolved.authority().without_wake() {
+            staged.resolve_admission_without_wake_with_active_turn_boundary(
+                &input,
+                resolved.authority().active_turn_boundary_available(),
+            )?
+        } else {
+            staged.resolve_admission_with_active_turn_boundary(
+                &input,
+                resolved.authority().active_turn_boundary_available(),
+            )?
+        };
+        if !resolved.semantically_equivalent_to(&staged_resolved) {
+            return Err(RuntimeDriverError::Internal(format!(
+                "staged admission resolution diverged from preview: preview={resolved:?}, staged={staged_resolved:?}"
+            )));
+        }
+        let flags = staged_resolved.coarse_flags();
         let staged_outcome = staged
-            .accept_resolved_input(input.clone(), resolved.clone())
+            .accept_resolved_input(input.clone(), staged_resolved)
             .await?;
 
         let AcceptOutcome::Accepted {
@@ -456,29 +474,27 @@ impl PersistentRuntimeDriver {
     pub(crate) async fn preview_accept_resolved_input(
         &self,
         input: Input,
-        resolved: crate::accept::ResolvedAdmission,
+        resolved: &crate::accept::ResolvedAdmission,
     ) -> Result<AcceptOutcome, RuntimeDriverError> {
         let mut staged = self.inner.clone_with_isolated_dsl_authority();
         staged.ensure_contract_session_authority()?;
-        staged.accept_resolved_input(input, resolved).await
-    }
-
-    /// Stage input (delegates to inner).
-    pub fn stage_input(
-        &mut self,
-        input_id: &InputId,
-        run_id: &meerkat_core::lifecycle::RunId,
-    ) -> Result<(), crate::traits::RuntimeDriverError> {
-        self.inner.stage_input(input_id, run_id)
-    }
-
-    /// Stage a batch of inputs atomically (delegates to inner).
-    pub fn stage_batch(
-        &mut self,
-        input_ids: &[InputId],
-        run_id: &meerkat_core::lifecycle::RunId,
-    ) -> Result<(), crate::traits::RuntimeDriverError> {
-        self.inner.stage_batch(input_ids, run_id)
+        let staged_resolved = if resolved.authority().without_wake() {
+            staged.resolve_admission_without_wake_with_active_turn_boundary(
+                &input,
+                resolved.authority().active_turn_boundary_available(),
+            )?
+        } else {
+            staged.resolve_admission_with_active_turn_boundary(
+                &input,
+                resolved.authority().active_turn_boundary_available(),
+            )?
+        };
+        if !resolved.semantically_equivalent_to(&staged_resolved) {
+            return Err(RuntimeDriverError::Internal(format!(
+                "staged admission preview diverged from caller resolution: preview={resolved:?}, staged={staged_resolved:?}"
+            )));
+        }
+        staged.accept_resolved_input(input, staged_resolved).await
     }
 
     pub(crate) fn machine_realize_stage_batch(

--- a/meerkat-runtime/src/meerkat_machine/dispatch_control.rs
+++ b/meerkat-runtime/src/meerkat_machine/dispatch_control.rs
@@ -156,7 +156,7 @@ impl MeerkatMachine {
                     let flags = resolved.coarse_flags();
                     let preview_result = {
                         let drv = driver.lock().await;
-                        drv.preview_accept_resolved_input(input.clone(), resolved.clone())
+                        drv.preview_accept_resolved_input(input.clone(), &resolved)
                             .await
                             .map_err(|err| RuntimeControlPlaneError::Internal(err.to_string()))?
                     };
@@ -196,7 +196,7 @@ impl MeerkatMachine {
                     let result = {
                         let mut drv = driver.lock().await;
                         let result = drv
-                            .accept_resolved_input(input, resolved.clone())
+                            .accept_resolved_input(input, resolved)
                             .await
                             .map_err(|err| RuntimeControlPlaneError::Internal(err.to_string()))?;
                         if !Self::accept_outcome_matches_preview(&preview_result, &result) {

--- a/meerkat-runtime/src/meerkat_machine/dispatch_ingress.rs
+++ b/meerkat-runtime/src/meerkat_machine/dispatch_ingress.rs
@@ -229,7 +229,7 @@ impl MeerkatMachine {
                     );
                 }
 
-                let (resolved, outcome, handle, accepted_input_id, signal) = {
+                let (flags, stages_run_boundary, outcome, handle, accepted_input_id, signal) = {
                     let mut driver = driver.lock().await;
                     // origin/main observability: surface the idle/running
                     // disposition (idle, attached non-steer, or attached peer)
@@ -265,6 +265,7 @@ impl MeerkatMachine {
                         active_turn_boundary_available,
                     )?;
                     let flags = resolved.coarse_flags();
+                    let stages_run_boundary = resolved.stages_run_boundary();
                     self.preview_session_dsl_input(
                         &session_id,
                         crate::meerkat_machine::dsl::MeerkatMachineInput::AcceptWithCompletion {
@@ -289,7 +290,7 @@ impl MeerkatMachine {
                         Self::classify_ingress_dsl_rejection(state, reason)
                     })?;
                     let result = match driver
-                        .accept_resolved_input(input, resolved.clone())
+                        .accept_resolved_input(input, resolved)
                         .await
                         .map_err(Self::normalize_destroyed_error)
                     {
@@ -311,7 +312,8 @@ impl MeerkatMachine {
                                 })
                             };
                             (
-                                resolved,
+                                flags,
+                                stages_run_boundary,
                                 result,
                                 handle,
                                 Some(accepted_input_id),
@@ -323,7 +325,8 @@ impl MeerkatMachine {
 
                             if is_terminal || !register_completion {
                                 (
-                                    resolved,
+                                    flags,
+                                    stages_run_boundary,
                                     result,
                                     None,
                                     None,
@@ -335,7 +338,8 @@ impl MeerkatMachine {
                                     completions.register(existing_id.clone())
                                 };
                                 (
-                                    resolved,
+                                    flags,
+                                    stages_run_boundary,
                                     result,
                                     Some(handle),
                                     None,
@@ -354,7 +358,6 @@ impl MeerkatMachine {
                 let (signal, runtime_effect, effect_previous_dsl_state) = if let Some(input_id) =
                     accepted_input_id.clone()
                 {
-                    let flags = resolved.coarse_flags();
                     let (previous_dsl_state, effects) = self
                         .apply_session_dsl_input(
                             &session_id,
@@ -420,7 +423,7 @@ impl MeerkatMachine {
                 let has_boundary_handle = boundary_handle.is_some();
                 if active_turn_boundary_available
                     && signal.should_interrupt_yielding()
-                    && resolved.stages_run_boundary()
+                    && stages_run_boundary
                     && let (Some(input_id), Some(boundary_handle)) =
                         (accepted_input_id_for_live_boundary, boundary_handle)
                 {
@@ -532,7 +535,7 @@ impl MeerkatMachine {
                             "accepted steer input had no live boundary plan; leaving input queued for ordinary post-turn drain"
                         );
                     }
-                } else if signal.should_interrupt_yielding() && resolved.stages_run_boundary() {
+                } else if signal.should_interrupt_yielding() && stages_run_boundary {
                     tracing::debug!(
                         session_id = %session_id,
                         runtime_state = ?state,

--- a/meerkat-runtime/src/meerkat_machine/driver.rs
+++ b/meerkat-runtime/src/meerkat_machine/driver.rs
@@ -30,7 +30,8 @@ pub(crate) type SharedDriver = Arc<Mutex<DriverEntry>>;
 ///
 /// The completion registry accepts this token rather than a bare generated enum
 /// so handwritten code cannot directly fabricate waiter public result truth.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[must_use = "runtime completion authority must be consumed by waiter resolution"]
+#[derive(Debug, PartialEq, Eq)]
 pub(crate) struct RuntimeCompletionResultAuthority {
     session_id: SessionId,
     agent_runtime_id: Option<crate::meerkat_machine::dsl::AgentRuntimeId>,
@@ -116,6 +117,68 @@ pub(crate) fn test_runtime_completion_authority(
         result_class,
         cleanup_observation,
     )
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum RuntimeLoopBatchSource {
+    Queue,
+    Steer,
+}
+
+#[must_use = "runtime loop batch authority must be consumed by stage authorization"]
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) struct AuthorizedRuntimeLoopBatch {
+    input_ids: Vec<InputId>,
+    source: RuntimeLoopBatchSource,
+}
+
+impl AuthorizedRuntimeLoopBatch {
+    fn from_machine_selection(
+        input_ids: Vec<InputId>,
+        source: RuntimeLoopBatchSource,
+    ) -> Option<Self> {
+        if input_ids.is_empty() {
+            None
+        } else {
+            Some(Self { input_ids, source })
+        }
+    }
+
+    pub(crate) fn input_ids(&self) -> &[InputId] {
+        &self.input_ids
+    }
+
+    fn into_stage_for_run(self, run_id: RunId) -> AuthorizedStageForRun {
+        AuthorizedStageForRun {
+            input_ids: self.input_ids,
+            run_id,
+            source: self.source,
+        }
+    }
+}
+
+#[cfg(test)]
+pub(crate) fn test_authorized_runtime_loop_batch(
+    input_ids: Vec<InputId>,
+) -> AuthorizedRuntimeLoopBatch {
+    AuthorizedRuntimeLoopBatch {
+        input_ids,
+        source: RuntimeLoopBatchSource::Queue,
+    }
+}
+
+#[must_use = "stage-for-run authority must be consumed by machine_realize_stage_batch"]
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) struct AuthorizedStageForRun {
+    input_ids: Vec<InputId>,
+    run_id: RunId,
+    source: RuntimeLoopBatchSource,
+}
+
+impl AuthorizedStageForRun {
+    fn into_parts(self) -> (Vec<InputId>, RunId, RuntimeLoopBatchSource) {
+        (self.input_ids, self.run_id, self.source)
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -314,7 +377,7 @@ impl DriverEntry {
     pub(crate) async fn preview_accept_resolved_input(
         &self,
         input: Input,
-        resolved: ResolvedAdmission,
+        resolved: &ResolvedAdmission,
     ) -> Result<AcceptOutcome, RuntimeDriverError> {
         match self {
             DriverEntry::Ephemeral(d) => d.preview_accept_resolved_input(input, resolved).await,
@@ -439,14 +502,13 @@ impl DriverEntry {
         }
     }
 
-    /// Dequeue a specific input by ID from whichever queue contains it.
-    pub(crate) fn dequeue_by_id(
+    pub(crate) fn dequeue_batch_exact(
         &mut self,
-        input_id: &InputId,
-    ) -> Option<(InputId, crate::input::Input)> {
+        batch: &AuthorizedRuntimeLoopBatch,
+    ) -> Result<Vec<(InputId, crate::input::Input)>, RuntimeDriverError> {
         match self {
-            DriverEntry::Ephemeral(d) => d.dequeue_by_id(input_id),
-            DriverEntry::Persistent(d) => d.dequeue_by_id(input_id),
+            DriverEntry::Ephemeral(d) => d.dequeue_batch_exact(batch),
+            DriverEntry::Persistent(d) => d.dequeue_batch_exact(batch),
         }
     }
 
@@ -683,12 +745,12 @@ impl DriverEntry {
     /// Stage a batch of inputs atomically in a single `StageDrainSnapshot`.
     pub(crate) fn machine_realize_stage_batch(
         &mut self,
-        input_ids: &[InputId],
-        run_id: &RunId,
+        authority: AuthorizedStageForRun,
     ) -> Result<(), crate::traits::RuntimeDriverError> {
+        let (input_ids, run_id, _source) = authority.into_parts();
         match self {
-            DriverEntry::Ephemeral(d) => d.machine_realize_stage_batch(input_ids, run_id),
-            DriverEntry::Persistent(d) => d.machine_realize_stage_batch(input_ids, run_id),
+            DriverEntry::Ephemeral(d) => d.machine_realize_stage_batch(&input_ids, &run_id),
+            DriverEntry::Persistent(d) => d.machine_realize_stage_batch(&input_ids, &run_id),
         }
     }
 
@@ -1317,6 +1379,21 @@ pub(crate) fn machine_select_runtime_loop_batch(driver: &DriverEntry) -> Vec<Inp
     }
 
     Vec::new()
+}
+
+pub(crate) fn machine_authorize_runtime_loop_batch(
+    driver: &DriverEntry,
+) -> Option<AuthorizedRuntimeLoopBatch> {
+    let ingress = driver.driver_ingress();
+    let source = if ingress.steer_queue().is_empty() {
+        RuntimeLoopBatchSource::Queue
+    } else {
+        RuntimeLoopBatchSource::Steer
+    };
+    AuthorizedRuntimeLoopBatch::from_machine_selection(
+        machine_select_runtime_loop_batch(driver),
+        source,
+    )
 }
 
 pub(crate) fn machine_validate_stage_drain_snapshot(
@@ -2636,16 +2713,18 @@ pub(crate) async fn machine_recycle_preserving_work(
 pub(crate) async fn prepare_runtime_loop_batch_start(
     driver: &SharedDriver,
     run_id: RunId,
-    staged_ids: &[InputId],
+    batch: AuthorizedRuntimeLoopBatch,
 ) -> Result<(), RuntimeDriverError> {
     let mut driver = driver.lock().await;
-    machine_validate_stage_drain_snapshot(&driver, staged_ids)?;
+    let staged_ids = batch.input_ids().to_vec();
+    machine_validate_stage_drain_snapshot(&driver, &staged_ids)?;
+    let stage_authority = batch.into_stage_for_run(run_id.clone());
     machine_begin_run(&mut driver, run_id.clone()).map_err(|err| {
         RuntimeDriverError::Internal(format!("failed to start runtime run: {err}"))
     })?;
 
-    if let Err(err) = driver.machine_realize_stage_batch(staged_ids, &run_id) {
-        let _ = driver.rollback_staged(staged_ids);
+    if let Err(err) = driver.machine_realize_stage_batch(stage_authority) {
+        let _ = driver.rollback_staged(&staged_ids);
         if let Err(rollback_err) = machine_apply_run_return_projection(
             &mut driver,
             &run_id,

--- a/meerkat-runtime/src/meerkat_machine/mod.rs
+++ b/meerkat-runtime/src/meerkat_machine/mod.rs
@@ -540,10 +540,7 @@ pub(crate) fn authorize_stored_input_state_seed(
             abandon_reason,
             abandon_attempt_count,
             attempt_count: u64::from(seed.attempt_count),
-            run_id: seed
-                .last_run_id
-                .as_ref()
-                .map(std::string::ToString::to_string),
+            run_id: seed.last_run_id.as_ref().map(dsl::RunId::from_domain),
             boundary_sequence: seed.last_boundary_sequence,
             admission_sequence: seed.admission_sequence,
             recovery_lane: seed.recovery_lane.map(dsl::InputLane::from),
@@ -894,14 +891,16 @@ type MeerkatMachineCommandFuture<'a> = Pin<
     Box<dyn Future<Output = Result<MeerkatMachineCommandResult, MeerkatMachineCommandError>> + 'a>,
 >;
 
+#[cfg(test)]
+pub(crate) use driver::machine_select_runtime_loop_batch;
 pub(crate) use driver::{
     DriverEntry, SharedCompletionRegistry, SharedDriver, cancel_runtime_loop_run,
     commit_runtime_loop_run, fail_machine_run, fail_runtime_loop_run,
-    machine_batch_primitive_projections, machine_batch_runtime_semantics,
-    machine_commit_prepared_destroy, machine_commit_service_turn_terminal_receipt,
-    machine_prepare_bindings_projection, machine_prepare_destroy, machine_recover_ephemeral_driver,
-    machine_recover_persistent_driver, machine_recycle_preserving_work, machine_reset,
-    machine_retire, machine_select_runtime_loop_batch, machine_stop_runtime,
+    machine_authorize_runtime_loop_batch, machine_batch_primitive_projections,
+    machine_batch_runtime_semantics, machine_commit_prepared_destroy,
+    machine_commit_service_turn_terminal_receipt, machine_prepare_bindings_projection,
+    machine_prepare_destroy, machine_recover_ephemeral_driver, machine_recover_persistent_driver,
+    machine_recycle_preserving_work, machine_reset, machine_retire, machine_stop_runtime,
     prepare_runtime_loop_batch_start,
 };
 

--- a/meerkat-runtime/src/meerkat_machine/session_management.rs
+++ b/meerkat-runtime/src/meerkat_machine/session_management.rs
@@ -1332,19 +1332,11 @@ impl MeerkatMachine {
         &self,
         entry: RuntimeSessionEntry,
         durability_authority: RuntimeOpsLifecycleDurabilityAuthority,
-        runtime_terminated_completion_authority:
-            crate::meerkat_machine::driver::RuntimeCompletionResultAuthority,
     ) {
         let runtime_id = entry.runtime_id.clone();
         let mut driver = entry.driver.lock().await;
         driver.sync_control_projection_from_dsl_authority();
         drop(driver);
-
-        let mut completions = entry.completions.lock().await;
-        completions.resolve_all_runtime_terminated(
-            "runtime session unregistered",
-            runtime_terminated_completion_authority,
-        );
 
         if durability_authority.action
             != crate::meerkat_machine::dsl::RuntimeOpsLifecycleDurabilityAction::DeleteSnapshot
@@ -1604,12 +1596,12 @@ impl MeerkatMachine {
                     .map(|entry| Arc::clone(&entry.completions))
             };
             if let Some(completions) = completions {
-                // Same client-facing reason as the finalize sweep below — the
-                // drain-phase vs finalize-phase split is an internal detail and
-                // must not fragment the observable CompletionOutcome contract.
+                // The drain-phase sweep is the single token-consuming
+                // terminalization point for waiters the in-flight run did not
+                // already resolve with its committed outcome.
                 completions.lock().await.resolve_all_runtime_terminated(
                     "runtime session unregistered",
-                    runtime_terminated_completion_authority.clone(),
+                    runtime_terminated_completion_authority,
                 );
             }
         }
@@ -1683,12 +1675,8 @@ impl MeerkatMachine {
 
         if let Some(entry) = entry {
             tracing::info!(%session_id, "MeerkatMachine::unregister_session_inner_locked_authorized finalizing entry");
-            self.finalize_unregistered_session(
-                entry,
-                durability_authority,
-                runtime_terminated_completion_authority,
-            )
-            .await;
+            self.finalize_unregistered_session(entry, durability_authority)
+                .await;
         }
         tracing::info!(%session_id, "MeerkatMachine::unregister_session_inner_locked_authorized complete");
         Ok(())
@@ -1720,12 +1708,12 @@ impl MeerkatMachine {
         let Some(_gate_guard) = self.lock_current_session_mutation_gate(session_id).await else {
             return false;
         };
-        let driver_handle = {
+        let (driver_handle, completions) = {
             let sessions = self.sessions.read().await;
             let Some(entry) = sessions.get(session_id) else {
                 return false;
             };
-            Arc::clone(&entry.driver)
+            (Arc::clone(&entry.driver), Arc::clone(&entry.completions))
         };
         let runtime_terminated_completion_authority =
             match crate::meerkat_machine::driver::machine_resolve_runtime_terminated_completion_result(
@@ -1743,6 +1731,10 @@ impl MeerkatMachine {
                     return false;
                 }
             };
+        completions.lock().await.resolve_all_runtime_terminated(
+            "storeless WASM session discarded",
+            runtime_terminated_completion_authority,
+        );
 
         // The terminal storeless session has no attached runtime loop or comms
         // drain task to quiesce, so the drain obligations are discharged
@@ -1868,7 +1860,6 @@ impl MeerkatMachine {
                 action:
                     crate::meerkat_machine::dsl::RuntimeOpsLifecycleDurabilityAction::RetainSnapshot,
             },
-            runtime_terminated_completion_authority,
         )
         .await;
         true

--- a/meerkat-runtime/src/meerkat_machine_tests.rs
+++ b/meerkat-runtime/src/meerkat_machine_tests.rs
@@ -1237,6 +1237,28 @@ fn make_prompt(text: &str) -> Input {
     })
 }
 
+fn make_queued_external_event(label: &str) -> Input {
+    Input::ExternalEvent(crate::input::ExternalEventInput {
+        header: crate::input::InputHeader {
+            id: InputId::new(),
+            timestamp: Utc::now(),
+            source: crate::input::InputOrigin::External {
+                source_name: "unit-test".into(),
+            },
+            durability: crate::input::InputDurability::Durable,
+            visibility: crate::input::InputVisibility::default(),
+            idempotency_key: None,
+            supersession_key: None,
+            correlation_id: None,
+        },
+        event_type: "batch_commit_atomicity".into(),
+        payload: serde_json::json!({ "label": label }),
+        blocks: None,
+        handling_mode: meerkat_core::types::HandlingMode::Queue,
+        render_metadata: None,
+    })
+}
+
 #[tokio::test]
 async fn runtime_apply_failure_preserves_typed_cause_through_terminalization() {
     use meerkat_core::lifecycle::core_executor::CoreApplyFailureCause;
@@ -15067,7 +15089,12 @@ async fn prepare_live_run_for_authority_test(
         )
     };
     let run_id = RunId::new();
-    prepare_runtime_loop_batch_start(&driver, run_id.clone(), std::slice::from_ref(&input_id))
+    let batch = {
+        let entry = driver.lock().await;
+        machine_authorize_runtime_loop_batch(&entry).expect("accepted input should authorize batch")
+    };
+    assert_eq!(batch.input_ids(), std::slice::from_ref(&input_id));
+    prepare_runtime_loop_batch_start(&driver, run_id.clone(), batch)
         .await
         .expect("run prepare should stage the accepted input");
     (driver, input_id, run_id)
@@ -15372,7 +15399,13 @@ async fn staged_batch_commit_driver(
         )
     };
     let run_id = RunId::new();
-    prepare_runtime_loop_batch_start(&driver, run_id.clone(), &staged_ids)
+    let batch = {
+        let entry = driver.lock().await;
+        machine_authorize_runtime_loop_batch(&entry)
+            .expect("accepted inputs should authorize batch")
+    };
+    assert_eq!(batch.input_ids(), staged_ids.as_slice());
+    prepare_runtime_loop_batch_start(&driver, run_id.clone(), batch)
         .await
         .expect("batch prepare should stage both inputs");
     (driver, run_id, staged_ids)
@@ -15602,7 +15635,7 @@ async fn persistent_staged_run_driver(
         .contract_begin_run_authority(run_id.clone())
         .expect("runtime run authority should begin through generated DSL");
     driver
-        .stage_input(&input_id, &run_id)
+        .machine_realize_stage_batch(std::slice::from_ref(&input_id), &run_id)
         .expect("input should stage for the run");
 
     (
@@ -15743,8 +15776,11 @@ async fn assert_commit_rejection_preserved_staged_batch(
 
 #[tokio::test]
 async fn run_commit_rejects_receipt_run_id_mismatch_before_mutation() {
-    let (driver, run_id, staged_ids) =
-        staged_batch_commit_driver(make_prompt("first"), make_prompt("second")).await;
+    let (driver, run_id, staged_ids) = staged_batch_commit_driver(
+        make_queued_external_event("first"),
+        make_queued_external_event("second"),
+    )
+    .await;
 
     let result = commit_runtime_loop_run(
         &driver,
@@ -15764,8 +15800,11 @@ async fn run_commit_rejects_receipt_run_id_mismatch_before_mutation() {
 
 #[tokio::test]
 async fn run_commit_rejects_reordered_receipt_contributors_before_mutation() {
-    let (driver, run_id, staged_ids) =
-        staged_batch_commit_driver(make_prompt("first"), make_prompt("second")).await;
+    let (driver, run_id, staged_ids) = staged_batch_commit_driver(
+        make_queued_external_event("first"),
+        make_queued_external_event("second"),
+    )
+    .await;
     let mut receipt_contributors = staged_ids.clone();
     receipt_contributors.reverse();
 
@@ -22515,9 +22554,13 @@ async fn prepare_runtime_loop_batch_start_unwinds_run_state_when_staging_rejects
         }
     };
 
-    let err = prepare_runtime_loop_batch_start(&driver, RunId::new(), &[InputId::new()])
-        .await
-        .expect_err("staging an unknown input should fail and unwind");
+    let err = prepare_runtime_loop_batch_start(
+        &driver,
+        RunId::new(),
+        crate::meerkat_machine::driver::test_authorized_runtime_loop_batch(vec![InputId::new()]),
+    )
+    .await
+    .expect_err("staging an unknown input should fail and unwind");
     assert!(
         err.to_string()
             .contains("failed to stage accepted input batch")

--- a/meerkat-runtime/src/runtime_loop.rs
+++ b/meerkat-runtime/src/runtime_loop.rs
@@ -153,9 +153,8 @@ async fn resolve_runtime_completion_waiters(
     .await;
     let mut registry = completions.lock().await;
     match result_class {
-        Ok(result_class) => resolve_completion_waiters_from_authority(
-            &mut registry,
-            input_ids,
+        Ok(result_class) => registry.resolve_runtime_completion_authorized(
+            input_ids.iter().cloned(),
             terminal,
             result_class,
             finalization_error,
@@ -188,9 +187,8 @@ async fn resolve_machine_terminal_completion_waiters(
     let error_metadata = machine_terminal_completion_error(driver, reason.clone()).await;
     let mut registry = completions.lock().await;
     match (result_class, error_metadata) {
-        (Ok(result_class), Ok(error_metadata)) => resolve_completion_waiters_from_authority(
-            &mut registry,
-            input_ids,
+        (Ok(result_class), Ok(error_metadata)) => registry.resolve_runtime_completion_authorized(
+            input_ids.iter().cloned(),
             None,
             result_class,
             error_metadata,
@@ -216,155 +214,6 @@ async fn runtime_terminated_completion_class(
         crate::meerkat_machine::dsl::RuntimeCompletionFinalizationObservation::Succeeded,
     )
     .await
-}
-
-fn resolve_completion_waiters_from_authority(
-    registry: &mut crate::completion::CompletionRegistry,
-    input_ids: &[InputId],
-    terminal: Option<&CoreApplyTerminal>,
-    authority: crate::meerkat_machine::driver::RuntimeCompletionResultAuthority,
-    finalization_error: Option<meerkat_core::TurnErrorMetadata>,
-) {
-    use crate::meerkat_machine::dsl::RuntimeCompletionResultClass;
-
-    match authority.class() {
-        RuntimeCompletionResultClass::Completed => {
-            let Some(CoreApplyTerminal::RunResult(result)) = terminal else {
-                fail_closed_completion_waiters(
-                    registry,
-                    input_ids,
-                    "runtime completion authority resolved Completed without result payload",
-                );
-                return;
-            };
-            for input_id in input_ids {
-                registry.resolve_completed_authorized(
-                    input_id,
-                    result.as_ref().clone(),
-                    authority.clone(),
-                );
-            }
-        }
-        RuntimeCompletionResultClass::CompletedWithoutResult => {
-            if !matches!(terminal, Some(CoreApplyTerminal::NoPendingBoundary) | None) {
-                fail_closed_completion_waiters(
-                    registry,
-                    input_ids,
-                    "runtime completion authority resolved CompletedWithoutResult with terminal payload",
-                );
-                return;
-            }
-            for input_id in input_ids {
-                registry.resolve_without_result_authorized(input_id, authority.clone());
-            }
-        }
-        RuntimeCompletionResultClass::CallbackPending => {
-            let Some(CoreApplyTerminal::CallbackPending { tool_name, args }) = terminal else {
-                fail_closed_completion_waiters(
-                    registry,
-                    input_ids,
-                    "runtime completion authority resolved CallbackPending without callback payload",
-                );
-                return;
-            };
-            for input_id in input_ids {
-                registry.resolve_callback_pending_authorized(
-                    input_id,
-                    tool_name.clone(),
-                    args.clone(),
-                    authority.clone(),
-                );
-            }
-        }
-        RuntimeCompletionResultClass::Cancelled => {
-            if terminal.is_some() || finalization_error.is_some() {
-                fail_closed_completion_waiters(
-                    registry,
-                    input_ids,
-                    "runtime completion authority resolved Cancelled with payload",
-                );
-                return;
-            }
-            for input_id in input_ids {
-                registry.resolve_cancelled_authorized(input_id, authority.clone());
-            }
-        }
-        RuntimeCompletionResultClass::AbandonedWithError => {
-            if matches!(terminal, Some(CoreApplyTerminal::RunResult(_))) {
-                fail_closed_completion_waiters(
-                    registry,
-                    input_ids,
-                    "runtime completion authority resolved AbandonedWithError with result payload",
-                );
-                return;
-            }
-            let Some(error) = finalization_error else {
-                fail_closed_completion_waiters(
-                    registry,
-                    input_ids,
-                    "runtime completion authority resolved AbandonedWithError without typed error",
-                );
-                return;
-            };
-            let reason = error
-                .detail
-                .clone()
-                .unwrap_or_else(|| "runtime finalization failed".to_string());
-            for input_id in input_ids {
-                registry.resolve_abandoned_with_error_authorized(
-                    input_id,
-                    reason.clone(),
-                    error.clone(),
-                    authority.clone(),
-                );
-            }
-        }
-        RuntimeCompletionResultClass::CompletedWithFinalizationFailure => {
-            // The class authority still requires that output was produced (a
-            // RunResult terminal), but the produced result is deliberately NOT
-            // forwarded to waiters: finalization (durable commit) failed, so the
-            // run is not durably terminal and the output must not be surfaced as
-            // a usable success result.
-            let Some(CoreApplyTerminal::RunResult(_result)) = terminal else {
-                fail_closed_completion_waiters(
-                    registry,
-                    input_ids,
-                    "runtime completion authority resolved CompletedWithFinalizationFailure without result payload",
-                );
-                return;
-            };
-            let Some(error) = finalization_error else {
-                fail_closed_completion_waiters(
-                    registry,
-                    input_ids,
-                    "runtime completion authority resolved finalization failure without typed error",
-                );
-                return;
-            };
-            for input_id in input_ids {
-                registry.resolve_completed_with_finalization_failure_authorized(
-                    input_id,
-                    error.clone(),
-                    authority.clone(),
-                );
-            }
-        }
-        RuntimeCompletionResultClass::RuntimeTerminated => {
-            if terminal.is_some() || finalization_error.is_some() {
-                fail_closed_completion_waiters(
-                    registry,
-                    input_ids,
-                    "runtime completion authority resolved RuntimeTerminated with payload",
-                );
-                return;
-            }
-            registry.resolve_inputs_runtime_terminated(
-                input_ids.iter().cloned(),
-                "runtime terminated",
-                authority,
-            );
-        }
-    }
 }
 
 fn fail_closed_completion_waiters(
@@ -1357,21 +1206,24 @@ async fn process_queue(
             // The authority implements steer-first priority and same-boundary
             // batching for steer inputs; queue inputs follow the prompt-aware
             // batching policy.
-            let batch_ids = crate::meerkat_machine::machine_select_runtime_loop_batch(&d);
-
-            if batch_ids.is_empty() {
+            let Some(batch) = crate::meerkat_machine::machine_authorize_runtime_loop_batch(&d)
+            else {
                 return false;
-            }
+            };
 
-            // Dequeue the batch members from the physical queues.
-            let staged_inputs: Vec<_> = batch_ids
-                .iter()
-                .filter_map(|id| d.dequeue_by_id(id))
-                .collect();
-
-            if staged_inputs.is_empty() {
-                return false;
-            }
+            // Dequeue the batch members from the physical queues. The physical
+            // projection must exactly match the machine-selected batch; partial
+            // shrinkage would turn projection drift into different semantic work.
+            let staged_inputs = match d.dequeue_batch_exact(&batch) {
+                Ok(staged_inputs) => staged_inputs,
+                Err(error) => {
+                    tracing::error!(
+                        error = %error,
+                        "runtime loop batch projection conformance failed"
+                    );
+                    return true;
+                }
+            };
 
             let run_id = prebound_run_id.unwrap_or_else(RunId::new);
 
@@ -1422,15 +1274,15 @@ async fn process_queue(
                     },
                 ),
             };
-            Some((contributing_input_ids, staged_ids, run_id, primitive))
+            Some((contributing_input_ids, run_id, primitive, batch))
         };
 
         match dequeued {
-            Some((input_ids, staged_ids, run_id, primitive)) => {
+            Some((input_ids, run_id, primitive, batch)) => {
                 if let Err(err) = crate::meerkat_machine::prepare_runtime_loop_batch_start(
                     driver,
                     run_id.clone(),
-                    &staged_ids,
+                    batch,
                 )
                 .await
                 {
@@ -3357,9 +3209,8 @@ mod tests {
             args: serde_json::json!({ "value": "browser" }),
         });
 
-        resolve_completion_waiters_from_authority(
-            &mut registry,
-            std::slice::from_ref(&input_id),
+        registry.resolve_runtime_completion_authorized(
+            std::iter::once(input_id.clone()),
             terminal.as_ref(),
             crate::meerkat_machine::driver::test_runtime_completion_authority(
                 crate::meerkat_machine::dsl::RuntimeCompletionResultClass::CallbackPending,
@@ -3396,9 +3247,8 @@ mod tests {
         };
         let terminal = Some(CoreApplyTerminal::RunResult(Box::new(run_result)));
 
-        resolve_completion_waiters_from_authority(
-            &mut registry,
-            std::slice::from_ref(&input_id),
+        registry.resolve_runtime_completion_authorized(
+            std::iter::once(input_id.clone()),
             terminal.as_ref(),
             crate::meerkat_machine::driver::test_runtime_completion_authority(
                 crate::meerkat_machine::dsl::RuntimeCompletionResultClass::Completed,

--- a/meerkat-runtime/tests/core_apply_terminal_truth.rs
+++ b/meerkat-runtime/tests/core_apply_terminal_truth.rs
@@ -73,6 +73,17 @@ fn assert_terminal_context_and_run_stages_pre_turn_appends(source: &str, owner: 
     );
 }
 
+fn derive_attribute_before<'a>(contents: &'a str, marker: &str) -> Result<&'a str, String> {
+    let start = contents
+        .find(marker)
+        .ok_or_else(|| format!("missing marker `{marker}`"))?;
+    contents[..start]
+        .lines()
+        .rev()
+        .find(|line| line.trim_start().starts_with("#[derive"))
+        .ok_or_else(|| format!("missing derive attribute before `{marker}`"))
+}
+
 #[test]
 fn core_apply_terminal_truth_has_one_authority() -> Result<(), String> {
     let root = workspace_root()?;
@@ -81,6 +92,22 @@ fn core_apply_terminal_truth_has_one_authority() -> Result<(), String> {
             .map_err(|err| format!("read core executor source: {err}"))?;
     let runtime_loop = fs::read_to_string(root.join("meerkat-runtime/src/runtime_loop.rs"))
         .map_err(|err| format!("read runtime loop source: {err}"))?;
+    let runtime_driver =
+        fs::read_to_string(root.join("meerkat-runtime/src/meerkat_machine/driver.rs"))
+            .map_err(|err| format!("read runtime driver source: {err}"))?;
+    let persistent_driver =
+        fs::read_to_string(root.join("meerkat-runtime/src/driver/persistent.rs"))
+            .map_err(|err| format!("read persistent driver source: {err}"))?;
+    let ephemeral_driver = fs::read_to_string(root.join("meerkat-runtime/src/driver/ephemeral.rs"))
+        .map_err(|err| format!("read ephemeral driver source: {err}"))?;
+    let meerkat_machine_schema =
+        fs::read_to_string(root.join("meerkat-machine-schema/src/catalog/dsl/meerkat_machine.rs"))
+            .map_err(|err| format!("read MeerkatMachine schema source: {err}"))?;
+    let meerkat_machine_model =
+        fs::read_to_string(root.join("specs/machines/meerkat_machine/model.tla"))
+            .map_err(|err| format!("read MeerkatMachine TLA source: {err}"))?;
+    let accept_source = fs::read_to_string(root.join("meerkat-runtime/src/accept.rs"))
+        .map_err(|err| format!("read accept source: {err}"))?;
 
     let output_struct = extract_braced_item(&core_executor, "pub struct CoreApplyOutput")?;
     assert!(
@@ -92,7 +119,8 @@ fn core_apply_terminal_truth_has_one_authority() -> Result<(), String> {
         "CoreApplyOutput must not duplicate terminal truth with a run_result mirror"
     );
 
-    let waiter_resolver = extract_braced_item(&runtime_loop, "fn resolve_completion_waiters")?;
+    let waiter_resolver =
+        extract_braced_item(&runtime_loop, "async fn resolve_runtime_completion_waiters")?;
     assert!(
         !waiter_resolver.contains("run_result:"),
         "runtime completion resolution must branch from CoreApplyTerminal only"
@@ -100,6 +128,195 @@ fn core_apply_terminal_truth_has_one_authority() -> Result<(), String> {
     assert!(
         !waiter_resolver.contains("if let Some(result) = run_result"),
         "runtime completion resolution must not keep a separate run_result branch"
+    );
+
+    let completion_authority = extract_braced_item(
+        &runtime_driver,
+        "pub(crate) struct RuntimeCompletionResultAuthority",
+    )?;
+    let completion_authority_derive = derive_attribute_before(
+        &runtime_driver,
+        "pub(crate) struct RuntimeCompletionResultAuthority",
+    )?;
+    assert!(
+        runtime_driver.contains(
+            "#[must_use = \"runtime completion authority must be consumed by waiter resolution\"]"
+        ),
+        "runtime completion authority must stay must-use so generated proof is not dropped silently"
+    );
+    assert!(
+        !completion_authority.contains("Clone") && !completion_authority_derive.contains("Clone"),
+        "runtime completion authority must not be Clone; waiter fanout consumes one token and clones only derived cleanup observations"
+    );
+    assert!(
+        !waiter_resolver.contains("authority.clone()"),
+        "runtime completion waiter fanout must not clone the generated authority token"
+    );
+    assert!(
+        runtime_loop.contains("machine_authorize_runtime_loop_batch(&d)")
+            && runtime_loop.contains("dequeue_batch_exact(&batch)")
+            && runtime_loop.contains("prepare_runtime_loop_batch_start(")
+            && !runtime_loop.contains("filter_map(|id| d.dequeue_by_id(id))"),
+        "runtime loop batch execution must use authorized batch tokens and fail closed on projection mismatch"
+    );
+    assert!(
+        !ephemeral_driver.contains("pub fn dequeue_by_id")
+            && !ephemeral_driver.contains("pub fn stage_input")
+            && !ephemeral_driver.contains("pub fn stage_batch")
+            && !persistent_driver.contains("pub fn dequeue_by_id")
+            && !persistent_driver.contains("pub fn stage_input")
+            && !persistent_driver.contains("pub fn stage_batch")
+            && !ephemeral_driver.contains("pub fn contract_stage_current_run_input"),
+        "raw driver dequeue/stage APIs must not be externally callable bypasses"
+    );
+    let runtime_batch_authority = extract_braced_item(
+        &runtime_driver,
+        "pub(crate) struct AuthorizedRuntimeLoopBatch",
+    )?;
+    let runtime_batch_authority_derive = derive_attribute_before(
+        &runtime_driver,
+        "pub(crate) struct AuthorizedRuntimeLoopBatch",
+    )?;
+    let stage_authority =
+        extract_braced_item(&runtime_driver, "pub(crate) struct AuthorizedStageForRun")?;
+    let stage_authority_derive =
+        derive_attribute_before(&runtime_driver, "pub(crate) struct AuthorizedStageForRun")?;
+    assert!(
+        runtime_driver.contains(
+            "#[must_use = \"runtime loop batch authority must be consumed by stage authorization\"]"
+        ) && !runtime_batch_authority.contains("Clone")
+            && !runtime_batch_authority_derive.contains("Clone"),
+        "runtime loop batch authority must be must-use and non-Clone"
+    );
+    assert!(
+        runtime_driver.contains(
+            "#[must_use = \"stage-for-run authority must be consumed by machine_realize_stage_batch\"]"
+        ) && !stage_authority.contains("Clone")
+            && !stage_authority_derive.contains("Clone"),
+        "stage-for-run authority must be must-use and non-Clone"
+    );
+    let shared_stage_realizer =
+        extract_braced_item(&runtime_driver, "pub(crate) fn machine_realize_stage_batch")?;
+    assert!(
+        shared_stage_realizer.contains("authority: AuthorizedStageForRun")
+            && shared_stage_realizer.contains("authority.into_parts()"),
+        "shared stage realization must consume AuthorizedStageForRun instead of raw ids"
+    );
+    let stage_for_run_transition =
+        extract_braced_item(&meerkat_machine_schema, "transition StageForRun")?;
+    assert!(
+        stage_for_run_transition.contains("guard \"input_queued\"")
+            && stage_for_run_transition.contains("guard \"input_lane_bound\"")
+            && stage_for_run_transition.contains("guard \"input_sequence_bound\"")
+            && stage_for_run_transition.contains("guard \"input_recovery_lane_bound\"")
+            && stage_for_run_transition.contains("guard \"input_not_run_associated\"")
+            && stage_for_run_transition.contains("guard \"current_run_matches\"")
+            && stage_for_run_transition
+                .contains("self.input_attempt_counts.increment(input_id, 1)"),
+        "StageForRun must own queued/lane/sequence/run-association/current-run predicates and fold attempt increment into staging"
+    );
+    let stage_start = meerkat_machine_model
+        .find("StageForRunIdle(input_id, run_id) ==")
+        .ok_or_else(|| "generated TLA missing StageForRunIdle operator".to_string())?;
+    let stage_end = meerkat_machine_model[stage_start..]
+        .find("StageForRunAttached(input_id, run_id) ==")
+        .map(|offset| stage_start + offset)
+        .ok_or_else(|| "generated TLA missing StageForRunAttached operator".to_string())?;
+    let stage_for_run_model = &meerkat_machine_model[stage_start..stage_end];
+    assert!(
+        stage_for_run_model.contains("current_run_id # None")
+            && stage_for_run_model.contains("current_run_id[\"value\"] ELSE None) = run_id"),
+        "generated StageForRun TLA must bind staging to the active machine-owned current_run_id"
+    );
+    let stage_realizer = extract_braced_item(
+        &ephemeral_driver,
+        "pub(crate) fn machine_realize_stage_batch",
+    )?;
+    assert!(
+        !stage_realizer.contains("IncrementAttemptCount"),
+        "runtime staging must not split StageForRun from the attempt-count update"
+    );
+
+    let ingress_capability = extract_braced_item(
+        &accept_source,
+        "pub(crate) struct RuntimeIngressExecutionCapability",
+    )?;
+    let resolved_admission = extract_braced_item(&accept_source, "pub struct ResolvedAdmission")?;
+    let ingress_capability_derive = derive_attribute_before(
+        &accept_source,
+        "pub(crate) struct RuntimeIngressExecutionCapability",
+    )?;
+    let resolved_admission_derive =
+        derive_attribute_before(&accept_source, "pub struct ResolvedAdmission")?;
+    assert!(
+        accept_source.contains(
+            "#[must_use = \"runtime ingress execution capability must be consumed by accept_resolved_input\"]"
+        ),
+        "runtime ingress execution capability must stay must-use so admission proof is not dropped silently"
+    );
+    assert!(
+        !ingress_capability.contains("Clone") && !ingress_capability_derive.contains("Clone"),
+        "runtime ingress execution capability must not be Clone"
+    );
+    assert!(
+        !accept_source.contains("pub(crate) fn from_admission_resolved_effect"),
+        "runtime ingress capability constructor must remain private to the accept module"
+    );
+    assert!(
+        !resolved_admission.contains("Clone") && !resolved_admission_derive.contains("Clone"),
+        "ResolvedAdmission must not be Clone because it carries a one-shot ingress execution capability"
+    );
+
+    let persistent_accept = extract_braced_item(
+        &persistent_driver,
+        "pub(crate) async fn accept_resolved_input",
+    )?;
+    let staged_equivalence = persistent_accept
+        .find("resolved.semantically_equivalent_to(&staged_resolved)")
+        .ok_or_else(|| {
+            "persistent accept must compare preview and staged admission resolutions".to_string()
+        })?;
+    let staged_flags = persistent_accept
+        .find("let flags = staged_resolved.coarse_flags();")
+        .ok_or_else(|| "persistent accept must derive flags from staged resolution".to_string())?;
+    let staged_accept = persistent_accept
+        .find(".accept_resolved_input(input.clone(), staged_resolved)")
+        .ok_or_else(|| {
+            "persistent accept must stage accepted input after comparison".to_string()
+        })?;
+    let staged_completion_signal = persistent_accept
+        .find("staged.machine_apply_accept_with_completion_signal")
+        .ok_or_else(|| {
+            "persistent accept must apply completion signal after staged comparison".to_string()
+        })?;
+    let staged_persist = persistent_accept
+        .find("self.persist_state(&staged_bundle).await?")
+        .ok_or_else(|| "persistent accept must persist staged state".to_string())?;
+    assert!(
+        staged_equivalence < staged_flags
+            && staged_flags < staged_accept
+            && staged_accept < staged_completion_signal
+            && staged_completion_signal < staged_persist,
+        "persistent accept must prove staged admission equivalence before deriving flags, accepting, signaling, or persisting"
+    );
+
+    let persistent_preview = extract_braced_item(
+        &persistent_driver,
+        "pub(crate) async fn preview_accept_resolved_input",
+    )?;
+    let preview_equivalence = persistent_preview
+        .find("resolved.semantically_equivalent_to(&staged_resolved)")
+        .ok_or_else(|| {
+            "persistent preview must compare caller and staged resolutions".to_string()
+        })?;
+    let preview_accept = persistent_preview
+        .find("staged.accept_resolved_input(input, staged_resolved).await")
+        .ok_or_else(|| {
+            "persistent preview must accept only the staged resolution after comparison".to_string()
+        })?;
+    assert!(
+        preview_equivalence < preview_accept,
+        "persistent preview must prove staged admission equivalence before staged accept"
     );
     Ok(())
 }

--- a/meerkat-runtime/tests/driver_ephemeral.rs
+++ b/meerkat-runtime/tests/driver_ephemeral.rs
@@ -414,47 +414,6 @@ async fn recovery_counts_queued_as_recovered() -> Result<(), RuntimeDriverError>
 }
 
 #[tokio::test]
-async fn recovery_applied_stays_applied() -> Result<(), RuntimeDriverError> {
-    let mut driver = EphemeralRuntimeDriver::new(LogicalRuntimeId::new("test"));
-
-    let input = make_prompt_input("hello");
-    let input_id = input.id().clone();
-    driver.accept_input(input).await.unwrap();
-
-    let run_id = RunId::new();
-    bind_running(&mut driver, run_id.clone(), RuntimeState::Idle);
-    driver.stage_input(&input_id, &run_id).unwrap();
-    driver.apply_input(&input_id, &run_id).unwrap();
-
-    let report = driver.recover_ephemeral()?;
-    assert_eq!(report.inputs_recovered, 1);
-
-    // Applied stays Applied (side effects already happened)
-    assert!(driver.input_state(&input_id).is_some());
-    assert_eq!(
-        driver.input_phase(&input_id),
-        Some(InputLifecycleState::AppliedPendingConsumption)
-    );
-    assert_queue_projection_alignment(&driver);
-    Ok(())
-}
-
-#[tokio::test]
-async fn stage_input_keeps_queue_projection_aligned() {
-    let mut driver = EphemeralRuntimeDriver::new(LogicalRuntimeId::new("test"));
-    let input = make_prompt_input("stage me");
-    let input_id = input.id().clone();
-    driver.accept_input(input).await.unwrap();
-
-    let run_id = RunId::new();
-    bind_running(&mut driver, run_id.clone(), RuntimeState::Idle);
-    driver.stage_input(&input_id, &run_id).unwrap();
-
-    assert!(driver.queue().is_empty());
-    assert_queue_projection_alignment(&driver);
-}
-
-#[tokio::test]
 async fn retired_rejects_input() {
     let (machine, session_id, _runtime_id) = registered_machine().await;
     SessionServiceRuntimeExt::retire_runtime(&machine, &session_id)

--- a/meerkat-runtime/tests/recovery_contract.rs
+++ b/meerkat-runtime/tests/recovery_contract.rs
@@ -159,13 +159,6 @@ fn sorted_id_strings(ids: impl IntoIterator<Item = InputId>) -> Vec<String> {
     ids
 }
 
-fn bind_running(driver: &mut EphemeralRuntimeDriver, run_id: RunId, pre_run_phase: RuntimeState) {
-    assert_eq!(driver.runtime_state(), pre_run_phase);
-    driver.contract_begin_run_authority(run_id).unwrap();
-    assert_eq!(driver.runtime_state(), RuntimeState::Running);
-    assert_eq!(driver.pre_run_phase(), Some(pre_run_phase));
-}
-
 async fn retire_runtime(
     driver: &mut PersistentRuntimeDriver,
 ) -> Result<meerkat_runtime::RetireReport, meerkat_runtime::RuntimeDriverError> {
@@ -590,63 +583,4 @@ async fn recovery_persistent_driver_contract_consumes_committed_boundary_contrib
             harness.name
         );
     }
-}
-
-#[tokio::test]
-async fn recovery_ephemeral_driver_contract_keeps_applied_boundary_inputs_out_of_replay() {
-    let mut driver = EphemeralRuntimeDriver::new(make_runtime_id("ephemeral"));
-    let first = make_prompt("first ephemeral contribution");
-    let second = make_prompt("second ephemeral contribution");
-    let first_id = first.id().clone();
-    let second_id = second.id().clone();
-    let expected_ids = sorted_id_strings(vec![first_id.clone(), second_id.clone()]);
-
-    driver.accept_input(first).await.unwrap();
-    driver.accept_input(second).await.unwrap();
-    let _ = driver.take_wake_requested();
-
-    let dequeued_first = driver.dequeue_next().unwrap().0;
-    let dequeued_second = driver.dequeue_next().unwrap().0;
-    assert_eq!(
-        dequeued_first, first_id,
-        "ephemeral driver should drain contributors in admission order before recovery"
-    );
-    assert_eq!(
-        dequeued_second, second_id,
-        "ephemeral driver should drain contributors in admission order before recovery"
-    );
-
-    let run_id = RunId::new();
-    bind_running(&mut driver, run_id.clone(), RuntimeState::Idle);
-    driver.stage_input(&first_id, &run_id).unwrap();
-    driver.stage_input(&second_id, &run_id).unwrap();
-    driver.apply_input(&first_id, &run_id).unwrap();
-    driver.apply_input(&second_id, &run_id).unwrap();
-
-    let report = driver.recover().await.unwrap();
-    assert_eq!(
-        report.inputs_recovered, 2,
-        "ephemeral recovery should preserve both applied contributors in memory"
-    );
-    assert_eq!(
-        sorted_id_strings(driver.active_input_ids()),
-        expected_ids,
-        "ephemeral recovery should keep the same contributors active"
-    );
-
-    for input_id in [&first_id, &second_id] {
-        assert!(
-            driver.input_state(input_id).is_some(),
-            "ephemeral recovery should keep contributors visible"
-        );
-        assert_eq!(
-            driver.input_phase(input_id),
-            Some(InputLifecycleState::AppliedPendingConsumption),
-            "ephemeral recovery should not replay already-applied contributors"
-        );
-    }
-    assert!(
-        driver.dequeue_next().is_none(),
-        "ephemeral recovery should not requeue already-applied contributors"
-    );
 }

--- a/specs/compositions/meerkat_mob_seam/ci.cfg
+++ b/specs/compositions/meerkat_mob_seam/ci.cfg
@@ -305,6 +305,8 @@ INVARIANTS
   meerkat_unregister_drain_obligations_require_draining
   meerkat_current_run_only_while_running_or_retired
   meerkat_current_run_has_pre_run_phase
+  meerkat_staged_inputs_are_not_queued
+  meerkat_staged_inputs_have_run_association
   meerkat_staged_surface_ops_are_known_and_sequenced
   meerkat_staged_reload_surfaces_are_active
   meerkat_peer_ingress_owner_consistency

--- a/specs/compositions/meerkat_mob_seam/deep.cfg
+++ b/specs/compositions/meerkat_mob_seam/deep.cfg
@@ -305,6 +305,8 @@ INVARIANTS
   meerkat_unregister_drain_obligations_require_draining
   meerkat_current_run_only_while_running_or_retired
   meerkat_current_run_has_pre_run_phase
+  meerkat_staged_inputs_are_not_queued
+  meerkat_staged_inputs_have_run_association
   meerkat_staged_surface_ops_are_known_and_sequenced
   meerkat_staged_reload_surfaces_are_active
   meerkat_peer_ingress_owner_consistency

--- a/specs/compositions/meerkat_mob_seam/witness-basic_round_trip.cfg
+++ b/specs/compositions/meerkat_mob_seam/witness-basic_round_trip.cfg
@@ -305,6 +305,8 @@ INVARIANTS
   meerkat_unregister_drain_obligations_require_draining
   meerkat_current_run_only_while_running_or_retired
   meerkat_current_run_has_pre_run_phase
+  meerkat_staged_inputs_are_not_queued
+  meerkat_staged_inputs_have_run_association
   meerkat_staged_surface_ops_are_known_and_sequenced
   meerkat_staged_reload_surfaces_are_active
   meerkat_peer_ingress_owner_consistency

--- a/specs/compositions/meerkat_mob_seam/witness-destroy_runtime_path.cfg
+++ b/specs/compositions/meerkat_mob_seam/witness-destroy_runtime_path.cfg
@@ -305,6 +305,8 @@ INVARIANTS
   meerkat_unregister_drain_obligations_require_draining
   meerkat_current_run_only_while_running_or_retired
   meerkat_current_run_has_pre_run_phase
+  meerkat_staged_inputs_are_not_queued
+  meerkat_staged_inputs_have_run_association
   meerkat_staged_surface_ops_are_known_and_sequenced
   meerkat_staged_reload_surfaces_are_active
   meerkat_peer_ingress_owner_consistency

--- a/specs/compositions/meerkat_mob_seam/witness-retire_runtime_path.cfg
+++ b/specs/compositions/meerkat_mob_seam/witness-retire_runtime_path.cfg
@@ -305,6 +305,8 @@ INVARIANTS
   meerkat_unregister_drain_obligations_require_draining
   meerkat_current_run_only_while_running_or_retired
   meerkat_current_run_has_pre_run_phase
+  meerkat_staged_inputs_are_not_queued
+  meerkat_staged_inputs_have_run_association
   meerkat_staged_surface_ops_are_known_and_sequenced
   meerkat_staged_reload_surfaces_are_active
   meerkat_peer_ingress_owner_consistency

--- a/specs/machines/meerkat_machine/ci.cfg
+++ b/specs/machines/meerkat_machine/ci.cfg
@@ -210,6 +210,8 @@ INVARIANTS
   unregister_drain_obligations_require_draining
   current_run_only_while_running_or_retired
   current_run_has_pre_run_phase
+  staged_inputs_are_not_queued
+  staged_inputs_have_run_association
   staged_surface_ops_are_known_and_sequenced
   staged_reload_surfaces_are_active
   peer_ingress_owner_consistency

--- a/specs/machines/meerkat_machine/contract.md
+++ b/specs/machines/meerkat_machine/contract.md
@@ -131,7 +131,7 @@ _Generated from the Rust machine catalog. Do not edit by hand._
 - `input_abandon_attempt_count`: `Map<String, u64>`
 - `input_attempt_counts`: `Map<String, u64>`
 - `max_stage_attempts`: `u64`
-- `input_run_associations`: `Map<String, String>`
+- `input_run_associations`: `Map<String, RunId>`
 - `input_boundary_sequences`: `Map<String, u64>`
 - `live_boundary_context_sequence_by_run`: `Map<RunId, u64>`
 - `next_admission_seq`: `u64`
@@ -382,7 +382,7 @@ _Generated from the Rust machine catalog. Do not edit by hand._
 - `ClassifyCallTimeout`(source: CallTimeoutSource, timeout_ms: u64)
 - `ClassifyLlmFailureRecovery`(failure_kind: Option<LlmRetryFailureKind>, retry_attempt: u64, max_retries: u64)
 - `ResolveTurnSurfaceResult`(outcome: TurnTerminalOutcome, cause_class: TerminalCauseClass)
-- `AuthorizeStoredInputStateSeed`(input_id: String, phase: RecoveredInputObservedPhase, terminal_kind: Option<InputTerminalKind>, superseded_by: Option<String>, aggregate_id: Option<String>, abandon_reason: Option<InputAbandonReason>, abandon_attempt_count: u64, attempt_count: u64, run_id: Option<String>, boundary_sequence: Option<u64>, admission_sequence: Option<u64>, recovery_lane: Option<InputLane>)
+- `AuthorizeStoredInputStateSeed`(input_id: String, phase: RecoveredInputObservedPhase, terminal_kind: Option<InputTerminalKind>, superseded_by: Option<String>, aggregate_id: Option<String>, abandon_reason: Option<InputAbandonReason>, abandon_attempt_count: u64, attempt_count: u64, run_id: Option<RunId>, boundary_sequence: Option<u64>, admission_sequence: Option<u64>, recovery_lane: Option<InputLane>)
 - `ClassifyRuntimeLifecycleState`(state: RuntimeLifecycleObservedState)
 - `ClassifyRuntimeLifecycleDurability`(state: RuntimeLifecycleObservedState)
 - `ClassifyRuntimeLoopQueueAdmission`(state: RuntimeLifecycleObservedState, current_run_bound: Bool)
@@ -423,13 +423,13 @@ _Generated from the Rust machine catalog. Do not edit by hand._
 - `RunFailed`(run_id: RunId, runtime_apply_failure_cause: Option<RuntimeApplyFailureCause>, runtime_apply_failure_message: Option<String>, machine_terminal_failure_observed: Bool, terminal_failure_source: Option<RunFailureSourceKind>, error: String)
 - `RunCancelled`(run_id: RunId)
 - `RecoverAdmittedInput`(input_id: String, input_kind: RecoveredInputKind, runtime_boundary: RecoveredRunApplyBoundary, runtime_execution_kind: RecoveredRuntimeExecutionKind, runtime_peer_response_terminal_apply_intent: Option<RecoveredPeerResponseTerminalApplyIntent>, lane: InputLane)
-- `RecoverInputLifecycle`(input_id: String, phase: InputPhase, terminal_kind: Option<InputTerminalKind>, superseded_by: Option<String>, aggregate_id: Option<String>, abandon_reason: Option<InputAbandonReason>, abandon_attempt_count: u64, attempt_count: u64, run_id: Option<String>, boundary_sequence: Option<u64>, admission_sequence: Option<u64>, admission_sequence_recovery: Option<RecoveredInputNormalizationReasonKind>, recovery_lane: Option<InputLane>, lane: Option<InputLane>)
+- `RecoverInputLifecycle`(input_id: String, phase: InputPhase, terminal_kind: Option<InputTerminalKind>, superseded_by: Option<String>, aggregate_id: Option<String>, abandon_reason: Option<InputAbandonReason>, abandon_attempt_count: u64, attempt_count: u64, run_id: Option<RunId>, boundary_sequence: Option<u64>, admission_sequence: Option<u64>, admission_sequence_recovery: Option<RecoveredInputNormalizationReasonKind>, recovery_lane: Option<InputLane>, lane: Option<InputLane>)
 - `QueueAccepted`(input_id: String)
 - `SteerAccepted`(input_id: String)
 - `ChangeLane`(input_id: String, new_lane: InputLane)
 - `PrioritizeInput`(input_id: String)
 - `DeferInputBehindBacklog`(input_id: String)
-- `StageForRun`(input_id: String, run_id: String)
+- `StageForRun`(input_id: String, run_id: RunId)
 - `IncrementAttemptCount`(input_id: String)
 - `RollbackStaged`(input_id: String, lane: InputLane)
 - `ResolveStagedRollback`(input_id: String, lane: InputLane)
@@ -770,6 +770,8 @@ _Generated from the Rust machine catalog. Do not edit by hand._
 - `unregister_drain_obligations_require_draining`
 - `current_run_only_while_running_or_retired`
 - `current_run_has_pre_run_phase`
+- `staged_inputs_are_not_queued`
+- `staged_inputs_have_run_association`
 - `staged_surface_ops_are_known_and_sequenced`
 - `staged_reload_surfaces_are_active`
 - `peer_ingress_owner_consistency`
@@ -8965,7 +8967,12 @@ _Generated from the Rust machine catalog. Do not edit by hand._
 - From: `Idle`
 - On: `StageForRun`(input_id, run_id)
 - Guards:
-  - `input_tracked`
+  - `input_queued`
+  - `input_lane_bound`
+  - `input_sequence_bound`
+  - `input_recovery_lane_bound`
+  - `input_not_run_associated`
+  - `current_run_matches`
 - Emits: `RecordRunAssociation`
 - To: `Idle`
 
@@ -8973,7 +8980,12 @@ _Generated from the Rust machine catalog. Do not edit by hand._
 - From: `Attached`
 - On: `StageForRun`(input_id, run_id)
 - Guards:
-  - `input_tracked`
+  - `input_queued`
+  - `input_lane_bound`
+  - `input_sequence_bound`
+  - `input_recovery_lane_bound`
+  - `input_not_run_associated`
+  - `current_run_matches`
 - Emits: `RecordRunAssociation`
 - To: `Attached`
 
@@ -8981,7 +8993,12 @@ _Generated from the Rust machine catalog. Do not edit by hand._
 - From: `Running`
 - On: `StageForRun`(input_id, run_id)
 - Guards:
-  - `input_tracked`
+  - `input_queued`
+  - `input_lane_bound`
+  - `input_sequence_bound`
+  - `input_recovery_lane_bound`
+  - `input_not_run_associated`
+  - `current_run_matches`
 - Emits: `RecordRunAssociation`
 - To: `Running`
 
@@ -8989,7 +9006,12 @@ _Generated from the Rust machine catalog. Do not edit by hand._
 - From: `Retired`
 - On: `StageForRun`(input_id, run_id)
 - Guards:
-  - `input_tracked`
+  - `input_queued`
+  - `input_lane_bound`
+  - `input_sequence_bound`
+  - `input_recovery_lane_bound`
+  - `input_not_run_associated`
+  - `current_run_matches`
 - Emits: `RecordRunAssociation`
 - To: `Retired`
 
@@ -8997,7 +9019,12 @@ _Generated from the Rust machine catalog. Do not edit by hand._
 - From: `Stopped`
 - On: `StageForRun`(input_id, run_id)
 - Guards:
-  - `input_tracked`
+  - `input_queued`
+  - `input_lane_bound`
+  - `input_sequence_bound`
+  - `input_recovery_lane_bound`
+  - `input_not_run_associated`
+  - `current_run_matches`
 - Emits: `RecordRunAssociation`
 - To: `Stopped`
 

--- a/specs/machines/meerkat_machine/deep.cfg
+++ b/specs/machines/meerkat_machine/deep.cfg
@@ -210,6 +210,8 @@ INVARIANTS
   unregister_drain_obligations_require_draining
   current_run_only_while_running_or_retired
   current_run_has_pre_run_phase
+  staged_inputs_are_not_queued
+  staged_inputs_have_run_association
   staged_surface_ops_are_known_and_sequenced
   staged_reload_surfaces_are_active
   peer_ingress_owner_consistency

--- a/specs/machines/meerkat_machine/mapping.md
+++ b/specs/machines/meerkat_machine/mapping.md
@@ -5529,6 +5529,12 @@ This section is generated from the Rust machine catalog. Do not edit it by hand.
 - `current_run_has_pre_run_phase`
   - anchors: (unclaimed)
   - scenarios: (unclaimed)
+- `staged_inputs_are_not_queued`
+  - anchors: (unclaimed)
+  - scenarios: (unclaimed)
+- `staged_inputs_have_run_association`
+  - anchors: (unclaimed)
+  - scenarios: (unclaimed)
 - `staged_surface_ops_are_known_and_sequenced`
   - anchors: (unclaimed)
   - scenarios: (unclaimed)


### PR DESCRIPTION
## Summary
- make runtime ingress, completion, batch selection, and staging authority consume machine-owned capabilities instead of raw public helpers
- move StageForRun ownership into the generated machine model, including current-run and attempt-count authority
- seal raw staging/dequeue bypasses and update generated TLA/runtime artifacts plus regression contracts

## Validation
- make machine-codegen
- make machine-check-drift
- ./scripts/repo-cargo fmt --all
- ./scripts/repo-cargo check -p meerkat-runtime -p meerkat-machine-schema -p meerkat-machine-kernels
- RUSTFLAGS='--cfg getrandom_backend="wasm_js"' ./scripts/repo-cargo check -p meerkat-web-runtime --target wasm32-unknown-unknown
- focused runtime/recovery/codegen tests
- make e2e-system
- focused e2e-smoke reruns for previously non-green scenarios 40, 47, and 48

Used adaptive-subagents methodology for bounded verification and adversarial review.