### PR TITLE
[codex] Fix scheduled delivery into attached sessions

### DIFF
--- a/meerkat-runtime/src/meerkat_machine/comms_drain.rs
+++ b/meerkat-runtime/src/meerkat_machine/comms_drain.rs
@@ -168,6 +168,10 @@ impl CommsDrainSlot {
             .is_some_and(|current| Arc::ptr_eq(current, runtime))
     }
 
+    pub(crate) fn task_runtime(&self) -> Option<Arc<dyn meerkat_core::agent::CommsRuntime>> {
+        self.task_runtime.clone()
+    }
+
     pub(crate) fn handle_present(&self) -> bool {
         self.handle.is_some()
     }
@@ -329,6 +333,46 @@ impl MeerkatMachine {
         }
     }
 
+    /// Refresh a session-owned peer ingress drain without re-attaching
+    /// ownership.
+    ///
+    /// This is intentionally narrower than
+    /// [`MeerkatMachine::update_peer_ingress_context`]: callers that only need
+    /// the existing authorized session-owned transport to be healthy can
+    /// respawn a missing/respawnable drain task without staging
+    /// `AttachSessionIngress` with a possibly different runtime handle.
+    /// Mob-owned ingress and missing cached session runtimes are left
+    /// untouched.
+    pub async fn refresh_session_owned_peer_ingress(
+        self: &Arc<Self>,
+        session_id: &SessionId,
+    ) -> Result<bool, RuntimeDriverError> {
+        if !self.sessions.read().await.contains_key(session_id) {
+            return Err(RuntimeDriverError::NotReady {
+                state: RuntimeState::Destroyed,
+            });
+        }
+        if matches!(
+            self.existing_session_runtime_state(session_id).await,
+            Some(RuntimeState::Destroyed)
+        ) {
+            return Err(RuntimeDriverError::Destroyed);
+        }
+
+        let gate = self.session_mutation_gate(session_id).await;
+        let _gate_guard = match gate {
+            Some(ref g) => Some(g.lock().await),
+            None => None,
+        };
+
+        let Some(comms_runtime) = self.session_owned_drain_runtime(session_id).await else {
+            return Ok(false);
+        };
+
+        self.update_peer_ingress_context_inner(session_id, true, Some(comms_runtime))
+            .await
+    }
+
     /// Mob-owned variant of [`MeerkatMachine::maybe_spawn_comms_drain`]
     /// (W2-G / issue #264).
     ///
@@ -414,6 +458,28 @@ impl MeerkatMachine {
                 }
             }
         }
+    }
+
+    async fn session_owned_drain_runtime(
+        &self,
+        session_id: &SessionId,
+    ) -> Option<Arc<dyn meerkat_core::agent::CommsRuntime>> {
+        let sessions = self.sessions.read().await;
+        let entry = sessions.get(session_id)?;
+        let authority = entry
+            .dsl_authority
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let state = authority.state();
+        if state.peer_ingress_owner_kind
+            != crate::meerkat_machine::dsl::PeerIngressOwnerKind::SessionOwned
+        {
+            return None;
+        }
+        let expected_runtime_id = state.peer_ingress_comms_runtime_id.as_ref()?;
+        let runtime = entry.drain_slot.task_runtime()?;
+        let actual_runtime_id = crate::meerkat_machine::dsl::CommsRuntimeId::from_runtime(&runtime);
+        (expected_runtime_id == &actual_runtime_id).then_some(runtime)
     }
 
     pub(super) async fn drain_authority_state(

--- a/meerkat-runtime/src/meerkat_machine_tests.rs
+++ b/meerkat-runtime/src/meerkat_machine_tests.rs
@@ -24624,6 +24624,93 @@ async fn attach_session_ingress_exact_reassertion_is_idempotent() {
 }
 
 #[tokio::test]
+async fn refresh_session_owned_peer_ingress_respawns_authorized_drain_without_reattach() {
+    let adapter = Arc::new(MeerkatMachine::ephemeral());
+    let session_id = SessionId::new();
+    adapter
+        .register_session(session_id.clone())
+        .await
+        .expect("register session");
+
+    let comms_runtime: Arc<dyn CommsRuntime> = Arc::new(FakeDrainRuntime::idle());
+    let expected_id = crate::meerkat_machine::dsl::CommsRuntimeId::from_runtime(&comms_runtime);
+    {
+        let mut sessions = adapter.sessions.write().await;
+        let entry = sessions
+            .get_mut(&session_id)
+            .expect("registered session entry");
+        let mut authority = entry
+            .dsl_authority
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        crate::meerkat_machine::dsl::MeerkatMachineMutator::apply(
+            &mut *authority,
+            crate::meerkat_machine::dsl::MeerkatMachineInput::AttachSessionIngress {
+                comms_runtime_id: expected_id.clone(),
+            },
+        )
+        .expect("session ingress attach should stage");
+        crate::meerkat_machine::dsl::MeerkatMachineMutator::apply(
+            &mut *authority,
+            crate::meerkat_machine::dsl::MeerkatMachineInput::SpawnDrain {
+                mode: crate::meerkat_machine::dsl::DrainMode::PersistentHost,
+            },
+        )
+        .expect("spawn drain should stage");
+        crate::meerkat_machine::dsl::MeerkatMachineMutator::apply(
+            &mut *authority,
+            crate::meerkat_machine::dsl::MeerkatMachineInput::NotifyDrainExited {
+                reason: crate::meerkat_machine::dsl::DrainExitReason::Failed,
+            },
+        )
+        .expect("failed persistent drain should become respawnable");
+        drop(authority);
+
+        entry
+            .drain_slot
+            .install_task(Arc::clone(&comms_runtime), tokio::spawn(async {}));
+        entry.drain_slot.clear_after_exit(true);
+    }
+
+    assert_eq!(
+        current_phase(&adapter, &session_id).await,
+        Some(CommsDrainPhase::ExitedRespawnable)
+    );
+    assert!(
+        !handle_present(&adapter, &session_id).await,
+        "fixture should retain runtime identity but have no live drain handle"
+    );
+
+    assert!(
+        adapter
+            .refresh_session_owned_peer_ingress(&session_id)
+            .await
+            .expect("refresh session-owned ingress"),
+        "refresh should respawn the authorized drain task"
+    );
+
+    assert_eq!(
+        current_phase(&adapter, &session_id).await,
+        Some(CommsDrainPhase::Running)
+    );
+    assert!(
+        handle_present(&adapter, &session_id).await,
+        "refresh should install a new drain handle"
+    );
+    let owner = adapter.peer_ingress_owner(&session_id).await;
+    assert!(
+        matches!(
+            owner,
+            crate::meerkat_machine::PeerIngressOwner::SessionOwned { ref comms_runtime_id }
+                if *comms_runtime_id == expected_id
+        ),
+        "refresh must preserve the existing session-owned runtime id, got {owner:?}"
+    );
+
+    adapter.unregister_session(&session_id).await;
+}
+
+#[tokio::test]
 async fn attach_mob_ingress_exact_reassertion_is_idempotent() {
     let adapter = Arc::new(MeerkatMachine::ephemeral());
     let session_id = SessionId::new();

--- a/meerkat/src/surface/runtime_schedule_host.rs
+++ b/meerkat/src/surface/runtime_schedule_host.rs
@@ -215,8 +215,88 @@ impl<B: SessionAgentBuilder + 'static> RuntimeBackedScheduleSessionHost<B> {
             )
             .await
             .map_err(schedule_internal)?;
-        self.update_peer_ingress_context(session_id).await?;
+        self.ensure_schedule_peer_ingress(session_id).await?;
         Ok(())
+    }
+
+    async fn ensure_schedule_peer_ingress(
+        &self,
+        session_id: &SessionId,
+    ) -> Result<(), ScheduleDomainError> {
+        #[cfg(feature = "comms")]
+        {
+            match self.runtime_adapter.peer_ingress_owner(session_id).await {
+                meerkat_runtime::PeerIngressOwner::Unattached => {}
+                meerkat_runtime::PeerIngressOwner::SessionOwned { .. } => {
+                    if !self.session_keep_alive(session_id).await? {
+                        return self.detach_schedule_peer_ingress(session_id).await;
+                    }
+                    // Scheduled delivery injects through the runtime input
+                    // queue. If session-owned peer ingress already exists,
+                    // refresh the authorized drain task without re-attaching
+                    // with a possibly different CommsRuntime handle.
+                    self.runtime_adapter
+                        .refresh_session_owned_peer_ingress(session_id)
+                        .await
+                        .map_err(schedule_internal)?;
+                    return Ok(());
+                }
+                meerkat_runtime::PeerIngressOwner::MobOwned { .. } => {
+                    // Mob ownership is authoritative. Schedule delivery must
+                    // not claim or downgrade the peer-ingress transport.
+                    return Ok(());
+                }
+                _ => return Ok(()),
+            }
+        }
+
+        self.update_peer_ingress_context(session_id).await
+    }
+
+    async fn detach_schedule_peer_ingress(
+        &self,
+        session_id: &SessionId,
+    ) -> Result<(), ScheduleDomainError> {
+        #[cfg(feature = "comms")]
+        {
+            self.runtime_adapter
+                .update_peer_ingress_context(session_id, false, None)
+                .await
+                .map_err(schedule_internal)?;
+        }
+        #[cfg(not(feature = "comms"))]
+        let _ = session_id;
+        Ok(())
+    }
+
+    async fn session_keep_alive(
+        &self,
+        session_id: &SessionId,
+    ) -> Result<bool, ScheduleDomainError> {
+        #[cfg(feature = "comms")]
+        {
+            let session = self
+                .service
+                .load_authoritative_session(session_id)
+                .await
+                .map_err(schedule_internal)?
+                .ok_or_else(|| {
+                    ScheduleDomainError::InvalidSchedule(format!("session not found: {session_id}"))
+                })?;
+            session
+                .session_metadata()
+                .map(|metadata| metadata.keep_alive)
+                .ok_or_else(|| {
+                    ScheduleDomainError::Internal(format!(
+                        "session {session_id} is missing session metadata"
+                    ))
+                })
+        }
+        #[cfg(not(feature = "comms"))]
+        {
+            let _ = session_id;
+            Ok(false)
+        }
     }
 
     async fn update_peer_ingress_context(
@@ -562,6 +642,242 @@ mod tests {
             chrono::Utc::now(),
         )
         .expect("sample occurrence planning should pass generated authority")
+    }
+
+    #[cfg(all(
+        feature = "session-store",
+        feature = "comms",
+        feature = "jsonl-store",
+        not(target_arch = "wasm32")
+    ))]
+    async fn build_comms_test_service(
+        temp: &tempfile::TempDir,
+        shared_runtime: Arc<crate::CommsRuntime>,
+    ) -> (
+        Arc<PersistentSessionService<crate::FactoryAgentBuilder>>,
+        Arc<MeerkatMachine>,
+    ) {
+        let jsonl_store = Arc::new(crate::JsonlStore::new(temp.path().join("sessions")));
+        jsonl_store.init().await.expect("init jsonl store");
+        let persistence = crate::PersistenceBundle::new(
+            jsonl_store as Arc<dyn crate::SessionStore>,
+            Some(Arc::new(meerkat_runtime::InMemoryRuntimeStore::new())
+                as Arc<dyn meerkat_runtime::RuntimeStore>),
+            Arc::new(crate::MemoryBlobStore::new()),
+        );
+        let factory = crate::AgentFactory::new(temp.path().join("sessions"))
+            .with_comms_runtime(shared_runtime);
+        let mut builder = crate::FactoryAgentBuilder::new(factory, crate::Config::default());
+        builder.default_llm_client = Some(Arc::new(meerkat_client::TestClient::default()));
+        let (service, runtime_adapter) =
+            crate::surface::build_runtime_backed_service(builder, 4, persistence);
+        (Arc::new(service), runtime_adapter)
+    }
+
+    #[cfg(all(
+        feature = "session-store",
+        feature = "comms",
+        feature = "jsonl-store",
+        not(target_arch = "wasm32")
+    ))]
+    fn make_runtime_backed_request(comms_name: &str, keep_alive: bool) -> CreateSessionRequest {
+        CreateSessionRequest {
+            model: "gpt-5.4".to_string(),
+            prompt: ContentInput::Text(String::new()),
+            system_prompt: crate::SystemPromptOverride::Set(
+                "scheduled attached-session regression".to_string(),
+            ),
+            max_tokens: None,
+            event_tx: None,
+            initial_turn: InitialTurnPolicy::Defer,
+            deferred_prompt_policy: DeferredPromptPolicy::Discard,
+            build: Some(SessionBuildOptions {
+                comms_name: Some(comms_name.to_string()),
+                keep_alive,
+                ..Default::default()
+            }),
+            labels: None,
+        }
+    }
+
+    #[cfg(all(
+        feature = "session-store",
+        feature = "comms",
+        feature = "jsonl-store",
+        not(target_arch = "wasm32")
+    ))]
+    #[tokio::test]
+    async fn deliver_prompt_to_already_session_owned_ingress_does_not_reattach() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let service_runtime = Arc::new(
+            crate::CommsRuntime::inproc_only("schedule-service-runtime")
+                .expect("service comms runtime"),
+        );
+        let preattached_runtime = Arc::new(
+            crate::CommsRuntime::inproc_only("schedule-preattached-runtime")
+                .expect("preattached comms runtime"),
+        );
+        let (service, runtime_adapter) =
+            build_comms_test_service(&temp, Arc::clone(&service_runtime)).await;
+
+        let session = Session::new();
+        let session_id = session.id().clone();
+        let result = Box::pin(materialize_session(
+            &service,
+            &runtime_adapter,
+            session,
+            make_runtime_backed_request("scheduled-attached-session", true),
+            {
+                let service = Arc::clone(&service);
+                let runtime_adapter = Arc::clone(&runtime_adapter);
+                move |session_id| default_persistent_executor(service, runtime_adapter, session_id)
+            },
+        ))
+        .await
+        .expect("materialize runtime-backed session");
+
+        let preattached_runtime: Arc<dyn meerkat_core::agent::CommsRuntime> = preattached_runtime;
+        runtime_adapter
+            .update_peer_ingress_context(&session_id, true, Some(Arc::clone(&preattached_runtime)))
+            .await
+            .expect("pre-attach session-owned ingress");
+        assert!(matches!(
+            runtime_adapter.peer_ingress_owner(&session_id).await,
+            meerkat_runtime::PeerIngressOwner::SessionOwned { .. }
+        ));
+
+        let host = RuntimeBackedScheduleSessionHost::new(
+            Arc::clone(&service),
+            Arc::clone(&runtime_adapter),
+            SessionBuildOptions::default(),
+        );
+        let occurrence = sample_occurrence();
+        let dispatch = host
+            .deliver_prompt(
+                &result.session_id,
+                &occurrence,
+                ScheduledPromptDispatch {
+                    prompt: ContentInput::Text("scheduled prompt".to_string()),
+                    render_metadata: None,
+                    skill_refs: Vec::new(),
+                    additional_instructions: Vec::new(),
+                    materialized_session_id: None,
+                },
+            )
+            .await
+            .expect("scheduled prompt delivery should enqueue without reattaching ingress");
+
+        let terminal = tokio::time::timeout(std::time::Duration::from_secs(2), dispatch.completion)
+            .await
+            .expect("scheduled prompt should complete")
+            .expect("delivery terminal should resolve");
+        assert_eq!(
+            terminal.phase,
+            meerkat_schedule::OccurrencePhase::AwaitingCompletion
+        );
+        assert_eq!(
+            terminal.runtime_completion_outcome,
+            Some(meerkat_schedule::RuntimeCompletionOutcome::Completed)
+        );
+
+        service
+            .discard_live_session(&result.session_id)
+            .await
+            .expect("discard live session");
+        runtime_adapter.unregister_session(&result.session_id).await;
+    }
+
+    #[cfg(all(
+        feature = "session-store",
+        feature = "comms",
+        feature = "jsonl-store",
+        not(target_arch = "wasm32")
+    ))]
+    #[tokio::test]
+    async fn deliver_prompt_to_session_owned_non_keep_alive_ingress_detaches_without_reattach() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let service_runtime = Arc::new(
+            crate::CommsRuntime::inproc_only("schedule-service-runtime-detach")
+                .expect("service comms runtime"),
+        );
+        let preattached_runtime = Arc::new(
+            crate::CommsRuntime::inproc_only("schedule-preattached-runtime-detach")
+                .expect("preattached comms runtime"),
+        );
+        let (service, runtime_adapter) =
+            build_comms_test_service(&temp, Arc::clone(&service_runtime)).await;
+
+        let session = Session::new();
+        let session_id = session.id().clone();
+        let result = Box::pin(materialize_session(
+            &service,
+            &runtime_adapter,
+            session,
+            make_runtime_backed_request("scheduled-detach-session", false),
+            {
+                let service = Arc::clone(&service);
+                let runtime_adapter = Arc::clone(&runtime_adapter);
+                move |session_id| default_persistent_executor(service, runtime_adapter, session_id)
+            },
+        ))
+        .await
+        .expect("materialize runtime-backed session");
+
+        let preattached_runtime: Arc<dyn meerkat_core::agent::CommsRuntime> = preattached_runtime;
+        runtime_adapter
+            .update_peer_ingress_context(&session_id, true, Some(Arc::clone(&preattached_runtime)))
+            .await
+            .expect("pre-attach session-owned ingress");
+        assert!(matches!(
+            runtime_adapter.peer_ingress_owner(&session_id).await,
+            meerkat_runtime::PeerIngressOwner::SessionOwned { .. }
+        ));
+
+        let host = RuntimeBackedScheduleSessionHost::new(
+            Arc::clone(&service),
+            Arc::clone(&runtime_adapter),
+            SessionBuildOptions::default(),
+        );
+        let occurrence = sample_occurrence();
+        let dispatch = host
+            .deliver_prompt(
+                &result.session_id,
+                &occurrence,
+                ScheduledPromptDispatch {
+                    prompt: ContentInput::Text("scheduled prompt".to_string()),
+                    render_metadata: None,
+                    skill_refs: Vec::new(),
+                    additional_instructions: Vec::new(),
+                    materialized_session_id: None,
+                },
+            )
+            .await
+            .expect("scheduled prompt delivery should detach without reattaching ingress");
+
+        let owner = runtime_adapter.peer_ingress_owner(&session_id).await;
+        assert!(
+            matches!(owner, meerkat_runtime::PeerIngressOwner::Unattached),
+            "non-keep-alive session-owned ingress must detach instead of reattaching, got {owner:?}"
+        );
+
+        let terminal = tokio::time::timeout(std::time::Duration::from_secs(2), dispatch.completion)
+            .await
+            .expect("scheduled prompt should complete")
+            .expect("delivery terminal should resolve");
+        assert_eq!(
+            terminal.phase,
+            meerkat_schedule::OccurrencePhase::AwaitingCompletion
+        );
+        assert_eq!(
+            terminal.runtime_completion_outcome,
+            Some(meerkat_schedule::RuntimeCompletionOutcome::Completed)
+        );
+
+        service
+            .discard_live_session(&result.session_id)
+            .await
+            .expect("discard live session");
+        runtime_adapter.unregister_session(&result.session_id).await;
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fix scheduled delivery into existing runtime-backed sessions whose peer ingress is already session-owned. The schedule host now distinguishes unattached, session-owned, and mob-owned ingress before delivery.

For session-owned keep-alive sessions, delivery refreshes the existing authorized drain task without staging `AttachSessionIngress` with a potentially different service runtime. For session-owned non-keep-alive sessions, delivery explicitly detaches with `keep_alive=false` and `comms_runtime=None`, avoiding the same rejected reattach shape.

## Root Cause

Scheduled delivery registered the runtime session and then always flowed through service-driven peer-ingress configuration. For an already attached session, that could attempt `AttachSessionIngress` from `Attached` with a different runtime id, which the staged-session FSM correctly rejects.

## Validation

- `./scripts/repo-cargo fmt --all`
- `./scripts/repo-cargo test -p meerkat --features 'session-store schedule comms jsonl-store' deliver_prompt_to_already_session_owned_ingress_does_not_reattach -- --nocapture`
- `./scripts/repo-cargo test -p meerkat --features 'session-store schedule comms jsonl-store' deliver_prompt_to_session_owned_non_keep_alive_ingress_detaches_without_reattach -- --nocapture`
- `./scripts/repo-cargo test -p meerkat --features 'session-store comms jsonl-store' surface::runtime_schedule_host::tests -- --nocapture`
- `./scripts/repo-cargo test -p meerkat-runtime refresh_session_owned_peer_ingress_respawns_authorized_drain_without_reattach -- --nocapture`
- `./scripts/repo-cargo test -p meerkat-runtime attach_session_ingress_exact_reassertion_is_idempotent -- --nocapture`
- `./scripts/repo-cargo test -p meerkat-runtime mob_owned_drain_rejects_silent_session_downgrade -- --nocapture`
- `./scripts/repo-cargo clippy -p meerkat -p meerkat-runtime --all-targets --all-features -- -D warnings`
- `make check`
- pre-push hook suite, including changed-crates clippy, machine drift/codegen checks, governance audits, and deterministic workspace gate

## Review Gate

Two adversarial read-only subagent reviews were run against the fix. Both reviewers returned green after the final keep-alive false detach patch.
