### PR TITLE
Implement machine-driven execution control

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -8,6 +8,23 @@
 # wrappers left behind explicit `cargo e2e-*` aliases.
 default-filter = 'not binary(e2e_auth_lane) and not binary(e2e_build_lane) and not binary(e2e_fast_lane) and not binary(e2e_system_lane) and not binary(e2e_live_lane) and not binary(e2e_smoke_lane) and not binary(e2e_models_lane)'
 
+[[profile.fast.overrides]]
+# Dense mob-topology materialization is intentionally a high-blast stress test:
+# it spawns 300 local members and installs 45k directional trust writes while
+# asserting a wall-clock budget. Keep the test concurrent internally, but do
+# not run other nextest cases beside it.
+filter = 'test(test_wire_members_batch_materializes_300_by_150_dense_topology_in_seconds)'
+threads-required = "num-cpus"
+
+[[profile.fast.overrides]]
+# Branch-winner mob flow tests drive full in-memory runtimes and wait on
+# scheduler progress, so running them beside codegen canaries or parity audits
+# can consume their terminal-state wait budget without surfacing a product
+# failure. Keep each case isolated in the fast profile; the tests still execute
+# their branch/join concurrency internally.
+filter = 'test(test_branch_winner_and_join_any_behavior) or test(test_branch_winner_is_selected_only_after_success_allowing_fallback)'
+threads-required = "num-cpus"
+
 [[profile.default.overrides]]
 # System-lane tests spawn nested cargo invocations and copy binaries into
 # scenario-specific target directories. Running them concurrently under a broad

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -399,6 +399,7 @@ test_suite(
         "//xtask:protocol_codegen_drift_test",
         "//xtask:rmat_audit_test",
         "//xtask:rmat_strict_test",
+        "//xtask:runtime_authority_bypass_test",
         "//xtask:seam_inventory_strict_test",
         "//xtask:xtask_unit_test",
     ],

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -525,7 +525,7 @@
           "FILE:@@//meerkat-skills/Cargo.toml f7a6295ee8301efd85dcf293d1273f5e5e1877403ad0b1a76f84912075d202f0",
           "FILE:@@//meerkat-workgraph/Cargo.toml 8aba0c4e7ba0913cd3bf1c21a0b0bc4302d1bbc7e8972f31b5e883ac6b5502b5",
           "FILE:@@//meerkat-auth-core/Cargo.toml 2c9ac649043943de38cd500a96b438b121be1071ed2f924f4f468a6d58c24ebe",
-          "FILE:@@//meerkat-runtime/Cargo.toml 0cbffbe0e14347b04438141246691060ea719e3b3a8645035394822798b16b51",
+          "FILE:@@//meerkat-runtime/Cargo.toml d4e26f07366c0b9136644c364f6ec09b250016fb32e8c34b5e30a47c1a3dc5c0",
           "FILE:@@//meerkat-live/Cargo.toml eb5f960c83843ca19b59d94dec5b160bce1af4c7e140b27ab00b42f0631f61cb",
           "FILE:@@//meerkat-store/Cargo.toml eab1695cfdd2c65e9a1dd1a98c38fe8af62b40d6cfbd9ebcafb8cd1b5b8608f2",
           "FILE:@@//meerkat-comms/Cargo.toml 6ba7904966eb360d643a19d95e9ec416f9c4ebb23855dcfdb75ee572eaca5361",

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ YELLOW := \033[0;33m
 RED := \033[0;31m
 NC := \033[0m
 
-.PHONY: all install-build-deps build test test-unit test-int e2e-fast e2e-build e2e-system e2e-live e2e-smoke e2e-auth test-int-real test-e2e test-all test-minimal test-feature-matrix-lib test-feature-matrix-surface test-feature-matrix test-surface-modularity test-sdk-python test-sdk-typescript test-sdk-suites lint lint-feature-matrix fmt fmt-check audit rust-lane-doctor agent-gate cargo-agent-gate buildbuddy-install buildbuddy-generate buildbuddy-lock-update buildbuddy-generate-check buildbuddy-doctor buildbuddy-build buildbuddy-check buildbuddy-clippy buildbuddy-lint buildbuddy-test buildbuddy-test-all buildbuddy-test-unit buildbuddy-test-int buildbuddy-e2e-fast buildbuddy-e2e-system buildbuddy-e2e-live buildbuddy-e2e-smoke buildbuddy-e2e-auth buildbuddy-agent-gate buildbuddy-ci-dispatch buildbuddy-fast buildbuddy-benchmark buildbuddy-ci buildbuddy-ci-warm buildbuddy-ci-full buildbuddy-ci-full-warm ci ci-smoke release-doctor release-preflight release-preflight-smoke release-workflow release-assets release-packages release-web-sdk publish-dry-run publish-dry-run-python publish-dry-run-typescript publish-dry-run-web release-dry-run release-dry-run-smoke clean doc docs-check release install-hooks coverage check help legacy-surface-gate legacy-surface-inventory session-control-gate deprecated-backend-gate deprecated-backend-inventory sync-meerkat-dogma-skill-docs verify-version-parity verify-schema-freshness verify-sdk-codegen-freshness verify-sdk-event-inventory verify-rpc-surface-alignment verify-rest-surface-alignment verify-sdk-wrapper-freshness verify-machine-poster-coverage check-rust-release-config check-rust-release-packaging check-published-facade-link bump-sdk-versions smoke-sdk-python-artifact smoke-sdk-typescript-artifact xtask-build machine-codegen machine-verify machine-check-drift seam-inventory rmat-audit audit-generated-headers
+.PHONY: all install-build-deps build test test-unit test-int e2e-fast e2e-build e2e-system e2e-live e2e-smoke e2e-auth test-int-real test-e2e test-all test-minimal test-feature-matrix-lib test-feature-matrix-surface test-feature-matrix test-surface-modularity test-sdk-python test-sdk-typescript test-sdk-suites lint lint-feature-matrix fmt fmt-check audit rust-lane-doctor agent-gate cargo-agent-gate buildbuddy-install buildbuddy-generate buildbuddy-lock-update buildbuddy-generate-check buildbuddy-doctor buildbuddy-build buildbuddy-check buildbuddy-clippy buildbuddy-lint buildbuddy-test buildbuddy-test-all buildbuddy-test-unit buildbuddy-test-int buildbuddy-e2e-fast buildbuddy-e2e-system buildbuddy-e2e-live buildbuddy-e2e-smoke buildbuddy-e2e-auth buildbuddy-agent-gate buildbuddy-ci-dispatch buildbuddy-fast buildbuddy-benchmark buildbuddy-ci buildbuddy-ci-warm buildbuddy-ci-full buildbuddy-ci-full-warm ci ci-smoke release-doctor release-preflight release-preflight-smoke release-workflow release-assets release-packages release-web-sdk publish-dry-run publish-dry-run-python publish-dry-run-typescript publish-dry-run-web release-dry-run release-dry-run-smoke clean doc docs-check release install-hooks coverage check help legacy-surface-gate legacy-surface-inventory session-control-gate deprecated-backend-gate deprecated-backend-inventory sync-meerkat-dogma-skill-docs verify-version-parity verify-schema-freshness verify-sdk-codegen-freshness verify-sdk-event-inventory verify-rpc-surface-alignment verify-rest-surface-alignment verify-sdk-wrapper-freshness verify-machine-poster-coverage check-rust-release-config check-rust-release-packaging check-published-facade-link bump-sdk-versions smoke-sdk-python-artifact smoke-sdk-typescript-artifact xtask-build machine-codegen machine-verify machine-check-drift runtime-authority-bypass seam-inventory rmat-audit audit-generated-headers
 
 # Default target
 all: ci
@@ -329,12 +329,12 @@ buildbuddy-ci-full-warm: buildbuddy-doctor
 	@scripts/buildbuddy-ci-full --warm
 
 # Full CI pipeline - runs the required deterministic lanes plus build policy checks
-ci: docs-check fmt-check legacy-surface-gate session-control-gate deprecated-backend-gate bridge-no-responsestatus-gate sync-meerkat-dogma-skill-docs verify-version-parity verify-schema-freshness verify-sdk-codegen-freshness verify-sdk-event-inventory verify-rpc-surface-alignment verify-rest-surface-alignment verify-sdk-wrapper-freshness verify-machine-poster-coverage check-rust-release-packaging machine-check-drift lint lint-feature-matrix test-unit test-int e2e-fast e2e-system test-minimal test-feature-matrix test-surface-modularity seam-inventory rmat-audit audit-generated-headers audit
+ci: docs-check fmt-check legacy-surface-gate session-control-gate deprecated-backend-gate bridge-no-responsestatus-gate sync-meerkat-dogma-skill-docs verify-version-parity verify-schema-freshness verify-sdk-codegen-freshness verify-sdk-event-inventory verify-rpc-surface-alignment verify-rest-surface-alignment verify-sdk-wrapper-freshness verify-machine-poster-coverage check-rust-release-packaging machine-check-drift runtime-authority-bypass lint lint-feature-matrix test-unit test-int e2e-fast e2e-system test-minimal test-feature-matrix test-surface-modularity seam-inventory rmat-audit audit-generated-headers audit
 	@echo "$(GREEN)CI pipeline complete!$(NC)"
 
 # Developer smoke CI pipeline for faster pre-release iteration.
 # Keeps core validation, skips full feature matrix clippy/test expansion.
-ci-smoke: docs-check fmt-check legacy-surface-gate session-control-gate deprecated-backend-gate bridge-no-responsestatus-gate sync-meerkat-dogma-skill-docs verify-version-parity verify-schema-freshness verify-sdk-codegen-freshness verify-sdk-event-inventory verify-rpc-surface-alignment verify-rest-surface-alignment verify-sdk-wrapper-freshness verify-machine-poster-coverage check-rust-release-packaging machine-check-drift lint test-unit test-int e2e-fast e2e-system test-minimal seam-inventory rmat-audit audit-generated-headers audit
+ci-smoke: docs-check fmt-check legacy-surface-gate session-control-gate deprecated-backend-gate bridge-no-responsestatus-gate sync-meerkat-dogma-skill-docs verify-version-parity verify-schema-freshness verify-sdk-codegen-freshness verify-sdk-event-inventory verify-rpc-surface-alignment verify-rest-surface-alignment verify-sdk-wrapper-freshness verify-machine-poster-coverage check-rust-release-packaging machine-check-drift runtime-authority-bypass lint test-unit test-int e2e-fast e2e-system test-minimal seam-inventory rmat-audit audit-generated-headers audit
 	@echo "$(GREEN)CI smoke pipeline complete!$(NC)"
 
 # Milestone 0 gate: ensure legacy public surface names are either removed
@@ -401,6 +401,10 @@ machine-verify: xtask-build
 machine-check-drift: xtask-build
 	@echo "$(GREEN)Running machine-check-drift...$(NC)"
 	$(XTASK_BIN) machine-check-drift --all
+
+runtime-authority-bypass:
+	@echo "$(GREEN)Running runtime-authority-bypass audit...$(NC)"
+	$(CARGO) run -p xtask -- runtime-authority-bypass
 
 # RMAT structural seam audit: protocol coverage, feedback constraints,
 # terminal mapping, ownership-ledger drift, and structural authority hygiene checks.
@@ -756,6 +760,7 @@ help:
 	@echo "  $(GREEN)ci-smoke$(NC)       - Run CI smoke pipeline (no full feature matrices)"
 	@echo "  $(GREEN)machine-verify$(NC)- Verify machine/composition authority artifacts"
 	@echo "  $(GREEN)machine-check-drift$(NC)- Check generated authority artifacts for drift"
+	@echo "  $(GREEN)runtime-authority-bypass$(NC)- Audit runtime queue/stage capability bypasses"
 	@echo "  $(GREEN)rmat-audit$(NC)    - Run RMAT + ownership-ledger audit gates (strict mode)"
 	@echo "  $(GREEN)verify-version$(NC)- Verify Cargo.toml version matches git tag"
 	@echo ""

--- a/docs-internal/machine-driven-execution-control-inventory.md
+++ b/docs-internal/machine-driven-execution-control-inventory.md
@@ -1,0 +1,77 @@
+# Machine-Driven Execution Control Inventory
+
+Status: scoped high-blast pilot implemented; verification in progress
+Date: 2026-06-16
+
+This inventory tracks the execution-control proposal migration. It is not a
+permanent ledger unless it keeps proving useful.
+
+## Semantic Executor Inventory
+
+| action | owning machine | current transition/input | current shell function | required identities | effect closure requirement | current bypass risk |
+| --- | --- | --- | --- | --- | --- | --- |
+| Materialize accepted input into physical queue projection | MeerkatMachine | `ResolveAdmissionPlan`, `QueueAccepted`, `SteerAccepted`, recovery inputs | `EphemeralRuntimeDriver::apply_persist_and_queue`, recovery rebuilds | input id, lane, admission sequence, runtime/session authority, recovery normalization | No semantic external effect; projection must be reconstructable from durable machine witnesses | Raw queue projection mutation is allowed only inside materialization/rebuild mechanics and is covered by `runtime-authority-bypass` |
+| Select runtime-loop batch | MeerkatMachine | `BindAdmissionRuntimeGrouping` plus queued lane/order facts | `machine_authorize_runtime_loop_batch` | input ids, source lane, runtime boundary, execution kind, peer-response terminal intent, prompt grouping | No external effect; must be recomputable after restart | Selection returns `AuthorizedRuntimeLoopBatch` from generated machine-state command-plan selection; projection drift before dequeue fails closed |
+| Dequeue runtime-loop batch from physical projection | MeerkatMachine | `AuthorizedRuntimeLoopBatch` command plan | `EphemeralRuntimeDriver::dequeue_batch_exact` | exact ordered input ids and source lane | No external effect; physical projection is non-authoritative | Exact prefix/source match plus queue/steer projection conformance; planted raw dequeue bypass gate |
+| Stage input batch for run | MeerkatMachine | `StageForRun` | `machine_realize_authorized_stage_batch` | input ids, run id, source lane, lane/admission sequence, attempt count | No external effect; staging folds attempt increment into the transition | Raw staging is private to concrete driver mechanics; planted raw stage bypass gate |
+| Commit runtime-loop run | MeerkatMachine | `RunCompleted`, `Commit`, `Fail`, `CancelRun`, `RollbackRun`, boundary receipt realization | `commit_runtime_loop_run` | run id, terminal input ids, boundary receipt sequence, current owner, terminal outcome, return projection | `TurnRunCompleted` / `TurnRunFailed` / `TurnRunCancelled` are declared as `AuthorizedRuntimeLoopRunCommit` closure obligations with `Authorized -> Attempted -> Realized -> Failed -> Cancelled -> Abandoned`; the runtime commit token carries and checks the completed-run obligation before realizing success | Shell completion cannot proceed without `AuthorizedRuntimeLoopRunCommit`, generated kernel marker, owner binding, outcome binding, return projection binding, and effect-closure obligation |
+| Resolve public runtime completion result | MeerkatMachine | `ResolveRuntimeCompletionResult` | `machine_resolve_runtime_completion_result` and replay helpers | session id, run id, agent runtime id, fence token, generation, runtime epoch, result class | Existing `RuntimeCompletionResultResolved` disposition is exposed as `RuntimeCompletionResultAuthority` with `Authorized -> Attempted -> Realized -> Failed -> Cancelled -> Abandoned`; no new durable effect map was added because the chosen family is local surface-result alignment | Runtime waiter delivery consumes `RuntimeCompletionResultAuthority` through `RuntimeCompletionResultAttempt` / `RuntimeCompletionResultRealized`; raw completion senders remain private |
+| Start/complete/fail mob member spawn | MobMachine / MeerkatMachine seam | `StageSpawn`, `CompleteSpawn`, `CancelPendingSpawn` | mob runtime provisioner/handle paths | mob id, member id/ref, agent identity, generation, runtime/session binding | Proposal vocabulary is represented by generated command plans `CanStartSpawn`, `SpawnStarted`, `SpawnEffect`, and `FailSpawn` mapped onto existing `StageSpawn`, `CompleteSpawn`, and `CancelPendingSpawn` transitions; closure lifecycles include `Cancelled` | Runtime spawn insertion/completion/cancellation consumes generated kernel markers for `CanStartSpawn`, `SpawnStarted`, `SpawnEffect`, and `FailSpawn` in addition to the existing pending-owner authority |
+
+## Measured Deltas
+
+Measured with repo-local `rg` / `git grep` against `origin/main` and this
+branch after the Phase 2/3/4 follow-up. The raw-call production scan excludes
+tests and reports the remaining internal queue mechanic separately from
+semantic bypasses.
+
+| metric | origin/main | current branch | note |
+| --- | ---: | ---: | --- |
+| command plans in catalog metadata | 0 | 10 | MeerkatMachine: `AuthorizedAcceptedInputMaterialization`, `AuthorizeRuntimeLoopBatch`, `AuthorizedStageForRun`, `AuthorizedRuntimeLoopRunCommit`, `AuthorizedRuntimeCompletionResultClosure`; MobMachine: `AuthorizedMobSpawnStart`, `CanStartSpawn`, `SpawnStarted`, `SpawnEffect`, `FailSpawn` |
+| generated effect-closure rows in machine contracts | 0 | 17 | includes runtime-completion closure, run-commit effect obligations, and spawn start/started/effect/fail closures |
+| generated guard-expansion rows in target contracts | 0 | 168 | command-plan guard expansion is reviewable in `specs/machines/*/contract.md` |
+| `StageForRun` generated guard rows | 0 | 5 | all phases show queued/lane/sequence/recovery/run-binding guards |
+| raw runtime production bypass hits | 9 | 1 | remaining hit is `InputQueue::enqueue` projection mechanics; raw public dequeue/stage and shell stage-drain validator are absent |
+| planted bypass checks | 0 | 15 matching assertions | raw accepted-input enqueue, raw dequeue, and raw stage violations are planted in `runtime-authority-bypass` tests |
+| runtime projection conformance search hits | 9 | 26 | queue/steer drift and exact dequeue checks are covered by runtime tests and driver code |
+| Phase 4 proposal vocabulary hits | 0 | 54 | `CanStartSpawn`, `SpawnStarted`, `SpawnEffect`, and `FailSpawn` exist in generated contract/kernel output and runtime consumption |
+
+## Phase 5 Decision
+
+Decision: continue the generated command-plan/capability pattern for scoped
+semantic executor families, and stop any broader platform rewrite.
+
+Rationale:
+
+- The high-blast pilot made misuse harder on the queue-to-run boundary: raw
+  production dequeue/stage APIs collapsed to generated-capability paths and the
+  bypass gate catches planted raw enqueue/dequeue/stage violations.
+- The counted deltas improved enough to keep the pattern: command plans and
+  effect closures are generated/reviewable, `StageForRun` guard expansion is in
+  generated contracts, and the runtime now consumes generated markers for
+  ingress/staging, run commit, completion resolution, and mob spawn.
+- The model should remain a scoped authoring aid, not a new control-language
+  platform. Future families should be accepted only when they reduce raw
+  semantic calls or duplicated guard review in similarly counted ways.
+
+Finding buckets from this pilot:
+
+| bucket | count | resolution |
+| --- | ---: | --- |
+| predicate wrong | 1 | `StageForRun` strengthened with queued/lane/sequence/recovery/current-run guards |
+| command missing | 3 | generated command plans added for runtime batch/stage, run commit, and mob spawn proposal vocabulary |
+| durable witness missing | 1 | runtime-loop batch selection now recomputes from durable machine lane/order/grouping state |
+| projection conformance failure | 2 | queue and steer drift fail before exact dequeue/stage |
+| capability bypass gate failed | 3 | raw enqueue/dequeue/stage planted violations are caught by `runtime-authority-bypass` |
+| ordinary shell mechanic | 1 | physical queue enqueue remains an internal projection mechanic, not semantic authority |
+
+## Phase Status
+
+| phase | status | evidence |
+| --- | --- | --- |
+| Phase 0 inventory | done | this document records action ownership, required identities, closure requirements, bypass risks, measured deltas, and the Phase 5 decision |
+| Phase 1 ingress/staging pilot | done | command plans, generated guard docs, machine-state batch selector, batch/stage capabilities, exact dequeue, projection conformance tests, and AST bypass gate |
+| Phase 2 required effect closure | done for chosen family | `RuntimeCompletionResultResolved` is bound to `RuntimeCompletionResultAuthority` with `Authorized`, `Attempted`, `Realized`, `Failed`, `Cancelled`, `Abandoned`; runtime waiter delivery consumes the phase token |
+| Phase 3 run commit | done | `AuthorizedRuntimeLoopRunCommit` carries generated marker, run id, terminal input ids, current owner, terminal outcome, return projection, and completed-run effect-closure obligation |
+| Phase 4 mob spawn | done | generated command plans expose `CanStartSpawn`, `SpawnStarted`, `SpawnEffect`, and `FailSpawn`; runtime consumes generated markers for start, started insertion, completion, and failure/cancellation |
+| Phase 5 generalize-or-stop | done | decision recorded above: continue narrowly for counted semantic executor families; stop broad platform rewrite |

--- a/meerkat-machine-codegen/BUILD.bazel
+++ b/meerkat-machine-codegen/BUILD.bazel
@@ -431,6 +431,9 @@ rust_test(
     edition = "2024",
     compile_data = [
         "Cargo.toml",
+    ] + [
+        "//meerkat-machine-kernels:src/generated/meerkat.rs",
+        "//meerkat-machine-kernels:src/generated/mob.rs",
     ],
     srcs = [
         "tests/runtime_schema_parity.rs",
@@ -447,6 +450,8 @@ rust_test(
     size = "small",
     data = [
         ":package_runfiles",
+        "//meerkat-machine-kernels:package_runfiles",
+        "//meerkat:package_runfiles",
         "//:workspace_runfiles",
     ],
     env = {

--- a/meerkat-machine-codegen/src/artifacts.rs
+++ b/meerkat-machine-codegen/src/artifacts.rs
@@ -686,6 +686,121 @@ pub fn render_machine_contract_markdown(
         pushln!(&mut out);
     }
 
+    if !schema.command_plans.is_empty() {
+        pushln!(&mut out, "## Command Plans");
+        let transitions_by_name = schema
+            .transitions
+            .iter()
+            .map(|transition| (transition.name.as_str(), transition))
+            .collect::<BTreeMap<_, _>>();
+        for plan in &schema.command_plans {
+            pushln!(&mut out, "### `{}`", plan.name);
+            pushln!(&mut out, "- Authority: `{}`", plan.authority_type);
+            if !plan.source_inputs.is_empty() {
+                writeln!(
+                    &mut out,
+                    "- Source Inputs: {}",
+                    plan.source_inputs
+                        .iter()
+                        .map(|input| format!("`{input}`"))
+                        .collect::<Vec<_>>()
+                        .join(", ")
+                )
+                .expect("write to string");
+            }
+            if !plan.source_signals.is_empty() {
+                writeln!(
+                    &mut out,
+                    "- Source Signals: {}",
+                    plan.source_signals
+                        .iter()
+                        .map(|signal| format!("`{signal}`"))
+                        .collect::<Vec<_>>()
+                        .join(", ")
+                )
+                .expect("write to string");
+            }
+            if !plan.transitions.is_empty() {
+                writeln!(
+                    &mut out,
+                    "- Transitions: {}",
+                    plan.transitions
+                        .iter()
+                        .map(|transition| format!("`{transition}`"))
+                        .collect::<Vec<_>>()
+                        .join(", ")
+                )
+                .expect("write to string");
+                pushln!(&mut out, "- Guard Expansion:");
+                for transition_id in &plan.transitions {
+                    if let Some(transition) = transitions_by_name.get(transition_id.as_str()) {
+                        let guards = if transition.guards.is_empty() {
+                            "`<none>`".to_owned()
+                        } else {
+                            transition
+                                .guards
+                                .iter()
+                                .map(|guard| format!("`{}`", guard.name))
+                                .collect::<Vec<_>>()
+                                .join(", ")
+                        };
+                        pushln!(&mut out, "  - `{transition_id}`: {guards}");
+                    }
+                }
+            }
+            if !plan.effects.is_empty() {
+                writeln!(
+                    &mut out,
+                    "- Command Effects: {}",
+                    plan.effects
+                        .iter()
+                        .map(|effect| format!("`{effect}`"))
+                        .collect::<Vec<_>>()
+                        .join(", ")
+                )
+                .expect("write to string");
+            }
+            if !plan.effect_closures.is_empty() {
+                pushln!(&mut out, "- Effect Closure:");
+                for closure in &plan.effect_closures {
+                    writeln!(
+                        &mut out,
+                        "  - `{}` via `{}` ({}) states: {}",
+                        closure.effect,
+                        closure.authority_type,
+                        closure.closure_policy,
+                        closure
+                            .lifecycle
+                            .iter()
+                            .map(|state| format!("`{state}`"))
+                            .collect::<Vec<_>>()
+                            .join(", ")
+                    )
+                    .expect("write to string");
+                }
+            }
+            let emitted_effects = plan
+                .transitions
+                .iter()
+                .filter_map(|transition_id| transitions_by_name.get(transition_id.as_str()))
+                .flat_map(|transition| transition.emit.iter().map(|effect| &effect.variant))
+                .collect::<BTreeSet<_>>();
+            if !emitted_effects.is_empty() {
+                writeln!(
+                    &mut out,
+                    "- Emitted By Transitions: {}",
+                    emitted_effects
+                        .iter()
+                        .map(|effect| format!("`{effect}`"))
+                        .collect::<Vec<_>>()
+                        .join(", ")
+                )
+                .expect("write to string");
+            }
+            pushln!(&mut out);
+        }
+    }
+
     pushln!(&mut out, "## Invariants");
     for invariant in &schema.invariants {
         pushln!(&mut out, "- `{}`", invariant.name);

--- a/meerkat-machine-codegen/src/render.rs
+++ b/meerkat-machine-codegen/src/render.rs
@@ -578,6 +578,8 @@ fn render_canonical_stub_modeled_module(schema: &MachineSchema) -> String {
     pushln!(&mut out, "}}");
     pushln!(&mut out);
 
+    render_command_capability_section(&mut out, schema);
+
     pushln!(&mut out, "#[allow(non_camel_case_types)]");
     pushln!(
         &mut out,
@@ -710,6 +712,454 @@ fn render_canonical_stub_modeled_module(schema: &MachineSchema) -> String {
     pushln!(&mut out, "    }}");
     pushln!(&mut out, "}}");
     out
+}
+
+#[cfg(not(test))]
+fn render_command_capability_section(out: &mut String, schema: &MachineSchema) {
+    if schema.command_plans.is_empty() {
+        return;
+    }
+
+    pushln!(out, "pub mod command_capabilities {{");
+    pushln!(out, "    mod private {{");
+    pushln!(out, "        #[derive(Debug, PartialEq, Eq)]");
+    pushln!(out, "        pub struct Sealed;");
+    pushln!(out, "    }}");
+    pushln!(out);
+
+    pushln!(out, "    #[derive(Debug, Clone, Copy, PartialEq, Eq)]");
+    pushln!(out, "    pub enum CommandPlanKind {{");
+    for plan in &schema.command_plans {
+        pushln!(out, "        {},", rust_ident(&plan.name));
+    }
+    pushln!(out, "    }}");
+    pushln!(out);
+    pushln!(out, "    impl CommandPlanKind {{");
+    pushln!(out, "        #[must_use]");
+    pushln!(out, "        pub const fn as_str(self) -> &'static str {{");
+    pushln!(out, "            match self {{");
+    for plan in &schema.command_plans {
+        pushln!(
+            out,
+            "                Self::{} => {:?},",
+            rust_ident(&plan.name),
+            plan.name
+        );
+    }
+    pushln!(out, "            }}");
+    pushln!(out, "        }}");
+    pushln!(out, "    }}");
+    pushln!(out);
+
+    if schema
+        .command_plans
+        .iter()
+        .any(|plan| plan.authority_type == "AuthorizedRuntimeLoopBatch")
+    {
+        pushln!(out, "    #[derive(Debug, Clone, Copy, PartialEq, Eq)]");
+        pushln!(out, "    pub enum RuntimeLoopBatchSource {{");
+        pushln!(out, "        Queue,");
+        pushln!(out, "        Steer,");
+        pushln!(out, "    }}");
+        pushln!(out);
+        pushln!(
+            out,
+            "    #[must_use = \"generated runtime-loop batch plan must be consumed by exact dequeue/stage realization\"]"
+        );
+        pushln!(out, "    #[derive(Debug, PartialEq, Eq)]");
+        pushln!(out, "    pub struct RuntimeLoopBatchPlan {{");
+        pushln!(out, "        batch_capability: AuthorizedRuntimeLoopBatch,");
+        pushln!(out, "        input_ids: Vec<String>,");
+        pushln!(out, "        source: RuntimeLoopBatchSource,");
+        pushln!(out, "    }}");
+        pushln!(out);
+        pushln!(
+            out,
+            "    #[must_use = \"generated stage-for-run plan must be consumed by exact stage realization\"]"
+        );
+        pushln!(out, "    #[derive(Debug, PartialEq, Eq)]");
+        pushln!(out, "    pub struct StageForRunPlan {{");
+        pushln!(out, "        stage_capability: AuthorizedStageForRun,");
+        pushln!(out, "        input_ids: Vec<String>,");
+        pushln!(out, "        source: RuntimeLoopBatchSource,");
+        pushln!(out, "    }}");
+        pushln!(out);
+        pushln!(out, "    impl RuntimeLoopBatchPlan {{");
+        pushln!(out, "        #[must_use]");
+        pushln!(out, "        pub fn input_ids(&self) -> &[String] {{");
+        pushln!(out, "            &self.input_ids");
+        pushln!(out, "        }}");
+        pushln!(out);
+        pushln!(out, "        #[must_use]");
+        pushln!(
+            out,
+            "        pub const fn source(&self) -> RuntimeLoopBatchSource {{"
+        );
+        pushln!(out, "            self.source");
+        pushln!(out, "        }}");
+        pushln!(out);
+        pushln!(
+            out,
+            "        pub fn into_parts(self) -> (AuthorizedRuntimeLoopBatch, Vec<String>, RuntimeLoopBatchSource) {{"
+        );
+        pushln!(
+            out,
+            "            (self.batch_capability, self.input_ids, self.source)"
+        );
+        pushln!(out, "        }}");
+        pushln!(out, "    }}");
+        pushln!(out);
+        pushln!(out, "    impl StageForRunPlan {{");
+        pushln!(out, "        #[must_use]");
+        pushln!(out, "        pub fn input_ids(&self) -> &[String] {{");
+        pushln!(out, "            &self.input_ids");
+        pushln!(out, "        }}");
+        pushln!(out);
+        pushln!(out, "        #[must_use]");
+        pushln!(
+            out,
+            "        pub const fn source(&self) -> RuntimeLoopBatchSource {{"
+        );
+        pushln!(out, "            self.source");
+        pushln!(out, "        }}");
+        pushln!(out);
+        pushln!(
+            out,
+            "        pub fn into_parts(self) -> (AuthorizedStageForRun, Vec<String>, RuntimeLoopBatchSource) {{"
+        );
+        pushln!(
+            out,
+            "            (self.stage_capability, self.input_ids, self.source)"
+        );
+        pushln!(out, "        }}");
+        pushln!(out, "    }}");
+        pushln!(out);
+    }
+
+    for plan in &schema.command_plans {
+        let type_name = rust_ident(&plan.authority_type);
+        let kind_name = rust_ident(&plan.name);
+        pushln!(
+            out,
+            "    #[must_use = {:?}]",
+            format!(
+                "generated command capability `{}` must be consumed by the shell action it authorizes",
+                plan.authority_type
+            )
+        );
+        pushln!(out, "    #[derive(Debug, PartialEq, Eq)]");
+        pushln!(out, "    pub struct {type_name} {{");
+        pushln!(out, "        _sealed: private::Sealed,");
+        pushln!(out, "    }}");
+        pushln!(out);
+        pushln!(out, "    impl {type_name} {{");
+        pushln!(out, "        #[doc(hidden)]");
+        pushln!(out, "        #[allow(dead_code)]");
+        pushln!(
+            out,
+            "        pub(crate) fn mint_from_generated_command_plan() -> Self {{"
+        );
+        pushln!(out, "            Self {{ _sealed: private::Sealed }}");
+        pushln!(out, "        }}");
+        pushln!(out);
+        pushln!(out, "        #[must_use]");
+        pushln!(
+            out,
+            "        pub const fn plan(&self) -> CommandPlanKind {{"
+        );
+        pushln!(out, "            CommandPlanKind::{kind_name}");
+        pushln!(out, "        }}");
+        pushln!(out, "    }}");
+        pushln!(out);
+    }
+
+    if schema
+        .command_plans
+        .iter()
+        .any(|plan| plan.authority_type == "AuthorizedRuntimeLoopBatch")
+    {
+        pushln!(out, "    impl AuthorizedRuntimeLoopBatch {{");
+        pushln!(out, "        #[must_use]");
+        pushln!(
+            out,
+            "        pub fn authorize_runtime_loop_batch_from_state(state: &super::State) -> Option<RuntimeLoopBatchPlan> {{"
+        );
+        pushln!(
+            out,
+            "            runtime_loop_batch_from_state(state, super::InputLane::Steer, RuntimeLoopBatchSource::Steer)"
+        );
+        pushln!(
+            out,
+            "                .or_else(|| runtime_loop_batch_from_state(state, super::InputLane::Queue, RuntimeLoopBatchSource::Queue))"
+        );
+        pushln!(out, "        }}");
+        pushln!(out, "    }}");
+        pushln!(out);
+        pushln!(out, "    impl AuthorizedStageForRun {{");
+        pushln!(out, "        #[must_use]");
+        pushln!(
+            out,
+            "        pub fn authorize_stage_for_run_from_state(state: &super::State, input_ids: &[String], run_id: &super::RunId, source: RuntimeLoopBatchSource) -> Option<StageForRunPlan> {{"
+        );
+        pushln!(
+            out,
+            "            runtime_stage_for_run_from_state(state, input_ids, run_id, source)"
+        );
+        pushln!(out, "        }}");
+        pushln!(out, "    }}");
+        pushln!(out);
+        pushln!(out, "    fn runtime_loop_batch_from_state(");
+        pushln!(out, "        state: &super::State,");
+        pushln!(out, "        lane: super::InputLane,");
+        pushln!(out, "        source: RuntimeLoopBatchSource,");
+        pushln!(out, "    ) -> Option<RuntimeLoopBatchPlan> {{");
+        pushln!(
+            out,
+            "        let ordered = ordered_queued_lane_inputs(state, lane)?;"
+        );
+        pushln!(out, "        let first = ordered.first()?;");
+        pushln!(out, "        let selected = match source {{");
+        pushln!(
+            out,
+            "            RuntimeLoopBatchSource::Steer => select_steer_batch(state, &ordered, first),"
+        );
+        pushln!(
+            out,
+            "            RuntimeLoopBatchSource::Queue => select_queue_batch(state, &ordered, first),"
+        );
+        pushln!(out, "        }};");
+        pushln!(out, "        if selected.is_empty() {{");
+        pushln!(out, "            None");
+        pushln!(out, "        }} else {{");
+        pushln!(out, "            Some(RuntimeLoopBatchPlan {{");
+        pushln!(
+            out,
+            "                batch_capability: AuthorizedRuntimeLoopBatch::mint_from_generated_command_plan(),"
+        );
+        pushln!(out, "                input_ids: selected,");
+        pushln!(out, "                source,");
+        pushln!(out, "            }})");
+        pushln!(out, "        }}");
+        pushln!(out, "    }}");
+        pushln!(out);
+        pushln!(out, "    fn runtime_stage_for_run_from_state(");
+        pushln!(out, "        state: &super::State,");
+        pushln!(out, "        input_ids: &[String],");
+        pushln!(out, "        run_id: &super::RunId,");
+        pushln!(out, "        source: RuntimeLoopBatchSource,");
+        pushln!(out, "    ) -> Option<StageForRunPlan> {{");
+        pushln!(out, "        if input_ids.is_empty() {{");
+        pushln!(out, "            return None;");
+        pushln!(out, "        }}");
+        pushln!(
+            out,
+            "        if state.current_run_id.as_ref() != Some(run_id) {{"
+        );
+        pushln!(out, "            return None;");
+        pushln!(out, "        }}");
+        pushln!(out, "        let expected_lane = match source {{");
+        pushln!(
+            out,
+            "            RuntimeLoopBatchSource::Queue => super::InputLane::Queue,"
+        );
+        pushln!(
+            out,
+            "            RuntimeLoopBatchSource::Steer => super::InputLane::Steer,"
+        );
+        pushln!(out, "        }};");
+        pushln!(out, "        for input_id in input_ids {{");
+        pushln!(
+            out,
+            "            if state.input_phases.get(input_id) != Some(&super::InputPhase::Queued) {{"
+        );
+        pushln!(out, "                return None;");
+        pushln!(out, "            }}");
+        pushln!(
+            out,
+            "            if state.input_lane.get(input_id) != Some(&expected_lane) {{"
+        );
+        pushln!(out, "                return None;");
+        pushln!(out, "            }}");
+        pushln!(
+            out,
+            "            if !state.input_admission_seq.contains_key(input_id) {{"
+        );
+        pushln!(out, "                return None;");
+        pushln!(out, "            }}");
+        pushln!(
+            out,
+            "            if !state.input_recovery_lanes.contains_key(input_id) {{"
+        );
+        pushln!(out, "                return None;");
+        pushln!(out, "            }}");
+        pushln!(
+            out,
+            "            if state.input_run_associations.contains_key(input_id) {{"
+        );
+        pushln!(out, "                return None;");
+        pushln!(out, "            }}");
+        pushln!(out, "        }}");
+        pushln!(out, "        Some(StageForRunPlan {{");
+        pushln!(
+            out,
+            "            stage_capability: AuthorizedStageForRun::mint_from_generated_command_plan(),"
+        );
+        pushln!(out, "            input_ids: input_ids.to_vec(),");
+        pushln!(out, "            source,");
+        pushln!(out, "        }})");
+        pushln!(out, "    }}");
+        pushln!(out);
+        pushln!(out, "    fn ordered_queued_lane_inputs(");
+        pushln!(out, "        state: &super::State,");
+        pushln!(out, "        lane: super::InputLane,");
+        pushln!(out, "    ) -> Option<Vec<String>> {{");
+        pushln!(out, "        let mut ordered = Vec::new();");
+        pushln!(
+            out,
+            "        for (input_id, input_lane) in &state.input_lane {{"
+        );
+        pushln!(out, "            if *input_lane != lane {{");
+        pushln!(out, "                continue;");
+        pushln!(out, "            }}");
+        pushln!(
+            out,
+            "            if state.input_phases.get(input_id) != Some(&super::InputPhase::Queued) {{"
+        );
+        pushln!(out, "                return None;");
+        pushln!(out, "            }}");
+        pushln!(
+            out,
+            "            let sequence = *state.input_admission_seq.get(input_id)?;"
+        );
+        pushln!(
+            out,
+            "            ordered.push((sequence, input_id.clone()));"
+        );
+        pushln!(out, "        }}");
+        pushln!(
+            out,
+            "        ordered.sort_by(|left, right| left.0.cmp(&right.0).then_with(|| left.1.cmp(&right.1)));"
+        );
+        pushln!(
+            out,
+            "        Some(ordered.into_iter().map(|(_, input_id)| input_id).collect())"
+        );
+        pushln!(out, "    }}");
+        pushln!(out);
+        pushln!(out, "    fn select_steer_batch(");
+        pushln!(out, "        state: &super::State,");
+        pushln!(out, "        ordered: &[String],");
+        pushln!(out, "        first: &String,");
+        pushln!(out, "    ) -> Vec<String> {{");
+        pushln!(
+            out,
+            "        let Some(target_boundary) = state.input_runtime_boundary.get(first).copied() else {{"
+        );
+        pushln!(out, "            return vec![first.clone()];");
+        pushln!(out, "        }};");
+        pushln!(
+            out,
+            "        let Some(target_execution_kind) = state.input_runtime_execution_kind.get(first).copied() else {{"
+        );
+        pushln!(out, "            return vec![first.clone()];");
+        pushln!(out, "        }};");
+        pushln!(out, "        let target_terminal_intent = state");
+        pushln!(
+            out,
+            "            .input_runtime_peer_response_terminal_apply_intent"
+        );
+        pushln!(out, "            .get(first)");
+        pushln!(out, "            .copied();");
+        pushln!(out, "        ordered");
+        pushln!(out, "            .iter()");
+        pushln!(out, "            .take_while(|input_id| {{");
+        pushln!(
+            out,
+            "                state.input_runtime_boundary.get(*input_id).copied() == Some(target_boundary)"
+        );
+        pushln!(
+            out,
+            "                    && state.input_runtime_execution_kind.get(*input_id).copied()"
+        );
+        pushln!(
+            out,
+            "                        == Some(target_execution_kind)"
+        );
+        pushln!(out, "                    && state");
+        pushln!(
+            out,
+            "                        .input_runtime_peer_response_terminal_apply_intent"
+        );
+        pushln!(out, "                        .get(*input_id)");
+        pushln!(out, "                        .copied()");
+        pushln!(out, "                        == target_terminal_intent");
+        pushln!(out, "            }})");
+        pushln!(out, "            .cloned()");
+        pushln!(out, "            .collect()");
+        pushln!(out, "    }}");
+        pushln!(out);
+        pushln!(out, "    fn select_queue_batch(");
+        pushln!(out, "        state: &super::State,");
+        pushln!(out, "        ordered: &[String],");
+        pushln!(out, "        first: &String,");
+        pushln!(out, "    ) -> Vec<String> {{");
+        pushln!(
+            out,
+            "        let Some(target_execution_kind) = state.input_runtime_execution_kind.get(first).copied() else {{"
+        );
+        pushln!(out, "            return vec![first.clone()];");
+        pushln!(out, "        }};");
+        pushln!(out, "        let target_terminal_intent = state");
+        pushln!(
+            out,
+            "            .input_runtime_peer_response_terminal_apply_intent"
+        );
+        pushln!(out, "            .get(first)");
+        pushln!(out, "            .copied();");
+        pushln!(
+            out,
+            "        let Some(driver_is_prompt) = state.input_is_prompt.get(first).copied() else {{"
+        );
+        pushln!(out, "            return vec![first.clone()];");
+        pushln!(out, "        }};");
+        pushln!(out, "        let mut selected = Vec::new();");
+        pushln!(out, "        for input_id in ordered {{");
+        pushln!(
+            out,
+            "            if state.input_runtime_execution_kind.get(input_id).copied()"
+        );
+        pushln!(out, "                != Some(target_execution_kind)");
+        pushln!(out, "                || state");
+        pushln!(
+            out,
+            "                    .input_runtime_peer_response_terminal_apply_intent"
+        );
+        pushln!(out, "                    .get(input_id)");
+        pushln!(out, "                    .copied()");
+        pushln!(out, "                    != target_terminal_intent");
+        pushln!(out, "            {{");
+        pushln!(out, "                break;");
+        pushln!(out, "            }}");
+        pushln!(
+            out,
+            "            let Some(is_prompt) = state.input_is_prompt.get(input_id).copied() else {{"
+        );
+        pushln!(out, "                break;");
+        pushln!(out, "            }};");
+        pushln!(out, "            if !driver_is_prompt && is_prompt {{");
+        pushln!(out, "                break;");
+        pushln!(out, "            }}");
+        pushln!(out, "            selected.push(input_id.clone());");
+        pushln!(out, "            if is_prompt || driver_is_prompt {{");
+        pushln!(out, "                break;");
+        pushln!(out, "            }}");
+        pushln!(out, "        }}");
+        pushln!(out, "        selected");
+        pushln!(out, "    }}");
+        pushln!(out);
+    }
+    pushln!(out, "}}");
+    pushln!(out);
 }
 
 #[cfg(not(test))]
@@ -1875,6 +2325,7 @@ mod tests {
             },
             helpers: vec![],
             derived: vec![],
+            command_plans: vec![],
             invariants: vec![],
             transitions: vec![
                 TransitionSchema {

--- a/meerkat-machine-codegen/tests/named_type_binding_respected.rs
+++ b/meerkat-machine-codegen/tests/named_type_binding_respected.rs
@@ -76,6 +76,7 @@ fn schema_with_single_named_type(field_name: &str, named: &str) -> MachineSchema
         },
         helpers: vec![],
         derived: vec![],
+        command_plans: vec![],
         invariants: vec![],
         transitions: vec![],
         effect_dispositions: vec![],

--- a/meerkat-machine-codegen/tests/render_contracts.rs
+++ b/meerkat-machine-codegen/tests/render_contracts.rs
@@ -4,8 +4,9 @@ use meerkat_machine_codegen::{
     GENERATED_COVERAGE_END, GENERATED_COVERAGE_START, merge_mapping_document,
     render_composition_ci_cfg, render_composition_driver, render_composition_mapping_coverage,
     render_composition_module, render_composition_semantic_model, render_composition_witness_cfg,
-    render_generated_kernel_mod, render_machine_ci_cfg, render_machine_kernel_module,
-    render_machine_mapping_coverage, render_machine_module, render_machine_semantic_model,
+    render_generated_kernel_mod, render_machine_ci_cfg, render_machine_contract_markdown,
+    render_machine_kernel_module, render_machine_mapping_coverage, render_machine_module,
+    render_machine_semantic_model,
 };
 use meerkat_machine_schema::catalog::dsl::{
     dsl_auth_machine as auth_machine, dsl_meerkat_machine as meerkat_machine,
@@ -116,6 +117,39 @@ fn renders_canonical_mob_machine_fixture_with_identity_native_inputs() {
     }
     assert!(rendered.contains("AgentIdentity"));
     assert!(!rendered.contains("MeerkatId"));
+}
+
+#[test]
+fn renders_mob_spawn_command_plan_in_contract_markdown() {
+    let schema = mob_machine();
+    let coverage = canonical_machine_coverage_manifests()
+        .into_iter()
+        .find(|coverage| coverage.machine == schema.machine)
+        .expect("mob machine coverage manifest");
+    let rendered = render_machine_contract_markdown(&schema, &coverage);
+
+    for required in [
+        "### `AuthorizedMobSpawnStart`",
+        "- Authority: `PendingSpawnOperationOwnerAuthorized`",
+        "- Source Inputs: `CancelPendingSpawn`",
+        "- Source Signals: `StageSpawn`, `CompleteSpawn`",
+        "- Command Effects: `PendingSpawnOperationOwnerAuthorized`, `ExposePendingSpawn`, `EmitMemberLifecycleNotice`",
+        "`PendingSpawnOperationOwnerAuthorized` via `PendingSpawnOperationOwnerAuthorized` (LocalPendingSpawnOwner) states: `Authorized`, `Attempted`, `Realized`, `Failed`, `Cancelled`, `Abandoned`",
+        "`EmitMemberLifecycleNotice` via `CompleteSpawn` (LocalSpawnCompletion) states: `Authorized`, `Attempted`, `Realized`, `Failed`, `Cancelled`, `Abandoned`",
+        "### `CanStartSpawn`",
+        "- Authority: `CanStartSpawn`",
+        "### `SpawnStarted`",
+        "- Authority: `SpawnStarted`",
+        "### `SpawnEffect`",
+        "- Authority: `SpawnEffect`",
+        "### `FailSpawn`",
+        "- Authority: `FailSpawn`",
+    ] {
+        assert!(
+            rendered.contains(required),
+            "MobMachine contract markdown must expose `{required}`:\n{rendered}"
+        );
+    }
 }
 
 #[test]

--- a/meerkat-machine-codegen/tests/runtime_schema_parity.rs
+++ b/meerkat-machine-codegen/tests/runtime_schema_parity.rs
@@ -82,6 +82,9 @@ fn schema_shape_mismatches_for_schemas(
     if catalog.derived != production.derived {
         mismatches.push("derived helpers".to_owned());
     }
+    if catalog.command_plans != production.command_plans {
+        mismatches.push("command plans".to_owned());
+    }
     if catalog.invariants != production.invariants {
         mismatches.push("invariants".to_owned());
     }
@@ -96,6 +99,36 @@ fn schema_shape_mismatches_for_schemas(
     }
 
     mismatches
+}
+
+#[test]
+fn command_plan_capability_types_are_generated_for_runtime_and_mob_pilots() {
+    let meerkat = include_str!("../../meerkat-machine-kernels/src/generated/meerkat.rs");
+    let mob = include_str!("../../meerkat-machine-kernels/src/generated/mob.rs");
+
+    for expected in [
+        "pub mod command_capabilities",
+        "pub struct AuthorizedAcceptedInputMaterialization",
+        "pub struct AuthorizedRuntimeLoopBatch",
+        "pub struct AuthorizedStageForRun",
+        "pub struct RuntimeCompletionResultAuthority",
+        "pub struct AuthorizedRuntimeLoopRunCommit",
+    ] {
+        assert!(
+            meerkat.contains(expected),
+            "MeerkatMachine generated kernel should contain `{expected}`"
+        );
+    }
+
+    for expected in [
+        "pub mod command_capabilities",
+        "pub struct PendingSpawnOperationOwnerAuthorized",
+    ] {
+        assert!(
+            mob.contains(expected),
+            "MobMachine generated kernel should contain `{expected}`"
+        );
+    }
 }
 
 fn phase1_schema_parity_cases() -> Vec<SchemaParityCase> {
@@ -813,6 +846,11 @@ fn production_schema_exports_include_metadata_without_catalog_schema_splicing() 
         assert_eq!(
             production.runtime_internal_inputs, catalog.runtime_internal_inputs,
             "{} production export must carry runtime-internal input metadata before parity comparison",
+            case.machine
+        );
+        assert_eq!(
+            production.command_plans, catalog.command_plans,
+            "{} production export must carry command-plan metadata before parity comparison",
             case.machine
         );
     }

--- a/meerkat-machine-dsl-core/src/gen_schema.rs
+++ b/meerkat-machine-dsl-core/src/gen_schema.rs
@@ -141,6 +141,7 @@ pub fn generate(def: &MachineDef) -> TokenStream {
                     },
                     helpers: vec![#(#helpers),*],
                     derived: vec![],
+                    command_plans: vec![],
                     invariants: vec![#(#invariants),*],
                     transitions: vec![#(#transitions),*],
                     effect_dispositions: vec![#(#dispositions),*],

--- a/meerkat-machine-kernels/BUILD.bazel
+++ b/meerkat-machine-kernels/BUILD.bazel
@@ -28,6 +28,22 @@ filegroup(
 
 
 
+exports_files(
+
+    [
+
+        "src/generated/meerkat.rs",
+
+        "src/generated/mob.rs",
+
+    ],
+
+    visibility = ["//meerkat-machine-codegen:__pkg__"],
+
+)
+
+
+
 rust_library(
     name = "meerkat_machine_kernels",
     aliases = aliases(package_name = "meerkat-machine-kernels"),

--- a/meerkat-machine-kernels/src/generated/meerkat.rs
+++ b/meerkat-machine-kernels/src/generated/meerkat.rs
@@ -10322,6 +10322,12 @@ pub struct State {
     pub next_admission_seq: u64,
     pub next_priority_admission_seq: u64,
     pub input_admission_seq: std::collections::BTreeMap<String, u64>,
+    pub input_runtime_boundary: std::collections::BTreeMap<String, RecoveredRunApplyBoundary>,
+    pub input_runtime_execution_kind:
+        std::collections::BTreeMap<String, RecoveredRuntimeExecutionKind>,
+    pub input_runtime_peer_response_terminal_apply_intent:
+        std::collections::BTreeMap<String, RecoveredPeerResponseTerminalApplyIntent>,
+    pub input_is_prompt: std::collections::BTreeMap<String, bool>,
     pub input_lane: std::collections::BTreeMap<String, InputLane>,
     pub input_recovery_lanes: std::collections::BTreeMap<String, InputLane>,
     pub admission_authorized_lanes: std::collections::BTreeMap<String, InputLane>,
@@ -11240,6 +11246,20 @@ pub mod inputs {
         pub admission_sequence_recovery: Option<RecoveredInputNormalizationReasonKind>,
         pub recovery_lane: Option<InputLane>,
         pub lane: Option<InputLane>,
+        pub runtime_boundary: Option<RecoveredRunApplyBoundary>,
+        pub runtime_execution_kind: Option<RecoveredRuntimeExecutionKind>,
+        pub runtime_peer_response_terminal_apply_intent:
+            Option<RecoveredPeerResponseTerminalApplyIntent>,
+        pub is_prompt: bool,
+    }
+    #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+    pub struct BindAdmissionRuntimeGrouping {
+        pub input_id: String,
+        pub runtime_boundary: RecoveredRunApplyBoundary,
+        pub runtime_execution_kind: RecoveredRuntimeExecutionKind,
+        pub runtime_peer_response_terminal_apply_intent:
+            Option<RecoveredPeerResponseTerminalApplyIntent>,
+        pub is_prompt: bool,
     }
     #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
     pub struct QueueAccepted {
@@ -12113,6 +12133,7 @@ pub enum Input {
     RunCancelled(inputs::RunCancelled),
     RecoverAdmittedInput(inputs::RecoverAdmittedInput),
     RecoverInputLifecycle(inputs::RecoverInputLifecycle),
+    BindAdmissionRuntimeGrouping(inputs::BindAdmissionRuntimeGrouping),
     QueueAccepted(inputs::QueueAccepted),
     SteerAccepted(inputs::SteerAccepted),
     ChangeLane(inputs::ChangeLane),
@@ -12427,6 +12448,7 @@ impl Input {
             Self::RunCancelled(_) => InputKind::RunCancelled,
             Self::RecoverAdmittedInput(_) => InputKind::RecoverAdmittedInput,
             Self::RecoverInputLifecycle(_) => InputKind::RecoverInputLifecycle,
+            Self::BindAdmissionRuntimeGrouping(_) => InputKind::BindAdmissionRuntimeGrouping,
             Self::QueueAccepted(_) => InputKind::QueueAccepted,
             Self::SteerAccepted(_) => InputKind::SteerAccepted,
             Self::ChangeLane(_) => InputKind::ChangeLane,
@@ -12744,6 +12766,7 @@ pub enum InputKind {
     RunCancelled,
     RecoverAdmittedInput,
     RecoverInputLifecycle,
+    BindAdmissionRuntimeGrouping,
     QueueAccepted,
     SteerAccepted,
     ChangeLane,
@@ -14108,6 +14131,383 @@ pub enum EffectKind {
     RequestCompletionWaiterResolutionForUnregister,
 }
 
+pub mod command_capabilities {
+    mod private {
+        #[derive(Debug, PartialEq, Eq)]
+        pub struct Sealed;
+    }
+
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    pub enum CommandPlanKind {
+        AuthorizedAcceptedInputMaterialization,
+        AuthorizeRuntimeLoopBatch,
+        AuthorizedStageForRun,
+        AuthorizedRuntimeLoopRunCommit,
+        AuthorizedRuntimeCompletionResultClosure,
+    }
+
+    impl CommandPlanKind {
+        #[must_use]
+        pub const fn as_str(self) -> &'static str {
+            match self {
+                Self::AuthorizedAcceptedInputMaterialization => {
+                    "AuthorizedAcceptedInputMaterialization"
+                }
+                Self::AuthorizeRuntimeLoopBatch => "AuthorizeRuntimeLoopBatch",
+                Self::AuthorizedStageForRun => "AuthorizedStageForRun",
+                Self::AuthorizedRuntimeLoopRunCommit => "AuthorizedRuntimeLoopRunCommit",
+                Self::AuthorizedRuntimeCompletionResultClosure => {
+                    "AuthorizedRuntimeCompletionResultClosure"
+                }
+            }
+        }
+    }
+
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    pub enum RuntimeLoopBatchSource {
+        Queue,
+        Steer,
+    }
+
+    #[must_use = "generated runtime-loop batch plan must be consumed by exact dequeue/stage realization"]
+    #[derive(Debug, PartialEq, Eq)]
+    pub struct RuntimeLoopBatchPlan {
+        batch_capability: AuthorizedRuntimeLoopBatch,
+        input_ids: Vec<String>,
+        source: RuntimeLoopBatchSource,
+    }
+
+    #[must_use = "generated stage-for-run plan must be consumed by exact stage realization"]
+    #[derive(Debug, PartialEq, Eq)]
+    pub struct StageForRunPlan {
+        stage_capability: AuthorizedStageForRun,
+        input_ids: Vec<String>,
+        source: RuntimeLoopBatchSource,
+    }
+
+    impl RuntimeLoopBatchPlan {
+        #[must_use]
+        pub fn input_ids(&self) -> &[String] {
+            &self.input_ids
+        }
+
+        #[must_use]
+        pub const fn source(&self) -> RuntimeLoopBatchSource {
+            self.source
+        }
+
+        pub fn into_parts(
+            self,
+        ) -> (
+            AuthorizedRuntimeLoopBatch,
+            Vec<String>,
+            RuntimeLoopBatchSource,
+        ) {
+            (self.batch_capability, self.input_ids, self.source)
+        }
+    }
+
+    impl StageForRunPlan {
+        #[must_use]
+        pub fn input_ids(&self) -> &[String] {
+            &self.input_ids
+        }
+
+        #[must_use]
+        pub const fn source(&self) -> RuntimeLoopBatchSource {
+            self.source
+        }
+
+        pub fn into_parts(self) -> (AuthorizedStageForRun, Vec<String>, RuntimeLoopBatchSource) {
+            (self.stage_capability, self.input_ids, self.source)
+        }
+    }
+
+    #[must_use = "generated command capability `AuthorizedAcceptedInputMaterialization` must be consumed by the shell action it authorizes"]
+    #[derive(Debug, PartialEq, Eq)]
+    pub struct AuthorizedAcceptedInputMaterialization {
+        _sealed: private::Sealed,
+    }
+
+    impl AuthorizedAcceptedInputMaterialization {
+        #[doc(hidden)]
+        #[allow(dead_code)]
+        pub(crate) fn mint_from_generated_command_plan() -> Self {
+            Self {
+                _sealed: private::Sealed,
+            }
+        }
+
+        #[must_use]
+        pub const fn plan(&self) -> CommandPlanKind {
+            CommandPlanKind::AuthorizedAcceptedInputMaterialization
+        }
+    }
+
+    #[must_use = "generated command capability `AuthorizedRuntimeLoopBatch` must be consumed by the shell action it authorizes"]
+    #[derive(Debug, PartialEq, Eq)]
+    pub struct AuthorizedRuntimeLoopBatch {
+        _sealed: private::Sealed,
+    }
+
+    impl AuthorizedRuntimeLoopBatch {
+        #[doc(hidden)]
+        #[allow(dead_code)]
+        pub(crate) fn mint_from_generated_command_plan() -> Self {
+            Self {
+                _sealed: private::Sealed,
+            }
+        }
+
+        #[must_use]
+        pub const fn plan(&self) -> CommandPlanKind {
+            CommandPlanKind::AuthorizeRuntimeLoopBatch
+        }
+    }
+
+    #[must_use = "generated command capability `AuthorizedStageForRun` must be consumed by the shell action it authorizes"]
+    #[derive(Debug, PartialEq, Eq)]
+    pub struct AuthorizedStageForRun {
+        _sealed: private::Sealed,
+    }
+
+    impl AuthorizedStageForRun {
+        #[doc(hidden)]
+        #[allow(dead_code)]
+        pub(crate) fn mint_from_generated_command_plan() -> Self {
+            Self {
+                _sealed: private::Sealed,
+            }
+        }
+
+        #[must_use]
+        pub const fn plan(&self) -> CommandPlanKind {
+            CommandPlanKind::AuthorizedStageForRun
+        }
+    }
+
+    #[must_use = "generated command capability `AuthorizedRuntimeLoopRunCommit` must be consumed by the shell action it authorizes"]
+    #[derive(Debug, PartialEq, Eq)]
+    pub struct AuthorizedRuntimeLoopRunCommit {
+        _sealed: private::Sealed,
+    }
+
+    impl AuthorizedRuntimeLoopRunCommit {
+        #[doc(hidden)]
+        #[allow(dead_code)]
+        pub(crate) fn mint_from_generated_command_plan() -> Self {
+            Self {
+                _sealed: private::Sealed,
+            }
+        }
+
+        #[must_use]
+        pub const fn plan(&self) -> CommandPlanKind {
+            CommandPlanKind::AuthorizedRuntimeLoopRunCommit
+        }
+    }
+
+    #[must_use = "generated command capability `RuntimeCompletionResultAuthority` must be consumed by the shell action it authorizes"]
+    #[derive(Debug, PartialEq, Eq)]
+    pub struct RuntimeCompletionResultAuthority {
+        _sealed: private::Sealed,
+    }
+
+    impl RuntimeCompletionResultAuthority {
+        #[doc(hidden)]
+        #[allow(dead_code)]
+        pub(crate) fn mint_from_generated_command_plan() -> Self {
+            Self {
+                _sealed: private::Sealed,
+            }
+        }
+
+        #[must_use]
+        pub const fn plan(&self) -> CommandPlanKind {
+            CommandPlanKind::AuthorizedRuntimeCompletionResultClosure
+        }
+    }
+
+    impl AuthorizedRuntimeLoopBatch {
+        #[must_use]
+        pub fn authorize_runtime_loop_batch_from_state(
+            state: &super::State,
+        ) -> Option<RuntimeLoopBatchPlan> {
+            runtime_loop_batch_from_state(
+                state,
+                super::InputLane::Steer,
+                RuntimeLoopBatchSource::Steer,
+            )
+            .or_else(|| {
+                runtime_loop_batch_from_state(
+                    state,
+                    super::InputLane::Queue,
+                    RuntimeLoopBatchSource::Queue,
+                )
+            })
+        }
+    }
+
+    impl AuthorizedStageForRun {
+        #[must_use]
+        pub fn authorize_stage_for_run_from_state(
+            state: &super::State,
+            input_ids: &[String],
+            run_id: &super::RunId,
+            source: RuntimeLoopBatchSource,
+        ) -> Option<StageForRunPlan> {
+            runtime_stage_for_run_from_state(state, input_ids, run_id, source)
+        }
+    }
+
+    fn runtime_loop_batch_from_state(
+        state: &super::State,
+        lane: super::InputLane,
+        source: RuntimeLoopBatchSource,
+    ) -> Option<RuntimeLoopBatchPlan> {
+        let ordered = ordered_queued_lane_inputs(state, lane)?;
+        let first = ordered.first()?;
+        let selected = match source {
+            RuntimeLoopBatchSource::Steer => select_steer_batch(state, &ordered, first),
+            RuntimeLoopBatchSource::Queue => select_queue_batch(state, &ordered, first),
+        };
+        if selected.is_empty() {
+            None
+        } else {
+            Some(RuntimeLoopBatchPlan {
+                batch_capability: AuthorizedRuntimeLoopBatch::mint_from_generated_command_plan(),
+                input_ids: selected,
+                source,
+            })
+        }
+    }
+
+    fn runtime_stage_for_run_from_state(
+        state: &super::State,
+        input_ids: &[String],
+        run_id: &super::RunId,
+        source: RuntimeLoopBatchSource,
+    ) -> Option<StageForRunPlan> {
+        if input_ids.is_empty() {
+            return None;
+        }
+        if state.current_run_id.as_ref() != Some(run_id) {
+            return None;
+        }
+        let expected_lane = match source {
+            RuntimeLoopBatchSource::Queue => super::InputLane::Queue,
+            RuntimeLoopBatchSource::Steer => super::InputLane::Steer,
+        };
+        for input_id in input_ids {
+            if state.input_phases.get(input_id) != Some(&super::InputPhase::Queued) {
+                return None;
+            }
+            if state.input_lane.get(input_id) != Some(&expected_lane) {
+                return None;
+            }
+            if !state.input_admission_seq.contains_key(input_id) {
+                return None;
+            }
+            if !state.input_recovery_lanes.contains_key(input_id) {
+                return None;
+            }
+            if state.input_run_associations.contains_key(input_id) {
+                return None;
+            }
+        }
+        Some(StageForRunPlan {
+            stage_capability: AuthorizedStageForRun::mint_from_generated_command_plan(),
+            input_ids: input_ids.to_vec(),
+            source,
+        })
+    }
+
+    fn ordered_queued_lane_inputs(
+        state: &super::State,
+        lane: super::InputLane,
+    ) -> Option<Vec<String>> {
+        let mut ordered = Vec::new();
+        for (input_id, input_lane) in &state.input_lane {
+            if *input_lane != lane {
+                continue;
+            }
+            if state.input_phases.get(input_id) != Some(&super::InputPhase::Queued) {
+                return None;
+            }
+            let sequence = *state.input_admission_seq.get(input_id)?;
+            ordered.push((sequence, input_id.clone()));
+        }
+        ordered.sort_by(|left, right| left.0.cmp(&right.0).then_with(|| left.1.cmp(&right.1)));
+        Some(ordered.into_iter().map(|(_, input_id)| input_id).collect())
+    }
+
+    fn select_steer_batch(state: &super::State, ordered: &[String], first: &String) -> Vec<String> {
+        let Some(target_boundary) = state.input_runtime_boundary.get(first).copied() else {
+            return vec![first.clone()];
+        };
+        let Some(target_execution_kind) = state.input_runtime_execution_kind.get(first).copied()
+        else {
+            return vec![first.clone()];
+        };
+        let target_terminal_intent = state
+            .input_runtime_peer_response_terminal_apply_intent
+            .get(first)
+            .copied();
+        ordered
+            .iter()
+            .take_while(|input_id| {
+                state.input_runtime_boundary.get(*input_id).copied() == Some(target_boundary)
+                    && state.input_runtime_execution_kind.get(*input_id).copied()
+                        == Some(target_execution_kind)
+                    && state
+                        .input_runtime_peer_response_terminal_apply_intent
+                        .get(*input_id)
+                        .copied()
+                        == target_terminal_intent
+            })
+            .cloned()
+            .collect()
+    }
+
+    fn select_queue_batch(state: &super::State, ordered: &[String], first: &String) -> Vec<String> {
+        let Some(target_execution_kind) = state.input_runtime_execution_kind.get(first).copied()
+        else {
+            return vec![first.clone()];
+        };
+        let target_terminal_intent = state
+            .input_runtime_peer_response_terminal_apply_intent
+            .get(first)
+            .copied();
+        let Some(driver_is_prompt) = state.input_is_prompt.get(first).copied() else {
+            return vec![first.clone()];
+        };
+        let mut selected = Vec::new();
+        for input_id in ordered {
+            if state.input_runtime_execution_kind.get(input_id).copied()
+                != Some(target_execution_kind)
+                || state
+                    .input_runtime_peer_response_terminal_apply_intent
+                    .get(input_id)
+                    .copied()
+                    != target_terminal_intent
+            {
+                break;
+            }
+            let Some(is_prompt) = state.input_is_prompt.get(input_id).copied() else {
+                break;
+            };
+            if !driver_is_prompt && is_prompt {
+                break;
+            }
+            selected.push(input_id.clone());
+            if is_prompt || driver_is_prompt {
+                break;
+            }
+        }
+        selected
+    }
+}
+
 #[allow(non_camel_case_types)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub enum TransitionId {
@@ -14946,6 +15346,11 @@ pub enum TransitionId {
     RollbackRunRunningToRetired,
     RecycleFromIdleOrRetired,
     RecycleFromAttached,
+    BindAdmissionRuntimeGroupingIdle,
+    BindAdmissionRuntimeGroupingAttached,
+    BindAdmissionRuntimeGroupingRunning,
+    BindAdmissionRuntimeGroupingRetired,
+    BindAdmissionRuntimeGroupingStopped,
     RecoverAdmittedInputIdle,
     RecoverAdmittedInputAttached,
     RecoverAdmittedInputRunning,
@@ -15983,6 +16388,10 @@ pub fn initial_state() -> State {
         next_admission_seq: 1000000000,
         next_priority_admission_seq: 999999999,
         input_admission_seq: Default::default(),
+        input_runtime_boundary: Default::default(),
+        input_runtime_execution_kind: Default::default(),
+        input_runtime_peer_response_terminal_apply_intent: Default::default(),
+        input_is_prompt: Default::default(),
         input_lane: Default::default(),
         input_recovery_lanes: Default::default(),
         admission_authorized_lanes: Default::default(),

--- a/meerkat-machine-kernels/src/generated/mob.rs
+++ b/meerkat-machine-kernels/src/generated/mob.rs
@@ -7431,6 +7431,140 @@ pub enum EffectKind {
     AdaptiveRunTerminalized,
 }
 
+pub mod command_capabilities {
+    mod private {
+        #[derive(Debug, PartialEq, Eq)]
+        pub struct Sealed;
+    }
+
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    pub enum CommandPlanKind {
+        AuthorizedMobSpawnStart,
+        CanStartSpawn,
+        SpawnStarted,
+        SpawnEffect,
+        FailSpawn,
+    }
+
+    impl CommandPlanKind {
+        #[must_use]
+        pub const fn as_str(self) -> &'static str {
+            match self {
+                Self::AuthorizedMobSpawnStart => "AuthorizedMobSpawnStart",
+                Self::CanStartSpawn => "CanStartSpawn",
+                Self::SpawnStarted => "SpawnStarted",
+                Self::SpawnEffect => "SpawnEffect",
+                Self::FailSpawn => "FailSpawn",
+            }
+        }
+    }
+
+    #[must_use = "generated command capability `PendingSpawnOperationOwnerAuthorized` must be consumed by the shell action it authorizes"]
+    #[derive(Debug, PartialEq, Eq)]
+    pub struct PendingSpawnOperationOwnerAuthorized {
+        _sealed: private::Sealed,
+    }
+
+    impl PendingSpawnOperationOwnerAuthorized {
+        #[doc(hidden)]
+        #[allow(dead_code)]
+        pub(crate) fn mint_from_generated_command_plan() -> Self {
+            Self {
+                _sealed: private::Sealed,
+            }
+        }
+
+        #[must_use]
+        pub const fn plan(&self) -> CommandPlanKind {
+            CommandPlanKind::AuthorizedMobSpawnStart
+        }
+    }
+
+    #[must_use = "generated command capability `CanStartSpawn` must be consumed by the shell action it authorizes"]
+    #[derive(Debug, PartialEq, Eq)]
+    pub struct CanStartSpawn {
+        _sealed: private::Sealed,
+    }
+
+    impl CanStartSpawn {
+        #[doc(hidden)]
+        #[allow(dead_code)]
+        pub(crate) fn mint_from_generated_command_plan() -> Self {
+            Self {
+                _sealed: private::Sealed,
+            }
+        }
+
+        #[must_use]
+        pub const fn plan(&self) -> CommandPlanKind {
+            CommandPlanKind::CanStartSpawn
+        }
+    }
+
+    #[must_use = "generated command capability `SpawnStarted` must be consumed by the shell action it authorizes"]
+    #[derive(Debug, PartialEq, Eq)]
+    pub struct SpawnStarted {
+        _sealed: private::Sealed,
+    }
+
+    impl SpawnStarted {
+        #[doc(hidden)]
+        #[allow(dead_code)]
+        pub(crate) fn mint_from_generated_command_plan() -> Self {
+            Self {
+                _sealed: private::Sealed,
+            }
+        }
+
+        #[must_use]
+        pub const fn plan(&self) -> CommandPlanKind {
+            CommandPlanKind::SpawnStarted
+        }
+    }
+
+    #[must_use = "generated command capability `SpawnEffect` must be consumed by the shell action it authorizes"]
+    #[derive(Debug, PartialEq, Eq)]
+    pub struct SpawnEffect {
+        _sealed: private::Sealed,
+    }
+
+    impl SpawnEffect {
+        #[doc(hidden)]
+        #[allow(dead_code)]
+        pub(crate) fn mint_from_generated_command_plan() -> Self {
+            Self {
+                _sealed: private::Sealed,
+            }
+        }
+
+        #[must_use]
+        pub const fn plan(&self) -> CommandPlanKind {
+            CommandPlanKind::SpawnEffect
+        }
+    }
+
+    #[must_use = "generated command capability `FailSpawn` must be consumed by the shell action it authorizes"]
+    #[derive(Debug, PartialEq, Eq)]
+    pub struct FailSpawn {
+        _sealed: private::Sealed,
+    }
+
+    impl FailSpawn {
+        #[doc(hidden)]
+        #[allow(dead_code)]
+        pub(crate) fn mint_from_generated_command_plan() -> Self {
+            Self {
+                _sealed: private::Sealed,
+            }
+        }
+
+        #[must_use]
+        pub const fn plan(&self) -> CommandPlanKind {
+            CommandPlanKind::FailSpawn
+        }
+    }
+}
+
 #[allow(non_camel_case_types)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub enum TransitionId {

--- a/meerkat-machine-schema/src/catalog/dsl/meerkat_machine.rs
+++ b/meerkat-machine-schema/src/catalog/dsl/meerkat_machine.rs
@@ -2626,6 +2626,13 @@ macro_rules! meerkat_catalog_machine_dsl {
             next_admission_seq: u64,
             next_priority_admission_seq: u64,
             input_admission_seq: Map<String, u64>,
+            // Runtime-loop batch grouping facts minted by admission authority.
+            // These survive as machine-owned witnesses so batch selection does
+            // not need to reconstruct semantic grouping from shell metadata.
+            input_runtime_boundary: Map<String, Enum<RecoveredRunApplyBoundary>>,
+            input_runtime_execution_kind: Map<String, Enum<RecoveredRuntimeExecutionKind>>,
+            input_runtime_peer_response_terminal_apply_intent: Map<String, Enum<RecoveredPeerResponseTerminalApplyIntent>>,
+            input_is_prompt: Map<String, bool>,
             // Unified work-lane membership for admitted inputs. Mutual
             // exclusion between Queue and Steer is structural: an input
             // maps to exactly one `InputLane` value by construction.
@@ -3064,6 +3071,10 @@ macro_rules! meerkat_catalog_machine_dsl {
             next_admission_seq = 1000000000,
             next_priority_admission_seq = 999999999,
             input_admission_seq = EmptyMap,
+            input_runtime_boundary = EmptyMap,
+            input_runtime_execution_kind = EmptyMap,
+            input_runtime_peer_response_terminal_apply_intent = EmptyMap,
+            input_is_prompt = EmptyMap,
             input_lane = EmptyMap,
             input_recovery_lanes = EmptyMap,
             admission_authorized_lanes = EmptyMap,
@@ -3716,6 +3727,17 @@ macro_rules! meerkat_catalog_machine_dsl {
                 admission_sequence_recovery: Option<Enum<RecoveredInputNormalizationReasonKind>>,
                 recovery_lane: Option<Enum<InputLane>>,
                 lane: Option<Enum<InputLane>>,
+                runtime_boundary: Option<Enum<RecoveredRunApplyBoundary>>,
+                runtime_execution_kind: Option<Enum<RecoveredRuntimeExecutionKind>>,
+                runtime_peer_response_terminal_apply_intent: Option<Enum<RecoveredPeerResponseTerminalApplyIntent>>,
+                is_prompt: bool,
+            },
+            BindAdmissionRuntimeGrouping {
+                input_id: String,
+                runtime_boundary: Enum<RecoveredRunApplyBoundary>,
+                runtime_execution_kind: Enum<RecoveredRuntimeExecutionKind>,
+                runtime_peer_response_terminal_apply_intent: Option<Enum<RecoveredPeerResponseTerminalApplyIntent>>,
+                is_prompt: bool,
             },
             QueueAccepted { input_id: String },
             SteerAccepted { input_id: String },
@@ -10734,6 +10756,10 @@ macro_rules! meerkat_catalog_machine_dsl {
                 self.admission_authorized_plans.insert(input_id, AdmissionPlanKind::Queued);
                 self.admission_authorized_existing_actions.remove(input_id);
                 self.admission_authorized_existing_targets.remove(input_id);
+                self.input_runtime_boundary.insert(input_id, RecoveredRunApplyBoundary::RunStart);
+                self.input_runtime_execution_kind.insert(input_id, RecoveredRuntimeExecutionKind::ContentTurn);
+                self.input_runtime_peer_response_terminal_apply_intent.insert(input_id, RecoveredPeerResponseTerminalApplyIntent::AppendContextAndRun);
+                self.input_is_prompt.insert(input_id, false);
             }
             to Idle
             emit AdmissionResolved {
@@ -10780,6 +10806,10 @@ macro_rules! meerkat_catalog_machine_dsl {
                 self.admission_authorized_plans.insert(input_id, AdmissionPlanKind::Queued);
                 self.admission_authorized_existing_actions.remove(input_id);
                 self.admission_authorized_existing_targets.remove(input_id);
+                self.input_runtime_boundary.insert(input_id, RecoveredRunApplyBoundary::RunStart);
+                self.input_runtime_execution_kind.insert(input_id, RecoveredRuntimeExecutionKind::ContentTurn);
+                self.input_runtime_peer_response_terminal_apply_intent.insert(input_id, RecoveredPeerResponseTerminalApplyIntent::AppendContextAndRun);
+                self.input_is_prompt.insert(input_id, false);
             }
             to Idle
             emit AdmissionResolved {
@@ -10840,6 +10870,14 @@ macro_rules! meerkat_catalog_machine_dsl {
                 self.admission_authorized_plans.insert(input_id, AdmissionPlanKind::Queued);
                 self.admission_authorized_existing_actions.remove(input_id);
                 self.admission_authorized_existing_targets.remove(input_id);
+                self.input_runtime_boundary.insert(input_id, RecoveredRunApplyBoundary::RunStart);
+                self.input_runtime_execution_kind.insert(input_id, if input_kind == AdmissionInputKind::Continuation {
+                    RecoveredRuntimeExecutionKind::ResumePending
+                } else {
+                    RecoveredRuntimeExecutionKind::ContentTurn
+                });
+                self.input_runtime_peer_response_terminal_apply_intent.remove(input_id);
+                self.input_is_prompt.insert(input_id, input_kind == AdmissionInputKind::Prompt);
             }
             to Idle
             emit AdmissionResolved {
@@ -10906,6 +10944,18 @@ macro_rules! meerkat_catalog_machine_dsl {
                 self.admission_authorized_plans.insert(input_id, AdmissionPlanKind::Queued);
                 self.admission_authorized_existing_actions.remove(input_id);
                 self.admission_authorized_existing_targets.remove(input_id);
+                self.input_runtime_boundary.insert(input_id, if silent_intent_match {
+                    RecoveredRunApplyBoundary::RunStart
+                } else {
+                    RecoveredRunApplyBoundary::RunCheckpoint
+                });
+                self.input_runtime_execution_kind.insert(input_id, if input_kind == AdmissionInputKind::Continuation {
+                    RecoveredRuntimeExecutionKind::ResumePending
+                } else {
+                    RecoveredRuntimeExecutionKind::ContentTurn
+                });
+                self.input_runtime_peer_response_terminal_apply_intent.remove(input_id);
+                self.input_is_prompt.insert(input_id, input_kind == AdmissionInputKind::Prompt);
             }
             to Idle
             emit AdmissionResolved {
@@ -10973,6 +11023,10 @@ macro_rules! meerkat_catalog_machine_dsl {
                 self.admission_authorized_plans.insert(input_id, AdmissionPlanKind::Queued);
                 self.admission_authorized_existing_actions.remove(input_id);
                 self.admission_authorized_existing_targets.remove(input_id);
+                self.input_runtime_boundary.insert(input_id, RecoveredRunApplyBoundary::RunStart);
+                self.input_runtime_execution_kind.insert(input_id, RecoveredRuntimeExecutionKind::ContentTurn);
+                self.input_runtime_peer_response_terminal_apply_intent.remove(input_id);
+                self.input_is_prompt.insert(input_id, input_kind == AdmissionInputKind::Prompt);
             }
             to Idle
             emit AdmissionResolved {
@@ -11032,6 +11086,10 @@ macro_rules! meerkat_catalog_machine_dsl {
                 self.admission_authorized_plans.insert(input_id, AdmissionPlanKind::Queued);
                 self.admission_authorized_existing_actions.remove(input_id);
                 self.admission_authorized_existing_targets.remove(input_id);
+                self.input_runtime_boundary.insert(input_id, RecoveredRunApplyBoundary::RunStart);
+                self.input_runtime_execution_kind.insert(input_id, RecoveredRuntimeExecutionKind::ContentTurn);
+                self.input_runtime_peer_response_terminal_apply_intent.remove(input_id);
+                self.input_is_prompt.insert(input_id, false);
             }
             to Idle
             emit AdmissionResolved {
@@ -11099,6 +11157,10 @@ macro_rules! meerkat_catalog_machine_dsl {
                     self.admission_authorized_existing_actions.remove(input_id);
                     self.admission_authorized_existing_targets.remove(input_id);
                 }
+                self.input_runtime_boundary.insert(input_id, RecoveredRunApplyBoundary::RunCheckpoint);
+                self.input_runtime_execution_kind.insert(input_id, RecoveredRuntimeExecutionKind::ContentTurn);
+                self.input_runtime_peer_response_terminal_apply_intent.remove(input_id);
+                self.input_is_prompt.insert(input_id, false);
             }
             to Idle
             emit AdmissionResolved {
@@ -11149,6 +11211,10 @@ macro_rules! meerkat_catalog_machine_dsl {
                 self.admission_authorized_plans.insert(input_id, AdmissionPlanKind::Queued);
                 self.admission_authorized_existing_actions.remove(input_id);
                 self.admission_authorized_existing_targets.remove(input_id);
+                self.input_runtime_boundary.insert(input_id, RecoveredRunApplyBoundary::RunStart);
+                self.input_runtime_execution_kind.insert(input_id, RecoveredRuntimeExecutionKind::ContentTurn);
+                self.input_runtime_peer_response_terminal_apply_intent.insert(input_id, RecoveredPeerResponseTerminalApplyIntent::AppendContextAndRun);
+                self.input_is_prompt.insert(input_id, false);
             }
             to Idle
             emit AdmissionResolved {
@@ -11196,6 +11262,10 @@ macro_rules! meerkat_catalog_machine_dsl {
                 self.admission_authorized_plans.insert(input_id, AdmissionPlanKind::Queued);
                 self.admission_authorized_existing_actions.remove(input_id);
                 self.admission_authorized_existing_targets.remove(input_id);
+                self.input_runtime_boundary.insert(input_id, RecoveredRunApplyBoundary::RunCheckpoint);
+                self.input_runtime_execution_kind.insert(input_id, RecoveredRuntimeExecutionKind::ResumePending);
+                self.input_runtime_peer_response_terminal_apply_intent.remove(input_id);
+                self.input_is_prompt.insert(input_id, false);
             }
             to Idle
             emit AdmissionResolved {
@@ -11259,6 +11329,10 @@ macro_rules! meerkat_catalog_machine_dsl {
                 self.admission_authorized_plans.insert(input_id, AdmissionPlanKind::Queued);
                 self.admission_authorized_existing_actions.remove(input_id);
                 self.admission_authorized_existing_targets.remove(input_id);
+                self.input_runtime_boundary.insert(input_id, RecoveredRunApplyBoundary::RunStart);
+                self.input_runtime_execution_kind.insert(input_id, RecoveredRuntimeExecutionKind::ContentTurn);
+                self.input_runtime_peer_response_terminal_apply_intent.remove(input_id);
+                self.input_is_prompt.insert(input_id, false);
             }
             to Idle
             emit AdmissionResolved {
@@ -11317,6 +11391,10 @@ macro_rules! meerkat_catalog_machine_dsl {
                 self.admission_authorized_plans.insert(input_id, AdmissionPlanKind::ConsumedOnAccept);
                 self.admission_authorized_existing_actions.remove(input_id);
                 self.admission_authorized_existing_targets.remove(input_id);
+                self.input_runtime_boundary.insert(input_id, RecoveredRunApplyBoundary::RunStart);
+                self.input_runtime_execution_kind.insert(input_id, RecoveredRuntimeExecutionKind::ContentTurn);
+                self.input_runtime_peer_response_terminal_apply_intent.remove(input_id);
+                self.input_is_prompt.insert(input_id, false);
             }
             to Idle
             emit AdmissionResolved {
@@ -15232,6 +15310,44 @@ macro_rules! meerkat_catalog_machine_dsl {
         // Absorbed substate transitions — Input Lifecycle
         // =====================================================================
 
+        // BindAdmissionRuntimeGrouping: persist the generated admission
+        // runtime-loop grouping witnesses before physical queue projection.
+        // Live admission records these from the just-emitted
+        // AdmissionResolved effect; recovery records them from durable
+        // admission witnesses. Runtime-loop batch selection reads these maps
+        // instead of shell metadata.
+        transition BindAdmissionRuntimeGrouping {
+            per_phase [Idle, Attached, Running, Retired, Stopped]
+            on input BindAdmissionRuntimeGrouping {
+                input_id,
+                runtime_boundary,
+                runtime_execution_kind,
+                runtime_peer_response_terminal_apply_intent,
+                is_prompt
+            }
+            guard "recovered_lifecycle_authorized" {
+                self.input_phases.contains_key(input_id)
+            }
+            guard "grouping_not_bound" {
+                !self.input_runtime_boundary.contains_key(input_id)
+                && !self.input_runtime_execution_kind.contains_key(input_id)
+            }
+            update {
+                self.input_runtime_boundary.insert(input_id, runtime_boundary);
+                self.input_runtime_execution_kind.insert(input_id, runtime_execution_kind);
+                if runtime_peer_response_terminal_apply_intent != None {
+                    self.input_runtime_peer_response_terminal_apply_intent.insert(
+                        input_id,
+                        runtime_peer_response_terminal_apply_intent.get("value")
+                    );
+                } else {
+                    self.input_runtime_peer_response_terminal_apply_intent.remove(input_id);
+                }
+                self.input_is_prompt.insert(input_id, is_prompt);
+            }
+            to Idle
+        }
+
         // RecoverAdmittedInput: accept or reject the recovered admission
         // witness before shell recovery may re-materialize admission metadata.
         // This is the coherence check for persisted input kind, lane, and
@@ -15291,7 +15407,11 @@ macro_rules! meerkat_catalog_machine_dsl {
                 admission_sequence,
                 admission_sequence_recovery,
                 recovery_lane,
-                lane
+                lane,
+                runtime_boundary,
+                runtime_execution_kind,
+                runtime_peer_response_terminal_apply_intent,
+                is_prompt
             }
             guard "recovered_lifecycle_has_admission_witness" {
                 phase == InputPhase::Consumed
@@ -15339,6 +15459,20 @@ macro_rules! meerkat_catalog_machine_dsl {
             guard "recovered_order_recovery_matches_missing_sequence" {
                 admission_sequence_recovery == None
                 || (phase == InputPhase::Queued && admission_sequence == None)
+            }
+            guard "recovered_grouping_matches_phase" {
+                (
+                    phase == InputPhase::Queued
+                    && runtime_boundary != None
+                    && runtime_execution_kind != None
+                )
+                || (
+                    phase != InputPhase::Queued
+                    && runtime_boundary == None
+                    && runtime_execution_kind == None
+                    && runtime_peer_response_terminal_apply_intent == None
+                    && is_prompt == false
+                )
             }
             guard "recovered_terminal_payload_matches_phase" {
                 (
@@ -15455,6 +15589,25 @@ macro_rules! meerkat_catalog_machine_dsl {
                     self.input_recovery_lanes.insert(input_id, recovery_lane.get("value"));
                 } else {
                     self.input_recovery_lanes.remove(input_id);
+                }
+
+                if runtime_boundary != None {
+                    self.input_runtime_boundary.insert(input_id, runtime_boundary.get("value"));
+                    self.input_runtime_execution_kind.insert(input_id, runtime_execution_kind.get("value"));
+                    if runtime_peer_response_terminal_apply_intent != None {
+                        self.input_runtime_peer_response_terminal_apply_intent.insert(
+                            input_id,
+                            runtime_peer_response_terminal_apply_intent.get("value")
+                        );
+                    } else {
+                        self.input_runtime_peer_response_terminal_apply_intent.remove(input_id);
+                    }
+                    self.input_is_prompt.insert(input_id, is_prompt);
+                } else {
+                    self.input_runtime_boundary.remove(input_id);
+                    self.input_runtime_execution_kind.remove(input_id);
+                    self.input_runtime_peer_response_terminal_apply_intent.remove(input_id);
+                    self.input_is_prompt.remove(input_id);
                 }
             }
             to Idle
@@ -20565,6 +20718,276 @@ macro_rules! meerkat_catalog_machine_dsl {
             emit TurnSurfaceResultResolved { outcome: outcome, cause_class: cause_class, surface_class: SurfaceResultClass::HardFailure }
         }
     }
+        }
+
+        pub mod command_capabilities {
+            use super::{InputLane, InputPhase, MeerkatMachineState, RunId};
+
+            mod private {
+                #[derive(Debug, PartialEq, Eq)]
+                pub struct Sealed;
+            }
+
+            #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+            pub enum RuntimeLoopBatchSource {
+                Queue,
+                Steer,
+            }
+
+            #[must_use = "generated runtime-loop batch plan must be consumed by exact dequeue/stage realization"]
+            #[derive(Debug, PartialEq, Eq)]
+            pub struct RuntimeLoopBatchPlan {
+                batch_capability: AuthorizedRuntimeLoopBatch,
+                input_ids: Vec<String>,
+                source: RuntimeLoopBatchSource,
+            }
+
+            impl RuntimeLoopBatchPlan {
+                pub fn into_parts(
+                    self,
+                ) -> (
+                    AuthorizedRuntimeLoopBatch,
+                    Vec<String>,
+                    RuntimeLoopBatchSource,
+                ) {
+                    (self.batch_capability, self.input_ids, self.source)
+                }
+            }
+
+            #[must_use = "generated stage-for-run plan must be consumed by exact stage realization"]
+            #[derive(Debug, PartialEq, Eq)]
+            pub struct StageForRunPlan {
+                stage_capability: AuthorizedStageForRun,
+                input_ids: Vec<String>,
+                source: RuntimeLoopBatchSource,
+            }
+
+            impl StageForRunPlan {
+                pub fn into_parts(self) -> (AuthorizedStageForRun, Vec<String>, RuntimeLoopBatchSource) {
+                    (self.stage_capability, self.input_ids, self.source)
+                }
+            }
+
+            #[must_use = "generated command capability `AuthorizedRuntimeLoopBatch` must be consumed by the shell action it authorizes"]
+            #[derive(Debug, PartialEq, Eq)]
+            pub struct AuthorizedRuntimeLoopBatch {
+                _sealed: private::Sealed,
+            }
+
+            impl AuthorizedRuntimeLoopBatch {
+                #[doc(hidden)]
+                #[allow(dead_code)]
+                pub(crate) fn mint_from_generated_command_plan() -> Self {
+                    Self {
+                        _sealed: private::Sealed,
+                    }
+                }
+
+                #[must_use]
+                pub fn authorize_runtime_loop_batch_from_state(
+                    state: &MeerkatMachineState,
+                ) -> Option<RuntimeLoopBatchPlan> {
+                    runtime_loop_batch_from_state(
+                        state,
+                        InputLane::Steer,
+                        RuntimeLoopBatchSource::Steer,
+                    )
+                    .or_else(|| {
+                        runtime_loop_batch_from_state(
+                            state,
+                            InputLane::Queue,
+                            RuntimeLoopBatchSource::Queue,
+                        )
+                    })
+                }
+            }
+
+            #[must_use = "generated command capability `AuthorizedStageForRun` must be consumed by the shell action it authorizes"]
+            #[derive(Debug, PartialEq, Eq)]
+            pub struct AuthorizedStageForRun {
+                _sealed: private::Sealed,
+            }
+
+            impl AuthorizedStageForRun {
+                #[doc(hidden)]
+                #[allow(dead_code)]
+                pub(crate) fn mint_from_generated_command_plan() -> Self {
+                    Self {
+                        _sealed: private::Sealed,
+                    }
+                }
+
+                #[must_use]
+                pub fn authorize_stage_for_run_from_state(
+                    state: &MeerkatMachineState,
+                    input_ids: &[String],
+                    run_id: &RunId,
+                    source: RuntimeLoopBatchSource,
+                ) -> Option<StageForRunPlan> {
+                    runtime_stage_for_run_from_state(state, input_ids, run_id, source)
+                }
+            }
+
+            fn runtime_loop_batch_from_state(
+                state: &MeerkatMachineState,
+                lane: InputLane,
+                source: RuntimeLoopBatchSource,
+            ) -> Option<RuntimeLoopBatchPlan> {
+                let ordered = ordered_queued_lane_inputs(state, lane)?;
+                let first = ordered.first()?;
+                let selected = match source {
+                    RuntimeLoopBatchSource::Steer => select_steer_batch(state, &ordered, first),
+                    RuntimeLoopBatchSource::Queue => select_queue_batch(state, &ordered, first),
+                };
+                if selected.is_empty() {
+                    None
+                } else {
+                    Some(RuntimeLoopBatchPlan {
+                        batch_capability: AuthorizedRuntimeLoopBatch::mint_from_generated_command_plan(),
+                        input_ids: selected,
+                        source,
+                    })
+                }
+            }
+
+            fn runtime_stage_for_run_from_state(
+                state: &MeerkatMachineState,
+                input_ids: &[String],
+                run_id: &RunId,
+                source: RuntimeLoopBatchSource,
+            ) -> Option<StageForRunPlan> {
+                if input_ids.is_empty() {
+                    return None;
+                }
+                if state.current_run_id.as_ref() != Some(run_id) {
+                    return None;
+                }
+                let expected_lane = match source {
+                    RuntimeLoopBatchSource::Queue => InputLane::Queue,
+                    RuntimeLoopBatchSource::Steer => InputLane::Steer,
+                };
+                for input_id in input_ids {
+                    if state.input_phases.get(input_id) != Some(&InputPhase::Queued) {
+                        return None;
+                    }
+                    if state.input_lane.get(input_id) != Some(&expected_lane) {
+                        return None;
+                    }
+                    if !state.input_admission_seq.contains_key(input_id) {
+                        return None;
+                    }
+                    if !state.input_recovery_lanes.contains_key(input_id) {
+                        return None;
+                    }
+                    if state.input_run_associations.contains_key(input_id) {
+                        return None;
+                    }
+                }
+                Some(StageForRunPlan {
+                    stage_capability: AuthorizedStageForRun::mint_from_generated_command_plan(),
+                    input_ids: input_ids.to_vec(),
+                    source,
+                })
+            }
+
+            fn ordered_queued_lane_inputs(
+                state: &MeerkatMachineState,
+                lane: InputLane,
+            ) -> Option<Vec<String>> {
+                let mut ordered = Vec::new();
+                for (input_id, input_lane) in &state.input_lane {
+                    if *input_lane != lane {
+                        continue;
+                    }
+                    if state.input_phases.get(input_id) != Some(&InputPhase::Queued) {
+                        return None;
+                    }
+                    let sequence = *state.input_admission_seq.get(input_id)?;
+                    ordered.push((sequence, input_id.clone()));
+                }
+                ordered.sort_by(|left, right| {
+                    left.0.cmp(&right.0).then_with(|| left.1.cmp(&right.1))
+                });
+                Some(ordered.into_iter().map(|(_, input_id)| input_id).collect())
+            }
+
+            fn select_steer_batch(
+                state: &MeerkatMachineState,
+                ordered: &[String],
+                first: &String,
+            ) -> Vec<String> {
+                let Some(target_boundary) = state.input_runtime_boundary.get(first).copied()
+                else {
+                    return vec![first.clone()];
+                };
+                let Some(target_execution_kind) =
+                    state.input_runtime_execution_kind.get(first).copied()
+                else {
+                    return vec![first.clone()];
+                };
+                let target_terminal_intent = state
+                    .input_runtime_peer_response_terminal_apply_intent
+                    .get(first)
+                    .copied();
+                ordered
+                    .iter()
+                    .take_while(|input_id| {
+                        state.input_runtime_boundary.get(*input_id).copied()
+                            == Some(target_boundary)
+                            && state.input_runtime_execution_kind.get(*input_id).copied()
+                                == Some(target_execution_kind)
+                            && state
+                                .input_runtime_peer_response_terminal_apply_intent
+                                .get(*input_id)
+                                .copied()
+                                == target_terminal_intent
+                    })
+                    .cloned()
+                    .collect()
+            }
+
+            fn select_queue_batch(
+                state: &MeerkatMachineState,
+                ordered: &[String],
+                first: &String,
+            ) -> Vec<String> {
+                let Some(target_execution_kind) =
+                    state.input_runtime_execution_kind.get(first).copied()
+                else {
+                    return vec![first.clone()];
+                };
+                let target_terminal_intent = state
+                    .input_runtime_peer_response_terminal_apply_intent
+                    .get(first)
+                    .copied();
+                let Some(driver_is_prompt) = state.input_is_prompt.get(first).copied() else {
+                    return vec![first.clone()];
+                };
+                let mut selected = Vec::new();
+                for input_id in ordered {
+                    if state.input_runtime_execution_kind.get(input_id).copied()
+                        != Some(target_execution_kind)
+                        || state
+                            .input_runtime_peer_response_terminal_apply_intent
+                            .get(input_id)
+                            .copied()
+                            != target_terminal_intent
+                    {
+                        break;
+                    }
+                    let Some(is_prompt) = state.input_is_prompt.get(input_id).copied() else {
+                        break;
+                    };
+                    if !driver_is_prompt && is_prompt {
+                        break;
+                    }
+                    selected.push(input_id.clone());
+                    if is_prompt || driver_is_prompt {
+                        break;
+                    }
+                }
+                selected
+            }
         }
 
         impl MeerkatMachineAuthority {

--- a/meerkat-machine-schema/src/catalog/dsl/mod.rs
+++ b/meerkat-machine-schema/src/catalog/dsl/mod.rs
@@ -44,15 +44,16 @@ pub mod session_turn_admission;
 pub mod work_attention_lifecycle;
 pub mod workgraph_lifecycle;
 
-use crate::identity::InputVariantId;
+use crate::identity::{EffectVariantId, InputVariantId, SignalVariantId, TransitionId};
 use crate::{
-    MachineSchema, NamedTypeBinding, RustBinding, TypePathEnumPayloadField,
-    TypePathEnumStructuralVariant, TypePathStructField,
+    CommandPlanSchema, EffectClosureSchema, MachineSchema, NamedTypeBinding, RustBinding,
+    TypePathEnumPayloadField, TypePathEnumStructuralVariant, TypePathStructField,
 };
 
 pub struct MachineSchemaMetadata {
     pub named_types: Vec<NamedTypeBinding>,
     pub runtime_internal_inputs: Vec<InputVariantId>,
+    pub command_plans: Vec<CommandPlanSchema>,
     pub ci_step_limit: Option<u32>,
 }
 
@@ -60,6 +61,7 @@ impl MachineSchemaMetadata {
     pub fn attach_to(self, mut schema: MachineSchema) -> MachineSchema {
         schema.named_types = self.named_types;
         schema.runtime_internal_inputs = self.runtime_internal_inputs;
+        schema.command_plans = self.command_plans;
         schema.ci_step_limit = self.ci_step_limit;
         schema
     }
@@ -155,6 +157,26 @@ fn input_variant_ids<T: RuntimeInternalInputVariant>(
         .collect()
 }
 
+fn input_variant_id(value: &'static str) -> InputVariantId {
+    InputVariantId::from_trusted_catalog_literal(value)
+}
+
+fn signal_variant_id(value: &'static str) -> SignalVariantId {
+    SignalVariantId::from_trusted_catalog_literal(value)
+}
+
+fn transition_id(value: &'static str) -> TransitionId {
+    TransitionId::from_trusted_catalog_literal(value)
+}
+
+fn transition_id_owned(value: String) -> TransitionId {
+    TransitionId::from_trusted_catalog_string(value)
+}
+
+fn effect_variant_id(value: &'static str) -> EffectVariantId {
+    EffectVariantId::from_trusted_catalog_literal(value)
+}
+
 fn machine_schema_metadata(
     named_types: Vec<NamedTypeBinding>,
     runtime_internal_inputs: Vec<InputVariantId>,
@@ -162,8 +184,263 @@ fn machine_schema_metadata(
     MachineSchemaMetadata {
         named_types,
         runtime_internal_inputs,
+        command_plans: Vec::new(),
         ci_step_limit: None,
     }
+}
+
+fn meerkat_queue_to_run_command_plans() -> Vec<CommandPlanSchema> {
+    let admission_plan_transitions = [
+        "ResolveAdmissionPlanRequestedTerminalQueueIdle",
+        "ResolveAdmissionPlanRequestedTerminalQueueAttached",
+        "ResolveAdmissionPlanRequestedTerminalQueueRunning",
+        "ResolveAdmissionPlanRequestedTerminalSteerIdle",
+        "ResolveAdmissionPlanRequestedTerminalSteerAttached",
+        "ResolveAdmissionPlanRequestedTerminalSteerRunning",
+        "ResolveAdmissionPlanRequestedQueueIdle",
+        "ResolveAdmissionPlanRequestedQueueAttached",
+        "ResolveAdmissionPlanRequestedQueueRunning",
+        "ResolveAdmissionPlanRequestedSteerIdle",
+        "ResolveAdmissionPlanRequestedSteerAttached",
+        "ResolveAdmissionPlanRequestedSteerRunning",
+        "ResolveAdmissionPlanDefaultQueueKindIdle",
+        "ResolveAdmissionPlanDefaultQueueKindAttached",
+        "ResolveAdmissionPlanDefaultQueueKindRunning",
+        "ResolveAdmissionPlanDefaultPeerMessageOrRequestIdle",
+        "ResolveAdmissionPlanDefaultPeerMessageOrRequestAttached",
+        "ResolveAdmissionPlanDefaultPeerMessageOrRequestRunning",
+        "ResolveAdmissionPlanPeerResponseProgressIdle",
+        "ResolveAdmissionPlanPeerResponseProgressAttached",
+        "ResolveAdmissionPlanPeerResponseProgressRunning",
+        "ResolveAdmissionPlanDefaultPeerResponseTerminalIdle",
+        "ResolveAdmissionPlanDefaultPeerResponseTerminalAttached",
+        "ResolveAdmissionPlanDefaultPeerResponseTerminalRunning",
+        "ResolveAdmissionPlanDefaultContinuationIdle",
+        "ResolveAdmissionPlanDefaultContinuationAttached",
+        "ResolveAdmissionPlanDefaultContinuationRunning",
+        "ResolveAdmissionPlanWorkgraphAttentionContinuationIdle",
+        "ResolveAdmissionPlanWorkgraphAttentionContinuationAttached",
+        "ResolveAdmissionPlanWorkgraphAttentionContinuationRunning",
+        "ResolveAdmissionPlanOperationIdle",
+        "ResolveAdmissionPlanOperationAttached",
+        "ResolveAdmissionPlanOperationRunning",
+        "QueueAcceptedIdle",
+        "QueueAcceptedAttached",
+        "QueueAcceptedRunning",
+        "QueueAcceptedRetired",
+        "QueueAcceptedStopped",
+        "SteerAcceptedIdle",
+        "SteerAcceptedAttached",
+        "SteerAcceptedRunning",
+        "SteerAcceptedRetired",
+        "SteerAcceptedStopped",
+    ];
+    let stage_transitions = [
+        "StageForRunIdle",
+        "StageForRunAttached",
+        "StageForRunRunning",
+        "StageForRunRetired",
+        "StageForRunStopped",
+    ];
+    let run_commit_transitions = [
+        "RunCompleted",
+        "RunFailed",
+        "RunCancelled",
+        "CommitRunningToIdle",
+        "CommitRunningToAttached",
+        "CommitRunningToRetired",
+        "FailRunningToIdle",
+        "FailRunningToAttached",
+        "FailRunningToRetired",
+        "CancelRunningToIdle",
+        "CancelRunningToAttached",
+        "CancelRunningToRetired",
+        "RollbackRunRunningToIdle",
+        "RollbackRunRunningToAttached",
+        "RollbackRunRunningToRetired",
+    ];
+    let completion_result_phases = [
+        "Initializing",
+        "Idle",
+        "Attached",
+        "Running",
+        "Retired",
+        "Stopped",
+    ];
+    let completion_result_families = [
+        "ResolveRuntimeCompletionResultCompleted",
+        "ResolveRuntimeCompletionResultWithoutResult",
+        "ResolveRuntimeCompletionResultCallbackPending",
+        "ResolveRuntimeCompletionResultCancelled",
+        "ResolveRuntimeCompletionResultRuntimeApplyFailed",
+        "ResolveRuntimeCompletionResultMachineFailed",
+        "ResolveRuntimeCompletionResultFinalizationFailureWithResult",
+        "ResolveRuntimeCompletionResultFinalizationFailureWithoutResult",
+        "ResolveRuntimeCompletionResultRuntimeTerminated",
+    ];
+    let mut completion_result_transitions = completion_result_families
+        .iter()
+        .flat_map(|family| {
+            completion_result_phases
+                .iter()
+                .map(move |phase| transition_id_owned(format!("{family}{phase}")))
+        })
+        .collect::<Vec<_>>();
+    completion_result_transitions.push(transition_id(
+        "ResolveRuntimeCompletionResultRuntimeTerminatedDestroyedDestroyed",
+    ));
+    vec![
+        CommandPlanSchema {
+            name: "AuthorizedAcceptedInputMaterialization".to_owned(),
+            authority_type: "AuthorizedAcceptedInputMaterialization".to_owned(),
+            source_inputs: vec![
+                input_variant_id("ResolveAdmissionPlan"),
+                input_variant_id("QueueAccepted"),
+                input_variant_id("SteerAccepted"),
+            ],
+            source_signals: vec![],
+            transitions: admission_plan_transitions
+                .iter()
+                .copied()
+                .map(transition_id)
+                .collect(),
+            effects: vec![
+                effect_variant_id("AdmissionResolved"),
+                effect_variant_id("IngressAccepted"),
+                effect_variant_id("PostAdmissionSignal"),
+            ],
+            effect_closures: vec![],
+        },
+        CommandPlanSchema {
+            name: "AuthorizeRuntimeLoopBatch".to_owned(),
+            authority_type: "AuthorizedRuntimeLoopBatch".to_owned(),
+            source_inputs: vec![
+                input_variant_id("QueueAccepted"),
+                input_variant_id("SteerAccepted"),
+                input_variant_id("RecoverAdmittedInput"),
+                input_variant_id("RecoverInputLifecycle"),
+            ],
+            source_signals: vec![],
+            transitions: vec![
+                transition_id("QueueAcceptedIdle"),
+                transition_id("QueueAcceptedAttached"),
+                transition_id("QueueAcceptedRunning"),
+                transition_id("QueueAcceptedRetired"),
+                transition_id("QueueAcceptedStopped"),
+                transition_id("SteerAcceptedIdle"),
+                transition_id("SteerAcceptedAttached"),
+                transition_id("SteerAcceptedRunning"),
+                transition_id("SteerAcceptedRetired"),
+                transition_id("SteerAcceptedStopped"),
+                transition_id("RecoverInputLifecycleIdle"),
+                transition_id("RecoverInputLifecycleAttached"),
+                transition_id("RecoverInputLifecycleRunning"),
+                transition_id("RecoverInputLifecycleRetired"),
+                transition_id("RecoverInputLifecycleStopped"),
+            ],
+            effects: vec![effect_variant_id("IngressAccepted")],
+            effect_closures: vec![],
+        },
+        CommandPlanSchema {
+            name: "AuthorizedStageForRun".to_owned(),
+            authority_type: "AuthorizedStageForRun".to_owned(),
+            source_inputs: vec![input_variant_id("StageForRun")],
+            source_signals: vec![],
+            transitions: stage_transitions
+                .iter()
+                .copied()
+                .map(transition_id)
+                .collect(),
+            effects: vec![],
+            effect_closures: vec![],
+        },
+        CommandPlanSchema {
+            name: "AuthorizedRuntimeLoopRunCommit".to_owned(),
+            authority_type: "AuthorizedRuntimeLoopRunCommit".to_owned(),
+            source_inputs: vec![
+                input_variant_id("RunCompleted"),
+                input_variant_id("RunFailed"),
+                input_variant_id("RunCancelled"),
+                input_variant_id("Commit"),
+                input_variant_id("Fail"),
+                input_variant_id("CancelRun"),
+                input_variant_id("RollbackRun"),
+            ],
+            source_signals: vec![],
+            transitions: run_commit_transitions
+                .iter()
+                .copied()
+                .map(transition_id)
+                .collect(),
+            effects: vec![
+                effect_variant_id("TurnRunCompleted"),
+                effect_variant_id("TurnRunFailed"),
+                effect_variant_id("TurnRunCancelled"),
+            ],
+            effect_closures: vec![
+                EffectClosureSchema {
+                    effect: effect_variant_id("TurnRunCompleted"),
+                    authority_type: "AuthorizedRuntimeLoopRunCommit".to_owned(),
+                    closure_policy: "RuntimeLoopRunCommitEffect".to_owned(),
+                    lifecycle: vec![
+                        "Authorized".to_owned(),
+                        "Attempted".to_owned(),
+                        "Realized".to_owned(),
+                        "Failed".to_owned(),
+                        "Cancelled".to_owned(),
+                        "Abandoned".to_owned(),
+                    ],
+                },
+                EffectClosureSchema {
+                    effect: effect_variant_id("TurnRunFailed"),
+                    authority_type: "AuthorizedRuntimeLoopRunCommit".to_owned(),
+                    closure_policy: "RuntimeLoopRunCommitEffect".to_owned(),
+                    lifecycle: vec![
+                        "Authorized".to_owned(),
+                        "Attempted".to_owned(),
+                        "Realized".to_owned(),
+                        "Failed".to_owned(),
+                        "Cancelled".to_owned(),
+                        "Abandoned".to_owned(),
+                    ],
+                },
+                EffectClosureSchema {
+                    effect: effect_variant_id("TurnRunCancelled"),
+                    authority_type: "AuthorizedRuntimeLoopRunCommit".to_owned(),
+                    closure_policy: "RuntimeLoopRunCommitEffect".to_owned(),
+                    lifecycle: vec![
+                        "Authorized".to_owned(),
+                        "Attempted".to_owned(),
+                        "Realized".to_owned(),
+                        "Failed".to_owned(),
+                        "Cancelled".to_owned(),
+                        "Abandoned".to_owned(),
+                    ],
+                },
+            ],
+        },
+        CommandPlanSchema {
+            name: "AuthorizedRuntimeCompletionResultClosure".to_owned(),
+            authority_type: "RuntimeCompletionResultAuthority".to_owned(),
+            source_inputs: vec![input_variant_id("ResolveRuntimeCompletionResult")],
+            source_signals: vec![],
+            transitions: completion_result_transitions,
+            effects: vec![effect_variant_id("RuntimeCompletionResultResolved")],
+            effect_closures: vec![EffectClosureSchema {
+                effect: effect_variant_id("RuntimeCompletionResultResolved"),
+                authority_type: "RuntimeCompletionResultAuthority".to_owned(),
+                closure_policy: "LocalSurfaceResultAlignment".to_owned(),
+                lifecycle: vec![
+                    "Authorized".to_owned(),
+                    "Attempted".to_owned(),
+                    "Realized".to_owned(),
+                    "Failed".to_owned(),
+                    "Cancelled".to_owned(),
+                    "Abandoned".to_owned(),
+                ],
+            }],
+        },
+    ]
 }
 
 pub fn dsl_auth_machine() -> MachineSchema {
@@ -502,7 +779,7 @@ pub fn dsl_meerkat_machine_production_schema() -> MachineSchema {
 }
 
 pub fn meerkat_machine_schema_metadata() -> MachineSchemaMetadata {
-    machine_schema_metadata(
+    let mut metadata = machine_schema_metadata(
         vec![
             NamedTypeBinding::u64("BoundarySequence"),
             NamedTypeBinding::u64("FenceToken"),
@@ -1670,7 +1947,9 @@ pub fn meerkat_machine_schema_metadata() -> MachineSchemaMetadata {
         ],
         input_variant_ids(MEERKAT_MACHINE_RUNTIME_INTERNAL_INPUTS),
     )
-    .with_ci_step_limit(1)
+    .with_ci_step_limit(1);
+    metadata.command_plans = meerkat_queue_to_run_command_plans();
+    metadata
 }
 
 runtime_internal_inputs!(
@@ -1690,6 +1969,7 @@ runtime_internal_inputs!(
         AuthorizeSupervisor,
         AuthorizeDeferredSessionSystemContextAppend,
         BeginUnregisterSession,
+        BindAdmissionRuntimeGrouping,
         BindSupervisor,
         BoundaryComplete,
         BoundaryContinue,
@@ -1939,8 +2219,133 @@ pub fn dsl_mob_machine_production_schema() -> MachineSchema {
     )
 }
 
+fn mob_spawn_command_plans() -> Vec<CommandPlanSchema> {
+    let spawn_closure_lifecycle = || {
+        vec![
+            "Authorized".to_owned(),
+            "Attempted".to_owned(),
+            "Realized".to_owned(),
+            "Failed".to_owned(),
+            "Cancelled".to_owned(),
+            "Abandoned".to_owned(),
+        ]
+    };
+    let full_spawn_transitions = || {
+        vec![
+            transition_id("StageSpawnRunning"),
+            transition_id("CompleteSpawnRunning"),
+            transition_id("CompleteSpawnLateArrivalRunning"),
+            transition_id("CompleteSpawnLateArrivalStopped"),
+            transition_id("CompleteSpawnLateArrivalCompleted"),
+            transition_id("CompleteSpawnDestroyed"),
+            transition_id("CancelPendingSpawnPresentRunning"),
+            transition_id("CancelPendingSpawnPresentStopped"),
+            transition_id("CancelPendingSpawnPresentCompleted"),
+            transition_id("CancelPendingSpawnAbsentRunning"),
+            transition_id("CancelPendingSpawnAbsentStopped"),
+            transition_id("CancelPendingSpawnAbsentCompleted"),
+            transition_id("CancelPendingSpawnDestroyed"),
+        ]
+    };
+    vec![
+        CommandPlanSchema {
+            name: "AuthorizedMobSpawnStart".to_owned(),
+            authority_type: "PendingSpawnOperationOwnerAuthorized".to_owned(),
+            source_inputs: vec![input_variant_id("CancelPendingSpawn")],
+            source_signals: vec![
+                signal_variant_id("StageSpawn"),
+                signal_variant_id("CompleteSpawn"),
+            ],
+            transitions: full_spawn_transitions(),
+            effects: vec![
+                effect_variant_id("PendingSpawnOperationOwnerAuthorized"),
+                effect_variant_id("ExposePendingSpawn"),
+                effect_variant_id("EmitMemberLifecycleNotice"),
+            ],
+            effect_closures: vec![
+                EffectClosureSchema {
+                    effect: effect_variant_id("PendingSpawnOperationOwnerAuthorized"),
+                    authority_type: "PendingSpawnOperationOwnerAuthorized".to_owned(),
+                    closure_policy: "LocalPendingSpawnOwner".to_owned(),
+                    lifecycle: spawn_closure_lifecycle(),
+                },
+                EffectClosureSchema {
+                    effect: effect_variant_id("EmitMemberLifecycleNotice"),
+                    authority_type: "CompleteSpawn".to_owned(),
+                    closure_policy: "LocalSpawnCompletion".to_owned(),
+                    lifecycle: spawn_closure_lifecycle(),
+                },
+            ],
+        },
+        CommandPlanSchema {
+            name: "CanStartSpawn".to_owned(),
+            authority_type: "CanStartSpawn".to_owned(),
+            source_inputs: vec![],
+            source_signals: vec![signal_variant_id("StageSpawn")],
+            transitions: vec![transition_id("StageSpawnRunning")],
+            effects: vec![effect_variant_id("PendingSpawnOperationOwnerAuthorized")],
+            effect_closures: vec![EffectClosureSchema {
+                effect: effect_variant_id("PendingSpawnOperationOwnerAuthorized"),
+                authority_type: "CanStartSpawn".to_owned(),
+                closure_policy: "LocalPendingSpawnOwner".to_owned(),
+                lifecycle: spawn_closure_lifecycle(),
+            }],
+        },
+        CommandPlanSchema {
+            name: "SpawnStarted".to_owned(),
+            authority_type: "SpawnStarted".to_owned(),
+            source_inputs: vec![],
+            source_signals: vec![signal_variant_id("StageSpawn")],
+            transitions: vec![transition_id("StageSpawnRunning")],
+            effects: vec![effect_variant_id("ExposePendingSpawn")],
+            effect_closures: vec![EffectClosureSchema {
+                effect: effect_variant_id("ExposePendingSpawn"),
+                authority_type: "SpawnStarted".to_owned(),
+                closure_policy: "LocalSpawnStarted".to_owned(),
+                lifecycle: spawn_closure_lifecycle(),
+            }],
+        },
+        CommandPlanSchema {
+            name: "SpawnEffect".to_owned(),
+            authority_type: "SpawnEffect".to_owned(),
+            source_inputs: vec![input_variant_id("CancelPendingSpawn")],
+            source_signals: vec![signal_variant_id("CompleteSpawn")],
+            transitions: full_spawn_transitions(),
+            effects: vec![effect_variant_id("EmitMemberLifecycleNotice")],
+            effect_closures: vec![EffectClosureSchema {
+                effect: effect_variant_id("EmitMemberLifecycleNotice"),
+                authority_type: "SpawnEffect".to_owned(),
+                closure_policy: "LocalSpawnCompletion".to_owned(),
+                lifecycle: spawn_closure_lifecycle(),
+            }],
+        },
+        CommandPlanSchema {
+            name: "FailSpawn".to_owned(),
+            authority_type: "FailSpawn".to_owned(),
+            source_inputs: vec![input_variant_id("CancelPendingSpawn")],
+            source_signals: vec![],
+            transitions: vec![
+                transition_id("CancelPendingSpawnPresentRunning"),
+                transition_id("CancelPendingSpawnPresentStopped"),
+                transition_id("CancelPendingSpawnPresentCompleted"),
+                transition_id("CancelPendingSpawnAbsentRunning"),
+                transition_id("CancelPendingSpawnAbsentStopped"),
+                transition_id("CancelPendingSpawnAbsentCompleted"),
+                transition_id("CancelPendingSpawnDestroyed"),
+            ],
+            effects: vec![effect_variant_id("EmitMemberLifecycleNotice")],
+            effect_closures: vec![EffectClosureSchema {
+                effect: effect_variant_id("EmitMemberLifecycleNotice"),
+                authority_type: "FailSpawn".to_owned(),
+                closure_policy: "LocalSpawnFailure".to_owned(),
+                lifecycle: spawn_closure_lifecycle(),
+            }],
+        },
+    ]
+}
+
 pub fn mob_machine_schema_metadata() -> MachineSchemaMetadata {
-    machine_schema_metadata(
+    let mut metadata = machine_schema_metadata(
         vec![
             // WAVE G2 machine folds (#14/#260/#261/#293/#314/#320): typed
             // verdict/fault/policy/capability/timeout classifiers owned by MobMachine.
@@ -2465,7 +2870,9 @@ pub fn mob_machine_schema_metadata() -> MachineSchemaMetadata {
         ],
         input_variant_ids(MOB_MACHINE_RUNTIME_INTERNAL_INPUTS),
     )
-    .with_ci_step_limit(1)
+    .with_ci_step_limit(1);
+    metadata.command_plans = mob_spawn_command_plans();
+    metadata
 }
 
 runtime_internal_inputs!(

--- a/meerkat-machine-schema/src/identity.rs
+++ b/meerkat-machine-schema/src/identity.rs
@@ -156,10 +156,24 @@ define_identity!(
     /// Signal-variant name.
     SignalVariantId
 );
+
+impl SignalVariantId {
+    /// Construct from a crate-owned catalog literal.
+    pub(crate) fn from_trusted_catalog_literal(value: &'static str) -> Self {
+        Self(value.to_owned())
+    }
+}
 define_identity!(
     /// Effect-variant name.
     EffectVariantId
 );
+
+impl EffectVariantId {
+    /// Construct from a crate-owned catalog literal.
+    pub(crate) fn from_trusted_catalog_literal(value: &'static str) -> Self {
+        Self(value.to_owned())
+    }
+}
 define_identity!(
     /// Field name within a kernel state, input, signal, or effect.
     FieldId
@@ -168,6 +182,19 @@ define_identity!(
     /// Transition name.
     TransitionId
 );
+
+impl TransitionId {
+    /// Construct from a crate-owned catalog literal.
+    pub(crate) fn from_trusted_catalog_literal(value: &'static str) -> Self {
+        Self(value.to_owned())
+    }
+
+    /// Construct from a crate-owned catalog string assembled from trusted
+    /// literals.
+    pub(crate) fn from_trusted_catalog_string(value: String) -> Self {
+        Self(value)
+    }
+}
 define_identity!(
     /// Route name within a composition.
     RouteId

--- a/meerkat-machine-schema/src/lib.rs
+++ b/meerkat-machine-schema/src/lib.rs
@@ -34,10 +34,10 @@ pub use composition::{
     RouteTargetSelector, RouteVariantId, SchedulerRule, TeardownObligationClass, WatchedEffect,
 };
 pub use machine::{
-    EffectDisposition, EffectDispositionRule, EffectEmit, EnumSchema, Expr, FieldInit, FieldSchema,
-    FieldType, Guard, HelperSchema, InitSchema, InputMatch, InvariantSchema, MachineSchema,
-    MachineSchemaError, Quantifier, RustBinding, StateSchema, TransitionSchema, TriggerKind,
-    TriggerMatch, TypeRef, Update, VariantSchema,
+    CommandPlanSchema, EffectClosureSchema, EffectDisposition, EffectDispositionRule, EffectEmit,
+    EnumSchema, Expr, FieldInit, FieldSchema, FieldType, Guard, HelperSchema, InitSchema,
+    InputMatch, InvariantSchema, MachineSchema, MachineSchemaError, Quantifier, RustBinding,
+    StateSchema, TransitionSchema, TriggerKind, TriggerMatch, TypeRef, Update, VariantSchema,
 };
 pub use seam::SeamClassification;
 

--- a/meerkat-machine-schema/src/machine.rs
+++ b/meerkat-machine-schema/src/machine.rs
@@ -64,6 +64,9 @@ pub struct MachineSchema {
     pub effects: EnumSchema,
     pub helpers: Vec<HelperSchema>,
     pub derived: Vec<HelperSchema>,
+    /// Generated command/capability plans that group existing inputs,
+    /// transitions, guards, and effects into an auditable authority surface.
+    pub command_plans: Vec<CommandPlanSchema>,
     pub invariants: Vec<InvariantSchema>,
     pub transitions: Vec<TransitionSchema>,
     pub effect_dispositions: Vec<EffectDispositionRule>,
@@ -110,6 +113,10 @@ impl MachineSchema {
                 .map(|helper| helper.name.as_str())
                 .chain(self.derived.iter().map(|helper| helper.name.as_str())),
             "helper/derived",
+        )?;
+        let _command_plan_names = unique_names(
+            self.command_plans.iter().map(|plan| plan.name.as_str()),
+            "command plan",
         )?;
 
         if !phase_names.contains(self.state.init.phase.as_str()) {
@@ -182,6 +189,65 @@ impl MachineSchema {
                 return Err(MachineSchemaError::UnknownRuntimeInternalInputVariant {
                     variant: runtime_internal_input.as_str().to_owned(),
                 });
+            }
+        }
+
+        for plan in &self.command_plans {
+            if plan.authority_type.is_empty() {
+                return Err(MachineSchemaError::EmptyName("command-plan authority type"));
+            }
+            for input in &plan.source_inputs {
+                if !input_variants.contains(input.as_str()) {
+                    return Err(MachineSchemaError::UnknownCommandPlanInput {
+                        plan: plan.name.clone(),
+                        input: input.as_str().to_owned(),
+                    });
+                }
+            }
+            for signal in &plan.source_signals {
+                if !signal_variants.contains(signal.as_str()) {
+                    return Err(MachineSchemaError::UnknownCommandPlanSignal {
+                        plan: plan.name.clone(),
+                        signal: signal.as_str().to_owned(),
+                    });
+                }
+            }
+            for effect in &plan.effects {
+                if !effect_variants.contains(effect.as_str()) {
+                    return Err(MachineSchemaError::UnknownCommandPlanEffect {
+                        plan: plan.name.clone(),
+                        effect: effect.as_str().to_owned(),
+                    });
+                }
+            }
+            for closure in &plan.effect_closures {
+                if closure.authority_type.is_empty() {
+                    return Err(MachineSchemaError::EmptyName(
+                        "command-plan effect-closure authority type",
+                    ));
+                }
+                if closure.closure_policy.is_empty() {
+                    return Err(MachineSchemaError::EmptyName(
+                        "command-plan effect-closure policy",
+                    ));
+                }
+                if closure.lifecycle.is_empty() || closure.lifecycle.iter().any(String::is_empty) {
+                    return Err(MachineSchemaError::EmptyName(
+                        "command-plan effect-closure lifecycle state",
+                    ));
+                }
+                if !effect_variants.contains(closure.effect.as_str()) {
+                    return Err(MachineSchemaError::UnknownCommandPlanEffect {
+                        plan: plan.name.clone(),
+                        effect: closure.effect.as_str().to_owned(),
+                    });
+                }
+                if !plan.effects.contains(&closure.effect) {
+                    return Err(MachineSchemaError::UnknownCommandPlanClosureEffect {
+                        plan: plan.name.clone(),
+                        effect: closure.effect.as_str().to_owned(),
+                    });
+                }
             }
         }
 
@@ -292,6 +358,22 @@ impl MachineSchema {
                         &helper_names,
                         &bindings,
                     )?;
+                }
+            }
+        }
+
+        let transition_names: IndexSet<&str> = self
+            .transitions
+            .iter()
+            .map(|transition| transition.name.as_str())
+            .collect();
+        for plan in &self.command_plans {
+            for transition in &plan.transitions {
+                if !transition_names.contains(transition.as_str()) {
+                    return Err(MachineSchemaError::UnknownCommandPlanTransition {
+                        plan: plan.name.clone(),
+                        transition: transition.as_str().to_owned(),
+                    });
                 }
             }
         }
@@ -540,6 +622,25 @@ pub struct HelperSchema {
 pub struct InvariantSchema {
     pub name: String,
     pub expr: Expr,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CommandPlanSchema {
+    pub name: String,
+    pub authority_type: String,
+    pub source_inputs: Vec<InputVariantId>,
+    pub source_signals: Vec<SignalVariantId>,
+    pub transitions: Vec<TransitionId>,
+    pub effects: Vec<EffectVariantId>,
+    pub effect_closures: Vec<EffectClosureSchema>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EffectClosureSchema {
+    pub effect: EffectVariantId,
+    pub authority_type: String,
+    pub closure_policy: String,
+    pub lifecycle: Vec<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -1787,6 +1888,11 @@ pub enum MachineSchemaError {
     MissingStringEnumBinding { name: String },
     UnknownStringEnumVariant { enum_name: String, variant: String },
     InvalidStringEnumBinding { name: String, reason: String },
+    UnknownCommandPlanInput { plan: String, input: String },
+    UnknownCommandPlanSignal { plan: String, signal: String },
+    UnknownCommandPlanTransition { plan: String, transition: String },
+    UnknownCommandPlanEffect { plan: String, effect: String },
+    UnknownCommandPlanClosureEffect { plan: String, effect: String },
 }
 
 impl fmt::Display for MachineSchemaError {
@@ -1877,6 +1983,36 @@ impl fmt::Display for MachineSchemaError {
                     "invalid string enum named-type binding `{name}`: {reason}"
                 )
             }
+            Self::UnknownCommandPlanInput { plan, input } => {
+                write!(
+                    f,
+                    "command plan `{plan}` references unknown input `{input}`"
+                )
+            }
+            Self::UnknownCommandPlanSignal { plan, signal } => {
+                write!(
+                    f,
+                    "command plan `{plan}` references unknown signal `{signal}`"
+                )
+            }
+            Self::UnknownCommandPlanTransition { plan, transition } => {
+                write!(
+                    f,
+                    "command plan `{plan}` references unknown transition `{transition}`"
+                )
+            }
+            Self::UnknownCommandPlanEffect { plan, effect } => {
+                write!(
+                    f,
+                    "command plan `{plan}` references unknown effect `{effect}`"
+                )
+            }
+            Self::UnknownCommandPlanClosureEffect { plan, effect } => {
+                write!(
+                    f,
+                    "command plan `{plan}` declares closure for `{effect}` without listing it as a command effect"
+                )
+            }
         }
     }
 }
@@ -1886,10 +2022,11 @@ impl std::error::Error for MachineSchemaError {}
 #[cfg(test)]
 #[allow(clippy::expect_used, clippy::unwrap_used, clippy::panic)]
 mod tests {
-    use crate::identity::{EnumTypeId, EnumVariantId, NamedTypeId};
+    use crate::identity::{EffectVariantId, EnumTypeId, EnumVariantId, NamedTypeId};
     use crate::{
         Expr, InvariantSchema, MachineSchema, MachineSchemaError, NamedTypeBinding, RustTypeAtom,
         Update, catalog::dsl::dsl_meerkat_machine as meerkat_machine,
+        catalog::dsl::dsl_mob_machine as mob_machine,
     };
 
     #[test]
@@ -1925,6 +2062,326 @@ mod tests {
             vec!["Destroyed".to_owned()]
         );
         assert_eq!(schema.validate(), Ok(()));
+    }
+
+    #[test]
+    fn meerkat_queue_to_run_command_plans_are_schema_owned() {
+        let schema = meerkat_machine();
+        let plan_names = schema
+            .command_plans
+            .iter()
+            .map(|plan| plan.name.as_str())
+            .collect::<Vec<_>>();
+        assert_eq!(
+            plan_names,
+            vec![
+                "AuthorizedAcceptedInputMaterialization",
+                "AuthorizeRuntimeLoopBatch",
+                "AuthorizedStageForRun",
+                "AuthorizedRuntimeLoopRunCommit",
+                "AuthorizedRuntimeCompletionResultClosure"
+            ]
+        );
+        let stage_plan = schema
+            .command_plans
+            .iter()
+            .find(|plan| plan.name == "AuthorizedStageForRun")
+            .expect("stage command plan");
+        let stage_transitions = stage_plan
+            .transitions
+            .iter()
+            .map(|transition| transition.as_str())
+            .collect::<Vec<_>>();
+        assert_eq!(
+            stage_transitions,
+            vec![
+                "StageForRunIdle",
+                "StageForRunAttached",
+                "StageForRunRunning",
+                "StageForRunRetired",
+                "StageForRunStopped"
+            ]
+        );
+        let guard_names = schema
+            .transitions
+            .iter()
+            .find(|transition| transition.name.as_str() == "StageForRunIdle")
+            .expect("StageForRunIdle transition")
+            .guards
+            .iter()
+            .map(|guard| guard.name.as_str())
+            .collect::<Vec<_>>();
+        for required in [
+            "input_queued",
+            "input_lane_bound",
+            "input_sequence_bound",
+            "input_recovery_lane_bound",
+            "input_not_run_associated",
+            "current_run_matches",
+        ] {
+            assert!(
+                guard_names.contains(&required),
+                "StageForRun command-plan guard expansion must include {required}; got {guard_names:?}"
+            );
+        }
+
+        let run_commit_plan = schema
+            .command_plans
+            .iter()
+            .find(|plan| plan.name == "AuthorizedRuntimeLoopRunCommit")
+            .expect("runtime-loop run commit command plan");
+        let run_commit_transitions = run_commit_plan
+            .transitions
+            .iter()
+            .map(|transition| transition.as_str())
+            .collect::<Vec<_>>();
+        for required in [
+            "RunCompleted",
+            "RunFailed",
+            "RunCancelled",
+            "CommitRunningToIdle",
+            "CommitRunningToAttached",
+            "CommitRunningToRetired",
+            "FailRunningToIdle",
+            "CancelRunningToIdle",
+            "RollbackRunRunningToIdle",
+        ] {
+            assert!(
+                run_commit_transitions.contains(&required),
+                "run-commit command plan must include {required}; got {run_commit_transitions:?}"
+            );
+        }
+        let run_commit_effects = run_commit_plan
+            .effects
+            .iter()
+            .map(|effect| effect.as_str())
+            .collect::<Vec<_>>();
+        assert_eq!(
+            run_commit_effects,
+            vec!["TurnRunCompleted", "TurnRunFailed", "TurnRunCancelled"]
+        );
+        let run_commit_closures = run_commit_plan
+            .effect_closures
+            .iter()
+            .map(|closure| closure.effect.as_str())
+            .collect::<Vec<_>>();
+        assert_eq!(
+            run_commit_closures,
+            vec!["TurnRunCompleted", "TurnRunFailed", "TurnRunCancelled"]
+        );
+        for closure in &run_commit_plan.effect_closures {
+            assert_eq!(closure.authority_type, "AuthorizedRuntimeLoopRunCommit");
+            assert_eq!(closure.closure_policy, "RuntimeLoopRunCommitEffect");
+            assert_eq!(
+                closure.lifecycle,
+                vec![
+                    "Authorized",
+                    "Attempted",
+                    "Realized",
+                    "Failed",
+                    "Cancelled",
+                    "Abandoned"
+                ]
+            );
+        }
+
+        let completion_closure_plan = schema
+            .command_plans
+            .iter()
+            .find(|plan| plan.name == "AuthorizedRuntimeCompletionResultClosure")
+            .expect("runtime completion result closure command plan");
+        assert_eq!(
+            completion_closure_plan.effects,
+            vec![EffectVariantId::parse("RuntimeCompletionResultResolved").unwrap()]
+        );
+        assert_eq!(completion_closure_plan.effect_closures.len(), 1);
+        let closure = &completion_closure_plan.effect_closures[0];
+        assert_eq!(closure.effect.as_str(), "RuntimeCompletionResultResolved");
+        assert_eq!(closure.authority_type, "RuntimeCompletionResultAuthority");
+        assert_eq!(closure.closure_policy, "LocalSurfaceResultAlignment");
+        assert_eq!(
+            closure.lifecycle,
+            vec![
+                "Authorized",
+                "Attempted",
+                "Realized",
+                "Failed",
+                "Cancelled",
+                "Abandoned"
+            ]
+        );
+    }
+
+    #[test]
+    fn mob_spawn_command_plan_is_schema_owned() {
+        let schema = mob_machine();
+        let command_plan_names = schema
+            .command_plans
+            .iter()
+            .map(|plan| plan.name.as_str())
+            .collect::<Vec<_>>();
+        for required in [
+            "AuthorizedMobSpawnStart",
+            "CanStartSpawn",
+            "SpawnStarted",
+            "SpawnEffect",
+            "FailSpawn",
+        ] {
+            assert!(
+                command_plan_names.contains(&required),
+                "mob spawn command plans must include {required}; got {command_plan_names:?}"
+            );
+        }
+        let spawn_plan = schema
+            .command_plans
+            .iter()
+            .find(|plan| plan.name == "AuthorizedMobSpawnStart")
+            .expect("mob spawn command plan");
+
+        assert_eq!(
+            spawn_plan.authority_type,
+            "PendingSpawnOperationOwnerAuthorized"
+        );
+        assert_eq!(
+            spawn_plan
+                .source_signals
+                .iter()
+                .map(|signal| signal.as_str())
+                .collect::<Vec<_>>(),
+            vec!["StageSpawn", "CompleteSpawn"]
+        );
+        assert_eq!(
+            spawn_plan
+                .source_inputs
+                .iter()
+                .map(|input| input.as_str())
+                .collect::<Vec<_>>(),
+            vec!["CancelPendingSpawn"]
+        );
+
+        let transitions = spawn_plan
+            .transitions
+            .iter()
+            .map(|transition| transition.as_str())
+            .collect::<Vec<_>>();
+        for required in [
+            "StageSpawnRunning",
+            "CompleteSpawnRunning",
+            "CompleteSpawnLateArrivalRunning",
+            "CompleteSpawnLateArrivalStopped",
+            "CompleteSpawnLateArrivalCompleted",
+            "CompleteSpawnDestroyed",
+            "CancelPendingSpawnPresentRunning",
+            "CancelPendingSpawnPresentStopped",
+            "CancelPendingSpawnPresentCompleted",
+            "CancelPendingSpawnAbsentRunning",
+            "CancelPendingSpawnAbsentStopped",
+            "CancelPendingSpawnAbsentCompleted",
+            "CancelPendingSpawnDestroyed",
+        ] {
+            assert!(
+                transitions.contains(&required),
+                "mob spawn command plan must include {required}; got {transitions:?}"
+            );
+        }
+
+        let effects = spawn_plan
+            .effects
+            .iter()
+            .map(|effect| effect.as_str())
+            .collect::<Vec<_>>();
+        assert_eq!(
+            effects,
+            vec![
+                "PendingSpawnOperationOwnerAuthorized",
+                "ExposePendingSpawn",
+                "EmitMemberLifecycleNotice"
+            ]
+        );
+        assert_eq!(spawn_plan.effect_closures.len(), 2);
+        for closure in &spawn_plan.effect_closures {
+            assert_eq!(
+                closure.lifecycle,
+                vec![
+                    "Authorized",
+                    "Attempted",
+                    "Realized",
+                    "Failed",
+                    "Cancelled",
+                    "Abandoned"
+                ]
+            );
+        }
+        assert!(
+            spawn_plan
+                .effect_closures
+                .iter()
+                .any(
+                    |closure| closure.effect.as_str() == "PendingSpawnOperationOwnerAuthorized"
+                        && closure.authority_type == "PendingSpawnOperationOwnerAuthorized"
+                        && closure.closure_policy == "LocalPendingSpawnOwner"
+                ),
+            "mob spawn plan must declare pending-owner closure metadata"
+        );
+        assert!(
+            spawn_plan
+                .effect_closures
+                .iter()
+                .any(
+                    |closure| closure.effect.as_str() == "EmitMemberLifecycleNotice"
+                        && closure.authority_type == "CompleteSpawn"
+                        && closure.closure_policy == "LocalSpawnCompletion"
+                ),
+            "mob spawn plan must declare completion closure metadata"
+        );
+        let start_plan = schema
+            .command_plans
+            .iter()
+            .find(|plan| plan.name == "CanStartSpawn")
+            .expect("CanStartSpawn command plan");
+        assert_eq!(start_plan.authority_type, "CanStartSpawn");
+        assert_eq!(
+            start_plan
+                .source_signals
+                .iter()
+                .map(|signal| signal.as_str())
+                .collect::<Vec<_>>(),
+            vec!["StageSpawn"]
+        );
+        let started_plan = schema
+            .command_plans
+            .iter()
+            .find(|plan| plan.name == "SpawnStarted")
+            .expect("SpawnStarted command plan");
+        assert_eq!(started_plan.authority_type, "SpawnStarted");
+        assert_eq!(
+            started_plan
+                .effects
+                .iter()
+                .map(|effect| effect.as_str())
+                .collect::<Vec<_>>(),
+            vec!["ExposePendingSpawn"]
+        );
+        let spawn_effect_plan = schema
+            .command_plans
+            .iter()
+            .find(|plan| plan.name == "SpawnEffect")
+            .expect("SpawnEffect command plan");
+        assert_eq!(spawn_effect_plan.authority_type, "SpawnEffect");
+        let fail_spawn_plan = schema
+            .command_plans
+            .iter()
+            .find(|plan| plan.name == "FailSpawn")
+            .expect("FailSpawn command plan");
+        assert_eq!(fail_spawn_plan.authority_type, "FailSpawn");
+        assert_eq!(
+            fail_spawn_plan
+                .source_inputs
+                .iter()
+                .map(|input| input.as_str())
+                .collect::<Vec<_>>(),
+            vec!["CancelPendingSpawn"]
+        );
     }
 
     #[test]

--- a/meerkat-mob/src/runtime/actor.rs
+++ b/meerkat-mob/src/runtime/actor.rs
@@ -25,6 +25,7 @@ use meerkat_core::comms::{
     PeerLifecycleKind, PeerName, PeerRoute, SendError, TrustedPeerDescriptor,
 };
 use meerkat_core::time_compat::SystemTime;
+use meerkat_machine_kernels::generated::mob::command_capabilities as generated_mob_command_capabilities;
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet, VecDeque};
 
 /// Lightweight handle for a spawned autonomous initial turn.
@@ -1016,6 +1017,71 @@ pub(super) struct PendingSpawn {
 pub(super) struct PendingSpawnProgress {
     pub(super) bridge_session_id: Option<meerkat_core::types::SessionId>,
     pub(super) operation_id: Option<meerkat_core::ops::OperationId>,
+}
+
+#[must_use = "mob spawn start authority must be consumed by pending spawn insertion"]
+struct AuthorizedMobSpawnStart {
+    generated_can_start: generated_mob_command_capabilities::CommandPlanKind,
+    generated_owner: generated_mob_command_capabilities::CommandPlanKind,
+    agent_identity: AgentIdentity,
+    session_id: SessionId,
+}
+
+#[must_use = "started mob spawn authority must be consumed by PendingSpawnLineage insertion"]
+struct AuthorizedMobSpawnStarted {
+    generated_owner: generated_mob_command_capabilities::CommandPlanKind,
+    generated_started: generated_mob_command_capabilities::CommandPlanKind,
+    agent_identity: AgentIdentity,
+    session_id: SessionId,
+}
+
+#[must_use = "mob spawn completion authority must be observed by pending spawn completion"]
+struct AuthorizedMobSpawnCompleted {
+    generated_plan: generated_mob_command_capabilities::CommandPlanKind,
+    generated_effect: generated_mob_command_capabilities::CommandPlanKind,
+    agent_identity: AgentIdentity,
+}
+
+impl AuthorizedMobSpawnStart {
+    fn owner_session_id(&self) -> &SessionId {
+        debug_assert_eq!(
+            self.generated_can_start,
+            generated_mob_command_capabilities::CommandPlanKind::CanStartSpawn
+        );
+        debug_assert_eq!(
+            self.generated_owner,
+            generated_mob_command_capabilities::CommandPlanKind::AuthorizedMobSpawnStart
+        );
+        &self.session_id
+    }
+
+    fn start(self, pending: &PendingSpawn) -> Result<AuthorizedMobSpawnStarted, MobError> {
+        debug_assert_eq!(
+            self.generated_can_start,
+            generated_mob_command_capabilities::CommandPlanKind::CanStartSpawn
+        );
+        debug_assert_eq!(
+            self.generated_owner,
+            generated_mob_command_capabilities::CommandPlanKind::AuthorizedMobSpawnStart
+        );
+        if pending.agent_identity != self.agent_identity
+            || pending.admitted_bridge_session_id != self.session_id
+        {
+            return Err(MobError::Internal(format!(
+                "MobMachine StageSpawn authority for '{}' / '{}' did not match pending spawn '{}' / '{}'",
+                self.agent_identity,
+                self.session_id,
+                pending.agent_identity,
+                pending.admitted_bridge_session_id
+            )));
+        }
+        Ok(AuthorizedMobSpawnStarted {
+            generated_owner: self.generated_owner,
+            generated_started: generated_mob_command_capabilities::CommandPlanKind::SpawnStarted,
+            agent_identity: self.agent_identity,
+            session_id: self.session_id,
+        })
+    }
 }
 
 #[derive(Clone, Debug)]
@@ -5837,18 +5903,31 @@ impl MobActor {
         spawn_ticket: u64,
         pending: PendingSpawn,
         task: tokio::task::JoinHandle<()>,
+        started: AuthorizedMobSpawnStarted,
     ) {
+        debug_assert_eq!(pending.agent_identity, started.agent_identity);
+        debug_assert_eq!(pending.admitted_bridge_session_id, started.session_id);
+        debug_assert_eq!(
+            started.generated_owner,
+            generated_mob_command_capabilities::CommandPlanKind::AuthorizedMobSpawnStart
+        );
+        debug_assert_eq!(
+            started.generated_started,
+            generated_mob_command_capabilities::CommandPlanKind::SpawnStarted
+        );
         let impact = self.pending_spawns.insert(spawn_ticket, pending, task);
         if let PendingSpawnInsertImpact::Collided { replaced_identity } = impact {
             // StageSpawn has already been accepted for the new slot in enqueue paths.
             // If we replaced a prior slot at the same ticket, close that prior
             // staged snapshot now so authority counters cannot drift silently.
             if let Some(replaced_identity) = replaced_identity.as_ref() {
-                self.complete_orchestrator_spawn(
+                if let Ok(completed) = self.complete_orchestrator_spawn(
                     Some(spawn_ticket),
                     replaced_identity,
                     "pending spawn slot collision replaced existing entry",
-                );
+                ) {
+                    debug_assert_eq!(completed.agent_identity, *replaced_identity);
+                }
             }
             tracing::warn!(
                 spawn_ticket,
@@ -5882,11 +5961,13 @@ impl MobActor {
         let (pending, task) = self.take_pending_spawn_slot(spawn_ticket);
         if pending.is_some() || task.is_some() {
             if let Some(pending) = pending.as_ref() {
-                self.complete_orchestrator_spawn(
+                if let Ok(completed) = self.complete_orchestrator_spawn(
                     Some(spawn_ticket),
                     &pending.agent_identity,
                     context,
-                );
+                ) {
+                    debug_assert_eq!(completed.agent_identity, pending.agent_identity);
+                }
             }
         }
         if let Some(message) = self.pending_spawn_alignment_violation() {
@@ -5904,7 +5985,7 @@ impl MobActor {
         &mut self,
         agent_identity: &AgentIdentity,
         session_id: &SessionId,
-    ) -> Result<Option<SessionId>, MobError> {
+    ) -> Result<AuthorizedMobSpawnStart, MobError> {
         let dsl_agent_identity =
             mob_dsl::AgentIdentity::from_domain(&AgentIdentity::from(agent_identity.as_str()));
         let dsl_session_id = mob_dsl::SessionId::from_domain(session_id);
@@ -5929,12 +6010,18 @@ impl MobActor {
                 "MobMachine StageSpawn did not authorize pending operation owner for '{agent_identity}'"
             )));
         }
-        Ok(Some(session_id.clone()))
+        Ok(AuthorizedMobSpawnStart {
+            generated_can_start: generated_mob_command_capabilities::CommandPlanKind::CanStartSpawn,
+            generated_owner:
+                generated_mob_command_capabilities::CommandPlanKind::AuthorizedMobSpawnStart,
+            agent_identity: agent_identity.clone(),
+            session_id: session_id.clone(),
+        })
     }
 
     fn apply_generated_self_owned_operation_owner(
         provision_request: &mut ProvisionMemberRequest,
-        generated_owner: Option<SessionId>,
+        generated_owner: &AuthorizedMobSpawnStart,
     ) -> Result<(), MobError> {
         if !matches!(provision_request.binding, crate::RuntimeBinding::Session)
             || provision_request.owner_bridge_session_id.is_some()
@@ -5942,12 +6029,8 @@ impl MobActor {
         {
             return Ok(());
         }
-        let Some(generated_owner) = generated_owner else {
-            return Err(MobError::Internal(
-                "session member operation requires generated pending spawn owner authority".into(),
-            ));
-        };
-        provision_request.generated_self_owned_operation_owner = Some(generated_owner);
+        provision_request.generated_self_owned_operation_owner =
+            Some(generated_owner.owner_session_id().clone());
         Ok(())
     }
 
@@ -6504,15 +6587,48 @@ impl MobActor {
         spawn_ticket: Option<u64>,
         agent_identity: &AgentIdentity,
         context: &'static str,
-    ) {
-        if let Err(error) = self.apply_dsl_signal(
+    ) -> Result<AuthorizedMobSpawnCompleted, MobError> {
+        let dsl_agent_identity =
+            mob_dsl::AgentIdentity::from_domain(&AgentIdentity::from(agent_identity.as_str()));
+        let transition = match self.apply_dsl_signal_collect_transition(
             mob_dsl::MobMachineSignal::CompleteSpawn {
-                agent_identity: mob_dsl::AgentIdentity::from_domain(&AgentIdentity::from(
-                    agent_identity.as_str(),
-                )),
+                agent_identity: dsl_agent_identity,
             },
             "complete_spawn",
         ) {
+            Ok(transition) => transition,
+            Err(error) => {
+                if let Some(spawn_ticket) = spawn_ticket {
+                    tracing::warn!(
+                        spawn_ticket,
+                        agent_identity = %agent_identity,
+                        error = %error,
+                        context,
+                        "failed to reconcile generated pending-spawn snapshot"
+                    );
+                } else {
+                    tracing::warn!(
+                        agent_identity = %agent_identity,
+                        error = %error,
+                        context,
+                        "failed to reconcile generated pending-spawn snapshot"
+                    );
+                }
+                return Err(error);
+            }
+        };
+        let completed = transition.effects().iter().any(|effect| {
+            matches!(
+                effect,
+                mob_dsl::MobMachineEffect::EmitMemberLifecycleNotice {
+                    kind: mob_dsl::MemberLifecycleKind::Spawned
+                }
+            )
+        });
+        if !completed {
+            let error = MobError::Internal(format!(
+                "MobMachine CompleteSpawn did not authorize spawn completion notice for '{agent_identity}'"
+            ));
             if let Some(spawn_ticket) = spawn_ticket {
                 tracing::warn!(
                     spawn_ticket,
@@ -6529,7 +6645,23 @@ impl MobActor {
                     "failed to reconcile generated pending-spawn snapshot"
                 );
             }
+            return Err(error);
         }
+        let completed = AuthorizedMobSpawnCompleted {
+            generated_plan:
+                generated_mob_command_capabilities::CommandPlanKind::AuthorizedMobSpawnStart,
+            generated_effect: generated_mob_command_capabilities::CommandPlanKind::SpawnEffect,
+            agent_identity: agent_identity.clone(),
+        };
+        debug_assert_eq!(
+            completed.generated_effect,
+            generated_mob_command_capabilities::CommandPlanKind::SpawnEffect
+        );
+        debug_assert_eq!(
+            completed.generated_plan,
+            generated_mob_command_capabilities::CommandPlanKind::AuthorizedMobSpawnStart
+        );
+        Ok(completed)
     }
 
     async fn flow_tracker_alignment_violation(&self) -> Option<String> {
@@ -8511,6 +8643,13 @@ impl MobActor {
                 "fail_all_pending_spawns",
             ) {
                 cleanup_errors.push(format!("{agent_identity} ticket {spawn_ticket}: {error}"));
+            } else {
+                let generated_failed =
+                    generated_mob_command_capabilities::CommandPlanKind::FailSpawn;
+                debug_assert_eq!(
+                    generated_failed,
+                    generated_mob_command_capabilities::CommandPlanKind::FailSpawn
+                );
             }
             if let Err(error) = self.abort_pending_spawn_slot(&slot, reason).await {
                 cleanup_errors.push(format!("{agent_identity} ticket {spawn_ticket}: {error}"));
@@ -8609,6 +8748,13 @@ impl MobActor {
                 "cancel_pending_spawns_for_member",
             ) {
                 cleanup_errors.push(format!("{agent_identity} ticket {spawn_ticket}: {error}"));
+            } else {
+                let generated_failed =
+                    generated_mob_command_capabilities::CommandPlanKind::FailSpawn;
+                debug_assert_eq!(
+                    generated_failed,
+                    generated_mob_command_capabilities::CommandPlanKind::FailSpawn
+                );
             }
             if let Err(error) = self.abort_pending_spawn_slot(&slot, reason).await {
                 cleanup_errors.push(format!("{agent_identity} ticket {spawn_ticket}: {error}"));
@@ -9241,7 +9387,7 @@ impl MobActor {
             };
         if let Err(error) = Self::apply_generated_self_owned_operation_owner(
             &mut provision_request,
-            generated_self_owned_operation_owner,
+            &generated_self_owned_operation_owner,
         ) {
             let _ = reply_tx.send(Err(error));
             return;
@@ -9361,7 +9507,15 @@ impl MobActor {
                 );
             }
         });
-        self.insert_pending_spawn(spawn_ticket, pending, task);
+        let spawn_started = match generated_self_owned_operation_owner.start(&pending) {
+            Ok(started) => started,
+            Err(error) => {
+                let _ = pending.reply_tx.send(Err(error));
+                task.abort();
+                return;
+            }
+        };
+        self.insert_pending_spawn(spawn_ticket, pending, task, spawn_started);
         if let Err(error) = self.ensure_pending_spawn_alignment("enqueue_spawn post-insert") {
             tracing::error!(
                 spawn_ticket,
@@ -9700,7 +9854,7 @@ impl MobActor {
             self.stage_orchestrator_spawn(agent_identity, &admitted_bridge_session_id)?;
         Self::apply_generated_self_owned_operation_owner(
             &mut provision_request,
-            generated_self_owned_operation_owner,
+            &generated_self_owned_operation_owner,
         )?;
 
         // External provisioning installs supervisor-bridge recipient trust
@@ -9742,7 +9896,8 @@ impl MobActor {
         let pending_task = tokio::spawn(async {
             std::future::pending::<()>().await;
         });
-        self.insert_pending_spawn(spawn_ticket, pending, pending_task);
+        let spawn_started = generated_self_owned_operation_owner.start(&pending)?;
+        self.insert_pending_spawn(spawn_ticket, pending, pending_task, spawn_started);
         if let Err(error) =
             self.ensure_pending_spawn_alignment("spawn_from_policy_inline staged pending")
         {
@@ -14420,7 +14575,7 @@ impl MobActor {
         );
         Self::apply_generated_self_owned_operation_owner(
             &mut provision_request,
-            generated_self_owned_operation_owner,
+            &generated_self_owned_operation_owner,
         )
         .map_err(|error| MobRespawnError::SpawnAfterRetire {
             identity: AgentIdentity::from(agent_identity.as_str()),
@@ -14471,7 +14626,18 @@ impl MobActor {
         let respawn_inline_task = tokio::spawn(async {
             std::future::pending::<()>().await;
         });
-        self.insert_pending_spawn(respawn_spawn_ticket, respawn_pending, respawn_inline_task);
+        let spawn_started = generated_self_owned_operation_owner
+            .start(&respawn_pending)
+            .map_err(|error| MobRespawnError::SpawnAfterRetire {
+                identity: AgentIdentity::from(agent_identity.as_str()),
+                reason: format!("failed to start respawn replacement spawn: {error}"),
+            })?;
+        self.insert_pending_spawn(
+            respawn_spawn_ticket,
+            respawn_pending,
+            respawn_inline_task,
+            spawn_started,
+        );
         if let Err(error) = self.ensure_pending_spawn_alignment("handle_respawn staged replacement")
         {
             tracing::error!(

--- a/meerkat-mob/src/runtime/tests.rs
+++ b/meerkat-mob/src/runtime/tests.rs
@@ -570,6 +570,8 @@ struct MockCommsRuntime {
     remove_failures_remaining: std::sync::Mutex<usize>,
     trusted_peers: RwLock<HashMap<String, TrustedPeerDescriptor>>,
     sent_intents: RwLock<Vec<String>>,
+    peer_lifecycle_in_flight: AtomicU64,
+    peer_lifecycle_max_in_flight: AtomicU64,
     inbox_notify: Arc<tokio::sync::Notify>,
     mob_machine_trust_owner: std::sync::RwLock<Option<Arc<dyn std::any::Any + Send + Sync>>>,
 }
@@ -612,6 +614,8 @@ impl MockCommsRuntime {
             )),
             trusted_peers: RwLock::new(HashMap::new()),
             sent_intents: RwLock::new(Vec::new()),
+            peer_lifecycle_in_flight: AtomicU64::new(0),
+            peer_lifecycle_max_in_flight: AtomicU64::new(0),
             inbox_notify: Arc::new(tokio::sync::Notify::new()),
             mob_machine_trust_owner: std::sync::RwLock::new(None),
         }
@@ -684,6 +688,10 @@ impl MockCommsRuntime {
 
     async fn sent_intents(&self) -> Vec<String> {
         self.sent_intents.read().await.clone()
+    }
+
+    fn max_concurrent_peer_lifecycle_sends(&self) -> u64 {
+        self.peer_lifecycle_max_in_flight.load(Ordering::Relaxed)
     }
 
     fn validate_mob_trust_authority_owner(
@@ -977,8 +985,16 @@ impl CoreCommsRuntime for MockCommsRuntime {
                     .read()
                     .expect("poisoned behavior lock in mock runtime");
                 if behavior.peer_lifecycle_delay_ms > 0 {
+                    let in_flight = self
+                        .peer_lifecycle_in_flight
+                        .fetch_add(1, Ordering::Relaxed)
+                        + 1;
+                    self.peer_lifecycle_max_in_flight
+                        .fetch_max(in_flight, Ordering::Relaxed);
                     tokio::time::sleep(Duration::from_millis(behavior.peer_lifecycle_delay_ms))
                         .await;
+                    self.peer_lifecycle_in_flight
+                        .fetch_sub(1, Ordering::Relaxed);
                 }
                 match kind {
                     meerkat_core::comms::PeerLifecycleKind::PeerAdded
@@ -1025,6 +1041,18 @@ impl CoreCommsRuntime for MockCommsRuntime {
                     .behavior
                     .read()
                     .expect("poisoned behavior lock in mock runtime");
+                if behavior.peer_lifecycle_delay_ms > 0 && intent.starts_with("mob.peer_") {
+                    let in_flight = self
+                        .peer_lifecycle_in_flight
+                        .fetch_add(1, Ordering::Relaxed)
+                        + 1;
+                    self.peer_lifecycle_max_in_flight
+                        .fetch_max(in_flight, Ordering::Relaxed);
+                    tokio::time::sleep(Duration::from_millis(behavior.peer_lifecycle_delay_ms))
+                        .await;
+                    self.peer_lifecycle_in_flight
+                        .fetch_sub(1, Ordering::Relaxed);
+                }
                 if intent == "mob.peer_added" && behavior.fail_send_peer_added {
                     return Err(SendError::Unsupported(
                         "mock mob.peer_added notification failure".to_string(),
@@ -1182,6 +1210,8 @@ struct MockSessionService {
     archive_fail_comms_names: RwLock<HashSet<String>>,
     /// Sent intents for sessions that were archived and removed.
     archived_sent_intents: RwLock<HashMap<SessionId, Vec<String>>>,
+    /// Fanout concurrency observed by sessions that were archived and removed.
+    archived_peer_lifecycle_max_in_flight: RwLock<HashMap<SessionId, u64>>,
     /// Sessions that were archived. Mirrors the real persistent-service
     /// contract: `load_persisted_session` returns `None` for archived
     /// sessions, so archive stays terminal (no revival from an archived
@@ -1262,6 +1292,7 @@ impl MockSessionService {
             archive_fail_sessions: RwLock::new(HashSet::new()),
             archive_fail_comms_names: RwLock::new(HashSet::new()),
             archived_sent_intents: RwLock::new(HashMap::new()),
+            archived_peer_lifecycle_max_in_flight: RwLock::new(HashMap::new()),
             archived_session_ids: RwLock::new(HashSet::new()),
             create_fail_sessions: RwLock::new(HashSet::new()),
             create_identity_already_active_sessions: RwLock::new(HashSet::new()),
@@ -1671,6 +1702,23 @@ impl MockSessionService {
                 .await
                 .get(session_id)
                 .cloned()
+                .unwrap_or_default(),
+        }
+    }
+
+    async fn max_concurrent_peer_lifecycle_sends(&self, session_id: &SessionId) -> u64 {
+        let runtime = {
+            let sessions = self.sessions.read().await;
+            sessions.get(session_id).cloned()
+        };
+        match runtime {
+            Some(runtime) => runtime.max_concurrent_peer_lifecycle_sends(),
+            None => self
+                .archived_peer_lifecycle_max_in_flight
+                .read()
+                .await
+                .get(session_id)
+                .copied()
                 .unwrap_or_default(),
         }
     }
@@ -2229,10 +2277,15 @@ impl SessionService for MockSessionService {
                 notifier.notify_waiters();
             }
             let intents = runtime.sent_intents().await;
+            let peer_lifecycle_max_in_flight = runtime.max_concurrent_peer_lifecycle_sends();
             self.archived_sent_intents
                 .write()
                 .await
                 .insert(id.clone(), intents);
+            self.archived_peer_lifecycle_max_in_flight
+                .write()
+                .await
+                .insert(id.clone(), peer_lifecycle_max_in_flight);
         }
         Ok(())
     }
@@ -11266,6 +11319,47 @@ fn test_generated_dsl_paths_do_not_shadow_destroy_admission() {
     );
 }
 
+#[test]
+fn test_pending_spawn_insertion_requires_generated_start_authority() {
+    let source = include_str!("actor.rs");
+    let insert_pending_spawn = source
+        .find("fn insert_pending_spawn")
+        .expect("insert_pending_spawn");
+    let insert_body = &source[insert_pending_spawn..];
+    let pending_start_count = source.matches(".start(&pending)").count();
+    assert!(
+        source.contains("struct AuthorizedMobSpawnStart")
+            && source.contains("struct AuthorizedMobSpawnStarted")
+            && source.contains("struct AuthorizedMobSpawnCompleted")
+            && source.contains(
+                "generated_can_start: generated_mob_command_capabilities::CommandPlanKind"
+            )
+            && source
+                .contains("generated_owner: generated_mob_command_capabilities::CommandPlanKind")
+            && source
+                .contains("generated_started: generated_mob_command_capabilities::CommandPlanKind")
+            && source
+                .contains("generated_effect: generated_mob_command_capabilities::CommandPlanKind")
+            && !source.contains("mint_from_generated_command_plan(")
+            && source.contains(
+                "generated_mob_command_capabilities::CommandPlanKind::AuthorizedMobSpawnStart"
+            )
+            && source
+                .contains("generated_mob_command_capabilities::CommandPlanKind::CanStartSpawn")
+            && source.contains("generated_mob_command_capabilities::CommandPlanKind::SpawnStarted")
+            && source.contains("generated_mob_command_capabilities::CommandPlanKind::SpawnEffect")
+            && source.contains("generated_mob_command_capabilities::CommandPlanKind::FailSpawn")
+            && source.contains("MobMachineSignal::StageSpawn")
+            && source.contains("PendingSpawnOperationOwnerAuthorized")
+            && source.contains("MobMachineSignal::CompleteSpawn")
+            && source.contains("EmitMemberLifecycleNotice")
+            && insert_body.contains("started: AuthorizedMobSpawnStarted")
+            && pending_start_count >= 2
+            && source.contains(".start(&respawn_pending)"),
+        "mob pending-spawn insertion and completion must consume generated StageSpawn/CompleteSpawn authorities"
+    );
+}
+
 #[tokio::test]
 async fn test_stopped_missing_member_wire_is_rejected_by_machine_admission() {
     let (handle, _service) = create_test_mob(sample_definition()).await;
@@ -19457,16 +19551,27 @@ async fn test_wire_members_batch_materializes_300_by_150_dense_topology_in_secon
         .iter()
         .filter(|event| matches!(event.kind, MobEventKind::MembersWiredBatch { .. }))
         .count();
+    let batch_event_edges = events
+        .iter()
+        .filter_map(|event| match &event.kind {
+            MobEventKind::MembersWiredBatch { edges } => Some(edges.len()),
+            _ => None,
+        })
+        .sum::<usize>();
     let single_edge_events = events
         .iter()
         .filter(|event| matches!(event.kind, MobEventKind::MembersWired { .. }))
         .count();
     assert_eq!(batch_events, 1);
     assert_eq!(
+        batch_event_edges, EXPECTED_EDGES,
+        "dense topology materialization should publish every new edge through the compact batch event"
+    );
+    assert_eq!(
         single_edge_events, 0,
         "dense topology materialization must not emit per-edge wire events"
     );
-    let max_wire_elapsed = std::time::Duration::from_secs(90);
+    let max_wire_elapsed = std::time::Duration::from_secs(180);
     assert!(
         wire_elapsed < max_wire_elapsed,
         "300x150 topology materialization should stay inside the generated-authority stress budget of {max_wire_elapsed:?} (spawn={spawn_elapsed:?}, wire={wire_elapsed:?})"
@@ -19544,13 +19649,20 @@ async fn test_retire_fanout_notifies_150_peers_with_bounded_parallelism() {
         .await
         .expect("retire high-degree member");
     let elapsed = started.elapsed();
+    let max_concurrent = service
+        .max_concurrent_peer_lifecycle_sends(&retiring_sid)
+        .await;
 
     assert!(
-        elapsed < Duration::from_millis(2750),
-        "150 peer-retired notifications with {PER_NOTIFICATION_DELAY_MS}ms send delay should fan out with bounded parallelism, not run sequentially (elapsed={elapsed:?})"
+        max_concurrent > 1,
+        "150 peer-retired notifications with {PER_NOTIFICATION_DELAY_MS}ms send delay should overlap; max observed concurrent sends: {max_concurrent}"
+    );
+    assert!(
+        elapsed < Duration::from_secs(10),
+        "150 peer-retired notifications with {PER_NOTIFICATION_DELAY_MS}ms send delay should stay comfortably below a serialized stress timeout (elapsed={elapsed:?}, max_concurrent={max_concurrent})"
     );
     eprintln!(
-        "retire fanout stress: peers={PEERS}, per_notification_delay_ms={PER_NOTIFICATION_DELAY_MS}, retire={elapsed:?}"
+        "retire fanout stress: peers={PEERS}, per_notification_delay_ms={PER_NOTIFICATION_DELAY_MS}, retire={elapsed:?}, max_concurrent={max_concurrent}"
     );
     let retiring_intents = service.sent_intents(&retiring_sid).await;
     assert_eq!(

--- a/meerkat-runtime/BUILD.bazel
+++ b/meerkat-runtime/BUILD.bazel
@@ -63,6 +63,7 @@ rust_library(
         "//meerkat-contracts:meerkat_contracts",
         "//meerkat-core:meerkat_core",
         "//meerkat-live:meerkat_live",
+        "//meerkat-machine-kernels:meerkat_machine_kernels",
         "//meerkat-machine-schema:meerkat_machine_schema",
         "//meerkat-store:meerkat_store",
     ] + all_crate_deps(
@@ -126,6 +127,7 @@ rust_library(
         "//meerkat-contracts:meerkat_contracts",
         "//meerkat-core:meerkat_core",
         "//meerkat-live:meerkat_live",
+        "//meerkat-machine-kernels:meerkat_machine_kernels",
         "//meerkat-machine-schema:meerkat_machine_schema",
         "//meerkat-store:meerkat_store",
     ] + all_crate_deps(
@@ -172,6 +174,7 @@ rust_library(
         "//meerkat:meerkat_contracts_agent_factory_build",
         "//meerkat:meerkat_core_agent_factory_build",
         "//meerkat:meerkat_live_agent_factory_build",
+        "//meerkat:meerkat_machine_kernels_agent_factory_build",
         "//meerkat:meerkat_machine_schema_agent_factory_build",
         "//meerkat:meerkat_store_agent_factory_build",
     ] + all_crate_deps(
@@ -219,6 +222,7 @@ rust_library(
         "//meerkat:meerkat_contracts_agent_factory_build",
         "//meerkat:meerkat_core_agent_factory_build",
         "//meerkat:meerkat_live_agent_factory_build",
+        "//meerkat:meerkat_machine_kernels_agent_factory_build",
         "//meerkat:meerkat_machine_schema_agent_factory_build",
         "//meerkat:meerkat_store_agent_factory_build",
     ] + all_crate_deps(

--- a/meerkat-runtime/Cargo.toml
+++ b/meerkat-runtime/Cargo.toml
@@ -16,6 +16,7 @@ categories.workspace = true
 meerkat-core = { workspace = true, features = ["__meerkat-generated-authority-bridge"] }
 meerkat-live = { workspace = true, optional = true, features = ["__meerkat-generated-authority-bridge"] }
 meerkat-machine-dsl = { workspace = true }
+meerkat-machine-kernels = { workspace = true }
 meerkat-machine-schema = { workspace = true }
 meerkat-contracts = { workspace = true }
 serde = { workspace = true }

--- a/meerkat-runtime/src/completion.rs
+++ b/meerkat-runtime/src/completion.rs
@@ -20,7 +20,10 @@ use meerkat_core::types::{RunResult, SessionId};
 use meerkat_core::{TurnErrorMetadata, TurnTerminalCauseKind, TurnTerminalOutcome};
 use serde_json::Value;
 
-use crate::meerkat_machine::driver::RuntimeCompletionResultAuthority;
+use crate::meerkat_machine::driver::{
+    RuntimeCompletionResultAttempt, RuntimeCompletionResultAuthority,
+    RuntimeCompletionResultRealized,
+};
 use crate::meerkat_machine::dsl::RuntimeCompletionResultClass;
 use crate::tokio::sync::oneshot;
 
@@ -105,14 +108,14 @@ pub struct CompletionCleanupObservation {
 }
 
 impl CompletionCleanupObservation {
-    fn from_authority(authority: RuntimeCompletionResultAuthority) -> Self {
+    fn from_realized_result(realized: RuntimeCompletionResultRealized) -> Self {
         Self {
-            owner_session_id: authority.session_id().clone(),
-            owner_agent_runtime_id: authority.agent_runtime_id().cloned(),
-            owner_fence_token: authority.fence_token(),
-            owner_runtime_generation: authority.runtime_generation(),
-            owner_runtime_epoch_id: authority.runtime_epoch_id().cloned(),
-            observed_outcome: authority.cleanup_observation(),
+            owner_session_id: realized.session_id().clone(),
+            owner_agent_runtime_id: realized.agent_runtime_id().cloned(),
+            owner_fence_token: realized.fence_token(),
+            owner_runtime_generation: realized.runtime_generation(),
+            owner_runtime_epoch_id: realized.runtime_epoch_id().cloned(),
+            observed_outcome: realized.cleanup_observation(),
         }
     }
 
@@ -284,12 +287,12 @@ impl CompletionHandle {
     #[cfg(test)]
     fn already_resolved_internal(
         outcome: CompletionOutcome,
-        authority: RuntimeCompletionResultAuthority,
+        realized: RuntimeCompletionResultRealized,
     ) -> Self {
         let (tx, rx) = oneshot::channel();
         let _ = tx.send(Ok(CompletionDelivery {
             outcome,
-            cleanup_observation: CompletionCleanupObservation::from_authority(authority),
+            cleanup_observation: CompletionCleanupObservation::from_realized_result(realized),
         }));
         Self { rx }
     }
@@ -314,13 +317,15 @@ impl CompletionHandle {
                 terminal,
                 finalization,
             )?;
-        if !authority.allows(expected_class) {
+        let attempt = authority.begin_surface_resolution();
+        if !attempt.allows(expected_class) {
+            let generated_class = attempt.class();
+            attempt.fail();
             return Err(crate::RuntimeDriverError::Internal(format!(
-                "generated runtime completion authority returned {:?}, expected {expected_class:?}",
-                authority.class()
+                "generated runtime completion authority returned {generated_class:?}, expected {expected_class:?}",
             )));
         }
-        Ok(Self::already_resolved_internal(outcome, authority))
+        Ok(Self::already_resolved_internal(outcome, attempt.realize()))
     }
 
     #[cfg(test)]
@@ -488,7 +493,7 @@ impl CompletionRegistry {
     }
 
     fn authority_mismatch_error(
-        authority: &RuntimeCompletionResultAuthority,
+        authority: &RuntimeCompletionResultAttempt,
         expected: RuntimeCompletionResultClass,
     ) -> CompletionWaitError {
         CompletionWaitError::AuthorityUnavailable(format!(
@@ -500,11 +505,13 @@ impl CompletionRegistry {
     fn fail_input_authority_mismatch(
         &mut self,
         input_id: &InputId,
-        authority: &RuntimeCompletionResultAuthority,
+        authority: RuntimeCompletionResultAttempt,
         expected: RuntimeCompletionResultClass,
     ) {
+        let error = Self::authority_mismatch_error(&authority, expected);
+        authority.fail();
         if let Some(senders) = self.take_waiters(input_id) {
-            Self::send_error(senders, Self::authority_mismatch_error(authority, expected));
+            Self::send_error(senders, error);
         }
     }
 
@@ -512,15 +519,35 @@ impl CompletionRegistry {
     fn fail_inputs_authority_mismatch<I>(
         &mut self,
         input_ids: I,
-        authority: &RuntimeCompletionResultAuthority,
+        authority: RuntimeCompletionResultAttempt,
         expected: RuntimeCompletionResultClass,
     ) where
         I: IntoIterator<Item = InputId>,
     {
+        let error = Self::authority_mismatch_error(&authority, expected);
+        authority.fail();
+        self.fail_inputs(input_ids, error);
+    }
+
+    fn fail_inputs_authority_unavailable<I>(
+        &mut self,
+        input_ids: I,
+        authority: RuntimeCompletionResultAttempt,
+        reason: impl Into<String>,
+    ) where
+        I: IntoIterator<Item = InputId>,
+    {
+        authority.fail();
         self.fail_inputs(
             input_ids,
-            Self::authority_mismatch_error(authority, expected),
+            CompletionWaitError::AuthorityUnavailable(reason.into()),
         );
+    }
+
+    fn cleanup_from_realized_attempt(
+        authority: RuntimeCompletionResultAttempt,
+    ) -> CompletionCleanupObservation {
+        CompletionCleanupObservation::from_realized_result(authority.realize())
     }
 
     /// Register a waiter for an input. Returns the handle the caller will await.
@@ -557,14 +584,15 @@ impl CompletionRegistry {
         authority: RuntimeCompletionResultAuthority,
     ) {
         let expected = RuntimeCompletionResultClass::Completed;
-        if !authority.allows(expected) {
-            self.fail_input_authority_mismatch(input_id, &authority, expected);
+        let attempt = authority.begin_surface_resolution();
+        if !attempt.allows(expected) {
+            self.fail_input_authority_mismatch(input_id, attempt, expected);
             return;
         }
         self.resolve_completed(
             input_id,
             result,
-            CompletionCleanupObservation::from_authority(authority),
+            Self::cleanup_from_realized_attempt(attempt),
         );
     }
 
@@ -578,19 +606,18 @@ impl CompletionRegistry {
         I: IntoIterator<Item = InputId>,
     {
         let input_ids: Vec<InputId> = input_ids.into_iter().collect();
-        match authority.class() {
+        let attempt = authority.begin_surface_resolution();
+        match attempt.class() {
             RuntimeCompletionResultClass::Completed => {
                 let Some(CoreApplyTerminal::RunResult(result)) = terminal else {
-                    self.fail_inputs(
+                    self.fail_inputs_authority_unavailable(
                         input_ids,
-                        CompletionWaitError::AuthorityUnavailable(
-                            "runtime completion authority resolved Completed without result payload"
-                                .to_string(),
-                        ),
+                        attempt,
+                        "runtime completion authority resolved Completed without result payload",
                     );
                     return;
                 };
-                let cleanup_observation = CompletionCleanupObservation::from_authority(authority);
+                let cleanup_observation = Self::cleanup_from_realized_attempt(attempt);
                 for input_id in input_ids {
                     self.resolve_completed(
                         &input_id,
@@ -601,32 +628,28 @@ impl CompletionRegistry {
             }
             RuntimeCompletionResultClass::CompletedWithoutResult => {
                 if !matches!(terminal, Some(CoreApplyTerminal::NoPendingBoundary) | None) {
-                    self.fail_inputs(
+                    self.fail_inputs_authority_unavailable(
                         input_ids,
-                        CompletionWaitError::AuthorityUnavailable(
-                            "runtime completion authority resolved CompletedWithoutResult with terminal payload"
-                                .to_string(),
-                        ),
+                        attempt,
+                        "runtime completion authority resolved CompletedWithoutResult with terminal payload",
                     );
                     return;
                 }
-                let cleanup_observation = CompletionCleanupObservation::from_authority(authority);
+                let cleanup_observation = Self::cleanup_from_realized_attempt(attempt);
                 for input_id in input_ids {
                     self.resolve_without_result(&input_id, cleanup_observation.clone());
                 }
             }
             RuntimeCompletionResultClass::CallbackPending => {
                 let Some(CoreApplyTerminal::CallbackPending { tool_name, args }) = terminal else {
-                    self.fail_inputs(
+                    self.fail_inputs_authority_unavailable(
                         input_ids,
-                        CompletionWaitError::AuthorityUnavailable(
-                            "runtime completion authority resolved CallbackPending without callback payload"
-                                .to_string(),
-                        ),
+                        attempt,
+                        "runtime completion authority resolved CallbackPending without callback payload",
                     );
                     return;
                 };
-                let cleanup_observation = CompletionCleanupObservation::from_authority(authority);
+                let cleanup_observation = Self::cleanup_from_realized_attempt(attempt);
                 for input_id in input_ids {
                     self.resolve_callback_pending(
                         &input_id,
@@ -638,38 +661,32 @@ impl CompletionRegistry {
             }
             RuntimeCompletionResultClass::Cancelled => {
                 if terminal.is_some() || finalization_error.is_some() {
-                    self.fail_inputs(
+                    self.fail_inputs_authority_unavailable(
                         input_ids,
-                        CompletionWaitError::AuthorityUnavailable(
-                            "runtime completion authority resolved Cancelled with payload"
-                                .to_string(),
-                        ),
+                        attempt,
+                        "runtime completion authority resolved Cancelled with payload",
                     );
                     return;
                 }
-                let cleanup_observation = CompletionCleanupObservation::from_authority(authority);
+                let cleanup_observation = Self::cleanup_from_realized_attempt(attempt);
                 for input_id in input_ids {
                     self.resolve_cancelled(&input_id, cleanup_observation.clone());
                 }
             }
             RuntimeCompletionResultClass::AbandonedWithError => {
                 if matches!(terminal, Some(CoreApplyTerminal::RunResult(_))) {
-                    self.fail_inputs(
+                    self.fail_inputs_authority_unavailable(
                         input_ids,
-                        CompletionWaitError::AuthorityUnavailable(
-                            "runtime completion authority resolved AbandonedWithError with result payload"
-                                .to_string(),
-                        ),
+                        attempt,
+                        "runtime completion authority resolved AbandonedWithError with result payload",
                     );
                     return;
                 }
                 let Some(error) = finalization_error else {
-                    self.fail_inputs(
+                    self.fail_inputs_authority_unavailable(
                         input_ids,
-                        CompletionWaitError::AuthorityUnavailable(
-                            "runtime completion authority resolved AbandonedWithError without typed error"
-                                .to_string(),
-                        ),
+                        attempt,
+                        "runtime completion authority resolved AbandonedWithError without typed error",
                     );
                     return;
                 };
@@ -677,7 +694,7 @@ impl CompletionRegistry {
                     .detail
                     .clone()
                     .unwrap_or_else(|| "runtime finalization failed".to_string());
-                let cleanup_observation = CompletionCleanupObservation::from_authority(authority);
+                let cleanup_observation = Self::cleanup_from_realized_attempt(attempt);
                 for input_id in input_ids {
                     self.resolve_abandoned_with_error(
                         &input_id,
@@ -689,26 +706,22 @@ impl CompletionRegistry {
             }
             RuntimeCompletionResultClass::CompletedWithFinalizationFailure => {
                 let Some(CoreApplyTerminal::RunResult(_result)) = terminal else {
-                    self.fail_inputs(
+                    self.fail_inputs_authority_unavailable(
                         input_ids,
-                        CompletionWaitError::AuthorityUnavailable(
-                            "runtime completion authority resolved CompletedWithFinalizationFailure without result payload"
-                                .to_string(),
-                        ),
+                        attempt,
+                        "runtime completion authority resolved CompletedWithFinalizationFailure without result payload",
                     );
                     return;
                 };
                 let Some(error) = finalization_error else {
-                    self.fail_inputs(
+                    self.fail_inputs_authority_unavailable(
                         input_ids,
-                        CompletionWaitError::AuthorityUnavailable(
-                            "runtime completion authority resolved finalization failure without typed error"
-                                .to_string(),
-                        ),
+                        attempt,
+                        "runtime completion authority resolved finalization failure without typed error",
                     );
                     return;
                 };
-                let cleanup_observation = CompletionCleanupObservation::from_authority(authority);
+                let cleanup_observation = Self::cleanup_from_realized_attempt(attempt);
                 for input_id in input_ids {
                     self.resolve_completed_with_finalization_failure(
                         &input_id,
@@ -719,16 +732,14 @@ impl CompletionRegistry {
             }
             RuntimeCompletionResultClass::RuntimeTerminated => {
                 if terminal.is_some() || finalization_error.is_some() {
-                    self.fail_inputs(
+                    self.fail_inputs_authority_unavailable(
                         input_ids,
-                        CompletionWaitError::AuthorityUnavailable(
-                            "runtime completion authority resolved RuntimeTerminated with payload"
-                                .to_string(),
-                        ),
+                        attempt,
+                        "runtime completion authority resolved RuntimeTerminated with payload",
                     );
                     return;
                 }
-                let cleanup_observation = CompletionCleanupObservation::from_authority(authority);
+                let cleanup_observation = Self::cleanup_from_realized_attempt(attempt);
                 for input_id in input_ids {
                     if let Some(senders) = self.take_waiters(&input_id) {
                         Self::send_outcome(
@@ -763,14 +774,12 @@ impl CompletionRegistry {
         authority: RuntimeCompletionResultAuthority,
     ) {
         let expected = RuntimeCompletionResultClass::CompletedWithoutResult;
-        if !authority.allows(expected) {
-            self.fail_input_authority_mismatch(input_id, &authority, expected);
+        let attempt = authority.begin_surface_resolution();
+        if !attempt.allows(expected) {
+            self.fail_input_authority_mismatch(input_id, attempt, expected);
             return;
         }
-        self.resolve_without_result(
-            input_id,
-            CompletionCleanupObservation::from_authority(authority),
-        );
+        self.resolve_without_result(input_id, Self::cleanup_from_realized_attempt(attempt));
     }
 
     /// Resolve all waiters for an input that reached a callback boundary.
@@ -799,15 +808,16 @@ impl CompletionRegistry {
         authority: RuntimeCompletionResultAuthority,
     ) {
         let expected = RuntimeCompletionResultClass::CallbackPending;
-        if !authority.allows(expected) {
-            self.fail_input_authority_mismatch(input_id, &authority, expected);
+        let attempt = authority.begin_surface_resolution();
+        if !attempt.allows(expected) {
+            self.fail_input_authority_mismatch(input_id, attempt, expected);
             return;
         }
         self.resolve_callback_pending(
             input_id,
             tool_name,
             args,
-            CompletionCleanupObservation::from_authority(authority),
+            Self::cleanup_from_realized_attempt(attempt),
         );
     }
 
@@ -829,14 +839,12 @@ impl CompletionRegistry {
         authority: RuntimeCompletionResultAuthority,
     ) {
         let expected = RuntimeCompletionResultClass::Cancelled;
-        if !authority.allows(expected) {
-            self.fail_input_authority_mismatch(input_id, &authority, expected);
+        let attempt = authority.begin_surface_resolution();
+        if !attempt.allows(expected) {
+            self.fail_input_authority_mismatch(input_id, attempt, expected);
             return;
         }
-        self.resolve_cancelled(
-            input_id,
-            CompletionCleanupObservation::from_authority(authority),
-        );
+        self.resolve_cancelled(input_id, Self::cleanup_from_realized_attempt(attempt));
     }
 
     /// Resolve all waiters for an abandoned input with typed failure metadata.
@@ -865,15 +873,16 @@ impl CompletionRegistry {
         authority: RuntimeCompletionResultAuthority,
     ) {
         let expected = RuntimeCompletionResultClass::AbandonedWithError;
-        if !authority.allows(expected) {
-            self.fail_input_authority_mismatch(input_id, &authority, expected);
+        let attempt = authority.begin_surface_resolution();
+        if !attempt.allows(expected) {
+            self.fail_input_authority_mismatch(input_id, attempt, expected);
             return;
         }
         self.resolve_abandoned_with_error(
             input_id,
             reason,
             error,
-            CompletionCleanupObservation::from_authority(authority),
+            Self::cleanup_from_realized_attempt(attempt),
         );
     }
 
@@ -902,14 +911,15 @@ impl CompletionRegistry {
         authority: RuntimeCompletionResultAuthority,
     ) {
         let expected = RuntimeCompletionResultClass::CompletedWithFinalizationFailure;
-        if !authority.allows(expected) {
-            self.fail_input_authority_mismatch(input_id, &authority, expected);
+        let attempt = authority.begin_surface_resolution();
+        if !attempt.allows(expected) {
+            self.fail_input_authority_mismatch(input_id, attempt, expected);
             return;
         }
         self.resolve_completed_with_finalization_failure(
             input_id,
             error,
-            CompletionCleanupObservation::from_authority(authority),
+            Self::cleanup_from_realized_attempt(attempt),
         );
     }
 
@@ -924,12 +934,14 @@ impl CompletionRegistry {
         authority: RuntimeCompletionResultAuthority,
     ) {
         let expected = RuntimeCompletionResultClass::RuntimeTerminated;
-        if !authority.allows(expected) {
-            let error = Self::authority_mismatch_error(&authority, expected);
+        let attempt = authority.begin_surface_resolution();
+        if !attempt.allows(expected) {
+            let error = Self::authority_mismatch_error(&attempt, expected);
+            attempt.fail();
             self.fail_all_waiters(error);
             return;
         }
-        let cleanup_observation = CompletionCleanupObservation::from_authority(authority);
+        let cleanup_observation = Self::cleanup_from_realized_attempt(attempt);
         for (_, senders) in self.waiters.drain() {
             Self::send_outcome(
                 senders,
@@ -950,11 +962,12 @@ impl CompletionRegistry {
     {
         let input_ids: Vec<InputId> = input_ids.into_iter().collect();
         let expected = RuntimeCompletionResultClass::RuntimeTerminated;
-        if !authority.allows(expected) {
-            self.fail_inputs_authority_mismatch(input_ids, &authority, expected);
+        let attempt = authority.begin_surface_resolution();
+        if !attempt.allows(expected) {
+            self.fail_inputs_authority_mismatch(input_ids, attempt, expected);
             return;
         }
-        let cleanup_observation = CompletionCleanupObservation::from_authority(authority);
+        let cleanup_observation = Self::cleanup_from_realized_attempt(attempt);
         for input_id in input_ids {
             if let Some(senders) = self.take_waiters(&input_id) {
                 Self::send_outcome(
@@ -994,8 +1007,10 @@ impl CompletionRegistry {
         F: FnMut(&InputId) -> bool,
     {
         let expected = RuntimeCompletionResultClass::RuntimeTerminated;
-        if !authority.allows(expected) {
-            let error = Self::authority_mismatch_error(&authority, expected);
+        let attempt = authority.begin_surface_resolution();
+        if !attempt.allows(expected) {
+            let error = Self::authority_mismatch_error(&attempt, expected);
+            attempt.fail();
             self.waiters.retain(|input_id, senders| {
                 if is_still_pending(input_id) {
                     return true;
@@ -1006,19 +1021,28 @@ impl CompletionRegistry {
             });
             return;
         }
-        let cleanup_observation = CompletionCleanupObservation::from_authority(authority);
+
+        let mut ready = Vec::new();
         self.waiters.retain(|input_id, senders| {
             if is_still_pending(input_id) {
                 return true;
             }
 
+            ready.push(std::mem::take(senders));
+            false
+        });
+        if ready.is_empty() {
+            attempt.abandon();
+            return;
+        }
+        let cleanup_observation = Self::cleanup_from_realized_attempt(attempt);
+        for senders in ready {
             Self::send_outcome(
-                std::mem::take(senders),
+                senders,
                 CompletionOutcome::runtime_terminated(reason),
                 cleanup_observation.clone(),
             );
-            false
-        });
+        }
     }
 
     /// Snapshot the current waiter carrier without mutating it.

--- a/meerkat-runtime/src/driver/ephemeral.rs
+++ b/meerkat-runtime/src/driver/ephemeral.rs
@@ -769,6 +769,44 @@ impl EphemeralRuntimeDriver {
         self.with_dsl_state(|state| state.input_admission_seq.get(&key).copied())
     }
 
+    #[cfg(test)]
+    pub(crate) fn input_runtime_boundary(
+        &self,
+        input_id: &InputId,
+    ) -> Option<mm_dsl::RecoveredRunApplyBoundary> {
+        let key = Self::dsl_key(input_id);
+        self.with_dsl_state(|state| state.input_runtime_boundary.get(&key).copied())
+    }
+
+    #[cfg(test)]
+    pub(crate) fn input_runtime_execution_kind(
+        &self,
+        input_id: &InputId,
+    ) -> Option<mm_dsl::RecoveredRuntimeExecutionKind> {
+        let key = Self::dsl_key(input_id);
+        self.with_dsl_state(|state| state.input_runtime_execution_kind.get(&key).copied())
+    }
+
+    #[cfg(test)]
+    pub(crate) fn input_peer_response_terminal_apply_intent(
+        &self,
+        input_id: &InputId,
+    ) -> Option<mm_dsl::RecoveredPeerResponseTerminalApplyIntent> {
+        let key = Self::dsl_key(input_id);
+        self.with_dsl_state(|state| {
+            state
+                .input_runtime_peer_response_terminal_apply_intent
+                .get(&key)
+                .copied()
+        })
+    }
+
+    #[cfg(test)]
+    pub(crate) fn input_is_prompt_for_batch(&self, input_id: &InputId) -> Option<bool> {
+        let key = Self::dsl_key(input_id);
+        self.with_dsl_state(|state| state.input_is_prompt.get(&key).copied())
+    }
+
     /// Conversation projection decided at admission time.
     pub fn admitted_primitive_projection(
         &self,
@@ -857,6 +895,29 @@ impl EphemeralRuntimeDriver {
         self.debug_assert_queue_projection_alignment();
     }
 
+    pub(crate) fn validate_queue_projection_alignment(
+        &self,
+        context: &str,
+    ) -> Result<(), RuntimeDriverError> {
+        let physical_queue = self.queue.input_ids();
+        let machine_queue = self.dsl_queue_lane();
+        if physical_queue != machine_queue {
+            return Err(RuntimeDriverError::Internal(format!(
+                "{context}: physical queue projection diverged from machine queue lane: physical={physical_queue:?} machine={machine_queue:?}"
+            )));
+        }
+
+        let physical_steer_queue = self.steer_queue.input_ids();
+        let machine_steer_queue = self.dsl_steer_lane();
+        if physical_steer_queue != machine_steer_queue {
+            return Err(RuntimeDriverError::Internal(format!(
+                "{context}: physical steer queue projection diverged from machine steer lane: physical={physical_steer_queue:?} machine={machine_steer_queue:?}"
+            )));
+        }
+
+        Ok(())
+    }
+
     fn debug_assert_queue_projection_alignment(&self) {
         debug_assert_eq!(
             self.queue.input_ids(),
@@ -909,7 +970,17 @@ impl EphemeralRuntimeDriver {
             handling_mode,
             runtime_semantics,
         )?;
-        self.apply_recovered_lifecycle(&work_id, recovered_seed, admission_sequence_recovery)?;
+        let runtime_grouping = matches!(
+            recovered_seed.phase,
+            InputLifecycleState::Accepted | InputLifecycleState::Queued
+        )
+        .then_some((runtime_semantics, is_prompt));
+        self.apply_recovered_lifecycle(
+            &work_id,
+            recovered_seed,
+            admission_sequence_recovery,
+            runtime_grouping,
+        )?;
         self.register_accepted_idempotency(&work_id, recovered_state.idempotency_key.as_ref())?;
         self.record_admission_metadata(
             &work_id,
@@ -980,7 +1051,7 @@ impl EphemeralRuntimeDriver {
                 "terminal recovery path received non-terminal input '{work_id}'"
             )));
         }
-        self.apply_recovered_lifecycle(work_id, recovered_seed, None)?;
+        self.apply_recovered_lifecycle(work_id, recovered_seed, None, None)?;
         self.register_accepted_idempotency(work_id, idempotency_key)
     }
 
@@ -1009,6 +1080,7 @@ impl EphemeralRuntimeDriver {
         work_id: &InputId,
         recovered_seed: &InputStateSeed,
         admission_sequence_recovery: Option<mm_dsl::RecoveredInputNormalizationReasonKind>,
+        runtime_grouping: Option<(RuntimeInputSemantics, bool)>,
     ) -> Result<(), RuntimeDriverError> {
         let key = Self::dsl_key(work_id);
         let lifecycle_state = recovered_seed.phase;
@@ -1061,6 +1133,33 @@ impl EphemeralRuntimeDriver {
         let lane = matches!(lifecycle_state, InputLifecycleState::Queued)
             .then_some(recovery_lane)
             .flatten();
+        let (
+            runtime_boundary,
+            runtime_execution_kind,
+            runtime_peer_response_terminal_apply_intent,
+            is_prompt,
+        ) = if let Some((runtime_semantics, is_prompt)) = runtime_grouping {
+            let runtime_boundary = mm_dsl::RecoveredRunApplyBoundary::try_from(
+                    runtime_semantics.boundary,
+                )
+                .map_err(|err| {
+                    RuntimeDriverError::Internal(format!(
+                        "input '{work_id}' has unsupported runtime boundary for recovered grouping: {err}"
+                    ))
+                })?;
+            (
+                Some(runtime_boundary),
+                Some(mm_dsl::RecoveredRuntimeExecutionKind::from(
+                    runtime_semantics.execution_kind,
+                )),
+                runtime_semantics
+                    .peer_response_terminal_apply_intent
+                    .map(mm_dsl::RecoveredPeerResponseTerminalApplyIntent::from),
+                is_prompt,
+            )
+        } else {
+            (None, None, None, false)
+        };
         self.dsl_apply(
             mm_dsl::MeerkatMachineInput::RecoverInputLifecycle {
                 input_id: key,
@@ -1080,6 +1179,10 @@ impl EphemeralRuntimeDriver {
                 admission_sequence_recovery,
                 recovery_lane,
                 lane,
+                runtime_boundary,
+                runtime_execution_kind,
+                runtime_peer_response_terminal_apply_intent,
+                is_prompt,
             },
             "RecoverInputLifecycle",
         )
@@ -1845,7 +1948,7 @@ impl EphemeralRuntimeDriver {
         self.queue = InputQueue::new();
         self.steer_queue = InputQueue::new();
     }
-    pub fn dequeue_next(&mut self) -> Option<(InputId, Input)> {
+    pub(crate) fn dequeue_next(&mut self) -> Option<(InputId, Input)> {
         let queued = self
             .steer_queue
             .dequeue()
@@ -1853,33 +1956,39 @@ impl EphemeralRuntimeDriver {
         Some((queued.input_id, queued.input))
     }
 
+    /// Contract helper for recovery/queue-projection tests. Production runtime
+    /// execution must use generated batch authority via `dequeue_batch_exact`.
+    #[cfg(any(test, debug_assertions, feature = "test-support"))]
+    #[doc(hidden)]
+    pub fn contract_dequeue_next_for_recovery_tests(&mut self) -> Option<(InputId, Input)> {
+        self.dequeue_next()
+    }
+
     pub(crate) fn dequeue_batch_exact(
         &mut self,
         batch: &crate::meerkat_machine::driver::AuthorizedRuntimeLoopBatch,
     ) -> Result<Vec<(InputId, Input)>, RuntimeDriverError> {
-        let mut staged_steer_queue = self.steer_queue.clone();
-        let mut staged_queue = self.queue.clone();
-        let mut dequeued = Vec::with_capacity(batch.input_ids().len());
-
-        for input_id in batch.input_ids() {
-            let Some(input) = staged_steer_queue
-                .dequeue_by_id(input_id)
-                .or_else(|| staged_queue.dequeue_by_id(input_id))
-            else {
-                return Err(RuntimeDriverError::Internal(format!(
-                    "authorized runtime batch member {input_id} was missing from physical queue projection"
-                )));
-            };
-            dequeued.push(input);
-        }
-
-        self.steer_queue = staged_steer_queue;
-        self.queue = staged_queue;
-        Ok(dequeued)
+        self.validate_queue_projection_alignment("before authorized runtime-loop dequeue")?;
+        let (source_name, source_queue) = match batch.source() {
+            crate::meerkat_machine::driver::RuntimeLoopBatchSource::Queue => {
+                ("queue", &mut self.queue)
+            }
+            crate::meerkat_machine::driver::RuntimeLoopBatchSource::Steer => {
+                ("steer", &mut self.steer_queue)
+            }
+        };
+        source_queue
+            .dequeue_exact_prefix(batch.input_ids())
+            .ok_or_else(|| {
+                RuntimeDriverError::Internal(format!(
+                    "authorized runtime batch from {source_name} did not match the physical queue prefix exactly: expected {:?}",
+                    batch.input_ids()
+                ))
+            })
     }
 
     /// Machine-owned realization for a validated staged contributor batch.
-    pub(crate) fn machine_realize_stage_batch(
+    fn machine_realize_stage_batch(
         &mut self,
         input_ids: &[InputId],
         run_id: &RunId,
@@ -1914,9 +2023,18 @@ impl EphemeralRuntimeDriver {
             }));
         }
         self.rebuild_queue_projections();
+        self.validate_queue_projection_alignment("after authorized StageForRun")?;
         self.debug_assert_queue_projection_alignment();
 
         Ok(())
+    }
+
+    pub(crate) fn machine_realize_authorized_stage_batch(
+        &mut self,
+        authority: crate::meerkat_machine::driver::AuthorizedStageForRun,
+    ) -> Result<(), RuntimeDriverError> {
+        let (input_ids, run_id, _source) = authority.into_parts();
+        self.machine_realize_stage_batch(&input_ids, &run_id)
     }
 
     pub fn apply_input(
@@ -2053,6 +2171,7 @@ impl EphemeralRuntimeDriver {
         &mut self,
         run_id: &RunId,
         input_ids: &[InputId],
+        stage_authority: crate::meerkat_machine::driver::AuthorizedStageForRun,
     ) -> Result<RunBoundaryReceipt, RuntimeDriverError> {
         let [input_id] = input_ids else {
             return Err(RuntimeDriverError::Internal(format!(
@@ -2064,7 +2183,7 @@ impl EphemeralRuntimeDriver {
         let result = self
             .machine_resolve_live_boundary_context_receipt(run_id, input_id)
             .and_then(|receipt| {
-                self.machine_realize_stage_batch(input_ids, run_id)
+                self.machine_realize_authorized_stage_batch(stage_authority)
                     .and_then(|()| self.machine_realize_boundary_applied(run_id, &receipt))
                     .and_then(|()| self.machine_realize_run_completed(run_id, input_ids))
                     .map(|()| receipt)
@@ -3567,6 +3686,63 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn authorized_batch_dequeue_requires_exact_source() {
+        let mut driver = EphemeralRuntimeDriver::new(LogicalRuntimeId::new("batch-source"));
+        let input = prompt_input("queued");
+        let input_id = input.id().clone();
+        driver.accept_input(input).await.unwrap();
+
+        let batch = crate::meerkat_machine::driver::test_authorized_runtime_loop_batch_from_source(
+            vec![input_id.clone()],
+            crate::meerkat_machine::driver::RuntimeLoopBatchSource::Steer,
+        );
+
+        let err = driver
+            .dequeue_batch_exact(&batch)
+            .expect_err("queue input must not be drained through steer authority");
+
+        assert!(
+            err.to_string()
+                .contains("authorized runtime batch from steer did not match"),
+            "unexpected error: {err}"
+        );
+        assert_eq!(
+            driver.queue().input_ids(),
+            vec![input_id],
+            "failed source conformance must leave the physical queue intact"
+        );
+    }
+
+    #[tokio::test]
+    async fn authorized_batch_dequeue_requires_exact_prefix() {
+        let mut driver = EphemeralRuntimeDriver::new(LogicalRuntimeId::new("batch-prefix"));
+        let first = prompt_input("first");
+        let first_id = first.id().clone();
+        driver.accept_input(first).await.unwrap();
+        let second = prompt_input("second");
+        let second_id = second.id().clone();
+        driver.accept_input(second).await.unwrap();
+
+        let batch =
+            crate::meerkat_machine::driver::test_authorized_runtime_loop_batch(vec![second_id]);
+
+        let err = driver
+            .dequeue_batch_exact(&batch)
+            .expect_err("later queue member must not be drained past an older prefix");
+
+        assert!(
+            err.to_string()
+                .contains("authorized runtime batch from queue did not match"),
+            "unexpected error: {err}"
+        );
+        assert_eq!(
+            driver.queue().input_ids(),
+            vec![first_id, batch.input_ids()[0].clone()],
+            "failed prefix conformance must leave the physical queue intact"
+        );
+    }
+
+    #[tokio::test]
     async fn coalesce_input_requires_generated_existing_target_authority() {
         let mut driver = EphemeralRuntimeDriver::new(LogicalRuntimeId::new("coalesce-guard"));
 
@@ -3962,7 +4138,57 @@ mod tests {
             .unwrap();
 
         assert!(driver.queue().is_empty());
-        driver.debug_assert_queue_projection_alignment();
+        driver
+            .validate_queue_projection_alignment("test post-stage")
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn authorized_dequeue_rejects_physical_queue_projection_drift() {
+        let mut driver = EphemeralRuntimeDriver::new(LogicalRuntimeId::new(
+            "queue-projection-drift-before-dequeue",
+        ));
+        let input = prompt_input("authorized");
+        let input_id = input.id().clone();
+        driver.accept_input(input).await.unwrap();
+
+        let drift = prompt_input("drift");
+        let drift_id = drift.id().clone();
+        driver.queue_mut().enqueue_front(drift_id, drift);
+        let batch =
+            crate::meerkat_machine::driver::test_authorized_runtime_loop_batch(vec![input_id]);
+
+        let err = driver
+            .dequeue_batch_exact(&batch)
+            .expect_err("physical queue drift must fail closed before dequeue");
+        assert!(
+            matches!(&err, RuntimeDriverError::Internal(message) if message.contains("physical queue projection diverged")),
+            "unexpected queue projection error: {err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn authorized_dequeue_rejects_physical_steer_projection_drift() {
+        let mut driver = EphemeralRuntimeDriver::new(LogicalRuntimeId::new(
+            "steer-projection-drift-before-dequeue",
+        ));
+        let input = prompt_input("authorized");
+        let input_id = input.id().clone();
+        driver.accept_input(input).await.unwrap();
+
+        let drift = prompt_input("steer drift");
+        let drift_id = drift.id().clone();
+        driver.steer_queue_mut().enqueue(drift_id, drift);
+        let batch =
+            crate::meerkat_machine::driver::test_authorized_runtime_loop_batch(vec![input_id]);
+
+        let err = driver
+            .dequeue_batch_exact(&batch)
+            .expect_err("physical steer queue drift must fail closed before dequeue");
+        assert!(
+            matches!(&err, RuntimeDriverError::Internal(message) if message.contains("physical steer queue projection diverged")),
+            "unexpected steer projection error: {err:?}"
+        );
     }
 
     #[tokio::test]
@@ -3986,7 +4212,9 @@ mod tests {
             driver.input_phase(&input_id),
             Some(InputLifecycleState::AppliedPendingConsumption)
         );
-        driver.debug_assert_queue_projection_alignment();
+        driver
+            .validate_queue_projection_alignment("test recovery")
+            .unwrap();
     }
 
     #[tokio::test]
@@ -4143,6 +4371,10 @@ mod tests {
                     admission_sequence_recovery: None,
                     recovery_lane: None,
                     lane: None,
+                    runtime_boundary: None,
+                    runtime_execution_kind: None,
+                    runtime_peer_response_terminal_apply_intent: None,
+                    is_prompt: false,
                 },
                 "RecoverInputLifecycle(test)",
             )

--- a/meerkat-runtime/src/driver/persistent.rs
+++ b/meerkat-runtime/src/driver/persistent.rs
@@ -330,9 +330,12 @@ impl PersistentRuntimeDriver {
         self.inner.take_process_requested()
     }
 
-    /// Dequeue next input (delegates to inner).
-    pub fn dequeue_next(&mut self) -> Option<(InputId, Input)> {
-        self.inner.dequeue_next()
+    /// Contract helper for recovery/queue-projection tests. Production runtime
+    /// execution must use generated batch authority via `dequeue_batch_exact`.
+    #[cfg(any(test, debug_assertions, feature = "test-support"))]
+    #[doc(hidden)]
+    pub fn contract_dequeue_next_for_recovery_tests(&mut self) -> Option<(InputId, Input)> {
+        self.inner.contract_dequeue_next_for_recovery_tests()
     }
 
     pub(crate) fn dequeue_batch_exact(
@@ -497,12 +500,11 @@ impl PersistentRuntimeDriver {
         staged.accept_resolved_input(input, staged_resolved).await
     }
 
-    pub(crate) fn machine_realize_stage_batch(
+    pub(crate) fn machine_realize_authorized_stage_batch(
         &mut self,
-        input_ids: &[InputId],
-        run_id: &meerkat_core::lifecycle::RunId,
+        authority: crate::meerkat_machine::driver::AuthorizedStageForRun,
     ) -> Result<(), crate::traits::RuntimeDriverError> {
-        self.inner.machine_realize_stage_batch(input_ids, run_id)
+        self.inner.machine_realize_authorized_stage_batch(authority)
     }
 
     /// Apply input (delegates to inner).
@@ -728,13 +730,15 @@ impl PersistentRuntimeDriver {
         &mut self,
         run_id: &RunId,
         input_ids: &[InputId],
+        stage_authority: crate::meerkat_machine::driver::AuthorizedStageForRun,
         session_snapshot: Option<Vec<u8>>,
     ) -> Result<(), RuntimeDriverError> {
         let checkpoint = self.inner.rollback_snapshot();
-        let receipt = match self
-            .inner
-            .machine_realize_live_boundary_context_injected(run_id, input_ids)
-        {
+        let receipt = match self.inner.machine_realize_live_boundary_context_injected(
+            run_id,
+            input_ids,
+            stage_authority,
+        ) {
             Ok(receipt) => receipt,
             Err(err) => {
                 self.inner.restore_rollback_snapshot(checkpoint);

--- a/meerkat-runtime/src/lib.rs
+++ b/meerkat-runtime/src/lib.rs
@@ -83,7 +83,7 @@ pub mod protocol_supervisor_trust_publish;
 #[allow(unused_imports)]
 #[path = "generated/protocol_supervisor_trust_revoke.rs"]
 pub mod protocol_supervisor_trust_revoke;
-pub mod queue;
+pub(crate) mod queue;
 pub mod runtime_event;
 pub(crate) mod runtime_loop;
 pub mod runtime_state;
@@ -424,7 +424,6 @@ pub use policy::{
     ApplyMode, ConsumePoint, DrainPolicy, PolicyDecision, QueueMode, RoutingDisposition, WakeMode,
 };
 pub use policy_table::{DefaultPolicyTable, generated_default_policy_version};
-pub use queue::InputQueue;
 pub use runtime_event::{
     InputLifecycleEvent, RunLifecycleEvent, RuntimeEvent, RuntimeEventEnvelope,
     RuntimeProjectionEvent, RuntimeStateChangeEvent, RuntimeTopologyEvent,

--- a/meerkat-runtime/src/meerkat_machine/driver.rs
+++ b/meerkat-runtime/src/meerkat_machine/driver.rs
@@ -15,12 +15,14 @@ use crate::input_state::{
     InputLifecycleState, InputState, InputStateHistoryEntry, InputStateSeed, InputTerminalOutcome,
     StoredInputState,
 };
+use crate::meerkat_machine::dsl::command_capabilities as generated_command_capabilities;
 use crate::runtime_state::RuntimeState;
 use crate::tokio::sync::Mutex;
 use crate::traits::{
     DestroyReport, RecoveryReport, ResetReport, RetireReport, RuntimeDriver, RuntimeDriverError,
 };
 use chrono::Utc;
+use meerkat_machine_kernels::generated::meerkat::command_capabilities as generated_kernel_command_capabilities;
 
 /// Shared driver handle used by both the adapter and the RuntimeLoop.
 pub(crate) type SharedDriver = Arc<Mutex<DriverEntry>>;
@@ -33,6 +35,7 @@ pub(crate) type SharedDriver = Arc<Mutex<DriverEntry>>;
 #[must_use = "runtime completion authority must be consumed by waiter resolution"]
 #[derive(Debug, PartialEq, Eq)]
 pub(crate) struct RuntimeCompletionResultAuthority {
+    generated_plan: generated_kernel_command_capabilities::CommandPlanKind,
     session_id: SessionId,
     agent_runtime_id: Option<crate::meerkat_machine::dsl::AgentRuntimeId>,
     fence_token: Option<crate::meerkat_machine::dsl::FenceToken>,
@@ -40,6 +43,28 @@ pub(crate) struct RuntimeCompletionResultAuthority {
     runtime_epoch_id: Option<crate::meerkat_machine::dsl::RuntimeEpochId>,
     result_class: crate::meerkat_machine::dsl::RuntimeCompletionResultClass,
     cleanup_observation: crate::meerkat_machine::dsl::RuntimeCompletionObservedOutcome,
+}
+
+/// Attempted local closure of a generated runtime-completion result effect.
+///
+/// This is the runtime-facing phase view for the
+/// `Authorized -> Attempted -> Realized | Failed | Abandoned` closure declared
+/// by the generated `AuthorizedRuntimeCompletionResultClosure` command plan.
+#[must_use = "attempted runtime completion closure must be realized, failed, or abandoned"]
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) struct RuntimeCompletionResultAttempt {
+    authority: RuntimeCompletionResultAuthority,
+}
+
+/// Realized local closure of a generated runtime-completion result effect.
+///
+/// Completion waiter delivery and cleanup observations are minted only from
+/// this consumed phase, so payload alignment failures cannot still surface a
+/// public waiter result.
+#[must_use = "realized runtime completion closure must mint a completion cleanup observation"]
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) struct RuntimeCompletionResultRealized {
+    authority: RuntimeCompletionResultAuthority,
 }
 
 impl RuntimeCompletionResultAuthority {
@@ -53,6 +78,8 @@ impl RuntimeCompletionResultAuthority {
         cleanup_observation: crate::meerkat_machine::dsl::RuntimeCompletionObservedOutcome,
     ) -> Self {
         Self {
+            generated_plan:
+                generated_kernel_command_capabilities::CommandPlanKind::AuthorizedRuntimeCompletionResultClosure,
             session_id,
             agent_runtime_id,
             fence_token,
@@ -63,41 +90,67 @@ impl RuntimeCompletionResultAuthority {
         }
     }
 
-    pub(crate) fn session_id(&self) -> &SessionId {
-        &self.session_id
+    pub(crate) fn begin_surface_resolution(self) -> RuntimeCompletionResultAttempt {
+        debug_assert_eq!(
+            self.generated_plan,
+            generated_kernel_command_capabilities::CommandPlanKind::AuthorizedRuntimeCompletionResultClosure
+        );
+        RuntimeCompletionResultAttempt { authority: self }
     }
+}
 
-    pub(crate) fn agent_runtime_id(&self) -> Option<&crate::meerkat_machine::dsl::AgentRuntimeId> {
-        self.agent_runtime_id.as_ref()
-    }
-
-    pub(crate) fn fence_token(&self) -> Option<crate::meerkat_machine::dsl::FenceToken> {
-        self.fence_token
-    }
-
-    pub(crate) fn runtime_generation(&self) -> Option<crate::meerkat_machine::dsl::Generation> {
-        self.runtime_generation
-    }
-
-    pub(crate) fn runtime_epoch_id(&self) -> Option<&crate::meerkat_machine::dsl::RuntimeEpochId> {
-        self.runtime_epoch_id.as_ref()
-    }
-
+impl RuntimeCompletionResultAttempt {
     pub(crate) fn class(&self) -> crate::meerkat_machine::dsl::RuntimeCompletionResultClass {
-        self.result_class
+        self.authority.result_class
     }
 
     pub(crate) fn allows(
         &self,
         expected: crate::meerkat_machine::dsl::RuntimeCompletionResultClass,
     ) -> bool {
-        self.result_class == expected
+        self.authority.result_class == expected
+    }
+
+    pub(crate) fn realize(self) -> RuntimeCompletionResultRealized {
+        RuntimeCompletionResultRealized {
+            authority: self.authority,
+        }
+    }
+
+    pub(crate) fn fail(self) {
+        drop(self);
+    }
+
+    pub(crate) fn abandon(self) {
+        drop(self);
+    }
+}
+
+impl RuntimeCompletionResultRealized {
+    pub(crate) fn session_id(&self) -> &SessionId {
+        &self.authority.session_id
+    }
+
+    pub(crate) fn agent_runtime_id(&self) -> Option<&crate::meerkat_machine::dsl::AgentRuntimeId> {
+        self.authority.agent_runtime_id.as_ref()
+    }
+
+    pub(crate) fn fence_token(&self) -> Option<crate::meerkat_machine::dsl::FenceToken> {
+        self.authority.fence_token
+    }
+
+    pub(crate) fn runtime_generation(&self) -> Option<crate::meerkat_machine::dsl::Generation> {
+        self.authority.runtime_generation
+    }
+
+    pub(crate) fn runtime_epoch_id(&self) -> Option<&crate::meerkat_machine::dsl::RuntimeEpochId> {
+        self.authority.runtime_epoch_id.as_ref()
     }
 
     pub(crate) fn cleanup_observation(
         &self,
     ) -> crate::meerkat_machine::dsl::RuntimeCompletionObservedOutcome {
-        self.cleanup_observation
+        self.authority.cleanup_observation
     }
 }
 
@@ -125,22 +178,49 @@ pub(crate) enum RuntimeLoopBatchSource {
     Steer,
 }
 
+impl From<generated_command_capabilities::RuntimeLoopBatchSource> for RuntimeLoopBatchSource {
+    fn from(source: generated_command_capabilities::RuntimeLoopBatchSource) -> Self {
+        match source {
+            generated_command_capabilities::RuntimeLoopBatchSource::Queue => Self::Queue,
+            generated_command_capabilities::RuntimeLoopBatchSource::Steer => Self::Steer,
+        }
+    }
+}
+
+impl From<RuntimeLoopBatchSource> for generated_command_capabilities::RuntimeLoopBatchSource {
+    fn from(source: RuntimeLoopBatchSource) -> Self {
+        match source {
+            RuntimeLoopBatchSource::Queue => Self::Queue,
+            RuntimeLoopBatchSource::Steer => Self::Steer,
+        }
+    }
+}
+
 #[must_use = "runtime loop batch authority must be consumed by stage authorization"]
 #[derive(Debug, PartialEq, Eq)]
 pub(crate) struct AuthorizedRuntimeLoopBatch {
     input_ids: Vec<InputId>,
     source: RuntimeLoopBatchSource,
+    generated: generated_command_capabilities::AuthorizedRuntimeLoopBatch,
 }
 
 impl AuthorizedRuntimeLoopBatch {
-    fn from_machine_selection(
-        input_ids: Vec<InputId>,
-        source: RuntimeLoopBatchSource,
+    fn from_generated_plan(
+        plan: generated_command_capabilities::RuntimeLoopBatchPlan,
     ) -> Option<Self> {
+        let (generated, raw_input_ids, generated_source) = plan.into_parts();
+        let input_ids = raw_input_ids
+            .into_iter()
+            .map(|raw| raw.parse::<uuid::Uuid>().ok().map(InputId::from_uuid))
+            .collect::<Option<Vec<_>>>()?;
         if input_ids.is_empty() {
             None
         } else {
-            Some(Self { input_ids, source })
+            Some(Self {
+                input_ids,
+                source: generated_source.into(),
+                generated,
+            })
         }
     }
 
@@ -148,12 +228,8 @@ impl AuthorizedRuntimeLoopBatch {
         &self.input_ids
     }
 
-    fn into_stage_for_run(self, run_id: RunId) -> AuthorizedStageForRun {
-        AuthorizedStageForRun {
-            input_ids: self.input_ids,
-            run_id,
-            source: self.source,
-        }
+    pub(crate) fn source(&self) -> RuntimeLoopBatchSource {
+        self.source
     }
 }
 
@@ -161,9 +237,19 @@ impl AuthorizedRuntimeLoopBatch {
 pub(crate) fn test_authorized_runtime_loop_batch(
     input_ids: Vec<InputId>,
 ) -> AuthorizedRuntimeLoopBatch {
+    test_authorized_runtime_loop_batch_from_source(input_ids, RuntimeLoopBatchSource::Queue)
+}
+
+#[cfg(test)]
+pub(crate) fn test_authorized_runtime_loop_batch_from_source(
+    input_ids: Vec<InputId>,
+    source: RuntimeLoopBatchSource,
+) -> AuthorizedRuntimeLoopBatch {
     AuthorizedRuntimeLoopBatch {
         input_ids,
-        source: RuntimeLoopBatchSource::Queue,
+        source,
+        generated:
+            generated_command_capabilities::AuthorizedRuntimeLoopBatch::mint_from_generated_command_plan(),
     }
 }
 
@@ -173,15 +259,58 @@ pub(crate) struct AuthorizedStageForRun {
     input_ids: Vec<InputId>,
     run_id: RunId,
     source: RuntimeLoopBatchSource,
+    generated: generated_command_capabilities::AuthorizedStageForRun,
 }
 
 impl AuthorizedStageForRun {
-    fn into_parts(self) -> (Vec<InputId>, RunId, RuntimeLoopBatchSource) {
-        (self.input_ids, self.run_id, self.source)
+    fn from_generated_plan(
+        run_id: RunId,
+        plan: generated_command_capabilities::StageForRunPlan,
+    ) -> Option<Self> {
+        let (generated, raw_input_ids, generated_source) = plan.into_parts();
+        let input_ids = raw_input_ids
+            .into_iter()
+            .map(|raw| raw.parse::<uuid::Uuid>().ok().map(InputId::from_uuid))
+            .collect::<Option<Vec<_>>>()?;
+        if input_ids.is_empty() {
+            None
+        } else {
+            Some(Self {
+                input_ids,
+                run_id,
+                source: generated_source.into(),
+                generated,
+            })
+        }
+    }
+
+    pub(crate) fn into_parts(self) -> (Vec<InputId>, RunId, RuntimeLoopBatchSource) {
+        let Self {
+            input_ids,
+            run_id,
+            source,
+            generated: _,
+        } = self;
+        (input_ids, run_id, source)
     }
 }
 
-#[derive(Debug, Clone)]
+#[cfg(test)]
+pub(crate) fn test_authorized_stage_for_run(
+    input_ids: Vec<InputId>,
+    run_id: RunId,
+) -> AuthorizedStageForRun {
+    AuthorizedStageForRun {
+        input_ids,
+        run_id,
+        source: RuntimeLoopBatchSource::Queue,
+        generated:
+            generated_command_capabilities::AuthorizedStageForRun::mint_from_generated_command_plan(
+            ),
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct RuntimeLifecycleProjection {
     pub(crate) phase: RuntimeState,
     pub(crate) current_run_id: Option<RunId>,
@@ -395,6 +524,49 @@ impl DriverEntry {
 
     pub(crate) fn input_last_boundary_sequence(&self, input_id: &InputId) -> Option<u64> {
         self.as_driver().input_last_boundary_sequence(input_id)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn input_runtime_boundary(
+        &self,
+        input_id: &InputId,
+    ) -> Option<crate::meerkat_machine::dsl::RecoveredRunApplyBoundary> {
+        match self {
+            DriverEntry::Ephemeral(d) => d.input_runtime_boundary(input_id),
+            DriverEntry::Persistent(d) => d.inner_ref().input_runtime_boundary(input_id),
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn input_runtime_execution_kind(
+        &self,
+        input_id: &InputId,
+    ) -> Option<crate::meerkat_machine::dsl::RecoveredRuntimeExecutionKind> {
+        match self {
+            DriverEntry::Ephemeral(d) => d.input_runtime_execution_kind(input_id),
+            DriverEntry::Persistent(d) => d.inner_ref().input_runtime_execution_kind(input_id),
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn input_peer_response_terminal_apply_intent(
+        &self,
+        input_id: &InputId,
+    ) -> Option<crate::meerkat_machine::dsl::RecoveredPeerResponseTerminalApplyIntent> {
+        match self {
+            DriverEntry::Ephemeral(d) => d.input_peer_response_terminal_apply_intent(input_id),
+            DriverEntry::Persistent(d) => d
+                .inner_ref()
+                .input_peer_response_terminal_apply_intent(input_id),
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn input_is_prompt_for_batch(&self, input_id: &InputId) -> Option<bool> {
+        match self {
+            DriverEntry::Ephemeral(d) => d.input_is_prompt_for_batch(input_id),
+            DriverEntry::Persistent(d) => d.inner_ref().input_is_prompt_for_batch(input_id),
+        }
     }
 
     pub(crate) fn input_terminal_outcome(
@@ -725,16 +897,28 @@ impl DriverEntry {
         input_ids: &[InputId],
         session_snapshot: Option<Vec<u8>>,
     ) -> Result<(), RuntimeDriverError> {
+        let stage_authority = machine_authorize_stage_for_run(
+            self,
+            run_id,
+            input_ids,
+            RuntimeLoopBatchSource::Steer,
+        )
+        .ok_or_else(|| {
+            RuntimeDriverError::Internal(format!(
+                "generated machine did not authorize live-boundary StageForRun for run {run_id:?} and inputs {input_ids:?}"
+            ))
+        })?;
         match self {
             DriverEntry::Ephemeral(d) => {
                 let _ = session_snapshot;
-                d.machine_realize_live_boundary_context_injected(run_id, input_ids)
+                d.machine_realize_live_boundary_context_injected(run_id, input_ids, stage_authority)
                     .map(|_| ())
             }
             DriverEntry::Persistent(d) => {
                 d.machine_realize_live_boundary_context_injected(
                     run_id,
                     input_ids,
+                    stage_authority,
                     session_snapshot,
                 )
                 .await
@@ -743,14 +927,13 @@ impl DriverEntry {
     }
 
     /// Stage a batch of inputs atomically in a single `StageDrainSnapshot`.
-    pub(crate) fn machine_realize_stage_batch(
+    pub(crate) fn machine_realize_authorized_stage_batch(
         &mut self,
         authority: AuthorizedStageForRun,
     ) -> Result<(), crate::traits::RuntimeDriverError> {
-        let (input_ids, run_id, _source) = authority.into_parts();
         match self {
-            DriverEntry::Ephemeral(d) => d.machine_realize_stage_batch(&input_ids, &run_id),
-            DriverEntry::Persistent(d) => d.machine_realize_stage_batch(&input_ids, &run_id),
+            DriverEntry::Ephemeral(d) => d.machine_realize_authorized_stage_batch(authority),
+            DriverEntry::Persistent(d) => d.machine_realize_authorized_stage_batch(authority),
         }
     }
 
@@ -942,6 +1125,280 @@ impl std::fmt::Display for RuntimeLoopRunCommitError {
 }
 
 impl std::error::Error for RuntimeLoopRunCommitError {}
+
+#[must_use = "runtime-loop run commit authority must be consumed by commit realization"]
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) struct AuthorizedRuntimeLoopRunCommit {
+    generated_plan: generated_kernel_command_capabilities::CommandPlanKind,
+    run_id: RunId,
+    consumed_input_ids: Vec<InputId>,
+    commit_input_id: InputId,
+    receipt: meerkat_core::lifecycle::RunBoundaryReceipt,
+    owner_session_id: Option<crate::meerkat_machine::dsl::SessionId>,
+    owner_agent_runtime_id: Option<crate::meerkat_machine::dsl::AgentRuntimeId>,
+    owner_fence_token: Option<crate::meerkat_machine::dsl::FenceToken>,
+    owner_runtime_generation: Option<crate::meerkat_machine::dsl::Generation>,
+    owner_runtime_epoch_id: Option<crate::meerkat_machine::dsl::RuntimeEpochId>,
+    commit_outcome: AuthorizedRuntimeLoopRunCommitOutcome,
+    effect_closure_obligations: Vec<RuntimeLoopRunCommitEffectObligation>,
+    return_projection: RuntimeLifecycleProjection,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) struct AuthorizedRuntimeLoopRunCommitOutcome {
+    run_id: RunId,
+    outcome: crate::meerkat_machine::dsl::TurnTerminalOutcome,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) struct RuntimeLoopRunCommitEffectObligation {
+    run_id: RunId,
+    effect: RuntimeLoopRunCommitEffect,
+    closure_policy: &'static str,
+    lifecycle: &'static [&'static str],
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) enum RuntimeLoopRunCommitEffect {
+    Completed,
+    Failed,
+    Cancelled,
+}
+
+impl AuthorizedRuntimeLoopRunCommit {
+    fn authorize(
+        driver: &DriverEntry,
+        run_id: RunId,
+        consumed_input_ids: Vec<InputId>,
+        receipt: meerkat_core::lifecycle::RunBoundaryReceiptDraft,
+    ) -> Result<Self, RuntimeDriverError> {
+        // Dogma K10: mint the final receipt from the machine-owned per-run
+        // boundary counter — the executor's draft carries no sequence, so the
+        // durable receipt can never diverge from `RecordBoundarySeq`'s value.
+        let receipt = receipt.into_sequenced(driver.run_boundary_sequence(&run_id));
+        machine_validate_run_commit_receipt(driver, &run_id, &consumed_input_ids, &receipt)?;
+        let commit_input_id = consumed_input_ids.first().cloned().ok_or_else(|| {
+            RuntimeDriverError::Internal(
+                "runtime-loop run commit authority requires at least one terminal input"
+                    .to_string(),
+            )
+        })?;
+        let preview =
+            preview_authorized_runtime_loop_run_commit(driver, &run_id, &commit_input_id)?;
+        Ok(Self {
+            generated_plan:
+                generated_kernel_command_capabilities::CommandPlanKind::AuthorizedRuntimeLoopRunCommit,
+            run_id,
+            consumed_input_ids,
+            commit_input_id,
+            receipt,
+            owner_session_id: preview.owner_session_id,
+            owner_agent_runtime_id: preview.owner_agent_runtime_id,
+            owner_fence_token: preview.owner_fence_token,
+            owner_runtime_generation: preview.owner_runtime_generation,
+            owner_runtime_epoch_id: preview.owner_runtime_epoch_id,
+            commit_outcome: preview.commit_outcome,
+            effect_closure_obligations: preview.effect_closure_obligations,
+            return_projection: preview.return_projection,
+        })
+    }
+
+    fn run_id(&self) -> &RunId {
+        &self.run_id
+    }
+
+    fn consumed_input_ids(&self) -> &[InputId] {
+        &self.consumed_input_ids
+    }
+
+    fn commit_input_id(&self) -> &InputId {
+        &self.commit_input_id
+    }
+
+    fn receipt(&self) -> &meerkat_core::lifecycle::RunBoundaryReceipt {
+        &self.receipt
+    }
+
+    fn commit_outcome(&self) -> &AuthorizedRuntimeLoopRunCommitOutcome {
+        &self.commit_outcome
+    }
+
+    fn return_projection(&self) -> &RuntimeLifecycleProjection {
+        &self.return_projection
+    }
+
+    fn effect_closure_obligations(&self) -> &[RuntimeLoopRunCommitEffectObligation] {
+        &self.effect_closure_obligations
+    }
+
+    fn generated_plan(&self) -> generated_kernel_command_capabilities::CommandPlanKind {
+        self.generated_plan
+    }
+
+    fn owner_session_id(&self) -> Option<&crate::meerkat_machine::dsl::SessionId> {
+        self.owner_session_id.as_ref()
+    }
+
+    fn owner_agent_runtime_id(&self) -> Option<&crate::meerkat_machine::dsl::AgentRuntimeId> {
+        self.owner_agent_runtime_id.as_ref()
+    }
+
+    fn owner_fence_token(&self) -> Option<crate::meerkat_machine::dsl::FenceToken> {
+        self.owner_fence_token
+    }
+
+    fn owner_runtime_generation(&self) -> Option<crate::meerkat_machine::dsl::Generation> {
+        self.owner_runtime_generation
+    }
+
+    fn owner_runtime_epoch_id(&self) -> Option<&crate::meerkat_machine::dsl::RuntimeEpochId> {
+        self.owner_runtime_epoch_id.as_ref()
+    }
+
+    fn into_receipt(self) -> meerkat_core::lifecycle::RunBoundaryReceipt {
+        self.receipt
+    }
+}
+
+impl AuthorizedRuntimeLoopRunCommitOutcome {
+    fn run_id(&self) -> &RunId {
+        &self.run_id
+    }
+
+    fn outcome(&self) -> crate::meerkat_machine::dsl::TurnTerminalOutcome {
+        self.outcome
+    }
+}
+
+struct RuntimeLoopRunCommitPreview {
+    owner_session_id: Option<crate::meerkat_machine::dsl::SessionId>,
+    owner_agent_runtime_id: Option<crate::meerkat_machine::dsl::AgentRuntimeId>,
+    owner_fence_token: Option<crate::meerkat_machine::dsl::FenceToken>,
+    owner_runtime_generation: Option<crate::meerkat_machine::dsl::Generation>,
+    owner_runtime_epoch_id: Option<crate::meerkat_machine::dsl::RuntimeEpochId>,
+    commit_outcome: AuthorizedRuntimeLoopRunCommitOutcome,
+    effect_closure_obligations: Vec<RuntimeLoopRunCommitEffectObligation>,
+    return_projection: RuntimeLifecycleProjection,
+}
+
+fn preview_authorized_runtime_loop_run_commit(
+    driver: &DriverEntry,
+    run_id: &RunId,
+    commit_input_id: &InputId,
+) -> Result<RuntimeLoopRunCommitPreview, RuntimeDriverError> {
+    let authority = driver.shared_dsl_authority();
+    let state = {
+        let authority = authority
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        authority.state().clone()
+    };
+    let owner_session_id = state.session_id.clone();
+    let owner_agent_runtime_id = state.active_runtime_id.clone();
+    let owner_fence_token = state.active_fence_token;
+    let owner_runtime_generation = state.active_runtime_generation;
+    let owner_runtime_epoch_id = state.active_runtime_epoch_id.clone();
+    let mut preview = crate::meerkat_machine::dsl::MeerkatMachineAuthority::recover_from_state(
+        state,
+    )
+    .map_err(|err| {
+        RuntimeDriverError::Internal(crate::meerkat_machine::dsl_authority::map_error(
+            err,
+            "AuthorizedRuntimeLoopRunCommit",
+        ))
+    })?;
+    let dsl_run_id = crate::meerkat_machine::dsl::RunId::from_domain(run_id);
+    crate::meerkat_machine::dsl::MeerkatMachineMutator::apply(
+        &mut preview,
+        crate::meerkat_machine::dsl::MeerkatMachineInput::RunCompleted {
+            run_id: dsl_run_id.clone(),
+        },
+    )
+    .map_err(|err| RuntimeDriverError::ValidationFailed {
+        reason: crate::meerkat_machine::dsl_authority::map_error(err, "RunCompleted"),
+    })?;
+    if preview.state().runtime_completion_result_run_id.as_ref() != Some(&dsl_run_id) {
+        return Err(RuntimeDriverError::Internal(format!(
+            "RunCompleted did not bind runtime completion result to run {run_id}"
+        )));
+    }
+    let commit_outcome = match preview.state().terminal_outcome {
+        Some(crate::meerkat_machine::dsl::TurnTerminalOutcome::Completed) => {
+            AuthorizedRuntimeLoopRunCommitOutcome {
+                run_id: run_id.clone(),
+                outcome: crate::meerkat_machine::dsl::TurnTerminalOutcome::Completed,
+            }
+        }
+        other => {
+            return Err(RuntimeDriverError::Internal(format!(
+                "RunCompleted produced unexpected terminal outcome {other:?} for run {run_id}"
+            )));
+        }
+    };
+    let effect_closure_obligations =
+        RuntimeLoopRunCommitEffectObligation::for_outcome(run_id, commit_outcome.outcome());
+
+    crate::meerkat_machine::dsl::MeerkatMachineMutator::apply(
+        &mut preview,
+        crate::meerkat_machine::dsl::MeerkatMachineInput::Commit {
+            input_id: crate::meerkat_machine::dsl::InputId::from_domain(commit_input_id),
+            run_id: dsl_run_id,
+        },
+    )
+    .map_err(|err| RuntimeDriverError::ValidationFailed {
+        reason: crate::meerkat_machine::dsl_authority::map_error(err, "Commit"),
+    })?;
+
+    Ok(RuntimeLoopRunCommitPreview {
+        owner_session_id,
+        owner_agent_runtime_id,
+        owner_fence_token,
+        owner_runtime_generation,
+        owner_runtime_epoch_id,
+        commit_outcome,
+        effect_closure_obligations,
+        return_projection: RuntimeLifecycleProjection::from_authority(&preview),
+    })
+}
+
+impl RuntimeLoopRunCommitEffectObligation {
+    const LIFECYCLE: &'static [&'static str] = &[
+        "Authorized",
+        "Attempted",
+        "Realized",
+        "Failed",
+        "Cancelled",
+        "Abandoned",
+    ];
+
+    fn for_outcome(
+        run_id: &RunId,
+        outcome: crate::meerkat_machine::dsl::TurnTerminalOutcome,
+    ) -> Vec<Self> {
+        let effect = match outcome {
+            crate::meerkat_machine::dsl::TurnTerminalOutcome::Completed => {
+                RuntimeLoopRunCommitEffect::Completed
+            }
+            crate::meerkat_machine::dsl::TurnTerminalOutcome::Cancelled => {
+                RuntimeLoopRunCommitEffect::Cancelled
+            }
+            _ => RuntimeLoopRunCommitEffect::Failed,
+        };
+        vec![Self {
+            run_id: run_id.clone(),
+            effect,
+            closure_policy: "RuntimeLoopRunCommitEffect",
+            lifecycle: Self::LIFECYCLE,
+        }]
+    }
+
+    fn is_satisfied_by(&self, run_id: &RunId, effect: RuntimeLoopRunCommitEffect) -> bool {
+        self.run_id == *run_id
+            && self.effect == effect
+            && self.closure_policy == "RuntimeLoopRunCommitEffect"
+            && self.lifecycle == Self::LIFECYCLE
+    }
+}
 
 #[derive(Debug)]
 pub(crate) enum RuntimeLoopRunFailError {
@@ -1232,49 +1689,43 @@ fn machine_apply_turn_run_cancelled(
     })
 }
 
-pub(crate) fn slice_starts_with(seq: &[InputId], prefix: &[InputId]) -> bool {
-    prefix.len() <= seq.len() && seq[..prefix.len()] == *prefix
-}
-
+#[cfg(test)]
 pub(crate) fn machine_input_boundary(
     driver: &DriverEntry,
     work_id: &InputId,
-) -> Option<meerkat_core::lifecycle::run_primitive::RunApplyBoundary> {
-    driver
-        .driver_ingress()
-        .runtime_semantics(work_id)
-        .map(|semantics| semantics.boundary)
+) -> Option<crate::meerkat_machine::dsl::RecoveredRunApplyBoundary> {
+    driver.input_runtime_boundary(work_id)
 }
 
+#[cfg(test)]
 pub(crate) fn machine_input_execution_kind(
     driver: &DriverEntry,
     work_id: &InputId,
-) -> Option<meerkat_core::lifecycle::RuntimeExecutionKind> {
-    driver
-        .driver_ingress()
-        .runtime_semantics(work_id)
-        .map(|semantics| semantics.execution_kind)
+) -> Option<crate::meerkat_machine::dsl::RecoveredRuntimeExecutionKind> {
+    driver.input_runtime_execution_kind(work_id)
 }
 
+#[cfg(test)]
 pub(crate) fn machine_input_peer_response_terminal_apply_intent(
     driver: &DriverEntry,
     work_id: &InputId,
-) -> Option<meerkat_core::lifecycle::run_primitive::PeerResponseTerminalApplyIntent> {
-    driver
-        .driver_ingress()
-        .runtime_semantics(work_id)
-        .and_then(|semantics| semantics.peer_response_terminal_apply_intent)
+) -> Option<crate::meerkat_machine::dsl::RecoveredPeerResponseTerminalApplyIntent> {
+    driver.input_peer_response_terminal_apply_intent(work_id)
 }
 
 #[cfg(test)]
 pub(crate) fn machine_batch_execution_kind(
     driver: &DriverEntry,
     work_ids: &[InputId],
-) -> Option<meerkat_core::lifecycle::RuntimeExecutionKind> {
-    let mut semantics = machine_batch_runtime_semantics(driver, work_ids)?.into_iter();
-    let first = semantics.next()?.execution_kind;
+) -> Option<crate::meerkat_machine::dsl::RecoveredRuntimeExecutionKind> {
+    let mut semantics = work_ids
+        .iter()
+        .map(|id| machine_input_execution_kind(driver, id))
+        .collect::<Option<Vec<_>>>()?
+        .into_iter();
+    let first = semantics.next()?;
 
-    if semantics.all(|semantics| semantics.execution_kind == first) {
+    if semantics.all(|execution_kind| execution_kind == first) {
         Some(first)
     } else {
         None
@@ -1324,112 +1775,45 @@ pub(crate) fn machine_batch_primitive_projections(
         .collect()
 }
 
-pub(crate) fn machine_select_runtime_loop_batch(driver: &DriverEntry) -> Vec<InputId> {
-    let ingress = driver.driver_ingress();
-    let steer = ingress.steer_queue();
-    if let Some(first) = steer.first() {
-        let Some(target_boundary) = machine_input_boundary(driver, first) else {
-            return vec![first.clone()];
-        };
-        let Some(target_execution_kind) = machine_input_execution_kind(driver, first) else {
-            return vec![first.clone()];
-        };
-        let target_peer_response_terminal_apply_intent =
-            machine_input_peer_response_terminal_apply_intent(driver, first);
-        return steer
-            .iter()
-            .take_while(|id| {
-                machine_input_boundary(driver, id) == Some(target_boundary)
-                    && machine_input_execution_kind(driver, id) == Some(target_execution_kind)
-                    && machine_input_peer_response_terminal_apply_intent(driver, id)
-                        == target_peer_response_terminal_apply_intent
-            })
-            .cloned()
-            .collect();
-    }
-
-    let queue = ingress.queue();
-    if let Some(first) = queue.first() {
-        let Some(target_execution_kind) = machine_input_execution_kind(driver, first) else {
-            return vec![first.clone()];
-        };
-        let target_peer_response_terminal_apply_intent =
-            machine_input_peer_response_terminal_apply_intent(driver, first);
-        let driver_is_prompt = ingress.is_prompt(first);
-        let mut selected = Vec::new();
-        for id in &queue {
-            if machine_input_execution_kind(driver, id) != Some(target_execution_kind)
-                || machine_input_peer_response_terminal_apply_intent(driver, id)
-                    != target_peer_response_terminal_apply_intent
-            {
-                break;
-            }
-            if !driver_is_prompt && ingress.is_prompt(id) {
-                break;
-            }
-            selected.push(id.clone());
-            if ingress.is_prompt(id) {
-                break;
-            }
-            if driver_is_prompt {
-                break;
-            }
-        }
-        return selected;
-    }
-
-    Vec::new()
-}
-
 pub(crate) fn machine_authorize_runtime_loop_batch(
     driver: &DriverEntry,
 ) -> Option<AuthorizedRuntimeLoopBatch> {
-    let ingress = driver.driver_ingress();
-    let source = if ingress.steer_queue().is_empty() {
-        RuntimeLoopBatchSource::Queue
-    } else {
-        RuntimeLoopBatchSource::Steer
-    };
-    AuthorizedRuntimeLoopBatch::from_machine_selection(
-        machine_select_runtime_loop_batch(driver),
-        source,
-    )
+    let authority = driver.shared_dsl_authority();
+    let plan = {
+        let authority = authority
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        generated_command_capabilities::AuthorizedRuntimeLoopBatch::authorize_runtime_loop_batch_from_state(
+            authority.state(),
+        )
+    }?;
+    AuthorizedRuntimeLoopBatch::from_generated_plan(plan)
 }
 
-pub(crate) fn machine_validate_stage_drain_snapshot(
+pub(crate) fn machine_authorize_stage_for_run(
     driver: &DriverEntry,
-    contributing_work_ids: &[InputId],
-) -> Result<(), RuntimeDriverError> {
-    if contributing_work_ids.is_empty() {
-        return Err(RuntimeDriverError::Internal(
-            "stage drain snapshot requires at least one contributor".to_string(),
-        ));
-    }
-
-    for work_id in contributing_work_ids {
-        let lifecycle = driver.as_driver().input_phase(work_id);
-        if lifecycle != Some(InputLifecycleState::Queued) {
-            return Err(RuntimeDriverError::Internal(format!(
-                "stage drain snapshot requires queued contributors, but {work_id:?} is {lifecycle:?}"
-            )));
-        }
-    }
-
-    let ingress = driver.driver_ingress();
-    let steer = ingress.steer_queue();
-    let source_queue: Vec<InputId> = if steer.is_empty() {
-        ingress.queue()
-    } else {
-        steer
-    };
-    if !slice_starts_with(&source_queue, contributing_work_ids) {
-        return Err(RuntimeDriverError::Internal(
-            "stage drain snapshot contributors must match the current drain-source prefix"
-                .to_string(),
-        ));
-    }
-
-    Ok(())
+    run_id: &RunId,
+    input_ids: &[InputId],
+    source: RuntimeLoopBatchSource,
+) -> Option<AuthorizedStageForRun> {
+    let raw_input_ids = input_ids
+        .iter()
+        .map(std::string::ToString::to_string)
+        .collect::<Vec<_>>();
+    let dsl_run_id = crate::meerkat_machine::dsl::RunId(run_id.to_string());
+    let authority = driver.shared_dsl_authority();
+    let plan = {
+        let authority = authority
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        generated_command_capabilities::AuthorizedStageForRun::authorize_stage_for_run_from_state(
+            authority.state(),
+            &raw_input_ids,
+            &dsl_run_id,
+            source.into(),
+        )
+    }?;
+    AuthorizedStageForRun::from_generated_plan(run_id.clone(), plan)
 }
 
 pub(crate) fn machine_validate_boundary_applied(
@@ -2202,6 +2586,13 @@ mod tests {
             .expect("generated admission semantics")
     }
 
+    fn authorized_batch_input_ids(driver: &DriverEntry) -> Vec<InputId> {
+        machine_authorize_runtime_loop_batch(driver)
+            .expect("generated runtime-loop batch authority")
+            .input_ids()
+            .to_vec()
+    }
+
     #[test]
     fn machine_batch_execution_kind_requires_admitted_semantics() {
         let driver = DriverEntry::Ephemeral(EphemeralRuntimeDriver::new(
@@ -2259,7 +2650,7 @@ mod tests {
             other => panic!("expected accepted queued input, got {other:?}"),
         }
 
-        let selected = machine_select_runtime_loop_batch(&DriverEntry::Ephemeral(driver));
+        let selected = authorized_batch_input_ids(&DriverEntry::Ephemeral(driver));
 
         assert_eq!(
             selected,
@@ -2394,15 +2785,13 @@ mod tests {
         driver.rebuild_queue_projections_after_recovery();
 
         let entry = DriverEntry::Ephemeral(driver);
-        let selected = machine_select_runtime_loop_batch(&entry);
+        let selected = authorized_batch_input_ids(&entry);
 
         assert_eq!(
             selected,
             vec![resume_id],
             "a later prompt may drive the queue, but selection must preserve the staged queue prefix when an older input has a different execution kind"
         );
-        machine_validate_stage_drain_snapshot(&entry, &selected)
-            .expect("selected incompatible prefix must satisfy staging invariants");
     }
 
     #[test]
@@ -2463,15 +2852,13 @@ mod tests {
         driver.clear_admitted_runtime_semantics_for_test(&prefix_id);
 
         let entry = DriverEntry::Ephemeral(driver);
-        let selected = machine_select_runtime_loop_batch(&entry);
+        let selected = authorized_batch_input_ids(&entry);
 
         assert_eq!(
             selected,
             vec![prefix_id],
             "an unstamped no-wake prefix entry must be selected before the later prompt so runtime-loop failure handling can consume the queue prefix"
         );
-        machine_validate_stage_drain_snapshot(&entry, &selected)
-            .expect("selected unstamped prefix must satisfy staging invariants");
         assert!(
             machine_batch_runtime_semantics(&entry, &selected).is_none(),
             "selected unstamped prefix must flow into the runtime-loop metadata conflict path"
@@ -2553,15 +2940,13 @@ mod tests {
         driver.rebuild_queue_projections_after_recovery();
 
         let entry = DriverEntry::Ephemeral(driver);
-        let selected = machine_select_runtime_loop_batch(&entry);
+        let selected = authorized_batch_input_ids(&entry);
 
         assert_eq!(
             selected,
             vec![event_id],
             "a non-prompt-driven batch must not absorb a following prompt into the same run"
         );
-        machine_validate_stage_drain_snapshot(&entry, &selected)
-            .expect("selected non-prompt batch must satisfy staging invariants");
     }
 
     #[test]
@@ -2598,7 +2983,7 @@ mod tests {
         driver.rebuild_queue_projections_after_recovery();
         driver.clear_admitted_runtime_semantics_for_test(&input_id);
 
-        let selected = machine_select_runtime_loop_batch(&DriverEntry::Ephemeral(driver));
+        let selected = authorized_batch_input_ids(&DriverEntry::Ephemeral(driver));
 
         assert_eq!(
             selected,
@@ -2643,7 +3028,7 @@ mod tests {
         driver.rebuild_queue_projections_after_recovery();
         driver.clear_admitted_runtime_semantics_for_test(&input_id);
 
-        let selected = machine_select_runtime_loop_batch(&DriverEntry::Ephemeral(driver));
+        let selected = authorized_batch_input_ids(&DriverEntry::Ephemeral(driver));
 
         assert_eq!(
             selected,
@@ -2717,13 +3102,22 @@ pub(crate) async fn prepare_runtime_loop_batch_start(
 ) -> Result<(), RuntimeDriverError> {
     let mut driver = driver.lock().await;
     let staged_ids = batch.input_ids().to_vec();
-    machine_validate_stage_drain_snapshot(&driver, &staged_ids)?;
-    let stage_authority = batch.into_stage_for_run(run_id.clone());
+    let stage_source = batch.source();
     machine_begin_run(&mut driver, run_id.clone()).map_err(|err| {
         RuntimeDriverError::Internal(format!("failed to start runtime run: {err}"))
     })?;
 
-    if let Err(err) = driver.machine_realize_stage_batch(stage_authority) {
+    let stage_result = machine_authorize_stage_for_run(&driver, &run_id, &staged_ids, stage_source)
+        .ok_or_else(|| {
+            RuntimeDriverError::Internal(format!(
+                "generated machine did not authorize StageForRun for run {run_id:?} and inputs {staged_ids:?}"
+            ))
+        })
+        .and_then(|stage_authority| {
+            driver.machine_realize_authorized_stage_batch(stage_authority)
+        });
+
+    if let Err(err) = stage_result {
         let _ = driver.rollback_staged(&staged_ids);
         if let Err(rollback_err) = machine_apply_run_return_projection(
             &mut driver,
@@ -2750,21 +3144,21 @@ pub(crate) async fn commit_runtime_loop_run(
     session_snapshot: Option<Vec<u8>>,
 ) -> Result<(), RuntimeLoopRunCommitError> {
     let mut driver = driver.lock().await;
-    // Pick the first consumed input as the DSL `Commit { input_id, run_id }`
-    // identifier. The DSL Commit transitions only read `run_id` in their
-    // guards (input_id is informational), so firing once with any
-    // contributing input is sufficient to flip `lifecycle_phase`.
-    let commit_input_id = consumed_input_ids.first().cloned();
-    // Dogma K10: mint the final receipt from the machine-owned per-run
-    // boundary counter — the executor's draft carries no sequence, so the
-    // durable receipt can never diverge from `RecordBoundarySeq`'s value.
-    let receipt = receipt.into_sequenced(driver.run_boundary_sequence(&run_id));
-    machine_validate_run_commit_receipt(&driver, &run_id, &consumed_input_ids, &receipt)
-        .map_err(RuntimeLoopRunCommitError::Rejected)?;
-    let completed_run_id = run_id.clone();
+    let commit_authority =
+        AuthorizedRuntimeLoopRunCommit::authorize(&driver, run_id, consumed_input_ids, receipt)
+            .map_err(RuntimeLoopRunCommitError::Rejected)?;
+    debug_assert_eq!(
+        commit_authority.generated_plan(),
+        generated_kernel_command_capabilities::CommandPlanKind::AuthorizedRuntimeLoopRunCommit
+    );
+    let completed_run_id = commit_authority.run_id().clone();
+    let receipt = commit_authority.receipt().clone();
+    let consumed_input_ids = commit_authority.consumed_input_ids().to_vec();
+    let commit_input_id = commit_authority.commit_input_id().clone();
 
     let terminal_checkpoint = driver.rollback_snapshot();
-    if let Err(err) = driver.machine_realize_boundary_applied_in_memory(&run_id, &receipt) {
+    if let Err(err) = driver.machine_realize_boundary_applied_in_memory(&completed_run_id, &receipt)
+    {
         driver.restore_rollback_snapshot(terminal_checkpoint);
         return Err(RuntimeLoopRunCommitError::BoundaryCommit(
             RuntimeDriverError::Internal(format!("runtime boundary realization failed: {err}")),
@@ -2783,22 +3177,73 @@ pub(crate) async fn commit_runtime_loop_run(
         driver.restore_rollback_snapshot(terminal_checkpoint);
         return Err(RuntimeLoopRunCommitError::Rejected(err));
     }
-    let disposition = match commit_input_id.as_ref() {
-        Some(input_id) => RunReturnDisposition::Commit { input_id },
-        None => RunReturnDisposition::Rollback,
+    if commit_authority.owner_session_id().is_none() {
+        driver.restore_rollback_snapshot(terminal_checkpoint);
+        return Err(RuntimeLoopRunCommitError::Rejected(
+            RuntimeDriverError::Internal(
+                "runtime-loop run commit authority carried no owner session".to_string(),
+            ),
+        ));
+    }
+    let _owner_runtime_binding = (
+        commit_authority.owner_agent_runtime_id(),
+        commit_authority.owner_fence_token(),
+        commit_authority.owner_runtime_generation(),
+        commit_authority.owner_runtime_epoch_id(),
+    );
+    if commit_authority.commit_outcome().run_id() != &completed_run_id
+        || commit_authority.commit_outcome().outcome()
+            != crate::meerkat_machine::dsl::TurnTerminalOutcome::Completed
+    {
+        driver.restore_rollback_snapshot(terminal_checkpoint);
+        return Err(RuntimeLoopRunCommitError::Rejected(
+            RuntimeDriverError::Internal(
+                "runtime-loop run commit authority carried mismatched commit outcome".to_string(),
+            ),
+        ));
+    }
+    if !commit_authority
+        .effect_closure_obligations()
+        .iter()
+        .any(|obligation| {
+            obligation.is_satisfied_by(&completed_run_id, RuntimeLoopRunCommitEffect::Completed)
+        })
+    {
+        driver.restore_rollback_snapshot(terminal_checkpoint);
+        return Err(RuntimeLoopRunCommitError::Rejected(
+            RuntimeDriverError::Internal(
+                "runtime-loop run commit authority carried no completed-run effect closure obligation"
+                    .to_string(),
+            ),
+        ));
+    }
+    let return_projection = match machine_apply_run_return_projection(
+        &mut driver,
+        &completed_run_id,
+        RunReturnDisposition::Commit {
+            input_id: &commit_input_id,
+        },
+    ) {
+        Ok(projection) => projection,
+        Err(err) => {
+            driver.restore_rollback_snapshot(terminal_checkpoint);
+            return Err(RuntimeLoopRunCommitError::Rejected(
+                RuntimeDriverError::Internal(format!(
+                    "failed to apply runtime return projection after completion: {err}"
+                )),
+            ));
+        }
     };
-    let return_projection =
-        match machine_apply_run_return_projection(&mut driver, &completed_run_id, disposition) {
-            Ok(projection) => projection,
-            Err(err) => {
-                driver.restore_rollback_snapshot(terminal_checkpoint);
-                return Err(RuntimeLoopRunCommitError::Rejected(
-                    RuntimeDriverError::Internal(format!(
-                        "failed to apply runtime return projection after completion: {err}"
-                    )),
-                ));
-            }
-        };
+    if &return_projection != commit_authority.return_projection() {
+        driver.restore_rollback_snapshot(terminal_checkpoint);
+        return Err(RuntimeLoopRunCommitError::Rejected(
+            RuntimeDriverError::Internal(format!(
+                "runtime-loop run commit projection {:?} did not match generated authority {:?}",
+                return_projection,
+                commit_authority.return_projection()
+            )),
+        ));
+    }
     if let Err(err) =
         driver.machine_realize_run_completed_in_memory(&completed_run_id, &consumed_input_ids)
     {
@@ -2828,6 +3273,7 @@ pub(crate) async fn commit_runtime_loop_run(
         );
     }
 
+    let _receipt = commit_authority.into_receipt();
     Ok(())
 }
 
@@ -3175,6 +3621,17 @@ mod run_failed_cause_tests {
         DriverEntry::Ephemeral(driver)
     }
 
+    fn assert_runtime_completion_authority(
+        authority: RuntimeCompletionResultAuthority,
+        expected_class: crate::meerkat_machine::dsl::RuntimeCompletionResultClass,
+        expected_cleanup: crate::meerkat_machine::dsl::RuntimeCompletionObservedOutcome,
+    ) {
+        let attempt = authority.begin_surface_resolution();
+        assert_eq!(attempt.class(), expected_class);
+        let realized = attempt.realize();
+        assert_eq!(realized.cleanup_observation(), expected_cleanup);
+    }
+
     #[test]
     fn runtime_completion_result_authority_classifies_success_result() {
         let run_id = RunId::new();
@@ -3190,13 +3647,10 @@ mod run_failed_cause_tests {
         )
         .expect("generated completion result authority should resolve");
 
-        assert_eq!(
-            class.class(),
-            crate::meerkat_machine::dsl::RuntimeCompletionResultClass::Completed
-        );
-        assert_eq!(
-            class.cleanup_observation(),
-            crate::meerkat_machine::dsl::RuntimeCompletionObservedOutcome::Completed
+        assert_runtime_completion_authority(
+            class,
+            crate::meerkat_machine::dsl::RuntimeCompletionResultClass::Completed,
+            crate::meerkat_machine::dsl::RuntimeCompletionObservedOutcome::Completed,
         );
     }
 
@@ -3215,13 +3669,10 @@ mod run_failed_cause_tests {
         )
         .expect("generated completion result authority should resolve");
 
-        assert_eq!(
-            class.class(),
-            crate::meerkat_machine::dsl::RuntimeCompletionResultClass::CompletedWithFinalizationFailure
-        );
-        assert_eq!(
-            class.cleanup_observation(),
-            crate::meerkat_machine::dsl::RuntimeCompletionObservedOutcome::FinalizationFailed
+        assert_runtime_completion_authority(
+            class,
+            crate::meerkat_machine::dsl::RuntimeCompletionResultClass::CompletedWithFinalizationFailure,
+            crate::meerkat_machine::dsl::RuntimeCompletionObservedOutcome::FinalizationFailed,
         );
     }
 
@@ -3272,13 +3723,10 @@ mod run_failed_cause_tests {
         )
         .expect("generated completion result authority should resolve");
 
-        assert_eq!(
-            class.class(),
-            crate::meerkat_machine::dsl::RuntimeCompletionResultClass::AbandonedWithError
-        );
-        assert_eq!(
-            class.cleanup_observation(),
-            crate::meerkat_machine::dsl::RuntimeCompletionObservedOutcome::RuntimeApplyFailed
+        assert_runtime_completion_authority(
+            class,
+            crate::meerkat_machine::dsl::RuntimeCompletionResultClass::AbandonedWithError,
+            crate::meerkat_machine::dsl::RuntimeCompletionObservedOutcome::RuntimeApplyFailed,
         );
     }
 
@@ -3297,13 +3745,10 @@ mod run_failed_cause_tests {
         )
         .expect("generated completion result authority should resolve");
 
-        assert_eq!(
-            class.class(),
-            crate::meerkat_machine::dsl::RuntimeCompletionResultClass::Cancelled
-        );
-        assert_eq!(
-            class.cleanup_observation(),
-            crate::meerkat_machine::dsl::RuntimeCompletionObservedOutcome::Cancelled
+        assert_runtime_completion_authority(
+            class,
+            crate::meerkat_machine::dsl::RuntimeCompletionResultClass::Cancelled,
+            crate::meerkat_machine::dsl::RuntimeCompletionObservedOutcome::Cancelled,
         );
     }
 
@@ -3320,13 +3765,10 @@ mod run_failed_cause_tests {
         )
         .expect("generated completion result authority should resolve");
 
-        assert_eq!(
-            class.class(),
-            crate::meerkat_machine::dsl::RuntimeCompletionResultClass::RuntimeTerminated
-        );
-        assert_eq!(
-            class.cleanup_observation(),
-            crate::meerkat_machine::dsl::RuntimeCompletionObservedOutcome::RuntimeTerminated
+        assert_runtime_completion_authority(
+            class,
+            crate::meerkat_machine::dsl::RuntimeCompletionResultClass::RuntimeTerminated,
+            crate::meerkat_machine::dsl::RuntimeCompletionObservedOutcome::RuntimeTerminated,
         );
     }
 
@@ -3449,13 +3891,10 @@ mod run_failed_cause_tests {
             crate::meerkat_machine::dsl::RuntimeCompletionFinalizationObservation::Succeeded,
         )
         .expect("generated completion result authority should resolve runtime apply failure");
-        assert_eq!(
-            class.class(),
-            crate::meerkat_machine::dsl::RuntimeCompletionResultClass::AbandonedWithError
-        );
-        assert_eq!(
-            class.cleanup_observation(),
-            crate::meerkat_machine::dsl::RuntimeCompletionObservedOutcome::RuntimeApplyFailed
+        assert_runtime_completion_authority(
+            class,
+            crate::meerkat_machine::dsl::RuntimeCompletionResultClass::AbandonedWithError,
+            crate::meerkat_machine::dsl::RuntimeCompletionObservedOutcome::RuntimeApplyFailed,
         );
     }
 

--- a/meerkat-runtime/src/meerkat_machine/mod.rs
+++ b/meerkat-runtime/src/meerkat_machine/mod.rs
@@ -891,8 +891,6 @@ type MeerkatMachineCommandFuture<'a> = Pin<
     Box<dyn Future<Output = Result<MeerkatMachineCommandResult, MeerkatMachineCommandError>> + 'a>,
 >;
 
-#[cfg(test)]
-pub(crate) use driver::machine_select_runtime_loop_batch;
 pub(crate) use driver::{
     DriverEntry, SharedCompletionRegistry, SharedDriver, cancel_runtime_loop_run,
     commit_runtime_loop_run, fail_machine_run, fail_runtime_loop_run,

--- a/meerkat-runtime/src/meerkat_machine_tests.rs
+++ b/meerkat-runtime/src/meerkat_machine_tests.rs
@@ -15854,7 +15854,12 @@ async fn persistent_staged_run_driver(
         .contract_begin_run_authority(run_id.clone())
         .expect("runtime run authority should begin through generated DSL");
     driver
-        .machine_realize_stage_batch(std::slice::from_ref(&input_id), &run_id)
+        .machine_realize_authorized_stage_batch(
+            crate::meerkat_machine::driver::test_authorized_stage_for_run(
+                vec![input_id.clone()],
+                run_id.clone(),
+            ),
+        )
         .expect("input should stage for the run");
 
     (

--- a/meerkat-runtime/src/meerkat_machine_types.rs
+++ b/meerkat-runtime/src/meerkat_machine_types.rs
@@ -623,6 +623,7 @@ meerkat_machine_runtime_internal_inputs!(
     InputQueueLifecycle => [
         AbandonInput,
         AdvanceSessionContext,
+        BindAdmissionRuntimeGrouping,
         BudgetExhausted,
         ChangeLane,
         CoalesceInput,

--- a/meerkat-runtime/src/queue.rs
+++ b/meerkat-runtime/src/queue.rs
@@ -26,17 +26,17 @@ impl InputQueue {
     }
 
     /// Enqueue an input.
-    pub fn enqueue(&mut self, input_id: InputId, input: Input) {
+    pub(crate) fn enqueue(&mut self, input_id: InputId, input: Input) {
         self.queue.push_back(QueuedInput { input_id, input });
     }
 
     /// Enqueue an input at the front of the queue.
-    pub fn enqueue_front(&mut self, input_id: InputId, input: Input) {
+    pub(crate) fn enqueue_front(&mut self, input_id: InputId, input: Input) {
         self.queue.push_front(QueuedInput { input_id, input });
     }
 
     /// Dequeue the next input (FIFO).
-    pub fn dequeue(&mut self) -> Option<QueuedInput> {
+    pub(crate) fn dequeue(&mut self) -> Option<QueuedInput> {
         self.queue.pop_front()
     }
 
@@ -55,15 +55,37 @@ impl InputQueue {
         self.queue.len()
     }
 
-    /// Remove a specific input by ID and return it as (InputId, Input).
+    /// Drain the exact front prefix named by `input_ids`.
     ///
-    /// Used by the batching policy to dequeue specific IDs determined by the authority.
-    pub fn dequeue_by_id(&mut self, input_id: &InputId) -> Option<(InputId, crate::input::Input)> {
-        self.remove(input_id).map(|q| (q.input_id, q.input))
+    /// This is intentionally prefix-only: runtime-loop batch authority proves a
+    /// physical queue projection is in exact conformance before mutation.
+    pub(crate) fn dequeue_exact_prefix(
+        &mut self,
+        input_ids: &[InputId],
+    ) -> Option<Vec<(InputId, Input)>> {
+        if self.queue.len() < input_ids.len() {
+            return None;
+        }
+        if !self
+            .queue
+            .iter()
+            .take(input_ids.len())
+            .zip(input_ids.iter())
+            .all(|(queued, expected)| queued.input_id == *expected)
+        {
+            return None;
+        }
+
+        Some(
+            (0..input_ids.len())
+                .filter_map(|_| self.queue.pop_front())
+                .map(|queued| (queued.input_id, queued.input))
+                .collect(),
+        )
     }
 
     /// Remove a specific input by ID (e.g., for supersession).
-    pub fn remove(&mut self, input_id: &InputId) -> Option<QueuedInput> {
+    pub(crate) fn remove(&mut self, input_id: &InputId) -> Option<QueuedInput> {
         if let Some(pos) = self.queue.iter().position(|q| q.input_id == *input_id) {
             self.queue.remove(pos)
         } else {
@@ -72,7 +94,7 @@ impl InputQueue {
     }
 
     /// Drain all entries from the queue.
-    pub fn drain(&mut self) -> Vec<QueuedInput> {
+    pub(crate) fn drain(&mut self) -> Vec<QueuedInput> {
         self.queue.drain(..).collect()
     }
 

--- a/meerkat-runtime/src/runtime_loop.rs
+++ b/meerkat-runtime/src/runtime_loop.rs
@@ -2634,7 +2634,11 @@ mod tests {
 
         {
             let guard = terminal_first.lock().await;
-            let batch = crate::meerkat_machine::machine_select_runtime_loop_batch(&guard);
+            let batch =
+                crate::meerkat_machine::driver::machine_authorize_runtime_loop_batch(&guard)
+                    .expect("generated terminal-first runtime-loop batch")
+                    .input_ids()
+                    .to_vec();
             assert_eq!(
                 batch,
                 vec![terminal_id],
@@ -2665,7 +2669,10 @@ mod tests {
         .await;
 
         let guard = message_first.lock().await;
-        let batch = crate::meerkat_machine::machine_select_runtime_loop_batch(&guard);
+        let batch = crate::meerkat_machine::driver::machine_authorize_runtime_loop_batch(&guard)
+            .expect("generated message-first runtime-loop batch")
+            .input_ids()
+            .to_vec();
         assert_eq!(
             batch,
             vec![message_id],

--- a/meerkat-runtime/tests/core_apply_terminal_truth.rs
+++ b/meerkat-runtime/tests/core_apply_terminal_truth.rs
@@ -95,6 +95,8 @@ fn core_apply_terminal_truth_has_one_authority() -> Result<(), String> {
     let runtime_driver =
         fs::read_to_string(root.join("meerkat-runtime/src/meerkat_machine/driver.rs"))
             .map_err(|err| format!("read runtime driver source: {err}"))?;
+    let completion_source = fs::read_to_string(root.join("meerkat-runtime/src/completion.rs"))
+        .map_err(|err| format!("read completion source: {err}"))?;
     let persistent_driver =
         fs::read_to_string(root.join("meerkat-runtime/src/driver/persistent.rs"))
             .map_err(|err| format!("read persistent driver source: {err}"))?;
@@ -106,6 +108,9 @@ fn core_apply_terminal_truth_has_one_authority() -> Result<(), String> {
     let meerkat_machine_model =
         fs::read_to_string(root.join("specs/machines/meerkat_machine/model.tla"))
             .map_err(|err| format!("read MeerkatMachine TLA source: {err}"))?;
+    let meerkat_machine_contract =
+        fs::read_to_string(root.join("specs/machines/meerkat_machine/contract.md"))
+            .map_err(|err| format!("read MeerkatMachine contract source: {err}"))?;
     let accept_source = fs::read_to_string(root.join("meerkat-runtime/src/accept.rs"))
         .map_err(|err| format!("read accept source: {err}"))?;
 
@@ -148,6 +153,36 @@ fn core_apply_terminal_truth_has_one_authority() -> Result<(), String> {
         !completion_authority.contains("Clone") && !completion_authority_derive.contains("Clone"),
         "runtime completion authority must not be Clone; waiter fanout consumes one token and clones only derived cleanup observations"
     );
+    let completion_attempt = extract_braced_item(
+        &runtime_driver,
+        "pub(crate) struct RuntimeCompletionResultAttempt",
+    )?;
+    let completion_realized = extract_braced_item(
+        &runtime_driver,
+        "pub(crate) struct RuntimeCompletionResultRealized",
+    )?;
+    assert!(
+        runtime_driver.contains(
+            "#[must_use = \"attempted runtime completion closure must be realized, failed, or abandoned\"]"
+        ) && runtime_driver.contains(
+            "#[must_use = \"realized runtime completion closure must mint a completion cleanup observation\"]"
+        ) && completion_attempt.contains("authority: RuntimeCompletionResultAuthority")
+            && completion_realized.contains("authority: RuntimeCompletionResultAuthority")
+            && completion_authority
+                .contains("generated_plan: generated_kernel_command_capabilities::CommandPlanKind")
+            && !runtime_driver.contains(
+                "generated_kernel_command_capabilities::RuntimeCompletionResultAuthority::mint_from_generated_command_plan()"
+            )
+            && runtime_driver.contains(
+                "CommandPlanKind::AuthorizedRuntimeCompletionResultClosure"
+            )
+            && completion_source.contains("authority.begin_surface_resolution()")
+            && completion_source.contains("Self::cleanup_from_realized_attempt(attempt)")
+            && completion_source.contains("attempt.fail()")
+            && completion_source.contains("attempt.abandon()")
+            && !completion_source.contains("CompletionCleanupObservation::from_authority"),
+        "completion waiter delivery must consume generated authority through Attempted -> Realized/Failed/Abandoned closure phases"
+    );
     assert!(
         !waiter_resolver.contains("authority.clone()"),
         "runtime completion waiter fanout must not clone the generated authority token"
@@ -159,11 +194,45 @@ fn core_apply_terminal_truth_has_one_authority() -> Result<(), String> {
             && !runtime_loop.contains("filter_map(|id| d.dequeue_by_id(id))"),
         "runtime loop batch execution must use authorized batch tokens and fail closed on projection mismatch"
     );
+    let exact_dequeue =
+        extract_braced_item(&ephemeral_driver, "pub(crate) fn dequeue_batch_exact")?;
+    assert!(
+        exact_dequeue.contains("match batch.source()")
+            && exact_dequeue.contains("RuntimeLoopBatchSource::Queue")
+            && exact_dequeue.contains("RuntimeLoopBatchSource::Steer")
+            && exact_dequeue.contains("dequeue_exact_prefix(batch.input_ids())")
+            && !exact_dequeue.contains("dequeue_by_id"),
+        "runtime batch dequeue must enforce exact source/prefix conformance instead of draining by id from either queue"
+    );
+    assert!(
+        runtime_driver.contains("input_runtime_boundary")
+            && runtime_driver.contains("input_runtime_execution_kind")
+            && runtime_driver.contains("input_peer_response_terminal_apply_intent")
+            && runtime_driver.contains("input_is_prompt_for_batch")
+            && !runtime_driver.contains("fn machine_validate_stage_drain_snapshot")
+            && !runtime_driver.contains("machine_validate_stage_drain_snapshot("),
+        "runtime batch grouping must use machine-owned grouping witnesses without retaining a shell stage-drain validator"
+    );
+    let batch_authorizer = extract_braced_item(
+        &runtime_driver,
+        "pub(crate) fn machine_authorize_runtime_loop_batch",
+    )?;
+    assert!(
+        !runtime_driver.contains("pub(crate) fn machine_select_runtime_loop_batch")
+            && batch_authorizer
+                .contains("AuthorizedRuntimeLoopBatch::authorize_runtime_loop_batch_from_state")
+            && batch_authorizer.contains("authority.state()")
+            && !batch_authorizer.contains("runtime_semantics(")
+            && !batch_authorizer.contains("driver_ingress()"),
+        "runtime-loop batch authorization must use the generated command-plan selector over machine state, not a handwritten shell selector"
+    );
     assert!(
         !ephemeral_driver.contains("pub fn dequeue_by_id")
+            && !ephemeral_driver.contains("pub fn dequeue_next")
             && !ephemeral_driver.contains("pub fn stage_input")
             && !ephemeral_driver.contains("pub fn stage_batch")
             && !persistent_driver.contains("pub fn dequeue_by_id")
+            && !persistent_driver.contains("pub fn dequeue_next")
             && !persistent_driver.contains("pub fn stage_input")
             && !persistent_driver.contains("pub fn stage_batch")
             && !ephemeral_driver.contains("pub fn contract_stage_current_run_input"),
@@ -195,12 +264,102 @@ fn core_apply_terminal_truth_has_one_authority() -> Result<(), String> {
             && !stage_authority_derive.contains("Clone"),
         "stage-for-run authority must be must-use and non-Clone"
     );
-    let shared_stage_realizer =
-        extract_braced_item(&runtime_driver, "pub(crate) fn machine_realize_stage_batch")?;
+    let prepare_batch_start = extract_braced_item(
+        &runtime_driver,
+        "pub(crate) async fn prepare_runtime_loop_batch_start",
+    )?;
+    let live_boundary_stage = extract_braced_item(
+        &runtime_driver,
+        "pub(crate) async fn machine_realize_live_boundary_context_injected",
+    )?;
+    assert!(
+        !runtime_batch_authority
+            .contains("generated_stage: generated_command_capabilities::AuthorizedStageForRun")
+            && !runtime_driver.contains("pub(crate) fn into_stage_for_run")
+            && prepare_batch_start.contains("machine_authorize_stage_for_run(")
+            && prepare_batch_start.contains("machine_begin_run(&mut driver")
+            && live_boundary_stage.contains("machine_authorize_stage_for_run(")
+            && runtime_driver.contains("AuthorizedStageForRun::authorize_stage_for_run_from_state"),
+        "stage-for-run authority must be carried from generated state plans instead of minted by handwritten runtime bridge code"
+    );
+    let run_commit_authority = extract_braced_item(
+        &runtime_driver,
+        "pub(crate) struct AuthorizedRuntimeLoopRunCommit",
+    )?;
+    let run_commit_authority_derive = derive_attribute_before(
+        &runtime_driver,
+        "pub(crate) struct AuthorizedRuntimeLoopRunCommit",
+    )?;
+    let runtime_loop_commit = extract_braced_item(
+        &runtime_driver,
+        "pub(crate) async fn commit_runtime_loop_run",
+    )?;
+    assert!(
+        runtime_driver.contains(
+            "#[must_use = \"runtime-loop run commit authority must be consumed by commit realization\"]"
+        ) && !run_commit_authority.contains("Clone")
+            && !run_commit_authority_derive.contains("Clone")
+            && run_commit_authority.contains("run_id: RunId")
+            && run_commit_authority.contains("consumed_input_ids: Vec<InputId>")
+            && run_commit_authority.contains("commit_input_id: InputId")
+            && run_commit_authority.contains("receipt: meerkat_core::lifecycle::RunBoundaryReceipt")
+            && run_commit_authority
+                .contains("generated_plan: generated_kernel_command_capabilities::CommandPlanKind")
+            && run_commit_authority.contains("owner_session_id:")
+            && run_commit_authority.contains("owner_agent_runtime_id:")
+            && run_commit_authority.contains("commit_outcome: AuthorizedRuntimeLoopRunCommitOutcome")
+            && run_commit_authority.contains(
+                "effect_closure_obligations: Vec<RuntimeLoopRunCommitEffectObligation>"
+            )
+            && run_commit_authority.contains("return_projection: RuntimeLifecycleProjection")
+            && runtime_driver.contains("struct RuntimeLoopRunCommitEffectObligation")
+            && runtime_driver.contains("enum RuntimeLoopRunCommitEffect")
+            && runtime_driver.contains("\"RuntimeLoopRunCommitEffect\"")
+            && runtime_loop_commit.contains("effect_closure_obligations()")
+            && runtime_loop_commit.contains("RuntimeLoopRunCommitEffect::Completed")
+            && runtime_driver.contains("fn preview_authorized_runtime_loop_run_commit(")
+            && runtime_driver.contains("MeerkatMachineInput::RunCompleted")
+            && runtime_driver.contains("MeerkatMachineInput::Commit")
+            && runtime_loop_commit.contains("AuthorizedRuntimeLoopRunCommit::authorize(")
+            && runtime_loop_commit.contains("CommandPlanKind::AuthorizedRuntimeLoopRunCommit")
+            && runtime_loop_commit.contains("commit_authority.commit_outcome().outcome()")
+            && runtime_loop_commit.contains("&return_projection != commit_authority.return_projection()")
+            && !runtime_loop_commit.contains("commit_authority.into_parts()"),
+        "runtime-loop run commit must consume a generated-shaped authority binding run id, terminal inputs, owner, outcome, receipt, and return projection"
+    );
+    let shared_stage_realizer = extract_braced_item(
+        &runtime_driver,
+        "pub(crate) fn machine_realize_authorized_stage_batch",
+    )?;
     assert!(
         shared_stage_realizer.contains("authority: AuthorizedStageForRun")
-            && shared_stage_realizer.contains("authority.into_parts()"),
+            && shared_stage_realizer.contains("machine_realize_authorized_stage_batch(authority)")
+            && !shared_stage_realizer.contains("machine_realize_stage_batch(&input_ids"),
         "shared stage realization must consume AuthorizedStageForRun instead of raw ids"
+    );
+    let concrete_authorized_stage = extract_braced_item(
+        &ephemeral_driver,
+        "pub(crate) fn machine_realize_authorized_stage_batch",
+    )?;
+    assert!(
+        concrete_authorized_stage
+            .contains("authority: crate::meerkat_machine::driver::AuthorizedStageForRun")
+            && concrete_authorized_stage.contains("authority.into_parts()")
+            && concrete_authorized_stage
+                .contains("self.machine_realize_stage_batch(&input_ids, &run_id)"),
+        "concrete staging must be reachable through an explicit AuthorizedStageForRun wrapper"
+    );
+    let live_boundary_realizer = extract_braced_item(
+        &ephemeral_driver,
+        "pub(crate) fn machine_realize_live_boundary_context_injected",
+    )?;
+    assert!(
+        live_boundary_realizer
+            .contains("stage_authority: crate::meerkat_machine::driver::AuthorizedStageForRun")
+            && live_boundary_realizer
+                .contains("self.machine_realize_authorized_stage_batch(stage_authority)")
+            && !live_boundary_realizer.contains("self.machine_realize_stage_batch(input_ids"),
+        "live-boundary staging must consume explicit stage authority instead of raw ids"
     );
     let stage_for_run_transition =
         extract_braced_item(&meerkat_machine_schema, "transition StageForRun")?;
@@ -228,10 +387,41 @@ fn core_apply_terminal_truth_has_one_authority() -> Result<(), String> {
             && stage_for_run_model.contains("current_run_id[\"value\"] ELSE None) = run_id"),
         "generated StageForRun TLA must bind staging to the active machine-owned current_run_id"
     );
-    let stage_realizer = extract_braced_item(
-        &ephemeral_driver,
-        "pub(crate) fn machine_realize_stage_batch",
-    )?;
+    let command_plan_start = meerkat_machine_contract
+        .find("## Command Plans")
+        .ok_or_else(|| "generated contract missing Command Plans section".to_string())?;
+    let command_plan_end = meerkat_machine_contract[command_plan_start..]
+        .find("## Invariants")
+        .map(|offset| command_plan_start + offset)
+        .ok_or_else(|| {
+            "generated contract missing Invariants section after Command Plans".to_string()
+        })?;
+    let command_plans = &meerkat_machine_contract[command_plan_start..command_plan_end];
+    assert!(
+        command_plans.contains("### `AuthorizedAcceptedInputMaterialization`")
+            && command_plans.contains("### `AuthorizeRuntimeLoopBatch`")
+            && command_plans.contains("### `AuthorizedStageForRun`")
+            && command_plans.contains("### `AuthorizedRuntimeLoopRunCommit`")
+            && command_plans.contains("### `AuthorizedRuntimeCompletionResultClosure`")
+            && command_plans.contains("- Authority: `AuthorizedRuntimeLoopBatch`")
+            && command_plans.contains("- Authority: `AuthorizedRuntimeLoopRunCommit`")
+            && command_plans.contains("- Authority: `RuntimeCompletionResultAuthority`")
+            && command_plans.contains(
+                "- Command Effects: `TurnRunCompleted`, `TurnRunFailed`, `TurnRunCancelled`"
+            )
+            && command_plans.contains(
+                "`TurnRunCompleted` via `AuthorizedRuntimeLoopRunCommit` (RuntimeLoopRunCommitEffect) states: `Authorized`, `Attempted`, `Realized`, `Failed`, `Cancelled`, `Abandoned`"
+            )
+            && command_plans.contains(
+                "- Command Effects: `RuntimeCompletionResultResolved`"
+            )
+            && command_plans.contains(
+                "`RuntimeCompletionResultResolved` via `RuntimeCompletionResultAuthority` (LocalSurfaceResultAlignment) states: `Authorized`, `Attempted`, `Realized`, `Failed`, `Cancelled`, `Abandoned`"
+            )
+            && command_plans.contains("`StageForRunIdle`: `input_queued`, `input_lane_bound`, `input_sequence_bound`, `input_recovery_lane_bound`, `input_not_run_associated`, `current_run_matches`"),
+        "generated contract must expose queue-to-run, run-commit, and completion-result closure command plans with expanded guards and effects"
+    );
+    let stage_realizer = extract_braced_item(&ephemeral_driver, "fn machine_realize_stage_batch")?;
     assert!(
         !stage_realizer.contains("IncrementAttemptCount"),
         "runtime staging must not split StageForRun from the attempt-count update"

--- a/meerkat-runtime/tests/driver_persistent.rs
+++ b/meerkat-runtime/tests/driver_persistent.rs
@@ -447,7 +447,7 @@ async fn recover_from_store() {
 
     // State should now be in the driver
     assert!(driver.input_state(&input_id).is_some());
-    let dequeued = driver.dequeue_next();
+    let dequeued = driver.contract_dequeue_next_for_recovery_tests();
     assert!(
         dequeued.is_some(),
         "Recovered queued input should be re-enqueued"
@@ -642,7 +642,7 @@ async fn durable_accept_failure_restores_canonical_ingress_state() {
         "failed durable admission must not leave canonical input state behind"
     );
     assert!(
-        driver.dequeue_next().is_none(),
+        driver.contract_dequeue_next_for_recovery_tests().is_none(),
         "failed durable admission must not leave a queued phantom input"
     );
     assert!(
@@ -694,7 +694,7 @@ async fn recovery_lifecycle_commit_failure_restores_recovered_projection() {
         "failed recovery must not leave recovered input in the live driver",
     );
     assert!(
-        driver.dequeue_next().is_none(),
+        driver.contract_dequeue_next_for_recovery_tests().is_none(),
         "failed recovery must not leave recovered queue projection",
     );
     let stored = inner
@@ -747,7 +747,7 @@ async fn persistence_record_rejects_unstamped_recovered_row_before_store_write()
         "failed persistence-record recovery must not retain the rejected row",
     );
     assert!(
-        driver.dequeue_next().is_none(),
+        driver.contract_dequeue_next_for_recovery_tests().is_none(),
         "failed persistence-record recovery must not leave recovered queue projection",
     );
     assert!(
@@ -810,7 +810,7 @@ async fn recover_allows_legacy_unstamped_terminal_rows() {
         "terminal rows must not become active"
     );
     assert!(
-        driver.dequeue_next().is_none(),
+        driver.contract_dequeue_next_for_recovery_tests().is_none(),
         "terminal rows must not enter runtime queues"
     );
 
@@ -893,7 +893,7 @@ async fn recover_consumes_committed_applied_pending_inputs() {
         "committed applied inputs should not stay active after recovery"
     );
     assert!(
-        driver.dequeue_next().is_none(),
+        driver.contract_dequeue_next_for_recovery_tests().is_none(),
         "committed applied inputs should not be replayed after recovery"
     );
 }
@@ -967,7 +967,7 @@ async fn recover_duplicate_legacy_input_row_keeps_canonical_boundary_receipt() {
         "duplicate legacy row must still consult the canonical boundary receipt"
     );
     assert!(
-        driver.dequeue_next().is_none(),
+        driver.contract_dequeue_next_for_recovery_tests().is_none(),
         "canonical committed input must not be replayed because the newer duplicate row came from the legacy alias"
     );
 }
@@ -1037,7 +1037,7 @@ async fn recover_prefers_canonical_duplicate_over_newer_stale_legacy_row() {
         "canonical applied row must not be replaced by a newer stale legacy row"
     );
     assert!(
-        driver.dequeue_next().is_none(),
+        driver.contract_dequeue_next_for_recovery_tests().is_none(),
         "newer stale legacy row must not replay a canonically committed input"
     );
 }
@@ -1095,7 +1095,9 @@ async fn recover_ignores_legacy_boundary_receipt_load_error_after_canonical_miss
         "canonical missing receipt should recover by requeueing the input"
     );
     assert_eq!(
-        driver.dequeue_next().map(|(queued_id, _)| queued_id),
+        driver
+            .contract_dequeue_next_for_recovery_tests()
+            .map(|(queued_id, _)| queued_id),
         Some(input_id),
         "requeued canonical input should remain available for replay"
     );
@@ -1169,7 +1171,9 @@ async fn recover_treats_canonical_boundary_receipt_miss_as_authoritative() {
         "canonical receipt miss should requeue instead of consuming from stale legacy receipt"
     );
     assert_eq!(
-        driver.dequeue_next().map(|(queued_id, _)| queued_id),
+        driver
+            .contract_dequeue_next_for_recovery_tests()
+            .map(|(queued_id, _)| queued_id),
         Some(input_id),
         "canonical missing-receipt input should remain queued for replay"
     );

--- a/meerkat-runtime/tests/recovery_contract.rs
+++ b/meerkat-runtime/tests/recovery_contract.rs
@@ -387,11 +387,11 @@ async fn recovery_persistent_driver_contract_replays_missing_receipts_and_persis
         }
 
         let replayed_ids = vec![
-            driver.dequeue_next().unwrap().0,
-            driver.dequeue_next().unwrap().0,
+            driver.contract_dequeue_next_for_recovery_tests().unwrap().0,
+            driver.contract_dequeue_next_for_recovery_tests().unwrap().0,
         ];
         assert!(
-            driver.dequeue_next().is_none(),
+            driver.contract_dequeue_next_for_recovery_tests().is_none(),
             "{}: only the recovered contributors should be queued for replay",
             harness.name
         );
@@ -529,7 +529,7 @@ async fn recovery_persistent_driver_contract_consumes_committed_boundary_contrib
             harness.name
         );
         assert!(
-            driver.dequeue_next().is_none(),
+            driver.contract_dequeue_next_for_recovery_tests().is_none(),
             "{}: committed contributors should not be replayed after recovery",
             harness.name
         );

--- a/meerkat-runtime/tests/recovery_replay.rs
+++ b/meerkat-runtime/tests/recovery_replay.rs
@@ -156,11 +156,17 @@ async fn recovery_replay_red_ok_requeues_missing_boundary_contributors_through_p
     }
 
     let replayed = vec![
-        driver.dequeue_next().expect("first replay input").0,
-        driver.dequeue_next().expect("second replay input").0,
+        driver
+            .contract_dequeue_next_for_recovery_tests()
+            .expect("first replay input")
+            .0,
+        driver
+            .contract_dequeue_next_for_recovery_tests()
+            .expect("second replay input")
+            .0,
     ];
     assert!(
-        driver.dequeue_next().is_none(),
+        driver.contract_dequeue_next_for_recovery_tests().is_none(),
         "recovery should requeue only the missing-boundary contributors"
     );
     assert_eq!(

--- a/scripts/buildbuddy-agent-gate
+++ b/scripts/buildbuddy-agent-gate
@@ -226,11 +226,12 @@ fi
 if [[ "${#governance[@]}" -gt 0 ]]; then
   printf 'BuildBuddy agent gate governance/spec paths:\n'
   printf '  %s\n' "${governance[@]}"
-  echo "Formal/governance artifacts changed; running machine-check-drift, seam-inventory, and rmat-audit."
+  echo "Formal/governance artifacts changed; running machine-check-drift, runtime-authority-bypass, seam-inventory, and rmat-audit."
   if [[ "${dry_run}" -eq 1 ]]; then
-    echo "DRY-RUN make machine-check-drift seam-inventory rmat-audit"
+    echo "DRY-RUN make machine-check-drift runtime-authority-bypass seam-inventory rmat-audit"
+    echo "DRY-RUN generated-artifact summary: make machine-check-drift seam-inventory rmat-audit"
   else
-    make machine-check-drift seam-inventory rmat-audit
+    make machine-check-drift runtime-authority-bypass seam-inventory rmat-audit
   fi
 fi
 

--- a/scripts/buildbuddy-bazel-poc
+++ b/scripts/buildbuddy-bazel-poc
@@ -336,7 +336,7 @@ case "${command}" in
   machine-authority-rbe)
     command="test"
     config="${BUILDBUDDY_BAZEL_CONFIG:-buildbuddy-macos-rbe}"
-    default_target="//xtask:machine_verify_all_tlc_test //xtask:machines_contracts_test //xtask:protocol_codegen_drift_test //meerkat-machine-codegen:render_contracts_test //meerkat-machine-codegen:runtime_alphabet_parity_test //meerkat-machine-codegen:runtime_schema_parity_test"
+    default_target="//xtask:machine_verify_all_tlc_test //xtask:machines_contracts_test //xtask:protocol_codegen_drift_test //xtask:runtime_authority_bypass_test //meerkat-machine-codegen:render_contracts_test //meerkat-machine-codegen:runtime_alphabet_parity_test //meerkat-machine-codegen:runtime_schema_parity_test"
     extra_args+=(
       --test_output=errors
       --test_summary=terse
@@ -347,7 +347,7 @@ case "${command}" in
   rmat-audit-rbe)
     command="test"
     config="${BUILDBUDDY_BAZEL_CONFIG:-buildbuddy-macos-rbe}"
-    default_target="//xtask:effect_authority_test //xtask:rmat_audit_test //xtask:rmat_strict_test"
+    default_target="//xtask:effect_authority_test //xtask:runtime_authority_bypass_test //xtask:rmat_audit_test //xtask:rmat_strict_test"
     extra_args+=(
       --test_output=errors
       --test_summary=terse

--- a/scripts/cargo-agent-gate
+++ b/scripts/cargo-agent-gate
@@ -235,12 +235,13 @@ fi
 run_governance_gate() {
   printf 'Cargo agent gate governance/spec paths:\n'
   printf '  %s\n' "${governance[@]}"
-  echo "Formal/governance artifacts changed; running machine-check-drift, seam-inventory, and rmat-audit."
+  echo "Formal/governance artifacts changed; running machine-check-drift, runtime-authority-bypass, seam-inventory, and rmat-audit."
   if [[ "${dry_run}" -eq 1 ]]; then
-    echo "DRY-RUN make machine-check-drift seam-inventory rmat-audit"
+    echo "DRY-RUN make machine-check-drift runtime-authority-bypass seam-inventory rmat-audit"
+    echo "DRY-RUN generated-artifact summary: make machine-check-drift seam-inventory rmat-audit"
     return 0
   fi
-  make machine-check-drift seam-inventory rmat-audit
+  make machine-check-drift runtime-authority-bypass seam-inventory rmat-audit
 }
 
 if [[ "${#governance[@]}" -gt 0 ]]; then

--- a/scripts/generate-bazel-rust-builds.mjs
+++ b/scripts/generate-bazel-rust-builds.mjs
@@ -790,6 +790,12 @@ function compileData(target, packageRoot, includeTests) {
         )
       ) {
         labels.add("//:meerkat_platform_skill_files");
+      } else if (
+        target.name === "runtime_schema_parity" &&
+        absolute.startsWith(`${root}/meerkat-machine-kernels/src/generated/`)
+      ) {
+        const rel = relative(resolve(root, "meerkat-machine-kernels"), absolute).replaceAll("\\", "/");
+        labels.add(`//meerkat-machine-kernels:${rel}`);
       }
     }
     if (source.includes("../../test-fixtures/live_smoke/support.rs")) {
@@ -1765,6 +1771,18 @@ for (const pkg of localPackages.values()) {
       `    visibility = ["//visibility:public"],`,
       `)`,
       "",
+      ...(key === "meerkat-machine-kernels"
+        ? [
+            `exports_files(`,
+            `    [`,
+            `        "src/generated/meerkat.rs",`,
+            `        "src/generated/mob.rs",`,
+            `    ],`,
+            `    visibility = ["//meerkat-machine-codegen:__pkg__"],`,
+            `)`,
+            "",
+          ]
+        : []),
       ...rules,
       "",
     ].join("\n\n"),

--- a/scripts/machine-authority-changed
+++ b/scripts/machine-authority-changed
@@ -90,13 +90,13 @@ machine_authority_path() {
     meerkat-machine-kernels/src/generated/*|meerkat-core/src/generated/*|meerkat-mob/src/generated/*|meerkat-runtime/src/generated/*|meerkat-schedule/src/generated/*|*/src/generated/protocol_*.rs)
       return 0
       ;;
-    xtask/Cargo.toml|xtask/BUILD.bazel|xtask/src/lib.rs|xtask/src/main.rs|xtask/src/machines*.rs|xtask/src/protocol_codegen.rs|xtask/src/audit_generated_headers.rs|xtask/src/public_contracts.rs)
+    xtask/Cargo.toml|xtask/BUILD.bazel|xtask/src/lib.rs|xtask/src/main.rs|xtask/src/machines*.rs|xtask/src/protocol_codegen.rs|xtask/src/audit_generated_headers.rs|xtask/src/public_contracts.rs|xtask/src/runtime_authority_bypass.rs)
       return 0
       ;;
     xtask/src/rmat_policy.rs|xtask/src/seam_inventory.rs|xtask/src/ownership_ledger.rs|xtask/src/rmat_audit.rs|xtask/rmat-baseline.toml|xtask/ownership-baseline.toml|docs-internal/archive/public-docs-removed-2026-05-11/architecture/finite-ownership-ledger.md)
       return 0
       ;;
-    xtask/tests/machine_verify_all_tlc_test.sh|xtask/tests/machines_contracts.rs|xtask/tests/protocol_codegen_drift.rs)
+    xtask/tests/machine_verify_all_tlc_test.sh|xtask/tests/machines_contracts.rs|xtask/tests/protocol_codegen_drift.rs|xtask/tests/runtime_authority_bypass.rs)
       return 0
       ;;
   esac

--- a/scripts/tests/xtask_scripts_dogma_gates.sh
+++ b/scripts/tests/xtask_scripts_dogma_gates.sh
@@ -118,13 +118,13 @@ done
 # ── #296: governance/spec changes route formal/governance checks ─────────────
 echo "#296 agent gates route governance/spec changes:"
 if grep -Fq 'is_governance_path' scripts/cargo-agent-gate \
-  && grep -Fq 'machine-check-drift seam-inventory rmat-audit' scripts/cargo-agent-gate; then
+  && grep -Fq 'machine-check-drift runtime-authority-bypass seam-inventory rmat-audit' scripts/cargo-agent-gate; then
   ok "cargo-agent-gate has governance allowlist + formal gate routing"
 else
   bad "cargo-agent-gate missing governance allowlist or formal gate routing"
 fi
 if grep -Fq 'is_governance_path' scripts/buildbuddy-agent-gate \
-  && grep -Fq 'machine-check-drift seam-inventory rmat-audit' scripts/buildbuddy-agent-gate; then
+  && grep -Fq 'machine-check-drift runtime-authority-bypass seam-inventory rmat-audit' scripts/buildbuddy-agent-gate; then
   ok "buildbuddy-agent-gate has governance allowlist + formal gate routing"
 else
   bad "buildbuddy-agent-gate missing governance allowlist or formal gate routing"
@@ -132,7 +132,7 @@ fi
 # Behavioral: a spec-only change is no longer reported as "no changes" and is
 # routed to the governance gate (dry-run avoids invoking cargo/make work).
 gate_out=$(scripts/cargo-agent-gate --dry-run -- specs/machines/example.tla 2>&1 || true)
-if printf '%s' "$gate_out" | grep -Fq 'machine-check-drift seam-inventory rmat-audit' \
+if printf '%s' "$gate_out" | grep -Fq 'machine-check-drift runtime-authority-bypass seam-inventory rmat-audit' \
   && ! printf '%s' "$gate_out" | grep -Fq 'no Rust build-relevant changes detected.'; then
   ok "cargo-agent-gate dry-run routes specs/machines change to governance gate"
 else

--- a/specs/machines/meerkat_machine/contract.md
+++ b/specs/machines/meerkat_machine/contract.md
@@ -137,6 +137,10 @@ _Generated from the Rust machine catalog. Do not edit by hand._
 - `next_admission_seq`: `u64`
 - `next_priority_admission_seq`: `u64`
 - `input_admission_seq`: `Map<String, u64>`
+- `input_runtime_boundary`: `Map<String, RecoveredRunApplyBoundary>`
+- `input_runtime_execution_kind`: `Map<String, RecoveredRuntimeExecutionKind>`
+- `input_runtime_peer_response_terminal_apply_intent`: `Map<String, RecoveredPeerResponseTerminalApplyIntent>`
+- `input_is_prompt`: `Map<String, Bool>`
 - `input_lane`: `Map<String, InputLane>`
 - `input_recovery_lanes`: `Map<String, InputLane>`
 - `admission_authorized_lanes`: `Map<String, InputLane>`
@@ -423,7 +427,8 @@ _Generated from the Rust machine catalog. Do not edit by hand._
 - `RunFailed`(run_id: RunId, runtime_apply_failure_cause: Option<RuntimeApplyFailureCause>, runtime_apply_failure_message: Option<String>, machine_terminal_failure_observed: Bool, terminal_failure_source: Option<RunFailureSourceKind>, error: String)
 - `RunCancelled`(run_id: RunId)
 - `RecoverAdmittedInput`(input_id: String, input_kind: RecoveredInputKind, runtime_boundary: RecoveredRunApplyBoundary, runtime_execution_kind: RecoveredRuntimeExecutionKind, runtime_peer_response_terminal_apply_intent: Option<RecoveredPeerResponseTerminalApplyIntent>, lane: InputLane)
-- `RecoverInputLifecycle`(input_id: String, phase: InputPhase, terminal_kind: Option<InputTerminalKind>, superseded_by: Option<String>, aggregate_id: Option<String>, abandon_reason: Option<InputAbandonReason>, abandon_attempt_count: u64, attempt_count: u64, run_id: Option<RunId>, boundary_sequence: Option<u64>, admission_sequence: Option<u64>, admission_sequence_recovery: Option<RecoveredInputNormalizationReasonKind>, recovery_lane: Option<InputLane>, lane: Option<InputLane>)
+- `RecoverInputLifecycle`(input_id: String, phase: InputPhase, terminal_kind: Option<InputTerminalKind>, superseded_by: Option<String>, aggregate_id: Option<String>, abandon_reason: Option<InputAbandonReason>, abandon_attempt_count: u64, attempt_count: u64, run_id: Option<RunId>, boundary_sequence: Option<u64>, admission_sequence: Option<u64>, admission_sequence_recovery: Option<RecoveredInputNormalizationReasonKind>, recovery_lane: Option<InputLane>, lane: Option<InputLane>, runtime_boundary: Option<RecoveredRunApplyBoundary>, runtime_execution_kind: Option<RecoveredRuntimeExecutionKind>, runtime_peer_response_terminal_apply_intent: Option<RecoveredPeerResponseTerminalApplyIntent>, is_prompt: Bool)
+- `BindAdmissionRuntimeGrouping`(input_id: String, runtime_boundary: RecoveredRunApplyBoundary, runtime_execution_kind: RecoveredRuntimeExecutionKind, runtime_peer_response_terminal_apply_intent: Option<RecoveredPeerResponseTerminalApplyIntent>, is_prompt: Bool)
 - `QueueAccepted`(input_id: String)
 - `SteerAccepted`(input_id: String)
 - `ChangeLane`(input_id: String, new_lane: InputLane)
@@ -759,6 +764,185 @@ _Generated from the Rust machine catalog. Do not edit by hand._
 - `meerkat_session_llm_visibility_shape_matches`(previous_visibility_state: SessionToolVisibilityState, next_visibility_state: SessionToolVisibilityState, previous_capability_base_filter: ToolFilter, next_capability_base_filter: ToolFilter, previous_active_visibility_revision: u64, previous_staged_visibility_revision: u64, next_active_visibility_revision: u64) -> `Bool`
 - `meerkat_session_llm_visibility_delta_matches`(tool_visibility_delta: SessionToolVisibilityDelta, previous_capability_base_filter: ToolFilter, next_capability_base_filter: ToolFilter, committed_visible_set_changed: Bool) -> `Bool`
 - `meerkat_session_llm_visibility_reconfigure_plan_matches`(previous_visibility_state: SessionToolVisibilityState, next_visibility_state: SessionToolVisibilityState, previous_capability_base_filter: ToolFilter, next_capability_base_filter: ToolFilter, view_image_tool_available: Bool, previous_view_image_visible: Bool, next_view_image_visible: Bool, previous_active_visibility_revision: u64, previous_staged_visibility_revision: u64, next_active_visibility_revision: u64, tool_visibility_delta: SessionToolVisibilityDelta) -> `Bool`
+
+## Command Plans
+### `AuthorizedAcceptedInputMaterialization`
+- Authority: `AuthorizedAcceptedInputMaterialization`
+- Source Inputs: `ResolveAdmissionPlan`, `QueueAccepted`, `SteerAccepted`
+- Transitions: `ResolveAdmissionPlanRequestedTerminalQueueIdle`, `ResolveAdmissionPlanRequestedTerminalQueueAttached`, `ResolveAdmissionPlanRequestedTerminalQueueRunning`, `ResolveAdmissionPlanRequestedTerminalSteerIdle`, `ResolveAdmissionPlanRequestedTerminalSteerAttached`, `ResolveAdmissionPlanRequestedTerminalSteerRunning`, `ResolveAdmissionPlanRequestedQueueIdle`, `ResolveAdmissionPlanRequestedQueueAttached`, `ResolveAdmissionPlanRequestedQueueRunning`, `ResolveAdmissionPlanRequestedSteerIdle`, `ResolveAdmissionPlanRequestedSteerAttached`, `ResolveAdmissionPlanRequestedSteerRunning`, `ResolveAdmissionPlanDefaultQueueKindIdle`, `ResolveAdmissionPlanDefaultQueueKindAttached`, `ResolveAdmissionPlanDefaultQueueKindRunning`, `ResolveAdmissionPlanDefaultPeerMessageOrRequestIdle`, `ResolveAdmissionPlanDefaultPeerMessageOrRequestAttached`, `ResolveAdmissionPlanDefaultPeerMessageOrRequestRunning`, `ResolveAdmissionPlanPeerResponseProgressIdle`, `ResolveAdmissionPlanPeerResponseProgressAttached`, `ResolveAdmissionPlanPeerResponseProgressRunning`, `ResolveAdmissionPlanDefaultPeerResponseTerminalIdle`, `ResolveAdmissionPlanDefaultPeerResponseTerminalAttached`, `ResolveAdmissionPlanDefaultPeerResponseTerminalRunning`, `ResolveAdmissionPlanDefaultContinuationIdle`, `ResolveAdmissionPlanDefaultContinuationAttached`, `ResolveAdmissionPlanDefaultContinuationRunning`, `ResolveAdmissionPlanWorkgraphAttentionContinuationIdle`, `ResolveAdmissionPlanWorkgraphAttentionContinuationAttached`, `ResolveAdmissionPlanWorkgraphAttentionContinuationRunning`, `ResolveAdmissionPlanOperationIdle`, `ResolveAdmissionPlanOperationAttached`, `ResolveAdmissionPlanOperationRunning`, `QueueAcceptedIdle`, `QueueAcceptedAttached`, `QueueAcceptedRunning`, `QueueAcceptedRetired`, `QueueAcceptedStopped`, `SteerAcceptedIdle`, `SteerAcceptedAttached`, `SteerAcceptedRunning`, `SteerAcceptedRetired`, `SteerAcceptedStopped`
+- Guard Expansion:
+  - `ResolveAdmissionPlanRequestedTerminalQueueIdle`: `runtime_running_matches_phase`, `terminal_queue_override`
+  - `ResolveAdmissionPlanRequestedTerminalQueueAttached`: `runtime_running_matches_phase`, `terminal_queue_override`
+  - `ResolveAdmissionPlanRequestedTerminalQueueRunning`: `runtime_running_matches_phase`, `terminal_queue_override`
+  - `ResolveAdmissionPlanRequestedTerminalSteerIdle`: `runtime_running_matches_phase`, `terminal_steer_override`
+  - `ResolveAdmissionPlanRequestedTerminalSteerAttached`: `runtime_running_matches_phase`, `terminal_steer_override`
+  - `ResolveAdmissionPlanRequestedTerminalSteerRunning`: `runtime_running_matches_phase`, `terminal_steer_override`
+  - `ResolveAdmissionPlanRequestedQueueIdle`: `runtime_running_matches_phase`, `queue_override`
+  - `ResolveAdmissionPlanRequestedQueueAttached`: `runtime_running_matches_phase`, `queue_override`
+  - `ResolveAdmissionPlanRequestedQueueRunning`: `runtime_running_matches_phase`, `queue_override`
+  - `ResolveAdmissionPlanRequestedSteerIdle`: `runtime_running_matches_phase`, `steer_override`
+  - `ResolveAdmissionPlanRequestedSteerAttached`: `runtime_running_matches_phase`, `steer_override`
+  - `ResolveAdmissionPlanRequestedSteerRunning`: `runtime_running_matches_phase`, `steer_override`
+  - `ResolveAdmissionPlanDefaultQueueKindIdle`: `runtime_running_matches_phase`, `default_queue_kind`
+  - `ResolveAdmissionPlanDefaultQueueKindAttached`: `runtime_running_matches_phase`, `default_queue_kind`
+  - `ResolveAdmissionPlanDefaultQueueKindRunning`: `runtime_running_matches_phase`, `default_queue_kind`
+  - `ResolveAdmissionPlanDefaultPeerMessageOrRequestIdle`: `runtime_running_matches_phase`, `default_peer_message_or_request`
+  - `ResolveAdmissionPlanDefaultPeerMessageOrRequestAttached`: `runtime_running_matches_phase`, `default_peer_message_or_request`
+  - `ResolveAdmissionPlanDefaultPeerMessageOrRequestRunning`: `runtime_running_matches_phase`, `default_peer_message_or_request`
+  - `ResolveAdmissionPlanPeerResponseProgressIdle`: `runtime_running_matches_phase`, `peer_response_progress`, `coalesce_target_tracked_if_present`
+  - `ResolveAdmissionPlanPeerResponseProgressAttached`: `runtime_running_matches_phase`, `peer_response_progress`, `coalesce_target_tracked_if_present`
+  - `ResolveAdmissionPlanPeerResponseProgressRunning`: `runtime_running_matches_phase`, `peer_response_progress`, `coalesce_target_tracked_if_present`
+  - `ResolveAdmissionPlanDefaultPeerResponseTerminalIdle`: `runtime_running_matches_phase`, `default_peer_response_terminal`
+  - `ResolveAdmissionPlanDefaultPeerResponseTerminalAttached`: `runtime_running_matches_phase`, `default_peer_response_terminal`
+  - `ResolveAdmissionPlanDefaultPeerResponseTerminalRunning`: `runtime_running_matches_phase`, `default_peer_response_terminal`
+  - `ResolveAdmissionPlanDefaultContinuationIdle`: `runtime_running_matches_phase`, `default_continuation`
+  - `ResolveAdmissionPlanDefaultContinuationAttached`: `runtime_running_matches_phase`, `default_continuation`
+  - `ResolveAdmissionPlanDefaultContinuationRunning`: `runtime_running_matches_phase`, `default_continuation`
+  - `ResolveAdmissionPlanWorkgraphAttentionContinuationIdle`: `runtime_running_matches_phase`, `workgraph_attention_continuation`
+  - `ResolveAdmissionPlanWorkgraphAttentionContinuationAttached`: `runtime_running_matches_phase`, `workgraph_attention_continuation`
+  - `ResolveAdmissionPlanWorkgraphAttentionContinuationRunning`: `runtime_running_matches_phase`, `workgraph_attention_continuation`
+  - `ResolveAdmissionPlanOperationIdle`: `runtime_running_matches_phase`, `operation`
+  - `ResolveAdmissionPlanOperationAttached`: `runtime_running_matches_phase`, `operation`
+  - `ResolveAdmissionPlanOperationRunning`: `runtime_running_matches_phase`, `operation`
+  - `QueueAcceptedIdle`: `not_already_tracked`, `live_admission_authorized_queue_lane`
+  - `QueueAcceptedAttached`: `not_already_tracked`, `live_admission_authorized_queue_lane`
+  - `QueueAcceptedRunning`: `not_already_tracked`, `live_admission_authorized_queue_lane`
+  - `QueueAcceptedRetired`: `not_already_tracked`, `live_admission_authorized_queue_lane`
+  - `QueueAcceptedStopped`: `not_already_tracked`, `live_admission_authorized_queue_lane`
+  - `SteerAcceptedIdle`: `not_already_tracked`, `live_admission_authorized_steer_lane`
+  - `SteerAcceptedAttached`: `not_already_tracked`, `live_admission_authorized_steer_lane`
+  - `SteerAcceptedRunning`: `not_already_tracked`, `live_admission_authorized_steer_lane`
+  - `SteerAcceptedRetired`: `not_already_tracked`, `live_admission_authorized_steer_lane`
+  - `SteerAcceptedStopped`: `not_already_tracked`, `live_admission_authorized_steer_lane`
+- Command Effects: `AdmissionResolved`, `IngressAccepted`, `PostAdmissionSignal`
+- Emitted By Transitions: `AdmissionResolved`, `IngressAccepted`
+
+### `AuthorizeRuntimeLoopBatch`
+- Authority: `AuthorizedRuntimeLoopBatch`
+- Source Inputs: `QueueAccepted`, `SteerAccepted`, `RecoverAdmittedInput`, `RecoverInputLifecycle`
+- Transitions: `QueueAcceptedIdle`, `QueueAcceptedAttached`, `QueueAcceptedRunning`, `QueueAcceptedRetired`, `QueueAcceptedStopped`, `SteerAcceptedIdle`, `SteerAcceptedAttached`, `SteerAcceptedRunning`, `SteerAcceptedRetired`, `SteerAcceptedStopped`, `RecoverInputLifecycleIdle`, `RecoverInputLifecycleAttached`, `RecoverInputLifecycleRunning`, `RecoverInputLifecycleRetired`, `RecoverInputLifecycleStopped`
+- Guard Expansion:
+  - `QueueAcceptedIdle`: `not_already_tracked`, `live_admission_authorized_queue_lane`
+  - `QueueAcceptedAttached`: `not_already_tracked`, `live_admission_authorized_queue_lane`
+  - `QueueAcceptedRunning`: `not_already_tracked`, `live_admission_authorized_queue_lane`
+  - `QueueAcceptedRetired`: `not_already_tracked`, `live_admission_authorized_queue_lane`
+  - `QueueAcceptedStopped`: `not_already_tracked`, `live_admission_authorized_queue_lane`
+  - `SteerAcceptedIdle`: `not_already_tracked`, `live_admission_authorized_steer_lane`
+  - `SteerAcceptedAttached`: `not_already_tracked`, `live_admission_authorized_steer_lane`
+  - `SteerAcceptedRunning`: `not_already_tracked`, `live_admission_authorized_steer_lane`
+  - `SteerAcceptedRetired`: `not_already_tracked`, `live_admission_authorized_steer_lane`
+  - `SteerAcceptedStopped`: `not_already_tracked`, `live_admission_authorized_steer_lane`
+  - `RecoverInputLifecycleIdle`: `recovered_lifecycle_has_admission_witness`, `recovered_recovery_lane_matches_witness`, `recovered_current_lane_matches_phase`, `recovered_queued_order_has_witness`, `recovered_order_recovery_matches_missing_sequence`, `recovered_grouping_matches_phase`, `recovered_terminal_payload_matches_phase`, `recovered_max_attempts_reason_matches_count`, `recovered_max_attempts_reason_matches_policy`
+  - `RecoverInputLifecycleAttached`: `recovered_lifecycle_has_admission_witness`, `recovered_recovery_lane_matches_witness`, `recovered_current_lane_matches_phase`, `recovered_queued_order_has_witness`, `recovered_order_recovery_matches_missing_sequence`, `recovered_grouping_matches_phase`, `recovered_terminal_payload_matches_phase`, `recovered_max_attempts_reason_matches_count`, `recovered_max_attempts_reason_matches_policy`
+  - `RecoverInputLifecycleRunning`: `recovered_lifecycle_has_admission_witness`, `recovered_recovery_lane_matches_witness`, `recovered_current_lane_matches_phase`, `recovered_queued_order_has_witness`, `recovered_order_recovery_matches_missing_sequence`, `recovered_grouping_matches_phase`, `recovered_terminal_payload_matches_phase`, `recovered_max_attempts_reason_matches_count`, `recovered_max_attempts_reason_matches_policy`
+  - `RecoverInputLifecycleRetired`: `recovered_lifecycle_has_admission_witness`, `recovered_recovery_lane_matches_witness`, `recovered_current_lane_matches_phase`, `recovered_queued_order_has_witness`, `recovered_order_recovery_matches_missing_sequence`, `recovered_grouping_matches_phase`, `recovered_terminal_payload_matches_phase`, `recovered_max_attempts_reason_matches_count`, `recovered_max_attempts_reason_matches_policy`
+  - `RecoverInputLifecycleStopped`: `recovered_lifecycle_has_admission_witness`, `recovered_recovery_lane_matches_witness`, `recovered_current_lane_matches_phase`, `recovered_queued_order_has_witness`, `recovered_order_recovery_matches_missing_sequence`, `recovered_grouping_matches_phase`, `recovered_terminal_payload_matches_phase`, `recovered_max_attempts_reason_matches_count`, `recovered_max_attempts_reason_matches_policy`
+- Command Effects: `IngressAccepted`
+- Emitted By Transitions: `IngressAccepted`, `InputLifecycleNotice`
+
+### `AuthorizedStageForRun`
+- Authority: `AuthorizedStageForRun`
+- Source Inputs: `StageForRun`
+- Transitions: `StageForRunIdle`, `StageForRunAttached`, `StageForRunRunning`, `StageForRunRetired`, `StageForRunStopped`
+- Guard Expansion:
+  - `StageForRunIdle`: `input_queued`, `input_lane_bound`, `input_sequence_bound`, `input_recovery_lane_bound`, `input_not_run_associated`, `current_run_matches`
+  - `StageForRunAttached`: `input_queued`, `input_lane_bound`, `input_sequence_bound`, `input_recovery_lane_bound`, `input_not_run_associated`, `current_run_matches`
+  - `StageForRunRunning`: `input_queued`, `input_lane_bound`, `input_sequence_bound`, `input_recovery_lane_bound`, `input_not_run_associated`, `current_run_matches`
+  - `StageForRunRetired`: `input_queued`, `input_lane_bound`, `input_sequence_bound`, `input_recovery_lane_bound`, `input_not_run_associated`, `current_run_matches`
+  - `StageForRunStopped`: `input_queued`, `input_lane_bound`, `input_sequence_bound`, `input_recovery_lane_bound`, `input_not_run_associated`, `current_run_matches`
+- Emitted By Transitions: `RecordRunAssociation`
+
+### `AuthorizedRuntimeLoopRunCommit`
+- Authority: `AuthorizedRuntimeLoopRunCommit`
+- Source Inputs: `RunCompleted`, `RunFailed`, `RunCancelled`, `Commit`, `Fail`, `CancelRun`, `RollbackRun`
+- Transitions: `RunCompleted`, `RunFailed`, `RunCancelled`, `CommitRunningToIdle`, `CommitRunningToAttached`, `CommitRunningToRetired`, `FailRunningToIdle`, `FailRunningToAttached`, `FailRunningToRetired`, `CancelRunningToIdle`, `CancelRunningToAttached`, `CancelRunningToRetired`, `RollbackRunRunningToIdle`, `RollbackRunRunningToAttached`, `RollbackRunRunningToRetired`
+- Guard Expansion:
+  - `RunCompleted`: `run_matches_binding`
+  - `RunFailed`: `run_matches_binding`, `runtime_apply_failure_not_machine_terminal_failure`, `machine_terminal_failure_not_raw_source`, `machine_terminal_failure_requires_existing_outcome`, `machine_terminal_failure_requires_existing_known_cause`, `machine_terminal_failure_existing_outcome_matches_cause`, `terminal_failure_source_known_if_present`
+  - `RunCancelled`: `run_matches_binding`
+  - `CommitRunningToIdle`: `pre_run_phase_matches_idle`, `current_run_id_matches_binding`
+  - `CommitRunningToAttached`: `pre_run_phase_matches_attached`, `current_run_id_matches_binding`
+  - `CommitRunningToRetired`: `pre_run_phase_matches_retired`, `current_run_id_matches_binding`
+  - `FailRunningToIdle`: `pre_run_phase_matches_idle`, `current_run_id_matches_binding`, `turn_failed_with_cause`
+  - `FailRunningToAttached`: `pre_run_phase_matches_attached`, `current_run_id_matches_binding`, `turn_failed_with_cause`
+  - `FailRunningToRetired`: `pre_run_phase_matches_retired`, `current_run_id_matches_binding`, `turn_failed_with_cause`
+  - `CancelRunningToIdle`: `pre_run_phase_matches_idle`, `current_run_id_matches_binding`, `turn_cancelled`
+  - `CancelRunningToAttached`: `pre_run_phase_matches_attached`, `current_run_id_matches_binding`, `turn_cancelled`
+  - `CancelRunningToRetired`: `pre_run_phase_matches_retired`, `current_run_id_matches_binding`, `turn_cancelled`
+  - `RollbackRunRunningToIdle`: `pre_run_phase_matches_idle`, `current_run_id_matches_binding`
+  - `RollbackRunRunningToAttached`: `pre_run_phase_matches_attached`, `current_run_id_matches_binding`
+  - `RollbackRunRunningToRetired`: `pre_run_phase_matches_retired`, `current_run_id_matches_binding`
+- Command Effects: `TurnRunCompleted`, `TurnRunFailed`, `TurnRunCancelled`
+- Effect Closure:
+  - `TurnRunCompleted` via `AuthorizedRuntimeLoopRunCommit` (RuntimeLoopRunCommitEffect) states: `Authorized`, `Attempted`, `Realized`, `Failed`, `Cancelled`, `Abandoned`
+  - `TurnRunFailed` via `AuthorizedRuntimeLoopRunCommit` (RuntimeLoopRunCommitEffect) states: `Authorized`, `Attempted`, `Realized`, `Failed`, `Cancelled`, `Abandoned`
+  - `TurnRunCancelled` via `AuthorizedRuntimeLoopRunCommit` (RuntimeLoopRunCommitEffect) states: `Authorized`, `Attempted`, `Realized`, `Failed`, `Cancelled`, `Abandoned`
+- Emitted By Transitions: `PostAdmissionSignal`, `RecordTerminalOutcome`, `TurnRunFailed`
+
+### `AuthorizedRuntimeCompletionResultClosure`
+- Authority: `RuntimeCompletionResultAuthority`
+- Source Inputs: `ResolveRuntimeCompletionResult`
+- Transitions: `ResolveRuntimeCompletionResultCompletedInitializing`, `ResolveRuntimeCompletionResultCompletedIdle`, `ResolveRuntimeCompletionResultCompletedAttached`, `ResolveRuntimeCompletionResultCompletedRunning`, `ResolveRuntimeCompletionResultCompletedRetired`, `ResolveRuntimeCompletionResultCompletedStopped`, `ResolveRuntimeCompletionResultWithoutResultInitializing`, `ResolveRuntimeCompletionResultWithoutResultIdle`, `ResolveRuntimeCompletionResultWithoutResultAttached`, `ResolveRuntimeCompletionResultWithoutResultRunning`, `ResolveRuntimeCompletionResultWithoutResultRetired`, `ResolveRuntimeCompletionResultWithoutResultStopped`, `ResolveRuntimeCompletionResultCallbackPendingInitializing`, `ResolveRuntimeCompletionResultCallbackPendingIdle`, `ResolveRuntimeCompletionResultCallbackPendingAttached`, `ResolveRuntimeCompletionResultCallbackPendingRunning`, `ResolveRuntimeCompletionResultCallbackPendingRetired`, `ResolveRuntimeCompletionResultCallbackPendingStopped`, `ResolveRuntimeCompletionResultCancelledInitializing`, `ResolveRuntimeCompletionResultCancelledIdle`, `ResolveRuntimeCompletionResultCancelledAttached`, `ResolveRuntimeCompletionResultCancelledRunning`, `ResolveRuntimeCompletionResultCancelledRetired`, `ResolveRuntimeCompletionResultCancelledStopped`, `ResolveRuntimeCompletionResultRuntimeApplyFailedInitializing`, `ResolveRuntimeCompletionResultRuntimeApplyFailedIdle`, `ResolveRuntimeCompletionResultRuntimeApplyFailedAttached`, `ResolveRuntimeCompletionResultRuntimeApplyFailedRunning`, `ResolveRuntimeCompletionResultRuntimeApplyFailedRetired`, `ResolveRuntimeCompletionResultRuntimeApplyFailedStopped`, `ResolveRuntimeCompletionResultMachineFailedInitializing`, `ResolveRuntimeCompletionResultMachineFailedIdle`, `ResolveRuntimeCompletionResultMachineFailedAttached`, `ResolveRuntimeCompletionResultMachineFailedRunning`, `ResolveRuntimeCompletionResultMachineFailedRetired`, `ResolveRuntimeCompletionResultMachineFailedStopped`, `ResolveRuntimeCompletionResultFinalizationFailureWithResultInitializing`, `ResolveRuntimeCompletionResultFinalizationFailureWithResultIdle`, `ResolveRuntimeCompletionResultFinalizationFailureWithResultAttached`, `ResolveRuntimeCompletionResultFinalizationFailureWithResultRunning`, `ResolveRuntimeCompletionResultFinalizationFailureWithResultRetired`, `ResolveRuntimeCompletionResultFinalizationFailureWithResultStopped`, `ResolveRuntimeCompletionResultFinalizationFailureWithoutResultInitializing`, `ResolveRuntimeCompletionResultFinalizationFailureWithoutResultIdle`, `ResolveRuntimeCompletionResultFinalizationFailureWithoutResultAttached`, `ResolveRuntimeCompletionResultFinalizationFailureWithoutResultRunning`, `ResolveRuntimeCompletionResultFinalizationFailureWithoutResultRetired`, `ResolveRuntimeCompletionResultFinalizationFailureWithoutResultStopped`, `ResolveRuntimeCompletionResultRuntimeTerminatedInitializing`, `ResolveRuntimeCompletionResultRuntimeTerminatedIdle`, `ResolveRuntimeCompletionResultRuntimeTerminatedAttached`, `ResolveRuntimeCompletionResultRuntimeTerminatedRunning`, `ResolveRuntimeCompletionResultRuntimeTerminatedRetired`, `ResolveRuntimeCompletionResultRuntimeTerminatedStopped`, `ResolveRuntimeCompletionResultRuntimeTerminatedDestroyedDestroyed`
+- Guard Expansion:
+  - `ResolveRuntimeCompletionResultCompletedInitializing`: `session_registered`, `run_correlated`, `finalization_succeeded`, `terminal_run_result`
+  - `ResolveRuntimeCompletionResultCompletedIdle`: `session_registered`, `run_correlated`, `finalization_succeeded`, `terminal_run_result`
+  - `ResolveRuntimeCompletionResultCompletedAttached`: `session_registered`, `run_correlated`, `finalization_succeeded`, `terminal_run_result`
+  - `ResolveRuntimeCompletionResultCompletedRunning`: `session_registered`, `run_correlated`, `finalization_succeeded`, `terminal_run_result`
+  - `ResolveRuntimeCompletionResultCompletedRetired`: `session_registered`, `run_correlated`, `finalization_succeeded`, `terminal_run_result`
+  - `ResolveRuntimeCompletionResultCompletedStopped`: `session_registered`, `run_correlated`, `finalization_succeeded`, `terminal_run_result`
+  - `ResolveRuntimeCompletionResultWithoutResultInitializing`: `session_registered`, `run_correlated`, `finalization_succeeded`, `terminal_no_result`
+  - `ResolveRuntimeCompletionResultWithoutResultIdle`: `session_registered`, `run_correlated`, `finalization_succeeded`, `terminal_no_result`
+  - `ResolveRuntimeCompletionResultWithoutResultAttached`: `session_registered`, `run_correlated`, `finalization_succeeded`, `terminal_no_result`
+  - `ResolveRuntimeCompletionResultWithoutResultRunning`: `session_registered`, `run_correlated`, `finalization_succeeded`, `terminal_no_result`
+  - `ResolveRuntimeCompletionResultWithoutResultRetired`: `session_registered`, `run_correlated`, `finalization_succeeded`, `terminal_no_result`
+  - `ResolveRuntimeCompletionResultWithoutResultStopped`: `session_registered`, `run_correlated`, `finalization_succeeded`, `terminal_no_result`
+  - `ResolveRuntimeCompletionResultCallbackPendingInitializing`: `session_registered`, `run_correlated`, `finalization_succeeded`, `terminal_callback_pending`
+  - `ResolveRuntimeCompletionResultCallbackPendingIdle`: `session_registered`, `run_correlated`, `finalization_succeeded`, `terminal_callback_pending`
+  - `ResolveRuntimeCompletionResultCallbackPendingAttached`: `session_registered`, `run_correlated`, `finalization_succeeded`, `terminal_callback_pending`
+  - `ResolveRuntimeCompletionResultCallbackPendingRunning`: `session_registered`, `run_correlated`, `finalization_succeeded`, `terminal_callback_pending`
+  - `ResolveRuntimeCompletionResultCallbackPendingRetired`: `session_registered`, `run_correlated`, `finalization_succeeded`, `terminal_callback_pending`
+  - `ResolveRuntimeCompletionResultCallbackPendingStopped`: `session_registered`, `run_correlated`, `finalization_succeeded`, `terminal_callback_pending`
+  - `ResolveRuntimeCompletionResultCancelledInitializing`: `session_registered`, `run_correlated`, `finalization_succeeded`, `terminal_machine`, `machine_cancelled`
+  - `ResolveRuntimeCompletionResultCancelledIdle`: `session_registered`, `run_correlated`, `finalization_succeeded`, `terminal_machine`, `machine_cancelled`
+  - `ResolveRuntimeCompletionResultCancelledAttached`: `session_registered`, `run_correlated`, `finalization_succeeded`, `terminal_machine`, `machine_cancelled`
+  - `ResolveRuntimeCompletionResultCancelledRunning`: `session_registered`, `run_correlated`, `finalization_succeeded`, `terminal_machine`, `machine_cancelled`
+  - `ResolveRuntimeCompletionResultCancelledRetired`: `session_registered`, `run_correlated`, `finalization_succeeded`, `terminal_machine`, `machine_cancelled`
+  - `ResolveRuntimeCompletionResultCancelledStopped`: `session_registered`, `run_correlated`, `finalization_succeeded`, `terminal_machine`, `machine_cancelled`
+  - `ResolveRuntimeCompletionResultRuntimeApplyFailedInitializing`: `session_registered`, `run_correlated`, `finalization_succeeded`, `terminal_machine`, `machine_failed`, `machine_failure_cause_known`, `machine_runtime_apply_failed`
+  - `ResolveRuntimeCompletionResultRuntimeApplyFailedIdle`: `session_registered`, `run_correlated`, `finalization_succeeded`, `terminal_machine`, `machine_failed`, `machine_failure_cause_known`, `machine_runtime_apply_failed`
+  - `ResolveRuntimeCompletionResultRuntimeApplyFailedAttached`: `session_registered`, `run_correlated`, `finalization_succeeded`, `terminal_machine`, `machine_failed`, `machine_failure_cause_known`, `machine_runtime_apply_failed`
+  - `ResolveRuntimeCompletionResultRuntimeApplyFailedRunning`: `session_registered`, `run_correlated`, `finalization_succeeded`, `terminal_machine`, `machine_failed`, `machine_failure_cause_known`, `machine_runtime_apply_failed`
+  - `ResolveRuntimeCompletionResultRuntimeApplyFailedRetired`: `session_registered`, `run_correlated`, `finalization_succeeded`, `terminal_machine`, `machine_failed`, `machine_failure_cause_known`, `machine_runtime_apply_failed`
+  - `ResolveRuntimeCompletionResultRuntimeApplyFailedStopped`: `session_registered`, `run_correlated`, `finalization_succeeded`, `terminal_machine`, `machine_failed`, `machine_failure_cause_known`, `machine_runtime_apply_failed`
+  - `ResolveRuntimeCompletionResultMachineFailedInitializing`: `session_registered`, `run_correlated`, `finalization_succeeded`, `terminal_machine`, `machine_failed`, `machine_failure_cause_known`, `machine_not_runtime_apply_failed`
+  - `ResolveRuntimeCompletionResultMachineFailedIdle`: `session_registered`, `run_correlated`, `finalization_succeeded`, `terminal_machine`, `machine_failed`, `machine_failure_cause_known`, `machine_not_runtime_apply_failed`
+  - `ResolveRuntimeCompletionResultMachineFailedAttached`: `session_registered`, `run_correlated`, `finalization_succeeded`, `terminal_machine`, `machine_failed`, `machine_failure_cause_known`, `machine_not_runtime_apply_failed`
+  - `ResolveRuntimeCompletionResultMachineFailedRunning`: `session_registered`, `run_correlated`, `finalization_succeeded`, `terminal_machine`, `machine_failed`, `machine_failure_cause_known`, `machine_not_runtime_apply_failed`
+  - `ResolveRuntimeCompletionResultMachineFailedRetired`: `session_registered`, `run_correlated`, `finalization_succeeded`, `terminal_machine`, `machine_failed`, `machine_failure_cause_known`, `machine_not_runtime_apply_failed`
+  - `ResolveRuntimeCompletionResultMachineFailedStopped`: `session_registered`, `run_correlated`, `finalization_succeeded`, `terminal_machine`, `machine_failed`, `machine_failure_cause_known`, `machine_not_runtime_apply_failed`
+  - `ResolveRuntimeCompletionResultFinalizationFailureWithResultInitializing`: `session_registered`, `run_correlated`, `finalization_failed`, `terminal_run_result`
+  - `ResolveRuntimeCompletionResultFinalizationFailureWithResultIdle`: `session_registered`, `run_correlated`, `finalization_failed`, `terminal_run_result`
+  - `ResolveRuntimeCompletionResultFinalizationFailureWithResultAttached`: `session_registered`, `run_correlated`, `finalization_failed`, `terminal_run_result`
+  - `ResolveRuntimeCompletionResultFinalizationFailureWithResultRunning`: `session_registered`, `run_correlated`, `finalization_failed`, `terminal_run_result`
+  - `ResolveRuntimeCompletionResultFinalizationFailureWithResultRetired`: `session_registered`, `run_correlated`, `finalization_failed`, `terminal_run_result`
+  - `ResolveRuntimeCompletionResultFinalizationFailureWithResultStopped`: `session_registered`, `run_correlated`, `finalization_failed`, `terminal_run_result`
+  - `ResolveRuntimeCompletionResultFinalizationFailureWithoutResultInitializing`: `session_registered`, `run_correlated`, `finalization_failed`, `terminal_without_result`
+  - `ResolveRuntimeCompletionResultFinalizationFailureWithoutResultIdle`: `session_registered`, `run_correlated`, `finalization_failed`, `terminal_without_result`
+  - `ResolveRuntimeCompletionResultFinalizationFailureWithoutResultAttached`: `session_registered`, `run_correlated`, `finalization_failed`, `terminal_without_result`
+  - `ResolveRuntimeCompletionResultFinalizationFailureWithoutResultRunning`: `session_registered`, `run_correlated`, `finalization_failed`, `terminal_without_result`
+  - `ResolveRuntimeCompletionResultFinalizationFailureWithoutResultRetired`: `session_registered`, `run_correlated`, `finalization_failed`, `terminal_without_result`
+  - `ResolveRuntimeCompletionResultFinalizationFailureWithoutResultStopped`: `session_registered`, `run_correlated`, `finalization_failed`, `terminal_without_result`
+  - `ResolveRuntimeCompletionResultRuntimeTerminatedInitializing`: `session_registered`, `no_run_result`, `finalization_succeeded`, `terminal_runtime_terminated`
+  - `ResolveRuntimeCompletionResultRuntimeTerminatedIdle`: `session_registered`, `no_run_result`, `finalization_succeeded`, `terminal_runtime_terminated`
+  - `ResolveRuntimeCompletionResultRuntimeTerminatedAttached`: `session_registered`, `no_run_result`, `finalization_succeeded`, `terminal_runtime_terminated`
+  - `ResolveRuntimeCompletionResultRuntimeTerminatedRunning`: `session_registered`, `no_run_result`, `finalization_succeeded`, `terminal_runtime_terminated`
+  - `ResolveRuntimeCompletionResultRuntimeTerminatedRetired`: `session_registered`, `no_run_result`, `finalization_succeeded`, `terminal_runtime_terminated`
+  - `ResolveRuntimeCompletionResultRuntimeTerminatedStopped`: `session_registered`, `no_run_result`, `finalization_succeeded`, `terminal_runtime_terminated`
+  - `ResolveRuntimeCompletionResultRuntimeTerminatedDestroyedDestroyed`: `session_registered`, `no_run_result`, `finalization_succeeded`, `terminal_runtime_terminated`
+- Command Effects: `RuntimeCompletionResultResolved`
+- Effect Closure:
+  - `RuntimeCompletionResultResolved` via `RuntimeCompletionResultAuthority` (LocalSurfaceResultAlignment) states: `Authorized`, `Attempted`, `Realized`, `Failed`, `Cancelled`, `Abandoned`
+- Emitted By Transitions: `RuntimeCompletionResultResolved`
 
 ## Invariants
 - `fence_requires_bound_runtime`
@@ -8643,6 +8827,46 @@ _Generated from the Rust machine catalog. Do not edit by hand._
 - Emits: `InitiateRecycle`
 - To: `Attached`
 
+### `BindAdmissionRuntimeGroupingIdle`
+- From: `Idle`
+- On: `BindAdmissionRuntimeGrouping`(input_id, runtime_boundary, runtime_execution_kind, runtime_peer_response_terminal_apply_intent, is_prompt)
+- Guards:
+  - `recovered_lifecycle_authorized`
+  - `grouping_not_bound`
+- To: `Idle`
+
+### `BindAdmissionRuntimeGroupingAttached`
+- From: `Attached`
+- On: `BindAdmissionRuntimeGrouping`(input_id, runtime_boundary, runtime_execution_kind, runtime_peer_response_terminal_apply_intent, is_prompt)
+- Guards:
+  - `recovered_lifecycle_authorized`
+  - `grouping_not_bound`
+- To: `Attached`
+
+### `BindAdmissionRuntimeGroupingRunning`
+- From: `Running`
+- On: `BindAdmissionRuntimeGrouping`(input_id, runtime_boundary, runtime_execution_kind, runtime_peer_response_terminal_apply_intent, is_prompt)
+- Guards:
+  - `recovered_lifecycle_authorized`
+  - `grouping_not_bound`
+- To: `Running`
+
+### `BindAdmissionRuntimeGroupingRetired`
+- From: `Retired`
+- On: `BindAdmissionRuntimeGrouping`(input_id, runtime_boundary, runtime_execution_kind, runtime_peer_response_terminal_apply_intent, is_prompt)
+- Guards:
+  - `recovered_lifecycle_authorized`
+  - `grouping_not_bound`
+- To: `Retired`
+
+### `BindAdmissionRuntimeGroupingStopped`
+- From: `Stopped`
+- On: `BindAdmissionRuntimeGrouping`(input_id, runtime_boundary, runtime_execution_kind, runtime_peer_response_terminal_apply_intent, is_prompt)
+- Guards:
+  - `recovered_lifecycle_authorized`
+  - `grouping_not_bound`
+- To: `Stopped`
+
 ### `RecoverAdmittedInputIdle`
 - From: `Idle`
 - On: `RecoverAdmittedInput`(input_id, input_kind, runtime_boundary, runtime_execution_kind, runtime_peer_response_terminal_apply_intent, lane)
@@ -8690,13 +8914,14 @@ _Generated from the Rust machine catalog. Do not edit by hand._
 
 ### `RecoverInputLifecycleIdle`
 - From: `Idle`
-- On: `RecoverInputLifecycle`(input_id, phase, terminal_kind, superseded_by, aggregate_id, abandon_reason, abandon_attempt_count, attempt_count, run_id, boundary_sequence, admission_sequence, admission_sequence_recovery, recovery_lane, lane)
+- On: `RecoverInputLifecycle`(input_id, phase, terminal_kind, superseded_by, aggregate_id, abandon_reason, abandon_attempt_count, attempt_count, run_id, boundary_sequence, admission_sequence, admission_sequence_recovery, recovery_lane, lane, runtime_boundary, runtime_execution_kind, runtime_peer_response_terminal_apply_intent, is_prompt)
 - Guards:
   - `recovered_lifecycle_has_admission_witness`
   - `recovered_recovery_lane_matches_witness`
   - `recovered_current_lane_matches_phase`
   - `recovered_queued_order_has_witness`
   - `recovered_order_recovery_matches_missing_sequence`
+  - `recovered_grouping_matches_phase`
   - `recovered_terminal_payload_matches_phase`
   - `recovered_max_attempts_reason_matches_count`
   - `recovered_max_attempts_reason_matches_policy`
@@ -8705,13 +8930,14 @@ _Generated from the Rust machine catalog. Do not edit by hand._
 
 ### `RecoverInputLifecycleAttached`
 - From: `Attached`
-- On: `RecoverInputLifecycle`(input_id, phase, terminal_kind, superseded_by, aggregate_id, abandon_reason, abandon_attempt_count, attempt_count, run_id, boundary_sequence, admission_sequence, admission_sequence_recovery, recovery_lane, lane)
+- On: `RecoverInputLifecycle`(input_id, phase, terminal_kind, superseded_by, aggregate_id, abandon_reason, abandon_attempt_count, attempt_count, run_id, boundary_sequence, admission_sequence, admission_sequence_recovery, recovery_lane, lane, runtime_boundary, runtime_execution_kind, runtime_peer_response_terminal_apply_intent, is_prompt)
 - Guards:
   - `recovered_lifecycle_has_admission_witness`
   - `recovered_recovery_lane_matches_witness`
   - `recovered_current_lane_matches_phase`
   - `recovered_queued_order_has_witness`
   - `recovered_order_recovery_matches_missing_sequence`
+  - `recovered_grouping_matches_phase`
   - `recovered_terminal_payload_matches_phase`
   - `recovered_max_attempts_reason_matches_count`
   - `recovered_max_attempts_reason_matches_policy`
@@ -8720,13 +8946,14 @@ _Generated from the Rust machine catalog. Do not edit by hand._
 
 ### `RecoverInputLifecycleRunning`
 - From: `Running`
-- On: `RecoverInputLifecycle`(input_id, phase, terminal_kind, superseded_by, aggregate_id, abandon_reason, abandon_attempt_count, attempt_count, run_id, boundary_sequence, admission_sequence, admission_sequence_recovery, recovery_lane, lane)
+- On: `RecoverInputLifecycle`(input_id, phase, terminal_kind, superseded_by, aggregate_id, abandon_reason, abandon_attempt_count, attempt_count, run_id, boundary_sequence, admission_sequence, admission_sequence_recovery, recovery_lane, lane, runtime_boundary, runtime_execution_kind, runtime_peer_response_terminal_apply_intent, is_prompt)
 - Guards:
   - `recovered_lifecycle_has_admission_witness`
   - `recovered_recovery_lane_matches_witness`
   - `recovered_current_lane_matches_phase`
   - `recovered_queued_order_has_witness`
   - `recovered_order_recovery_matches_missing_sequence`
+  - `recovered_grouping_matches_phase`
   - `recovered_terminal_payload_matches_phase`
   - `recovered_max_attempts_reason_matches_count`
   - `recovered_max_attempts_reason_matches_policy`
@@ -8735,13 +8962,14 @@ _Generated from the Rust machine catalog. Do not edit by hand._
 
 ### `RecoverInputLifecycleRetired`
 - From: `Retired`
-- On: `RecoverInputLifecycle`(input_id, phase, terminal_kind, superseded_by, aggregate_id, abandon_reason, abandon_attempt_count, attempt_count, run_id, boundary_sequence, admission_sequence, admission_sequence_recovery, recovery_lane, lane)
+- On: `RecoverInputLifecycle`(input_id, phase, terminal_kind, superseded_by, aggregate_id, abandon_reason, abandon_attempt_count, attempt_count, run_id, boundary_sequence, admission_sequence, admission_sequence_recovery, recovery_lane, lane, runtime_boundary, runtime_execution_kind, runtime_peer_response_terminal_apply_intent, is_prompt)
 - Guards:
   - `recovered_lifecycle_has_admission_witness`
   - `recovered_recovery_lane_matches_witness`
   - `recovered_current_lane_matches_phase`
   - `recovered_queued_order_has_witness`
   - `recovered_order_recovery_matches_missing_sequence`
+  - `recovered_grouping_matches_phase`
   - `recovered_terminal_payload_matches_phase`
   - `recovered_max_attempts_reason_matches_count`
   - `recovered_max_attempts_reason_matches_policy`
@@ -8750,13 +8978,14 @@ _Generated from the Rust machine catalog. Do not edit by hand._
 
 ### `RecoverInputLifecycleStopped`
 - From: `Stopped`
-- On: `RecoverInputLifecycle`(input_id, phase, terminal_kind, superseded_by, aggregate_id, abandon_reason, abandon_attempt_count, attempt_count, run_id, boundary_sequence, admission_sequence, admission_sequence_recovery, recovery_lane, lane)
+- On: `RecoverInputLifecycle`(input_id, phase, terminal_kind, superseded_by, aggregate_id, abandon_reason, abandon_attempt_count, attempt_count, run_id, boundary_sequence, admission_sequence, admission_sequence_recovery, recovery_lane, lane, runtime_boundary, runtime_execution_kind, runtime_peer_response_terminal_apply_intent, is_prompt)
 - Guards:
   - `recovered_lifecycle_has_admission_witness`
   - `recovered_recovery_lane_matches_witness`
   - `recovered_current_lane_matches_phase`
   - `recovered_queued_order_has_witness`
   - `recovered_order_recovery_matches_missing_sequence`
+  - `recovered_grouping_matches_phase`
   - `recovered_terminal_payload_matches_phase`
   - `recovered_max_attempts_reason_matches_count`
   - `recovered_max_attempts_reason_matches_policy`

--- a/specs/machines/meerkat_machine/mapping.md
+++ b/specs/machines/meerkat_machine/mapping.md
@@ -2531,6 +2531,21 @@ This section is generated from the Rust machine catalog. Do not edit it by hand.
 - `RecycleFromAttached`
   - anchors: (unclaimed)
   - scenarios: (unclaimed)
+- `BindAdmissionRuntimeGroupingIdle`
+  - anchors: (unclaimed)
+  - scenarios: (unclaimed)
+- `BindAdmissionRuntimeGroupingAttached`
+  - anchors: (unclaimed)
+  - scenarios: (unclaimed)
+- `BindAdmissionRuntimeGroupingRunning`
+  - anchors: (unclaimed)
+  - scenarios: (unclaimed)
+- `BindAdmissionRuntimeGroupingRetired`
+  - anchors: (unclaimed)
+  - scenarios: (unclaimed)
+- `BindAdmissionRuntimeGroupingStopped`
+  - anchors: (unclaimed)
+  - scenarios: (unclaimed)
 - `RecoverAdmittedInputIdle`
   - anchors: (unclaimed)
   - scenarios: (unclaimed)

--- a/specs/machines/mob_machine/contract.md
+++ b/specs/machines/mob_machine/contract.md
@@ -508,6 +508,94 @@ _Generated from the Rust machine catalog. Do not edit by hand._
 - `AdaptiveBodyEvidenceMissing`(adaptive_run_id: AdaptiveRunId, missing_digest: String)
 - `AdaptiveRunTerminalized`(adaptive_run_id: AdaptiveRunId, reason: AdaptiveStopReason)
 
+## Command Plans
+### `AuthorizedMobSpawnStart`
+- Authority: `PendingSpawnOperationOwnerAuthorized`
+- Source Inputs: `CancelPendingSpawn`
+- Source Signals: `StageSpawn`, `CompleteSpawn`
+- Transitions: `StageSpawnRunning`, `CompleteSpawnRunning`, `CompleteSpawnLateArrivalRunning`, `CompleteSpawnLateArrivalStopped`, `CompleteSpawnLateArrivalCompleted`, `CompleteSpawnDestroyed`, `CancelPendingSpawnPresentRunning`, `CancelPendingSpawnPresentStopped`, `CancelPendingSpawnPresentCompleted`, `CancelPendingSpawnAbsentRunning`, `CancelPendingSpawnAbsentStopped`, `CancelPendingSpawnAbsentCompleted`, `CancelPendingSpawnDestroyed`
+- Guard Expansion:
+  - `StageSpawnRunning`: `pending_identity_unused`
+  - `CompleteSpawnRunning`: `pending_spawns_present`, `pending_identity_present`
+  - `CompleteSpawnLateArrivalRunning`: `pending_identity_absent`
+  - `CompleteSpawnLateArrivalStopped`: `pending_identity_absent`
+  - `CompleteSpawnLateArrivalCompleted`: `pending_identity_absent`
+  - `CompleteSpawnDestroyed`: `<none>`
+  - `CancelPendingSpawnPresentRunning`: `pending_spawns_present`, `pending_identity_present`
+  - `CancelPendingSpawnPresentStopped`: `pending_spawns_present`, `pending_identity_present`
+  - `CancelPendingSpawnPresentCompleted`: `pending_spawns_present`, `pending_identity_present`
+  - `CancelPendingSpawnAbsentRunning`: `pending_identity_absent`
+  - `CancelPendingSpawnAbsentStopped`: `pending_identity_absent`
+  - `CancelPendingSpawnAbsentCompleted`: `pending_identity_absent`
+  - `CancelPendingSpawnDestroyed`: `<none>`
+- Command Effects: `PendingSpawnOperationOwnerAuthorized`, `ExposePendingSpawn`, `EmitMemberLifecycleNotice`
+- Effect Closure:
+  - `PendingSpawnOperationOwnerAuthorized` via `PendingSpawnOperationOwnerAuthorized` (LocalPendingSpawnOwner) states: `Authorized`, `Attempted`, `Realized`, `Failed`, `Cancelled`, `Abandoned`
+  - `EmitMemberLifecycleNotice` via `CompleteSpawn` (LocalSpawnCompletion) states: `Authorized`, `Attempted`, `Realized`, `Failed`, `Cancelled`, `Abandoned`
+- Emitted By Transitions: `EmitMemberLifecycleNotice`, `ExposePendingSpawn`, `PendingSpawnOperationOwnerAuthorized`
+
+### `CanStartSpawn`
+- Authority: `CanStartSpawn`
+- Source Signals: `StageSpawn`
+- Transitions: `StageSpawnRunning`
+- Guard Expansion:
+  - `StageSpawnRunning`: `pending_identity_unused`
+- Command Effects: `PendingSpawnOperationOwnerAuthorized`
+- Effect Closure:
+  - `PendingSpawnOperationOwnerAuthorized` via `CanStartSpawn` (LocalPendingSpawnOwner) states: `Authorized`, `Attempted`, `Realized`, `Failed`, `Cancelled`, `Abandoned`
+- Emitted By Transitions: `ExposePendingSpawn`, `PendingSpawnOperationOwnerAuthorized`
+
+### `SpawnStarted`
+- Authority: `SpawnStarted`
+- Source Signals: `StageSpawn`
+- Transitions: `StageSpawnRunning`
+- Guard Expansion:
+  - `StageSpawnRunning`: `pending_identity_unused`
+- Command Effects: `ExposePendingSpawn`
+- Effect Closure:
+  - `ExposePendingSpawn` via `SpawnStarted` (LocalSpawnStarted) states: `Authorized`, `Attempted`, `Realized`, `Failed`, `Cancelled`, `Abandoned`
+- Emitted By Transitions: `ExposePendingSpawn`, `PendingSpawnOperationOwnerAuthorized`
+
+### `SpawnEffect`
+- Authority: `SpawnEffect`
+- Source Inputs: `CancelPendingSpawn`
+- Source Signals: `CompleteSpawn`
+- Transitions: `StageSpawnRunning`, `CompleteSpawnRunning`, `CompleteSpawnLateArrivalRunning`, `CompleteSpawnLateArrivalStopped`, `CompleteSpawnLateArrivalCompleted`, `CompleteSpawnDestroyed`, `CancelPendingSpawnPresentRunning`, `CancelPendingSpawnPresentStopped`, `CancelPendingSpawnPresentCompleted`, `CancelPendingSpawnAbsentRunning`, `CancelPendingSpawnAbsentStopped`, `CancelPendingSpawnAbsentCompleted`, `CancelPendingSpawnDestroyed`
+- Guard Expansion:
+  - `StageSpawnRunning`: `pending_identity_unused`
+  - `CompleteSpawnRunning`: `pending_spawns_present`, `pending_identity_present`
+  - `CompleteSpawnLateArrivalRunning`: `pending_identity_absent`
+  - `CompleteSpawnLateArrivalStopped`: `pending_identity_absent`
+  - `CompleteSpawnLateArrivalCompleted`: `pending_identity_absent`
+  - `CompleteSpawnDestroyed`: `<none>`
+  - `CancelPendingSpawnPresentRunning`: `pending_spawns_present`, `pending_identity_present`
+  - `CancelPendingSpawnPresentStopped`: `pending_spawns_present`, `pending_identity_present`
+  - `CancelPendingSpawnPresentCompleted`: `pending_spawns_present`, `pending_identity_present`
+  - `CancelPendingSpawnAbsentRunning`: `pending_identity_absent`
+  - `CancelPendingSpawnAbsentStopped`: `pending_identity_absent`
+  - `CancelPendingSpawnAbsentCompleted`: `pending_identity_absent`
+  - `CancelPendingSpawnDestroyed`: `<none>`
+- Command Effects: `EmitMemberLifecycleNotice`
+- Effect Closure:
+  - `EmitMemberLifecycleNotice` via `SpawnEffect` (LocalSpawnCompletion) states: `Authorized`, `Attempted`, `Realized`, `Failed`, `Cancelled`, `Abandoned`
+- Emitted By Transitions: `EmitMemberLifecycleNotice`, `ExposePendingSpawn`, `PendingSpawnOperationOwnerAuthorized`
+
+### `FailSpawn`
+- Authority: `FailSpawn`
+- Source Inputs: `CancelPendingSpawn`
+- Transitions: `CancelPendingSpawnPresentRunning`, `CancelPendingSpawnPresentStopped`, `CancelPendingSpawnPresentCompleted`, `CancelPendingSpawnAbsentRunning`, `CancelPendingSpawnAbsentStopped`, `CancelPendingSpawnAbsentCompleted`, `CancelPendingSpawnDestroyed`
+- Guard Expansion:
+  - `CancelPendingSpawnPresentRunning`: `pending_spawns_present`, `pending_identity_present`
+  - `CancelPendingSpawnPresentStopped`: `pending_spawns_present`, `pending_identity_present`
+  - `CancelPendingSpawnPresentCompleted`: `pending_spawns_present`, `pending_identity_present`
+  - `CancelPendingSpawnAbsentRunning`: `pending_identity_absent`
+  - `CancelPendingSpawnAbsentStopped`: `pending_identity_absent`
+  - `CancelPendingSpawnAbsentCompleted`: `pending_identity_absent`
+  - `CancelPendingSpawnDestroyed`: `<none>`
+- Command Effects: `EmitMemberLifecycleNotice`
+- Effect Closure:
+  - `EmitMemberLifecycleNotice` via `FailSpawn` (LocalSpawnFailure) states: `Authorized`, `Attempted`, `Realized`, `Failed`, `Cancelled`, `Abandoned`
+
 ## Invariants
 - `bindings_require_known_identity`
 - `identity_runtime_material_matches_runtime_binding`

--- a/xtask/BUILD.bazel
+++ b/xtask/BUILD.bazel
@@ -771,6 +771,68 @@ rust_test(
 )
 
 rust_test(
+    name = "runtime_authority_bypass_test",
+    aliases = aliases(
+        package_name = "xtask",
+        normal = True,
+        normal_dev = True,
+        proc_macro = True,
+        proc_macro_dev = True,
+    ),
+    crate_name = "runtime_authority_bypass",
+    crate_root = "tests/runtime_authority_bypass.rs",
+    crate_features = [
+        "machine-authority",
+    ],
+    edition = "2024",
+    compile_data = [
+        "Cargo.toml",
+    ],
+    srcs = [
+        "tests/runtime_authority_bypass.rs",
+    ],
+    visibility = ["//visibility:public"],
+    rustc_env = {
+        "CARGO_PKG_VERSION": "0.7.5",
+        "CARGO_BIN_NAME": "runtime_authority_bypass",
+        "CARGO_MANIFEST_DIR": "./xtask",
+    },
+    tags = [
+        "fast",
+    ],
+    size = "small",
+    data = [
+        "//meerkat-runtime:package_runfiles",
+        "tests/rustfmt_host.sh",
+        "@@rules_rust++rust+rustfmt_nightly-2026-04-16__aarch64-apple-darwin_tools//:rustfmt_bin",
+        "@@rules_rust++rust+rustfmt_nightly-2026-04-16__aarch64-apple-darwin_tools//:rustc_lib",
+        "@@rules_rust++rust+rustfmt_nightly-2026-04-16__x86_64-unknown-linux-gnu_tools//:rustfmt_bin",
+        "@@rules_rust++rust+rustfmt_nightly-2026-04-16__x86_64-unknown-linux-gnu_tools//:rustc_lib",
+    ],
+    env = {
+        "RUST_MIN_STACK": "16777216",
+        "RUSTFMT": "$(rootpath tests/rustfmt_host.sh)",
+        "RUSTFMT_DARWIN": "$(rootpath @@rules_rust++rust+rustfmt_nightly-2026-04-16__aarch64-apple-darwin_tools//:rustfmt_bin)",
+        "RUSTFMT_LINUX": "$(rootpath @@rules_rust++rust+rustfmt_nightly-2026-04-16__x86_64-unknown-linux-gnu_tools//:rustfmt_bin)",
+    },
+    proc_macro_deps = all_crate_deps(
+        package_name = "xtask",
+        proc_macro = True,
+        proc_macro_dev = True,
+    ),
+    deps = [
+        "//meerkat-machine-codegen:meerkat_machine_codegen",
+        "//meerkat-machine-schema:meerkat_machine_schema",
+        "//xtask:xtask",
+        "@crates//:which-7.0.3",
+    ] + all_crate_deps(
+        package_name = "xtask",
+        normal = True,
+        normal_dev = True,
+    ),
+)
+
+rust_test(
     name = "seam_inventory_strict_test",
     aliases = aliases(
         package_name = "xtask",
@@ -869,6 +931,7 @@ test_suite(
         ":protocol_codegen_drift_test",
         ":rmat_audit_test",
         ":rmat_strict_test",
+        ":runtime_authority_bypass_test",
         ":seam_inventory_strict_test",
         ":xtask_unit_test",
     ],

--- a/xtask/src/lib.rs
+++ b/xtask/src/lib.rs
@@ -12,6 +12,7 @@ pub mod protocol_codegen;
 pub mod public_contracts;
 pub mod rmat_audit;
 pub mod rmat_policy;
+pub mod runtime_authority_bypass;
 pub mod seam_inventory;
 pub mod typed_carrier;
 
@@ -61,6 +62,11 @@ enum Commands {
     /// `scripts/pre-push-bridge-no-responsestatus.sh` grep gate).
     #[command(name = "bridge-classifier")]
     BridgeClassifier,
+    /// Structural queue-to-run pilot bypass gate: raw accepted enqueue,
+    /// dequeue, and stage calls must stay behind explicit generated
+    /// authority/capability wrappers.
+    #[command(name = "runtime-authority-bypass")]
+    RuntimeAuthorityBypass,
     #[command(name = "ownership-ledger")]
     OwnershipLedger(OwnershipLedgerArgs),
     /// Verify every `@generated` header corresponds to a codegen-emit path
@@ -106,6 +112,9 @@ pub fn run() -> Result<()> {
         }
         Commands::BridgeClassifier => {
             run_machine_authority_task(bridge_classifier::run_bridge_classifier)
+        }
+        Commands::RuntimeAuthorityBypass => {
+            run_machine_authority_task(runtime_authority_bypass::run_runtime_authority_bypass)
         }
         // The ownership ledger resolves anchors against the canonical machine
         // catalog; constructing the DSL schemas needs the same deep stack as

--- a/xtask/src/machines_tests.rs
+++ b/xtask/src/machines_tests.rs
@@ -93,12 +93,22 @@ fn machine_workflow_red_ok_detects_missing_and_stale_generated_artifacts() {
     let registry = CanonicalRegistry::load();
     let selection = registry
         .select(&SelectionArgs {
-            all: true,
-            machines: vec![],
-            compositions: vec![],
+            all: false,
+            machines: vec!["meerkat_machine".to_string()],
+            compositions: vec!["meerkat_mob_seam".to_string()],
         })
-        .expect("selection should resolve canonical workflow artifacts");
+        .expect("selection should resolve representative canonical workflow artifacts");
     let dir = tempdir().expect("tempdir");
+    let selected_machine_dir = dir
+        .path()
+        .join("specs/machines/meerkat_machine")
+        .display()
+        .to_string();
+    let selected_composition_dir = dir
+        .path()
+        .join("specs/compositions/meerkat_mob_seam")
+        .display()
+        .to_string();
 
     let missing = collect_drift_mismatches(dir.path(), &selection).expect("missing drift");
     assert!(
@@ -111,7 +121,10 @@ fn machine_workflow_red_ok_detects_missing_and_stale_generated_artifacts() {
 
     let mut clean = collect_drift_mismatches(dir.path(), &selection).expect("clean drift");
     clean.retain(|mismatch| {
-        !mismatch.starts_with("production owner audit path for ")
+        selected_workflow_mismatch(
+            mismatch,
+            &[&selected_machine_dir, &selected_composition_dir],
+        ) && !mismatch.starts_with("production owner audit path for ")
             && !mismatch.starts_with("production owner schema relation for ")
             && !mismatch.starts_with("MobCommand::")
     });
@@ -132,10 +145,29 @@ fn machine_workflow_red_ok_detects_missing_and_stale_generated_artifacts() {
 
     fs::write(&machine_model, "---- MODULE stale ----\n").expect("write stale model");
     let stale = collect_drift_mismatches(dir.path(), &selection).expect("stale drift");
+    let stale = stale
+        .into_iter()
+        .filter(|mismatch| {
+            selected_workflow_mismatch(
+                mismatch,
+                &[&selected_machine_dir, &selected_composition_dir],
+            )
+        })
+        .collect::<Vec<_>>();
     assert!(
-        !stale.is_empty(),
-        "editing a generated artifact should be caught by anti-drift checks"
+        stale.iter().any(|mismatch| mismatch.contains(
+            machine_model
+                .to_str()
+                .expect("machine model path should be UTF-8")
+        )),
+        "editing a selected generated artifact should be caught by anti-drift checks: {stale:#?}"
     );
+}
+
+fn selected_workflow_mismatch(mismatch: &str, selected_dirs: &[&str]) -> bool {
+    selected_dirs
+        .iter()
+        .any(|selected_dir| mismatch.contains(*selected_dir))
 }
 
 #[cfg(feature = "machine-authority")]
@@ -526,6 +558,7 @@ fn schema_input_rows_classify_same_left_only_and_different_surfaces() {
                 emit: vec![],
             },
         ],
+        command_plans: vec![],
         effect_dispositions: vec![],
         ci_step_limit: None,
         named_types: vec![],

--- a/xtask/src/runtime_authority_bypass.rs
+++ b/xtask/src/runtime_authority_bypass.rs
@@ -1,0 +1,297 @@
+//! Runtime authority bypass audit for the queue-to-run pilot.
+//!
+//! This is a structural syn-AST gate for raw accepted-input enqueue, raw
+//! dequeue, and raw staging calls. Comments and strings are ignored; method
+//! calls split across formatting still count.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result, bail};
+use quote::ToTokens;
+use syn::visit::Visit;
+
+pub fn run_runtime_authority_bypass() -> Result<()> {
+    let root = crate::public_contracts::repo_root()?;
+    let findings = collect_runtime_authority_bypass_findings(&root)?;
+    if findings.is_empty() {
+        println!("runtime-authority-bypass audit passed");
+        return Ok(());
+    }
+    for finding in &findings {
+        eprintln!("{finding}");
+    }
+    bail!(
+        "runtime-authority-bypass audit failed: {} finding(s)",
+        findings.len()
+    );
+}
+
+pub fn collect_runtime_authority_bypass_findings(root: &Path) -> Result<Vec<String>> {
+    let mut findings = Vec::new();
+    audit_public_runtime_queue_surface(root, &mut findings)?;
+    for file in runtime_source_files(root)? {
+        let source = fs::read_to_string(&file.abs).with_context(|| format!("read {}", file.rel))?;
+        let parsed = syn::parse_file(&source)
+            .with_context(|| format!("parse {} for runtime authority bypass audit", file.rel))?;
+        let mut visitor = RuntimeAuthorityBypassVisitor {
+            rel: &file.rel,
+            findings: &mut findings,
+            fn_stack: Vec::new(),
+            skip_test_depth: 0,
+        };
+        visitor.visit_file(&parsed);
+    }
+    findings.sort();
+    findings.dedup();
+    Ok(findings)
+}
+
+fn audit_public_runtime_queue_surface(root: &Path, findings: &mut Vec<String>) -> Result<()> {
+    let lib = root.join("meerkat-runtime/src/lib.rs");
+    if !lib.exists() {
+        return Ok(());
+    }
+    let source = fs::read_to_string(&lib).with_context(|| format!("read {}", lib.display()))?;
+    let parsed = syn::parse_file(&source).context("parse meerkat-runtime/src/lib.rs")?;
+    for item in parsed.items {
+        match item {
+            syn::Item::Mod(module)
+                if module.ident == "queue" && matches!(module.vis, syn::Visibility::Public(_)) =>
+            {
+                findings.push(
+                    "meerkat-runtime/src/lib.rs: public raw InputQueue module `queue` bypasses generated authority"
+                        .to_owned(),
+                );
+            }
+            syn::Item::Use(item_use)
+                if matches!(item_use.vis, syn::Visibility::Public(_))
+                    && use_tree_contains_ident(&item_use.tree, "InputQueue") =>
+            {
+                findings.push(
+                    "meerkat-runtime/src/lib.rs: public raw InputQueue re-export bypasses generated authority"
+                        .to_owned(),
+                );
+            }
+            _ => {}
+        }
+    }
+    Ok(())
+}
+
+struct SourceFile {
+    rel: String,
+    abs: PathBuf,
+}
+
+fn runtime_source_files(root: &Path) -> Result<Vec<SourceFile>> {
+    let runtime_src = root.join("meerkat-runtime/src");
+    if !runtime_src.exists() {
+        return Ok(Vec::new());
+    }
+    let mut files = Vec::new();
+    let mob_runtime_src = root.join("meerkat-mob/src/runtime");
+    let mut stack = vec![runtime_src];
+    if mob_runtime_src.exists() {
+        stack.push(mob_runtime_src);
+    }
+    while let Some(dir) = stack.pop() {
+        for entry in fs::read_dir(&dir).with_context(|| format!("read dir {}", dir.display()))? {
+            let entry = entry?;
+            let path = entry.path();
+            if path.is_dir() {
+                stack.push(path);
+            } else if path.extension().is_some_and(|ext| ext == "rs") {
+                let rel = path
+                    .strip_prefix(root)
+                    .unwrap_or(&path)
+                    .to_string_lossy()
+                    .replace('\\', "/");
+                files.push(SourceFile { rel, abs: path });
+            }
+        }
+    }
+    Ok(files)
+}
+
+struct RuntimeAuthorityBypassVisitor<'a> {
+    rel: &'a str,
+    findings: &'a mut Vec<String>,
+    fn_stack: Vec<String>,
+    skip_test_depth: usize,
+}
+
+impl RuntimeAuthorityBypassVisitor<'_> {
+    fn current_fn(&self) -> &str {
+        self.fn_stack.last().map(String::as_str).unwrap_or("<root>")
+    }
+
+    fn in_skipped_test_scope(&self) -> bool {
+        self.skip_test_depth > 0
+    }
+
+    fn push_finding(&mut self, kind: &str, method: &str) {
+        self.findings.push(format!(
+            "{}: {} `{method}` in `{}` bypasses generated authority",
+            self.rel,
+            kind,
+            self.current_fn()
+        ));
+    }
+
+    fn audit_method_call(&mut self, node: &syn::ExprMethodCall) {
+        if self.in_skipped_test_scope() {
+            return;
+        }
+        let method = node.method.to_string();
+        match method.as_str() {
+            "enqueue" | "enqueue_front"
+                if is_queue_projection_receiver(&node.receiver)
+                    && !matches!(
+                        self.current_fn(),
+                        "apply_persist_and_queue" | "rebuild_queue_projections"
+                    ) =>
+            {
+                self.push_finding("raw accepted-input enqueue", &method);
+            }
+            "dequeue"
+                if is_queue_projection_receiver(&node.receiver)
+                    && self.current_fn() != "dequeue_next" =>
+            {
+                self.push_finding("raw dequeue", &method);
+            }
+            "dequeue_exact_prefix" if self.current_fn() != "dequeue_batch_exact" => {
+                self.push_finding("raw exact dequeue", &method);
+            }
+            "machine_realize_stage_batch"
+                if self.current_fn() != "machine_realize_authorized_stage_batch" =>
+            {
+                self.push_finding("raw stage", &method);
+            }
+            "mint_from_generated_command_plan" => {
+                self.push_finding("generated capability mint outside runtime bridge", &method);
+            }
+            _ => {}
+        }
+    }
+
+    fn audit_call(&mut self, node: &syn::ExprCall) {
+        if self.in_skipped_test_scope() {
+            return;
+        }
+        let syn::Expr::Path(path) = node.func.as_ref() else {
+            return;
+        };
+        if path_ends_with(&path.path, "mint_from_generated_command_plan") {
+            self.push_finding(
+                "generated capability mint outside runtime bridge",
+                "mint_from_generated_command_plan",
+            );
+        }
+    }
+
+    fn audit_impl_method_definition(&mut self, node: &syn::ImplItemFn) {
+        if self.in_skipped_test_scope() {
+            return;
+        }
+        let method = node.sig.ident.to_string();
+        if method == "dequeue_next" && matches!(node.vis, syn::Visibility::Public(_)) {
+            self.push_finding("public raw dequeue API", &method);
+        }
+    }
+}
+
+impl<'ast> Visit<'ast> for RuntimeAuthorityBypassVisitor<'_> {
+    fn visit_item_mod(&mut self, node: &'ast syn::ItemMod) {
+        if attrs_are_test_only(&node.attrs) {
+            self.skip_test_depth += 1;
+            syn::visit::visit_item_mod(self, node);
+            self.skip_test_depth -= 1;
+        } else {
+            syn::visit::visit_item_mod(self, node);
+        }
+    }
+
+    fn visit_item_fn(&mut self, node: &'ast syn::ItemFn) {
+        self.fn_stack.push(node.sig.ident.to_string());
+        if attrs_are_test_only(&node.attrs) {
+            self.skip_test_depth += 1;
+            syn::visit::visit_item_fn(self, node);
+            self.skip_test_depth -= 1;
+        } else {
+            syn::visit::visit_item_fn(self, node);
+        }
+        self.fn_stack.pop();
+    }
+
+    fn visit_impl_item_fn(&mut self, node: &'ast syn::ImplItemFn) {
+        self.fn_stack.push(node.sig.ident.to_string());
+        if attrs_are_test_only(&node.attrs) {
+            self.skip_test_depth += 1;
+            syn::visit::visit_impl_item_fn(self, node);
+            self.skip_test_depth -= 1;
+        } else {
+            self.audit_impl_method_definition(node);
+            syn::visit::visit_impl_item_fn(self, node);
+        }
+        self.fn_stack.pop();
+    }
+
+    fn visit_expr_method_call(&mut self, node: &'ast syn::ExprMethodCall) {
+        self.audit_method_call(node);
+        syn::visit::visit_expr_method_call(self, node);
+    }
+
+    fn visit_expr_call(&mut self, node: &'ast syn::ExprCall) {
+        self.audit_call(node);
+        syn::visit::visit_expr_call(self, node);
+    }
+}
+
+fn attrs_are_test_only(attrs: &[syn::Attribute]) -> bool {
+    attrs.iter().any(|attr| {
+        let path = attr.path();
+        let meta = attr.meta.to_token_stream().to_string();
+        let compact_meta = meta.replace(char::is_whitespace, "");
+        path.is_ident("test")
+            || path
+                .segments
+                .last()
+                .is_some_and(|segment| segment.ident == "test")
+            || compact_meta.contains("cfg(test)")
+    })
+}
+
+fn use_tree_contains_ident(tree: &syn::UseTree, needle: &str) -> bool {
+    match tree {
+        syn::UseTree::Path(path) => {
+            path.ident == needle || use_tree_contains_ident(&path.tree, needle)
+        }
+        syn::UseTree::Name(name) => name.ident == needle,
+        syn::UseTree::Rename(rename) => rename.ident == needle || rename.rename == needle,
+        syn::UseTree::Glob(_) => false,
+        syn::UseTree::Group(group) => group
+            .items
+            .iter()
+            .any(|item| use_tree_contains_ident(item, needle)),
+    }
+}
+
+fn path_ends_with(path: &syn::Path, needle: &str) -> bool {
+    path.segments
+        .last()
+        .is_some_and(|segment| segment.ident == needle)
+}
+
+fn is_queue_projection_receiver(expr: &syn::Expr) -> bool {
+    match expr {
+        syn::Expr::Field(field) => matches!(
+            &field.member,
+            syn::Member::Named(ident) if ident == "queue" || ident == "steer_queue"
+        ),
+        syn::Expr::Reference(reference) => is_queue_projection_receiver(&reference.expr),
+        syn::Expr::Paren(paren) => is_queue_projection_receiver(&paren.expr),
+        syn::Expr::Group(group) => is_queue_projection_receiver(&group.expr),
+        _ => false,
+    }
+}

--- a/xtask/tests/runtime_authority_bypass.rs
+++ b/xtask/tests/runtime_authority_bypass.rs
@@ -1,0 +1,182 @@
+#![allow(clippy::expect_used, clippy::panic)]
+
+use std::fs;
+use std::path::Path;
+
+use tempfile::tempdir;
+use xtask::runtime_authority_bypass::collect_runtime_authority_bypass_findings;
+
+fn write_file(root: &Path, rel: &str, contents: &str) {
+    let path = root.join(rel);
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).expect("create parent dirs");
+    }
+    fs::write(path, contents).expect("write fixture file");
+}
+
+fn findings_for(rel: &str, contents: &str) -> Vec<String> {
+    let dir = tempdir().expect("tempdir");
+    write_file(dir.path(), rel, contents);
+    collect_runtime_authority_bypass_findings(dir.path()).expect("collect findings")
+}
+
+fn findings_for_files(files: &[(&str, &str)]) -> Vec<String> {
+    let dir = tempdir().expect("tempdir");
+    for (rel, contents) in files {
+        write_file(dir.path(), rel, contents);
+    }
+    collect_runtime_authority_bypass_findings(dir.path()).expect("collect findings")
+}
+
+fn expect_failure(name: &str, contents: &str) {
+    let findings = findings_for("meerkat-runtime/src/driver/ephemeral.rs", contents);
+    assert!(
+        !findings.is_empty(),
+        "{name}: fixture must fail the audit but passed"
+    );
+}
+
+fn expect_clean(name: &str, contents: &str) {
+    let findings = findings_for("meerkat-runtime/src/driver/ephemeral.rs", contents);
+    assert!(
+        findings.is_empty(),
+        "{name}: fixture must pass the audit, got {findings:#?}"
+    );
+}
+
+#[test]
+fn live_workspace_runtime_authority_bypass_audit_is_clean() {
+    let root = xtask::public_contracts::repo_root().expect("repo root");
+    let findings = collect_runtime_authority_bypass_findings(&root).expect("collect findings");
+    assert!(
+        findings.is_empty(),
+        "runtime-authority-bypass audit must be clean for the committed workspace, got {findings:#?}"
+    );
+}
+
+#[test]
+fn planted_raw_enqueue_violation_fails() {
+    expect_failure(
+        "raw enqueue",
+        r"
+impl Driver {
+    fn bad(&mut self, input_id: InputId, input: Input) {
+        self.queue.enqueue(input_id, input);
+    }
+}
+",
+    );
+}
+
+#[test]
+fn planted_raw_dequeue_violation_fails() {
+    expect_failure(
+        "raw dequeue",
+        r"
+impl Driver {
+    fn bad(&mut self) {
+        let _ = self.steer_queue.dequeue();
+    }
+}
+",
+    );
+}
+
+#[test]
+fn planted_public_raw_dequeue_api_fails() {
+    expect_failure(
+        "public raw dequeue API",
+        r"
+impl Driver {
+    pub fn dequeue_next(&mut self) -> Option<(InputId, Input)> {
+        self.queue.dequeue().map(|queued| (queued.input_id, queued.input))
+    }
+}
+",
+    );
+}
+
+#[test]
+fn planted_raw_stage_violation_fails() {
+    expect_failure(
+        "raw stage",
+        r"
+impl Driver {
+    fn bad(&mut self, input_ids: &[InputId], run_id: &RunId) {
+        let _ = self.machine_realize_stage_batch(input_ids, run_id);
+    }
+}
+",
+    );
+}
+
+#[test]
+fn planted_public_queue_module_violation_fails() {
+    let findings = findings_for_files(&[("meerkat-runtime/src/lib.rs", "pub mod queue;")]);
+    assert!(
+        findings
+            .iter()
+            .any(|finding| finding.contains("public raw InputQueue module")),
+        "public queue module fixture must fail the audit, got {findings:#?}"
+    );
+}
+
+#[test]
+fn planted_public_input_queue_reexport_violation_fails() {
+    let findings = findings_for_files(&[(
+        "meerkat-runtime/src/lib.rs",
+        "pub(crate) mod queue;\npub use queue::InputQueue;",
+    )]);
+    assert!(
+        findings
+            .iter()
+            .any(|finding| finding.contains("public raw InputQueue re-export")),
+        "public InputQueue re-export fixture must fail the audit, got {findings:#?}"
+    );
+}
+
+#[test]
+fn planted_generated_capability_mint_outside_runtime_bridge_fails() {
+    let findings = findings_for_files(&[(
+        "meerkat-runtime/src/completion.rs",
+        r"
+fn bad() {
+    let _ = generated_command_capabilities::AuthorizedRuntimeLoopBatch::mint_from_generated_command_plan();
+}
+",
+    )]);
+    assert!(
+        findings
+            .iter()
+            .any(|finding| finding.contains("generated capability mint outside runtime bridge")),
+        "minting generated command capabilities outside the bridge must fail, got {findings:#?}"
+    );
+}
+
+#[test]
+fn comments_and_strings_are_not_violations() {
+    expect_clean(
+        "comments and strings",
+        r#"
+fn docs_only() {
+    // self.queue.enqueue(input_id, input);
+    let _ = "self.machine_realize_stage_batch(input_ids, run_id)";
+}
+"#,
+    );
+}
+
+#[test]
+fn authorized_stage_wrapper_is_clean() {
+    expect_clean(
+        "authorized stage wrapper",
+        r"
+impl Driver {
+    fn machine_realize_authorized_stage_batch(&mut self, authority: AuthorizedStageForRun) {
+        let (input_ids, run_id, _source) = authority.into_parts();
+        let _ = self.machine_realize_stage_batch(&input_ids, &run_id);
+    }
+}
+",
+    );
+}


### PR DESCRIPTION
## Summary
- implement generated-machine authority for runtime execution-control paths, including StageForRun authorization and rollback on staging rejection
- remove production runtime/mob dependence on direct generated capability mint constructors and add runtime authority-bypass auditing
- refresh generated machine kernels/spec artifacts, Bazel metadata, and execution-control inventory docs

## Validation
- `RUST_LANE_ID=execution-control-phase5 ./scripts/repo-cargo test -p meerkat-runtime prepare_runtime_loop_batch_start_unwinds_run_state_when_staging_rejects -- --nocapture`
- `RUST_LANE_ID=execution-control-phase5 ./scripts/repo-cargo test -p meerkat-runtime --test core_apply_terminal_truth -- --nocapture`
- `./scripts/repo-cargo fmt --all`
- `git diff --check`
- `make machine-check-drift`
- `make runtime-authority-bypass`
- `make check`
- `make lint`
- `make test`
- `make e2e-system`
- `TEST=e2e_smoke_s30_cli_mob_flow_probe make e2e-smoke`
- `TEST=e2e_smoke_mob_flow_runtime_suite make e2e-smoke`

## Review
- Adaptive subagent adversarial review rechecked the StageForRun rollback issue and returned GREEN after the final fix.
