### PR TITLE
Fix mob smoke AGENTS fixtures

### DIFF
--- a/meerkat-mob/tests/smoke_mob_generated_image_comms.rs
+++ b/meerkat-mob/tests/smoke_mob_generated_image_comms.rs
@@ -17,6 +17,8 @@ use meerkat_session::PersistentSessionService;
 use meerkat_store::{JsonlStore, MemoryBlobStore, StoreAdapter};
 use serde_json::Value;
 use std::collections::{BTreeMap, BTreeSet};
+use std::fs;
+use std::path::Path;
 use std::sync::Arc;
 use tempfile::TempDir;
 use tokio::time::{Duration, Instant, sleep};
@@ -189,12 +191,24 @@ fn image_relay_definition(
     definition
 }
 
+fn materialize_project_context(root: &Path) -> Result<(), Box<dyn std::error::Error>> {
+    for dir in [root.join("project-root"), root.join("context-root")] {
+        fs::create_dir_all(&dir)?;
+        fs::write(
+            dir.join("AGENTS.md"),
+            "# Generated Image Mob Smoke\n\nUse concise responses for live mob smoke tests.\n",
+        )?;
+    }
+    Ok(())
+}
+
 async fn setup_generated_image_comms_mob(
     api_key: String,
     model: &str,
 ) -> Result<(MobHandle, Arc<dyn MobSessionService>, TempDir), Box<dyn std::error::Error>> {
     let temp_dir = TempDir::new()?;
     let root = temp_dir.path();
+    materialize_project_context(root)?;
     let runtime_store = Arc::new(meerkat_runtime::InMemoryRuntimeStore::default());
     let blob_store: Arc<dyn meerkat_core::BlobStore> = Arc::new(MemoryBlobStore::default());
     let runtime_adapter = Arc::new(MeerkatMachine::persistent(
@@ -245,6 +259,7 @@ async fn setup_image_relay_mob(
 ) -> Result<(MobHandle, Arc<dyn MobSessionService>, TempDir), Box<dyn std::error::Error>> {
     let temp_dir = TempDir::new()?;
     let root = temp_dir.path();
+    materialize_project_context(root)?;
     let runtime_store = Arc::new(meerkat_runtime::InMemoryRuntimeStore::default());
     let blob_store: Arc<dyn meerkat_core::BlobStore> = Arc::new(MemoryBlobStore::default());
     let runtime_adapter = Arc::new(MeerkatMachine::persistent(

--- a/meerkat-mob/tests/smoke_mob_resume.rs
+++ b/meerkat-mob/tests/smoke_mob_resume.rs
@@ -23,6 +23,7 @@ use meerkat_session::PersistentSessionService;
 use meerkat_store::{JsonlStore, StoreAdapter};
 use serde_json::to_string;
 use std::collections::BTreeMap;
+use std::fs;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use tempfile::TempDir;
@@ -96,6 +97,17 @@ impl SmokePaths {
             mob_db_path: root.join("mob.db"),
         }
     }
+
+    fn materialize_project_context(&self) {
+        for root in [&self.project_root, &self.context_root] {
+            fs::create_dir_all(root).expect("create mob smoke project/context root");
+            fs::write(
+                root.join("AGENTS.md"),
+                "# Mob Smoke\n\nUse concise responses for live mob smoke tests.\n",
+            )
+            .expect("write mob smoke AGENTS.md");
+        }
+    }
 }
 
 fn smoke_factory(paths: &SmokePaths) -> AgentFactory {
@@ -115,6 +127,7 @@ fn persistent_service(
     Arc<PersistentSessionService<FactoryAgentBuilder>>,
     Arc<JsonlStore>,
 ) {
+    paths.materialize_project_context();
     let factory = smoke_factory(paths);
     let mut builder = FactoryAgentBuilder::new(factory, Config::default());
     let store = Arc::new(JsonlStore::new(paths.sessions_root.clone()));


### PR DESCRIPTION
Fixes additional Turbo S mob smoke fixtures so temporary project/context roots include AGENTS.md before spawning live mob members.\n\nValidation:\n- ./scripts/repo-cargo test -p meerkat-mob --test smoke_mob_resume --features integration-real-tests -- --list\n- ./scripts/repo-cargo test -p meerkat-mob --test smoke_mob_generated_image_comms --features integration-real-tests -- --list\n- Hosted BuildBuddy failing-target rerun: https://app.buildbuddy.io/invocation/efb77b81-b87e-452b-9f0b-1bcc74a0cc9c (3/3 passed)