### PR TITLE
[codex] Add @file expansion for prompts and AGENTS

### DIFF
--- a/meerkat-cli/src/main.rs
+++ b/meerkat-cli/src/main.rs
@@ -64,7 +64,7 @@ use meerkat_mob_pack::trust::{TrustPolicy, load_trusted_signers};
 use meerkat_runtime::input::{InputDurability, InputHeader, InputVisibility};
 use meerkat_runtime::{CorrelationId, IdempotencyKey, Input, InputOrigin, PromptInput};
 use meerkat_tools::find_project_root;
-use tokio::io::{AsyncBufRead, AsyncWrite, AsyncWriteExt, BufReader};
+use tokio::io::{AsyncBufRead, AsyncReadExt, AsyncWrite, AsyncWriteExt, BufReader};
 use tokio::sync::mpsc;
 
 use clap::{Parser, Subcommand, ValueEnum};
@@ -806,6 +806,314 @@ fn prepend_stdin_blob_context(prompt: String) -> String {
         return prompt;
     }
     format!("<stdin>\n{stdin_content}\n</stdin>\n\n{prompt}")
+}
+
+const USER_PROMPT_FILE_MENTION_MAX_FILES: usize = 16;
+const USER_PROMPT_FILE_MENTION_MAX_FILE_BYTES: usize = 64 * 1024;
+const USER_PROMPT_FILE_MENTION_MAX_TOTAL_BYTES: usize = 128 * 1024;
+const USER_PROMPT_FILE_MENTION_MAX_FILE_LINES: usize = 2_000;
+const USER_PROMPT_FILE_MENTION_MAX_TOTAL_LINES: usize = 4_000;
+const USER_PROMPT_FILE_MENTION_READ_SLOP_BYTES: usize = 4;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct UserPromptFileMention {
+    token: String,
+    path: PathBuf,
+    explicit: bool,
+}
+
+#[derive(Debug)]
+struct UserPromptFileAttachment {
+    mention: UserPromptFileMention,
+    display_path: PathBuf,
+    content: String,
+    bytes_included: usize,
+    lines_included: usize,
+    truncated: bool,
+}
+
+async fn expand_user_prompt_file_mentions(
+    prompt: String,
+    base_dir: &Path,
+) -> anyhow::Result<String> {
+    let tokens = scan_user_prompt_file_mention_tokens(&prompt);
+    if tokens.is_empty() {
+        return Ok(prompt);
+    }
+    if tokens.len() > USER_PROMPT_FILE_MENTION_MAX_FILES {
+        anyhow::bail!(
+            "too many @file mentions in prompt: {} found, maximum is {}",
+            tokens.len(),
+            USER_PROMPT_FILE_MENTION_MAX_FILES
+        );
+    }
+    let mentions = collect_user_prompt_file_mentions(tokens, base_dir).await?;
+    if mentions.is_empty() {
+        return Ok(prompt);
+    }
+
+    let mention_tokens = mentions
+        .iter()
+        .map(|mention| mention.token.clone())
+        .collect::<Vec<_>>();
+    let mut attachments = Vec::new();
+    let mut mentions_processed = 0;
+    let mut total_remaining_bytes = USER_PROMPT_FILE_MENTION_MAX_TOTAL_BYTES;
+    let mut total_remaining_lines = USER_PROMPT_FILE_MENTION_MAX_TOTAL_LINES;
+    for mention in mentions {
+        let attachment = read_user_prompt_file_attachment(
+            mention,
+            &mut total_remaining_bytes,
+            &mut total_remaining_lines,
+        )
+        .await?;
+        attachments.push(attachment);
+        mentions_processed += 1;
+        if total_remaining_bytes == 0 || total_remaining_lines == 0 {
+            break;
+        }
+    }
+
+    if attachments.is_empty() {
+        return Ok(prompt);
+    }
+
+    let mut expanded = String::new();
+    expanded.push_str("<user_mentioned_files>\n");
+    for attachment in attachments {
+        let path = attachment.display_path.display();
+        expanded.push_str(&format!(
+            "--- BEGIN @file: {path} (token=@{}, bytes={}, lines={}, truncated={}) ---\n",
+            attachment.mention.token,
+            attachment.bytes_included,
+            attachment.lines_included,
+            attachment.truncated
+        ));
+        expanded.push_str(&attachment.content);
+        if !attachment.content.ends_with('\n') {
+            expanded.push('\n');
+        }
+        expanded.push_str(&format!("--- END @file: {path} ---\n"));
+    }
+    if mentions_processed < mention_tokens.len() {
+        expanded.push_str(&format!(
+            "--- OMITTED @file mentions: {} (total byte/line expansion limits reached) ---\n",
+            mention_tokens[mentions_processed..]
+                .iter()
+                .map(|token| format!("@{token}"))
+                .collect::<Vec<_>>()
+                .join(", ")
+        ));
+    }
+    expanded.push_str("</user_mentioned_files>\n\n");
+    expanded.push_str(&prompt);
+    Ok(expanded)
+}
+
+async fn collect_user_prompt_file_mentions(
+    tokens: Vec<String>,
+    base_dir: &Path,
+) -> anyhow::Result<Vec<UserPromptFileMention>> {
+    let mut mentions = Vec::new();
+    let mut seen = std::collections::HashSet::new();
+    for token in tokens {
+        let explicit = is_explicit_user_prompt_file_token(&token);
+        let path = resolve_user_prompt_file_token(&token, base_dir)?;
+        let exists = tokio::fs::try_exists(&path)
+            .await
+            .map_err(|source| anyhow::anyhow!("failed to inspect @{token}: {source}"))?;
+        if !exists {
+            if explicit {
+                anyhow::bail!("prompt referenced @{token} but file does not exist");
+            }
+            continue;
+        }
+        let metadata = tokio::fs::metadata(&path)
+            .await
+            .map_err(|source| anyhow::anyhow!("failed to inspect @{token}: {source}"))?;
+        if !metadata.is_file() {
+            if explicit {
+                anyhow::bail!("prompt referenced @{token} but it is not a file");
+            }
+            continue;
+        }
+        let canonical = tokio::fs::canonicalize(&path)
+            .await
+            .map_err(|source| anyhow::anyhow!("failed to resolve @{token}: {source}"))?;
+        // Unlike project AGENTS.md includes, prompt mentions are direct
+        // operator input. Absolute and parent-relative paths are intentionally
+        // allowed so commands like `rkat "read @/tmp/log.txt"` work as explicit
+        // context requests.
+        if seen.insert(canonical.clone()) {
+            mentions.push(UserPromptFileMention {
+                token,
+                path: canonical,
+                explicit,
+            });
+        }
+    }
+    Ok(mentions)
+}
+
+fn scan_user_prompt_file_mention_tokens(prompt: &str) -> Vec<String> {
+    let mut tokens = Vec::new();
+    let indices: Vec<(usize, char)> = prompt.char_indices().collect();
+    let mut pos = 0;
+    while pos < indices.len() {
+        let (byte_index, ch) = indices[pos];
+        if ch != '@' || mention_has_word_char_before(prompt, byte_index) {
+            pos += 1;
+            continue;
+        }
+        let start = byte_index + ch.len_utf8();
+        let mut end = start;
+        let mut next_pos = pos + 1;
+        while next_pos < indices.len() {
+            let (candidate_end, candidate_ch) = indices[next_pos];
+            if is_user_prompt_file_token_terminator(candidate_ch) {
+                break;
+            }
+            end = candidate_end + candidate_ch.len_utf8();
+            next_pos += 1;
+        }
+        if end > start {
+            let token = prompt[start..end].trim_end_matches(|ch: char| {
+                matches!(ch, ',' | ';' | ':' | '.' | '!' | '?' | ')' | ']' | '}')
+            });
+            if is_potential_user_prompt_file_token(token) {
+                tokens.push(token.to_string());
+            }
+        }
+        pos = next_pos.max(pos + 1);
+    }
+    tokens
+}
+
+fn mention_has_word_char_before(prompt: &str, byte_index: usize) -> bool {
+    prompt[..byte_index]
+        .chars()
+        .next_back()
+        .is_some_and(|ch| ch.is_ascii_alphanumeric() || ch == '_' || ch == '-')
+}
+
+fn is_user_prompt_file_token_terminator(ch: char) -> bool {
+    ch.is_whitespace() || matches!(ch, '"' | '\'' | '`' | '<' | '>')
+}
+
+fn is_potential_user_prompt_file_token(token: &str) -> bool {
+    !token.is_empty()
+        && !token.starts_with('@')
+        && token != "."
+        && token != ".."
+        && !token.contains('\\')
+}
+
+fn is_explicit_user_prompt_file_token(token: &str) -> bool {
+    token.starts_with('/')
+        || token.starts_with("~/")
+        || token.starts_with("./")
+        || token.starts_with("../")
+}
+
+fn resolve_user_prompt_file_token(token: &str, base_dir: &Path) -> anyhow::Result<PathBuf> {
+    if let Some(rest) = token.strip_prefix("~/") {
+        let home =
+            dirs::home_dir().ok_or_else(|| anyhow::anyhow!("unable to resolve home directory"))?;
+        Ok(home.join(rest))
+    } else {
+        let path = PathBuf::from(token);
+        if path.is_absolute() {
+            Ok(path)
+        } else {
+            Ok(base_dir.join(path))
+        }
+    }
+}
+
+async fn read_user_prompt_file_attachment(
+    mention: UserPromptFileMention,
+    total_remaining_bytes: &mut usize,
+    total_remaining_lines: &mut usize,
+) -> anyhow::Result<UserPromptFileAttachment> {
+    let per_file_limit = USER_PROMPT_FILE_MENTION_MAX_FILE_BYTES
+        .min(*total_remaining_bytes)
+        .saturating_add(USER_PROMPT_FILE_MENTION_READ_SLOP_BYTES);
+    let file = tokio::fs::File::open(&mention.path)
+        .await
+        .map_err(|source| anyhow::anyhow!("failed to read @{}: {source}", mention.token))?;
+    let mut bytes = Vec::new();
+    file.take(per_file_limit as u64)
+        .read_to_end(&mut bytes)
+        .await
+        .map_err(|source| anyhow::anyhow!("failed to read @{}: {source}", mention.token))?;
+
+    let read_hit_limit = bytes.len() == per_file_limit && per_file_limit > 0;
+    let mut content =
+        utf8_from_possibly_capped_prompt_file(&bytes, read_hit_limit).map_err(|source| {
+            anyhow::anyhow!("failed to read @{} as UTF-8: {source}", mention.token)
+        })?;
+    let mut truncated = read_hit_limit;
+    let byte_limit = USER_PROMPT_FILE_MENTION_MAX_FILE_BYTES.min(*total_remaining_bytes);
+    if content.len() > byte_limit {
+        truncate_string_to_byte_limit(&mut content, byte_limit);
+        truncated = true;
+    }
+
+    let line_limit = USER_PROMPT_FILE_MENTION_MAX_FILE_LINES.min(*total_remaining_lines);
+    let original_line_count = content.lines().count();
+    if original_line_count > line_limit {
+        content = content
+            .lines()
+            .take(line_limit)
+            .collect::<Vec<_>>()
+            .join("\n");
+        content.push('\n');
+        truncated = true;
+    }
+
+    let bytes_included = content.len();
+    let lines_included = content.lines().count();
+    *total_remaining_bytes = total_remaining_bytes.saturating_sub(bytes_included);
+    *total_remaining_lines = total_remaining_lines.saturating_sub(lines_included);
+    if truncated {
+        content.push_str(&format!(
+            "\n[truncated @{}: byte/file/line expansion limits reached]\n",
+            mention.token
+        ));
+    }
+
+    Ok(UserPromptFileAttachment {
+        display_path: mention.path.clone(),
+        mention,
+        content,
+        bytes_included,
+        lines_included,
+        truncated,
+    })
+}
+
+fn utf8_from_possibly_capped_prompt_file(
+    bytes: &[u8],
+    read_hit_limit: bool,
+) -> Result<String, std::str::Utf8Error> {
+    match std::str::from_utf8(bytes) {
+        Ok(content) => Ok(content.to_string()),
+        Err(error) if read_hit_limit && error.error_len().is_none() => {
+            Ok(std::str::from_utf8(&bytes[..error.valid_up_to()])?.to_string())
+        }
+        Err(error) => Err(error),
+    }
+}
+
+fn truncate_string_to_byte_limit(content: &mut String, byte_limit: usize) {
+    if content.len() <= byte_limit {
+        return;
+    }
+    let mut end = byte_limit;
+    while end > 0 && !content.is_char_boundary(end) {
+        end -= 1;
+    }
+    content.truncate(end);
 }
 
 async fn init_project_config() -> anyhow::Result<()> {
@@ -3168,6 +3476,11 @@ async fn handle_run_command(
     };
     let html_output_request =
         resolve_html_output_request(&output, &config, &config_base_dir).await?;
+    let prompt_file_base = match scope.context_root.clone() {
+        Some(root) => root,
+        None => std::env::current_dir()?,
+    };
+    prompt = expand_user_prompt_file_mentions(prompt, &prompt_file_base).await?;
     if matches!(stdin, StdinMode::Blob | StdinMode::Auto) {
         prompt = prepend_stdin_blob_context(prompt);
     }
@@ -8994,6 +9307,11 @@ async fn resume_session(
     comms_overrides: CommsOverrides,
 ) -> anyhow::Result<()> {
     let stdin = resolve_stdin_mode(stdin);
+    let prompt_file_base = match scope.context_root.clone() {
+        Some(root) => root,
+        None => std::env::current_dir()?,
+    };
+    prompt = expand_user_prompt_file_mentions(prompt, &prompt_file_base).await?;
     if matches!(stdin, StdinMode::Blob | StdinMode::Auto) {
         prompt = prepend_stdin_blob_context(prompt);
     }
@@ -13775,6 +14093,203 @@ mod tests {
         let skill_name = meerkat_core::skills::SkillName::parse(name)
             .expect("fixture skill name should be valid");
         meerkat_core::skills::SkillKey::new(meerkat_core::skills::SourceUuid::builtin(), skill_name)
+    }
+
+    #[tokio::test]
+    async fn user_prompt_file_mentions_expand_multiple_files_and_preserve_prompt() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let relative_path = temp.path().join("notes.md");
+        let outside = tempfile::tempdir().expect("outside tempdir");
+        let absolute_path = outside.path().join("absolute.md");
+        tokio::fs::write(&relative_path, "relative context")
+            .await
+            .unwrap();
+        tokio::fs::write(&absolute_path, "absolute context")
+            .await
+            .unwrap();
+
+        let prompt = format!(
+            "Read @notes.md and @{} but ignore person@example.com and @missing-handle",
+            absolute_path.display()
+        );
+        let expanded = expand_user_prompt_file_mentions(prompt.clone(), temp.path())
+            .await
+            .unwrap();
+
+        assert!(expanded.starts_with("<user_mentioned_files>"));
+        assert!(expanded.contains("relative context"));
+        assert!(expanded.contains("absolute context"));
+        assert!(expanded.ends_with(&prompt));
+        assert!(!expanded.contains("token=@missing-handle"));
+        assert_eq!(expanded.matches("--- BEGIN @file:").count(), 2);
+    }
+
+    #[tokio::test]
+    async fn user_prompt_file_mentions_trim_sentence_punctuation() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        tokio::fs::write(temp.path().join("notes.md"), "sentence context")
+            .await
+            .unwrap();
+
+        let expanded = expand_user_prompt_file_mentions("Read @notes.md.".to_string(), temp.path())
+            .await
+            .unwrap();
+
+        assert!(expanded.contains("token=@notes.md"));
+        assert!(expanded.contains("sentence context"));
+    }
+
+    #[tokio::test]
+    async fn user_prompt_file_mentions_missing_explicit_path_is_error() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let err = expand_user_prompt_file_mentions("Read @./missing.md".to_string(), temp.path())
+            .await
+            .expect_err("explicit missing @file should fail");
+
+        assert!(err.to_string().contains("does not exist"));
+    }
+
+    #[tokio::test]
+    async fn user_prompt_file_mentions_invalid_utf8_is_error() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        tokio::fs::write(temp.path().join("bad.bin"), [0xff, 0xfe])
+            .await
+            .unwrap();
+
+        let err = expand_user_prompt_file_mentions("Read @bad.bin".to_string(), temp.path())
+            .await
+            .expect_err("invalid UTF-8 prompt file should fail closed");
+
+        assert!(err.to_string().contains("UTF-8"));
+    }
+
+    #[tokio::test]
+    async fn user_prompt_file_mentions_dedupe_canonical_paths() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let target = temp.path().join("target.txt");
+        tokio::fs::write(&target, "deduped context").await.unwrap();
+
+        #[cfg(unix)]
+        {
+            std::os::unix::fs::symlink(&target, temp.path().join("alias.txt")).unwrap();
+            let expanded = expand_user_prompt_file_mentions(
+                "Read @target.txt @alias.txt".to_string(),
+                temp.path(),
+            )
+            .await
+            .unwrap();
+
+            assert_eq!(expanded.matches("--- BEGIN @file:").count(), 1);
+            assert!(expanded.contains("deduped context"));
+        }
+    }
+
+    #[tokio::test]
+    async fn user_prompt_file_mentions_truncate_large_file_with_marker() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        tokio::fs::write(
+            temp.path().join("large.txt"),
+            "x".repeat(USER_PROMPT_FILE_MENTION_MAX_FILE_BYTES + 1024),
+        )
+        .await
+        .unwrap();
+
+        let expanded = expand_user_prompt_file_mentions("Read @large.txt".to_string(), temp.path())
+            .await
+            .unwrap();
+
+        assert!(expanded.contains("truncated=true"));
+        assert!(expanded.contains("[truncated @large.txt"));
+        assert!(expanded.len() < USER_PROMPT_FILE_MENTION_MAX_FILE_BYTES + 4096);
+    }
+
+    #[tokio::test]
+    async fn user_prompt_file_mentions_truncate_line_count_with_marker() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let content = (0..USER_PROMPT_FILE_MENTION_MAX_FILE_LINES + 10)
+            .map(|line| format!("line-{line}"))
+            .collect::<Vec<_>>()
+            .join("\n");
+        tokio::fs::write(temp.path().join("many-lines.txt"), content)
+            .await
+            .unwrap();
+
+        let expanded =
+            expand_user_prompt_file_mentions("Read @many-lines.txt".to_string(), temp.path())
+                .await
+                .unwrap();
+
+        assert!(expanded.contains("truncated=true"));
+        assert!(expanded.contains("[truncated @many-lines.txt"));
+        assert!(!expanded.contains(&format!(
+            "line-{}",
+            USER_PROMPT_FILE_MENTION_MAX_FILE_LINES + 1
+        )));
+    }
+
+    #[tokio::test]
+    async fn user_prompt_file_mentions_enforce_file_count_limit() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let mut prompt = String::from("Read");
+        for index in 0..=USER_PROMPT_FILE_MENTION_MAX_FILES {
+            let filename = format!("file-{index}.txt");
+            tokio::fs::write(temp.path().join(&filename), format!("content-{index}"))
+                .await
+                .unwrap();
+            prompt.push_str(&format!(" @{filename}"));
+        }
+
+        let err = expand_user_prompt_file_mentions(prompt, temp.path())
+            .await
+            .expect_err("too many files should fail");
+
+        assert!(err.to_string().contains("too many @file mentions"));
+    }
+
+    #[tokio::test]
+    async fn user_prompt_file_mentions_enforce_token_limit_before_io() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let mut prompt = String::from("Read");
+        for index in 0..=USER_PROMPT_FILE_MENTION_MAX_FILES {
+            prompt.push_str(&format!(" @missing-{index}.txt"));
+        }
+
+        let err = expand_user_prompt_file_mentions(prompt, temp.path())
+            .await
+            .expect_err("too many candidate tokens should fail before filesystem filtering");
+
+        assert!(err.to_string().contains("too many @file mentions"));
+    }
+
+    #[tokio::test]
+    async fn user_prompt_file_mentions_report_mentions_omitted_by_total_budget() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        tokio::fs::write(
+            temp.path().join("first.txt"),
+            "a".repeat(USER_PROMPT_FILE_MENTION_MAX_FILE_BYTES),
+        )
+        .await
+        .unwrap();
+        tokio::fs::write(
+            temp.path().join("second.txt"),
+            "b".repeat(USER_PROMPT_FILE_MENTION_MAX_FILE_BYTES),
+        )
+        .await
+        .unwrap();
+        tokio::fs::write(temp.path().join("third.txt"), "third context")
+            .await
+            .unwrap();
+
+        let expanded = expand_user_prompt_file_mentions(
+            "Read @first.txt @second.txt @third.txt".to_string(),
+            temp.path(),
+        )
+        .await
+        .unwrap();
+
+        assert!(expanded.contains("OMITTED @file mentions"));
+        assert!(expanded.contains("@third.txt"));
+        assert!(!expanded.contains("third context"));
     }
 
     #[cfg(feature = "session-store")]

--- a/meerkat-core/src/prompt.rs
+++ b/meerkat-core/src/prompt.rs
@@ -120,7 +120,11 @@ pub fn normalize_agents_md_content(content: &str) -> Option<String> {
     }
 
     if content.len() > AGENTS_MD_MAX_BYTES {
-        return Some(content.chars().take(AGENTS_MD_MAX_BYTES).collect());
+        let mut end = AGENTS_MD_MAX_BYTES;
+        while end > 0 && !content.is_char_boundary(end) {
+            end -= 1;
+        }
+        return Some(content[..end].to_string());
     }
 
     Some(content.to_string())
@@ -206,6 +210,15 @@ mod tests {
         let agents_section_start = prompt.find("# Project Instructions").unwrap();
         let agents_content = &prompt[agents_section_start..];
         assert!(agents_content.len() <= AGENTS_MD_MAX_BYTES + 100);
+    }
+
+    #[test]
+    fn test_normalize_agents_md_content_truncates_multibyte_on_byte_boundary() {
+        let large_content = "🤖".repeat(AGENTS_MD_MAX_BYTES);
+        let normalized = normalize_agents_md_content(&large_content).unwrap();
+
+        assert!(normalized.len() <= AGENTS_MD_MAX_BYTES);
+        assert!(normalized.is_char_boundary(normalized.len()));
     }
 
     #[test]

--- a/meerkat/src/prompt_assembly.rs
+++ b/meerkat/src/prompt_assembly.rs
@@ -13,8 +13,20 @@
 //! 6. Dispatcher-provided tool usage instructions (appended last).
 
 use crate::SystemPromptOverride;
-use meerkat_core::{Config, SystemPromptConfig, prompt::normalize_agents_md_content};
-use std::path::Path;
+use meerkat_core::{
+    Config, SystemPromptConfig,
+    prompt::{AGENTS_MD_MAX_BYTES, normalize_agents_md_content},
+};
+use std::{
+    future::Future,
+    path::{Path, PathBuf},
+    pin::Pin,
+};
+use tokio::io::AsyncReadExt;
+
+const AGENTS_MD_INCLUDE_MAX_DEPTH: usize = 4;
+const AGENTS_MD_INCLUDE_MAX_FILES: usize = 32;
+const AGENTS_MD_READ_SLOP_BYTES: usize = 4;
 
 /// A fault assembling the system prompt from explicitly-configured sources.
 ///
@@ -154,8 +166,14 @@ pub async fn assemble_system_prompt(
 }
 
 async fn load_project_agents_md_in(dir: &Path) -> Result<Option<String>, PromptAssemblyError> {
+    let canonical_root = tokio::fs::canonicalize(dir).await.map_err(|source| {
+        PromptAssemblyError::AgentsMdUnreadable {
+            path: dir.display().to_string(),
+            source,
+        }
+    })?;
     for candidate in [dir.join("AGENTS.md"), dir.join(".rkat/AGENTS.md")] {
-        if let Some(content) = load_agents_md_file(&candidate).await? {
+        if let Some(content) = load_agents_md_file(&candidate, &canonical_root).await? {
             return Ok(Some(content));
         }
     }
@@ -169,7 +187,10 @@ async fn load_project_agents_md_in(dir: &Path) -> Result<Option<String>, PromptA
 /// file that exists but cannot be read (permissions, invalid UTF-8) — is a
 /// typed [`PromptAssemblyError::AgentsMdUnreadable`], never laundered into
 /// absence.
-async fn load_agents_md_file(path: &Path) -> Result<Option<String>, PromptAssemblyError> {
+async fn load_agents_md_file(
+    path: &Path,
+    canonical_root: &Path,
+) -> Result<Option<String>, PromptAssemblyError> {
     let exists = tokio::fs::try_exists(path).await.map_err(|source| {
         PromptAssemblyError::AgentsMdUnreadable {
             path: path.display().to_string(),
@@ -180,13 +201,289 @@ async fn load_agents_md_file(path: &Path) -> Result<Option<String>, PromptAssemb
         return Ok(None);
     }
 
-    let content = tokio::fs::read_to_string(path).await.map_err(|source| {
+    let canonical_path = tokio::fs::canonicalize(path).await.map_err(|source| {
         PromptAssemblyError::AgentsMdUnreadable {
             path: path.display().to_string(),
             source,
         }
     })?;
+    if !canonical_path.starts_with(canonical_root) {
+        return Err(PromptAssemblyError::AgentsMdUnreadable {
+            path: path.display().to_string(),
+            source: std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                format!(
+                    "{} resolves outside context root {}",
+                    canonical_path.display(),
+                    canonical_root.display()
+                ),
+            ),
+        });
+    }
+
+    let mut remaining_files = AGENTS_MD_INCLUDE_MAX_FILES;
+    let mut stack = Vec::new();
+    let content = match expand_agents_md_file(
+        canonical_path.clone(),
+        canonical_root,
+        &mut stack,
+        &mut remaining_files,
+        0,
+    )
+    .await
+    {
+        Ok(content) => content,
+        Err(reason)
+            if reason.starts_with(&format!("failed to read {}:", canonical_path.display())) =>
+        {
+            return Err(PromptAssemblyError::AgentsMdUnreadable {
+                path: path.display().to_string(),
+                source: std::io::Error::new(std::io::ErrorKind::InvalidData, reason),
+            });
+        }
+        Err(reason) => {
+            return Err(PromptAssemblyError::AgentsMdUnreadable {
+                path: path.display().to_string(),
+                source: std::io::Error::new(std::io::ErrorKind::InvalidData, reason),
+            });
+        }
+    };
     Ok(normalize_agents_md_content(&content))
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct MarkdownFence {
+    ch: char,
+    len: usize,
+}
+
+fn expand_agents_md_file<'a>(
+    canonical_path: PathBuf,
+    canonical_root: &'a Path,
+    stack: &'a mut Vec<PathBuf>,
+    remaining_files: &'a mut usize,
+    depth: usize,
+) -> Pin<Box<dyn Future<Output = Result<String, String>> + Send + 'a>> {
+    Box::pin(async move {
+        if depth > AGENTS_MD_INCLUDE_MAX_DEPTH {
+            return Err(format!(
+                "include depth exceeded at {} via {}",
+                canonical_path.display(),
+                format_include_chain(stack, Some(&canonical_path))
+            ));
+        }
+        if stack.iter().any(|path| path == &canonical_path) {
+            return Err(format!(
+                "cyclic include at {} via {}",
+                canonical_path.display(),
+                format_include_chain(stack, Some(&canonical_path))
+            ));
+        }
+        if !canonical_path.starts_with(canonical_root) {
+            return Err(format!(
+                "{} resolves outside context root {}",
+                canonical_path.display(),
+                canonical_root.display()
+            ));
+        }
+        let metadata = tokio::fs::metadata(&canonical_path)
+            .await
+            .map_err(|source| {
+                format!("failed to inspect {}: {source}", canonical_path.display())
+            })?;
+        if !metadata.is_file() {
+            return Err(format!("{} is not a file", canonical_path.display()));
+        }
+        if *remaining_files == 0 {
+            return Err(format!(
+                "include file count exceeded at {} via {}",
+                canonical_path.display(),
+                format_include_chain(stack, Some(&canonical_path))
+            ));
+        }
+        *remaining_files -= 1;
+
+        stack.push(canonical_path.clone());
+        let read_limit = AGENTS_MD_MAX_BYTES
+            .saturating_add(AGENTS_MD_READ_SLOP_BYTES)
+            .saturating_add(1);
+        let content = read_utf8_file_capped(&canonical_path, read_limit)
+            .await
+            .map_err(|source| format!("failed to read {}: {source}", canonical_path.display()))?;
+        let mut remaining_bytes = AGENTS_MD_MAX_BYTES;
+        let expanded = expand_agents_md_content(
+            &canonical_path,
+            canonical_root,
+            stack,
+            &mut remaining_bytes,
+            remaining_files,
+            &content,
+        )
+        .await;
+        stack.pop();
+        expanded
+    })
+}
+
+fn expand_agents_md_content<'a>(
+    source_path: &'a Path,
+    canonical_root: &'a Path,
+    stack: &'a mut Vec<PathBuf>,
+    remaining_bytes: &'a mut usize,
+    remaining_files: &'a mut usize,
+    content: &'a str,
+) -> Pin<Box<dyn Future<Output = Result<String, String>> + Send + 'a>> {
+    Box::pin(async move {
+        let mut output = String::new();
+        let mut fence: Option<MarkdownFence> = None;
+        for raw_line in content.split_inclusive('\n') {
+            let line_without_lf = raw_line.strip_suffix('\n').unwrap_or(raw_line);
+            let line_body = line_without_lf
+                .strip_suffix('\r')
+                .unwrap_or(line_without_lf);
+            if let Some(marker) = markdown_fence_marker(line_body) {
+                if let Some(open) = fence {
+                    if marker.ch == open.ch
+                        && marker.len >= open.len
+                        && markdown_fence_closer_has_no_info(line_body, marker)
+                    {
+                        fence = None;
+                    }
+                } else {
+                    fence = Some(marker);
+                }
+                append_with_budget(&mut output, remaining_bytes, raw_line);
+                continue;
+            }
+
+            if fence.is_none()
+                && let Some(include_path) = parse_agents_md_include_directive(line_body)
+            {
+                let base = source_path.parent().unwrap_or_else(|| Path::new("."));
+                let raw_target = base.join(include_path);
+                let canonical_target =
+                    tokio::fs::canonicalize(&raw_target)
+                        .await
+                        .map_err(|source| {
+                            format!(
+                                "failed to resolve include `{}` from {}: {source}",
+                                include_path,
+                                source_path.display()
+                            )
+                        })?;
+                if !canonical_target.starts_with(canonical_root) {
+                    return Err(format!(
+                        "include `{}` from {} resolves outside context root {}",
+                        include_path,
+                        source_path.display(),
+                        canonical_root.display()
+                    ));
+                }
+                let included = expand_agents_md_file(
+                    canonical_target,
+                    canonical_root,
+                    stack,
+                    remaining_files,
+                    stack.len(),
+                )
+                .await?;
+                append_with_budget(&mut output, remaining_bytes, &included);
+                if raw_line.ends_with('\n') && !included.ends_with('\n') {
+                    append_with_budget(&mut output, remaining_bytes, "\n");
+                }
+            } else {
+                append_with_budget(&mut output, remaining_bytes, raw_line);
+            }
+        }
+        Ok(output)
+    })
+}
+
+fn parse_agents_md_include_directive(line: &str) -> Option<&str> {
+    let trimmed = line.trim_matches(|ch| ch == ' ' || ch == '\t');
+    let path = trimmed.strip_prefix('@')?;
+    if path.is_empty()
+        || path.starts_with('@')
+        || path.starts_with('/')
+        || path.starts_with('~')
+        || path.contains(char::is_whitespace)
+        || path.contains('#')
+    {
+        return None;
+    }
+    Some(path)
+}
+
+fn markdown_fence_marker(line: &str) -> Option<MarkdownFence> {
+    let trimmed = line.trim_start_matches([' ', '\t']);
+    let leading_spaces = line.len().saturating_sub(trimmed.len());
+    if leading_spaces > 3 {
+        return None;
+    }
+    let ch = trimmed.chars().next()?;
+    if ch != '`' && ch != '~' {
+        return None;
+    }
+    let len = trimmed
+        .chars()
+        .take_while(|candidate| *candidate == ch)
+        .count();
+    if len < 3 {
+        return None;
+    }
+    Some(MarkdownFence { ch, len })
+}
+
+fn markdown_fence_closer_has_no_info(line: &str, marker: MarkdownFence) -> bool {
+    let trimmed = line.trim_start_matches([' ', '\t']);
+    trimmed[marker.len..]
+        .chars()
+        .all(|ch| ch == ' ' || ch == '\t')
+}
+
+fn append_with_budget(output: &mut String, remaining_bytes: &mut usize, text: &str) {
+    if *remaining_bytes == 0 || text.is_empty() {
+        return;
+    }
+    if text.len() <= *remaining_bytes {
+        output.push_str(text);
+        *remaining_bytes -= text.len();
+        return;
+    }
+    let mut end = *remaining_bytes;
+    while end > 0 && !text.is_char_boundary(end) {
+        end -= 1;
+    }
+    output.push_str(&text[..end]);
+    *remaining_bytes = 0;
+}
+
+async fn read_utf8_file_capped(path: &Path, max_bytes: usize) -> Result<String, std::io::Error> {
+    let file = tokio::fs::File::open(path).await?;
+    let mut bytes = Vec::new();
+    file.take(max_bytes as u64).read_to_end(&mut bytes).await?;
+    match std::str::from_utf8(&bytes) {
+        Ok(content) => Ok(content.to_string()),
+        Err(error) if bytes.len() == max_bytes && error.error_len().is_none() => {
+            let valid_prefix = &bytes[..error.valid_up_to()];
+            std::str::from_utf8(valid_prefix)
+                .map(str::to_string)
+                .map_err(|source| std::io::Error::new(std::io::ErrorKind::InvalidData, source))
+        }
+        Err(error) => Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            format!("invalid UTF-8: {error}"),
+        )),
+    }
+}
+
+fn format_include_chain(stack: &[PathBuf], terminal: Option<&Path>) -> String {
+    stack
+        .iter()
+        .map(|path| path.display().to_string())
+        .chain(terminal.map(|path| path.display().to_string()))
+        .collect::<Vec<_>>()
+        .join(" -> ")
 }
 
 /// Append extra sections and tool instructions to a base prompt.
@@ -494,6 +791,364 @@ mod tests {
         let agents_section_start = result.find("# Project Instructions").unwrap();
         let agents_content = &result[agents_section_start..];
         assert!(agents_content.len() <= AGENTS_MD_MAX_BYTES + 100);
+    }
+
+    #[tokio::test]
+    async fn test_context_root_agents_md_include_near_size_limit_is_charged_once() {
+        let temp = TempDir::new().unwrap();
+        let included = "x".repeat(AGENTS_MD_MAX_BYTES - 20);
+        tokio::fs::write(temp.path().join("AGENTS.md"), "@included.md")
+            .await
+            .unwrap();
+        tokio::fs::write(temp.path().join("included.md"), &included)
+            .await
+            .unwrap();
+
+        let config = default_config();
+        let result = assemble_system_prompt(
+            &config,
+            &SystemPromptOverride::Inherit,
+            Some(temp.path()),
+            &[],
+            "",
+        )
+        .await
+        .unwrap();
+
+        assert!(
+            result.contains(&included),
+            "included AGENTS content should not be double-charged against the byte budget"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_context_root_agents_md_expands_line_scoped_file_include() {
+        let temp = TempDir::new().unwrap();
+        tokio::fs::write(temp.path().join("AGENTS.md"), "Before\n@CLAUDE.md\nAfter")
+            .await
+            .unwrap();
+        tokio::fs::write(temp.path().join("CLAUDE.md"), "Included instructions")
+            .await
+            .unwrap();
+
+        let config = default_config();
+        let result = assemble_system_prompt(
+            &config,
+            &SystemPromptOverride::Inherit,
+            Some(temp.path()),
+            &[],
+            "",
+        )
+        .await
+        .unwrap();
+
+        assert!(result.contains("Before\nIncluded instructions\nAfter"));
+        assert!(!result.contains("@CLAUDE.md"));
+    }
+
+    #[tokio::test]
+    async fn test_context_root_agents_md_does_not_expand_inline_or_fenced_mentions() {
+        let temp = TempDir::new().unwrap();
+        tokio::fs::write(
+            temp.path().join("AGENTS.md"),
+            "Inline @CLAUDE.md\n```\n@CLAUDE.md\n```\n",
+        )
+        .await
+        .unwrap();
+        tokio::fs::write(temp.path().join("CLAUDE.md"), "Included instructions")
+            .await
+            .unwrap();
+
+        let config = default_config();
+        let result = assemble_system_prompt(
+            &config,
+            &SystemPromptOverride::Inherit,
+            Some(temp.path()),
+            &[],
+            "",
+        )
+        .await
+        .unwrap();
+
+        assert!(result.contains("Inline @CLAUDE.md"));
+        assert!(result.contains("```\n@CLAUDE.md\n```"));
+        assert!(!result.contains("Included instructions"));
+    }
+
+    #[tokio::test]
+    async fn test_context_root_agents_md_keeps_extended_fences_inert() {
+        let temp = TempDir::new().unwrap();
+        tokio::fs::write(
+            temp.path().join("AGENTS.md"),
+            "````markdown\n```\n@CLAUDE.md\n````\n",
+        )
+        .await
+        .unwrap();
+        tokio::fs::write(temp.path().join("CLAUDE.md"), "Included instructions")
+            .await
+            .unwrap();
+
+        let config = default_config();
+        let result = assemble_system_prompt(
+            &config,
+            &SystemPromptOverride::Inherit,
+            Some(temp.path()),
+            &[],
+            "",
+        )
+        .await
+        .unwrap();
+
+        assert!(result.contains("````markdown\n```\n@CLAUDE.md\n````"));
+        assert!(!result.contains("Included instructions"));
+    }
+
+    #[tokio::test]
+    async fn test_context_root_agents_md_does_not_close_fence_on_info_string() {
+        let temp = TempDir::new().unwrap();
+        tokio::fs::write(
+            temp.path().join("AGENTS.md"),
+            "```\n```rust\n@CLAUDE.md\n```\n",
+        )
+        .await
+        .unwrap();
+        tokio::fs::write(temp.path().join("CLAUDE.md"), "Included instructions")
+            .await
+            .unwrap();
+
+        let config = default_config();
+        let result = assemble_system_prompt(
+            &config,
+            &SystemPromptOverride::Inherit,
+            Some(temp.path()),
+            &[],
+            "",
+        )
+        .await
+        .unwrap();
+
+        assert!(result.contains("```\n```rust\n@CLAUDE.md\n```"));
+        assert!(!result.contains("Included instructions"));
+    }
+
+    #[tokio::test]
+    async fn test_dot_rkat_agents_md_expands_include_relative_to_dot_rkat() {
+        let temp = TempDir::new().unwrap();
+        let rkat_dir = temp.path().join(".rkat");
+        tokio::fs::create_dir_all(&rkat_dir).await.unwrap();
+        tokio::fs::write(rkat_dir.join("AGENTS.md"), "@nested.md\n@../ROOT.md")
+            .await
+            .unwrap();
+        tokio::fs::write(rkat_dir.join("nested.md"), "Nested instructions")
+            .await
+            .unwrap();
+        tokio::fs::write(temp.path().join("ROOT.md"), "Root instructions")
+            .await
+            .unwrap();
+
+        let config = default_config();
+        let result = assemble_system_prompt(
+            &config,
+            &SystemPromptOverride::Inherit,
+            Some(temp.path()),
+            &[],
+            "",
+        )
+        .await
+        .unwrap();
+
+        assert!(result.contains("Nested instructions"));
+        assert!(result.contains("Root instructions"));
+    }
+
+    #[tokio::test]
+    async fn test_context_root_agents_md_missing_include_fails_closed() {
+        let temp = TempDir::new().unwrap();
+        tokio::fs::write(temp.path().join("AGENTS.md"), "@MISSING.md")
+            .await
+            .unwrap();
+        let rkat_dir = temp.path().join(".rkat");
+        tokio::fs::create_dir_all(&rkat_dir).await.unwrap();
+        tokio::fs::write(rkat_dir.join("AGENTS.md"), "Fallback instructions")
+            .await
+            .unwrap();
+
+        let config = default_config();
+        let err = assemble_system_prompt(
+            &config,
+            &SystemPromptOverride::Inherit,
+            Some(temp.path()),
+            &[],
+            "",
+        )
+        .await
+        .expect_err("bad top-level include must not fall through to .rkat/AGENTS.md");
+
+        assert!(matches!(
+            err,
+            PromptAssemblyError::AgentsMdUnreadable { .. }
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_context_root_agents_md_directory_include_fails_closed() {
+        let temp = TempDir::new().unwrap();
+        tokio::fs::write(temp.path().join("AGENTS.md"), "@.")
+            .await
+            .unwrap();
+
+        let config = default_config();
+        let err = assemble_system_prompt(
+            &config,
+            &SystemPromptOverride::Inherit,
+            Some(temp.path()),
+            &[],
+            "",
+        )
+        .await
+        .expect_err("directory include must fail closed");
+
+        match err {
+            PromptAssemblyError::AgentsMdUnreadable { source, .. } => {
+                assert!(source.to_string().contains("is not a file"));
+            }
+            other => panic!("unexpected error: {other}"),
+        }
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn test_context_root_agents_md_symlink_escape_fails_closed() {
+        let temp = TempDir::new().unwrap();
+        let outside = TempDir::new().unwrap();
+        tokio::fs::write(outside.path().join("outside.md"), "Outside instructions")
+            .await
+            .unwrap();
+        std::os::unix::fs::symlink(
+            outside.path().join("outside.md"),
+            temp.path().join("link.md"),
+        )
+        .unwrap();
+        tokio::fs::write(temp.path().join("AGENTS.md"), "@link.md")
+            .await
+            .unwrap();
+
+        let config = default_config();
+        let err = assemble_system_prompt(
+            &config,
+            &SystemPromptOverride::Inherit,
+            Some(temp.path()),
+            &[],
+            "",
+        )
+        .await
+        .expect_err("symlink escape must fail closed");
+
+        match err {
+            PromptAssemblyError::AgentsMdUnreadable { source, .. } => {
+                assert!(source.to_string().contains("outside context root"));
+            }
+            other => panic!("unexpected error: {other}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_context_root_agents_md_cycle_fails_closed() {
+        let temp = TempDir::new().unwrap();
+        tokio::fs::write(temp.path().join("AGENTS.md"), "@a.md")
+            .await
+            .unwrap();
+        tokio::fs::write(temp.path().join("a.md"), "@AGENTS.md")
+            .await
+            .unwrap();
+
+        let config = default_config();
+        let err = assemble_system_prompt(
+            &config,
+            &SystemPromptOverride::Inherit,
+            Some(temp.path()),
+            &[],
+            "",
+        )
+        .await
+        .expect_err("cyclic AGENTS include must fail closed");
+
+        assert!(matches!(
+            err,
+            PromptAssemblyError::AgentsMdUnreadable { .. }
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_context_root_agents_md_depth_limit_fails_closed() {
+        let temp = TempDir::new().unwrap();
+        tokio::fs::write(temp.path().join("AGENTS.md"), "@a0.md")
+            .await
+            .unwrap();
+        for index in 0..=AGENTS_MD_INCLUDE_MAX_DEPTH {
+            tokio::fs::write(
+                temp.path().join(format!("a{index}.md")),
+                format!("@a{}.md", index + 1),
+            )
+            .await
+            .unwrap();
+        }
+        tokio::fs::write(
+            temp.path()
+                .join(format!("a{}.md", AGENTS_MD_INCLUDE_MAX_DEPTH + 1)),
+            "too deep",
+        )
+        .await
+        .unwrap();
+
+        let config = default_config();
+        let err = assemble_system_prompt(
+            &config,
+            &SystemPromptOverride::Inherit,
+            Some(temp.path()),
+            &[],
+            "",
+        )
+        .await
+        .expect_err("over-deep AGENTS include must fail closed");
+
+        assert!(matches!(
+            err,
+            PromptAssemblyError::AgentsMdUnreadable { .. }
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_context_root_agents_md_file_count_limit_fails_closed() {
+        let temp = TempDir::new().unwrap();
+        let includes = (0..AGENTS_MD_INCLUDE_MAX_FILES)
+            .map(|index| format!("@file-{index}.md"))
+            .collect::<Vec<_>>()
+            .join("\n");
+        tokio::fs::write(temp.path().join("AGENTS.md"), includes)
+            .await
+            .unwrap();
+        for index in 0..AGENTS_MD_INCLUDE_MAX_FILES {
+            tokio::fs::write(temp.path().join(format!("file-{index}.md")), "included")
+                .await
+                .unwrap();
+        }
+
+        let config = default_config();
+        let err = assemble_system_prompt(
+            &config,
+            &SystemPromptOverride::Inherit,
+            Some(temp.path()),
+            &[],
+            "",
+        )
+        .await
+        .expect_err("too many AGENTS include files must fail closed");
+
+        assert!(matches!(
+            err,
+            PromptAssemblyError::AgentsMdUnreadable { .. }
+        ));
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
- add guarded @file expansion for AGENTS.md includes
- add guarded user-prompt @file expansion for fresh and resumed rkat runs
- fix AGENTS.md byte truncation for multibyte text

## Validation
- ./scripts/repo-cargo test -p meerkat prompt_assembly
- ./scripts/repo-cargo test -p rkat user_prompt_file_mentions
- ./scripts/repo-cargo test -p meerkat-core normalize_agents_md_content
- ./scripts/repo-cargo fmt
- git diff --check
- pre-push hook passed

## Review
- adversarial review 1: green
- adversarial review 2: green