### PR TITLE
fix(mob): join comms-drain task on detach — close "Session identity already active" revival race

### DIFF
--- a/meerkat-mob/src/runtime/tests.rs
+++ b/meerkat-mob/src/runtime/tests.rs
@@ -1192,6 +1192,16 @@ struct MockSessionService {
     /// Sessions whose create_session should materialize live state but return
     /// the already-active comms identity error observed in the #37 deliver race.
     create_identity_already_active_sessions: RwLock<HashSet<SessionId>>,
+    /// Sessions whose create_session should fail with the "Session identity
+    /// already active" error WITHOUT registering a live session — the
+    /// production-faithful shape of the user-reported revival failure, where the
+    /// inproc comms-claim acquire fails inside `build_agent` (before the live
+    /// handle is registered) because a not-yet-dropped prior runtime still holds
+    /// the process-scoped claim, so `has_live_session` reads false at the
+    /// recovery re-check. Distinct from
+    /// `create_identity_already_active_sessions`, which leaves the session live
+    /// (the idempotent-success case).
+    create_identity_already_active_no_live_sessions: RwLock<HashSet<SessionId>>,
     fail_start_turn: std::sync::atomic::AtomicBool,
     fail_inject: std::sync::atomic::AtomicBool,
     disable_interaction_event_injector: std::sync::atomic::AtomicBool,
@@ -1255,6 +1265,7 @@ impl MockSessionService {
             archived_session_ids: RwLock::new(HashSet::new()),
             create_fail_sessions: RwLock::new(HashSet::new()),
             create_identity_already_active_sessions: RwLock::new(HashSet::new()),
+            create_identity_already_active_no_live_sessions: RwLock::new(HashSet::new()),
             fail_start_turn: std::sync::atomic::AtomicBool::new(false),
             fail_inject: std::sync::atomic::AtomicBool::new(false),
             disable_interaction_event_injector: std::sync::atomic::AtomicBool::new(false),
@@ -1469,6 +1480,21 @@ impl MockSessionService {
 
     async fn set_create_session_identity_already_active(&self, session_id: &SessionId) {
         self.create_identity_already_active_sessions
+            .write()
+            .await
+            .insert(session_id.clone());
+    }
+
+    /// Inject the production-faithful revival failure: create_session fails with
+    /// the wrapped "Session identity already active" error and does NOT register
+    /// a live session, so `has_live_session` returns false at the actor's
+    /// recovery re-check (the leaked-claim-without-live-session terminal path the
+    /// user hit).
+    async fn set_create_session_identity_already_active_without_live_session(
+        &self,
+        session_id: &SessionId,
+    ) {
+        self.create_identity_already_active_no_live_sessions
             .write()
             .await
             .insert(session_id.clone());
@@ -1748,6 +1774,26 @@ impl SessionService for MockSessionService {
             return Err(SessionError::Store(Box::new(std::io::Error::other(
                 "mock create_session failure",
             ))));
+        }
+        // Production-faithful "already active" failure: the inproc comms-claim
+        // acquire fails INSIDE build_agent, before any live session handle is
+        // registered, so this returns the wrapped BuildError WITHOUT inserting
+        // into self.sessions — leaving has_live_session false at the actor's
+        // recovery re-check (the leaked-claim-without-live-session terminal path).
+        if self
+            .create_identity_already_active_no_live_sessions
+            .read()
+            .await
+            .contains(&session_id)
+        {
+            self.create_session_in_flight
+                .fetch_sub(1, Ordering::Relaxed);
+            return Err(SessionError::Agent(
+                meerkat_core::error::AgentError::BuildError(format!(
+                    "Comms runtime failed: Failed to create inproc comms runtime: \
+                     Session identity already active: {session_id}"
+                )),
+            ));
         }
         let n = self.session_counter.fetch_add(1, Ordering::Relaxed);
 
@@ -33632,6 +33678,117 @@ async fn test_revival_failure_is_typed_terminal_without_retry_loop() {
             .await
             .expect("has_live_session"),
         "no shell retry may re-materialize a broken member's session"
+    );
+}
+
+/// Direct regression for the user-reported mob bridge failure
+/// ("...machine-authorized revival of bridge session '...' failed: ...Comms
+/// runtime failed: Failed to create inproc comms runtime: Session identity
+/// already active: ..."): on revival, the re-provision fails with the
+/// "Session identity already active" comms-claim error AND there is no live
+/// session (the discard already removed it), because a not-yet-dropped prior
+/// runtime still holds the process-scoped identity claim. The mob shell must
+/// surface the typed terminal `MemberRestoreFailed` (member Broken) — NOT
+/// silently treat it as idempotent success, which is what the
+/// `has_live_session` re-check guards.
+///
+/// This is the exact (already-active ∧ has_live_session=false) branch that no
+/// prior test could reach: the idempotent-success test leaves the session live
+/// (so `has_live_session` is true), and the generic terminal test injects a
+/// `Store` error that never matches the already-active classifier. Closing that
+/// fidelity gap is why the original failure shipped uncaught. The runtime-layer
+/// drain-task join (`detach_drops_drain_task_runtime_clone_so_identity_claim_is_released`)
+/// removes the race at its source; this pins the mob shell's recovery decision
+/// boundary as the fail-closed backstop.
+#[tokio::test]
+async fn test_revival_already_active_without_live_session_is_typed_terminal() {
+    let mut definition = sample_definition();
+    definition
+        .profiles
+        .get_mut(&ProfileName::from("worker"))
+        .expect("worker profile")
+        .as_inline_mut()
+        .unwrap()
+        .runtime_mode = crate::MobRuntimeMode::TurnDriven;
+    let (handle, service) = create_test_mob(definition).await;
+    let receipt = handle
+        .spawn(
+            ProfileName::from("worker"),
+            AgentIdentity::from("w-1"),
+            None,
+        )
+        .await
+        .expect("spawn worker");
+    let bridge_session_id = receipt
+        .bridge_session_id()
+        .expect("session-backed member")
+        .clone();
+
+    MobSessionService::discard_live_session(service.as_ref(), &bridge_session_id)
+        .await
+        .expect("discard live session");
+    assert!(
+        !service
+            .has_live_session(&bridge_session_id)
+            .await
+            .expect("has_live_session"),
+        "discard must remove the live materialization"
+    );
+    // Re-provision fails with the production-faithful already-active error and
+    // leaves NO live session — the leaked-claim-without-live-session shape.
+    service
+        .set_create_session_identity_already_active_without_live_session(&bridge_session_id)
+        .await;
+
+    let error = handle
+        .member(&AgentIdentity::from("w-1"))
+        .await
+        .expect("member handle")
+        .internal_turn(ContentInput::from("come back online".to_string()))
+        .await
+        .expect_err(
+            "already-active with no live session must surface the typed terminal restore failure, \
+             not idempotent success",
+        );
+    match error {
+        MobError::MemberRestoreFailed {
+            member_id,
+            session_id,
+            reason,
+        } => {
+            assert_eq!(member_id, AgentIdentity::from("w-1"));
+            assert_eq!(session_id, Some(bridge_session_id.clone()));
+            assert!(
+                reason.contains("machine-authorized revival"),
+                "failure reason must carry the typed revival outcome: {reason}"
+            );
+            assert!(
+                reason.contains("Session identity already active"),
+                "failure reason must carry the underlying comms-claim cause: {reason}"
+            );
+        }
+        other => panic!("expected MemberRestoreFailed, got {other:?}"),
+    }
+
+    // Machine state: terminal Broken, revival obligation resolved (no dangling
+    // pending revival, no retry loop).
+    let machine_state = handle
+        .query_machine_state()
+        .await
+        .expect("query MobMachine state");
+    let machine_identity =
+        crate::machines::mob_machine::AgentIdentity::from_domain(&AgentIdentity::from("w-1"));
+    let lifecycle = machine_state.member_lifecycle_for_identity(&machine_identity);
+    assert_eq!(
+        lifecycle.status,
+        crate::machines::mob_machine::MobMemberLifecycleStatus::Broken,
+        "already-active-with-no-live-session revival must resolve into Broken: {lifecycle:?}"
+    );
+    assert!(
+        !machine_state
+            .member_revival_pending
+            .contains(&machine_identity),
+        "failed revival must resolve the machine-owned revival obligation"
     );
 }
 

--- a/meerkat-runtime/src/meerkat_machine/dispatch_drain.rs
+++ b/meerkat-runtime/src/meerkat_machine/dispatch_drain.rs
@@ -215,9 +215,47 @@ impl MeerkatMachine {
                 if drain_is_running && !self.stage_drain_stop_dsl(&session_id).await {
                     return Ok(MeerkatMachineCommandResult::Unit);
                 }
-                let mut sessions = self.sessions.write().await;
-                if let Some(entry) = sessions.get_mut(&session_id) {
-                    abort_slot(&mut entry.drain_slot);
+                // Abort the drain task AND await its quiescence before returning.
+                //
+                // The drain task captured its own `Arc<dyn CommsRuntime>` clone at
+                // spawn (`spawn_comms_drain`). That runtime owns the process-scoped
+                // session-identity `SessionClaim`, which is released only when its
+                // LAST `Arc` is dropped. A fire-and-forget `handle.abort()` merely
+                // schedules cancellation, so the task's clone — and with it the
+                // claim — can outlive this call. A caller that immediately rebuilds
+                // the same session id under the same identity (mob post-discard
+                // member revival via `update_peer_ingress_context(.., false, None)`
+                // → `provision_member`) then hits "Session identity already active"
+                // at `CommsRuntime`'s `try_acquire`, which surfaces as a terminal
+                // `MemberRestoreFailed`. Take the handle out (which also drops the
+                // slot's own clone) OUTSIDE the held `sessions` lock and bounded-await
+                // quiescence so every drain-task-held clone is dropped before we
+                // return. Mirrors the bounded comms-drain join in
+                // `unregister_session_inner_locked_authorized`.
+                let drain_handle = {
+                    let mut sessions = self.sessions.write().await;
+                    sessions
+                        .get_mut(&session_id)
+                        .and_then(|entry| entry.drain_slot.abort_keeping_handle())
+                };
+                if let Some(drain_handle) = drain_handle {
+                    // Far above realistic cancel latency (a parked drain unwinds in
+                    // sub-ms once aborted) and far below caller shutdown budgets. On
+                    // elapse the task is already aborted and will unwind on its own;
+                    // we stop waiting rather than wedge the caller on a drain that is
+                    // not observing cooperative cancellation promptly (e.g. an
+                    // external transport drain parked in a syscall).
+                    const COMMS_DRAIN_ABORT_GRACE: std::time::Duration =
+                        std::time::Duration::from_secs(2);
+                    if crate::tokio::time::timeout(COMMS_DRAIN_ABORT_GRACE, drain_handle)
+                        .await
+                        .is_err()
+                    {
+                        tracing::warn!(
+                            %session_id,
+                            "comms drain task did not quiesce within the abort grace window; proceeding (task already aborted)"
+                        );
+                    }
                 }
                 Ok(MeerkatMachineCommandResult::Unit)
             }

--- a/meerkat-runtime/src/meerkat_machine_tests.rs
+++ b/meerkat-runtime/src/meerkat_machine_tests.rs
@@ -24569,6 +24569,58 @@ async fn detach_ingress_clears_owner() {
 }
 
 #[tokio::test]
+async fn detach_drops_drain_task_runtime_clone_so_identity_claim_is_released() {
+    // Regression for the mob post-discard revival failure
+    // "Session identity already active". The spawned comms-drain task captures
+    // its own `Arc<dyn CommsRuntime>` clone, and a session-scoped inproc runtime
+    // owns the process-scoped session-identity `SessionClaim`, released ONLY when
+    // its LAST `Arc` is dropped. A fire-and-forget `handle.abort()` merely
+    // schedules cancellation, so on a single-threaded runtime the task's clone is
+    // still alive right after detach returns — and a same-id rebuild
+    // (`materialize_revived_member_session` -> `provision_member`) then collides
+    // with the still-held claim. The detach must JOIN the aborted drain task,
+    // dropping its captured clone before returning. We observe that here through a
+    // `Weak` handle: after detach, no strong `Arc` clone may survive.
+    let adapter = Arc::new(MeerkatMachine::ephemeral());
+    let session_id = SessionId::new();
+    adapter
+        .register_session(session_id.clone())
+        .await
+        .expect("register session");
+
+    let comms_runtime: Arc<dyn CommsRuntime> = Arc::new(FakeDrainRuntime::idle());
+    let weak_runtime = Arc::downgrade(&comms_runtime);
+    assert!(
+        adapter
+            .update_peer_ingress_context(&session_id, true, Some(Arc::clone(&comms_runtime)))
+            .await
+            .expect("attach session-owned drain"),
+        "first session-owned attach should spawn the drain task"
+    );
+
+    // Drop the test's own strong reference so the only remaining strong holders
+    // are the drain slot's `task_runtime` and the spawned drain task's captured
+    // clone — exactly the state a live keep-alive session is in before revival.
+    drop(comms_runtime);
+    assert!(
+        weak_runtime.upgrade().is_some(),
+        "precondition: the drain slot + drain task must still hold the comms runtime"
+    );
+
+    adapter
+        .update_peer_ingress_context(&session_id, false, None)
+        .await
+        .expect("detach drain");
+
+    assert!(
+        weak_runtime.upgrade().is_none(),
+        "after detach, every Arc<dyn CommsRuntime> clone (slot + drain task) must be \
+         dropped so the session-identity claim is released before any same-id rebuild; \
+         a lingering clone is the race that surfaces as 'Session identity already active'"
+    );
+}
+
+#[tokio::test]
 async fn attach_mob_ingress_promotes_from_session_owned() {
     // Mob provisioning is allowed to take over a session-owned drain
     // (the spec's promotion case). Silent downgrade is blocked; promotion


### PR DESCRIPTION
## Summary

Fixes the mob bridge revival failure reported from a live session:

```
interaction_failed: internal: bridge deliver: ... member mk--rt_c..._c1 failed to
restore session <id>: machine-authorized revival of bridge session '<id>' failed:
session error: agent error: Build error: Comms runtime failed: Failed to create
inproc comms runtime: Session identity already active: <id>
```

This is a **`SessionClaim` lifetime race** on the mob post-discard member revival path — not a session-service bug. Confirmed by a fan-out investigation across the claim lifecycle, the test harness, and adjacent claim sites, with each conclusion adversarially re-verified against the code.

## Root cause

A session-scoped inproc `CommsRuntime` owns the process-scoped session-identity `SessionClaim`, released **only when its last `Arc` is dropped**. On revival:

1. The `#34` fail-closed discard drops the live agent task but leaves the **dead** `CommsRuntime` alive, held by the runtime adapter's drain slot **and** the spawned comms-drain task's captured `Arc`.
2. The revival detach `update_peer_ingress_context(.., false, None)` → `MeerkatMachineCommand::Abort` used a fire-and-forget `abort_slot`: it dropped the slot's `Arc` and called `JoinHandle::abort()` **without awaiting**, so the drain task's captured `Arc<CommsRuntime>` — and the claim — could outlive the detach.
3. `materialize_revived_member_session` immediately re-provisions; `try_acquire` collides with the still-held claim → `"Session identity already active"`. Because the discarded session is no longer live (`has_live_session == false`), the idempotent-recovery branch doesn't apply and the member goes terminally `Broken` — the user's exact error.

The proper teardown (`unregister_session_inner_locked_authorized`) already aborts **and** bounded-joins the drain task to quiescence; the revival detach took the non-joining shortcut.

> Note on "is this already fixed?": the *deterministic* old-version failure was partly addressed by `#37` (detach-before-revive) and yesterday's idempotent `has_live_session` recovery, but a **race window** remained on current `main`. This PR closes it at the source.

## Fix

The single-session drain `Abort` now aborts **and** bounded-joins the drain task (`abort_keeping_handle` + 2s grace), mirroring the comms-drain quiescence join in `unregister_session_inner_locked_authorized`, so every claim-holding `Arc` is dropped before any caller rebuilds the same session id. The join runs off the `sessions` lock; the drain task's cancellation never re-enters the per-session mutation gate, so it is deadlock-free. This also makes `abort_comms_drain` deterministically quiesce the drain for all callers.

## Why it shipped uncaught

The mob `MockSessionService` inserted the session into its live map **before** returning the injected `"already active"` error, so `has_live_session` was always `true` — every revival test exercised only the idempotent-success branch. The terminal `(already-active ∧ has_live_session == false)` path had **no coverage**, and `comms_drain.rs` had no tests of the detach claim-release invariant.

## Tests

- **meerkat-runtime** `detach_drops_drain_task_runtime_clone_so_identity_claim_is_released` — pins the invariant via a `Weak` handle. **Verified red** on the old fire-and-forget abort, green with the join.
- **meerkat-mob** `test_revival_already_active_without_live_session_is_typed_terminal` — exercises the exact terminal path that shipped uncaught, plus a test-double knob that injects the already-active error **without** registering a live session (production-faithful: the comms-claim acquire fails inside `build_agent`, before the handle is registered).

Verification: `clippy -D warnings` clean (runtime + mob); full `meerkat-runtime` + `meerkat-mob` suites (2229 tests) green; full `make test` (unit + integration-fast) green; pre-push gate (machine codegen, bridge gate, Bazel freshness, workspace deterministic) green.

## Adjacent findings (documented, intentionally out of scope here)

- **Ephemeral discard agent-task race** (`ephemeral.rs` `discard_live_session`): sends `Shutdown` fire-and-forget without awaiting session-task exit, so the agent's `Arc<CommsRuntime>` drops off-thread. This is a *different surface* (ephemeral resume, not mob runtime-backed revival) and needs a `JoinHandle`/completion signal on `SessionHandle` — an invasive core-lifecycle change deserving its own PR.
- **Claim registry split** (per-`MeerkatMachine` `session_claims` vs `DefaultSessionClaimRegistry::global()`): a latent permanent-leak hazard only for mixed-mode / multi-machine processes; not implicated in this bug (mob always rebuilds `SessionOwned` against the same machine).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
