### PR TITLE
ci(buildbuddy): raise GCP CI SLO deadline 1200s → 1500s

### DIFF
--- a/.github/workflows/buildbuddy.yml
+++ b/.github/workflows/buildbuddy.yml
@@ -81,7 +81,7 @@ env:
   MEERKAT_GCP_BUILDBUDDY_CACHE_DISK_GB: ${{ vars.MEERKAT_GCP_BUILDBUDDY_CACHE_DISK_GB || '1000' }}
   MEERKAT_GCP_BUILDBUDDY_CACHE_DISK_TYPE: ${{ vars.MEERKAT_GCP_BUILDBUDDY_CACHE_DISK_TYPE || 'pd-ssd' }}
   MEERKAT_GCP_BUILDBUDDY_DOWN_MODE: ${{ vars.MEERKAT_GCP_BUILDBUDDY_DOWN_MODE || 'stopped' }}
-  MEERKAT_GCP_BUILDBUDDY_CI_MAX_SECONDS: ${{ vars.MEERKAT_GCP_BUILDBUDDY_CI_MAX_SECONDS || '1200' }}
+  MEERKAT_GCP_BUILDBUDDY_CI_MAX_SECONDS: ${{ vars.MEERKAT_GCP_BUILDBUDDY_CI_MAX_SECONDS || '1500' }}
   MEERKAT_BUILDBUDDY_EXECUTOR_POOL: ${{ vars.MEERKAT_BUILDBUDDY_EXECUTOR_POOL || 'meerkat-ci' }}
   MEERKAT_BUILDBUDDY_CI_IMAGE: ${{ vars.MEERKAT_BUILDBUDDY_CI_IMAGE || 'europe-west1-docker.pkg.dev/king-dnn-training-dev/meerkat-ci/meerkat-ci-rust:1.94.0' }}
   MEERKAT_HOST_CARGO_HOME: /usr/local/cargo
@@ -625,7 +625,7 @@ jobs:
         shell: bash
         env:
           CI_STARTED_AT_EPOCH: ${{ needs.control-plane-up.outputs.started_at_epoch }}
-          MAX_SECONDS: ${{ vars.MEERKAT_GCP_BUILDBUDDY_CI_MAX_SECONDS || '1200' }}
+          MAX_SECONDS: ${{ vars.MEERKAT_GCP_BUILDBUDDY_CI_MAX_SECONDS || '1500' }}
         run: |
           if ! [[ "${CI_STARTED_AT_EPOCH}" =~ ^[0-9]+$ ]]; then
             echo "::error::Missing or invalid GCP BuildBuddy CI start timestamp: '${CI_STARTED_AT_EPOCH}'"


### PR DESCRIPTION
## What

Bump the BuildBuddy lane-batch SLO watchdog deadline (`MEERKAT_GCP_BUILDBUDDY_CI_MAX_SECONDS`) default from **1200s → 1500s**.

## Why

PR #783 CI failed with `exit 124` — "BuildBuddy lane batch reached the GCP CI SLO deadline" — when the batch hit the 1200s watchdog with the final `test-unit` lane ~99% complete (`xtask_unit_test` at 40/41 tests, zero failures). It was a marginal timeout, not a real failure, but it forced a full CI rerun.

1500s gives ~5 min of headroom over the marginal case while still catching genuinely hung batches. Still overridable per-repo via the `MEERKAT_GCP_BUILDBUDDY_CI_MAX_SECONDS` variable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)