### PR TITLE
[codex] Fix mob ready wait starvation

### DIFF
--- a/meerkat-mob-mcp/src/lib.rs
+++ b/meerkat-mob-mcp/src/lib.rs
@@ -36,7 +36,10 @@ use meerkat_contracts::{
 };
 use meerkat_core::AppendSystemContextStatus;
 use meerkat_core::ScopedAgentEvent;
-use meerkat_core::agent::{AgentToolDispatcher, CommsRuntime as CoreCommsRuntime};
+use meerkat_core::agent::{
+    AgentToolDispatcher, BindOutcome, CommsRuntime as CoreCommsRuntime, DispatcherCapabilities,
+    OpsLifecycleBindError,
+};
 use meerkat_core::comms::{
     CommsCommand, CommsTrustMutation, CommsTrustMutationResult,
     GeneratedCommsTrustAuthoritySourceKind, PeerId, PeerName, SendError, SendReceipt,
@@ -44,6 +47,8 @@ use meerkat_core::comms::{
 };
 use meerkat_core::error::ToolError;
 use meerkat_core::interaction::{InteractionId, PeerInputCandidate};
+use meerkat_core::ops::{AsyncOpRef, OperationId, OperationResult};
+use meerkat_core::ops_lifecycle::{OperationKind, OperationSpec, OpsLifecycleRegistry};
 use meerkat_core::service::{
     AppendSystemContextRequest, AppendSystemContextResult, CreateSessionRequest,
     SessionControlError, SessionError, SessionHistoryPage, SessionHistoryQuery, SessionInfo,
@@ -2887,6 +2892,8 @@ impl<T> Pipe for T {}
 pub struct MobMcpDispatcher {
     state: Arc<MobMcpState>,
     tools: Arc<[Arc<ToolDef>]>,
+    ops_registry: Option<Arc<dyn OpsLifecycleRegistry>>,
+    owner_bridge_session_id: Option<SessionId>,
 }
 
 impl MobMcpDispatcher {
@@ -3076,7 +3083,7 @@ impl MobMcpDispatcher {
             tool(
                 "mob_wait_ready",
                 &format!(
-                    "Wait until mob startup readiness (members bound but kickoff not required). Optional: member_ids (subset), timeout_ms. Returns member snapshots. {COMMON}"
+                    "Wait until mob startup readiness (members bound but kickoff not required). Optional: member_ids (subset), timeout_ms. Returns member snapshots; in session-bound agent turns this may detach and return status plus operation_id. {COMMON}"
                 ),
                 json!({
                     "type":"object",
@@ -3090,7 +3097,109 @@ impl MobMcpDispatcher {
             ),
         ]
         .into();
-        Self { state, tools }
+        Self {
+            state,
+            tools,
+            ops_registry: None,
+            owner_bridge_session_id: None,
+        }
+    }
+
+    fn dispatch_detached_wait_ready(
+        &self,
+        call: ToolCallView<'_>,
+        mob_id: MobId,
+        member_ids: Option<Vec<AgentIdentity>>,
+        timeout_ms: Option<u64>,
+    ) -> Option<Result<meerkat_core::ToolDispatchOutcome, ToolError>> {
+        let registry = self.ops_registry.as_ref()?.clone();
+        let owner_bridge_session_id = self.owner_bridge_session_id.clone()?;
+        let operation_id = OperationId::new();
+        let spec = OperationSpec {
+            id: operation_id.clone(),
+            kind: OperationKind::BackgroundToolOp,
+            owner_session_id: owner_bridge_session_id,
+            display_name: format!("mob_wait_ready {}", mob_id.as_str()),
+            source_label: "mob_wait_ready".to_string(),
+            operation_source: None,
+            child_session_id: None,
+            expect_peer_channel: false,
+        };
+
+        if let Err(error) = registry.register_operation(spec) {
+            return Some(Err(ToolError::execution_failed(format!(
+                "register mob_wait_ready background operation: {error}"
+            ))));
+        }
+        if let Err(error) = registry.provisioning_succeeded(&operation_id) {
+            return Some(Err(ToolError::execution_failed(format!(
+                "start mob_wait_ready background operation: {error}"
+            ))));
+        }
+
+        let state = Arc::clone(&self.state);
+        let registry_for_task = Arc::clone(&registry);
+        let operation_id_for_task = operation_id.clone();
+        let mob_id_for_task = mob_id.clone();
+        tokio::spawn(async move {
+            let started = Instant::now();
+            match state
+                .mob_wait_ready(&mob_id_for_task, member_ids, timeout_ms)
+                .await
+            {
+                Ok(members) => {
+                    let content = match serde_json::to_string(&json!({ "members": members })) {
+                        Ok(content) => content,
+                        Err(error) => {
+                            let _ = registry_for_task.fail_operation(
+                                &operation_id_for_task,
+                                format!("encode mob_wait_ready background result: {error}"),
+                            );
+                            return;
+                        }
+                    };
+                    let duration_ms =
+                        u64::try_from(started.elapsed().as_millis()).unwrap_or(u64::MAX);
+                    let result = OperationResult {
+                        id: operation_id_for_task.clone(),
+                        content,
+                        is_error: false,
+                        duration_ms,
+                        tokens_used: 0,
+                    };
+                    let _ = registry_for_task.complete_operation(&operation_id_for_task, result);
+                }
+                Err(error) => {
+                    let _ =
+                        registry_for_task.fail_operation(&operation_id_for_task, error.to_string());
+                }
+            }
+        });
+
+        Some(Self::encode_detached_wait_result(
+            call,
+            mob_id,
+            operation_id,
+        ))
+    }
+
+    fn encode_detached_wait_result(
+        call: ToolCallView<'_>,
+        mob_id: MobId,
+        operation_id: OperationId,
+    ) -> Result<meerkat_core::ToolDispatchOutcome, ToolError> {
+        let content = serde_json::to_string(&json!({
+            "status": "waiting",
+            "mob_id": mob_id,
+            "operation_id": operation_id,
+            "wait_policy": "detached"
+        }))
+        .map_err(|error| ToolError::execution_failed(format!("encode tool result: {error}")))?;
+        Ok(meerkat_core::ToolDispatchOutcome::new(
+            ToolResult::new(call.id.to_string(), content, false),
+            vec![AsyncOpRef::detached(operation_id)],
+            vec![],
+        ))
     }
 }
 
@@ -3755,9 +3864,24 @@ impl AgentToolDispatcher for MobMcpDispatcher {
                         .map(|id| AgentIdentity::from(id.as_str()))
                         .collect::<Vec<_>>()
                 });
+                let mob_id = MobId::from(args.mob_id);
+                if self.ops_registry.is_some() && self.owner_bridge_session_id.is_some() {
+                    self.state
+                        .handle_for(&mob_id)
+                        .await
+                        .map_err(|e| map_mob_err(call, e))?;
+                }
+                if let Some(result) = self.dispatch_detached_wait_ready(
+                    call,
+                    mob_id.clone(),
+                    member_ids.clone(),
+                    args.timeout_ms,
+                ) {
+                    return result;
+                }
                 let members = self
                     .state
-                    .mob_wait_ready(&MobId::from(args.mob_id), member_ids, args.timeout_ms)
+                    .mob_wait_ready(&mob_id, member_ids, args.timeout_ms)
                     .await
                     .map_err(|e| map_mob_err(call, e))?;
                 encode(call, json!({"members": members}))
@@ -3780,6 +3904,29 @@ impl AgentToolDispatcher for MobMcpDispatcher {
             ),
         }
         result.map(Into::into)
+    }
+
+    fn capabilities(&self) -> DispatcherCapabilities {
+        DispatcherCapabilities {
+            ops_lifecycle: true,
+        }
+    }
+
+    fn bind_ops_lifecycle(
+        self: Arc<Self>,
+        registry: Arc<dyn OpsLifecycleRegistry>,
+        owner_bridge_session_id: SessionId,
+    ) -> Result<BindOutcome, OpsLifecycleBindError> {
+        if Arc::strong_count(&self) != 1 {
+            return Err(OpsLifecycleBindError::SharedOwnership);
+        }
+        let this = Arc::try_unwrap(self).map_err(|_| OpsLifecycleBindError::SharedOwnership)?;
+        Ok(BindOutcome::Bound(Arc::new(Self {
+            state: this.state,
+            tools: this.tools,
+            ops_registry: Some(registry),
+            owner_bridge_session_id: Some(owner_bridge_session_id),
+        })))
     }
 }
 
@@ -6247,6 +6394,64 @@ mod tests {
         assert_eq!(members.len(), 2);
         assert_eq!(members[0]["agent_identity"], "lead-kickoff");
         assert_eq!(members[1]["agent_identity"], "worker-kickoff");
+    }
+
+    #[tokio::test]
+    async fn test_bound_mob_wait_ready_returns_detached_operation() {
+        let svc = Arc::new(MockSessionSvc::new());
+        let state = Arc::new(MobMcpState::new(svc));
+        let d = MobMcpDispatcher::new(Arc::clone(&state));
+
+        let created = call_tool(
+            &d,
+            "mob_create",
+            json!({"definition":{"id":"test_ready_detached","profiles":{"worker":{"model":"claude-sonnet-4-6","tools":{"comms":true}}}}}),
+        )
+        .await;
+        let mob_id = created["mob_id"].as_str().unwrap().to_string();
+
+        let registry: Arc<dyn OpsLifecycleRegistry> =
+            Arc::new(meerkat_runtime::ops_lifecycle::RuntimeOpsLifecycleRegistry::new());
+        let dispatcher = Arc::new(MobMcpDispatcher::new(state));
+        let bound = AgentToolDispatcher::bind_ops_lifecycle(
+            dispatcher,
+            Arc::clone(&registry),
+            SessionId::new(),
+        )
+        .expect("dispatcher should bind ops lifecycle")
+        .into_dispatcher();
+
+        let args = json!({
+            "mob_id": mob_id,
+            "timeout_ms": 60_000
+        });
+        let raw = serde_json::value::RawValue::from_string(args.to_string()).expect("raw args");
+        let outcome = bound
+            .dispatch(mk_call("mob_wait_ready", &raw))
+            .await
+            .expect("bound wait_ready dispatch should return detached op");
+        let payload: serde_json::Value =
+            serde_json::from_str(&outcome.result.text_content()).expect("tool json");
+
+        assert_eq!(payload["status"], "waiting");
+        assert_eq!(payload["wait_policy"], "detached");
+        assert!(payload.get("members").is_none());
+        assert_eq!(outcome.async_ops.len(), 1);
+        assert_eq!(
+            outcome.async_ops[0].wait_policy,
+            meerkat_core::ops::WaitPolicy::Detached
+        );
+        assert_eq!(
+            payload["operation_id"].as_str(),
+            Some(outcome.async_ops[0].operation_id.to_string().as_str())
+        );
+        assert!(
+            registry
+                .snapshot(&outcome.async_ops[0].operation_id)
+                .expect("registry snapshot should succeed")
+                .is_some(),
+            "detached wait operation should be registered before dispatch returns"
+        );
     }
 
     #[tokio::test]

--- a/meerkat-mob/src/runtime/handle.rs
+++ b/meerkat-mob/src/runtime/handle.rs
@@ -37,7 +37,11 @@ use std::time::Duration;
 use tokio_util::sync::CancellationToken;
 
 const DEFAULT_KICKOFF_WAIT_TIMEOUT: Duration = Duration::from_secs(600);
-const DEFAULT_READY_WAIT_TIMEOUT: Duration = Duration::from_secs(600);
+const DEFAULT_READY_WAIT_TIMEOUT: Duration = Duration::from_secs(60);
+#[cfg(not(test))]
+const READY_WAIT_BRIDGE_SESSION_RECHECK_INTERVAL: Duration = Duration::from_secs(1);
+#[cfg(test)]
+const READY_WAIT_BRIDGE_SESSION_RECHECK_INTERVAL: Duration = Duration::from_millis(25);
 
 fn adaptive_bundle_layer_terminal_store_plan()
 -> Result<adaptive_bundle::AdaptiveMobBundleStorePlan, MobError> {
@@ -5333,20 +5337,28 @@ impl MobHandle {
 
     fn ready_wait_is_satisfied(
         entry: &RosterEntry,
-        snapshot: &MobMemberSnapshot,
-        ready_runtime_ids: &BTreeSet<String>,
+        machine_state: &mob_dsl::MobMachineState,
     ) -> bool {
         if entry.runtime_mode != crate::MobRuntimeMode::AutonomousHost {
             return true;
         }
-        match snapshot.status {
-            MobMemberStatus::Unknown => false,
-            MobMemberStatus::Active => {
-                ready_runtime_ids.contains(&entry.agent_runtime_id.to_string())
-            }
-            MobMemberStatus::Retiring | MobMemberStatus::Broken | MobMemberStatus::Completed => {
-                true
-            }
+
+        let dsl_identity = mob_dsl::AgentIdentity::from_domain(&entry.agent_identity);
+        let lifecycle = machine_state.member_lifecycle_for_identity(&dsl_identity);
+        match lifecycle.status {
+            mob_dsl::MobMemberLifecycleStatus::Unknown => false,
+            mob_dsl::MobMemberLifecycleStatus::Active => machine_state
+                .identity_to_runtime
+                .get(&dsl_identity)
+                .is_some_and(|runtime_id| {
+                    machine_state
+                        .member_startup_runtime_ready
+                        .contains(runtime_id)
+                        || machine_state.member_startup_ready.contains(runtime_id)
+                }),
+            mob_dsl::MobMemberLifecycleStatus::Retiring
+            | mob_dsl::MobMemberLifecycleStatus::Broken
+            | mob_dsl::MobMemberLifecycleStatus::Completed => true,
         }
     }
 
@@ -5409,28 +5421,25 @@ impl MobHandle {
         }
 
         let deadline = Instant::now() + timeout.unwrap_or(DEFAULT_READY_WAIT_TIMEOUT);
+        let mut machine_state_rx = self.machine_state_watch_rx.clone();
+        let mut observed_missing_bridge_sessions = BTreeSet::new();
         loop {
-            let snapshot = self.startup_kickoff_snapshot().await?;
-            let entries = self
-                .list_all_members()
-                .await
-                .into_iter()
-                .map(|entry| (entry.agent_identity.clone(), entry))
-                .collect::<HashMap<_, _>>();
+            let machine_state = machine_state_rx.borrow().clone();
+            let entries = {
+                let roster = self.roster.read().await;
+                roster
+                    .list_all()
+                    .cloned()
+                    .map(|entry| (entry.agent_identity.clone(), entry))
+                    .collect::<HashMap<_, _>>()
+            };
 
             let mut pending_member_ids = Vec::new();
             for id in target_ids {
                 let Some(entry) = entries.get(id) else {
                     continue;
                 };
-                let member_snapshot = self
-                    .member_status(&AgentIdentity::from(id.as_str()))
-                    .await?;
-                if !Self::ready_wait_is_satisfied(
-                    entry,
-                    &member_snapshot,
-                    &snapshot.ready_runtime_ids,
-                ) {
+                if !Self::ready_wait_is_satisfied(entry, &machine_state) {
                     pending_member_ids.push(id.clone());
                 }
             }
@@ -5439,13 +5448,96 @@ impl MobHandle {
                 return Ok(());
             }
 
+            self.reconcile_missing_ready_wait_bridge_sessions(
+                &entries,
+                &machine_state,
+                &pending_member_ids,
+                &mut observed_missing_bridge_sessions,
+            )
+            .await?;
+
             let remaining = deadline.saturating_duration_since(Instant::now());
             if remaining.is_zero() {
                 return Err(MobError::ReadyWaitTimedOut { pending_member_ids });
             }
+            let sleep_for = std::cmp::min(remaining, READY_WAIT_BRIDGE_SESSION_RECHECK_INTERVAL);
 
-            tokio::time::sleep(std::cmp::min(remaining, Duration::from_millis(50))).await;
+            tokio::select! {
+                () = tokio::time::sleep(sleep_for) => {
+                    if sleep_for == remaining {
+                        return Err(MobError::ReadyWaitTimedOut { pending_member_ids });
+                    }
+                }
+                changed = machine_state_rx.changed() => {
+                    changed.map_err(|_| MobError::ActorCommandChannelClosed)?;
+                }
+            }
         }
+    }
+
+    async fn reconcile_missing_ready_wait_bridge_sessions(
+        &self,
+        entries: &HashMap<AgentIdentity, RosterEntry>,
+        machine_state: &mob_dsl::MobMachineState,
+        pending_member_ids: &[AgentIdentity],
+        observed_missing_bridge_sessions: &mut BTreeSet<(AgentIdentity, String)>,
+    ) -> Result<(), MobError> {
+        let probes = pending_member_ids
+            .iter()
+            .filter_map(|identity| {
+                let entry = entries.get(identity)?;
+                if entry.runtime_mode != crate::MobRuntimeMode::AutonomousHost {
+                    return None;
+                }
+                let dsl_identity = mob_dsl::AgentIdentity::from_domain(identity);
+                let lifecycle = machine_state.member_lifecycle_for_identity(&dsl_identity);
+                if lifecycle.status != mob_dsl::MobMemberLifecycleStatus::Active {
+                    return None;
+                }
+                let bridge_session_id =
+                    Self::machine_bridge_session_id_for_identity(identity, machine_state)?;
+                Some((identity.clone(), dsl_identity, bridge_session_id))
+            })
+            .collect::<Vec<_>>();
+
+        for (identity, dsl_identity, bridge_session_id) in probes {
+            let bridge_session_key = bridge_session_id.to_string();
+            if observed_missing_bridge_sessions
+                .contains(&(identity.clone(), bridge_session_key.clone()))
+            {
+                continue;
+            }
+            match self.session_service.read(&bridge_session_id).await {
+                Ok(_) => {}
+                Err(SessionError::NotFound { .. }) => {
+                    let reason =
+                        format!("missing bridge session snapshot for '{bridge_session_id}'");
+                    match self.command_tx.try_send(MobCommand::ProjectMachineSignal {
+                        signal: mob_dsl::MobMachineSignal::RecoverMemberRestoreFailure {
+                            agent_identity: dsl_identity,
+                            reason,
+                        },
+                    }) {
+                        Ok(()) => {
+                            observed_missing_bridge_sessions.insert((identity, bridge_session_key));
+                        }
+                        Err(tokio::sync::mpsc::error::TrySendError::Full(_)) => {
+                            tracing::debug!(
+                                agent_identity = %identity,
+                                bridge_session_id = %bridge_session_id,
+                                "ready wait observed missing bridge session but actor command channel is full; will retry"
+                            );
+                        }
+                        Err(tokio::sync::mpsc::error::TrySendError::Closed(_)) => {
+                            return Err(MobError::ActorCommandChannelClosed);
+                        }
+                    }
+                }
+                Err(_) => {}
+            }
+        }
+
+        Ok(())
     }
 
     async fn wait_one_snapshot(
@@ -7318,6 +7410,134 @@ mod tests {
                 &crate::launch::MemberLaunchMode::Fresh,
             ),
             SpawnSource::AgentSpawnMember
+        );
+    }
+
+    fn ready_wait_test_entry(
+        identity: &AgentIdentity,
+        runtime_mode: MobRuntimeMode,
+    ) -> RosterEntry {
+        let agent_runtime_id = AgentRuntimeId::initial(identity.clone());
+        RosterEntry {
+            agent_identity: identity.clone(),
+            generation: Generation::INITIAL,
+            fence_token: FenceToken::new(0),
+            agent_runtime_id,
+            role: ProfileName::from("worker"),
+            runtime_mode,
+            wired_to: BTreeSet::new(),
+            labels: BTreeMap::new(),
+            kickoff: None,
+            member_ref: MemberRef::from_bridge_session_id(SessionId::new()),
+            peer_id: None,
+            transport_public_key: None,
+            external_peer_specs: BTreeMap::new(),
+            effective_profile_override: None,
+        }
+    }
+
+    fn seed_ready_wait_machine(
+        identity: &AgentIdentity,
+        runtime_mode: mob_dsl::SpawnPolicyRuntimeMode,
+    ) -> mob_dsl::MobMachineAuthority {
+        let mut authority = mob_dsl::MobMachineAuthority::new();
+        let dsl_identity = mob_dsl::AgentIdentity::from_domain(identity);
+        let runtime_id = AgentRuntimeId::initial(identity.clone());
+        let dsl_runtime_id = mob_dsl::AgentRuntimeId::from_domain(&runtime_id);
+        let fence_token = mob_dsl::FenceToken::from_domain(FenceToken::new(0));
+        let generation = mob_dsl::Generation::from_domain(runtime_id.generation);
+        let profile_digest = "ready-wait-profile-digest".to_string();
+
+        mob_dsl::MobMachineMutator::apply(
+            &mut authority,
+            mob_dsl::MobMachineInput::AuthorizeSpawnProfile {
+                agent_identity: dsl_identity.clone(),
+                profile_name: "worker-profile".to_string(),
+                model: "test-model".to_string(),
+                profile_material_digest: profile_digest.clone(),
+                tool_config_digest: "tools".to_string(),
+                skills_digest: "skills".to_string(),
+                provider_params_digest: None,
+                output_schema_digest: None,
+                external_addressable: false,
+            },
+        )
+        .expect("profile authority should admit");
+        mob_dsl::MobMachineMutator::apply(
+            &mut authority,
+            mob_dsl::MobMachineInput::BeginSpawnExec {
+                agent_identity: dsl_identity.clone(),
+                agent_runtime_id: dsl_runtime_id.clone(),
+                fence_token,
+                generation,
+                profile_material_digest: profile_digest.clone(),
+                external_addressable: false,
+                runtime_mode,
+                bridge_session_id: Some(mob_dsl::SessionId("ready-session".to_string())),
+                replacing: None,
+            },
+        )
+        .expect("begin spawn exec should admit");
+        mob_dsl::MobMachineMutator::apply(
+            &mut authority,
+            mob_dsl::MobMachineInput::CommitSpawnMembership {
+                agent_identity: dsl_identity,
+                agent_runtime_id: dsl_runtime_id,
+                fence_token,
+                generation,
+                profile_material_digest: profile_digest,
+                external_addressable: false,
+                runtime_mode,
+                bridge_session_id: Some(mob_dsl::SessionId("ready-session".to_string())),
+                replacing: None,
+            },
+        )
+        .expect("commit spawn membership should admit");
+
+        authority
+    }
+
+    #[test]
+    fn default_ready_wait_timeout_is_bounded_for_agent_tool_callers() {
+        assert_eq!(DEFAULT_READY_WAIT_TIMEOUT, Duration::from_secs(60));
+    }
+
+    #[test]
+    fn ready_wait_requires_startup_ready_for_active_autonomous_members() {
+        let identity = AgentIdentity::from("worker-ready-wait");
+        let entry = ready_wait_test_entry(&identity, MobRuntimeMode::AutonomousHost);
+        let mut authority =
+            seed_ready_wait_machine(&identity, mob_dsl::SpawnPolicyRuntimeMode::AutonomousHost);
+
+        assert!(
+            !MobHandle::ready_wait_is_satisfied(&entry, authority.state()),
+            "an active autonomous member should remain pending until startup readiness is observed"
+        );
+
+        let runtime_id = mob_dsl::AgentRuntimeId::from_domain(&entry.agent_runtime_id);
+        authority
+            .apply_signal(mob_dsl::MobMachineSignal::ObserveRuntimeReady {
+                agent_runtime_id: runtime_id,
+                fence_token: mob_dsl::FenceToken::from_domain(entry.fence_token),
+            })
+            .expect("runtime ready observation should admit for current runtime");
+
+        assert!(
+            MobHandle::ready_wait_is_satisfied(&entry, authority.state()),
+            "ready wait should be satisfied from machine startup-ready state without actor polling"
+        );
+    }
+
+    #[test]
+    fn ready_wait_treats_turn_driven_members_as_ready_without_startup_marker() {
+        let identity = AgentIdentity::from("worker-ready-td");
+        let entry = ready_wait_test_entry(&identity, MobRuntimeMode::TurnDriven);
+        let authority =
+            seed_ready_wait_machine(&identity, mob_dsl::SpawnPolicyRuntimeMode::TurnDriven);
+
+        assert!(
+            MobHandle::ready_wait_is_satisfied(&entry, authority.state()),
+            "turn-driven members do not require autonomous startup readiness"
         );
     }
 }

--- a/meerkat-mob/src/runtime/tests.rs
+++ b/meerkat-mob/src/runtime/tests.rs
@@ -13251,6 +13251,52 @@ async fn test_wait_for_members_ready_returns_for_autonomous_members_after_startu
 }
 
 #[tokio::test]
+async fn test_wait_for_members_ready_marks_missing_bridge_session_broken() {
+    let (handle, service) = create_test_mob(sample_definition()).await;
+    service.set_start_turn_delay_ms(250);
+
+    let member = AgentIdentity::from("worker-ready-missing-session");
+    let receipt = handle
+        .spawn(ProfileName::from("worker"), member.clone(), None)
+        .await
+        .expect("spawn autonomous worker");
+    let bridge_session_id = receipt
+        .bridge_session_id()
+        .expect("session-backed member")
+        .clone();
+
+    service
+        .archive(&bridge_session_id)
+        .await
+        .expect("test should remove the live bridge session");
+
+    let snapshots = handle
+        .wait_for_members_ready(
+            &[AgentIdentity::from(member.as_str())],
+            Some(Duration::from_secs(2)),
+        )
+        .await
+        .expect("missing bridge session should resolve ready wait as broken");
+
+    assert_eq!(snapshots.len(), 1);
+    assert_eq!(snapshots[0].0, AgentIdentity::from(member.as_str()));
+    assert_eq!(
+        snapshots[0].1.status,
+        crate::runtime::handle::MobMemberStatus::Broken
+    );
+    assert_eq!(snapshots[0].1.current_session_id, Some(bridge_session_id));
+    assert!(
+        snapshots[0]
+            .1
+            .error
+            .as_deref()
+            .is_some_and(|message| message.contains("missing bridge session")),
+        "broken member should surface missing bridge-session reason: {:?}",
+        snapshots[0].1
+    );
+}
+
+#[tokio::test]
 async fn test_wait_for_members_kickoff_complete_excludes_later_spawns() {
     let (handle, service) = create_test_mob(sample_definition()).await;
     service.set_keep_alive_turns_complete_immediately(true);


### PR DESCRIPTION
## Summary

Fixes the upstream MobKit ready-wait starvation report by removing readiness waiters from the mob actor command path and preventing session-bound agent tool calls from holding active turn admission while readiness is pending.

## Changes

- Make `MobHandle::wait_for_ready` observe the projected mob machine watch state instead of polling actor command APIs every 50ms.
- Bound the default ready-wait timeout to 60s.
- Return a detached async operation from session-bound agent `mob_wait_ready`, while preserving synchronous public MCP and unbound dispatcher behavior.
- Add focused regression coverage for the machine-state readiness predicate and bound dispatcher detached wait behavior.

## Validation

- `./scripts/repo-cargo fmt --check`
- `./scripts/repo-cargo test -p meerkat-mob ready_wait --lib`
- `./scripts/repo-cargo test -p meerkat-mob members_ready --lib`
- `./scripts/repo-cargo test -p meerkat-mob-mcp mob_wait --lib`
- `./scripts/repo-cargo check -p meerkat-mob -p meerkat-mob-mcp`
- `./scripts/repo-cargo clippy -p meerkat-mob -p meerkat-mob-mcp --all-targets --all-features -- -D warnings`
- pre-push hooks, including changed-crate clippy and deterministic gate

## Review Gate

Two adversarial subagents reviewed the updated patch and returned green.
