### PR TITLE
Add provider cache hints and OpenAI continuations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- Provider params now expose typed prompt-cache hints for OpenAI, Anthropic,
+  and Gemini. OpenAI Responses requests still default to `store: false`, with
+  explicit overrides for `store`, `prompt_cache_key`, and
+  `prompt_cache_retention`; Anthropic can mark the stable system prefix for
+  `cache_control`; Gemini can pass an explicit cached-content resource name.
+- OpenAI Responses streaming can reuse stored response IDs as
+  `previous_response_id` continuation hints when `store: true` is explicitly
+  enabled, while preserving full local transcript replay as the fallback path.
 - Gemini video inputs can now be passed by provider-readable URI as
   `VideoData::Uri` / `WireVideoData::Uri`. Vertex accepts `gs://` references
   directly. Gemini API clients use public or already-registered file URIs as

--- a/artifacts/schemas/params.json
+++ b/artifacts/schemas/params.json
@@ -2358,6 +2358,21 @@
   },
   "CreateScheduleRequest": {
     "$defs": {
+      "AnthropicCacheControlPolicy": {
+        "description": "Typed shape of Anthropic's prompt-cache breakpoint policy.",
+        "oneOf": [
+          {
+            "const": "disabled",
+            "description": "Do not request Anthropic prompt-cache breakpoints.",
+            "type": "string"
+          },
+          {
+            "const": "system_prefix",
+            "description": "Mark the stable top-level system prompt as an ephemeral cache prefix.",
+            "type": "string"
+          }
+        ]
+      },
       "AnthropicCompactionConfig": {
         "description": "Typed shape of Anthropic's automatic-compaction knob.",
         "oneOf": [
@@ -3093,6 +3108,21 @@
         "description": "Opaque provider-native JSON body carried verbatim from caller to\nprovider. Used for pass-through sub-shapes (web search config,\nprovider-native custom compaction edits, OpenAI-compatible\n`chat_template_kwargs`/`thinking`/`reasoning` forwards) where the\nexact wire shape varies across downstream providers (Anthropic /\nDeepSeek / OpenRouter / custom proxies) and the runtime deliberately\ndoes not parse the body — it simply forwards it.",
         "type": "string"
       },
+      "OpenAiPromptCacheRetention": {
+        "description": "Typed shape of OpenAI's prompt-cache retention hint.",
+        "oneOf": [
+          {
+            "const": "in_memory",
+            "description": "Retain only in memory.",
+            "type": "string"
+          },
+          {
+            "const": "24h",
+            "description": "Retain for 24 hours.",
+            "type": "string"
+          }
+        ]
+      },
       "OutputSchema": {
         "description": "Configuration for structured output extraction.\n\nWhen provided to an agent, the agent will perform an extraction turn after\ncompleting the agentic work, forcing the LLM to output validated JSON that\nconforms to the provided schema. [`RunResult::text`] remains the committed\nmain-turn output; extraction populates [`RunResult::structured_output`] on\nsuccess or [`RunResult::extraction_error`] on failure.",
         "properties": {
@@ -3230,6 +3260,17 @@
             "additionalProperties": false,
             "description": "Per-turn Anthropic-specific knobs carried in `ProviderTag::Anthropic`.",
             "properties": {
+              "cache_control": {
+                "anyOf": [
+                  {
+                    "$ref": "#/$defs/AnthropicCacheControlPolicy"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "description": "Prompt-cache breakpoint policy."
+              },
               "compaction": {
                 "anyOf": [
                   {
@@ -3373,6 +3414,24 @@
                   "null"
                 ]
               },
+              "prompt_cache_key": {
+                "description": "OpenAI prompt-cache affinity routing key.",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "prompt_cache_retention": {
+                "anyOf": [
+                  {
+                    "$ref": "#/$defs/OpenAiPromptCacheRetention"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "description": "OpenAI prompt-cache retention hint."
+              },
               "provider": {
                 "const": "open_ai",
                 "type": "string"
@@ -3404,6 +3463,13 @@
                 "format": "int64",
                 "type": [
                   "integer",
+                  "null"
+                ]
+              },
+              "store": {
+                "description": "Responses API persistence override. Absent means the client sends\n`store: false` by default; callers may explicitly opt in with\n`Some(true)`.",
+                "type": [
+                  "boolean",
                   "null"
                 ]
               },
@@ -3464,6 +3530,13 @@
             "additionalProperties": false,
             "description": "Per-turn Gemini-specific knobs carried in `ProviderTag::Gemini`.",
             "properties": {
+              "cached_content_name": {
+                "description": "Gemini explicit context-cache resource name.",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
               "candidate_count": {
                 "description": "Number of candidate completions (runtime/persistence knob, not\nread by the Gemini client today — preserved for V3 round-trip).",
                 "format": "uint32",
@@ -6118,11 +6191,33 @@
               "provider": {
                 "const": "open_ai",
                 "type": "string"
+              },
+              "response_id": {
+                "type": [
+                  "string",
+                  "null"
+                ]
               }
             },
             "required": [
               "provider",
               "id"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "provider": {
+                "const": "open_ai_response",
+                "type": "string"
+              },
+              "response_id": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "provider",
+              "response_id"
             ],
             "type": "object"
           },
@@ -8989,6 +9084,13 @@
         ],
         "type": "object"
       },
+      "WireAnthropicCacheControlPolicy": {
+        "enum": [
+          "disabled",
+          "system_prefix"
+        ],
+        "type": "string"
+      },
       "WireAnthropicCompactionConfig": {
         "oneOf": [
           {
@@ -9343,6 +9445,13 @@
         ],
         "type": "string"
       },
+      "WireOpenAiPromptCacheRetention": {
+        "enum": [
+          "in_memory",
+          "24h"
+        ],
+        "type": "string"
+      },
       "WireProviderParamsOverride": {
         "description": "Typed wire projection of [`meerkat_core::lifecycle::run_primitive::ProviderParamsOverride`].",
         "properties": {
@@ -9404,6 +9513,16 @@
         "oneOf": [
           {
             "properties": {
+              "cache_control": {
+                "anyOf": [
+                  {
+                    "$ref": "#/$defs/WireAnthropicCacheControlPolicy"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
               "compaction": {
                 "anyOf": [
                   {
@@ -9514,6 +9633,22 @@
                   "null"
                 ]
               },
+              "prompt_cache_key": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "prompt_cache_retention": {
+                "anyOf": [
+                  {
+                    "$ref": "#/$defs/WireOpenAiPromptCacheRetention"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
               "provider": {
                 "const": "open_ai",
                 "type": "string"
@@ -9533,6 +9668,12 @@
                 "format": "int64",
                 "type": [
                   "integer",
+                  "null"
+                ]
+              },
+              "store": {
+                "type": [
+                  "boolean",
                   "null"
                 ]
               },
@@ -9568,6 +9709,12 @@
           },
           {
             "properties": {
+              "cached_content_name": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
               "candidate_count": {
                 "format": "uint32",
                 "minimum": 0,
@@ -11311,6 +11458,13 @@
         ],
         "type": "object"
       },
+      "WireAnthropicCacheControlPolicy": {
+        "enum": [
+          "disabled",
+          "system_prefix"
+        ],
+        "type": "string"
+      },
       "WireAnthropicCompactionConfig": {
         "oneOf": [
           {
@@ -11496,6 +11650,13 @@
         ],
         "type": "string"
       },
+      "WireOpenAiPromptCacheRetention": {
+        "enum": [
+          "in_memory",
+          "24h"
+        ],
+        "type": "string"
+      },
       "WireProviderParamsOverride": {
         "description": "Typed wire projection of [`meerkat_core::lifecycle::run_primitive::ProviderParamsOverride`].",
         "properties": {
@@ -11557,6 +11718,16 @@
         "oneOf": [
           {
             "properties": {
+              "cache_control": {
+                "anyOf": [
+                  {
+                    "$ref": "#/$defs/WireAnthropicCacheControlPolicy"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
               "compaction": {
                 "anyOf": [
                   {
@@ -11667,6 +11838,22 @@
                   "null"
                 ]
               },
+              "prompt_cache_key": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "prompt_cache_retention": {
+                "anyOf": [
+                  {
+                    "$ref": "#/$defs/WireOpenAiPromptCacheRetention"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
               "provider": {
                 "const": "open_ai",
                 "type": "string"
@@ -11686,6 +11873,12 @@
                 "format": "int64",
                 "type": [
                   "integer",
+                  "null"
+                ]
+              },
+              "store": {
+                "type": [
+                  "boolean",
                   "null"
                 ]
               },
@@ -11721,6 +11914,12 @@
           },
           {
             "properties": {
+              "cached_content_name": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
               "candidate_count": {
                 "format": "uint32",
                 "minimum": 0,
@@ -12145,6 +12344,13 @@
         ],
         "type": "object"
       },
+      "WireAnthropicCacheControlPolicy": {
+        "enum": [
+          "disabled",
+          "system_prefix"
+        ],
+        "type": "string"
+      },
       "WireAnthropicCompactionConfig": {
         "oneOf": [
           {
@@ -12330,6 +12536,13 @@
         ],
         "type": "string"
       },
+      "WireOpenAiPromptCacheRetention": {
+        "enum": [
+          "in_memory",
+          "24h"
+        ],
+        "type": "string"
+      },
       "WireProviderParamsOverride": {
         "description": "Typed wire projection of [`meerkat_core::lifecycle::run_primitive::ProviderParamsOverride`].",
         "properties": {
@@ -12391,6 +12604,16 @@
         "oneOf": [
           {
             "properties": {
+              "cache_control": {
+                "anyOf": [
+                  {
+                    "$ref": "#/$defs/WireAnthropicCacheControlPolicy"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
               "compaction": {
                 "anyOf": [
                   {
@@ -12501,6 +12724,22 @@
                   "null"
                 ]
               },
+              "prompt_cache_key": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "prompt_cache_retention": {
+                "anyOf": [
+                  {
+                    "$ref": "#/$defs/WireOpenAiPromptCacheRetention"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
               "provider": {
                 "const": "open_ai",
                 "type": "string"
@@ -12520,6 +12759,12 @@
                 "format": "int64",
                 "type": [
                   "integer",
+                  "null"
+                ]
+              },
+              "store": {
+                "type": [
+                  "boolean",
                   "null"
                 ]
               },
@@ -12555,6 +12800,12 @@
           },
           {
             "properties": {
+              "cached_content_name": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
               "candidate_count": {
                 "format": "uint32",
                 "minimum": 0,
@@ -13799,6 +14050,13 @@
         ],
         "type": "object"
       },
+      "WireAnthropicCacheControlPolicy": {
+        "enum": [
+          "disabled",
+          "system_prefix"
+        ],
+        "type": "string"
+      },
       "WireAnthropicCompactionConfig": {
         "oneOf": [
           {
@@ -14493,6 +14751,13 @@
         },
         "type": "object"
       },
+      "WireOpenAiPromptCacheRetention": {
+        "enum": [
+          "in_memory",
+          "24h"
+        ],
+        "type": "string"
+      },
       "WireProviderParamsOverride": {
         "description": "Typed wire projection of [`meerkat_core::lifecycle::run_primitive::ProviderParamsOverride`].",
         "properties": {
@@ -14554,6 +14819,16 @@
         "oneOf": [
           {
             "properties": {
+              "cache_control": {
+                "anyOf": [
+                  {
+                    "$ref": "#/$defs/WireAnthropicCacheControlPolicy"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
               "compaction": {
                 "anyOf": [
                   {
@@ -14664,6 +14939,22 @@
                   "null"
                 ]
               },
+              "prompt_cache_key": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "prompt_cache_retention": {
+                "anyOf": [
+                  {
+                    "$ref": "#/$defs/WireOpenAiPromptCacheRetention"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
               "provider": {
                 "const": "open_ai",
                 "type": "string"
@@ -14683,6 +14974,12 @@
                 "format": "int64",
                 "type": [
                   "integer",
+                  "null"
+                ]
+              },
+              "store": {
+                "type": [
+                  "boolean",
                   "null"
                 ]
               },
@@ -14718,6 +15015,12 @@
           },
           {
             "properties": {
+              "cached_content_name": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
               "candidate_count": {
                 "format": "uint32",
                 "minimum": 0,
@@ -15568,6 +15871,13 @@
         "description": "Canonical typed name for an LLM-callable tool.\n\nThe model-facing wire shape is still the provider's string tool name, but\ninternal policy, routing, and registry surfaces carry this handle so raw\nstrings do not become the tool identity owner.",
         "type": "string"
       },
+      "WireAnthropicCacheControlPolicy": {
+        "enum": [
+          "disabled",
+          "system_prefix"
+        ],
+        "type": "string"
+      },
       "WireAnthropicCompactionConfig": {
         "oneOf": [
           {
@@ -15925,6 +16235,13 @@
         ],
         "type": "string"
       },
+      "WireOpenAiPromptCacheRetention": {
+        "enum": [
+          "in_memory",
+          "24h"
+        ],
+        "type": "string"
+      },
       "WireProviderParamsOverride": {
         "description": "Typed wire projection of [`meerkat_core::lifecycle::run_primitive::ProviderParamsOverride`].",
         "properties": {
@@ -15986,6 +16303,16 @@
         "oneOf": [
           {
             "properties": {
+              "cache_control": {
+                "anyOf": [
+                  {
+                    "$ref": "#/$defs/WireAnthropicCacheControlPolicy"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
               "compaction": {
                 "anyOf": [
                   {
@@ -16096,6 +16423,22 @@
                   "null"
                 ]
               },
+              "prompt_cache_key": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "prompt_cache_retention": {
+                "anyOf": [
+                  {
+                    "$ref": "#/$defs/WireOpenAiPromptCacheRetention"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
               "provider": {
                 "const": "open_ai",
                 "type": "string"
@@ -16115,6 +16458,12 @@
                 "format": "int64",
                 "type": [
                   "integer",
+                  "null"
+                ]
+              },
+              "store": {
+                "type": [
+                  "boolean",
                   "null"
                 ]
               },
@@ -16150,6 +16499,12 @@
           },
           {
             "properties": {
+              "cached_content_name": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
               "candidate_count": {
                 "format": "uint32",
                 "minimum": 0,
@@ -18547,11 +18902,33 @@
               "provider": {
                 "const": "open_ai",
                 "type": "string"
+              },
+              "response_id": {
+                "type": [
+                  "string",
+                  "null"
+                ]
               }
             },
             "required": [
               "provider",
               "id"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "provider": {
+                "const": "open_ai_response",
+                "type": "string"
+              },
+              "response_id": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "provider",
+              "response_id"
             ],
             "type": "object"
           },
@@ -19010,6 +19387,21 @@
   },
   "UpdateScheduleParams": {
     "$defs": {
+      "AnthropicCacheControlPolicy": {
+        "description": "Typed shape of Anthropic's prompt-cache breakpoint policy.",
+        "oneOf": [
+          {
+            "const": "disabled",
+            "description": "Do not request Anthropic prompt-cache breakpoints.",
+            "type": "string"
+          },
+          {
+            "const": "system_prefix",
+            "description": "Mark the stable top-level system prompt as an ephemeral cache prefix.",
+            "type": "string"
+          }
+        ]
+      },
       "AnthropicCompactionConfig": {
         "description": "Typed shape of Anthropic's automatic-compaction knob.",
         "oneOf": [
@@ -19745,6 +20137,21 @@
         "description": "Opaque provider-native JSON body carried verbatim from caller to\nprovider. Used for pass-through sub-shapes (web search config,\nprovider-native custom compaction edits, OpenAI-compatible\n`chat_template_kwargs`/`thinking`/`reasoning` forwards) where the\nexact wire shape varies across downstream providers (Anthropic /\nDeepSeek / OpenRouter / custom proxies) and the runtime deliberately\ndoes not parse the body — it simply forwards it.",
         "type": "string"
       },
+      "OpenAiPromptCacheRetention": {
+        "description": "Typed shape of OpenAI's prompt-cache retention hint.",
+        "oneOf": [
+          {
+            "const": "in_memory",
+            "description": "Retain only in memory.",
+            "type": "string"
+          },
+          {
+            "const": "24h",
+            "description": "Retain for 24 hours.",
+            "type": "string"
+          }
+        ]
+      },
       "OutputSchema": {
         "description": "Configuration for structured output extraction.\n\nWhen provided to an agent, the agent will perform an extraction turn after\ncompleting the agentic work, forcing the LLM to output validated JSON that\nconforms to the provided schema. [`RunResult::text`] remains the committed\nmain-turn output; extraction populates [`RunResult::structured_output`] on\nsuccess or [`RunResult::extraction_error`] on failure.",
         "properties": {
@@ -19882,6 +20289,17 @@
             "additionalProperties": false,
             "description": "Per-turn Anthropic-specific knobs carried in `ProviderTag::Anthropic`.",
             "properties": {
+              "cache_control": {
+                "anyOf": [
+                  {
+                    "$ref": "#/$defs/AnthropicCacheControlPolicy"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "description": "Prompt-cache breakpoint policy."
+              },
               "compaction": {
                 "anyOf": [
                   {
@@ -20025,6 +20443,24 @@
                   "null"
                 ]
               },
+              "prompt_cache_key": {
+                "description": "OpenAI prompt-cache affinity routing key.",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "prompt_cache_retention": {
+                "anyOf": [
+                  {
+                    "$ref": "#/$defs/OpenAiPromptCacheRetention"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "description": "OpenAI prompt-cache retention hint."
+              },
               "provider": {
                 "const": "open_ai",
                 "type": "string"
@@ -20056,6 +20492,13 @@
                 "format": "int64",
                 "type": [
                   "integer",
+                  "null"
+                ]
+              },
+              "store": {
+                "description": "Responses API persistence override. Absent means the client sends\n`store: false` by default; callers may explicitly opt in with\n`Some(true)`.",
+                "type": [
+                  "boolean",
                   "null"
                 ]
               },
@@ -20116,6 +20559,13 @@
             "additionalProperties": false,
             "description": "Per-turn Gemini-specific knobs carried in `ProviderTag::Gemini`.",
             "properties": {
+              "cached_content_name": {
+                "description": "Gemini explicit context-cache resource name.",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
               "candidate_count": {
                 "description": "Number of candidate completions (runtime/persistence knob, not\nread by the Gemini client today — preserved for V3 round-trip).",
                 "format": "uint32",
@@ -20954,6 +21404,21 @@
   },
   "UpdateScheduleRequest": {
     "$defs": {
+      "AnthropicCacheControlPolicy": {
+        "description": "Typed shape of Anthropic's prompt-cache breakpoint policy.",
+        "oneOf": [
+          {
+            "const": "disabled",
+            "description": "Do not request Anthropic prompt-cache breakpoints.",
+            "type": "string"
+          },
+          {
+            "const": "system_prefix",
+            "description": "Mark the stable top-level system prompt as an ephemeral cache prefix.",
+            "type": "string"
+          }
+        ]
+      },
       "AnthropicCompactionConfig": {
         "description": "Typed shape of Anthropic's automatic-compaction knob.",
         "oneOf": [
@@ -21689,6 +22154,21 @@
         "description": "Opaque provider-native JSON body carried verbatim from caller to\nprovider. Used for pass-through sub-shapes (web search config,\nprovider-native custom compaction edits, OpenAI-compatible\n`chat_template_kwargs`/`thinking`/`reasoning` forwards) where the\nexact wire shape varies across downstream providers (Anthropic /\nDeepSeek / OpenRouter / custom proxies) and the runtime deliberately\ndoes not parse the body — it simply forwards it.",
         "type": "string"
       },
+      "OpenAiPromptCacheRetention": {
+        "description": "Typed shape of OpenAI's prompt-cache retention hint.",
+        "oneOf": [
+          {
+            "const": "in_memory",
+            "description": "Retain only in memory.",
+            "type": "string"
+          },
+          {
+            "const": "24h",
+            "description": "Retain for 24 hours.",
+            "type": "string"
+          }
+        ]
+      },
       "OutputSchema": {
         "description": "Configuration for structured output extraction.\n\nWhen provided to an agent, the agent will perform an extraction turn after\ncompleting the agentic work, forcing the LLM to output validated JSON that\nconforms to the provided schema. [`RunResult::text`] remains the committed\nmain-turn output; extraction populates [`RunResult::structured_output`] on\nsuccess or [`RunResult::extraction_error`] on failure.",
         "properties": {
@@ -21826,6 +22306,17 @@
             "additionalProperties": false,
             "description": "Per-turn Anthropic-specific knobs carried in `ProviderTag::Anthropic`.",
             "properties": {
+              "cache_control": {
+                "anyOf": [
+                  {
+                    "$ref": "#/$defs/AnthropicCacheControlPolicy"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "description": "Prompt-cache breakpoint policy."
+              },
               "compaction": {
                 "anyOf": [
                   {
@@ -21969,6 +22460,24 @@
                   "null"
                 ]
               },
+              "prompt_cache_key": {
+                "description": "OpenAI prompt-cache affinity routing key.",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "prompt_cache_retention": {
+                "anyOf": [
+                  {
+                    "$ref": "#/$defs/OpenAiPromptCacheRetention"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "description": "OpenAI prompt-cache retention hint."
+              },
               "provider": {
                 "const": "open_ai",
                 "type": "string"
@@ -22000,6 +22509,13 @@
                 "format": "int64",
                 "type": [
                   "integer",
+                  "null"
+                ]
+              },
+              "store": {
+                "description": "Responses API persistence override. Absent means the client sends\n`store: false` by default; callers may explicitly opt in with\n`Some(true)`.",
+                "type": [
+                  "boolean",
                   "null"
                 ]
               },
@@ -22060,6 +22576,13 @@
             "additionalProperties": false,
             "description": "Per-turn Gemini-specific knobs carried in `ProviderTag::Gemini`.",
             "properties": {
+              "cached_content_name": {
+                "description": "Gemini explicit context-cache resource name.",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
               "candidate_count": {
                 "description": "Number of candidate completions (runtime/persistence knob, not\nread by the Gemini client today — preserved for V3 round-trip).",
                 "format": "uint32",

--- a/artifacts/schemas/rest-openapi.json
+++ b/artifacts/schemas/rest-openapi.json
@@ -1,6 +1,21 @@
 {
   "components": {
     "schemas": {
+      "AnthropicCacheControlPolicy": {
+        "description": "Typed shape of Anthropic's prompt-cache breakpoint policy.",
+        "oneOf": [
+          {
+            "const": "disabled",
+            "description": "Do not request Anthropic prompt-cache breakpoints.",
+            "type": "string"
+          },
+          {
+            "const": "system_prefix",
+            "description": "Mark the stable top-level system prompt as an ephemeral cache prefix.",
+            "type": "string"
+          }
+        ]
+      },
       "AnthropicCompactionConfig": {
         "description": "Typed shape of Anthropic's automatic-compaction knob.",
         "oneOf": [
@@ -4209,6 +4224,21 @@
         ],
         "type": "object"
       },
+      "OpenAiPromptCacheRetention": {
+        "description": "Typed shape of OpenAI's prompt-cache retention hint.",
+        "oneOf": [
+          {
+            "const": "in_memory",
+            "description": "Retain only in memory.",
+            "type": "string"
+          },
+          {
+            "const": "24h",
+            "description": "Retain for 24 hours.",
+            "type": "string"
+          }
+        ]
+      },
       "OutputSchema": {
         "description": "Configuration for structured output extraction.\n\nWhen provided to an agent, the agent will perform an extraction turn after\ncompleting the agentic work, forcing the LLM to output validated JSON that\nconforms to the provided schema. [`RunResult::text`] remains the committed\nmain-turn output; extraction populates [`RunResult::structured_output`] on\nsuccess or [`RunResult::extraction_error`] on failure.",
         "properties": {
@@ -4585,6 +4615,17 @@
             "additionalProperties": false,
             "description": "Per-turn Anthropic-specific knobs carried in `ProviderTag::Anthropic`.",
             "properties": {
+              "cache_control": {
+                "anyOf": [
+                  {
+                    "$ref": "#/components/schemas/AnthropicCacheControlPolicy"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "description": "Prompt-cache breakpoint policy."
+              },
               "compaction": {
                 "anyOf": [
                   {
@@ -4728,6 +4769,24 @@
                   "null"
                 ]
               },
+              "prompt_cache_key": {
+                "description": "OpenAI prompt-cache affinity routing key.",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "prompt_cache_retention": {
+                "anyOf": [
+                  {
+                    "$ref": "#/components/schemas/OpenAiPromptCacheRetention"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "description": "OpenAI prompt-cache retention hint."
+              },
               "provider": {
                 "const": "open_ai",
                 "type": "string"
@@ -4759,6 +4818,13 @@
                 "format": "int64",
                 "type": [
                   "integer",
+                  "null"
+                ]
+              },
+              "store": {
+                "description": "Responses API persistence override. Absent means the client sends\n`store: false` by default; callers may explicitly opt in with\n`Some(true)`.",
+                "type": [
+                  "boolean",
                   "null"
                 ]
               },
@@ -4819,6 +4885,13 @@
             "additionalProperties": false,
             "description": "Per-turn Gemini-specific knobs carried in `ProviderTag::Gemini`.",
             "properties": {
+              "cached_content_name": {
+                "description": "Gemini explicit context-cache resource name.",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
               "candidate_count": {
                 "description": "Number of candidate completions (runtime/persistence knob, not\nread by the Gemini client today — preserved for V3 round-trip).",
                 "format": "uint32",
@@ -8097,6 +8170,13 @@
         "title": "UpdateScheduleRequest",
         "type": "object"
       },
+      "WireAnthropicCacheControlPolicy": {
+        "enum": [
+          "disabled",
+          "system_prefix"
+        ],
+        "type": "string"
+      },
       "WireAnthropicCompactionConfig": {
         "oneOf": [
           {
@@ -9367,6 +9447,13 @@
           }
         ]
       },
+      "WireOpenAiPromptCacheRetention": {
+        "enum": [
+          "in_memory",
+          "24h"
+        ],
+        "type": "string"
+      },
       "WireProviderBinding": {
         "description": "Wire projection of [`meerkat_core::ProviderBinding`].",
         "properties": {
@@ -9492,11 +9579,33 @@
               "provider": {
                 "const": "open_ai",
                 "type": "string"
+              },
+              "response_id": {
+                "type": [
+                  "string",
+                  "null"
+                ]
               }
             },
             "required": [
               "provider",
               "id"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "provider": {
+                "const": "open_ai_response",
+                "type": "string"
+              },
+              "response_id": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "provider",
+              "response_id"
             ],
             "type": "object"
           },
@@ -9575,6 +9684,16 @@
         "oneOf": [
           {
             "properties": {
+              "cache_control": {
+                "anyOf": [
+                  {
+                    "$ref": "#/components/schemas/WireAnthropicCacheControlPolicy"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
               "compaction": {
                 "anyOf": [
                   {
@@ -9685,6 +9804,22 @@
                   "null"
                 ]
               },
+              "prompt_cache_key": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "prompt_cache_retention": {
+                "anyOf": [
+                  {
+                    "$ref": "#/components/schemas/WireOpenAiPromptCacheRetention"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
               "provider": {
                 "const": "open_ai",
                 "type": "string"
@@ -9704,6 +9839,12 @@
                 "format": "int64",
                 "type": [
                   "integer",
+                  "null"
+                ]
+              },
+              "store": {
+                "type": [
+                  "boolean",
                   "null"
                 ]
               },
@@ -9739,6 +9880,12 @@
           },
           {
             "properties": {
+              "cached_content_name": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
               "candidate_count": {
                 "format": "uint32",
                 "minimum": 0,

--- a/artifacts/schemas/wire-types.json
+++ b/artifacts/schemas/wire-types.json
@@ -23257,6 +23257,13 @@
         ],
         "type": "object"
       },
+      "WireAnthropicCacheControlPolicy": {
+        "enum": [
+          "disabled",
+          "system_prefix"
+        ],
+        "type": "string"
+      },
       "WireAnthropicCompactionConfig": {
         "oneOf": [
           {
@@ -23611,6 +23618,13 @@
         ],
         "type": "string"
       },
+      "WireOpenAiPromptCacheRetention": {
+        "enum": [
+          "in_memory",
+          "24h"
+        ],
+        "type": "string"
+      },
       "WireProviderParamsOverride": {
         "description": "Typed wire projection of [`meerkat_core::lifecycle::run_primitive::ProviderParamsOverride`].",
         "properties": {
@@ -23672,6 +23686,16 @@
         "oneOf": [
           {
             "properties": {
+              "cache_control": {
+                "anyOf": [
+                  {
+                    "$ref": "#/$defs/WireAnthropicCacheControlPolicy"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
               "compaction": {
                 "anyOf": [
                   {
@@ -23782,6 +23806,22 @@
                   "null"
                 ]
               },
+              "prompt_cache_key": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "prompt_cache_retention": {
+                "anyOf": [
+                  {
+                    "$ref": "#/$defs/WireOpenAiPromptCacheRetention"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
               "provider": {
                 "const": "open_ai",
                 "type": "string"
@@ -23801,6 +23841,12 @@
                 "format": "int64",
                 "type": [
                   "integer",
+                  "null"
+                ]
+              },
+              "store": {
+                "type": [
+                  "boolean",
                   "null"
                 ]
               },
@@ -23836,6 +23882,12 @@
           },
           {
             "properties": {
+              "cached_content_name": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
               "candidate_count": {
                 "format": "uint32",
                 "minimum": 0,
@@ -25978,6 +26030,13 @@
         ],
         "type": "object"
       },
+      "WireAnthropicCacheControlPolicy": {
+        "enum": [
+          "disabled",
+          "system_prefix"
+        ],
+        "type": "string"
+      },
       "WireAnthropicCompactionConfig": {
         "oneOf": [
           {
@@ -26328,6 +26387,13 @@
         },
         "type": "object"
       },
+      "WireOpenAiPromptCacheRetention": {
+        "enum": [
+          "in_memory",
+          "24h"
+        ],
+        "type": "string"
+      },
       "WireProviderParamsOverride": {
         "description": "Typed wire projection of [`meerkat_core::lifecycle::run_primitive::ProviderParamsOverride`].",
         "properties": {
@@ -26389,6 +26455,16 @@
         "oneOf": [
           {
             "properties": {
+              "cache_control": {
+                "anyOf": [
+                  {
+                    "$ref": "#/$defs/WireAnthropicCacheControlPolicy"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
               "compaction": {
                 "anyOf": [
                   {
@@ -26499,6 +26575,22 @@
                   "null"
                 ]
               },
+              "prompt_cache_key": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "prompt_cache_retention": {
+                "anyOf": [
+                  {
+                    "$ref": "#/$defs/WireOpenAiPromptCacheRetention"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
               "provider": {
                 "const": "open_ai",
                 "type": "string"
@@ -26518,6 +26610,12 @@
                 "format": "int64",
                 "type": [
                   "integer",
+                  "null"
+                ]
+              },
+              "store": {
+                "type": [
+                  "boolean",
                   "null"
                 ]
               },
@@ -26553,6 +26651,12 @@
           },
           {
             "properties": {
+              "cached_content_name": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
               "candidate_count": {
                 "format": "uint32",
                 "minimum": 0,
@@ -26770,6 +26874,13 @@
         ],
         "type": "object"
       },
+      "WireAnthropicCacheControlPolicy": {
+        "enum": [
+          "disabled",
+          "system_prefix"
+        ],
+        "type": "string"
+      },
       "WireAnthropicCompactionConfig": {
         "oneOf": [
           {
@@ -27120,6 +27231,13 @@
         },
         "type": "object"
       },
+      "WireOpenAiPromptCacheRetention": {
+        "enum": [
+          "in_memory",
+          "24h"
+        ],
+        "type": "string"
+      },
       "WireProviderParamsOverride": {
         "description": "Typed wire projection of [`meerkat_core::lifecycle::run_primitive::ProviderParamsOverride`].",
         "properties": {
@@ -27181,6 +27299,16 @@
         "oneOf": [
           {
             "properties": {
+              "cache_control": {
+                "anyOf": [
+                  {
+                    "$ref": "#/$defs/WireAnthropicCacheControlPolicy"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
               "compaction": {
                 "anyOf": [
                   {
@@ -27291,6 +27419,22 @@
                   "null"
                 ]
               },
+              "prompt_cache_key": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "prompt_cache_retention": {
+                "anyOf": [
+                  {
+                    "$ref": "#/$defs/WireOpenAiPromptCacheRetention"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
               "provider": {
                 "const": "open_ai",
                 "type": "string"
@@ -27310,6 +27454,12 @@
                 "format": "int64",
                 "type": [
                   "integer",
+                  "null"
+                ]
+              },
+              "store": {
+                "type": [
+                  "boolean",
                   "null"
                 ]
               },
@@ -27345,6 +27495,12 @@
           },
           {
             "properties": {
+              "cached_content_name": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
               "candidate_count": {
                 "format": "uint32",
                 "minimum": 0,
@@ -29771,6 +29927,21 @@
   },
   "Schedule": {
     "$defs": {
+      "AnthropicCacheControlPolicy": {
+        "description": "Typed shape of Anthropic's prompt-cache breakpoint policy.",
+        "oneOf": [
+          {
+            "const": "disabled",
+            "description": "Do not request Anthropic prompt-cache breakpoints.",
+            "type": "string"
+          },
+          {
+            "const": "system_prefix",
+            "description": "Mark the stable top-level system prompt as an ephemeral cache prefix.",
+            "type": "string"
+          }
+        ]
+      },
       "AnthropicCompactionConfig": {
         "description": "Typed shape of Anthropic's automatic-compaction knob.",
         "oneOf": [
@@ -30510,6 +30681,21 @@
         "description": "Opaque provider-native JSON body carried verbatim from caller to\nprovider. Used for pass-through sub-shapes (web search config,\nprovider-native custom compaction edits, OpenAI-compatible\n`chat_template_kwargs`/`thinking`/`reasoning` forwards) where the\nexact wire shape varies across downstream providers (Anthropic /\nDeepSeek / OpenRouter / custom proxies) and the runtime deliberately\ndoes not parse the body — it simply forwards it.",
         "type": "string"
       },
+      "OpenAiPromptCacheRetention": {
+        "description": "Typed shape of OpenAI's prompt-cache retention hint.",
+        "oneOf": [
+          {
+            "const": "in_memory",
+            "description": "Retain only in memory.",
+            "type": "string"
+          },
+          {
+            "const": "24h",
+            "description": "Retain for 24 hours.",
+            "type": "string"
+          }
+        ]
+      },
       "OutputSchema": {
         "description": "Configuration for structured output extraction.\n\nWhen provided to an agent, the agent will perform an extraction turn after\ncompleting the agentic work, forcing the LLM to output validated JSON that\nconforms to the provided schema. [`RunResult::text`] remains the committed\nmain-turn output; extraction populates [`RunResult::structured_output`] on\nsuccess or [`RunResult::extraction_error`] on failure.",
         "properties": {
@@ -30647,6 +30833,17 @@
             "additionalProperties": false,
             "description": "Per-turn Anthropic-specific knobs carried in `ProviderTag::Anthropic`.",
             "properties": {
+              "cache_control": {
+                "anyOf": [
+                  {
+                    "$ref": "#/$defs/AnthropicCacheControlPolicy"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "description": "Prompt-cache breakpoint policy."
+              },
               "compaction": {
                 "anyOf": [
                   {
@@ -30790,6 +30987,24 @@
                   "null"
                 ]
               },
+              "prompt_cache_key": {
+                "description": "OpenAI prompt-cache affinity routing key.",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "prompt_cache_retention": {
+                "anyOf": [
+                  {
+                    "$ref": "#/$defs/OpenAiPromptCacheRetention"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "description": "OpenAI prompt-cache retention hint."
+              },
               "provider": {
                 "const": "open_ai",
                 "type": "string"
@@ -30821,6 +31036,13 @@
                 "format": "int64",
                 "type": [
                   "integer",
+                  "null"
+                ]
+              },
+              "store": {
+                "description": "Responses API persistence override. Absent means the client sends\n`store: false` by default; callers may explicitly opt in with\n`Some(true)`.",
+                "type": [
+                  "boolean",
                   "null"
                 ]
               },
@@ -30881,6 +31103,13 @@
             "additionalProperties": false,
             "description": "Per-turn Gemini-specific knobs carried in `ProviderTag::Gemini`.",
             "properties": {
+              "cached_content_name": {
+                "description": "Gemini explicit context-cache resource name.",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
               "candidate_count": {
                 "description": "Number of candidate completions (runtime/persistence knob, not\nread by the Gemini client today — preserved for V3 round-trip).",
                 "format": "uint32",
@@ -31745,6 +31974,21 @@
   },
   "ScheduleListResult": {
     "$defs": {
+      "AnthropicCacheControlPolicy": {
+        "description": "Typed shape of Anthropic's prompt-cache breakpoint policy.",
+        "oneOf": [
+          {
+            "const": "disabled",
+            "description": "Do not request Anthropic prompt-cache breakpoints.",
+            "type": "string"
+          },
+          {
+            "const": "system_prefix",
+            "description": "Mark the stable top-level system prompt as an ephemeral cache prefix.",
+            "type": "string"
+          }
+        ]
+      },
       "AnthropicCompactionConfig": {
         "description": "Typed shape of Anthropic's automatic-compaction knob.",
         "oneOf": [
@@ -32484,6 +32728,21 @@
         "description": "Opaque provider-native JSON body carried verbatim from caller to\nprovider. Used for pass-through sub-shapes (web search config,\nprovider-native custom compaction edits, OpenAI-compatible\n`chat_template_kwargs`/`thinking`/`reasoning` forwards) where the\nexact wire shape varies across downstream providers (Anthropic /\nDeepSeek / OpenRouter / custom proxies) and the runtime deliberately\ndoes not parse the body — it simply forwards it.",
         "type": "string"
       },
+      "OpenAiPromptCacheRetention": {
+        "description": "Typed shape of OpenAI's prompt-cache retention hint.",
+        "oneOf": [
+          {
+            "const": "in_memory",
+            "description": "Retain only in memory.",
+            "type": "string"
+          },
+          {
+            "const": "24h",
+            "description": "Retain for 24 hours.",
+            "type": "string"
+          }
+        ]
+      },
       "OutputSchema": {
         "description": "Configuration for structured output extraction.\n\nWhen provided to an agent, the agent will perform an extraction turn after\ncompleting the agentic work, forcing the LLM to output validated JSON that\nconforms to the provided schema. [`RunResult::text`] remains the committed\nmain-turn output; extraction populates [`RunResult::structured_output`] on\nsuccess or [`RunResult::extraction_error`] on failure.",
         "properties": {
@@ -32621,6 +32880,17 @@
             "additionalProperties": false,
             "description": "Per-turn Anthropic-specific knobs carried in `ProviderTag::Anthropic`.",
             "properties": {
+              "cache_control": {
+                "anyOf": [
+                  {
+                    "$ref": "#/$defs/AnthropicCacheControlPolicy"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "description": "Prompt-cache breakpoint policy."
+              },
               "compaction": {
                 "anyOf": [
                   {
@@ -32764,6 +33034,24 @@
                   "null"
                 ]
               },
+              "prompt_cache_key": {
+                "description": "OpenAI prompt-cache affinity routing key.",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "prompt_cache_retention": {
+                "anyOf": [
+                  {
+                    "$ref": "#/$defs/OpenAiPromptCacheRetention"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "description": "OpenAI prompt-cache retention hint."
+              },
               "provider": {
                 "const": "open_ai",
                 "type": "string"
@@ -32795,6 +33083,13 @@
                 "format": "int64",
                 "type": [
                   "integer",
+                  "null"
+                ]
+              },
+              "store": {
+                "description": "Responses API persistence override. Absent means the client sends\n`store: false` by default; callers may explicitly opt in with\n`Some(true)`.",
+                "type": [
+                  "boolean",
                   "null"
                 ]
               },
@@ -32855,6 +33150,13 @@
             "additionalProperties": false,
             "description": "Per-turn Gemini-specific knobs carried in `ProviderTag::Gemini`.",
             "properties": {
+              "cached_content_name": {
+                "description": "Gemini explicit context-cache resource name.",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
               "candidate_count": {
                 "description": "Number of candidate completions (runtime/persistence knob, not\nread by the Gemini client today — preserved for V3 round-trip).",
                 "format": "uint32",
@@ -33733,6 +34035,21 @@
   },
   "ScheduleOccurrencesResult": {
     "$defs": {
+      "AnthropicCacheControlPolicy": {
+        "description": "Typed shape of Anthropic's prompt-cache breakpoint policy.",
+        "oneOf": [
+          {
+            "const": "disabled",
+            "description": "Do not request Anthropic prompt-cache breakpoints.",
+            "type": "string"
+          },
+          {
+            "const": "system_prefix",
+            "description": "Mark the stable top-level system prompt as an ephemeral cache prefix.",
+            "type": "string"
+          }
+        ]
+      },
       "AnthropicCompactionConfig": {
         "description": "Typed shape of Anthropic's automatic-compaction knob.",
         "oneOf": [
@@ -34738,6 +35055,21 @@
         "description": "Opaque provider-native JSON body carried verbatim from caller to\nprovider. Used for pass-through sub-shapes (web search config,\nprovider-native custom compaction edits, OpenAI-compatible\n`chat_template_kwargs`/`thinking`/`reasoning` forwards) where the\nexact wire shape varies across downstream providers (Anthropic /\nDeepSeek / OpenRouter / custom proxies) and the runtime deliberately\ndoes not parse the body — it simply forwards it.",
         "type": "string"
       },
+      "OpenAiPromptCacheRetention": {
+        "description": "Typed shape of OpenAI's prompt-cache retention hint.",
+        "oneOf": [
+          {
+            "const": "in_memory",
+            "description": "Retain only in memory.",
+            "type": "string"
+          },
+          {
+            "const": "24h",
+            "description": "Retain for 24 hours.",
+            "type": "string"
+          }
+        ]
+      },
       "OutputSchema": {
         "description": "Configuration for structured output extraction.\n\nWhen provided to an agent, the agent will perform an extraction turn after\ncompleting the agentic work, forcing the LLM to output validated JSON that\nconforms to the provided schema. [`RunResult::text`] remains the committed\nmain-turn output; extraction populates [`RunResult::structured_output`] on\nsuccess or [`RunResult::extraction_error`] on failure.",
         "properties": {
@@ -34875,6 +35207,17 @@
             "additionalProperties": false,
             "description": "Per-turn Anthropic-specific knobs carried in `ProviderTag::Anthropic`.",
             "properties": {
+              "cache_control": {
+                "anyOf": [
+                  {
+                    "$ref": "#/$defs/AnthropicCacheControlPolicy"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "description": "Prompt-cache breakpoint policy."
+              },
               "compaction": {
                 "anyOf": [
                   {
@@ -35018,6 +35361,24 @@
                   "null"
                 ]
               },
+              "prompt_cache_key": {
+                "description": "OpenAI prompt-cache affinity routing key.",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "prompt_cache_retention": {
+                "anyOf": [
+                  {
+                    "$ref": "#/$defs/OpenAiPromptCacheRetention"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "description": "OpenAI prompt-cache retention hint."
+              },
               "provider": {
                 "const": "open_ai",
                 "type": "string"
@@ -35049,6 +35410,13 @@
                 "format": "int64",
                 "type": [
                   "integer",
+                  "null"
+                ]
+              },
+              "store": {
+                "description": "Responses API persistence override. Absent means the client sends\n`store: false` by default; callers may explicitly opt in with\n`Some(true)`.",
+                "type": [
+                  "boolean",
                   "null"
                 ]
               },
@@ -35109,6 +35477,13 @@
             "additionalProperties": false,
             "description": "Per-turn Gemini-specific knobs carried in `ProviderTag::Gemini`.",
             "properties": {
+              "cached_content_name": {
+                "description": "Gemini explicit context-cache resource name.",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
               "candidate_count": {
                 "description": "Number of candidate completions (runtime/persistence knob, not\nread by the Gemini client today — preserved for V3 round-trip).",
                 "format": "uint32",
@@ -38565,11 +38940,33 @@
               "provider": {
                 "const": "open_ai",
                 "type": "string"
+              },
+              "response_id": {
+                "type": [
+                  "string",
+                  "null"
+                ]
               }
             },
             "required": [
               "provider",
               "id"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "provider": {
+                "const": "open_ai_response",
+                "type": "string"
+              },
+              "response_id": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "provider",
+              "response_id"
             ],
             "type": "object"
           },
@@ -39197,11 +39594,33 @@
               "provider": {
                 "const": "open_ai",
                 "type": "string"
+              },
+              "response_id": {
+                "type": [
+                  "string",
+                  "null"
+                ]
               }
             },
             "required": [
               "provider",
               "id"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "provider": {
+                "const": "open_ai_response",
+                "type": "string"
+              },
+              "response_id": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "provider",
+              "response_id"
             ],
             "type": "object"
           },
@@ -46555,6 +46974,13 @@
         ],
         "type": "object"
       },
+      "WireAnthropicCacheControlPolicy": {
+        "enum": [
+          "disabled",
+          "system_prefix"
+        ],
+        "type": "string"
+      },
       "WireAnthropicCompactionConfig": {
         "oneOf": [
           {
@@ -46786,6 +47212,13 @@
         },
         "type": "object"
       },
+      "WireOpenAiPromptCacheRetention": {
+        "enum": [
+          "in_memory",
+          "24h"
+        ],
+        "type": "string"
+      },
       "WireProviderParamsOverride": {
         "description": "Typed wire projection of [`meerkat_core::lifecycle::run_primitive::ProviderParamsOverride`].",
         "properties": {
@@ -46847,6 +47280,16 @@
         "oneOf": [
           {
             "properties": {
+              "cache_control": {
+                "anyOf": [
+                  {
+                    "$ref": "#/$defs/WireAnthropicCacheControlPolicy"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
               "compaction": {
                 "anyOf": [
                   {
@@ -46957,6 +47400,22 @@
                   "null"
                 ]
               },
+              "prompt_cache_key": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "prompt_cache_retention": {
+                "anyOf": [
+                  {
+                    "$ref": "#/$defs/WireOpenAiPromptCacheRetention"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
               "provider": {
                 "const": "open_ai",
                 "type": "string"
@@ -46976,6 +47435,12 @@
                 "format": "int64",
                 "type": [
                   "integer",
+                  "null"
+                ]
+              },
+              "store": {
+                "type": [
+                  "boolean",
                   "null"
                 ]
               },
@@ -47011,6 +47476,12 @@
           },
           {
             "properties": {
+              "cached_content_name": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
               "candidate_count": {
                 "format": "uint32",
                 "minimum": 0,
@@ -48012,11 +48483,33 @@
           "provider": {
             "const": "open_ai",
             "type": "string"
+          },
+          "response_id": {
+            "type": [
+              "string",
+              "null"
+            ]
           }
         },
         "required": [
           "provider",
           "id"
+        ],
+        "type": "object"
+      },
+      {
+        "properties": {
+          "provider": {
+            "const": "open_ai_response",
+            "type": "string"
+          },
+          "response_id": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "provider",
+          "response_id"
         ],
         "type": "object"
       },
@@ -50689,11 +51182,33 @@
               "provider": {
                 "const": "open_ai",
                 "type": "string"
+              },
+              "response_id": {
+                "type": [
+                  "string",
+                  "null"
+                ]
               }
             },
             "required": [
               "provider",
               "id"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "provider": {
+                "const": "open_ai_response",
+                "type": "string"
+              },
+              "response_id": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "provider",
+              "response_id"
             ],
             "type": "object"
           },
@@ -52602,11 +53117,33 @@
               "provider": {
                 "const": "open_ai",
                 "type": "string"
+              },
+              "response_id": {
+                "type": [
+                  "string",
+                  "null"
+                ]
               }
             },
             "required": [
               "provider",
               "id"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "provider": {
+                "const": "open_ai_response",
+                "type": "string"
+              },
+              "response_id": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "provider",
+              "response_id"
             ],
             "type": "object"
           },
@@ -54980,11 +55517,33 @@
               "provider": {
                 "const": "open_ai",
                 "type": "string"
+              },
+              "response_id": {
+                "type": [
+                  "string",
+                  "null"
+                ]
               }
             },
             "required": [
               "provider",
               "id"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "provider": {
+                "const": "open_ai_response",
+                "type": "string"
+              },
+              "response_id": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "provider",
+              "response_id"
             ],
             "type": "object"
           },

--- a/docs/rust/advanced.mdx
+++ b/docs/rust/advanced.mdx
@@ -117,6 +117,14 @@ Pass provider parameter overrides via `AgentBuildConfig`. The JSON bag is retire
 `provider_params` is the typed `ProviderParamsOverride` (temperature, `top_p`,
 `max_output_tokens`, reasoning mode, `thinking_budget_tokens`, and an optional
 provider-specific `provider_tag`), parsed fail-closed at each surface ingress.
+Provider tags also carry opt-in provider cache hints: OpenAI can override
+Responses `store` (default remains `false`) and set `prompt_cache_key` /
+`prompt_cache_retention`; Anthropic can mark the stable system prefix with
+`cache_control`; Gemini can pass an explicit `cached_content_name`. When
+OpenAI `store` is explicitly enabled, stored response IDs may be reused as
+`previous_response_id` hints; Meerkat still keeps the local transcript as the
+canonical replay source and falls back to full replay if the provider rejects
+the hint.
 
 ```rust
 use meerkat_core::lifecycle::run_primitive::ProviderParamsOverride;

--- a/meerkat-anthropic/src/client.rs
+++ b/meerkat-anthropic/src/client.rs
@@ -5,8 +5,9 @@
 use async_trait::async_trait;
 use futures::StreamExt;
 use meerkat_core::lifecycle::run_primitive::{
-    AnthropicCompactionConfig, AnthropicContextWindow, AnthropicEffort, AnthropicInferenceGeo,
-    AnthropicProviderTag, AnthropicThinkingConfig, ProviderTag,
+    AnthropicCacheControlPolicy, AnthropicCompactionConfig, AnthropicContextWindow,
+    AnthropicEffort, AnthropicInferenceGeo, AnthropicProviderTag, AnthropicThinkingConfig,
+    ProviderTag,
 };
 use meerkat_core::schema::{CompiledSchema, SchemaError};
 use meerkat_core::{
@@ -664,7 +665,7 @@ impl AnthropicClient {
         });
 
         if let Some(system) = system_prompt {
-            body["system"] = Value::String(system);
+            body["system"] = Self::anthropic_system_prompt_value(&system, anthropic_tag(request));
         }
 
         if Self::request_supports_temperature(request)
@@ -784,6 +785,17 @@ impl AnthropicClient {
         }
 
         Ok(body)
+    }
+
+    fn anthropic_system_prompt_value(system: &str, tag: Option<&AnthropicProviderTag>) -> Value {
+        match tag.and_then(|t| t.cache_control) {
+            Some(AnthropicCacheControlPolicy::SystemPrefix) => serde_json::json!([{
+                "type": "text",
+                "text": system,
+                "cache_control": {"type": "ephemeral"}
+            }]),
+            _ => Value::String(system.to_string()),
+        }
     }
 
     fn ensure_claude_ai_oauth_system_marker(body: &mut Value) {
@@ -2265,6 +2277,59 @@ mod tests {
     }
 
     #[test]
+    fn test_build_request_body_cache_control_system_prefix()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let client = AnthropicClient::new("test-key".to_string())?;
+        let request = LlmRequest::new(
+            "claude-sonnet-4-20250514",
+            vec![
+                Message::System(SystemMessage::new("stable system prefix".to_string())),
+                Message::User(UserMessage::text("test".to_string())),
+            ],
+        )
+        .with_anthropic_tag_merge(|t| {
+            t.cache_control = Some(AnthropicCacheControlPolicy::SystemPrefix);
+        });
+
+        let body = client.build_request_body(&request)?;
+
+        assert_eq!(
+            body["system"],
+            serde_json::json!([{
+                "type": "text",
+                "text": "stable system prefix",
+                "cache_control": {"type": "ephemeral"}
+            }])
+        );
+        assert!(
+            body["messages"].to_string().find("cache_control").is_none(),
+            "dynamic conversation messages must not receive cache_control"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn test_build_request_body_cache_control_disabled_preserves_system_string()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let client = AnthropicClient::new("test-key".to_string())?;
+        let request = LlmRequest::new(
+            "claude-sonnet-4-20250514",
+            vec![
+                Message::System(SystemMessage::new("stable system prefix".to_string())),
+                Message::User(UserMessage::text("test".to_string())),
+            ],
+        )
+        .with_anthropic_tag_merge(|t| {
+            t.cache_control = Some(AnthropicCacheControlPolicy::Disabled);
+        });
+
+        let body = client.build_request_body(&request)?;
+
+        assert_eq!(body["system"], "stable system prefix");
+        Ok(())
+    }
+
+    #[test]
     fn test_client_builder_creates_configured_client() -> Result<(), Box<dyn std::error::Error>> {
         let client = AnthropicClient::builder("test-key".to_string())
             .connect_timeout(std::time::Duration::from_secs(5))
@@ -2859,6 +2924,50 @@ mod tests {
             axum::serve(listener, app).await.expect("serve test server");
         });
         (format!("http://{addr}"), handle)
+    }
+
+    #[tokio::test]
+    async fn stream_emits_cache_usage_fields() {
+        let payload = [
+            r#"data: {"type":"message_start","message":{"usage":{"input_tokens":120,"output_tokens":0,"cache_creation_input_tokens":32,"cache_read_input_tokens":16}}}"#,
+            r#"data: {"type":"content_block_start","content_block":{"type":"text","text":""}}"#,
+            r#"data: {"type":"content_block_delta","delta":{"type":"text_delta","text":"Hello"}}"#,
+            r#"data: {"type":"content_block_stop"}"#,
+            r#"data: {"type":"message_delta","usage":{"output_tokens":5},"delta":{"stop_reason":"end_turn"}}"#,
+            r#"data: {"type":"message_stop"}"#,
+            "",
+        ]
+        .join("\n");
+        let (base_url, server) = spawn_anthropic_stub_server(payload).await;
+        let client = AnthropicClient::builder("test-key".to_string())
+            .base_url(base_url)
+            .build()
+            .unwrap();
+        let request = LlmRequest::new(
+            "claude-sonnet-4-5",
+            vec![Message::User(UserMessage::text("hello".to_string()))],
+        );
+
+        let mut stream = client.stream(&request);
+        let mut usage_updates = Vec::new();
+        while let Some(event) = stream.next().await {
+            match event.expect("stream event") {
+                LlmEvent::UsageUpdate { usage } => usage_updates.push(usage),
+                LlmEvent::Done { .. } => break,
+                _ => {}
+            }
+        }
+        server.abort();
+
+        assert!(!usage_updates.is_empty(), "expected usage update");
+        let first = &usage_updates[0];
+        assert_eq!(first.input_tokens, 120);
+        assert_eq!(first.cache_creation_tokens, Some(32));
+        assert_eq!(first.cache_read_tokens, Some(16));
+        let last = usage_updates.last().expect("usage update");
+        assert_eq!(last.output_tokens, 5);
+        assert_eq!(last.cache_creation_tokens, Some(32));
+        assert_eq!(last.cache_read_tokens, Some(16));
     }
 
     /// Regression: message_delta with stop_reason (no "type" in delta) must yield Done.

--- a/meerkat-contracts/src/wire/runtime.rs
+++ b/meerkat-contracts/src/wire/runtime.rs
@@ -748,6 +748,69 @@ impl From<WireAnthropicContextWindow>
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[serde(rename_all = "snake_case")]
+pub enum WireAnthropicCacheControlPolicy {
+    Disabled,
+    SystemPrefix,
+}
+
+impl From<meerkat_core::lifecycle::run_primitive::AnthropicCacheControlPolicy>
+    for WireAnthropicCacheControlPolicy
+{
+    fn from(value: meerkat_core::lifecycle::run_primitive::AnthropicCacheControlPolicy) -> Self {
+        use meerkat_core::lifecycle::run_primitive::AnthropicCacheControlPolicy as Core;
+        match value {
+            Core::Disabled => Self::Disabled,
+            Core::SystemPrefix => Self::SystemPrefix,
+        }
+    }
+}
+
+impl From<WireAnthropicCacheControlPolicy>
+    for meerkat_core::lifecycle::run_primitive::AnthropicCacheControlPolicy
+{
+    fn from(value: WireAnthropicCacheControlPolicy) -> Self {
+        match value {
+            WireAnthropicCacheControlPolicy::Disabled => Self::Disabled,
+            WireAnthropicCacheControlPolicy::SystemPrefix => Self::SystemPrefix,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[serde(rename_all = "snake_case")]
+pub enum WireOpenAiPromptCacheRetention {
+    InMemory,
+    #[serde(rename = "24h")]
+    TwentyFourHours,
+}
+
+impl From<meerkat_core::lifecycle::run_primitive::OpenAiPromptCacheRetention>
+    for WireOpenAiPromptCacheRetention
+{
+    fn from(value: meerkat_core::lifecycle::run_primitive::OpenAiPromptCacheRetention) -> Self {
+        use meerkat_core::lifecycle::run_primitive::OpenAiPromptCacheRetention as Core;
+        match value {
+            Core::InMemory => Self::InMemory,
+            Core::TwentyFourHours => Self::TwentyFourHours,
+        }
+    }
+}
+
+impl From<WireOpenAiPromptCacheRetention>
+    for meerkat_core::lifecycle::run_primitive::OpenAiPromptCacheRetention
+{
+    fn from(value: WireOpenAiPromptCacheRetention) -> Self {
+        match value {
+            WireOpenAiPromptCacheRetention::InMemory => Self::InMemory,
+            WireOpenAiPromptCacheRetention::TwentyFourHours => Self::TwentyFourHours,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[serde(rename_all = "snake_case")]
 pub enum WireGeminiThinkingLevel {
     Minimal,
     Low,
@@ -851,6 +914,8 @@ pub enum WireProviderTag {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         context: Option<WireAnthropicContextWindow>,
         #[serde(default, skip_serializing_if = "Option::is_none")]
+        cache_control: Option<WireAnthropicCacheControlPolicy>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         supports_temperature_override: Option<bool>,
     },
     OpenAi {
@@ -889,6 +954,12 @@ pub enum WireProviderTag {
         )]
         thinking: Option<serde_json::Value>,
         #[serde(default, skip_serializing_if = "Option::is_none")]
+        store: Option<bool>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        prompt_cache_key: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        prompt_cache_retention: Option<WireOpenAiPromptCacheRetention>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         supports_temperature_override: Option<bool>,
         #[serde(default, skip_serializing_if = "Option::is_none")]
         supports_reasoning_override: Option<bool>,
@@ -914,6 +985,8 @@ pub enum WireProviderTag {
         google_search: Option<serde_json::Value>,
         #[serde(default, skip_serializing_if = "Option::is_none")]
         candidate_count: Option<u32>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        cached_content_name: Option<String>,
     },
     /// Wire projection of `ProviderTag::Unknown { bag }` — the typed
     /// escape hatch for V3 legacy-row provider knobs that don't (yet) map
@@ -935,6 +1008,7 @@ impl From<meerkat_core::lifecycle::run_primitive::ProviderTag> for WireProviderT
                 inference_geo: t.inference_geo.map(Into::into),
                 compaction: t.compaction.map(Into::into),
                 context: t.context.map(Into::into),
+                cache_control: t.cache_control.map(Into::into),
                 supports_temperature_override: t.supports_temperature_override,
             },
             Core::OpenAi(t) => Self::OpenAi {
@@ -947,6 +1021,9 @@ impl From<meerkat_core::lifecycle::run_primitive::ProviderTag> for WireProviderT
                 reasoning: t.reasoning.map(|v| v.as_value()),
                 chat_template_kwargs: t.chat_template_kwargs.map(|v| v.as_value()),
                 thinking: t.thinking.map(|v| v.as_value()),
+                store: t.store,
+                prompt_cache_key: t.prompt_cache_key,
+                prompt_cache_retention: t.prompt_cache_retention.map(Into::into),
                 supports_temperature_override: t.supports_temperature_override,
                 supports_reasoning_override: t.supports_reasoning_override,
             },
@@ -959,6 +1036,7 @@ impl From<meerkat_core::lifecycle::run_primitive::ProviderTag> for WireProviderT
                 structured_output: t.structured_output,
                 google_search: t.google_search.map(|v| v.as_value()),
                 candidate_count: t.candidate_count,
+                cached_content_name: t.cached_content_name,
             },
             Core::Unknown { bag } => Self::Unknown { bag },
         }
@@ -981,6 +1059,7 @@ impl From<WireProviderTag> for meerkat_core::lifecycle::run_primitive::ProviderT
                 inference_geo,
                 compaction,
                 context,
+                cache_control,
                 supports_temperature_override,
             } => Self::Anthropic(AnthropicProviderTag {
                 thinking: thinking.map(Into::into),
@@ -992,6 +1071,7 @@ impl From<WireProviderTag> for meerkat_core::lifecycle::run_primitive::ProviderT
                 inference_geo: inference_geo.map(Into::into),
                 compaction: compaction.map(Into::into),
                 context: context.map(Into::into),
+                cache_control: cache_control.map(Into::into),
                 supports_temperature_override,
             }),
             WireProviderTag::OpenAi {
@@ -1004,6 +1084,9 @@ impl From<WireProviderTag> for meerkat_core::lifecycle::run_primitive::ProviderT
                 reasoning,
                 chat_template_kwargs,
                 thinking,
+                store,
+                prompt_cache_key,
+                prompt_cache_retention,
                 supports_temperature_override,
                 supports_reasoning_override,
             } => Self::OpenAi(OpenAiProviderTag {
@@ -1017,6 +1100,9 @@ impl From<WireProviderTag> for meerkat_core::lifecycle::run_primitive::ProviderT
                 chat_template_kwargs: chat_template_kwargs
                     .map(|v| OpaqueProviderBody::from_value(&v)),
                 thinking: thinking.map(|v| OpaqueProviderBody::from_value(&v)),
+                store,
+                prompt_cache_key,
+                prompt_cache_retention: prompt_cache_retention.map(Into::into),
                 supports_temperature_override,
                 supports_reasoning_override,
             }),
@@ -1029,6 +1115,7 @@ impl From<WireProviderTag> for meerkat_core::lifecycle::run_primitive::ProviderT
                 structured_output,
                 google_search,
                 candidate_count,
+                cached_content_name,
             } => Self::Gemini(GeminiProviderTag {
                 thinking: thinking.map(Into::into),
                 thinking_budget,
@@ -1038,6 +1125,7 @@ impl From<WireProviderTag> for meerkat_core::lifecycle::run_primitive::ProviderT
                 structured_output,
                 google_search: google_search.map(|v| OpaqueProviderBody::from_value(&v)),
                 candidate_count,
+                cached_content_name,
             }),
             WireProviderTag::Unknown { bag } => Self::Unknown { bag },
         }

--- a/meerkat-contracts/src/wire/session.rs
+++ b/meerkat-contracts/src/wire/session.rs
@@ -348,6 +348,12 @@ pub enum WireProviderMeta {
         #[serde(default)]
         #[serde(skip_serializing_if = "Option::is_none")]
         phase: Option<String>,
+        #[serde(default)]
+        #[serde(skip_serializing_if = "Option::is_none")]
+        response_id: Option<String>,
+    },
+    OpenAiResponse {
+        response_id: String,
     },
     Unknown,
 }
@@ -363,12 +369,14 @@ impl From<ProviderMeta> for WireProviderMeta {
                 id,
                 encrypted_content,
                 phase,
-                ..
+                response_id,
             } => Self::OpenAi {
                 id,
                 encrypted_content,
                 phase,
+                response_id,
             },
+            ProviderMeta::OpenAiResponse { response_id } => Self::OpenAiResponse { response_id },
             _ => Self::Unknown,
         }
     }
@@ -900,11 +908,16 @@ fn wire_provider_meta_to_core(value: WireProviderMeta) -> Option<ProviderMeta> {
             id,
             encrypted_content,
             phase,
+            response_id,
         } => Some(ProviderMeta::OpenAi {
             id,
             encrypted_content,
             phase,
+            response_id,
         }),
+        WireProviderMeta::OpenAiResponse { response_id } => {
+            Some(ProviderMeta::OpenAiResponse { response_id })
+        }
         WireProviderMeta::Unknown => None,
     }
 }
@@ -2286,6 +2299,7 @@ mod tests {
                     id: "rs_1".to_string(),
                     encrypted_content: Some("enc".to_string()),
                     phase: Some("draft".to_string()),
+                    response_id: None,
                 })),
             },
             AssistantBlock::Transcript {

--- a/meerkat-contracts/tests/runtime_turn_metadata_wire_override.rs
+++ b/meerkat-contracts/tests/runtime_turn_metadata_wire_override.rs
@@ -243,3 +243,92 @@ fn wire_metadata_openai_reasoning_effort_none_and_xhigh_round_trip() {
         assert_eq!(tag.reasoning_effort, Some(effort));
     }
 }
+
+#[test]
+fn wire_metadata_prompt_cache_fields_round_trip() {
+    use meerkat_core::lifecycle::run_primitive::{
+        AnthropicCacheControlPolicy, AnthropicProviderTag, GeminiProviderTag,
+        OpenAiPromptCacheRetention, OpenAiProviderTag, ProviderTag,
+    };
+
+    let openai_params = ProviderParamsOverride {
+        provider_tag: Some(ProviderTag::OpenAi(OpenAiProviderTag {
+            store: Some(false),
+            prompt_cache_key: Some("tenant-a:stable-prefix".to_string()),
+            prompt_cache_retention: Some(OpenAiPromptCacheRetention::TwentyFourHours),
+            ..Default::default()
+        })),
+        ..Default::default()
+    };
+    let wire: WireRuntimeTurnMetadata = RuntimeTurnMetadata {
+        provider_params: Some(TurnMetadataOverride::Set(openai_params)),
+        ..Default::default()
+    }
+    .into();
+    let json = serde_json::to_value(&wire).expect("serialize openai wire metadata");
+    let openai_tag = &json["provider_params"]["value"]["provider_tag"];
+    assert_eq!(openai_tag["store"], serde_json::json!(false));
+    assert_eq!(
+        openai_tag["prompt_cache_key"],
+        serde_json::json!("tenant-a:stable-prefix")
+    );
+    assert_eq!(
+        openai_tag["prompt_cache_retention"],
+        serde_json::json!("24h")
+    );
+    let round_tripped: RuntimeTurnMetadata =
+        serde_json::from_value::<WireRuntimeTurnMetadata>(json)
+            .expect("deserialize openai wire metadata")
+            .into();
+    let Some(TurnMetadataOverride::Set(params)) = round_tripped.provider_params else {
+        panic!("openai provider params should survive wire round trip");
+    };
+    let Some(ProviderTag::OpenAi(tag)) = params.provider_tag else {
+        panic!("openai provider tag expected");
+    };
+    assert_eq!(tag.store, Some(false));
+    assert_eq!(
+        tag.prompt_cache_key.as_deref(),
+        Some("tenant-a:stable-prefix")
+    );
+    assert_eq!(
+        tag.prompt_cache_retention,
+        Some(OpenAiPromptCacheRetention::TwentyFourHours)
+    );
+
+    let anthropic_params = ProviderParamsOverride {
+        provider_tag: Some(ProviderTag::Anthropic(AnthropicProviderTag {
+            cache_control: Some(AnthropicCacheControlPolicy::SystemPrefix),
+            ..Default::default()
+        })),
+        ..Default::default()
+    };
+    let wire: WireRuntimeTurnMetadata = RuntimeTurnMetadata {
+        provider_params: Some(TurnMetadataOverride::Set(anthropic_params)),
+        ..Default::default()
+    }
+    .into();
+    let json = serde_json::to_value(&wire).expect("serialize anthropic wire metadata");
+    assert_eq!(
+        json["provider_params"]["value"]["provider_tag"]["cache_control"],
+        serde_json::json!("system_prefix")
+    );
+
+    let gemini_params = ProviderParamsOverride {
+        provider_tag: Some(ProviderTag::Gemini(GeminiProviderTag {
+            cached_content_name: Some("cachedContents/stable-prefix".to_string()),
+            ..Default::default()
+        })),
+        ..Default::default()
+    };
+    let wire: WireRuntimeTurnMetadata = RuntimeTurnMetadata {
+        provider_params: Some(TurnMetadataOverride::Set(gemini_params)),
+        ..Default::default()
+    }
+    .into();
+    let json = serde_json::to_value(&wire).expect("serialize gemini wire metadata");
+    assert_eq!(
+        json["provider_params"]["value"]["provider_tag"]["cached_content_name"],
+        serde_json::json!("cachedContents/stable-prefix")
+    );
+}

--- a/meerkat-core/src/agent/state.rs
+++ b/meerkat-core/src/agent/state.rs
@@ -8219,6 +8219,7 @@ mod tests {
                         id: "rs_reasoning_only".to_string(),
                         encrypted_content: Some("encrypted-reasoning".to_string()),
                         phase: None,
+                        response_id: None,
                     })),
                 }],
                 StopReason::EndTurn,

--- a/meerkat-core/src/lifecycle/run_primitive.rs
+++ b/meerkat-core/src/lifecycle/run_primitive.rs
@@ -384,6 +384,17 @@ pub enum AnthropicCompactionConfig {
     Custom { edit: OpaqueProviderBody },
 }
 
+/// Typed shape of Anthropic's prompt-cache breakpoint policy.
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AnthropicCacheControlPolicy {
+    /// Do not request Anthropic prompt-cache breakpoints.
+    Disabled,
+    /// Mark the stable top-level system prompt as an ephemeral cache prefix.
+    SystemPrefix,
+}
+
 /// Per-turn Anthropic-specific knobs carried in `ProviderTag::Anthropic`.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
@@ -419,11 +430,26 @@ pub struct AnthropicProviderTag {
     /// Context-window opt-in (1M beta).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub context: Option<AnthropicContextWindow>,
+    /// Prompt-cache breakpoint policy.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cache_control: Option<AnthropicCacheControlPolicy>,
     /// Internal override: force-enable temperature for this request even
     /// when the model profile says unsupported. Used by proxied /
     /// custom deployments.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub supports_temperature_override: Option<bool>,
+}
+
+/// Typed shape of OpenAI's prompt-cache retention hint.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[serde(rename_all = "snake_case")]
+pub enum OpenAiPromptCacheRetention {
+    /// Retain only in memory.
+    InMemory,
+    /// Retain for 24 hours.
+    #[serde(rename = "24h")]
+    TwentyFourHours,
 }
 
 /// Per-turn OpenAI-specific knobs carried in `ProviderTag::OpenAi`.
@@ -461,6 +487,17 @@ pub struct OpenAiProviderTag {
     /// forwarded verbatim.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub thinking: Option<OpaqueProviderBody>,
+    /// Responses API persistence override. Absent means the client sends
+    /// `store: false` by default; callers may explicitly opt in with
+    /// `Some(true)`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub store: Option<bool>,
+    /// OpenAI prompt-cache affinity routing key.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub prompt_cache_key: Option<String>,
+    /// OpenAI prompt-cache retention hint.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub prompt_cache_retention: Option<OpenAiPromptCacheRetention>,
     /// Internal override: force-enable temperature for this request.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub supports_temperature_override: Option<bool>,
@@ -539,6 +576,9 @@ pub struct GeminiProviderTag {
     /// read by the Gemini client today — preserved for V3 round-trip).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub candidate_count: Option<u32>,
+    /// Gemini explicit context-cache resource name.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cached_content_name: Option<String>,
 }
 
 /// Typed projection of OpenAI's reasoning-effort knob.
@@ -751,6 +791,7 @@ impl ProviderTag {
                 fill(&mut target.inference_geo, &default.inference_geo);
                 fill(&mut target.compaction, &default.compaction);
                 fill(&mut target.context, &default.context);
+                fill(&mut target.cache_control, &default.cache_control);
                 fill(
                     &mut target.supports_temperature_override,
                     &default.supports_temperature_override,
@@ -770,6 +811,12 @@ impl ProviderTag {
                     &default.chat_template_kwargs,
                 );
                 fill(&mut target.thinking, &default.thinking);
+                fill(&mut target.store, &default.store);
+                fill(&mut target.prompt_cache_key, &default.prompt_cache_key);
+                fill(
+                    &mut target.prompt_cache_retention,
+                    &default.prompt_cache_retention,
+                );
                 fill(
                     &mut target.supports_temperature_override,
                     &default.supports_temperature_override,
@@ -789,6 +836,10 @@ impl ProviderTag {
                 fill(&mut target.structured_output, &default.structured_output);
                 fill(&mut target.google_search, &default.google_search);
                 fill(&mut target.candidate_count, &default.candidate_count);
+                fill(
+                    &mut target.cached_content_name,
+                    &default.cached_content_name,
+                );
                 Ok(())
             }
             // An opaque pass-through bag cannot be field-merged; the explicit
@@ -2023,12 +2074,14 @@ mod tests {
                 temperature: Some(0.3),
                 provider_tag: Some(ProviderTag::Anthropic(AnthropicProviderTag {
                     effort: Some(AnthropicEffort::High),
+                    cache_control: Some(AnthropicCacheControlPolicy::Disabled),
                     ..Default::default()
                 })),
                 ..Default::default()
             },
             tool_defaults: Some(ProviderTag::Anthropic(AnthropicProviderTag {
                 effort: Some(AnthropicEffort::Low),
+                cache_control: Some(AnthropicCacheControlPolicy::SystemPrefix),
                 web_search: Some(OpaqueProviderBody::from_value(
                     &serde_json::json!({"type": "web_search_20250305"}),
                 )),
@@ -2043,6 +2096,10 @@ mod tests {
         };
         // Explicit knob wins over the default.
         assert_eq!(tag.effort, Some(AnthropicEffort::High));
+        assert_eq!(
+            tag.cache_control,
+            Some(AnthropicCacheControlPolicy::Disabled)
+        );
         // Unset slot is filled from the build-derived default.
         assert_eq!(
             tag.web_search,
@@ -2071,6 +2128,31 @@ mod tests {
                 defaults: "openai",
             }
         );
+    }
+
+    #[test]
+    fn carrier_effective_params_preserves_explicit_openai_store_false() {
+        let carrier = ProviderParamsCarrier {
+            params: ProviderParamsOverride {
+                provider_tag: Some(ProviderTag::OpenAi(OpenAiProviderTag {
+                    store: Some(false),
+                    ..Default::default()
+                })),
+                ..Default::default()
+            },
+            tool_defaults: Some(ProviderTag::OpenAi(OpenAiProviderTag {
+                store: Some(true),
+                prompt_cache_key: Some("default-key".to_string()),
+                ..Default::default()
+            })),
+        };
+
+        let effective = carrier.effective_params().expect("merge succeeds");
+        let Some(ProviderTag::OpenAi(tag)) = effective.provider_tag else {
+            panic!("openai tag expected");
+        };
+        assert_eq!(tag.store, Some(false));
+        assert_eq!(tag.prompt_cache_key.as_deref(), Some("default-key"));
     }
 
     /// K2 invariant: the carrier's durable face is exactly the typed override

--- a/meerkat-core/src/types.rs
+++ b/meerkat-core/src/types.rs
@@ -625,6 +625,19 @@ pub enum ProviderMeta {
         #[serde(default)]
         #[serde(skip_serializing_if = "Option::is_none")]
         phase: Option<String>,
+        /// Provider response ID for server-side continuation. This is an
+        /// optimization hint only; canonical transcript replay does not
+        /// depend on it being present or valid.
+        #[serde(default)]
+        #[serde(skip_serializing_if = "Option::is_none")]
+        response_id: Option<String>,
+    },
+    /// OpenAI response-level continuation metadata for non-reasoning blocks.
+    /// The ID is an optimization hint for `previous_response_id`; it is not
+    /// semantic transcript content.
+    OpenAiResponse {
+        /// Provider response ID returned by the Responses API.
+        response_id: String,
     },
 }
 

--- a/meerkat-core/src/types/tests.rs
+++ b/meerkat-core/src/types/tests.rs
@@ -898,6 +898,7 @@ mod ordered_transcript_types {
             id: "reasoning_item_123".to_string(),
             encrypted_content: Some("encrypted_tokens_abc".to_string()),
             phase: Some("reasoning".to_string()),
+            response_id: None,
         };
 
         let json = serde_json::to_string(&meta).unwrap();
@@ -918,6 +919,7 @@ mod ordered_transcript_types {
             id: "reasoning_item_456".to_string(),
             encrypted_content: None,
             phase: None,
+            response_id: None,
         };
 
         let json = serde_json::to_string(&meta).unwrap();
@@ -932,6 +934,21 @@ mod ordered_transcript_types {
         // Roundtrip still works
         let parsed: ProviderMeta = serde_json::from_str(&json).unwrap();
         assert_eq!(meta, parsed);
+    }
+
+    #[test]
+    fn test_provider_meta_openai_response_roundtrip() {
+        let meta = ProviderMeta::OpenAiResponse {
+            response_id: "resp_123".to_string(),
+        };
+
+        let json = serde_json::to_string(&meta).unwrap();
+        let parsed: ProviderMeta = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(meta, parsed);
+        let value: Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(value["provider"], "open_ai_response");
+        assert_eq!(value["response_id"], "resp_123");
     }
 
     // -----------------------------------------------------------------------
@@ -999,6 +1016,7 @@ mod ordered_transcript_types {
                 id: "reasoning_123".to_string(),
                 encrypted_content: Some("encrypted".to_string()),
                 phase: None,
+                response_id: None,
             })),
         };
 
@@ -1016,6 +1034,7 @@ mod ordered_transcript_types {
                 id: "reasoning_123".to_string(),
                 encrypted_content: Some("encrypted".to_string()),
                 phase: None,
+                response_id: None,
             })),
         }];
 
@@ -1180,6 +1199,7 @@ mod ordered_transcript_types {
                 id: "item_abc".to_string(),
                 encrypted_content: None,
                 phase: Some("response".to_string()),
+                response_id: None,
             })),
         };
 

--- a/meerkat-core/tests/runtime_turn_metadata_typed_round_trip.rs
+++ b/meerkat-core/tests/runtime_turn_metadata_typed_round_trip.rs
@@ -10,9 +10,10 @@ use std::time::Duration;
 use meerkat_core::connection::{AuthBindingRef, BindingOrigin};
 use meerkat_core::lifecycle::run_primitive::{
     AnthropicProviderTag, GeminiProviderTag, KeepAliveDirective, KeepAliveMode, KeepAlivePolicy,
-    ModelId, OpenAiProviderTag, PeerResponseTerminalApplyIntent, ProviderParamsOverride,
-    ProviderTag, ReasoningEffort, ReasoningMode, RuntimeExecutionKind, RuntimeTurnMetadata,
-    TurnInstruction, TurnInstructionKind, TurnMetadataMergeConflict, TurnMetadataOverride,
+    ModelId, OpenAiPromptCacheRetention, OpenAiProviderTag, PeerResponseTerminalApplyIntent,
+    ProviderParamsOverride, ProviderTag, ReasoningEffort, ReasoningMode, RuntimeExecutionKind,
+    RuntimeTurnMetadata, TurnInstruction, TurnInstructionKind, TurnMetadataMergeConflict,
+    TurnMetadataOverride,
 };
 use meerkat_core::provider::Provider;
 use meerkat_core::service::TurnToolOverlay;
@@ -88,6 +89,9 @@ fn provider_tag_openai_round_trips() {
         provider_params: Some(TurnMetadataOverride::Set(ProviderParamsOverride {
             provider_tag: Some(ProviderTag::OpenAi(OpenAiProviderTag {
                 reasoning_effort: Some(ReasoningEffort::High),
+                store: Some(false),
+                prompt_cache_key: Some("tenant-a:stable-prefix".to_string()),
+                prompt_cache_retention: Some(OpenAiPromptCacheRetention::InMemory),
                 ..Default::default()
             })),
             ..Default::default()
@@ -106,6 +110,7 @@ fn provider_tag_gemini_round_trips() {
         provider_params: Some(TurnMetadataOverride::Set(ProviderParamsOverride {
             provider_tag: Some(ProviderTag::Gemini(GeminiProviderTag {
                 candidate_count: Some(4),
+                cached_content_name: Some("cachedContents/stable-prefix".to_string()),
                 ..Default::default()
             })),
             ..Default::default()

--- a/meerkat-gemini/src/client.rs
+++ b/meerkat-gemini/src/client.rs
@@ -604,6 +604,10 @@ impl GeminiClient {
                     Value::String("application/json".to_string());
                 body["generationConfig"]["responseJsonSchema"] = compiled.schema;
             }
+
+            if let Some(name) = tag.cached_content_name.as_ref() {
+                body["cachedContent"] = Value::String(name.clone());
+            }
         }
 
         let has_function_declarations = !request.tools.is_empty();
@@ -1804,7 +1808,7 @@ impl LlmClient for GeminiClient {
                                     input_tokens: usage.prompt_token_count.unwrap_or(0),
                                     output_tokens: usage.candidates_token_count.unwrap_or(0),
                                     cache_creation_tokens: None,
-                                    cache_read_tokens: None,
+                                    cache_read_tokens: usage.cached_content_token_count,
                                 }
                             };
                         }
@@ -1975,6 +1979,7 @@ struct FunctionCall {
 #[serde(rename_all = "camelCase")]
 struct GeminiUsage {
     prompt_token_count: Option<u64>,
+    cached_content_token_count: Option<u64>,
     candidates_token_count: Option<u64>,
 }
 
@@ -3045,6 +3050,24 @@ mod tests {
     }
 
     #[test]
+    fn test_build_request_body_with_cached_content_name() -> Result<(), Box<dyn std::error::Error>>
+    {
+        let client = GeminiClient::new("test-key".to_string());
+        let request = LlmRequest::new(
+            "gemini-1.5-pro",
+            vec![Message::User(UserMessage::text("test".to_string()))],
+        )
+        .with_gemini_tag_merge(|t| {
+            t.cached_content_name = Some("cachedContents/stable-prefix".to_string());
+        });
+
+        let body = client.build_request_body(&request)?;
+
+        assert_eq!(body["cachedContent"], "cachedContents/stable-prefix");
+        Ok(())
+    }
+
+    #[test]
     fn test_openai_reasoning_effort_provider_tag_does_not_affect_gemini_body()
     -> Result<(), Box<dyn std::error::Error>> {
         let client = GeminiClient::new("test-key".to_string());
@@ -3155,11 +3178,48 @@ mod tests {
 
     #[test]
     fn test_parse_stream_line_with_usage() -> Result<(), Box<dyn std::error::Error>> {
-        let line = r#"{"usageMetadata":{"promptTokenCount":10,"candidatesTokenCount":5}}"#;
+        let line = r#"{"usageMetadata":{"promptTokenCount":10,"cachedContentTokenCount":7,"candidatesTokenCount":5}}"#;
         let response = GeminiClient::parse_stream_line(line)?.ok_or("missing response")?;
         assert!(response.usage_metadata.is_some());
         let usage = response.usage_metadata.ok_or("missing usage")?;
         assert_eq!(usage.prompt_token_count, Some(10));
+        assert_eq!(usage.cached_content_token_count, Some(7));
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn stream_emits_cached_content_usage() -> Result<(), Box<dyn std::error::Error>> {
+        let seen = Arc::new(Mutex::new(Vec::new()));
+        let payload = [
+            r#"data: {"usageMetadata":{"promptTokenCount":100,"cachedContentTokenCount":64,"candidatesTokenCount":5}}"#,
+            r#"data: {"candidates":[{"content":{"parts":[{"text":"done"}]},"finishReason":"STOP"}]}"#,
+            "",
+        ]
+        .join("\n");
+        let (base_url, handle) =
+            spawn_gemini_stream_stub("gemini-3.5-flash", payload, seen.clone()).await;
+        let client = GeminiClient::new_with_base_url("test-key".to_string(), base_url);
+        let request = LlmRequest::new(
+            "gemini-3.5-flash",
+            vec![Message::User(UserMessage::text("hello".to_string()))],
+        );
+
+        let mut stream = client.stream(&request);
+        let mut usage_update = None;
+        while let Some(event) = stream.next().await {
+            match event? {
+                LlmEvent::UsageUpdate { usage } => usage_update = Some(usage),
+                LlmEvent::Done { .. } => break,
+                _ => {}
+            }
+        }
+        handle.abort();
+
+        let usage = usage_update.ok_or("missing usage update")?;
+        assert_eq!(usage.input_tokens, 100);
+        assert_eq!(usage.output_tokens, 5);
+        assert_eq!(usage.cache_read_tokens, Some(64));
+        assert_eq!(usage.cache_creation_tokens, None);
         Ok(())
     }
 

--- a/meerkat-llm-core/src/block_assembler.rs
+++ b/meerkat-llm-core/src/block_assembler.rs
@@ -85,11 +85,14 @@ impl BlockAssembler {
     /// Handle a text delta event.
     ///
     /// Text deltas can always succeed - no Result needed.
-    /// `meta` is used by Gemini for thoughtSignature on text parts.
+    /// `meta` is used for provider continuity metadata on text parts.
     pub fn on_text_delta(&mut self, delta: &str, meta: Option<Box<ProviderMeta>>) {
-        if meta.is_none()
-            && let Some(BlockSlot::Finalized(block)) = self.slots.last_mut()
-            && let AssistantBlock::Text { text, meta: None } = block.as_mut()
+        if let Some(BlockSlot::Finalized(block)) = self.slots.last_mut()
+            && let AssistantBlock::Text {
+                text,
+                meta: previous_meta,
+            } = block.as_mut()
+            && previous_meta == &meta
         {
             text.push_str(delta);
             return;
@@ -353,6 +356,78 @@ mod tests {
         // Third starts new block because previous has meta
         match &blocks[2] {
             AssistantBlock::Text { text, .. } => assert_eq!(text, "Third"),
+            _ => panic!("Expected Text block"),
+        }
+    }
+
+    #[test]
+    fn test_text_deltas_with_identical_meta_coalesce() {
+        let mut assembler = BlockAssembler::new();
+        let meta = Some(Box::new(ProviderMeta::OpenAiResponse {
+            response_id: "resp_123".to_string(),
+        }));
+
+        assembler.on_text_delta("Hello", meta.clone());
+        assembler.on_text_delta(" ", meta.clone());
+        assembler.on_text_delta("World", meta);
+
+        let blocks = assembler.finalize();
+        assert_eq!(blocks.len(), 1);
+
+        match &blocks[0] {
+            AssistantBlock::Text { text, meta } => {
+                assert_eq!(text, "Hello World");
+                match meta.as_deref() {
+                    Some(ProviderMeta::OpenAiResponse { response_id }) => {
+                        assert_eq!(response_id, "resp_123");
+                    }
+                    _ => panic!("Expected OpenAI response metadata"),
+                }
+            }
+            _ => panic!("Expected Text block"),
+        }
+    }
+
+    #[test]
+    fn test_text_deltas_with_different_meta_do_not_coalesce() {
+        let mut assembler = BlockAssembler::new();
+
+        assembler.on_text_delta(
+            "First",
+            Some(Box::new(ProviderMeta::OpenAiResponse {
+                response_id: "resp_first".to_string(),
+            })),
+        );
+        assembler.on_text_delta(
+            "Second",
+            Some(Box::new(ProviderMeta::OpenAiResponse {
+                response_id: "resp_second".to_string(),
+            })),
+        );
+
+        let blocks = assembler.finalize();
+        assert_eq!(blocks.len(), 2);
+
+        match &blocks[0] {
+            AssistantBlock::Text { text, meta } => {
+                assert_eq!(text, "First");
+                assert!(matches!(
+                    meta.as_deref(),
+                    Some(ProviderMeta::OpenAiResponse { response_id })
+                        if response_id == "resp_first"
+                ));
+            }
+            _ => panic!("Expected Text block"),
+        }
+        match &blocks[1] {
+            AssistantBlock::Text { text, meta } => {
+                assert_eq!(text, "Second");
+                assert!(matches!(
+                    meta.as_deref(),
+                    Some(ProviderMeta::OpenAiResponse { response_id })
+                        if response_id == "resp_second"
+                ));
+            }
             _ => panic!("Expected Text block"),
         }
     }

--- a/meerkat-openai/src/client.rs
+++ b/meerkat-openai/src/client.rs
@@ -5,7 +5,9 @@
 
 use async_trait::async_trait;
 use futures::StreamExt;
-use meerkat_core::lifecycle::run_primitive::{OpenAiProviderTag, ProviderTag};
+use meerkat_core::lifecycle::run_primitive::{
+    OpenAiPromptCacheRetention, OpenAiProviderTag, ProviderTag,
+};
 use meerkat_core::schema::{CompiledSchema, SchemaError};
 use meerkat_core::{
     AssistantBlock, BlockAssistantMessage, ContentBlock, ImageData, ImageGenerationIntent,
@@ -88,6 +90,12 @@ enum OpenAiBackendWire {
 enum SystemMessageMode {
     IncludeInInput,
     ExtractToInstructions,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct OpenAiContinuationPlan {
+    previous_response_id: String,
+    replay_from_message_index: usize,
 }
 
 #[derive(Clone, Copy)]
@@ -173,6 +181,74 @@ fn openai_server_tool_content_replayable(
         ),
         OpenAiReplayProjectionMode::ChatCompletions => false,
     }
+}
+
+fn openai_response_id_from_meta(meta: &Option<Box<ProviderMeta>>) -> Option<&str> {
+    match meta.as_deref() {
+        Some(
+            ProviderMeta::OpenAi {
+                response_id: Some(response_id),
+                ..
+            }
+            | ProviderMeta::OpenAiResponse { response_id },
+        ) => Some(response_id.as_str()),
+        _ => None,
+    }
+}
+
+fn openai_response_id_from_block(block: &AssistantBlock) -> Option<&str> {
+    match block {
+        AssistantBlock::Text { meta, .. }
+        | AssistantBlock::Reasoning { meta, .. }
+        | AssistantBlock::ToolUse { meta, .. }
+        | AssistantBlock::Transcript { meta, .. }
+        | AssistantBlock::ServerToolContent { meta, .. } => openai_response_id_from_meta(meta),
+        AssistantBlock::Image { .. } | _ => None,
+    }
+}
+
+fn openai_response_meta(response_id: Option<&str>) -> Option<Box<ProviderMeta>> {
+    response_id.map(|response_id| {
+        Box::new(ProviderMeta::OpenAiResponse {
+            response_id: response_id.to_string(),
+        })
+    })
+}
+
+fn openai_response_id_from_response(response: &Value) -> Option<String> {
+    response
+        .get("id")
+        .and_then(Value::as_str)
+        .filter(|id| !id.trim().is_empty())
+        .map(str::to_string)
+}
+
+fn openai_continuation_plan(request: &LlmRequest) -> Option<OpenAiContinuationPlan> {
+    let tag = openai_tag(request)?;
+    if tag.store != Some(true) {
+        return None;
+    }
+
+    request
+        .messages
+        .iter()
+        .enumerate()
+        .rev()
+        .find_map(|(index, message)| {
+            let Message::BlockAssistant(assistant) = message else {
+                return None;
+            };
+            assistant
+                .blocks
+                .iter()
+                .rev()
+                .find_map(openai_response_id_from_block)
+                .map(|response_id| OpenAiContinuationPlan {
+                    previous_response_id: response_id.to_string(),
+                    replay_from_message_index: index + 1,
+                })
+        })
+        .filter(|plan| plan.replay_from_message_index < request.messages.len())
 }
 
 fn project_openai_assistant_blocks(
@@ -594,6 +670,24 @@ impl OpenAiClient {
         }
 
         if let Some(tag) = openai_tag(request) {
+            if let Some(store) = tag.store {
+                body["store"] = Value::Bool(store);
+            }
+
+            if let Some(prompt_cache_key) = tag.prompt_cache_key.as_ref() {
+                body["prompt_cache_key"] = Value::String(prompt_cache_key.clone());
+            }
+
+            if let Some(retention) = tag.prompt_cache_retention {
+                body["prompt_cache_retention"] = Value::String(
+                    match retention {
+                        OpenAiPromptCacheRetention::InMemory => "in_memory",
+                        OpenAiPromptCacheRetention::TwentyFourHours => "24h",
+                    }
+                    .to_string(),
+                );
+            }
+
             if reasoning_enabled && let Some(effort) = tag.reasoning_effort {
                 let s = effort.as_legacy_str();
                 body["reasoning"]["effort"] = Value::String(s.to_string());
@@ -636,6 +730,100 @@ impl OpenAiClient {
         }
 
         Ok(body)
+    }
+
+    fn build_request_body_with_continuation(
+        &self,
+        request: &LlmRequest,
+    ) -> Result<(Value, Option<OpenAiContinuationPlan>), LlmError> {
+        let Some(plan) = openai_continuation_plan(request) else {
+            return self.build_request_body(request).map(|body| (body, None));
+        };
+
+        let mut continuation_request = request.clone();
+        continuation_request.messages = request.messages[plan.replay_from_message_index..].to_vec();
+        let mut body = self.build_request_body(&continuation_request)?;
+        if self.is_chatgpt_backend_wire() {
+            let full_body = self.build_request_body(request)?;
+            if let Some(instructions) = full_body.get("instructions").cloned() {
+                body["instructions"] = instructions;
+            }
+        }
+        body["previous_response_id"] = Value::String(plan.previous_response_id.clone());
+        Ok((body, Some(plan)))
+    }
+
+    fn previous_response_id_retriable_error(status_code: u16, text: &str) -> bool {
+        if !matches!(status_code, 400 | 404 | 409 | 422) {
+            return false;
+        }
+        let lowered = text.to_ascii_lowercase();
+        lowered.contains("previous_response_id")
+            || lowered.contains("previous response")
+            || lowered.contains("response id")
+    }
+
+    async fn send_responses_request(
+        &self,
+        endpoint: &str,
+        body: &Value,
+    ) -> Result<reqwest::Response, LlmError> {
+        let mut request_builder = self
+            .http
+            .post(endpoint)
+            .header("Content-Type", "application/json");
+        request_builder = self
+            .apply_request_headers(request_builder, endpoint, &[])
+            .await?;
+        request_builder.json(body).send().await.map_err(|e| {
+            if e.is_timeout() {
+                LlmError::NetworkTimeout { duration_ms: 30000 }
+            } else {
+                #[cfg(not(target_arch = "wasm32"))]
+                if e.is_connect() {
+                    return LlmError::ConnectionReset;
+                }
+                LlmError::Unknown {
+                    message: e.to_string(),
+                }
+            }
+        })
+    }
+
+    async fn responses_response_with_fallback(
+        &self,
+        endpoint: &str,
+        body: &Value,
+        fallback_body: Option<Value>,
+    ) -> Result<reqwest::Response, LlmError> {
+        let response = self.send_responses_request(endpoint, body).await?;
+        let status_code = response.status().as_u16();
+        if (200..=299).contains(&status_code) {
+            return Ok(response);
+        }
+
+        let headers = response.headers().clone();
+        let text = response.text().await.unwrap_or_default();
+        if let Some(fallback_body) = fallback_body
+            && Self::previous_response_id_retriable_error(status_code, &text)
+        {
+            let retry = self
+                .send_responses_request(endpoint, &fallback_body)
+                .await?;
+            let retry_status = retry.status().as_u16();
+            if (200..=299).contains(&retry_status) {
+                return Ok(retry);
+            }
+            let retry_headers = retry.headers().clone();
+            let retry_text = retry.text().await.unwrap_or_default();
+            return Err(LlmError::from_http_response(
+                retry_status,
+                retry_text,
+                &retry_headers,
+            ));
+        }
+
+        Err(LlmError::from_http_response(status_code, text, &headers))
     }
 
     /// Convert messages to Responses API input format.
@@ -1555,42 +1743,22 @@ impl LlmClient for OpenAiClient {
             let mut projected_request = request.clone();
             projected_request.messages = self.project_replay_messages(&request.messages)?;
             let request = &projected_request;
-            let body = self.build_request_body(request)?;
+            let (body, continuation_plan) = self.build_request_body_with_continuation(request)?;
+            let fallback_body = if continuation_plan.is_some() {
+                Some(self.build_request_body(request)?)
+            } else {
+                None
+            };
 
             let endpoint = self.responses_endpoint();
-            let mut request_builder = self
-                .http
-                .post(&endpoint)
-                .header("Content-Type", "application/json");
-            request_builder = self.apply_request_headers(request_builder, &endpoint, &[]).await?;
-            let response = request_builder
-                .json(&body)
-                .send()
-                .await
-                .map_err(|e| {
-                    if e.is_timeout() {
-                        LlmError::NetworkTimeout { duration_ms: 30000 }
-                    } else {
-                        #[cfg(not(target_arch = "wasm32"))]
-                        if e.is_connect() {
-                            return LlmError::ConnectionReset;
-                        }
-                        LlmError::Unknown { message: e.to_string() }
-                    }
-                })?;
-
-            let status_code = response.status().as_u16();
-            let stream_result = if (200..=299).contains(&status_code) {
-                Ok(response.bytes_stream())
-            } else {
-                let headers = response.headers().clone();
-                let text = response.text().await.unwrap_or_default();
-                Err(LlmError::from_http_response(status_code, text, &headers))
-            };
-            let mut stream = stream_result?;
+            let response = self
+                .responses_response_with_fallback(&endpoint, &body, fallback_body)
+                .await?;
+            let mut stream = response.bytes_stream();
             let mut buffer = String::with_capacity(512);
             let mut assembler = BlockAssembler::new();
             let mut usage = Usage::default();
+            let mut active_response_id: Option<String> = None;
             let mut saw_stream_text_delta = false;
             let mut streamed_tool_ids: HashSet<String> = HashSet::with_capacity(4);
             let mut response_item_tool_calls: HashMap<String, (String, String)> =
@@ -1630,6 +1798,13 @@ impl LlmClient for OpenAiClient {
                     buffer.drain(..=newline_pos);
 
                     if let Some(event) = parsed_event {
+                        if let Some(response_id) = event
+                            .response
+                            .as_ref()
+                            .and_then(openai_response_id_from_response)
+                        {
+                            active_response_id = Some(response_id);
+                        }
                         // Handle response.completed event (non-streaming final response)
                         if event.event_type == "response.completed" {
                             if done_emitted {
@@ -1659,24 +1834,26 @@ impl LlmClient for OpenAiClient {
                                                                                     "type": "message_annotations",
                                                                                     "annotations": annotations
                                                                                 }),
-                                                                                meta: None,
+                                                                                meta: openai_response_meta(active_response_id.as_deref()),
                                                                             };
                                                                         }
                                                                         if let Some(text) = part.get("text").and_then(|t| t.as_str())
                                                                             && !saw_stream_text_delta
                                                                         {
+                                                                            let meta = openai_response_meta(active_response_id.as_deref());
                                                                             saw_terminal_fallback_output = true;
-                                                                            assembler.on_text_delta(text, None);
-                                                                            yield LlmEvent::TextDelta { delta: text.to_string(), meta: None };
+                                                                            assembler.on_text_delta(text, meta.clone());
+                                                                            yield LlmEvent::TextDelta { delta: text.to_string(), meta };
                                                                         }
                                                                     }
                                                                     "refusal" => {
                                                                         if let Some(refusal) = part.get("refusal").and_then(|r| r.as_str())
                                                                             && !saw_stream_text_delta
                                                                         {
+                                                                            let meta = openai_response_meta(active_response_id.as_deref());
                                                                             saw_terminal_fallback_output = true;
-                                                                            assembler.on_text_delta(refusal, None);
-                                                                            yield LlmEvent::TextDelta { delta: refusal.to_string(), meta: None };
+                                                                            assembler.on_text_delta(refusal, meta.clone());
+                                                                            yield LlmEvent::TextDelta { delta: refusal.to_string(), meta };
                                                                         }
                                                                     }
                                                                     _ => {}
@@ -1722,6 +1899,7 @@ impl LlmClient for OpenAiClient {
                                                         id: reasoning_id.to_string(),
                                                         encrypted_content: encrypted,
                                                         phase,
+                                                        response_id: active_response_id.clone(),
                                                     }));
 
                                                     assembler.on_reasoning_start();
@@ -1767,14 +1945,14 @@ impl LlmClient for OpenAiClient {
                                                         call_id.to_string(),
                                                         name.to_string(),
                                                         args.clone(),
-                                                        None,
+                                                        openai_response_meta(active_response_id.as_deref()),
                                                     );
 
                                                     yield LlmEvent::ToolCallComplete {
                                                         id: call_id.to_string(),
                                                         name: name.into(),
                                                         args: args_value,
-                                                        meta: None,
+                                                        meta: openai_response_meta(active_response_id.as_deref()),
                                                     };
                                                     saw_terminal_fallback_output = true;
                                                 }
@@ -1790,7 +1968,7 @@ impl LlmClient for OpenAiClient {
                                                         id,
                                                         kind: ServerToolKind::WebSearch,
                                                         content: item.clone(),
-                                                        meta: None,
+                                                        meta: openai_response_meta(active_response_id.as_deref()),
                                                     };
                                                 }
                                                 _ => {}
@@ -1801,12 +1979,7 @@ impl LlmClient for OpenAiClient {
 
                                 // Extract usage
                                 if let Some(usage_obj) = response_obj.get("usage") {
-                                    usage.input_tokens = usage_obj.get("input_tokens")
-                                        .and_then(serde_json::Value::as_u64)
-                                        .unwrap_or(0);
-                                    usage.output_tokens = usage_obj.get("output_tokens")
-                                        .and_then(serde_json::Value::as_u64)
-                                        .unwrap_or(0);
+                                    apply_responses_usage(&mut usage, usage_obj);
                                     yield LlmEvent::UsageUpdate { usage: usage.clone() };
                                 }
 
@@ -1860,8 +2033,9 @@ impl LlmClient for OpenAiClient {
                             if let Some(delta) = &event.delta {
                                 saw_stream_text_delta = true;
                                 saw_terminal_fallback_output = true;
-                                assembler.on_text_delta(delta, None);
-                                yield LlmEvent::TextDelta { delta: delta.clone(), meta: None };
+                                let meta = openai_response_meta(active_response_id.as_deref());
+                                assembler.on_text_delta(delta, meta.clone());
+                                yield LlmEvent::TextDelta { delta: delta.clone(), meta };
                             }
                         }
                         else if event.event_type == "response.reasoning_summary_text.delta" {
@@ -1922,7 +2096,7 @@ impl LlmClient for OpenAiClient {
                                     call_id.clone(),
                                     name.clone(),
                                     args.clone(),
-                                    None,
+                                    openai_response_meta(active_response_id.as_deref()),
                                 );
 
                                 streamed_tool_ids.insert(call_id.clone());
@@ -1931,7 +2105,7 @@ impl LlmClient for OpenAiClient {
                                     id: call_id.clone(),
                                     name,
                                     args: args_value,
-                                    meta: None,
+                                    meta: openai_response_meta(active_response_id.as_deref()),
                                 };
                             }
                         }
@@ -1966,7 +2140,7 @@ impl LlmClient for OpenAiClient {
                                     call_id.to_string(),
                                     name.to_string(),
                                     args,
-                                    None,
+                                    openai_response_meta(active_response_id.as_deref()),
                                 );
 
                                 streamed_tool_ids.insert(call_id.to_string());
@@ -1975,7 +2149,7 @@ impl LlmClient for OpenAiClient {
                                     id: call_id.to_string(),
                                     name: name.to_string(),
                                     args: args_value,
-                                    meta: None,
+                                    meta: openai_response_meta(active_response_id.as_deref()),
                                 };
                             }
                         }
@@ -2011,6 +2185,7 @@ impl LlmClient for OpenAiClient {
                                     id: reasoning_id.to_string(),
                                     encrypted_content: encrypted,
                                     phase,
+                                    response_id: active_response_id.clone(),
                                 }));
 
                                 assembler.on_reasoning_start();
@@ -2046,19 +2221,14 @@ impl LlmClient for OpenAiClient {
                                 id: event.item_id.clone(),
                                 kind: ServerToolKind::WebSearch,
                                 content: Value::Object(content),
-                                meta: None,
+                                meta: openai_response_meta(active_response_id.as_deref()),
                             };
                         }
                         else if event.event_type == "response.done" {
                             // Final done event — always update usage
                             if let Some(response_obj) = &event.response {
                                 if let Some(usage_obj) = response_obj.get("usage") {
-                                    usage.input_tokens = usage_obj.get("input_tokens")
-                                        .and_then(serde_json::Value::as_u64)
-                                        .unwrap_or(0);
-                                    usage.output_tokens = usage_obj.get("output_tokens")
-                                        .and_then(serde_json::Value::as_u64)
-                                        .unwrap_or(0);
+                                    apply_responses_usage(&mut usage, usage_obj);
                                     yield LlmEvent::UsageUpdate { usage: usage.clone() };
                                 }
 
@@ -2235,6 +2405,26 @@ struct ResponsesStreamEvent {
     sequence_number: Option<u64>,
 }
 
+fn apply_responses_usage(target: &mut Usage, usage: &Value) {
+    target.input_tokens = usage
+        .get("input_tokens")
+        .and_then(Value::as_u64)
+        .unwrap_or(0);
+    target.output_tokens = usage
+        .get("output_tokens")
+        .and_then(Value::as_u64)
+        .unwrap_or(0);
+
+    let cached_tokens = usage
+        .get("input_tokens_details")
+        .or_else(|| usage.get("prompt_tokens_details"))
+        .and_then(|details| details.get("cached_tokens"))
+        .and_then(Value::as_u64);
+    if let Some(cached_tokens) = cached_tokens {
+        target.cache_read_tokens = Some(cached_tokens);
+    }
+}
+
 #[allow(clippy::unwrap_used, clippy::expect_used)]
 fn empty_tool_args_raw_value() -> Box<RawValue> {
     RawValue::from_string("{}".to_string()).expect("static JSON is valid")
@@ -2267,7 +2457,11 @@ fn parse_tool_call_arguments(
 mod tests {
     use super::*;
     use axum::{
-        Json, Router, extract::State, http::HeaderMap, response::IntoResponse, routing::post,
+        Json, Router,
+        extract::State,
+        http::{HeaderMap, StatusCode},
+        response::IntoResponse,
+        routing::post,
     };
     use meerkat_core::{
         AssistantImageId, BlobId, BlobRef, BlockAssistantMessage, MediaType, ProviderImageMetadata,
@@ -2338,6 +2532,7 @@ mod tests {
                             id: "rs_1".to_string(),
                             encrypted_content: Some("ciphertext".to_string()),
                             phase: Some("reasoning".to_string()),
+                            response_id: None,
                         })),
                     },
                     AssistantBlock::ServerToolContent {
@@ -2520,6 +2715,7 @@ mod tests {
                         id: "rs_1".to_string(),
                         encrypted_content: Some("enc".to_string()),
                         phase: Some("reasoning".to_string()),
+                        response_id: None,
                     })),
                 },
                 AssistantBlock::ServerToolContent {
@@ -2611,6 +2807,34 @@ mod tests {
     }
 
     #[derive(Clone)]
+    struct FallbackStreamStubState {
+        payload: String,
+        seen: Arc<Mutex<Vec<Value>>>,
+        calls: Arc<Mutex<usize>>,
+    }
+
+    async fn responses_sse_with_previous_response_fallback(
+        State(state): State<FallbackStreamStubState>,
+        Json(body): Json<Value>,
+    ) -> impl IntoResponse {
+        state.seen.lock().expect("seen mutex").push(body.clone());
+        let mut calls = state.calls.lock().expect("calls mutex");
+        *calls += 1;
+        if *calls == 1 && body.get("previous_response_id").is_some() {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(serde_json::json!({
+                    "error": {
+                        "message": "previous_response_id was not found"
+                    }
+                })),
+            )
+                .into_response();
+        }
+        ([("content-type", "text/event-stream")], state.payload).into_response()
+    }
+
+    #[derive(Clone)]
     struct HeaderStreamStubState {
         payload: String,
         seen: Arc<Mutex<Vec<Value>>>,
@@ -2656,6 +2880,30 @@ mod tests {
         let app = Router::new()
             .route("/v1/responses", post(responses_sse))
             .with_state(payload);
+        let listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind test server");
+        let addr = listener.local_addr().expect("local addr");
+        let handle = tokio::spawn(async move {
+            axum::serve(listener, app).await.expect("serve test server");
+        });
+        (format!("http://{addr}"), handle)
+    }
+
+    async fn spawn_openai_fallback_stub_server(
+        payload: String,
+        seen: Arc<Mutex<Vec<Value>>>,
+    ) -> (String, tokio::task::JoinHandle<()>) {
+        let app = Router::new()
+            .route(
+                "/v1/responses",
+                post(responses_sse_with_previous_response_fallback),
+            )
+            .with_state(FallbackStreamStubState {
+                payload,
+                seen,
+                calls: Arc::new(Mutex::new(0)),
+            });
         let listener = TcpListener::bind("127.0.0.1:0")
             .await
             .expect("bind test server");
@@ -3350,6 +3598,144 @@ mod tests {
         );
     }
 
+    #[test]
+    fn openai_prompt_cache_knobs_are_explicit_and_store_defaults_false() {
+        let client = OpenAiClient::new("test-key".to_string());
+        let request = LlmRequest::new(
+            "gpt-5.4",
+            vec![Message::User(UserMessage::text("Hello".to_string()))],
+        )
+        .with_openai_tag_merge(|t| {
+            t.store = Some(true);
+            t.prompt_cache_key = Some("tenant-a:stable-prefix".to_string());
+            t.prompt_cache_retention = Some(OpenAiPromptCacheRetention::TwentyFourHours);
+        });
+
+        let body = client.build_request_body(&request).expect("build request");
+
+        assert_eq!(body["store"], true);
+        assert_eq!(body["prompt_cache_key"], "tenant-a:stable-prefix");
+        assert_eq!(body["prompt_cache_retention"], "24h");
+
+        let default_body = client
+            .build_request_body(&LlmRequest::new(
+                "gpt-5.4",
+                vec![Message::User(UserMessage::text("Hello".to_string()))],
+            ))
+            .expect("build default request");
+        assert_eq!(default_body["store"], false);
+        assert!(default_body.get("prompt_cache_key").is_none());
+        assert!(default_body.get("prompt_cache_retention").is_none());
+    }
+
+    #[test]
+    fn openai_continuation_uses_previous_response_id_and_new_turn_only() {
+        let client = OpenAiClient::new("test-key".to_string());
+        let request = LlmRequest::new(
+            "gpt-5.4",
+            vec![
+                Message::User(UserMessage::text("old question".to_string())),
+                Message::BlockAssistant(BlockAssistantMessage::new(
+                    vec![AssistantBlock::Text {
+                        text: "old answer".to_string(),
+                        meta: Some(Box::new(ProviderMeta::OpenAiResponse {
+                            response_id: "resp_previous".to_string(),
+                        })),
+                    }],
+                    StopReason::EndTurn,
+                )),
+                Message::User(UserMessage::text("new question".to_string())),
+            ],
+        )
+        .with_openai_tag_merge(|t| t.store = Some(true));
+
+        let (body, plan) = client
+            .build_request_body_with_continuation(&request)
+            .expect("build continuation request");
+
+        assert_eq!(
+            plan.expect("continuation plan").previous_response_id,
+            "resp_previous"
+        );
+        assert_eq!(body["store"], true);
+        assert_eq!(body["previous_response_id"], "resp_previous");
+        let input = body["input"].as_array().expect("input array");
+        assert_eq!(input.len(), 1);
+        assert_eq!(input[0]["role"], "user");
+        assert_eq!(input[0]["content"], "new question");
+    }
+
+    #[test]
+    fn chatgpt_backend_continuation_preserves_full_request_instructions() {
+        let client = OpenAiClient::new("test-key".to_string()).with_chatgpt_backend_wire();
+        let request = LlmRequest::new(
+            "gpt-5.5",
+            vec![
+                Message::System(meerkat_core::SystemMessage::new(
+                    "You are a careful assistant.".to_string(),
+                )),
+                Message::User(UserMessage::text("old question".to_string())),
+                Message::BlockAssistant(BlockAssistantMessage::new(
+                    vec![AssistantBlock::Text {
+                        text: "old answer".to_string(),
+                        meta: Some(Box::new(ProviderMeta::OpenAiResponse {
+                            response_id: "resp_previous".to_string(),
+                        })),
+                    }],
+                    StopReason::EndTurn,
+                )),
+                Message::User(UserMessage::text("new question".to_string())),
+            ],
+        )
+        .with_openai_tag_merge(|t| t.store = Some(true));
+
+        let (body, plan) = client
+            .build_request_body_with_continuation(&request)
+            .expect("build continuation request");
+
+        assert_eq!(
+            plan.expect("continuation plan").previous_response_id,
+            "resp_previous"
+        );
+        assert_eq!(body["store"], true);
+        assert_eq!(body["previous_response_id"], "resp_previous");
+        assert_eq!(body["instructions"], "You are a careful assistant.");
+        let input = body["input"].as_array().expect("input array");
+        assert_eq!(input.len(), 1);
+        assert_eq!(input[0]["role"], "user");
+        assert_eq!(input[0]["content"], "new question");
+    }
+
+    #[test]
+    fn openai_store_false_keeps_full_replay_without_previous_response_id() {
+        let client = OpenAiClient::new("test-key".to_string());
+        let request = LlmRequest::new(
+            "gpt-5.4",
+            vec![
+                Message::User(UserMessage::text("old question".to_string())),
+                Message::BlockAssistant(BlockAssistantMessage::new(
+                    vec![AssistantBlock::Text {
+                        text: "old answer".to_string(),
+                        meta: Some(Box::new(ProviderMeta::OpenAiResponse {
+                            response_id: "resp_previous".to_string(),
+                        })),
+                    }],
+                    StopReason::EndTurn,
+                )),
+                Message::User(UserMessage::text("new question".to_string())),
+            ],
+        );
+
+        let (body, plan) = client
+            .build_request_body_with_continuation(&request)
+            .expect("build request");
+
+        assert!(plan.is_none());
+        assert_eq!(body["store"], false);
+        assert!(body.get("previous_response_id").is_none());
+        assert_eq!(body["input"].as_array().expect("input array").len(), 3);
+    }
+
     #[tokio::test]
     async fn chatgpt_backend_wire_uses_codex_responses_path()
     -> Result<(), Box<dyn std::error::Error>> {
@@ -3401,6 +3787,66 @@ mod tests {
                 .all(|item| item.get("role").and_then(Value::as_str) != Some("system")),
             "ChatGPT Codex backend rejects system messages in input; they must be lifted to instructions"
         );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn openai_previous_response_id_rejection_falls_back_to_full_replay()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let payload = [
+            r#"data: {"type":"response.created","response":{"id":"resp_retry"}}"#,
+            r#"data: {"type":"response.output_text.delta","delta":"Recovered"}"#,
+            r#"data: {"type":"response.done","response":{"id":"resp_retry","status":"completed","output":[],"usage":{"input_tokens":3,"output_tokens":1}}}"#,
+            "data: [DONE]",
+            "",
+        ]
+        .join("\n");
+        let seen = Arc::new(Mutex::new(Vec::new()));
+        let (base_url, server) = spawn_openai_fallback_stub_server(payload, seen.clone()).await;
+        let client = OpenAiClient::new_with_base_url("test-key".to_string(), base_url);
+        let request = LlmRequest::new(
+            "gpt-5.4",
+            vec![
+                Message::User(UserMessage::text("old question".to_string())),
+                Message::BlockAssistant(BlockAssistantMessage::new(
+                    vec![AssistantBlock::Text {
+                        text: "old answer".to_string(),
+                        meta: Some(Box::new(ProviderMeta::OpenAiResponse {
+                            response_id: "resp_missing".to_string(),
+                        })),
+                    }],
+                    StopReason::EndTurn,
+                )),
+                Message::User(UserMessage::text("new question".to_string())),
+            ],
+        )
+        .with_openai_tag_merge(|t| t.store = Some(true));
+
+        let mut stream = client.stream(&request);
+        let mut deltas = Vec::new();
+        while let Some(event) = stream.next().await {
+            match event? {
+                LlmEvent::TextDelta { delta, meta } => {
+                    deltas.push(delta);
+                    assert!(matches!(
+                        meta.as_deref(),
+                        Some(ProviderMeta::OpenAiResponse { response_id })
+                            if response_id == "resp_retry"
+                    ));
+                }
+                LlmEvent::Done { .. } => break,
+                _ => {}
+            }
+        }
+        server.abort();
+
+        assert_eq!(deltas, vec!["Recovered"]);
+        let bodies = seen.lock().expect("seen mutex");
+        assert_eq!(bodies.len(), 2);
+        assert_eq!(bodies[0]["previous_response_id"], "resp_missing");
+        assert_eq!(bodies[0]["input"].as_array().expect("input array").len(), 1);
+        assert!(bodies[1].get("previous_response_id").is_none());
+        assert_eq!(bodies[1]["input"].as_array().expect("input array").len(), 3);
         Ok(())
     }
 
@@ -3864,6 +4310,7 @@ mod tests {
                                 id: "rs_abc123".to_string(),
                                 encrypted_content: Some("encrypted_data".to_string()),
                                 phase: None,
+                                response_id: None,
                             })),
                         },
                         AssistantBlock::Text {
@@ -4443,6 +4890,25 @@ mod tests {
     }
 
     #[test]
+    fn test_responses_usage_maps_cached_tokens() {
+        let usage_value = serde_json::json!({
+            "input_tokens": 100,
+            "output_tokens": 7,
+            "input_tokens_details": {
+                "cached_tokens": 64
+            }
+        });
+        let mut usage = Usage::default();
+
+        apply_responses_usage(&mut usage, &usage_value);
+
+        assert_eq!(usage.input_tokens, 100);
+        assert_eq!(usage.output_tokens, 7);
+        assert_eq!(usage.cache_read_tokens, Some(64));
+        assert_eq!(usage.cache_creation_tokens, None);
+    }
+
+    #[test]
     fn test_parse_responses_sse_line_done_marker() {
         let line = "data: [DONE]";
         let event = OpenAiClient::parse_responses_sse_line(line);
@@ -4515,6 +4981,66 @@ mod tests {
         server.abort();
 
         assert_eq!(deltas, vec!["Hello"]);
+    }
+
+    #[tokio::test]
+    async fn test_stream_maps_cached_tokens_from_completed_usage() {
+        let payload = [
+            r#"data: {"type":"response.completed","response":{"status":"completed","output":[],"usage":{"input_tokens":100,"output_tokens":5,"input_tokens_details":{"cached_tokens":40}}}}"#,
+            "data: [DONE]",
+            "",
+        ]
+        .join("\n");
+        let (base_url, server) = spawn_openai_stub_server(payload).await;
+        let client = OpenAiClient::new_with_base_url("test-key".to_string(), base_url);
+        let request = LlmRequest::new(
+            "gpt-5-mini",
+            vec![Message::User(UserMessage::text("hello".to_string()))],
+        );
+
+        let mut stream = client.stream(&request);
+        let mut usage_updates = Vec::new();
+        while let Some(event) = stream.next().await {
+            if let LlmEvent::UsageUpdate { usage } = event.expect("stream event") {
+                usage_updates.push(usage);
+            }
+        }
+        server.abort();
+
+        assert_eq!(usage_updates.len(), 1);
+        assert_eq!(usage_updates[0].input_tokens, 100);
+        assert_eq!(usage_updates[0].output_tokens, 5);
+        assert_eq!(usage_updates[0].cache_read_tokens, Some(40));
+    }
+
+    #[tokio::test]
+    async fn test_stream_maps_cached_tokens_from_done_usage() {
+        let payload = [
+            r#"data: {"type":"response.done","response":{"status":"completed","output":[],"usage":{"input_tokens":101,"output_tokens":6,"input_tokens_details":{"cached_tokens":41}}}}"#,
+            "data: [DONE]",
+            "",
+        ]
+        .join("\n");
+        let (base_url, server) = spawn_openai_stub_server(payload).await;
+        let client = OpenAiClient::new_with_base_url("test-key".to_string(), base_url);
+        let request = LlmRequest::new(
+            "gpt-5-mini",
+            vec![Message::User(UserMessage::text("hello".to_string()))],
+        );
+
+        let mut stream = client.stream(&request);
+        let mut usage_updates = Vec::new();
+        while let Some(event) = stream.next().await {
+            if let LlmEvent::UsageUpdate { usage } = event.expect("stream event") {
+                usage_updates.push(usage);
+            }
+        }
+        server.abort();
+
+        assert_eq!(usage_updates.len(), 1);
+        assert_eq!(usage_updates[0].input_tokens, 101);
+        assert_eq!(usage_updates[0].output_tokens, 6);
+        assert_eq!(usage_updates[0].cache_read_tokens, Some(41));
     }
 
     #[tokio::test]
@@ -4835,6 +5361,7 @@ mod tests {
                             id: "rs_orphan".to_string(),
                             encrypted_content: None,
                             phase: None,
+                            response_id: None,
                         })),
                     }],
                     stop_reason: StopReason::EndTurn,
@@ -4869,6 +5396,7 @@ mod tests {
                             id: "rs_mid".to_string(),
                             encrypted_content: None,
                             phase: None,
+                            response_id: None,
                         })),
                     }],
                     stop_reason: StopReason::EndTurn,
@@ -4917,6 +5445,7 @@ mod tests {
                             id: "rs_before_tool".to_string(),
                             encrypted_content: None,
                             phase: None,
+                            response_id: None,
                         })),
                     }],
                     stop_reason: StopReason::EndTurn,
@@ -4963,6 +5492,7 @@ mod tests {
                                 id: "rs_valid".to_string(),
                                 encrypted_content: Some("enc_valid".to_string()),
                                 phase: None,
+                                response_id: None,
                             })),
                         },
                         AssistantBlock::ToolUse {
@@ -5044,6 +5574,7 @@ mod tests {
                             id: "rs_first".to_string(),
                             encrypted_content: Some("enc_1".to_string()),
                             phase: None,
+                            response_id: None,
                         })),
                     }],
                     stop_reason: StopReason::EndTurn,
@@ -5056,6 +5587,7 @@ mod tests {
                             id: "rs_second".to_string(),
                             encrypted_content: None,
                             phase: None,
+                            response_id: None,
                         })),
                     }],
                     stop_reason: StopReason::EndTurn,
@@ -5125,6 +5657,7 @@ mod tests {
                                 id: "rs_no_enc".to_string(),
                                 encrypted_content: None,
                                 phase: None,
+                                response_id: None,
                             })),
                         },
                         AssistantBlock::ToolUse {
@@ -5168,6 +5701,7 @@ mod tests {
                                 id: "rs_enc".to_string(),
                                 encrypted_content: Some("enc_data_here".to_string()),
                                 phase: None,
+                                response_id: None,
                             })),
                         },
                         AssistantBlock::Text {

--- a/meerkat-session/src/compactor.rs
+++ b/meerkat-session/src/compactor.rs
@@ -974,6 +974,7 @@ mod tests {
                             id: "rs_1".to_string(),
                             encrypted_content: Some("enc_data".to_string()),
                             phase: None,
+                            response_id: None,
                         })),
                     },
                     AssistantBlock::Text {
@@ -1012,6 +1013,7 @@ mod tests {
                         id: "rs_orphan".to_string(),
                         encrypted_content: Some("enc".to_string()),
                         phase: None,
+                        response_id: None,
                     })),
                 }],
                 StopReason::EndTurn,


### PR DESCRIPTION
## Summary
- parse provider cache-hit usage for OpenAI Responses, Gemini cached content, and Anthropic stream fixtures
- add typed cache provider knobs across OpenAI, Anthropic, and Gemini, including OpenAI `store: false` by default with explicit override support
- add OpenAI Responses continuation hints via `previous_response_id` behind explicit `store: true`, preserving full transcript replay as fallback
- regenerate schemas and update docs/changelog for the new caching controls

## Verification
- `make agent-gate`
- `make check`
- `make verify-schema-freshness`
- `make verify-sdk-codegen-freshness`
- `make verify-sdk-event-inventory`
- `make verify-rpc-surface-alignment`
- `make verify-rest-surface-alignment`
- targeted provider/core/contracts tests for cache usage, cache controls, provider metadata, and OpenAI continuation fallback
- three two-agent adversarial phase gates completed green
