### PR TITLE
Fix dogma audit violations

### DIFF
--- a/docs/api/mcp.mdx
+++ b/docs/api/mcp.mdx
@@ -617,12 +617,12 @@ Response includes config envelope fields:
 - `resolved_paths` (only when the server runs with `--expose-paths`)
 
 The MCP surface returns only the `ConfigEnvelope` shown above. It does **not**
-carry the `live_propagation` field: that is part of the richer RPC/REST
+carry the `live_propagation` field: that is part of the richer JSON-RPC
 `ConfigWriteResult` contract, which reports the per-channel hot-swap / refresh /
 close outcome (`swapped`, `skipped`, `swap_failed`, `refreshed`, `closed`,
 `refresh_failed`, `close_failed`) when a `set`/`patch` write fans out to live
-channels. Use the JSON-RPC or REST `config/set` / `config/patch` methods when
-you need the typed live-propagation report.
+channels. Use the JSON-RPC `config/set` / `config/patch` methods when you need
+the typed live-propagation report.
 
 ### meerkat_capabilities
 

--- a/meerkat-auth-core/src/authorizers/aws.rs
+++ b/meerkat-auth-core/src/authorizers/aws.rs
@@ -107,11 +107,9 @@ pub struct AwsStsAuthorizer {
     service: String,
     provider: AwsCredentialProvider,
     label: String,
-    /// AuthMachine freshness owner. When wired, the authorizer consults the
-    /// per-binding lease for a credential-use verdict before signing rather
-    /// than implicitly treating its resolved credential material as
-    /// always-fresh. Optional so hermetic tests and surfaces without a runtime
-    /// lease handle still construct the authorizer.
+    /// AuthMachine freshness owner. SigV4 signing fails closed unless this is
+    /// wired, so credential material is never treated as implicitly fresh outside
+    /// the generated AuthMachine lease lifecycle.
     lease_observer: Option<LeaseFreshnessObserver>,
 }
 
@@ -218,6 +216,9 @@ impl HttpAuthorizer for AwsStsAuthorizer {
                 Ok(())
             }
             other => {
+                let Some(observer) = &self.lease_observer else {
+                    return Err(AuthError::HostOwnedUnavailable);
+                };
                 // Single authoritative `now`: the same instant feeds the
                 // AuthMachine freshness verdict and the SigV4 signing time, so
                 // a request is never signed against a clock the lease did not
@@ -226,16 +227,13 @@ impl HttpAuthorizer for AwsStsAuthorizer {
                 // owns whether they are still usable.
                 let now = Utc::now();
                 let creds = other.resolve_sigv4().map_err(AuthError::from)?;
-                if let Some(observer) = &self.lease_observer {
-                    // Fail closed: expired/missing/refresh-needed creds surface
-                    // a typed reauth/refresh disposition rather than silently
-                    // signing with stale or absent material. Env/Static creds
-                    // carry no expiry, so the lease holds them as an explicit
-                    // `Valid` (no-expiry) phase rather than implicit
-                    // always-fresh.
-                    let credential_expiry = creds.expiry().map(DateTime::<Utc>::from);
-                    observer.ensure_valid_for_signing(&self.label, now, credential_expiry)?;
-                }
+                // Fail closed: expired/missing/refresh-needed creds surface a
+                // typed reauth/refresh disposition rather than silently signing
+                // with stale or absent material. Env/Static creds carry no
+                // expiry, so the lease holds them as an explicit `Valid`
+                // (no-expiry) phase rather than implicit always-fresh.
+                let credential_expiry = creds.expiry().map(DateTime::<Utc>::from);
+                observer.ensure_valid_for_signing(&self.label, now, credential_expiry)?;
                 let signed = self.sign_sigv4(&creds, req, now).map_err(AuthError::from)?;
                 for (k, v) in signed {
                     req.headers.push((k, v));

--- a/meerkat-auth-core/src/authorizers/aws.rs
+++ b/meerkat-auth-core/src/authorizers/aws.rs
@@ -30,6 +30,10 @@ use meerkat_core::{AuthError, HttpAuthorizationRequest, HttpAuthorizer};
 pub enum AwsAuthError {
     #[error("missing AWS env var: {0}")]
     MissingEnv(&'static str),
+    #[error("AWS_SESSION_TOKEN requires AWS_CREDENTIAL_EXPIRATION")]
+    MissingSessionTokenExpiry,
+    #[error("invalid AWS_CREDENTIAL_EXPIRATION: {0}")]
+    InvalidCredentialExpiration(String),
     #[error("sigv4 signing failed: {0}")]
     Sign(String),
     #[error("invalid URL: {0}")]
@@ -40,6 +44,10 @@ impl From<AwsAuthError> for AuthError {
     fn from(e: AwsAuthError) -> Self {
         match e {
             AwsAuthError::MissingEnv(_) => AuthError::MissingSecret,
+            AwsAuthError::MissingSessionTokenExpiry => AuthError::RefreshRequired,
+            AwsAuthError::InvalidCredentialExpiration(msg) => {
+                AuthError::Other(format!("aws credential expiration: {msg}"))
+            }
             AwsAuthError::Sign(msg) => AuthError::Other(format!("aws sigv4: {msg}")),
             AwsAuthError::InvalidUrl(msg) => AuthError::Other(format!("aws url: {msg}")),
         }
@@ -95,7 +103,17 @@ impl AwsCredentialProvider {
                 let sk = lookup("AWS_SECRET_ACCESS_KEY")
                     .ok_or(AwsAuthError::MissingEnv("AWS_SECRET_ACCESS_KEY"))?;
                 let tok = lookup("AWS_SESSION_TOKEN");
-                Ok(SdkCredentials::new(ak, sk, tok, None, "meerkat-env"))
+                let expires_at = if tok.is_some() {
+                    let raw = lookup("AWS_CREDENTIAL_EXPIRATION")
+                        .ok_or(AwsAuthError::MissingSessionTokenExpiry)?;
+                    let parsed = DateTime::parse_from_rfc3339(&raw)
+                        .map_err(|err| AwsAuthError::InvalidCredentialExpiration(err.to_string()))?
+                        .with_timezone(&Utc);
+                    Some(std::time::SystemTime::from(parsed))
+                } else {
+                    None
+                };
+                Ok(SdkCredentials::new(ak, sk, tok, expires_at, "meerkat-env"))
             }
             Self::BearerToken(_) => Err(AwsAuthError::MissingEnv("<bearer mode active>")),
         }
@@ -107,10 +125,46 @@ pub struct AwsStsAuthorizer {
     service: String,
     provider: AwsCredentialProvider,
     label: String,
-    /// AuthMachine freshness owner. SigV4 signing fails closed unless this is
-    /// wired, so credential material is never treated as implicitly fresh outside
-    /// the generated AuthMachine lease lifecycle.
-    lease_observer: Option<LeaseFreshnessObserver>,
+    /// Explicit SigV4 freshness authority. Runtime-backed provider resolution
+    /// upgrades this to the generated AuthMachine observer; direct public
+    /// construction remains a standalone user-owned credential authority so the
+    /// API stays usable outside Meerkat runtime sessions.
+    freshness_authority: AwsSigV4FreshnessAuthority,
+}
+
+enum AwsSigV4FreshnessAuthority {
+    StandaloneDirect,
+    RuntimeLease(LeaseFreshnessObserver),
+}
+
+impl AwsSigV4FreshnessAuthority {
+    fn ensure_valid_for_signing(
+        &self,
+        label: &str,
+        now: DateTime<Utc>,
+        credential_expiry: Option<DateTime<Utc>>,
+    ) -> Result<(), AuthError> {
+        match self {
+            Self::RuntimeLease(observer) => {
+                observer.ensure_valid_for_signing(label, now, credential_expiry)
+            }
+            Self::StandaloneDirect => {
+                if let Some(expires_at) = credential_expiry
+                    && expires_at <= now
+                {
+                    return Err(AuthError::Expired);
+                }
+                Ok(())
+            }
+        }
+    }
+
+    fn expires_at(&self) -> Option<DateTime<Utc>> {
+        match self {
+            Self::RuntimeLease(observer) => observer.expires_at(),
+            Self::StandaloneDirect => None,
+        }
+    }
 }
 
 impl AwsStsAuthorizer {
@@ -132,7 +186,7 @@ impl AwsStsAuthorizer {
             service,
             provider,
             label,
-            lease_observer: None,
+            freshness_authority: AwsSigV4FreshnessAuthority::StandaloneDirect,
         }
     }
 
@@ -144,7 +198,9 @@ impl AwsStsAuthorizer {
         handle: GeneratedAuthLeaseHandle,
         lease_key: LeaseKey,
     ) -> Self {
-        self.lease_observer = Some(LeaseFreshnessObserver::new(handle, lease_key));
+        self.freshness_authority = AwsSigV4FreshnessAuthority::RuntimeLease(
+            LeaseFreshnessObserver::new(handle, lease_key),
+        );
         self
     }
 
@@ -216,24 +272,20 @@ impl HttpAuthorizer for AwsStsAuthorizer {
                 Ok(())
             }
             other => {
-                let Some(observer) = &self.lease_observer else {
-                    return Err(AuthError::HostOwnedUnavailable);
-                };
                 // Single authoritative `now`: the same instant feeds the
-                // AuthMachine freshness verdict and the SigV4 signing time, so
-                // a request is never signed against a clock the lease did not
-                // admit. SigV4 credentials (especially STS session tokens) are
-                // time-bound; the lease — not a buried `SystemTime::now()` —
-                // owns whether they are still usable.
+                // freshness verdict and the SigV4 signing time. Runtime-backed
+                // authorizers delegate that verdict to the AuthMachine lease;
+                // direct public authorizers use their explicit standalone
+                // credential owner and fail closed only when credential expiry
+                // metadata is present and already expired.
                 let now = Utc::now();
                 let creds = other.resolve_sigv4().map_err(AuthError::from)?;
-                // Fail closed: expired/missing/refresh-needed creds surface a
-                // typed reauth/refresh disposition rather than silently signing
-                // with stale or absent material. Env/Static creds carry no
-                // expiry, so the lease holds them as an explicit `Valid`
-                // (no-expiry) phase rather than implicit always-fresh.
                 let credential_expiry = creds.expiry().map(DateTime::<Utc>::from);
-                observer.ensure_valid_for_signing(&self.label, now, credential_expiry)?;
+                self.freshness_authority.ensure_valid_for_signing(
+                    &self.label,
+                    now,
+                    credential_expiry,
+                )?;
                 let signed = self.sign_sigv4(&creds, req, now).map_err(AuthError::from)?;
                 for (k, v) in signed {
                     req.headers.push((k, v));
@@ -248,8 +300,6 @@ impl HttpAuthorizer for AwsStsAuthorizer {
     }
 
     fn expires_at(&self) -> Option<DateTime<Utc>> {
-        self.lease_observer
-            .as_ref()
-            .and_then(LeaseFreshnessObserver::expires_at)
+        self.freshness_authority.expires_at()
     }
 }

--- a/meerkat-auth-core/src/authorizers/mod.rs
+++ b/meerkat-auth-core/src/authorizers/mod.rs
@@ -70,6 +70,11 @@ impl LeaseFreshnessObserver {
         now: DateTime<Utc>,
         expires_at: Option<DateTime<Utc>>,
     ) -> Result<(), AuthError> {
+        if let Some(expires_at) = expires_at
+            && expires_at <= now
+        {
+            return Err(AuthError::Expired);
+        }
         self.handle
             .observe_credential_freshness(
                 &self.lease_key,

--- a/meerkat-auth-core/tests/aws_sts_authorizer.rs
+++ b/meerkat-auth-core/tests/aws_sts_authorizer.rs
@@ -96,7 +96,7 @@ async fn sigv4_adds_required_headers_for_bedrock() {
 }
 
 #[tokio::test]
-async fn sigv4_without_auth_lease_observer_fails_closed_before_signing() {
+async fn sigv4_direct_public_authorizer_signs_without_runtime_observer() {
     let authorizer = AwsStsAuthorizer::new("us-east-1", static_provider());
     let mut headers = vec![(
         "host".to_string(),
@@ -104,16 +104,13 @@ async fn sigv4_without_auth_lease_observer_fails_closed_before_signing() {
     )];
     let mut req = bedrock_request(&mut headers);
 
-    let err = authorizer.authorize(&mut req).await.unwrap_err();
+    authorizer.authorize(&mut req).await.unwrap();
     assert!(
-        matches!(err, AuthError::HostOwnedUnavailable),
-        "unobserved SigV4 signing must fail closed, got {err:?}"
-    );
-    assert!(
-        !headers
+        headers
             .iter()
-            .any(|(k, _)| k.eq_ignore_ascii_case("authorization")),
-        "unobserved SigV4 signing must not add authorization headers"
+            .any(|(k, v)| k.eq_ignore_ascii_case("authorization")
+                && v.starts_with("AWS4-HMAC-SHA256 ")),
+        "direct public authorizer should remain usable for standalone SigV4 signing"
     );
 }
 
@@ -178,6 +175,102 @@ async fn env_provider_reads_sigv4_credentials_from_env_lookup() {
         .unwrap();
     assert!(auth.1.contains("Credential=AKIAFROMENV00000000/"));
     assert!(auth.1.contains("/us-west-2/bedrock/aws4_request"));
+}
+
+#[tokio::test]
+async fn sigv4_env_session_token_without_expiry_does_not_acquire_no_expiry_lease() {
+    let provider = AwsCredentialProvider::from_env(|k| match k {
+        "AWS_ACCESS_KEY_ID" => Some("AKIAFROMENV00000000".into()),
+        "AWS_SECRET_ACCESS_KEY" => Some("secretfromenvsecretfromenvsecretfromenv".into()),
+        "AWS_SESSION_TOKEN" => Some("FQoGZXIvYXdzEJr//////////wEaENVSESSION".into()),
+        _ => None,
+    });
+    let authorizer = with_test_observer(AwsStsAuthorizer::new("us-west-2", provider));
+    let mut headers = vec![(
+        "host".into(),
+        "bedrock-runtime.us-west-2.amazonaws.com".into(),
+    )];
+    let mut req = HttpAuthorizationRequest {
+        method: "POST",
+        url: "https://bedrock-runtime.us-west-2.amazonaws.com/model/x/invoke",
+        headers: &mut headers,
+    };
+
+    let err = authorizer.authorize(&mut req).await.unwrap_err();
+    assert!(
+        matches!(err, AuthError::RefreshRequired),
+        "env STS credentials without expiry must fail closed, got {err:?}"
+    );
+    assert!(
+        !headers
+            .iter()
+            .any(|(k, _)| k.eq_ignore_ascii_case("authorization")),
+        "missing-expiry STS credentials must not sign"
+    );
+}
+
+#[tokio::test]
+async fn sigv4_env_session_token_with_expiry_signs_with_session_token() {
+    let provider = AwsCredentialProvider::from_env(|k| match k {
+        "AWS_ACCESS_KEY_ID" => Some("AKIAFROMENV00000000".into()),
+        "AWS_SECRET_ACCESS_KEY" => Some("secretfromenvsecretfromenvsecretfromenv".into()),
+        "AWS_SESSION_TOKEN" => Some("FQoGZXIvYXdzEJr//////////wEaENVSESSION".into()),
+        "AWS_CREDENTIAL_EXPIRATION" => Some("2999-01-01T00:00:00Z".into()),
+        _ => None,
+    });
+    let authorizer = with_test_observer(AwsStsAuthorizer::new("us-west-2", provider));
+    let mut headers = vec![(
+        "host".into(),
+        "bedrock-runtime.us-west-2.amazonaws.com".into(),
+    )];
+    let mut req = HttpAuthorizationRequest {
+        method: "POST",
+        url: "https://bedrock-runtime.us-west-2.amazonaws.com/model/x/invoke",
+        headers: &mut headers,
+    };
+
+    authorizer.authorize(&mut req).await.unwrap();
+    assert!(headers.iter().any(
+        |(k, v)| k.eq_ignore_ascii_case("authorization") && v.starts_with("AWS4-HMAC-SHA256 ")
+    ));
+    assert!(
+        headers
+            .iter()
+            .any(|(k, v)| k.eq_ignore_ascii_case("x-amz-security-token") && v.starts_with("FQoG"))
+    );
+}
+
+#[tokio::test]
+async fn sigv4_env_session_token_with_expired_expiry_fails_before_first_use_signing() {
+    let provider = AwsCredentialProvider::from_env(|k| match k {
+        "AWS_ACCESS_KEY_ID" => Some("AKIAFROMENV00000000".into()),
+        "AWS_SECRET_ACCESS_KEY" => Some("secretfromenvsecretfromenvsecretfromenv".into()),
+        "AWS_SESSION_TOKEN" => Some("FQoGZXIvYXdzEJr//////////wEaENVSESSION".into()),
+        "AWS_CREDENTIAL_EXPIRATION" => Some("2000-01-01T00:00:00Z".into()),
+        _ => None,
+    });
+    let authorizer = with_test_observer(AwsStsAuthorizer::new("us-west-2", provider));
+    let mut headers = vec![(
+        "host".into(),
+        "bedrock-runtime.us-west-2.amazonaws.com".into(),
+    )];
+    let mut req = HttpAuthorizationRequest {
+        method: "POST",
+        url: "https://bedrock-runtime.us-west-2.amazonaws.com/model/x/invoke",
+        headers: &mut headers,
+    };
+
+    let err = authorizer.authorize(&mut req).await.unwrap_err();
+    assert!(
+        matches!(err, AuthError::Expired),
+        "expired env STS credentials must fail before first-use signing, got {err:?}"
+    );
+    assert!(
+        !headers
+            .iter()
+            .any(|(k, _)| k.eq_ignore_ascii_case("authorization")),
+        "expired env STS credentials must not sign"
+    );
 }
 
 #[tokio::test]

--- a/meerkat-auth-core/tests/aws_sts_authorizer.rs
+++ b/meerkat-auth-core/tests/aws_sts_authorizer.rs
@@ -48,9 +48,14 @@ fn static_provider() -> AwsCredentialProvider {
     }
 }
 
+fn with_test_observer(authorizer: AwsStsAuthorizer) -> AwsStsAuthorizer {
+    let handle = Arc::new(meerkat_runtime::RuntimeAuthLeaseHandle::new());
+    authorizer.with_auth_lease_observer(generated_auth_lease_handle_for_test(handle), lease_key())
+}
+
 #[tokio::test]
 async fn sigv4_adds_required_headers_for_bedrock() {
-    let authorizer = AwsStsAuthorizer::new("us-east-1", static_provider());
+    let authorizer = with_test_observer(AwsStsAuthorizer::new("us-east-1", static_provider()));
     let mut headers = vec![(
         "host".to_string(),
         "bedrock-runtime.us-east-1.amazonaws.com".to_string(),
@@ -91,6 +96,28 @@ async fn sigv4_adds_required_headers_for_bedrock() {
 }
 
 #[tokio::test]
+async fn sigv4_without_auth_lease_observer_fails_closed_before_signing() {
+    let authorizer = AwsStsAuthorizer::new("us-east-1", static_provider());
+    let mut headers = vec![(
+        "host".to_string(),
+        "bedrock-runtime.us-east-1.amazonaws.com".to_string(),
+    )];
+    let mut req = bedrock_request(&mut headers);
+
+    let err = authorizer.authorize(&mut req).await.unwrap_err();
+    assert!(
+        matches!(err, AuthError::HostOwnedUnavailable),
+        "unobserved SigV4 signing must fail closed, got {err:?}"
+    );
+    assert!(
+        !headers
+            .iter()
+            .any(|(k, _)| k.eq_ignore_ascii_case("authorization")),
+        "unobserved SigV4 signing must not add authorization headers"
+    );
+}
+
+#[tokio::test]
 async fn bearer_token_mode_emits_bearer_header_and_skips_sigv4() {
     let authorizer = AwsStsAuthorizer::new(
         "us-east-1",
@@ -113,7 +140,7 @@ async fn bearer_token_mode_emits_bearer_header_and_skips_sigv4() {
 #[tokio::test]
 async fn env_provider_missing_keys_returns_missing_secret() {
     let provider = AwsCredentialProvider::from_env(|_| None);
-    let authorizer = AwsStsAuthorizer::new("us-east-1", provider);
+    let authorizer = with_test_observer(AwsStsAuthorizer::new("us-east-1", provider));
     let mut headers = Vec::new();
     let mut req = HttpAuthorizationRequest {
         method: "POST",
@@ -134,7 +161,7 @@ async fn env_provider_reads_sigv4_credentials_from_env_lookup() {
         "AWS_SECRET_ACCESS_KEY" => Some("secretfromenvsecretfromenvsecretfromenv".into()),
         _ => None,
     });
-    let authorizer = AwsStsAuthorizer::new("us-west-2", provider);
+    let authorizer = with_test_observer(AwsStsAuthorizer::new("us-west-2", provider));
     let mut headers = vec![(
         "host".into(),
         "bedrock-runtime.us-west-2.amazonaws.com".into(),

--- a/meerkat-core/src/agent/state.rs
+++ b/meerkat-core/src/agent/state.rs
@@ -73,6 +73,37 @@ type AppliedModelFallbackSwitch = (
     Message,
 );
 
+struct MachineAcceptedModelFallbackActivation {
+    switch: AgentLlmFallbackSwitch,
+    retry_attempt: u32,
+}
+
+impl MachineAcceptedModelFallbackActivation {
+    fn authorize(
+        switch: AgentLlmFallbackSwitch,
+        recovery_transition: &TurnExecutionTransition,
+        retry_schedule: &crate::retry::LlmRetrySchedule,
+    ) -> Result<Self, AgentError> {
+        if recovery_transition.prev_phase != TurnPhase::CallingLlm {
+            return Err(AgentError::InternalError(format!(
+                "model fallback activation requires machine-accepted RecoverableFailure from an \
+                 LLM phase, got {:?}",
+                recovery_transition.prev_phase
+            )));
+        }
+        if switch.request_policy.model != switch.new_identity.model {
+            return Err(AgentError::ConfigError(format!(
+                "model fallback activation target '{}' does not match request policy model '{}'",
+                switch.new_identity.model, switch.request_policy.model
+            )));
+        }
+        Ok(Self {
+            switch,
+            retry_attempt: retry_schedule.plan.attempt,
+        })
+    }
+}
+
 fn turn_input_failure_source(input: &TurnExecutionInput) -> Option<&TurnFailureSource> {
     match input {
         TurnExecutionInput::FatalFailure { failure, .. } => Some(failure),
@@ -270,10 +301,11 @@ where
 
     fn apply_model_fallback_switch(
         &mut self,
-        switch: AgentLlmFallbackSwitch,
+        activation: MachineAcceptedModelFallbackActivation,
         failure: &AgentError,
         previous_tools: &[Arc<ToolDef>],
     ) -> Result<AppliedModelFallbackSwitch, AgentError> {
+        let switch = activation.switch;
         self.rotate_auth_lease_auth_binding(
             switch.previous_identity.auth_binding.as_ref(),
             switch.new_identity.auth_binding.as_ref(),
@@ -355,6 +387,7 @@ where
         );
         let payload = serde_json::json!({
             "event": "model_fallback",
+            "retry_attempt": activation.retry_attempt,
             "from": {
                 "model": switch.previous_identity.model,
                 "provider": switch.previous_identity.provider.as_str(),
@@ -721,22 +754,15 @@ where
                         )?;
                         if let LlmFailureRecoveryKind::Recover = recovery {
                             // P0 Dogma Invariant 1: the MeerkatMachine
-                            // `RecoverableFailure` gate must commit BEFORE any
-                            // durable/client mutation. `prepare_model_fallback`
-                            // is non-mutating, so we only *compute* the pending
-                            // switch here; activation (auth-lease rotation,
-                            // durable metadata persistence, client active-index
-                            // commit) is deferred until the machine accepts the
-                            // recovery.
-                            let pending_switch: Option<AgentLlmFallbackSwitch> =
-                                if fallback_activation_is_pre_stream_safe(
-                                    &error,
-                                    self.client.stream_output_observed(),
-                                ) {
-                                    self.client.prepare_model_fallback(&error)
-                                } else {
-                                    None
-                                };
+                            // `RecoverableFailure` gate must commit BEFORE the
+                            // fallback target is selected or any durable/client
+                            // mutation happens. Keep this as a boolean
+                            // precondition only; the actual candidate proposal
+                            // is requested after the machine accepts recovery.
+                            let may_activate_fallback = fallback_activation_is_pre_stream_safe(
+                                &error,
+                                self.client.stream_output_observed(),
+                            );
                             let retry_schedule = self
                                 .retry_policy
                                 .schedule_retry(&error, attempt, self.budget.remaining_duration())
@@ -757,14 +783,23 @@ where
                                     run_id: run_id.clone(),
                                     retry: retry_schedule.clone(),
                                 })?;
-                            // Machine accepted the recovery: only now activate
-                            // the fallback switch (rotate auth lease, persist
-                            // identity, commit the client active index).
-                            if let Some(switch) = pending_switch {
-                                let new_identity = switch.new_identity.clone();
+                            // Machine accepted the recovery: only now ask the
+                            // client for a fallback proposal, wrap it in the
+                            // machine-accepted activation authority, then
+                            // mutate identity/policy/tool visibility atomically
+                            // for the retry attempt.
+                            if may_activate_fallback
+                                && let Some(switch) = self.client.prepare_model_fallback(&error)
+                            {
+                                let activation = MachineAcceptedModelFallbackActivation::authorize(
+                                    switch,
+                                    &recover,
+                                    &retry_schedule,
+                                )?;
+                                let new_identity = activation.switch.new_identity.clone();
                                 let (next_tools, next_params, next_max_tokens, notice) = self
                                     .apply_model_fallback_switch(
-                                        switch,
+                                        activation,
                                         &error,
                                         current_tools.as_ref(),
                                     )?;
@@ -819,21 +854,15 @@ where
                     )?;
                     if let LlmFailureRecoveryKind::Recover = recovery {
                         // P0 Dogma Invariant 1: the MeerkatMachine
-                        // `RecoverableFailure` gate must commit BEFORE any
-                        // durable/client mutation. `prepare_model_fallback` is
-                        // non-mutating, so we only *compute* the pending switch
-                        // here; activation (auth-lease rotation, durable
-                        // metadata persistence, client active-index commit) is
-                        // deferred until the machine accepts the recovery.
-                        let pending_switch: Option<AgentLlmFallbackSwitch> =
-                            if fallback_activation_is_pre_stream_safe(
-                                &e,
-                                self.client.stream_output_observed(),
-                            ) {
-                                self.client.prepare_model_fallback(&e)
-                            } else {
-                                None
-                            };
+                        // `RecoverableFailure` gate must commit BEFORE the
+                        // fallback target is selected or any durable/client
+                        // mutation happens. Keep this as a boolean precondition
+                        // only; the actual candidate proposal is requested
+                        // after the machine accepts recovery.
+                        let may_activate_fallback = fallback_activation_is_pre_stream_safe(
+                            &e,
+                            self.client.stream_output_observed(),
+                        );
                         let retry_schedule = self
                             .retry_policy
                             .schedule_retry(&e, attempt, self.budget.remaining_duration())
@@ -855,13 +884,26 @@ where
                                 run_id: run_id.clone(),
                                 retry: retry_schedule.clone(),
                             })?;
-                        // Machine accepted the recovery: only now activate the
-                        // fallback switch (rotate auth lease, persist identity,
-                        // commit the client active index).
-                        if let Some(switch) = pending_switch {
-                            let new_identity = switch.new_identity.clone();
+                        // Machine accepted the recovery: only now ask the client
+                        // for a fallback proposal, wrap it in the
+                        // machine-accepted activation authority, then mutate
+                        // identity/policy/tool visibility atomically for the
+                        // retry attempt.
+                        if may_activate_fallback
+                            && let Some(switch) = self.client.prepare_model_fallback(&e)
+                        {
+                            let activation = MachineAcceptedModelFallbackActivation::authorize(
+                                switch,
+                                &recover,
+                                &retry_schedule,
+                            )?;
+                            let new_identity = activation.switch.new_identity.clone();
                             let (next_tools, next_params, next_max_tokens, notice) = self
-                                .apply_model_fallback_switch(switch, &e, current_tools.as_ref())?;
+                                .apply_model_fallback_switch(
+                                    activation,
+                                    &e,
+                                    current_tools.as_ref(),
+                                )?;
                             let next_params = Self::apply_extraction_request_overrides(
                                 new_identity.provider,
                                 next_params,
@@ -8958,6 +9000,7 @@ mod tests {
 
     struct FallbackActivatingClient {
         active: std::sync::atomic::AtomicUsize,
+        fallback_proposals: std::sync::atomic::AtomicUsize,
         seen_tools: Mutex<Vec<Vec<String>>>,
         seen_notice_bodies: Mutex<Vec<Vec<String>>>,
         seen_max_tokens: Mutex<Vec<u32>>,
@@ -8969,6 +9012,7 @@ mod tests {
         fn new() -> Self {
             Self {
                 active: std::sync::atomic::AtomicUsize::new(0),
+                fallback_proposals: std::sync::atomic::AtomicUsize::new(0),
                 seen_tools: Mutex::new(Vec::new()),
                 seen_notice_bodies: Mutex::new(Vec::new()),
                 seen_max_tokens: Mutex::new(Vec::new()),
@@ -8992,6 +9036,11 @@ mod tests {
             &self,
         ) -> Vec<Option<crate::lifecycle::run_primitive::ProviderParamsOverride>> {
             self.seen_provider_params.lock().unwrap().clone()
+        }
+
+        fn fallback_proposals(&self) -> usize {
+            self.fallback_proposals
+                .load(std::sync::atomic::Ordering::SeqCst)
         }
     }
 
@@ -9066,6 +9115,8 @@ mod tests {
             &self,
             _failure: &AgentError,
         ) -> Option<crate::AgentLlmFallbackSwitch> {
+            self.fallback_proposals
+                .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
             if self.active.load(std::sync::atomic::Ordering::SeqCst) != 0 {
                 return None;
             }
@@ -9827,6 +9878,11 @@ mod tests {
             client.seen_tools().len(),
             1,
             "exactly one (primary) stream call should have run before the rejected gate"
+        );
+        assert_eq!(
+            client.fallback_proposals(),
+            0,
+            "fallback target selection must happen only after the machine accepts recovery"
         );
     }
 

--- a/meerkat-mcp-server/src/lib.rs
+++ b/meerkat-mcp-server/src/lib.rs
@@ -4507,10 +4507,48 @@ mod tests {
         CancelActionInstallOutcome, SurfaceRequestExecutor, noop_request_action,
     };
     use meerkat::{LlmClient, LlmDoneOutcome, LlmError, LlmEvent, LlmRequest};
+    use meerkat_core::lifecycle::core_executor::CoreApplyOutput;
     use std::path::PathBuf;
     use std::pin::Pin;
     use std::sync::atomic::{AtomicBool, Ordering};
     use tokio::time::{Duration, timeout};
+
+    struct RuntimeTerminationFixtureExecutor;
+
+    #[async_trait]
+    impl meerkat_core::lifecycle::CoreExecutor for RuntimeTerminationFixtureExecutor {
+        async fn apply(
+            &mut self,
+            run_id: meerkat_core::RunId,
+            primitive: meerkat_core::lifecycle::run_primitive::RunPrimitive,
+        ) -> Result<CoreApplyOutput, meerkat_core::lifecycle::CoreExecutorError> {
+            Ok(CoreApplyOutput {
+                receipt: meerkat_core::lifecycle::run_receipt::RunBoundaryReceiptDraft {
+                    run_id,
+                    boundary: meerkat_core::lifecycle::run_primitive::RunApplyBoundary::RunStart,
+                    contributing_input_ids: primitive.contributing_input_ids().to_vec(),
+                    conversation_digest: None,
+                    message_count: 0,
+                },
+                session_snapshot: None,
+                terminal: None,
+            })
+        }
+
+        async fn cancel_after_boundary(
+            &mut self,
+            _reason: String,
+        ) -> Result<(), meerkat_core::lifecycle::CoreExecutorError> {
+            Ok(())
+        }
+
+        async fn stop_runtime_executor(
+            &mut self,
+            _reason: String,
+        ) -> Result<(), meerkat_core::lifecycle::CoreExecutorError> {
+            Ok(())
+        }
+    }
 
     struct MockLlmClient;
 
@@ -6140,9 +6178,12 @@ mod tests {
         let runtime_state_existed = state.runtime_sessions.read().await.contains_key(&parsed);
         state
             .runtime_adapter
-            .prepare_bindings(parsed.clone())
+            .ensure_session_with_executor(
+                parsed.clone(),
+                Box::new(RuntimeTerminationFixtureExecutor),
+            )
             .await
-            .expect("prepare runtime bindings");
+            .expect("attach runtime executor");
 
         let input = Input::ExternalEvent(ExternalEventInput {
             header: InputHeader {

--- a/meerkat-mcp/src/router.rs
+++ b/meerkat-mcp/src/router.rs
@@ -1991,6 +1991,12 @@ impl McpRouter {
         }
     }
 
+    fn tool_definitions_equivalent(left: &ToolDef, right: &ToolDef) -> bool {
+        left.description == right.description
+            && left.input_schema == right.input_schema
+            && left.provenance == right.provenance
+    }
+
     fn publish_projection_snapshot(&mut self) -> bool {
         let epoch = self.surface_owner.snapshot_epoch();
         let server_names: BTreeSet<String> = self
@@ -2014,10 +2020,34 @@ impl McpRouter {
                 complete = false;
                 continue;
             };
+            let mut server_tools: BTreeMap<String, Arc<ToolDef>> = BTreeMap::new();
+            let mut same_server_divergent: BTreeSet<String> = BTreeSet::new();
+
             for tool in &entry.tools {
+                let tool_name = tool.name.to_string();
+                if let Some(existing) = server_tools.get(&tool_name) {
+                    if !Self::tool_definitions_equivalent(existing, tool) {
+                        tracing::warn!(
+                            tool = %tool.name,
+                            server = %server_name,
+                            "MCP projection saw divergent duplicate tool definitions from one server; excluding the tool from the published catalog (ambiguous => denied)"
+                        );
+                        same_server_divergent.insert(tool_name);
+                        complete = false;
+                    }
+                    continue;
+                }
+                server_tools.insert(tool_name, Arc::clone(tool));
+            }
+
+            for name in &same_server_divergent {
+                server_tools.remove(name);
+                collided.insert(name.clone());
+            }
+
+            for tool in server_tools.values() {
                 // Fail closed by exclusion: a tool name owned by two different
                 // servers is ambiguous, so it must be dispatchable from NEITHER.
-                // A same-name-same-server re-entry is not a collision.
                 if let Some(existing_owner) = tool_to_server.get(tool.name.as_str())
                     && existing_owner != &server_name
                 {
@@ -3197,6 +3227,23 @@ mod tests {
         );
     }
 
+    fn insert_entry_with_tool_defs(router: &mut McpRouter, server_name: &str, tools: Vec<ToolDef>) {
+        router.servers.insert(
+            server_name.to_string(),
+            ServerEntry {
+                config: McpServerConfig::stdio(
+                    server_name,
+                    "noop".to_string(),
+                    vec![],
+                    HashMap::new(),
+                ),
+                connection: None,
+                tools: tools.into_iter().map(Arc::new).collect(),
+                active_calls: AtomicUsize::new(0),
+            },
+        );
+    }
+
     /// Gate for fixes #6: a tool name exposed by two different servers is
     /// ambiguous and must be dispatchable from NEITHER. The OLD behavior was
     /// last-wins (silently route to an arbitrary owner). The published
@@ -3268,10 +3315,10 @@ mod tests {
         );
     }
 
-    /// Same-name-same-server re-entry (the same tool listed twice by one server)
-    /// is NOT a collision; the tool stays routable and the projection complete.
+    /// Same-name-same-server re-entry with identical definitions is NOT a
+    /// collision; the tool stays routable and the projection complete.
     #[test]
-    fn duplicate_tool_name_within_single_server_is_not_a_collision() {
+    fn same_server_identical_duplicate_definitions_collapse_once() {
         let mut router = generated_handle_owner_router();
         complete_add(&mut router, "solo");
         insert_entry_with_tools(&mut router, "solo", &["dup", "dup", "unique"]);
@@ -3279,7 +3326,7 @@ mod tests {
         let complete = router.publish_projection_snapshot();
         assert!(
             complete,
-            "a same-server duplicate is not a collision; projection stays complete"
+            "an identical same-server duplicate is not a collision; projection stays complete"
         );
 
         let projection = Arc::clone(&router.projection);
@@ -3289,8 +3336,121 @@ mod tests {
             "same-server duplicate tool name remains routable"
         );
         assert_eq!(
+            projection
+                .catalog_entries
+                .iter()
+                .filter(|entry| entry.tool.name.as_str() == "dup")
+                .count(),
+            1,
+            "identical same-server duplicates collapse to one exact catalog entry"
+        );
+        assert_eq!(
             projection.tool_to_server.get("unique").map(String::as_str),
             Some("solo")
+        );
+    }
+
+    #[tokio::test]
+    async fn same_server_divergent_duplicate_definitions_are_excluded_from_projection() {
+        let mut router = generated_handle_owner_router();
+        complete_add(&mut router, "solo");
+        insert_entry_with_tool_defs(
+            &mut router,
+            "solo",
+            vec![
+                ToolDef::new(
+                    "dup",
+                    "first definition",
+                    serde_json::json!({"type": "object", "properties": {"a": {"type": "string"}}}),
+                ),
+                ToolDef::new(
+                    "dup",
+                    "first definition",
+                    serde_json::json!({"type": "object", "properties": {"b": {"type": "number"}}}),
+                ),
+                ToolDef::new("unique", "unique", serde_json::json!({"type": "object"})),
+            ],
+        );
+
+        let complete = router.publish_projection_snapshot();
+        assert!(
+            !complete,
+            "divergent same-server duplicate definitions make the projection incomplete"
+        );
+
+        let projection = Arc::clone(&router.projection);
+        assert!(
+            !projection.tool_to_server.contains_key("dup"),
+            "divergent same-server duplicate must not be routable"
+        );
+        assert!(
+            projection
+                .catalog_entries
+                .iter()
+                .all(|entry| entry.tool.name.as_str() != "dup"),
+            "divergent same-server duplicate must be excluded from the exact catalog"
+        );
+        assert!(
+            projection
+                .visible_tools
+                .iter()
+                .all(|tool| tool.name.as_str() != "dup"),
+            "divergent same-server duplicate must be excluded from visible tools"
+        );
+        assert_eq!(
+            projection.tool_to_server.get("unique").map(String::as_str),
+            Some("solo"),
+            "non-ambiguous tools from the same server remain routable"
+        );
+
+        let err = router
+            .call_tool("dup", &serde_json::json!({}))
+            .await
+            .expect_err("divergent same-server duplicate must not dispatch");
+        assert!(
+            matches!(err, McpError::ToolNotFound(_)),
+            "ambiguous same-server tool name must be denied as not_found, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn same_server_duplicate_description_mismatch_is_divergent() {
+        let mut router = generated_handle_owner_router();
+        complete_add(&mut router, "solo");
+        insert_entry_with_tool_defs(
+            &mut router,
+            "solo",
+            vec![
+                ToolDef::new(
+                    "dup",
+                    "first definition",
+                    serde_json::json!({"type": "object"}),
+                ),
+                ToolDef::new(
+                    "dup",
+                    "second definition",
+                    serde_json::json!({"type": "object"}),
+                ),
+            ],
+        );
+
+        let complete = router.publish_projection_snapshot();
+        assert!(
+            !complete,
+            "same-server duplicate description drift makes the projection incomplete"
+        );
+
+        let projection = Arc::clone(&router.projection);
+        assert!(
+            !projection.tool_to_server.contains_key("dup"),
+            "description-divergent duplicate must not be routable"
+        );
+        assert!(
+            projection
+                .catalog_entries
+                .iter()
+                .all(|entry| entry.tool.name.as_str() != "dup"),
+            "description-divergent duplicate must be excluded from catalog"
         );
     }
 

--- a/meerkat-mob-mcp/src/agent_tools.rs
+++ b/meerkat-mob-mcp/src/agent_tools.rs
@@ -809,6 +809,17 @@ impl AgentMobToolSurface {
             .parse_args()
             .map_err(|e| ToolError::invalid_arguments(call.name, e.to_string()))?;
 
+        // Build spawn identity before any implicit-mob mutation. The tool
+        // surface must not create durable mob state for a request that has not
+        // supplied its substrate-owned member identity.
+        let Some(member_id) = args.member_id else {
+            return Err(ToolError::invalid_arguments(
+                call.name,
+                "delegate requires member_id; the tool surface does not allocate member identity",
+            ));
+        };
+        let identity = AgentIdentity::from(member_id);
+
         let (mob_id, first_delegate) = self
             .ensure_implicit_mob()
             .await
@@ -842,13 +853,6 @@ impl AgentMobToolSurface {
         // missing `member_id` fails closed with typed invalid-arguments rather
         // than fabricating a synthetic `helper-{uuid}` on the runtime identity
         // path — identity allocation is the mob substrate's responsibility.
-        let Some(member_id) = args.member_id else {
-            return Err(ToolError::invalid_arguments(
-                call.name,
-                "delegate requires member_id; the tool surface does not allocate member identity",
-            ));
-        };
-        let identity = AgentIdentity::from(member_id);
         // Implicit mob always uses the "delegate" profile.
         let mut spec = SpawnMemberSpec::new(ProfileName::from("delegate"), identity.clone());
         spec.initial_message = Some(ContentInput::Text(args.task));
@@ -3679,6 +3683,47 @@ mod tests {
         // is part of the ToolDispatchOutcome which is only produced on success.
         // This is correct: the turn owner should not widen authority for a
         // failed tool call.
+    }
+
+    #[tokio::test]
+    async fn test_delegate_missing_member_id_does_not_create_implicit_mob() {
+        let state = MobMcpState::new_in_memory();
+        let session_id = SessionId::new();
+        let session_key = session_id.to_string();
+        let surface = AgentMobToolSurface::new(
+            Arc::clone(&state),
+            None,
+            create_only_authority(),
+            "claude-sonnet-4-5".to_string(),
+            session_id,
+            None,
+            None,
+            None,
+        );
+
+        let delegate_args =
+            serde_json::value::RawValue::from_string(json!({ "task": "say hi" }).to_string())
+                .unwrap();
+        let delegate_error = surface
+            .dispatch(ToolCallView {
+                id: "delegate-missing-member",
+                name: "delegate",
+                args: &delegate_args,
+            })
+            .await
+            .expect_err("delegate without member_id must fail before mob creation");
+        assert!(
+            matches!(delegate_error, ToolError::InvalidArguments { .. }),
+            "unexpected delegate error: {delegate_error:?}"
+        );
+
+        assert!(
+            state
+                .find_implicit_mob_for_bridge_session(&session_key)
+                .await
+                .is_none(),
+            "invalid delegate args must not create an implicit mob"
+        );
     }
 
     #[tokio::test]

--- a/meerkat-mob/BUILD.bazel
+++ b/meerkat-mob/BUILD.bazel
@@ -46,6 +46,7 @@ rust_library(
         "src/runtime/builder.rs",
         "src/runtime/flow_frame_engine.rs",
         "src/runtime/recovery.rs",
+        "src/runtime/state.rs",
     ],
     srcs = glob(["src/**/*.rs"]),
     visibility = ["//visibility:public"],
@@ -96,6 +97,7 @@ rust_library(
         "src/runtime/builder.rs",
         "src/runtime/flow_frame_engine.rs",
         "src/runtime/recovery.rs",
+        "src/runtime/state.rs",
     ],
     srcs = glob(["src/**/*.rs"]),
     visibility = [
@@ -164,6 +166,7 @@ rust_test(
         "src/runtime/builder.rs",
         "src/runtime/flow_frame_engine.rs",
         "src/runtime/recovery.rs",
+        "src/runtime/state.rs",
     ],
     srcs = glob(["src/**/*.rs"]),
     visibility = ["//visibility:public"],
@@ -234,6 +237,7 @@ rust_test(
         "src/runtime/builder.rs",
         "src/runtime/flow_frame_engine.rs",
         "src/runtime/recovery.rs",
+        "src/runtime/state.rs",
     ],
     srcs = [
         "tests/dispatcher_rule_synthetic_injection.rs",
@@ -307,6 +311,7 @@ rust_test(
         "src/runtime/builder.rs",
         "src/runtime/flow_frame_engine.rs",
         "src/runtime/recovery.rs",
+        "src/runtime/state.rs",
     ],
     srcs = [
         "tests/flow_frame_recovery_tests.rs",
@@ -378,6 +383,7 @@ rust_test(
         "src/runtime/builder.rs",
         "src/runtime/flow_frame_engine.rs",
         "src/runtime/recovery.rs",
+        "src/runtime/state.rs",
     ],
     srcs = [
         "tests/kickoff_spawn_teardown_quiesce.rs",
@@ -449,6 +455,7 @@ rust_test(
         "src/runtime/builder.rs",
         "src/runtime/flow_frame_engine.rs",
         "src/runtime/recovery.rs",
+        "src/runtime/state.rs",
     ],
     srcs = [
         "tests/member_session_bindings.rs",
@@ -520,6 +527,7 @@ rust_test(
         "src/runtime/builder.rs",
         "src/runtime/flow_frame_engine.rs",
         "src/runtime/recovery.rs",
+        "src/runtime/state.rs",
     ],
     srcs = [
         "tests/mob_orchestrator_kernel.rs",
@@ -591,6 +599,7 @@ rust_test(
         "src/runtime/builder.rs",
         "src/runtime/flow_frame_engine.rs",
         "src/runtime/recovery.rs",
+        "src/runtime/state.rs",
     ],
     srcs = [
         "tests/shadow_state_absent.rs",
@@ -662,6 +671,7 @@ rust_test(
         "src/runtime/builder.rs",
         "src/runtime/flow_frame_engine.rs",
         "src/runtime/recovery.rs",
+        "src/runtime/state.rs",
     ],
     srcs = [
         "tests/smoke_mob_flow_runtime.rs",
@@ -733,6 +743,7 @@ rust_test(
         "src/runtime/builder.rs",
         "src/runtime/flow_frame_engine.rs",
         "src/runtime/recovery.rs",
+        "src/runtime/state.rs",
     ],
     srcs = [
         "tests/smoke_mob_generated_image_comms.rs",
@@ -804,6 +815,7 @@ rust_test(
         "src/runtime/builder.rs",
         "src/runtime/flow_frame_engine.rs",
         "src/runtime/recovery.rs",
+        "src/runtime/state.rs",
     ],
     srcs = [
         "tests/smoke_mob_pictionary.rs",
@@ -875,6 +887,7 @@ rust_test(
         "src/runtime/builder.rs",
         "src/runtime/flow_frame_engine.rs",
         "src/runtime/recovery.rs",
+        "src/runtime/state.rs",
     ],
     srcs = [
         "tests/smoke_mob_resume.rs",

--- a/meerkat-mob/src/adaptive.rs
+++ b/meerkat-mob/src/adaptive.rs
@@ -2759,6 +2759,46 @@ mod tests {
     }
 
     #[test]
+    fn adaptive_policy_preserves_already_canonical_namespaced_tool_allowlists() {
+        let pack = AdaptivePolicy {
+            limits: limits(7),
+            allowed_tool_classes: BTreeSet::from([
+                "mcp:filesystem".to_string(),
+                "rust_bundle:review-tools".to_string(),
+            ]),
+            allowed_skill_classes: BTreeSet::from(["lint-review".to_string()]),
+            ..AdaptivePolicy::default()
+        };
+        let host = AdaptivePolicy {
+            limits: limits(5),
+            allowed_tool_classes: BTreeSet::from([
+                "mcp:filesystem".to_string(),
+                "rust_bundle:review-tools".to_string(),
+                "builtins".to_string(),
+            ]),
+            allowed_skill_classes: BTreeSet::from([
+                "lint-review".to_string(),
+                "docs-review".to_string(),
+            ]),
+            ..AdaptivePolicy::default()
+        };
+
+        let composed = AdaptivePolicy::compose(&pack, &host).unwrap();
+        let runtime_limits = adaptive_run_limits_from_policy(&composed, 1_000).unwrap();
+        assert_eq!(
+            runtime_limits.allowed_tool_classes,
+            BTreeSet::from([
+                "mcp:filesystem".to_string(),
+                "rust_bundle:review-tools".to_string(),
+            ])
+        );
+        assert_eq!(
+            runtime_limits.allowed_skill_identities,
+            BTreeSet::from(["lint-review".to_string()])
+        );
+    }
+
+    #[test]
     fn adaptive_layer_evidence_canonicalizes_profile_tools_and_skills() {
         let mut context = compile_context();
         let verifier = context

--- a/meerkat-mob/src/adaptive.rs
+++ b/meerkat-mob/src/adaptive.rs
@@ -446,6 +446,67 @@ pub struct LayerPolicyEvidence {
     pub used_auth_binding_refs: BTreeSet<String>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum AdaptiveToolIdentity {
+    Class(String),
+    McpServer(String),
+    RustBundle(String),
+}
+
+impl AdaptiveToolIdentity {
+    fn parse(raw: &str) -> Result<Self, AdaptiveError> {
+        if let Some(name) = raw.strip_prefix("mcp:") {
+            validate_adaptive_identity_component("adaptive tool mcp server", name)?;
+            return Ok(Self::McpServer(name.to_string()));
+        }
+        if let Some(name) = raw.strip_prefix("rust_bundle:") {
+            validate_adaptive_identity_component("adaptive tool rust bundle", name)?;
+            return Ok(Self::RustBundle(name.to_string()));
+        }
+        validate_adaptive_identity_component("adaptive tool class", raw)?;
+        Ok(Self::Class(raw.to_string()))
+    }
+
+    fn mcp_server(name: &str) -> Result<Self, AdaptiveError> {
+        validate_adaptive_identity_component("adaptive tool mcp server", name)?;
+        Ok(Self::McpServer(name.to_string()))
+    }
+
+    fn rust_bundle(name: &str) -> Result<Self, AdaptiveError> {
+        validate_adaptive_identity_component("adaptive tool rust bundle", name)?;
+        Ok(Self::RustBundle(name.to_string()))
+    }
+
+    fn into_canonical(self) -> String {
+        match self {
+            Self::Class(name) => name,
+            Self::McpServer(name) => format!("mcp:{name}"),
+            Self::RustBundle(name) => format!("rust_bundle:{name}"),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct AdaptiveSkillIdentity(String);
+
+impl AdaptiveSkillIdentity {
+    fn parse(raw: &str) -> Result<Self, AdaptiveError> {
+        validate_adaptive_identity_component("adaptive skill identity", raw)?;
+        if raw.starts_with("mcp:") || raw.starts_with("rust_bundle:") {
+            return Err(AdaptiveError::InvalidAdaptiveIdentity {
+                field: "adaptive skill identity",
+                value: raw.to_string(),
+                reason: "reserved tool-identity prefix".to_string(),
+            });
+        }
+        Ok(Self(raw.to_string()))
+    }
+
+    fn into_canonical(self) -> String {
+        self.0
+    }
+}
+
 #[derive(Clone)]
 pub struct AdaptiveDriver {
     control_mob: MobHandle,
@@ -1309,8 +1370,14 @@ pub fn adaptive_run_limits_from_policy(
         max_aggregate_tokens: policy.limits.max_aggregate_tokens,
         max_aggregate_tool_calls: policy.limits.max_aggregate_tool_calls,
         allowed_model_classes: policy.allowed_model_classes.clone(),
-        allowed_tool_classes: policy.allowed_tool_classes.clone(),
-        allowed_skill_identities: policy.allowed_skill_classes.clone(),
+        allowed_tool_classes: canonical_adaptive_tool_set(
+            "allowed_tool_classes",
+            &policy.allowed_tool_classes,
+        )?,
+        allowed_skill_identities: canonical_adaptive_skill_set(
+            "allowed_skill_classes",
+            &policy.allowed_skill_classes,
+        )?,
         allowed_auth_binding_refs: policy.allowed_auth_bindings.clone(),
         deadline_ms: started_at_ms.saturating_add(policy.limits.max_wall_clock_ms),
     })
@@ -1342,7 +1409,7 @@ pub fn compile_layer(
         profile: plan.collector.profile.clone(),
     });
     definition.profiles = compile_profiles(plan, context, policy)?;
-    let policy_evidence = collect_layer_policy_evidence(&definition.profiles, &spawn_specs);
+    let policy_evidence = collect_layer_policy_evidence(&definition.profiles, &spawn_specs)?;
     definition.wiring = compile_wiring(plan);
     definition.flows.insert(
         FlowId::from("layer-flow"),
@@ -1440,7 +1507,7 @@ fn compile_profiles(
 fn collect_layer_policy_evidence(
     profiles: &BTreeMap<ProfileName, ProfileBinding>,
     spawn_specs: &[LayerSpawnSpec],
-) -> LayerPolicyEvidence {
+) -> Result<LayerPolicyEvidence, AdaptiveError> {
     let mut evidence = LayerPolicyEvidence::default();
     for spec in spawn_specs {
         let Some(profile) = profiles
@@ -1450,15 +1517,20 @@ fn collect_layer_policy_evidence(
             continue;
         };
         evidence.used_model_classes.insert(profile.model.clone());
-        collect_profile_tool_classes(profile, &mut evidence.used_tool_classes);
-        evidence
-            .used_skill_identities
-            .extend(profile.skills.iter().cloned());
+        collect_profile_tool_classes(profile, &mut evidence.used_tool_classes)?;
+        for skill in &profile.skills {
+            evidence
+                .used_skill_identities
+                .insert(AdaptiveSkillIdentity::parse(skill)?.into_canonical());
+        }
     }
-    evidence
+    Ok(evidence)
 }
 
-fn collect_profile_tool_classes(profile: &Profile, out: &mut BTreeSet<String>) {
+fn collect_profile_tool_classes(
+    profile: &Profile,
+    out: &mut BTreeSet<String>,
+) -> Result<(), AdaptiveError> {
     if profile.tools.builtins {
         out.insert("builtins".to_string());
     }
@@ -1483,14 +1555,13 @@ fn collect_profile_tool_classes(profile: &Profile, out: &mut BTreeSet<String>) {
     if profile.tools.image_generation {
         out.insert("image_generation".to_string());
     }
-    out.extend(profile.tools.mcp.iter().map(|name| format!("mcp:{name}")));
-    out.extend(
-        profile
-            .tools
-            .rust_bundles
-            .iter()
-            .map(|name| format!("rust_bundle:{name}")),
-    );
+    for name in &profile.tools.mcp {
+        out.insert(AdaptiveToolIdentity::mcp_server(name)?.into_canonical());
+    }
+    for name in &profile.tools.rust_bundles {
+        out.insert(AdaptiveToolIdentity::rust_bundle(name)?.into_canonical());
+    }
+    Ok(())
 }
 
 fn compile_wiring(plan: &LayerPlan) -> WiringRules {
@@ -1730,6 +1801,80 @@ fn parse_path(raw: &str) -> Result<Vec<&str>, AdaptiveError> {
     Ok(segments)
 }
 
+fn validate_adaptive_identity_component(
+    field: &'static str,
+    value: &str,
+) -> Result<(), AdaptiveError> {
+    if value.is_empty() {
+        return Err(AdaptiveError::InvalidAdaptiveIdentity {
+            field,
+            value: value.to_string(),
+            reason: "empty component".to_string(),
+        });
+    }
+    if value.trim() != value {
+        return Err(AdaptiveError::InvalidAdaptiveIdentity {
+            field,
+            value: value.to_string(),
+            reason: "leading or trailing whitespace".to_string(),
+        });
+    }
+    if value.contains(':') {
+        return Err(AdaptiveError::InvalidAdaptiveIdentity {
+            field,
+            value: value.to_string(),
+            reason: "colon is reserved for adaptive identity namespaces".to_string(),
+        });
+    }
+    Ok(())
+}
+
+fn canonical_adaptive_tool_set(
+    field: &'static str,
+    values: &BTreeSet<String>,
+) -> Result<BTreeSet<String>, AdaptiveError> {
+    values
+        .iter()
+        .map(|value| {
+            AdaptiveToolIdentity::parse(value)
+                .map(AdaptiveToolIdentity::into_canonical)
+                .map_err(|error| match error {
+                    AdaptiveError::InvalidAdaptiveIdentity { value, reason, .. } => {
+                        AdaptiveError::InvalidAdaptiveIdentity {
+                            field,
+                            value,
+                            reason,
+                        }
+                    }
+                    other => other,
+                })
+        })
+        .collect()
+}
+
+fn canonical_adaptive_skill_set(
+    field: &'static str,
+    values: &BTreeSet<String>,
+) -> Result<BTreeSet<String>, AdaptiveError> {
+    values
+        .iter()
+        .map(|value| {
+            AdaptiveSkillIdentity::parse(value)
+                .map(AdaptiveSkillIdentity::into_canonical)
+                .map_err(|error| match error {
+                    AdaptiveError::InvalidAdaptiveIdentity { value, reason, .. } => {
+                        AdaptiveError::InvalidAdaptiveIdentity {
+                            field,
+                            value,
+                            reason,
+                        }
+                    }
+                    other => other,
+                })
+        })
+        .collect()
+}
+
 fn sanitize_identifier(raw: &str) -> Result<String, AdaptiveError> {
     let mut out = String::with_capacity(raw.len());
     for ch in raw.chars() {
@@ -1784,6 +1929,12 @@ pub enum AdaptiveError {
     IncompletePolicy { owner: String, field: &'static str },
     #[error("invalid {field} identifier: {value}")]
     InvalidFieldIdentifier { field: &'static str, value: String },
+    #[error("invalid {field}: {value} ({reason})")]
+    InvalidAdaptiveIdentity {
+        field: &'static str,
+        value: String,
+        reason: String,
+    },
     #[error("invalid identifier: {0}")]
     InvalidIdentifier(String),
     #[error("invalid adaptive ref: {0}")]
@@ -2577,6 +2728,96 @@ mod tests {
         policy.allow_inline_profiles = true;
         compile_layer(&plan, &compile_context(), &policy)
             .expect("inline profile should compile with explicit adaptive policy authority");
+    }
+
+    #[test]
+    fn adaptive_policy_canonicalizes_tool_and_skill_allowlists() {
+        let policy = AdaptivePolicy {
+            limits: limits(7),
+            allowed_tool_classes: BTreeSet::from([
+                "builtins".to_string(),
+                "mcp:filesystem".to_string(),
+                "rust_bundle:review-tools".to_string(),
+            ]),
+            allowed_skill_classes: BTreeSet::from(["lint-review".to_string()]),
+            ..AdaptivePolicy::default()
+        };
+
+        let runtime_limits = adaptive_run_limits_from_policy(&policy, 1_000).unwrap();
+        assert_eq!(
+            runtime_limits.allowed_tool_classes,
+            BTreeSet::from([
+                "builtins".to_string(),
+                "mcp:filesystem".to_string(),
+                "rust_bundle:review-tools".to_string(),
+            ])
+        );
+        assert_eq!(
+            runtime_limits.allowed_skill_identities,
+            BTreeSet::from(["lint-review".to_string()])
+        );
+    }
+
+    #[test]
+    fn adaptive_layer_evidence_canonicalizes_profile_tools_and_skills() {
+        let mut context = compile_context();
+        let verifier = context
+            .profile_templates
+            .get_mut(&ProfileName::from("verifier"))
+            .expect("verifier profile");
+        verifier.tools.mcp = vec!["filesystem".to_string()];
+        verifier.tools.rust_bundles = vec!["review-tools".to_string()];
+        verifier.skills = vec!["lint-review".to_string()];
+
+        let compiled = compile_layer(&layer_plan(), &context, &compile_policy()).unwrap();
+        assert!(
+            compiled
+                .policy_evidence
+                .used_tool_classes
+                .contains("mcp:filesystem")
+        );
+        assert!(
+            compiled
+                .policy_evidence
+                .used_tool_classes
+                .contains("rust_bundle:review-tools")
+        );
+        assert!(
+            compiled
+                .policy_evidence
+                .used_skill_identities
+                .contains("lint-review")
+        );
+    }
+
+    #[test]
+    fn adaptive_layer_rejects_ambiguous_profile_tool_and_skill_identities() {
+        let mut context = compile_context();
+        context
+            .profile_templates
+            .get_mut(&ProfileName::from("verifier"))
+            .expect("verifier profile")
+            .tools
+            .mcp = vec!["mcp:filesystem".to_string()];
+        let denied = compile_layer(&layer_plan(), &context, &compile_policy()).unwrap_err();
+        assert!(matches!(
+            denied,
+            AdaptiveError::InvalidAdaptiveIdentity { field, .. }
+                if field == "adaptive tool mcp server"
+        ));
+
+        let mut context = compile_context();
+        context
+            .profile_templates
+            .get_mut(&ProfileName::from("verifier"))
+            .expect("verifier profile")
+            .skills = vec!["mcp:filesystem".to_string()];
+        let denied = compile_layer(&layer_plan(), &context, &compile_policy()).unwrap_err();
+        assert!(matches!(
+            denied,
+            AdaptiveError::InvalidAdaptiveIdentity { field, reason, .. }
+                if field == "adaptive skill identity" && reason.contains("reserved")
+        ));
     }
 
     #[test]

--- a/meerkat-mob/src/runtime/actor.rs
+++ b/meerkat-mob/src/runtime/actor.rs
@@ -7536,7 +7536,17 @@ impl MobActor {
                         tracing::error!(error = %error, "flow finished cleanup failed");
                     }
                 }
-                MobCommand::FlowCanceledCleanup { run_id } => {
+                MobCommand::FlowCanceledCleanup {
+                    run_id,
+                    terminalized,
+                } => {
+                    if !terminalized {
+                        tracing::error!(
+                            %run_id,
+                            "flow canceled cleanup refused: spawned cancellation path did not prove persisted terminalization"
+                        );
+                        continue;
+                    }
                     if let Err(error) = self
                         .handle_flow_cleanup(run_id, "flow canceled cleanup")
                         .await
@@ -18710,7 +18720,9 @@ impl MobActor {
                 () = tokio::time::sleep(cancel_grace_timeout) => false,
             };
             if completed {
+                let mut terminalized = true;
                 if let Err(error) = flow_engine.cancel_unfinished_steps(&run_id).await {
+                    terminalized = false;
                     tracing::error!(
                         error = %error,
                         "failed to settle dispatched steps after flow task completion during cancellation"
@@ -18720,6 +18732,7 @@ impl MobActor {
                     .terminalize_canceled(run_id.clone(), flow_id)
                     .await
                 {
+                    terminalized = false;
                     tracing::error!(
                         error = %error,
                         "failed to apply canceled terminalization after flow task completion"
@@ -18728,6 +18741,7 @@ impl MobActor {
                 if cleanup_tx
                     .send(MobCommand::FlowCanceledCleanup {
                         run_id: cleanup_run_id,
+                        terminalized,
                     })
                     .await
                     .is_err()
@@ -18740,13 +18754,19 @@ impl MobActor {
             }
 
             handle.abort();
+            let mut terminalized = true;
             if let Err(error) = flow_engine.cancel_unfinished_steps(&run_id).await {
+                terminalized = false;
                 tracing::error!(
                     error = %error,
                     "failed to settle dispatched steps before flow cancellation terminalization"
                 );
             }
-            if let Err(error) = flow_engine.terminalize_canceled(run_id, flow_id).await {
+            if let Err(error) = flow_engine
+                .terminalize_canceled(run_id.clone(), flow_id)
+                .await
+            {
+                terminalized = false;
                 tracing::error!(
                     error = %error,
                     "failed flow-run kernel cancellation terminalization"
@@ -18755,6 +18775,7 @@ impl MobActor {
             if cleanup_tx
                 .send(MobCommand::FlowCanceledCleanup {
                     run_id: cleanup_run_id,
+                    terminalized,
                 })
                 .await
                 .is_err()

--- a/meerkat-mob/src/runtime/state.rs
+++ b/meerkat-mob/src/runtime/state.rs
@@ -405,6 +405,7 @@ pub(super) enum MobCommand {
     },
     FlowCanceledCleanup {
         run_id: RunId,
+        terminalized: bool,
     },
     #[cfg(test)]
     FlowTrackerCounts {

--- a/meerkat-mob/src/runtime/tests.rs
+++ b/meerkat-mob/src/runtime/tests.rs
@@ -25728,6 +25728,29 @@ fn test_flow_cleanup_uses_terminal_projection_not_authority_clone_probe() {
 }
 
 #[test]
+fn test_flow_canceled_cleanup_requires_terminalization_proof() {
+    let actor = include_str!("actor.rs");
+    let state = include_str!("state.rs");
+    assert!(
+        state
+            .contains("FlowCanceledCleanup {\n        run_id: RunId,\n        terminalized: bool,"),
+        "FlowCanceledCleanup must carry spawned-path terminalization proof"
+    );
+    assert!(
+        actor.contains("if !terminalized"),
+        "actor must fail closed before cleanup when terminalization proof is false"
+    );
+    assert!(
+        actor.contains("terminalized = false"),
+        "spawned cancellation path must downgrade the proof on settle/terminalization errors"
+    );
+    assert!(
+        actor.contains("terminalized,"),
+        "FlowCanceledCleanup sends must include the proof field"
+    );
+}
+
+#[test]
 fn test_lifecycle_commands_admit_on_live_authority_not_clone_probe() {
     let source = include_str!("actor.rs");
     let start = source

--- a/meerkat-rest/src/lib.rs
+++ b/meerkat-rest/src/lib.rs
@@ -6925,6 +6925,43 @@ mod tests {
     use std::sync::atomic::{AtomicUsize, Ordering as AtomicOrdering};
     use tempfile::TempDir;
 
+    struct RuntimeTerminationFixtureExecutor;
+
+    #[async_trait]
+    impl CoreExecutor for RuntimeTerminationFixtureExecutor {
+        async fn apply(
+            &mut self,
+            run_id: meerkat_core::RunId,
+            primitive: RunPrimitive,
+        ) -> Result<CoreApplyOutput, CoreExecutorError> {
+            Ok(CoreApplyOutput {
+                receipt: meerkat_core::lifecycle::run_receipt::RunBoundaryReceiptDraft {
+                    run_id,
+                    boundary: RunApplyBoundary::RunStart,
+                    contributing_input_ids: primitive.contributing_input_ids().to_vec(),
+                    conversation_digest: None,
+                    message_count: 0,
+                },
+                session_snapshot: None,
+                terminal: None,
+            })
+        }
+
+        async fn cancel_after_boundary(
+            &mut self,
+            _reason: String,
+        ) -> Result<(), CoreExecutorError> {
+            Ok(())
+        }
+
+        async fn stop_runtime_executor(
+            &mut self,
+            _reason: String,
+        ) -> Result<(), CoreExecutorError> {
+            Ok(())
+        }
+    }
+
     /// Test-side view of the canonical create-session default model: resolved
     /// per call from the state's current config (the `AppState` no longer
     /// carries a default-model mirror).
@@ -6971,14 +7008,17 @@ mod tests {
     }
 
     async fn runtime_terminated_completion_handle(
-        adapter: &meerkat_runtime::meerkat_machine::MeerkatMachine,
+        adapter: &Arc<meerkat_runtime::meerkat_machine::MeerkatMachine>,
         session_id: &SessionId,
         reason: &str,
     ) -> meerkat_runtime::CompletionHandle {
         adapter
-            .prepare_bindings(session_id.clone())
+            .ensure_session_with_executor(
+                session_id.clone(),
+                Box::new(RuntimeTerminationFixtureExecutor),
+            )
             .await
-            .expect("test machine should prepare runtime bindings");
+            .expect("test machine should attach runtime executor");
         let input = meerkat_runtime::Input::Prompt(meerkat_runtime::PromptInput::new(
             "pending completion fixture",
             None,
@@ -11501,7 +11541,7 @@ mod tests {
         let state = load_rest_state_with_capacity(&temp, 1).await;
         let session_id = SessionId::new();
         let handle = runtime_terminated_completion_handle(
-            state.runtime_adapter.as_ref(),
+            &state.runtime_adapter,
             &session_id,
             "cleanup preserves outcome",
         )
@@ -11545,7 +11585,7 @@ mod tests {
         .expect("insert runtime pre-admission");
 
         let handle = runtime_terminated_completion_handle(
-            state.runtime_adapter.as_ref(),
+            &state.runtime_adapter,
             &session_id,
             "runtime stopped during cleanup",
         )

--- a/meerkat-rpc/src/session_runtime.rs
+++ b/meerkat-rpc/src/session_runtime.rs
@@ -3394,23 +3394,7 @@ impl SessionRuntime {
     ) -> Result<SessionLlmIdentity, RpcError> {
         let registry = self.model_registry().await?;
         let model = build_config.model.clone();
-        let provider = if let Some(provider) = build_config.provider {
-            if let Some(reason) =
-                registered_model_provider_mismatch_reason(&registry, provider, &model)
-            {
-                return Err(RpcError {
-                    code: error::INVALID_PARAMS,
-                    message: reason,
-                    data: None,
-                });
-            }
-            provider
-        } else {
-            registry
-                .entry(&model)
-                .map(|entry| entry.provider)
-                .unwrap_or(meerkat_core::Provider::Other)
-        };
+        let provider = self.resolve_create_provider(build_config).await?;
         let self_hosted_server_id = if provider == meerkat_core::Provider::SelfHosted {
             if let Some(server_id) = build_config.self_hosted_server_id.clone() {
                 Some(server_id)
@@ -8851,6 +8835,45 @@ mod tests {
             .await
             .expect_err("explicit provider contradicting the catalog owner must be rejected");
         assert_eq!(err.code, error::INVALID_PARAMS);
+    }
+
+    #[tokio::test]
+    async fn pending_build_identity_rejects_unknown_model_without_provider() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let runtime = make_runtime(temp_factory(&temp), 4);
+        let build_config = AgentBuildConfig::new("totally-unregistered-model-xyz");
+
+        let err = runtime
+            .llm_identity_from_pending_build(&build_config)
+            .await
+            .expect_err("pending staging identity must fail closed for unknown owner");
+
+        assert_eq!(err.code, error::INVALID_PARAMS);
+        assert!(
+            err.message
+                .contains("explicit provider or a registered model owner"),
+            "error should name the missing registry owner contract: {}",
+            err.message
+        );
+    }
+
+    #[tokio::test]
+    async fn create_session_rejects_unknown_model_before_staging_slot() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let runtime = make_runtime(temp_factory(&temp), 4);
+        let build_config = AgentBuildConfig::new("totally-unregistered-model-xyz");
+
+        let err = runtime
+            .create_session(build_config, None, None)
+            .await
+            .expect_err("deferred create must reject before reserving a pending session");
+
+        assert_eq!(err.code, error::INVALID_PARAMS);
+        assert_eq!(
+            runtime.staged_sessions.len().await,
+            0,
+            "unknown-model create must not leave a staged session behind"
+        );
     }
 
     /// B19 helper sanity: realtime capability lookup must round-trip the

--- a/meerkat-rpc/src/session_runtime.rs
+++ b/meerkat-rpc/src/session_runtime.rs
@@ -8426,15 +8426,58 @@ mod tests {
     use std::sync::Arc;
     use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering as AtomicOrdering};
 
+    struct RuntimeTerminationFixtureExecutor;
+
+    #[async_trait]
+    impl meerkat_core::lifecycle::CoreExecutor for RuntimeTerminationFixtureExecutor {
+        async fn apply(
+            &mut self,
+            run_id: meerkat_core::lifecycle::RunId,
+            primitive: meerkat_core::lifecycle::RunPrimitive,
+        ) -> Result<
+            meerkat_core::lifecycle::core_executor::CoreApplyOutput,
+            meerkat_core::lifecycle::CoreExecutorError,
+        > {
+            Ok(meerkat_core::lifecycle::core_executor::CoreApplyOutput {
+                receipt: meerkat_core::lifecycle::RunBoundaryReceiptDraft {
+                    run_id,
+                    boundary: meerkat_core::lifecycle::RunApplyBoundary::RunStart,
+                    contributing_input_ids: primitive.contributing_input_ids().to_vec(),
+                    conversation_digest: None,
+                    message_count: 0,
+                },
+                session_snapshot: None,
+                terminal: None,
+            })
+        }
+
+        async fn cancel_after_boundary(
+            &mut self,
+            _reason: String,
+        ) -> Result<(), meerkat_core::lifecycle::CoreExecutorError> {
+            Ok(())
+        }
+
+        async fn stop_runtime_executor(
+            &mut self,
+            _reason: String,
+        ) -> Result<(), meerkat_core::lifecycle::CoreExecutorError> {
+            Ok(())
+        }
+    }
+
     async fn runtime_terminated_completion_handle(
-        adapter: &meerkat_runtime::meerkat_machine::MeerkatMachine,
+        adapter: &Arc<meerkat_runtime::meerkat_machine::MeerkatMachine>,
         session_id: &SessionId,
         reason: &str,
     ) -> meerkat_runtime::CompletionHandle {
         adapter
-            .prepare_bindings(session_id.clone())
+            .ensure_session_with_executor(
+                session_id.clone(),
+                Box::new(RuntimeTerminationFixtureExecutor),
+            )
             .await
-            .expect("test machine should prepare runtime bindings");
+            .expect("test machine should attach runtime executor");
         let input = meerkat_runtime::Input::Prompt(meerkat_runtime::PromptInput::new(
             "pending completion fixture",
             None,
@@ -14989,7 +15032,7 @@ mod tests {
             .expect("insert pre-admission");
 
         let handle = runtime_terminated_completion_handle(
-            runtime.runtime_adapter.as_ref(),
+            &runtime.runtime_adapter,
             &session_id,
             "executor never took pre-admission",
         )
@@ -15037,7 +15080,7 @@ mod tests {
             .expect("insert pre-admission");
 
         let handle = runtime_terminated_completion_handle(
-            runtime.runtime_adapter.as_ref(),
+            &runtime.runtime_adapter,
             &session_id,
             "runtime stopped during cleanup",
         )
@@ -15183,7 +15226,7 @@ mod tests {
             .expect("insert second pre-admission");
 
         let stale_handle = runtime_terminated_completion_handle(
-            runtime.runtime_adapter.as_ref(),
+            &runtime.runtime_adapter,
             &session_id,
             "stale cleanup for first input",
         )

--- a/meerkat-runtime/src/meerkat_machine/dispatch_control.rs
+++ b/meerkat-runtime/src/meerkat_machine/dispatch_control.rs
@@ -184,6 +184,11 @@ impl MeerkatMachine {
                                     &effects,
                                 )
                                 .map_err(RuntimeControlPlaneError::Internal)?;
+                            if signal.should_wake() && wake_tx.is_none() {
+                                return Err(RuntimeControlPlaneError::InvalidState {
+                                    state: RuntimeState::Destroyed,
+                                });
+                            }
                             (signal, runtime_effect, Some(effects))
                         }
                         AcceptOutcome::Deduplicated { .. } | AcceptOutcome::Rejected { .. } => (

--- a/meerkat-runtime/src/meerkat_machine/dispatch_ingress.rs
+++ b/meerkat-runtime/src/meerkat_machine/dispatch_ingress.rs
@@ -36,6 +36,23 @@ impl MeerkatMachine {
         }
     }
 
+    async fn reject_unregistration_drain_ingress(
+        &self,
+        session_id: &SessionId,
+        state: RuntimeState,
+    ) -> Result<(), RuntimeDriverError> {
+        let dsl_state = self.session_dsl_state(session_id).await.map_err(|reason| {
+            RuntimeDriverError::Internal(format!(
+                "failed to read generated registration phase for ingress admission: {reason}"
+            ))
+        })?;
+        if dsl_state.registration_phase == crate::meerkat_machine::dsl::RegistrationPhase::Draining
+        {
+            return Err(RuntimeDriverError::NotReady { state });
+        }
+        Ok(())
+    }
+
     pub(super) async fn observe_active_turn_boundary_available(
         session_id: &SessionId,
         boundary_handle: Option<
@@ -215,6 +232,8 @@ impl MeerkatMachine {
                     "MeerkatMachine::AcceptWithCompletion read runtime state"
                 );
                 Self::reject_visible_terminal_ingress(visible_state)?;
+                self.reject_unregistration_drain_ingress(&session_id, state)
+                    .await?;
 
                 let active_turn_boundary_available = Self::observe_active_turn_boundary_available(
                     &session_id,
@@ -553,14 +572,18 @@ impl MeerkatMachine {
                 })
             }
             MeerkatMachineCommand::AcceptWithoutWake { session_id, input } => {
-                let (driver, boundary_handle) = {
+                let (driver, boundary_handle, has_live_attachment) = {
                     let sessions = self.sessions.read().await;
                     let entry = sessions
                         .get(&session_id)
                         .ok_or(RuntimeDriverError::NotReady {
                             state: RuntimeState::Destroyed,
                         })?;
-                    (entry.driver.clone(), entry.boundary_handle())
+                    (
+                        entry.driver.clone(),
+                        entry.boundary_handle(),
+                        entry.has_live_attachment(),
+                    )
                 };
 
                 let gate = self.session_mutation_gate(&session_id).await;
@@ -578,6 +601,11 @@ impl MeerkatMachine {
                     .await
                     .unwrap_or(RuntimeState::Destroyed);
                 Self::reject_visible_terminal_ingress(visible_state)?;
+                self.reject_unregistration_drain_ingress(&session_id, state)
+                    .await?;
+                if !has_live_attachment {
+                    return Err(RuntimeDriverError::NotReady { state });
+                }
                 let active_turn_boundary_available = Self::observe_active_turn_boundary_available(
                     &session_id,
                     boundary_handle.as_ref(),

--- a/meerkat-runtime/src/meerkat_machine/session_management.rs
+++ b/meerkat-runtime/src/meerkat_machine/session_management.rs
@@ -1330,29 +1330,28 @@ impl MeerkatMachine {
 
     async fn finalize_unregistered_session(
         &self,
-        entry: RuntimeSessionEntry,
+        runtime_id: LogicalRuntimeId,
+        driver: SharedDriver,
         durability_authority: RuntimeOpsLifecycleDurabilityAuthority,
-    ) {
-        let runtime_id = entry.runtime_id.clone();
-        let mut driver = entry.driver.lock().await;
+    ) -> Result<(), RuntimeDriverError> {
+        let mut driver = driver.lock().await;
         driver.sync_control_projection_from_dsl_authority();
         drop(driver);
 
         if durability_authority.action
             != crate::meerkat_machine::dsl::RuntimeOpsLifecycleDurabilityAction::DeleteSnapshot
         {
-            return;
+            return Ok(());
         }
         let Some(store) = self.store.as_ref() else {
-            return;
+            return Ok(());
         };
-        if let Err(err) = store.delete_ops_lifecycle(&runtime_id).await {
-            tracing::warn!(
-                %runtime_id,
-                error = %err,
-                "failed to delete ops lifecycle snapshot for unregistered runtime"
-            );
-        }
+        store.delete_ops_lifecycle(&runtime_id).await.map_err(|err| {
+            RuntimeDriverError::Internal(format!(
+                "failed to delete ops lifecycle snapshot for unregistered runtime {runtime_id}: {err}"
+            ))
+        })?;
+        Ok(())
     }
 
     pub(super) async fn unregister_session_inner(&self, session_id: &SessionId) {
@@ -1426,14 +1425,16 @@ impl MeerkatMachine {
         // machine records whether teardown intent should retain the durable
         // runtime snapshot before the drain can advance lifecycle state.
         tracing::info!(%session_id, "MeerkatMachine::unregister_session_inner_locked_authorized beginning drain window");
-        match self
+        let unregister_retry_snapshot = match self
             .stage_begin_unregister_session_authority(session_id)
             .await
         {
             Ok(staged) => {
+                let retry_snapshot = staged.previous_snapshot.clone();
                 self.commit_session_dsl_transition(session_id, staged, "BeginUnregisterSession")
                     .await
                     .map_err(RuntimeDriverError::Internal)?;
+                Some(retry_snapshot)
             }
             Err(reason) => {
                 let already_draining =
@@ -1452,7 +1453,7 @@ impl MeerkatMachine {
                     .classify_session_dsl_rejection(session_id, reason)
                     .await);
             }
-        }
+        };
 
         // Phase 2: discharge the runtime-loop-stop and comms-drain-abort
         // obligations, retaining both JoinHandles to await below. The live
@@ -1645,6 +1646,8 @@ impl MeerkatMachine {
         tracing::info!(%session_id, "MeerkatMachine::unregister_session_inner_locked_authorized staging unregister");
         let (staged, durability_authority) =
             self.stage_unregister_session_authority(session_id).await?;
+        let unregister_rollback_snapshot =
+            unregister_retry_snapshot.unwrap_or_else(|| staged.previous_snapshot.clone());
         tracing::info!(%session_id, "MeerkatMachine::unregister_session_inner_locked_authorized committing unregister");
         self.commit_session_dsl_transition(session_id, staged, "UnregisterSession")
             .await
@@ -1659,6 +1662,41 @@ impl MeerkatMachine {
                 .persist_current_machine_lifecycle("unregister")
                 .await?;
         }
+        let finalize_target = {
+            let sessions = self.sessions.read().await;
+            sessions
+                .get(session_id)
+                .map(|entry| (entry.runtime_id.clone(), Arc::clone(&entry.driver)))
+        };
+        if let Some((runtime_id, driver)) = finalize_target {
+            tracing::info!(%session_id, "MeerkatMachine::unregister_session_inner_locked_authorized finalizing durable unregister");
+            if let Err(err) = self
+                .finalize_unregistered_session(
+                    runtime_id,
+                    Arc::clone(&driver),
+                    durability_authority,
+                )
+                .await
+            {
+                self.restore_session_dsl_state(session_id, unregister_rollback_snapshot)
+                    .await;
+                driver
+                    .lock()
+                    .await
+                    .sync_control_projection_from_dsl_authority();
+                if let Err(rollback_error) = driver
+                    .lock()
+                    .await
+                    .persist_current_machine_lifecycle("unregister rollback")
+                    .await
+                {
+                    return Err(RuntimeDriverError::Internal(format!(
+                        "{err}; additionally failed to persist unregister rollback: {rollback_error}"
+                    )));
+                }
+                return Err(err);
+            }
+        }
         tracing::info!(%session_id, "MeerkatMachine::unregister_session_inner_locked_authorized removing entry");
         let entry = {
             let mut sessions = self.sessions.write().await;
@@ -1672,12 +1710,7 @@ impl MeerkatMachine {
             }
             sessions.remove(session_id)
         };
-
-        if let Some(entry) = entry {
-            tracing::info!(%session_id, "MeerkatMachine::unregister_session_inner_locked_authorized finalizing entry");
-            self.finalize_unregistered_session(entry, durability_authority)
-                .await;
-        }
+        drop(entry);
         tracing::info!(%session_id, "MeerkatMachine::unregister_session_inner_locked_authorized complete");
         Ok(())
     }
@@ -1854,14 +1887,26 @@ impl MeerkatMachine {
         let Some(entry) = entry else {
             return false;
         };
-        self.finalize_unregistered_session(
-            entry,
+        let runtime_id = entry.runtime_id.clone();
+        let driver = Arc::clone(&entry.driver);
+        if let Err(err) = self
+            .finalize_unregistered_session(
+                runtime_id,
+                driver,
             RuntimeOpsLifecycleDurabilityAuthority {
                 action:
                     crate::meerkat_machine::dsl::RuntimeOpsLifecycleDurabilityAction::RetainSnapshot,
             },
         )
-        .await;
+            .await
+        {
+            tracing::warn!(
+                %session_id,
+                error = %err,
+                "failed to finalize storeless WASM session discard"
+            );
+            return false;
+        }
         true
     }
 

--- a/meerkat-runtime/src/meerkat_machine/session_management.rs
+++ b/meerkat-runtime/src/meerkat_machine/session_management.rs
@@ -1425,16 +1425,15 @@ impl MeerkatMachine {
         // machine records whether teardown intent should retain the durable
         // runtime snapshot before the drain can advance lifecycle state.
         tracing::info!(%session_id, "MeerkatMachine::unregister_session_inner_locked_authorized beginning drain window");
-        let unregister_retry_snapshot = match self
+        let retry_final_unregister_only = match self
             .stage_begin_unregister_session_authority(session_id)
             .await
         {
             Ok(staged) => {
-                let retry_snapshot = staged.previous_snapshot.clone();
                 self.commit_session_dsl_transition(session_id, staged, "BeginUnregisterSession")
                     .await
                     .map_err(RuntimeDriverError::Internal)?;
-                Some(retry_snapshot)
+                false
             }
             Err(reason) => {
                 let already_draining =
@@ -1445,15 +1444,25 @@ impl MeerkatMachine {
                 if already_draining {
                     tracing::debug!(
                         %session_id,
-                        "BeginUnregisterSession rejected: drain already in progress (benign)"
+                        "BeginUnregisterSession rejected: drain already in progress; attempting final unregister retry only"
                     );
-                    return Ok(());
+                    true
+                } else {
+                    return Err(self
+                        .classify_session_dsl_rejection(session_id, reason)
+                        .await);
                 }
-                return Err(self
-                    .classify_session_dsl_rejection(session_id, reason)
-                    .await);
             }
         };
+
+        if retry_final_unregister_only {
+            return self
+                .retry_final_unregister_after_completed_drain(
+                    session_id,
+                    Arc::clone(&driver_handle),
+                )
+                .await;
+        }
 
         // Phase 2: discharge the runtime-loop-stop and comms-drain-abort
         // obligations, retaining both JoinHandles to await below. The live
@@ -1633,10 +1642,13 @@ impl MeerkatMachine {
                 "CompletionWaitersResolvedForUnregister",
             ),
         ] {
-            let staged = self
+            let staged = match self
                 .stage_session_dsl_transition(session_id, input, context)
                 .await
-                .map_err(|reason| RuntimeDriverError::ValidationFailed { reason })?;
+            {
+                Ok(staged) => staged,
+                Err(reason) => return Err(RuntimeDriverError::ValidationFailed { reason }),
+            };
             self.commit_session_dsl_transition(session_id, staged, context)
                 .await
                 .map_err(RuntimeDriverError::Internal)?;
@@ -1646,8 +1658,7 @@ impl MeerkatMachine {
         tracing::info!(%session_id, "MeerkatMachine::unregister_session_inner_locked_authorized staging unregister");
         let (staged, durability_authority) =
             self.stage_unregister_session_authority(session_id).await?;
-        let unregister_rollback_snapshot =
-            unregister_retry_snapshot.unwrap_or_else(|| staged.previous_snapshot.clone());
+        let unregister_rollback_snapshot = staged.previous_snapshot.clone();
         tracing::info!(%session_id, "MeerkatMachine::unregister_session_inner_locked_authorized committing unregister");
         self.commit_session_dsl_transition(session_id, staged, "UnregisterSession")
             .await
@@ -1712,6 +1723,82 @@ impl MeerkatMachine {
         };
         drop(entry);
         tracing::info!(%session_id, "MeerkatMachine::unregister_session_inner_locked_authorized complete");
+        Ok(())
+    }
+
+    async fn retry_final_unregister_after_completed_drain(
+        &self,
+        session_id: &SessionId,
+        driver_handle: SharedDriver,
+    ) -> Result<(), RuntimeDriverError> {
+        let (staged, durability_authority) =
+            match self.stage_unregister_session_authority(session_id).await {
+                Ok(pair) => pair,
+                Err(err @ RuntimeDriverError::ValidationFailed { .. }) => {
+                    tracing::debug!(
+                        %session_id,
+                        error = %err,
+                        "final unregister retry is not ready; original drain remains in progress"
+                    );
+                    return Ok(());
+                }
+                Err(err) => return Err(err),
+            };
+        let unregister_rollback_snapshot = staged.previous_snapshot.clone();
+        self.commit_session_dsl_transition(session_id, staged, "UnregisterSession")
+            .await
+            .map_err(RuntimeDriverError::Internal)?;
+        if durability_authority.action
+            == crate::meerkat_machine::dsl::RuntimeOpsLifecycleDurabilityAction::DeleteSnapshot
+        {
+            driver_handle
+                .lock()
+                .await
+                .persist_current_machine_lifecycle("unregister")
+                .await?;
+        }
+        let finalize_target = {
+            let sessions = self.sessions.read().await;
+            sessions
+                .get(session_id)
+                .map(|entry| (entry.runtime_id.clone(), Arc::clone(&entry.driver)))
+        };
+        if let Some((runtime_id, driver)) = finalize_target
+            && let Err(err) = self
+                .finalize_unregistered_session(
+                    runtime_id,
+                    Arc::clone(&driver),
+                    durability_authority,
+                )
+                .await
+        {
+            self.restore_session_dsl_state(session_id, unregister_rollback_snapshot)
+                .await;
+            driver
+                .lock()
+                .await
+                .sync_control_projection_from_dsl_authority();
+            if let Err(rollback_error) = driver
+                .lock()
+                .await
+                .persist_current_machine_lifecycle("unregister rollback")
+                .await
+            {
+                return Err(RuntimeDriverError::Internal(format!(
+                    "{err}; additionally failed to persist unregister rollback: {rollback_error}"
+                )));
+            }
+            return Err(err);
+        }
+        let entry = {
+            let mut sessions = self.sessions.write().await;
+            if let Some(entry) = sessions.get_mut(session_id) {
+                entry.close_handle_teardown_gate();
+                abort_slot(&mut entry.drain_slot);
+            }
+            sessions.remove(session_id)
+        };
+        drop(entry);
         Ok(())
     }
 

--- a/meerkat-runtime/src/meerkat_machine_tests.rs
+++ b/meerkat-runtime/src/meerkat_machine_tests.rs
@@ -1279,14 +1279,14 @@ async fn runtime_apply_failure_preserves_typed_cause_through_terminalization() {
             })
         }
 
-        async fn cancel_after_boundary(
+        async fn stop_runtime_executor(
             &mut self,
             _reason: String,
         ) -> Result<(), CoreExecutorError> {
             Ok(())
         }
 
-        async fn stop_runtime_executor(
+        async fn cancel_after_boundary(
             &mut self,
             _reason: String,
         ) -> Result<(), CoreExecutorError> {
@@ -2552,6 +2552,42 @@ async fn unregister_session_delete_failure_retains_live_entry_and_stale_snapshot
             .is_some(),
         "failed DeleteSnapshot teardown must not hide the stale durable snapshot"
     );
+    let post_failure_accept = <MeerkatMachine as SessionServiceRuntimeExt>::accept_input(
+        &adapter,
+        &session_id,
+        make_prompt("must not enter drained runtime"),
+    )
+    .await;
+    match post_failure_accept {
+        Err(_) => {}
+        Ok(outcome) => panic!(
+            "failed DeleteSnapshot rollback must leave the retained entry retry-only, got {outcome:?}"
+        ),
+    }
+    let post_failure_progress_accept = <MeerkatMachine as SessionServiceRuntimeExt>::accept_input(
+        &adapter,
+        &session_id,
+        make_progress_input("must-not-enter-drained-runtime"),
+    )
+    .await;
+    match post_failure_progress_accept {
+        Err(_) => {}
+        Ok(outcome) => panic!(
+            "failed DeleteSnapshot rollback must reject wake-effect peer progress too, got {outcome:?}"
+        ),
+    }
+    let post_failure_without_wake_accept = adapter
+        .accept_input_without_wake(
+            &session_id,
+            make_progress_input("must-not-enter-drained-runtime-without-wake"),
+        )
+        .await;
+    match post_failure_without_wake_accept {
+        Err(_) => {}
+        Ok(outcome) => panic!(
+            "failed DeleteSnapshot rollback must reject no-wake ingress too, got {outcome:?}"
+        ),
+    }
 
     adapter.unregister_session(&session_id).await;
     assert!(
@@ -2564,6 +2600,116 @@ async fn unregister_session_delete_failure_retains_live_entry_and_stale_snapshot
             .expect("store should load")
             .is_none(),
         "successful retry must delete stale ops lifecycle snapshot"
+    );
+}
+
+#[tokio::test]
+async fn concurrent_unregister_retry_does_not_commit_feedback_until_original_drain_finishes() {
+    struct BlockingExecutor {
+        apply_started: Arc<Notify>,
+        allow_finish: Option<tokio::sync::oneshot::Receiver<()>>,
+    }
+
+    #[async_trait::async_trait]
+    impl CoreExecutor for BlockingExecutor {
+        async fn apply(
+            &mut self,
+            run_id: RunId,
+            primitive: RunPrimitive,
+        ) -> Result<CoreApplyOutput, CoreExecutorError> {
+            self.apply_started.notify_waiters();
+            self.allow_finish
+                .take()
+                .expect("blocking executor should only apply once")
+                .await
+                .expect("test release sender should stay alive until apply is released");
+
+            Ok(CoreApplyOutput {
+                receipt: RunBoundaryReceiptDraft {
+                    run_id,
+                    boundary: RunApplyBoundary::RunStart,
+                    contributing_input_ids: primitive.contributing_input_ids().to_vec(),
+                    conversation_digest: None,
+                    message_count: 0,
+                },
+                session_snapshot: None,
+                terminal: None,
+            })
+        }
+
+        async fn stop_runtime_executor(
+            &mut self,
+            _reason: String,
+        ) -> Result<(), CoreExecutorError> {
+            Ok(())
+        }
+
+        async fn cancel_after_boundary(
+            &mut self,
+            _reason: String,
+        ) -> Result<(), CoreExecutorError> {
+            Ok(())
+        }
+    }
+
+    let adapter = Arc::new(MeerkatMachine::ephemeral());
+    let session_id = SessionId::new();
+    let apply_started = Arc::new(Notify::new());
+    let (allow_finish_tx, allow_finish_rx) = tokio::sync::oneshot::channel();
+
+    adapter
+        .register_session_with_executor(
+            session_id.clone(),
+            Box::new(BlockingExecutor {
+                apply_started: Arc::clone(&apply_started),
+                allow_finish: Some(allow_finish_rx),
+            }),
+        )
+        .await
+        .expect("runtime executor registration should succeed");
+    adapter
+        .accept_input(&session_id, make_prompt("block unregister drain"))
+        .await
+        .expect("prompt should start attached runtime");
+    tokio::time::timeout(Duration::from_secs(1), apply_started.notified())
+        .await
+        .expect("runtime should enter blocking apply");
+
+    let first_unregister = tokio::spawn({
+        let adapter = Arc::clone(&adapter);
+        let session_id = session_id.clone();
+        async move { adapter.unregister_session(&session_id).await }
+    });
+    tokio::time::timeout(Duration::from_secs(1), async {
+        loop {
+            let state = adapter
+                .session_dsl_state(&session_id)
+                .await
+                .expect("session should still have DSL state");
+            if state.registration_phase == mm_dsl::RegistrationPhase::Draining {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .expect("first unregister should open the drain window");
+
+    adapter.unregister_session(&session_id).await;
+    assert!(
+        adapter.contains_session(&session_id).await,
+        "concurrent unregister retry must not fabricate drain feedback or remove the entry"
+    );
+
+    allow_finish_tx
+        .send(())
+        .expect("blocking executor should still be awaiting release");
+    first_unregister
+        .await
+        .expect("first unregister task should not panic");
+    assert!(
+        !adapter.contains_session(&session_id).await,
+        "original unregister should remove the entry after the real drain finishes"
     );
 }
 

--- a/meerkat-runtime/src/meerkat_machine_tests.rs
+++ b/meerkat-runtime/src/meerkat_machine_tests.rs
@@ -2514,6 +2514,60 @@ async fn unregister_session_deletes_persisted_ops_lifecycle_epoch() {
 }
 
 #[tokio::test]
+async fn unregister_session_delete_failure_retains_live_entry_and_stale_snapshot() {
+    let inner = Arc::new(crate::store::InMemoryRuntimeStore::new());
+    let store = Arc::new(RuntimeCommitAtomicityStore::fail_delete_ops_lifecycle_once(
+        Arc::clone(&inner),
+    ));
+    let adapter = Arc::new(MeerkatMachine::persistent(
+        store.clone() as Arc<dyn crate::store::RuntimeStore>,
+        memory_blob_store(),
+    ));
+    let session_id = SessionId::new();
+    let runtime_id = runtime_id_for_session(&session_id);
+    let stale_epoch = meerkat_core::RuntimeEpochId::new();
+    let stale_cursor = meerkat_core::EpochCursorState::new();
+    let stale_snapshot = crate::ops_lifecycle::RuntimeOpsLifecycleRegistry::new()
+        .capture_persistence_snapshot(stale_epoch, &stale_cursor)
+        .unwrap();
+
+    crate::store::RuntimeStore::persist_ops_lifecycle(inner.as_ref(), &runtime_id, &stale_snapshot)
+        .await
+        .expect("test snapshot should persist");
+
+    adapter
+        .register_session(session_id.clone())
+        .await
+        .expect("register session");
+    adapter.unregister_session(&session_id).await;
+
+    assert!(
+        adapter.contains_session(&session_id).await,
+        "failed DeleteSnapshot teardown must retain the live entry instead of forgetting it"
+    );
+    assert!(
+        crate::store::RuntimeStore::load_ops_lifecycle(inner.as_ref(), &runtime_id)
+            .await
+            .expect("store should load")
+            .is_some(),
+        "failed DeleteSnapshot teardown must not hide the stale durable snapshot"
+    );
+
+    adapter.unregister_session(&session_id).await;
+    assert!(
+        !adapter.contains_session(&session_id).await,
+        "second unregister should remove the entry after delete succeeds"
+    );
+    assert!(
+        crate::store::RuntimeStore::load_ops_lifecycle(inner.as_ref(), &runtime_id)
+            .await
+            .expect("store should load")
+            .is_none(),
+        "successful retry must delete stale ops lifecycle snapshot"
+    );
+}
+
+#[tokio::test]
 async fn unregister_session_retains_terminal_machine_lifecycle_snapshot() {
     let store = Arc::new(crate::store::InMemoryRuntimeStore::new());
     let adapter = Arc::new(MeerkatMachine::persistent(
@@ -15425,6 +15479,7 @@ struct RuntimeCommitAtomicityStore {
     inner: Arc<crate::store::InMemoryRuntimeStore>,
     fail_atomic_apply: AtomicBool,
     fail_commit_machine_lifecycle: AtomicBool,
+    fail_delete_ops_lifecycle: AtomicBool,
     commit_machine_lifecycle_calls: AtomicUsize,
 }
 
@@ -15434,6 +15489,7 @@ impl RuntimeCommitAtomicityStore {
             inner,
             fail_atomic_apply: AtomicBool::new(false),
             fail_commit_machine_lifecycle: AtomicBool::new(false),
+            fail_delete_ops_lifecycle: AtomicBool::new(false),
             commit_machine_lifecycle_calls: AtomicUsize::new(0),
         }
     }
@@ -15443,6 +15499,7 @@ impl RuntimeCommitAtomicityStore {
             inner,
             fail_atomic_apply: AtomicBool::new(true),
             fail_commit_machine_lifecycle: AtomicBool::new(false),
+            fail_delete_ops_lifecycle: AtomicBool::new(false),
             commit_machine_lifecycle_calls: AtomicUsize::new(0),
         }
     }
@@ -15452,6 +15509,17 @@ impl RuntimeCommitAtomicityStore {
             inner,
             fail_atomic_apply: AtomicBool::new(false),
             fail_commit_machine_lifecycle: AtomicBool::new(true),
+            fail_delete_ops_lifecycle: AtomicBool::new(false),
+            commit_machine_lifecycle_calls: AtomicUsize::new(0),
+        }
+    }
+
+    fn fail_delete_ops_lifecycle_once(inner: Arc<crate::store::InMemoryRuntimeStore>) -> Self {
+        Self {
+            inner,
+            fail_atomic_apply: AtomicBool::new(false),
+            fail_commit_machine_lifecycle: AtomicBool::new(false),
+            fail_delete_ops_lifecycle: AtomicBool::new(true),
             commit_machine_lifecycle_calls: AtomicUsize::new(0),
         }
     }
@@ -15614,6 +15682,11 @@ impl RuntimeStore for RuntimeCommitAtomicityStore {
         &self,
         runtime_id: &LogicalRuntimeId,
     ) -> Result<(), crate::store::RuntimeStoreError> {
+        if self.fail_delete_ops_lifecycle.swap(false, Ordering::SeqCst) {
+            return Err(crate::store::RuntimeStoreError::WriteFailed(
+                "synthetic delete_ops_lifecycle failure".into(),
+            ));
+        }
         self.inner.delete_ops_lifecycle(runtime_id).await
     }
 }

--- a/meerkat-runtime/src/ops_lifecycle.rs
+++ b/meerkat-runtime/src/ops_lifecycle.rs
@@ -1043,12 +1043,6 @@ impl ShellState {
         }
     }
 
-    fn publish_completion_entries(&self, entries: Vec<CompletionEntry>) {
-        for entry in entries {
-            self.feed_buffer.push(entry);
-        }
-    }
-
     /// Read barrier membership from DSL state (sole owner).
     fn wait_operation_ids(&self) -> Result<Vec<OperationId>, OpsLifecycleError> {
         self.dsl
@@ -2584,6 +2578,21 @@ fn apply_op_transition(
         .map_err(|err| classify_generated_op_rejection(state, err, id, action))
 }
 
+fn apply_terminal_op_transition_and_persist(
+    state: &mut ShellState,
+    id: &OperationId,
+    input: mm_dsl::MeerkatMachineInput,
+    action: mm_dsl::OpLifecycleActionKind,
+) -> Result<(), OpsLifecycleError> {
+    let previous_snapshot = state.dsl.0.snapshot();
+    apply_op_transition(state, id, input, action)?;
+    if let Err(err) = state.maybe_persist() {
+        state.dsl.0.restore_snapshot(previous_snapshot);
+        return Err(err);
+    }
+    Ok(())
+}
+
 fn op_registration_error_from_effects(
     id: &OperationId,
     effects: &[mm_dsl::MeerkatMachineEffect],
@@ -2727,7 +2736,7 @@ impl OpsLifecycleRegistry for RuntimeOpsLifecycleRegistry {
         let terminal_outcome = OperationTerminalOutcome::Failed { error };
         let outcome_kind = mm_dsl::OperationTerminalOutcomeKind::from(&terminal_outcome);
 
-        apply_op_transition(
+        apply_terminal_op_transition_and_persist(
             &mut state,
             id,
             mm_dsl::MeerkatMachineInput::FailOp {
@@ -2739,7 +2748,6 @@ impl OpsLifecycleRegistry for RuntimeOpsLifecycleRegistry {
         )?;
 
         let completion_entry = state.finalize_terminal(id)?;
-        state.maybe_persist()?;
         state.publish_completion_entry(completion_entry);
         Ok(())
     }
@@ -2818,7 +2826,7 @@ impl OpsLifecycleRegistry for RuntimeOpsLifecycleRegistry {
         let terminal_outcome = OperationTerminalOutcome::Completed(result);
         let outcome_kind = mm_dsl::OperationTerminalOutcomeKind::from(&terminal_outcome);
 
-        apply_op_transition(
+        apply_terminal_op_transition_and_persist(
             &mut state,
             id,
             mm_dsl::MeerkatMachineInput::CompleteOp {
@@ -2830,7 +2838,6 @@ impl OpsLifecycleRegistry for RuntimeOpsLifecycleRegistry {
         )?;
 
         let completion_entry = state.finalize_terminal(id)?;
-        state.maybe_persist()?;
         state.publish_completion_entry(completion_entry);
         Ok(())
     }
@@ -2841,7 +2848,7 @@ impl OpsLifecycleRegistry for RuntimeOpsLifecycleRegistry {
         let terminal_outcome = OperationTerminalOutcome::Failed { error };
         let outcome_kind = mm_dsl::OperationTerminalOutcomeKind::from(&terminal_outcome);
 
-        apply_op_transition(
+        apply_terminal_op_transition_and_persist(
             &mut state,
             id,
             mm_dsl::MeerkatMachineInput::FailOp {
@@ -2853,7 +2860,6 @@ impl OpsLifecycleRegistry for RuntimeOpsLifecycleRegistry {
         )?;
 
         let completion_entry = state.finalize_terminal(id)?;
-        state.maybe_persist()?;
         state.publish_completion_entry(completion_entry);
         Ok(())
     }
@@ -2868,7 +2874,7 @@ impl OpsLifecycleRegistry for RuntimeOpsLifecycleRegistry {
         let terminal_outcome = OperationTerminalOutcome::Aborted { reason };
         let outcome_kind = mm_dsl::OperationTerminalOutcomeKind::from(&terminal_outcome);
 
-        apply_op_transition(
+        apply_terminal_op_transition_and_persist(
             &mut state,
             id,
             mm_dsl::MeerkatMachineInput::AbortOp {
@@ -2880,7 +2886,6 @@ impl OpsLifecycleRegistry for RuntimeOpsLifecycleRegistry {
         )?;
 
         let completion_entry = state.finalize_terminal(id)?;
-        state.maybe_persist()?;
         state.publish_completion_entry(completion_entry);
         Ok(())
     }
@@ -2895,7 +2900,7 @@ impl OpsLifecycleRegistry for RuntimeOpsLifecycleRegistry {
         let terminal_outcome = OperationTerminalOutcome::Cancelled { reason };
         let outcome_kind = mm_dsl::OperationTerminalOutcomeKind::from(&terminal_outcome);
 
-        apply_op_transition(
+        apply_terminal_op_transition_and_persist(
             &mut state,
             id,
             mm_dsl::MeerkatMachineInput::CancelOp {
@@ -2907,7 +2912,6 @@ impl OpsLifecycleRegistry for RuntimeOpsLifecycleRegistry {
         )?;
 
         let completion_entry = state.finalize_terminal(id)?;
-        state.maybe_persist()?;
         state.publish_completion_entry(completion_entry);
         Ok(())
     }
@@ -2932,7 +2936,7 @@ impl OpsLifecycleRegistry for RuntimeOpsLifecycleRegistry {
         let terminal_outcome = OperationTerminalOutcome::Retired;
         let outcome_kind = mm_dsl::OperationTerminalOutcomeKind::from(&terminal_outcome);
 
-        apply_op_transition(
+        apply_terminal_op_transition_and_persist(
             &mut state,
             id,
             mm_dsl::MeerkatMachineInput::RetireCompletedOp {
@@ -2944,7 +2948,6 @@ impl OpsLifecycleRegistry for RuntimeOpsLifecycleRegistry {
         )?;
 
         let completion_entry = state.finalize_terminal(id)?;
-        state.maybe_persist()?;
         state.publish_completion_entry(completion_entry);
         Ok(())
     }
@@ -3031,7 +3034,6 @@ impl OpsLifecycleRegistry for RuntimeOpsLifecycleRegistry {
         let mut state = self.write_state()?;
 
         let to_terminate = state.owner_termination_targets()?;
-        let mut completion_entries = Vec::new();
 
         for (op_id, _status) in &to_terminate {
             let terminal_outcome = OperationTerminalOutcome::Terminated {
@@ -3039,7 +3041,7 @@ impl OpsLifecycleRegistry for RuntimeOpsLifecycleRegistry {
             };
             let outcome_kind = mm_dsl::OperationTerminalOutcomeKind::from(&terminal_outcome);
 
-            apply_op_transition(
+            apply_terminal_op_transition_and_persist(
                 &mut state,
                 op_id,
                 mm_dsl::MeerkatMachineInput::TerminateOp {
@@ -3051,13 +3053,8 @@ impl OpsLifecycleRegistry for RuntimeOpsLifecycleRegistry {
             )?;
 
             if let Some(entry) = state.finalize_terminal(op_id)? {
-                completion_entries.push(entry);
+                state.publish_completion_entry(Some(entry));
             }
-        }
-
-        if !to_terminate.is_empty() {
-            state.maybe_persist()?;
-            state.publish_completion_entries(completion_entries);
         }
         Ok(())
     }
@@ -3741,7 +3738,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn completion_feed_does_not_publish_before_persistence_succeeds() {
+    async fn terminal_transition_rolls_back_publication_when_persistence_fails() {
         let registry = RuntimeOpsLifecycleRegistry::new();
         let (tx, mut rx) = crate::tokio::sync::mpsc::unbounded_channel();
         registry.set_persistence_channel(
@@ -3760,6 +3757,7 @@ mod tests {
         let op_id = spec.id.clone();
         registry.register_operation(spec).unwrap();
         registry.provisioning_succeeded(&op_id).unwrap();
+        let watch = registry.register_watcher(&op_id).unwrap();
 
         let err = registry
             .complete_operation(
@@ -3786,6 +3784,45 @@ mod tests {
             "completion feed must not publish entries before durable snapshot success"
         );
         assert_eq!(batch.watermark, 0);
+        assert!(
+            tokio::time::timeout(std::time::Duration::from_millis(10), watch)
+                .await
+                .is_err(),
+            "watchers must not resolve before durable terminal snapshot success"
+        );
+        assert_eq!(
+            registry.snapshot(&op_id).unwrap().unwrap().status,
+            OperationStatus::Running,
+            "failed persistence must roll the generated terminal transition back"
+        );
+
+        let (tx, mut rx) = crate::tokio::sync::mpsc::unbounded_channel();
+        registry.set_persistence_channel(
+            tx,
+            meerkat_core::RuntimeEpochId::new(),
+            Arc::new(meerkat_core::EpochCursorState::new()),
+        );
+        let worker = std::thread::spawn(move || {
+            let request = rx.blocking_recv().expect("second persistence request");
+            let _ = request.result_tx.send(Ok(()));
+        });
+        registry
+            .complete_operation(
+                &op_id,
+                OperationResult {
+                    id: op_id.clone(),
+                    content: "done".into(),
+                    is_error: false,
+                    duration_ms: 1,
+                    tokens_used: 0,
+                },
+            )
+            .expect("rolled-back terminal transition should remain retryable");
+        worker.join().expect("second persistence worker");
+
+        let batch = feed.list_since(0);
+        assert_eq!(batch.entries.len(), 1);
+        assert_eq!(batch.entries[0].operation_id, op_id);
     }
 
     #[tokio::test]

--- a/meerkat-runtime/src/ops_lifecycle.rs
+++ b/meerkat-runtime/src/ops_lifecycle.rs
@@ -939,7 +939,10 @@ impl ShellState {
     /// push generated-authorized CompletionEntry rows, retain in FIFO, evict
     /// as needed. Called AFTER the DSL transition has already persisted the
     /// terminal status + outcome.
-    fn finalize_terminal(&mut self, id: &OperationId) -> Result<(), OpsLifecycleError> {
+    fn finalize_terminal(
+        &mut self,
+        id: &OperationId,
+    ) -> Result<Option<CompletionEntry>, OpsLifecycleError> {
         let outcome = self.terminal_outcome(id)?.ok_or_else(|| {
             OpsLifecycleError::Internal(format!(
                 "generated op terminal transition did not mint terminal outcome for {id}"
@@ -963,9 +966,10 @@ impl ShellState {
             )?;
             self.records.remove(id);
             self.completed_order.retain(|queued| queued != id);
-            return Ok(());
+            return Ok(None);
         }
 
+        let mut completion_entry = None;
         if Self::operation_completion_feed_class(id, kind)?
             == mm_dsl::OperationCompletionFeedClass::Emit
         {
@@ -1001,7 +1005,7 @@ impl ShellState {
                 .records
                 .get(id)
                 .and_then(|r| r.completed_at.map(|i| r.epoch_millis_for_instant(i)));
-            self.feed_buffer.push(CompletionEntry {
+            completion_entry = Some(CompletionEntry {
                 seq: feed_authority.seq,
                 operation_id: id.clone(),
                 kind: feed_authority.kind,
@@ -1030,7 +1034,19 @@ impl ShellState {
         // drops the barrier oneshot so the waiter resolves to Err) instead of
         // reporting the op terminal with a silently-hung barrier.
         self.maybe_satisfy_wait()?;
-        Ok(())
+        Ok(completion_entry)
+    }
+
+    fn publish_completion_entry(&self, entry: Option<CompletionEntry>) {
+        if let Some(entry) = entry {
+            self.feed_buffer.push(entry);
+        }
+    }
+
+    fn publish_completion_entries(&self, entries: Vec<CompletionEntry>) {
+        for entry in entries {
+            self.feed_buffer.push(entry);
+        }
     }
 
     /// Read barrier membership from DSL state (sole owner).
@@ -2722,8 +2738,9 @@ impl OpsLifecycleRegistry for RuntimeOpsLifecycleRegistry {
             mm_dsl::OpLifecycleActionKind::Fail,
         )?;
 
-        state.finalize_terminal(id)?;
+        let completion_entry = state.finalize_terminal(id)?;
         state.maybe_persist()?;
+        state.publish_completion_entry(completion_entry);
         Ok(())
     }
 
@@ -2812,8 +2829,9 @@ impl OpsLifecycleRegistry for RuntimeOpsLifecycleRegistry {
             mm_dsl::OpLifecycleActionKind::Complete,
         )?;
 
-        state.finalize_terminal(id)?;
+        let completion_entry = state.finalize_terminal(id)?;
         state.maybe_persist()?;
+        state.publish_completion_entry(completion_entry);
         Ok(())
     }
 
@@ -2834,8 +2852,9 @@ impl OpsLifecycleRegistry for RuntimeOpsLifecycleRegistry {
             mm_dsl::OpLifecycleActionKind::Fail,
         )?;
 
-        state.finalize_terminal(id)?;
+        let completion_entry = state.finalize_terminal(id)?;
         state.maybe_persist()?;
+        state.publish_completion_entry(completion_entry);
         Ok(())
     }
 
@@ -2860,8 +2879,9 @@ impl OpsLifecycleRegistry for RuntimeOpsLifecycleRegistry {
             mm_dsl::OpLifecycleActionKind::Abort,
         )?;
 
-        state.finalize_terminal(id)?;
+        let completion_entry = state.finalize_terminal(id)?;
         state.maybe_persist()?;
+        state.publish_completion_entry(completion_entry);
         Ok(())
     }
 
@@ -2886,8 +2906,9 @@ impl OpsLifecycleRegistry for RuntimeOpsLifecycleRegistry {
             mm_dsl::OpLifecycleActionKind::Cancel,
         )?;
 
-        state.finalize_terminal(id)?;
+        let completion_entry = state.finalize_terminal(id)?;
         state.maybe_persist()?;
+        state.publish_completion_entry(completion_entry);
         Ok(())
     }
 
@@ -2922,8 +2943,9 @@ impl OpsLifecycleRegistry for RuntimeOpsLifecycleRegistry {
             mm_dsl::OpLifecycleActionKind::RetireCompleted,
         )?;
 
-        state.finalize_terminal(id)?;
+        let completion_entry = state.finalize_terminal(id)?;
         state.maybe_persist()?;
+        state.publish_completion_entry(completion_entry);
         Ok(())
     }
 
@@ -3009,6 +3031,7 @@ impl OpsLifecycleRegistry for RuntimeOpsLifecycleRegistry {
         let mut state = self.write_state()?;
 
         let to_terminate = state.owner_termination_targets()?;
+        let mut completion_entries = Vec::new();
 
         for (op_id, _status) in &to_terminate {
             let terminal_outcome = OperationTerminalOutcome::Terminated {
@@ -3027,11 +3050,14 @@ impl OpsLifecycleRegistry for RuntimeOpsLifecycleRegistry {
                 mm_dsl::OpLifecycleActionKind::Terminate,
             )?;
 
-            state.finalize_terminal(op_id)?;
+            if let Some(entry) = state.finalize_terminal(op_id)? {
+                completion_entries.push(entry);
+            }
         }
 
         if !to_terminate.is_empty() {
             state.maybe_persist()?;
+            state.publish_completion_entries(completion_entries);
         }
         Ok(())
     }
@@ -3712,6 +3738,54 @@ mod tests {
             [(returned_id, OperationTerminalOutcome::Completed(_))] if *returned_id == op_id
         ));
         assert!(registry.read_state().unwrap().wait_request_id.is_none());
+    }
+
+    #[tokio::test]
+    async fn completion_feed_does_not_publish_before_persistence_succeeds() {
+        let registry = RuntimeOpsLifecycleRegistry::new();
+        let (tx, mut rx) = crate::tokio::sync::mpsc::unbounded_channel();
+        registry.set_persistence_channel(
+            tx,
+            meerkat_core::RuntimeEpochId::new(),
+            Arc::new(meerkat_core::EpochCursorState::new()),
+        );
+        let worker = std::thread::spawn(move || {
+            let request = rx.blocking_recv().expect("persistence request");
+            let _ = request.result_tx.send(Err(OpsLifecycleError::Internal(
+                "injected persistence failure".to_string(),
+            )));
+        });
+
+        let spec = background_spec("feed-after-persist");
+        let op_id = spec.id.clone();
+        registry.register_operation(spec).unwrap();
+        registry.provisioning_succeeded(&op_id).unwrap();
+
+        let err = registry
+            .complete_operation(
+                &op_id,
+                OperationResult {
+                    id: op_id.clone(),
+                    content: "done".into(),
+                    is_error: false,
+                    duration_ms: 1,
+                    tokens_used: 0,
+                },
+            )
+            .expect_err("persistence failure must fail the terminal transition");
+        assert!(
+            matches!(&err, OpsLifecycleError::Internal(message) if message.contains("injected persistence failure")),
+            "unexpected persistence error: {err:?}"
+        );
+        worker.join().expect("persistence worker");
+
+        let feed = registry.completion_feed_handle();
+        let batch = feed.list_since(0);
+        assert!(
+            batch.entries.is_empty(),
+            "completion feed must not publish entries before durable snapshot success"
+        );
+        assert_eq!(batch.watermark, 0);
     }
 
     #[tokio::test]

--- a/meerkat-session/src/event_store.rs
+++ b/meerkat-session/src/event_store.rs
@@ -95,6 +95,19 @@ impl StoredEvent {
 /// any row whose `schema_version` does not match this constant.
 pub const EVENT_SCHEMA_VERSION: u32 = 2;
 
+/// Durable marker that a session's detached event projection halted.
+///
+/// The event log remains the replay authority, but a projection task that
+/// observes an append failure has no caller to return to. File-backed stores
+/// persist this marker beside the log so restarted services keep failing replay
+/// closed instead of forgetting the halt in a process-local map.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EventProjectionHaltMarker {
+    pub session_id: SessionId,
+    pub reason: String,
+    pub recorded_at: SystemTime,
+}
+
 /// Append-only event log.
 ///
 /// The canonical append surface is [`EventStore::append_envelopes`], which
@@ -142,6 +155,23 @@ pub trait EventStore: Send + Sync {
             })
             .collect();
         self.append_envelopes(session_id, &envelopes).await
+    }
+
+    /// Persist a fail-closed marker after detached event projection halts.
+    async fn record_projection_halt(
+        &self,
+        _session_id: &SessionId,
+        _reason: &str,
+    ) -> Result<(), EventStoreError> {
+        Ok(())
+    }
+
+    /// Read a durable projection-halt marker, if this store supports one.
+    async fn projection_halt(
+        &self,
+        _session_id: &SessionId,
+    ) -> Result<Option<EventProjectionHaltMarker>, EventStoreError> {
+        Ok(None)
     }
 
     /// Read events from a given sequence number onward.
@@ -218,6 +248,15 @@ impl FileEventStore {
 
     fn sequence_lock_path(&self, session_id: &SessionId) -> PathBuf {
         self.sequence_dir().join(format!("{session_id}.lock"))
+    }
+
+    fn projection_halt_dir(&self) -> PathBuf {
+        self.root.join(".projection-halts")
+    }
+
+    fn projection_halt_path(&self, session_id: &SessionId) -> PathBuf {
+        self.projection_halt_dir()
+            .join(format!("{session_id}.json"))
     }
 
     async fn acquire_sequence_lock(
@@ -395,6 +434,50 @@ impl EventStore for FileEventStore {
         Ok(last_allocated_seq)
     }
 
+    async fn record_projection_halt(
+        &self,
+        session_id: &SessionId,
+        reason: &str,
+    ) -> Result<(), EventStoreError> {
+        let marker = EventProjectionHaltMarker {
+            session_id: session_id.clone(),
+            reason: reason.to_string(),
+            recorded_at: SystemTime::now(),
+        };
+        let path = self.projection_halt_path(session_id);
+        if let Some(parent) = path.parent() {
+            tokio::fs::create_dir_all(parent).await?;
+        }
+        let bytes = serde_json::to_vec_pretty(&marker)
+            .map_err(|err| EventStoreError::Serialization(err.to_string()))?;
+        let mut file = tokio::fs::OpenOptions::new()
+            .create(true)
+            .write(true)
+            .truncate(true)
+            .open(&path)
+            .await?;
+        file.write_all(&bytes).await?;
+        file.write_all(b"\n").await?;
+        file.flush().await?;
+        file.sync_all().await?;
+        Ok(())
+    }
+
+    async fn projection_halt(
+        &self,
+        session_id: &SessionId,
+    ) -> Result<Option<EventProjectionHaltMarker>, EventStoreError> {
+        let path = self.projection_halt_path(session_id);
+        let contents = match tokio::fs::read_to_string(path).await {
+            Ok(contents) => contents,
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+            Err(err) => return Err(EventStoreError::Io(err)),
+        };
+        serde_json::from_str::<EventProjectionHaltMarker>(&contents)
+            .map(Some)
+            .map_err(|err| EventStoreError::Serialization(err.to_string()))
+    }
+
     async fn read_from(
         &self,
         session_id: &SessionId,
@@ -471,6 +554,28 @@ mod tests {
         assert_eq!(events.len(), 1);
         assert!(matches!(events[0].event, AgentEvent::TextComplete { .. }));
         assert!(store.root().join(format!("{session_id}.jsonl")).exists());
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn file_event_store_persists_projection_halt_marker()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let temp = tempfile::tempdir()?;
+        let root = temp.path().join("events");
+        let store = FileEventStore::new(&root);
+        let session_id = SessionId::new();
+
+        store
+            .record_projection_halt(&session_id, "synthetic append failure")
+            .await?;
+
+        let restarted = FileEventStore::new(&root);
+        let marker = restarted
+            .projection_halt(&session_id)
+            .await?
+            .expect("halt marker should survive store restart");
+        assert_eq!(marker.session_id, session_id);
+        assert_eq!(marker.reason, "synthetic append failure");
         Ok(())
     }
 

--- a/meerkat-session/src/persistent.rs
+++ b/meerkat-session/src/persistent.rs
@@ -130,16 +130,43 @@ pub struct EventProjectionHalted {
     cause: Arc<SessionError>,
 }
 
+/// Typed source carried by a durable halt marker after process restart.
+#[derive(Debug, thiserror::Error)]
+#[error("durable event projection halt marker for session {session_id}: {reason}")]
+pub struct DurableEventProjectionHaltMarker {
+    session_id: SessionId,
+    reason: String,
+}
+
+fn event_projection_halted_error(session_id: &SessionId, cause: Arc<SessionError>) -> SessionError {
+    SessionError::Store(Box::new(EventProjectionHalted {
+        session_id: session_id.clone(),
+        cause,
+    }))
+}
+
 async fn record_event_projection_fault(
     faults: &EventProjectionFaultRegistry,
+    event_store: &Arc<dyn EventStore>,
     session_id: &SessionId,
     error: SessionError,
 ) {
+    let cause = Arc::new(error);
+    if let Err(marker_error) = event_store
+        .record_projection_halt(session_id, &cause.to_string())
+        .await
+    {
+        tracing::error!(
+            session_id = %session_id,
+            error = %marker_error,
+            "failed to persist durable event projection halt marker"
+        );
+    }
     faults
         .lock()
         .await
         .entry(session_id.clone())
-        .or_insert_with(|| Arc::new(error));
+        .or_insert(cause);
 }
 
 async fn append_and_project_event(
@@ -230,7 +257,13 @@ async fn project_create_time_events(
                             error = %error,
                             "create-time event projection halted: durable event append failed"
                         );
-                        record_event_projection_fault(&projection_faults, session_id, error).await;
+                        record_event_projection_fault(
+                            &projection_faults,
+                            &event_store,
+                            session_id,
+                            error,
+                        )
+                        .await;
                         break;
                     }
                 } else {
@@ -251,7 +284,13 @@ async fn project_create_time_events(
                         error = %error,
                         "create-time event projection halted: durable event append failed"
                     );
-                    record_event_projection_fault(&projection_faults, session_id, error).await;
+                    record_event_projection_fault(
+                        &projection_faults,
+                        &event_store,
+                        session_id,
+                        error,
+                    )
+                    .await;
                     break;
                 }
             }
@@ -267,7 +306,7 @@ async fn project_create_time_events(
             error = %error,
             "final create-time event projection flush failed: durable event append failed"
         );
-        record_event_projection_fault(&projection_faults, session_id, error).await;
+        record_event_projection_fault(&projection_faults, &event_store, session_id, error).await;
     }
 }
 
@@ -3768,14 +3807,26 @@ impl<B: SessionAgentBuilder + 'static> PersistentSessionService<B> {
         let Some(event_store) = self.event_store.as_ref() else {
             return Ok(None);
         };
+        if let Some(marker) = event_store
+            .projection_halt(id)
+            .await
+            .map_err(|err| SessionError::Store(Box::new(err)))?
+        {
+            return Err(event_projection_halted_error(
+                id,
+                Arc::new(SessionError::Store(Box::new(
+                    DurableEventProjectionHaltMarker {
+                        session_id: marker.session_id,
+                        reason: marker.reason,
+                    },
+                ))),
+            ));
+        }
         // Fail closed if this session's projection task halted on a durable
         // append failure: the log has a sequence hole from the halt point, so
         // serving it as replay truth would launder the recorded typed fault.
         if let Some(cause) = self.event_projection_faults.lock().await.get(id) {
-            return Err(SessionError::Store(Box::new(EventProjectionHalted {
-                session_id: id.clone(),
-                cause: Arc::clone(cause),
-            })));
+            return Err(event_projection_halted_error(id, Arc::clone(cause)));
         }
         event_store
             .read_from(id, from_seq)
@@ -3843,7 +3894,13 @@ impl<B: SessionAgentBuilder + 'static> PersistentSessionService<B> {
                         error = %error,
                         "event projection halted: durable event append failed"
                     );
-                    record_event_projection_fault(&projection_faults, &session_id, error).await;
+                    record_event_projection_fault(
+                        &projection_faults,
+                        &event_store,
+                        &session_id,
+                        error,
+                    )
+                    .await;
                     break;
                 }
             }
@@ -6637,6 +6694,54 @@ mod tests {
                 .await?
                 .is_some_and(|events| events.is_empty())
         );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn durable_event_projection_halt_marker_fails_replay_after_restart()
+    -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+        // Gate: the replay stop condition must not be only process-local. A
+        // restarted service over the same file event store must observe the
+        // durable halt marker before it serves any event-log replay.
+        let dir = tempfile::tempdir()?;
+        let event_root = dir.path().join("events");
+        let session_id = SessionId::new();
+        let initial_store = crate::event_store::FileEventStore::new(&event_root);
+        initial_store
+            .record_projection_halt(&session_id, "injected durable append failure")
+            .await?;
+
+        let store: Arc<dyn SessionStore> = Arc::new(MemoryStore::new());
+        let restarted_event_store: Arc<dyn EventStore> =
+            Arc::new(crate::event_store::FileEventStore::new(&event_root));
+        let projector = Arc::new(SessionProjector::new(dir.path().join(".rkat")));
+        let restarted = PersistentSessionService::new(
+            DummyBuilder,
+            4,
+            Arc::clone(&store),
+            None,
+            memory_blob_store(),
+        )
+        .with_event_projection(restarted_event_store, projector);
+
+        let err = restarted
+            .event_log_read_from(&session_id, 0)
+            .await
+            .expect_err("durable halt marker must fail replay after restart");
+        match err {
+            SessionError::Store(source) => {
+                let halted = source
+                    .downcast_ref::<EventProjectionHalted>()
+                    .expect("expected typed EventProjectionHalted replay error");
+                let cause = halted.cause.as_ref();
+                assert!(
+                    matches!(cause, SessionError::Store(marker)
+                        if marker.downcast_ref::<DurableEventProjectionHaltMarker>().is_some()),
+                    "expected durable marker source, got: {cause}"
+                );
+            }
+            other => panic!("expected SessionError::Store, got: {other}"),
+        }
         Ok(())
     }
 

--- a/scripts/buildbuddy-agent-gate
+++ b/scripts/buildbuddy-agent-gate
@@ -186,28 +186,22 @@ is_global_path() {
 # "no build-relevant changes". Matched separately so they escalate to `make`
 # governance targets instead of the BuildBuddy changed-path test/build gate.
 is_governance_path() {
-  case "${1#./}" in
-    specs/machines/*|specs/compositions/*)
+  local path="${1#./}"
+  if scripts/machine-authority-changed -- "${path}" >/dev/null 2>&1; then
+    return 0
+  fi
+  case "${path}" in
+    .claude/skills/meerkat-dogma-inquisition/*|docs/architecture/meerkat-dogma.md|docs/architecture/meerkat-dogma-commentary.md|docs-internal/dogma-audits/*)
       return 0
-      ;;
-    xtask/rmat-baseline.toml|xtask/ownership-baseline.toml|xtask/src/rmat_policy.rs|xtask/src/seam_inventory.rs|xtask/src/ownership_ledger.rs|xtask/src/rmat_audit.rs|docs-internal/archive/public-docs-removed-2026-05-11/architecture/finite-ownership-ledger.md)
-      return 0
-      ;;
-    .claude/skills/meerkat-dogma-inquisition/*)
-      return 0
-      ;;
-    docs/architecture/meerkat-dogma.md|docs/architecture/meerkat-dogma-commentary.md|docs-internal/dogma-audits/*)
-      return 0
-      ;;
-    *)
-      return 1
       ;;
   esac
+  return 1
 }
 
 mapfile -t changed < <(collect_changed_paths | awk 'NF' | sort -u)
 relevant=()
 governance=()
+generated_contract=()
 global=0
 for path in "${changed[@]}"; do
   if is_relevant_path "${path}"; then
@@ -219,9 +213,12 @@ for path in "${changed[@]}"; do
   if is_governance_path "${path}"; then
     governance+=("${path}")
   fi
+  if scripts/generated-contract-ratchet-changed -- "${path}" >/dev/null 2>&1; then
+    generated_contract+=("${path}")
+  fi
 done
 
-if [[ "${#relevant[@]}" -eq 0 && "${#governance[@]}" -eq 0 ]]; then
+if [[ "${#relevant[@]}" -eq 0 && "${#governance[@]}" -eq 0 && "${#generated_contract[@]}" -eq 0 ]]; then
   echo "BuildBuddy agent gate: no build-relevant changes detected."
   exit 0
 fi
@@ -237,8 +234,19 @@ if [[ "${#governance[@]}" -gt 0 ]]; then
   fi
 fi
 
+if [[ "${#generated_contract[@]}" -gt 0 ]]; then
+  printf 'BuildBuddy agent gate generated contract paths:\n'
+  printf '  %s\n' "${generated_contract[@]}"
+  echo "Generated schemas/SDK contracts changed; running freshness and surface ratchets."
+  if [[ "${dry_run}" -eq 1 ]]; then
+    echo "DRY-RUN make verify-schema-freshness verify-sdk-codegen-freshness verify-sdk-event-inventory verify-rpc-surface-alignment verify-rest-surface-alignment"
+  else
+    make verify-schema-freshness verify-sdk-codegen-freshness verify-sdk-event-inventory verify-rpc-surface-alignment verify-rest-surface-alignment
+  fi
+fi
+
 if [[ "${#relevant[@]}" -eq 0 ]]; then
-  echo "BuildBuddy agent gate: no build-relevant changes detected (governance checks ran above)."
+  echo "BuildBuddy agent gate: no build-relevant changes detected (non-build ratchets ran above)."
   exit 0
 fi
 

--- a/scripts/buildbuddy-doctor
+++ b/scripts/buildbuddy-doctor
@@ -604,7 +604,7 @@ if grep -Fq '//xtask:machine_verify_all_tlc_test' scripts/buildbuddy-bazel-poc &
   grep -Fq '@@rules_rust++rust+rustfmt_nightly-2026-04-16__aarch64-apple-darwin_tools//:rustc_lib' xtask/BUILD.bazel &&
   grep -Fq '"RUSTFMT": "$(rootpath tests/rustfmt_host.sh)"' xtask/BUILD.bazel &&
   grep -Fq 'export RUSTFMT' xtask/tests/machine_verify_all_tlc_test.sh; then
-  pass "BuildBuddy machine-authority lane runs hermetic machine-verify with hermetic rustfmt, bounded adaptive witness, broad-composition structural guards, and fail-closed missing-TLC behavior"
+  pass "BuildBuddy machine-authority lane runs hermetic machine-verify with hermetic rustfmt, bounded adaptive witness, broad-composition structural guards, and fails closed when tlc is absent"
 else
   bad "BuildBuddy machine-authority lane does not run hermetic machine-verify, lacks the bounded adaptive witness/broad-composition structural guards, or still launders a silent no-TLC drift fallback as TLC verification"
 fi

--- a/scripts/cargo-agent-gate
+++ b/scripts/cargo-agent-gate
@@ -149,23 +149,16 @@ is_rust_relevant_path() {
 # "no build-relevant changes". These are matched separately from Rust paths so
 # they escalate to `make` governance targets instead of package-scoped nextest.
 is_governance_path() {
-  case "${1#./}" in
-    specs/machines/*|specs/compositions/*)
+  local path="${1#./}"
+  if scripts/machine-authority-changed -- "${path}" >/dev/null 2>&1; then
+    return 0
+  fi
+  case "${path}" in
+    .claude/skills/meerkat-dogma-inquisition/*|docs/architecture/meerkat-dogma.md|docs/architecture/meerkat-dogma-commentary.md|docs-internal/dogma-audits/*)
       return 0
-      ;;
-    xtask/rmat-baseline.toml|xtask/ownership-baseline.toml|xtask/src/rmat_policy.rs|xtask/src/seam_inventory.rs|xtask/src/ownership_ledger.rs|xtask/src/rmat_audit.rs|docs-internal/archive/public-docs-removed-2026-05-11/architecture/finite-ownership-ledger.md)
-      return 0
-      ;;
-    .claude/skills/meerkat-dogma-inquisition/*)
-      return 0
-      ;;
-    docs/architecture/meerkat-dogma.md|docs/architecture/meerkat-dogma-commentary.md|docs-internal/dogma-audits/*)
-      return 0
-      ;;
-    *)
-      return 1
       ;;
   esac
+  return 1
 }
 
 is_global_path() {
@@ -215,6 +208,7 @@ done < <(collect_changed_paths | awk 'NF' | sort -u)
 
 relevant=()
 governance=()
+generated_contract=()
 global=0
 if [[ "${#changed[@]}" -gt 0 ]]; then
   for path in "${changed[@]}"; do
@@ -227,10 +221,13 @@ if [[ "${#changed[@]}" -gt 0 ]]; then
     if is_governance_path "${path}"; then
       governance+=("${path}")
     fi
+    if scripts/generated-contract-ratchet-changed -- "${path}" >/dev/null 2>&1; then
+      generated_contract+=("${path}")
+    fi
   done
 fi
 
-if [[ "${#relevant[@]}" -eq 0 && "${#governance[@]}" -eq 0 ]]; then
+if [[ "${#relevant[@]}" -eq 0 && "${#governance[@]}" -eq 0 && "${#generated_contract[@]}" -eq 0 ]]; then
   echo "Cargo agent gate: no Rust build-relevant changes detected."
   exit 0
 fi
@@ -250,8 +247,19 @@ if [[ "${#governance[@]}" -gt 0 ]]; then
   run_governance_gate
 fi
 
+if [[ "${#generated_contract[@]}" -gt 0 ]]; then
+  printf 'Cargo agent gate generated contract paths:\n'
+  printf '  %s\n' "${generated_contract[@]}"
+  echo "Generated schemas/SDK contracts changed; running freshness and surface ratchets."
+  if [[ "${dry_run}" -eq 1 ]]; then
+    echo "DRY-RUN make verify-schema-freshness verify-sdk-codegen-freshness verify-sdk-event-inventory verify-rpc-surface-alignment verify-rest-surface-alignment"
+  else
+    make verify-schema-freshness verify-sdk-codegen-freshness verify-sdk-event-inventory verify-rpc-surface-alignment verify-rest-surface-alignment
+  fi
+fi
+
 if [[ "${#relevant[@]}" -eq 0 ]]; then
-  echo "Cargo agent gate: no Rust build-relevant changes detected (governance checks ran above)."
+  echo "Cargo agent gate: no Rust build-relevant changes detected (non-Rust ratchets ran above)."
   exit 0
 fi
 

--- a/scripts/generated-contract-ratchet-changed
+++ b/scripts/generated-contract-ratchet-changed
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+usage: generated-contract-ratchet-changed [--base <rev> --head <rev>] [changed-path ...]
+
+Exits 0 when any changed path can affect generated public contract ratchets
+(schemas, SDK generated types/wrappers, or SDK codegen tooling). Exits 1 when
+the supplied or diffed paths are unrelated.
+EOF
+}
+
+base=""
+head=""
+paths=()
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --base)
+      if [[ $# -lt 2 ]]; then
+        echo "error: --base requires a revision" >&2
+        usage >&2
+        exit 2
+      fi
+      base="$2"
+      shift 2
+      ;;
+    --head)
+      if [[ $# -lt 2 ]]; then
+        echo "error: --head requires a revision" >&2
+        usage >&2
+        exit 2
+      fi
+      head="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    --)
+      shift
+      while [[ $# -gt 0 ]]; do
+        paths+=("$1")
+        shift
+      done
+      ;;
+    -*)
+      echo "unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+    *)
+      paths+=("$1")
+      shift
+      ;;
+  esac
+done
+
+if [[ -n "${base}" || -n "${head}" ]]; then
+  if [[ -z "${base}" || -z "${head}" ]]; then
+    echo "error: --base and --head must be supplied together" >&2
+    usage >&2
+    exit 2
+  fi
+  diff_output="$(git diff --name-only "${base}" "${head}" --)" || {
+    echo "error: cannot diff ${base}..${head}" >&2
+    exit 2
+  }
+  paths=()
+  if [[ -n "${diff_output}" ]]; then
+    while IFS= read -r path; do
+      paths+=("${path}")
+    done <<<"${diff_output}"
+  fi
+fi
+
+generated_contract_path() {
+  local path="${1#./}"
+  case "${path}" in
+    artifacts/schemas/*.json)
+      return 0
+      ;;
+    sdks/python/meerkat/generated/*|sdks/typescript/src/generated/*|sdks/web/src/generated/*)
+      return 0
+      ;;
+    tools/sdk-codegen/*|tools/sdk-codegen/**/*)
+      return 0
+      ;;
+    meerkat-contracts/src/emit.rs|meerkat-contracts/src/rpc_catalog.rs|meerkat-contracts/src/rest_catalog.rs|meerkat-contracts/src/wire/*)
+      return 0
+      ;;
+    xtask/src/public_contracts.rs|xtask/tests/protocol_codegen_drift.rs)
+      return 0
+      ;;
+  esac
+  return 1
+}
+
+for path in "${paths[@]}"; do
+  if generated_contract_path "${path}"; then
+    echo "generated-contract ratchet changed: ${path}"
+    exit 0
+  fi
+done
+
+echo "generated-contract ratchet unchanged"
+exit 1

--- a/scripts/generated-contract-ratchet-changed
+++ b/scripts/generated-contract-ratchet-changed
@@ -5,9 +5,10 @@ usage() {
   cat <<'EOF'
 usage: generated-contract-ratchet-changed [--base <rev> --head <rev>] [changed-path ...]
 
-Exits 0 when any changed path can affect generated public contract ratchets
-(schemas, SDK generated types/wrappers, or SDK codegen tooling). Exits 1 when
-the supplied or diffed paths are unrelated.
+Exits 0 when any changed path can affect generated public contract ratchets or
+surface alignment ratchets (schemas, SDK generated types/wrappers, SDK codegen
+tooling, RPC/REST/MCP public surfaces, and surface docs). Exits 1 when the
+supplied or diffed paths are unrelated.
 EOF
 }
 
@@ -89,6 +90,24 @@ generated_contract_path() {
       return 0
       ;;
     meerkat-contracts/src/emit.rs|meerkat-contracts/src/rpc_catalog.rs|meerkat-contracts/src/rest_catalog.rs|meerkat-contracts/src/wire/*)
+      return 0
+      ;;
+    meerkat-rpc/src/*|meerkat-rpc/src/**/*)
+      return 0
+      ;;
+    meerkat-rest/src/*|meerkat-rest/src/**/*)
+      return 0
+      ;;
+    meerkat-mcp/src/router.rs)
+      return 0
+      ;;
+    meerkat-mob-mcp/src/*|meerkat-mob-mcp/src/**/*)
+      return 0
+      ;;
+    docs/api/*|docs/api/**/*)
+      return 0
+      ;;
+    sdks/python/README.md|sdks/typescript/README.md|sdks/web/README.md)
       return 0
       ;;
     xtask/src/public_contracts.rs|xtask/tests/protocol_codegen_drift.rs)

--- a/scripts/tests/xtask_scripts_dogma_gates.sh
+++ b/scripts/tests/xtask_scripts_dogma_gates.sh
@@ -166,6 +166,20 @@ if printf '%s' "$sdk_gate_out" | grep -Fq 'verify-schema-freshness verify-sdk-co
 else
   bad "buildbuddy-agent-gate dry-run did not route SDK generated artifacts"
 fi
+surface_gate_out=$(scripts/cargo-agent-gate --dry-run -- meerkat-mcp/src/router.rs meerkat-mob-mcp/src/agent_tools.rs docs/api/mcp.mdx sdks/typescript/README.md 2>&1 || true)
+if printf '%s' "$surface_gate_out" | grep -Fq 'verify-schema-freshness verify-sdk-codegen-freshness verify-sdk-event-inventory verify-rpc-surface-alignment verify-rest-surface-alignment' \
+  && ! printf '%s' "$surface_gate_out" | grep -Fq 'no Rust build-relevant changes detected.'; then
+  ok "cargo-agent-gate dry-run routes public surface docs/router/mob-mcp changes to generated contract ratchets"
+else
+  bad "cargo-agent-gate dry-run did not route public surface docs/router/mob-mcp changes"
+fi
+rest_gate_out=$(scripts/buildbuddy-agent-gate --dry-run -- meerkat-rest/src/lib.rs meerkat-rpc/src/session_runtime.rs 2>&1 || true)
+if printf '%s' "$rest_gate_out" | grep -Fq 'verify-schema-freshness verify-sdk-codegen-freshness verify-sdk-event-inventory verify-rpc-surface-alignment verify-rest-surface-alignment' \
+  && ! printf '%s' "$rest_gate_out" | grep -Fq 'no build-relevant changes detected.'; then
+  ok "buildbuddy-agent-gate dry-run routes RPC/REST surface changes to generated contract ratchets"
+else
+  bad "buildbuddy-agent-gate dry-run did not route RPC/REST surface changes"
+fi
 
 # ── #266: dogma doctrine mirror is a CI gate ─────────────────────────────────
 echo "#266 dogma skill doctrine mirror is gated in CI:"

--- a/scripts/tests/xtask_scripts_dogma_gates.sh
+++ b/scripts/tests/xtask_scripts_dogma_gates.sh
@@ -138,6 +138,34 @@ if printf '%s' "$gate_out" | grep -Fq 'machine-check-drift seam-inventory rmat-a
 else
   bad "cargo-agent-gate dry-run did not route specs/machines change to governance gate"
 fi
+generated_machine_gate_out=$(scripts/cargo-agent-gate --dry-run -- meerkat-machine-schema/src/catalog/dsl/meerkat_machine.rs 2>&1 || true)
+if printf '%s' "$generated_machine_gate_out" | grep -Fq 'machine-check-drift seam-inventory rmat-audit' \
+  && ! printf '%s' "$generated_machine_gate_out" | grep -Fq 'no Rust build-relevant changes detected.'; then
+  ok "cargo-agent-gate dry-run routes generated machine catalog changes to governance gate"
+else
+  bad "cargo-agent-gate dry-run did not route generated machine catalog changes"
+fi
+generated_buildbuddy_gate_out=$(scripts/buildbuddy-agent-gate --dry-run -- meerkat-core/src/generated/protocol_runtime.rs 2>&1 || true)
+if printf '%s' "$generated_buildbuddy_gate_out" | grep -Fq 'machine-check-drift seam-inventory rmat-audit' \
+  && ! printf '%s' "$generated_buildbuddy_gate_out" | grep -Fq 'no build-relevant changes detected.'; then
+  ok "buildbuddy-agent-gate dry-run routes generated protocol changes to governance gate"
+else
+  bad "buildbuddy-agent-gate dry-run did not route generated protocol changes"
+fi
+schema_gate_out=$(scripts/cargo-agent-gate --dry-run -- artifacts/schemas/rest-openapi.json 2>&1 || true)
+if printf '%s' "$schema_gate_out" | grep -Fq 'verify-schema-freshness verify-sdk-codegen-freshness verify-sdk-event-inventory verify-rpc-surface-alignment verify-rest-surface-alignment' \
+  && ! printf '%s' "$schema_gate_out" | grep -Fq 'no Rust build-relevant changes detected.'; then
+  ok "cargo-agent-gate dry-run routes schema artifacts to generated contract ratchets"
+else
+  bad "cargo-agent-gate dry-run did not route schema artifacts to generated contract ratchets"
+fi
+sdk_gate_out=$(scripts/buildbuddy-agent-gate --dry-run -- sdks/typescript/src/generated/types.ts sdks/python/meerkat/generated/types.py 2>&1 || true)
+if printf '%s' "$sdk_gate_out" | grep -Fq 'verify-schema-freshness verify-sdk-codegen-freshness verify-sdk-event-inventory verify-rpc-surface-alignment verify-rest-surface-alignment' \
+  && ! printf '%s' "$sdk_gate_out" | grep -Fq 'no build-relevant changes detected.'; then
+  ok "buildbuddy-agent-gate dry-run routes SDK generated artifacts to generated contract ratchets"
+else
+  bad "buildbuddy-agent-gate dry-run did not route SDK generated artifacts"
+fi
 
 # ── #266: dogma doctrine mirror is a CI gate ─────────────────────────────────
 echo "#266 dogma skill doctrine mirror is gated in CI:"

--- a/sdks/python/README.md
+++ b/sdks/python/README.md
@@ -81,9 +81,9 @@ Both use integer unix timestamps for `created_at` and `updated_at`.
 
 `DeferredSession.start_turn(...)` supports the same override set.
 
-### Config APIs return envelopes
+### Config APIs return config write results
 
-`get_config`, `set_config`, and `patch_config` return a `ConfigEnvelope`:
+`get_config` returns a `ConfigEnvelope`:
 
 ```python
 {
@@ -95,6 +95,9 @@ Both use integer unix timestamps for `created_at` and `updated_at`.
   "resolved_paths": {...} | None,
 }
 ```
+
+`set_config` and `patch_config` return the same envelope fields plus optional
+`live_propagation` when a write fans out to live channels.
 
 Example:
 

--- a/sdks/typescript/README.md
+++ b/sdks/typescript/README.md
@@ -266,18 +266,18 @@ Returns a config envelope: `{ config, generation, realmId?, instanceId?, backend
 ### setConfig(config)
 
 ```ts
-async setConfig(config: Record<string, unknown>): Promise<ConfigEnvelope>
+async setConfig(config: Record<string, unknown>): Promise<ConfigWriteResult>
 ```
 
-Replaces the entire runtime configuration and returns the updated envelope.
+Replaces the entire runtime configuration and returns the updated envelope plus any live-propagation report.
 
 ### patchConfig(patch)
 
 ```ts
-async patchConfig(patch: Record<string, unknown>): Promise<ConfigEnvelope>
+async patchConfig(patch: Record<string, unknown>): Promise<ConfigWriteResult>
 ```
 
-Merge-patches the runtime configuration and returns the updated envelope.
+Merge-patches the runtime configuration and returns the updated envelope plus any live-propagation report.
 
 ## Public Types
 


### PR DESCRIPTION
## Summary
- validated all 12 active dogma-ledger claims with scoped/adversarial review and fixed the surviving real items
- added machine/runtime authority gates for model fallback, auth signing, durable projection halts, mob cancellation cleanup, unregister rollback, completion feed ordering, MCP duplicate projection, and adaptive identity canonicalization
- updated generated-contract ratchets and refreshed the dogma ledger to zero active rows

## Validation
- make agent-gate
- make buildbuddy-generate-check audit-generated-headers
- ./scripts/tests/xtask_scripts_dogma_gates.sh
- targeted regression tests across meerkat-core, meerkat-session, meerkat-mcp, meerkat-auth-core, meerkat-rpc, meerkat-mob-mcp, meerkat-mob, and meerkat-runtime

Note: repo label codex-automation was not present, so this PR is labeled codex.