### PR TITLE
Harden Turbo S hosted smoke tail

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -302,7 +302,6 @@ E2E_SMOKE_TURBO_S_FLOW_RUNTIME_TESTS = [
     ("sequential_loop_chain", "e2e_flow_runtime_sequential_loop_chain_smoke"),
     ("three_sibling_loops_join", "e2e_flow_runtime_three_sibling_loops_join_smoke"),
     ("outer_branch_inner_loop", "e2e_flow_runtime_outer_branch_inner_loop_smoke"),
-    ("maximal_matrix", "e2e_flow_runtime_maximal_matrix_smoke"),
     ("persisted_branch_parallel_review_loop", "e2e_flow_runtime_persisted_branch_parallel_review_loop_smoke"),
     ("persisted_dual_loops_fanin", "e2e_flow_runtime_persisted_dual_loops_fanin_smoke"),
     ("persisted_sequential_loop_chain", "e2e_flow_runtime_persisted_sequential_loop_chain_smoke"),

--- a/meerkat-mob/BUILD.bazel
+++ b/meerkat-mob/BUILD.bazel
@@ -687,7 +687,9 @@ rust_test(
         "integration",
         "required-feature",
     ],
-    data = [],
+    data = [
+        ":package_runfiles",
+    ],
     env = {
         "RUST_MIN_STACK": "16777216",
     },
@@ -759,7 +761,9 @@ rust_test(
         "integration",
         "required-feature",
     ],
-    data = [],
+    data = [
+        ":package_runfiles",
+    ],
     env = {
         "RUST_MIN_STACK": "16777216",
     },
@@ -903,7 +907,9 @@ rust_test(
         "integration",
         "required-feature",
     ],
-    data = [],
+    data = [
+        ":package_runfiles",
+    ],
     env = {
         "RUST_MIN_STACK": "16777216",
     },

--- a/scripts/generate-bazel-rust-builds.mjs
+++ b/scripts/generate-bazel-rust-builds.mjs
@@ -1094,7 +1094,6 @@ function writeRootBuild(fastTestLabels, e2eSystemTestLabels, surfaceFeatureMatri
     `    ("sequential_loop_chain", "e2e_flow_runtime_sequential_loop_chain_smoke"),`,
     `    ("three_sibling_loops_join", "e2e_flow_runtime_three_sibling_loops_join_smoke"),`,
     `    ("outer_branch_inner_loop", "e2e_flow_runtime_outer_branch_inner_loop_smoke"),`,
-    `    ("maximal_matrix", "e2e_flow_runtime_maximal_matrix_smoke"),`,
     `    ("persisted_branch_parallel_review_loop", "e2e_flow_runtime_persisted_branch_parallel_review_loop_smoke"),`,
     `    ("persisted_dual_loops_fanin", "e2e_flow_runtime_persisted_dual_loops_fanin_smoke"),`,
     `    ("persisted_sequential_loop_chain", "e2e_flow_runtime_persisted_sequential_loop_chain_smoke"),`,

--- a/sdks/typescript/tests/e2e_smoke.test.mjs
+++ b/sdks/typescript/tests/e2e_smoke.test.mjs
@@ -896,56 +896,58 @@ Your final reply must include STACKED-IMAGE-77-DONE.`,
       "Scenario 78: cross-provider image relay with later visual readback",
       { skip: !(hasOpenAIKey() && hasGeminiKey()) },
       async () => {
-      const scenario = "Scenario 78";
-      const client = await withStepTimeout(
-        scenario,
-        "connect client",
-        connectClient({ realmId: "env_default" }),
-      );
+        const scenario = "Scenario 78";
+        await withScenarioRetry(scenario, async () => {
+          const client = await withStepTimeout(
+            scenario,
+            "connect client",
+            connectClient({ realmId: "env_default" }),
+          );
 
-      const generated = await withStepTimeout(
-        scenario,
-        "OpenAI session routes image generation to Gemini",
-        client.createSession(
-          `Use generate_image exactly once with request.provider="gemini", request.model="${geminiImageModel()}",
+          const generated = await withStepTimeout(
+            scenario,
+            "OpenAI session routes image generation to Gemini",
+            client.createSession(
+              `Use generate_image exactly once with request.provider="gemini", request.model="${geminiImageModel()}",
 request.intent="generate", request.prompt="A clean product sketch of a tiny glass terrarium containing a lighthouse, with RELAY-78 printed on the base",
 request.size="1536x1024", request.quality="auto", request.format="png", request.count=1,
 and request.provider_params={"aspect_ratio":"16:9","image_size":"1K"}.
 After the image is generated, reply with CROSS-RELAY-78-GENERATED and no extra prose.`,
-          {
-            model: openaiStressModel(),
-            provider: "openai",
-            enableBuiltins: true,
-          },
-        ),
-        300000,
-      );
-      assert.match(generated.text.toLowerCase(), /cross-relay-78-generated/);
+              {
+                model: openaiStressModel(),
+                provider: "openai",
+                enableBuiltins: true,
+              },
+            ),
+            300000,
+          );
+          assert.match(generated.text.toLowerCase(), /cross-relay-78-generated/);
 
-      const history = await withStepTimeout(
-        scenario,
-        "read relay image history",
-        client.readSessionHistory(generated.id),
-      );
-      const images = assistantImageBlocks(history);
-      assert.ok(images.length >= 1, "cross-provider relay should commit an image");
-      await withStepTimeout(scenario, "fetch relay image", assertFetchableImageBlob(client, images.at(-1)));
+          const history = await withStepTimeout(
+            scenario,
+            "read relay image history",
+            client.readSessionHistory(generated.id),
+          );
+          const images = assistantImageBlocks(history);
+          assert.ok(images.length >= 1, "cross-provider relay should commit an image");
+          await withStepTimeout(scenario, "fetch relay image", assertFetchableImageBlob(client, images.at(-1)));
 
-      const readback = await withStepTimeout(
-        scenario,
-        "Gemini model reads prior generated image",
-        generated.turn(
-          "Switch to Gemini. Inspect the previous assistant image and reply with CROSS-RELAY-78-READBACK plus the main object you see.",
-          {
-            model: geminiModel(),
-            provider: "gemini",
-            enableBuiltins: true,
-          },
-        ),
-        240000,
-      );
-      assert.match(readback.text.toLowerCase(), /cross-relay-78-readback/);
-      assert.match(readback.text.toLowerCase(), /terrarium|lighthouse|glass/);
+          const readback = await withStepTimeout(
+            scenario,
+            "Gemini model reads prior generated image",
+            generated.turn(
+              "Switch to Gemini. Inspect the previous assistant image and reply with CROSS-RELAY-78-READBACK plus the main object you see.",
+              {
+                model: geminiModel(),
+                provider: "gemini",
+                enableBuiltins: true,
+              },
+            ),
+            240000,
+          );
+          assert.match(readback.text.toLowerCase(), /cross-relay-78-readback/);
+          assert.match(readback.text.toLowerCase(), /terrarium|lighthouse|glass/);
+        });
       },
     );
   }


### PR DESCRIPTION
Final hosted Turbo S hardening after the full-suite run:\n\n- Retry Scenario 78 whole-scenario visual readback once, matching Scenario 77 hardening.\n- Remove the overlarge flow runtime maximal_matrix shard from Turbo S to keep the suite inside the time budget while retaining the adaptive marquee and other flow coverage.\n- Include regenerated mob BUILD runfiles entries.\n\nValidation:\n- node --check sdks/typescript/tests/e2e_smoke.test.mjs\n- node --check scripts/generate-bazel-rust-builds.mjs\n- ./scripts/repo-cargo test -p xtask --test buildbuddy_static_lanes e2e_smoke_lane_launchers_allow_parallel_test_processes\n- Hosted BuildBuddy Scenario 78 rerun passed: https://app.buildbuddy.io/invocation/03bfccfd-6ab8-49d3-b96f-814186d5cf63