### PR TITLE
Fix dogma violations in mob surfaces

### DIFF
--- a/meerkat-comms/src/runtime/comms_runtime.rs
+++ b/meerkat-comms/src/runtime/comms_runtime.rs
@@ -28,7 +28,7 @@ use meerkat_core::config::PlainEventSource;
 use meerkat_core::handles::{SessionClaim, SessionClaimError, SessionClaimHandle};
 use meerkat_core::hydrate_content_blocks;
 use meerkat_core::time_compat::Instant;
-use meerkat_core::{BlobStore, MissingBlobBehavior};
+use meerkat_core::{BlobStore, MissingBlobBehavior, SessionId};
 use parking_lot::Mutex;
 use sha2::{Digest, Sha256};
 use std::collections::{HashMap, HashSet};
@@ -1400,7 +1400,7 @@ pub enum CommsRuntimeError {
     #[error("Identity error: {0}")]
     IdentityError(String),
     #[error("Session identity already active: {0}")]
-    SessionIdentityInUse(String),
+    SessionIdentityInUse(SessionId),
     #[error("Trust load error: {0}")]
     TrustLoadError(String),
     #[error("Listener error: {0}")]
@@ -1471,9 +1471,7 @@ fn observe_inproc_registration(
 impl From<SessionClaimError> for CommsRuntimeError {
     fn from(err: SessionClaimError) -> Self {
         match err {
-            SessionClaimError::SessionIdentityInUse(sid) => {
-                Self::SessionIdentityInUse(sid.to_string())
-            }
+            SessionClaimError::SessionIdentityInUse(sid) => Self::SessionIdentityInUse(sid),
         }
     }
 }

--- a/meerkat-core/src/error.rs
+++ b/meerkat-core/src/error.rs
@@ -345,6 +345,10 @@ pub enum AgentError {
     #[error("Build error: {0}")]
     BuildError(String),
 
+    /// Agent construction attempted to claim a session identity that is already live.
+    #[error("Session identity already active: {0}")]
+    SessionIdentityInUse(SessionId),
+
     /// MeerkatMachine DSL observed an auth lease in `reauth_required`
     /// state at a CallingLlm boundary; the lease cannot proceed
     /// until the user re-authenticates (`rkat auth login`). This is a

--- a/meerkat-core/src/event.rs
+++ b/meerkat-core/src/event.rs
@@ -444,7 +444,7 @@ impl From<&AgentError> for AgentErrorClass {
             AgentError::InvalidToolAccess { .. } => Self::Tool,
             AgentError::SkillResolutionFailed { .. } => Self::Skill,
             AgentError::InternalError(_) => Self::Internal,
-            AgentError::BuildError(_) => Self::Build,
+            AgentError::BuildError(_) | AgentError::SessionIdentityInUse(_) => Self::Build,
             AgentError::AuthReauthRequired { .. } => Self::Auth,
             AgentError::CallbackPending { .. } => Self::CallbackPending,
             AgentError::StructuredOutputValidationFailed { .. } => Self::StructuredOutput,

--- a/meerkat-core/src/turn_execution_authority.rs
+++ b/meerkat-core/src/turn_execution_authority.rs
@@ -213,7 +213,7 @@ impl TurnFailureSourceKind {
             AgentError::InvalidToolAccess { .. } => Self::InvalidToolAccess,
             AgentError::SkillResolutionFailed { .. } => Self::SkillResolutionFailed,
             AgentError::InternalError(_) => Self::InternalError,
-            AgentError::BuildError(_) => Self::BuildError,
+            AgentError::BuildError(_) | AgentError::SessionIdentityInUse(_) => Self::BuildError,
             AgentError::AuthReauthRequired { .. } => Self::AuthReauthRequired,
             AgentError::CallbackPending { .. } => Self::CallbackPending,
             AgentError::StructuredOutputValidationFailed { .. } => {

--- a/meerkat-mob/src/runtime/actor.rs
+++ b/meerkat-mob/src/runtime/actor.rs
@@ -20454,15 +20454,12 @@ fn revival_error_means_session_already_live(
     error: &MobError,
     bridge_session_id: &SessionId,
 ) -> bool {
-    let expected = format!("Session identity already active: {bridge_session_id}");
-    match error {
+    matches!(
+        error,
         MobError::SessionError(meerkat_core::service::SessionError::Agent(
-            meerkat_core::error::AgentError::InternalError(message)
-            | meerkat_core::error::AgentError::BuildError(message),
-        ))
-        | MobError::Internal(message) => message.contains(&expected),
-        _ => false,
-    }
+            meerkat_core::error::AgentError::SessionIdentityInUse(session_id),
+        )) if session_id == bridge_session_id
+    )
 }
 
 #[cfg(test)]

--- a/meerkat-mob/src/runtime/provisioner.rs
+++ b/meerkat-mob/src/runtime/provisioner.rs
@@ -1249,14 +1249,11 @@ fn session_error_means_session_identity_already_active(
     error: &SessionError,
     bridge_session_id: &SessionId,
 ) -> bool {
-    let expected = format!("Session identity already active: {bridge_session_id}");
     matches!(
         error,
         SessionError::Agent(
-            meerkat_core::error::AgentError::InternalError(message)
-                | meerkat_core::error::AgentError::BuildError(message)
-        )
-            if message.contains(&expected)
+            meerkat_core::error::AgentError::SessionIdentityInUse(session_id)
+        ) if session_id == bridge_session_id
     )
 }
 

--- a/meerkat-mob/src/runtime/tests.rs
+++ b/meerkat-mob/src/runtime/tests.rs
@@ -1535,10 +1535,9 @@ impl MockSessionService {
     }
 
     /// Inject the production-faithful revival failure: create_session fails with
-    /// the wrapped "Session identity already active" error and does NOT register
-    /// a live session, so `has_live_session` returns false at the actor's
-    /// recovery re-check (the leaked-claim-without-live-session terminal path the
-    /// user hit).
+    /// the typed `SessionIdentityInUse` cause and does NOT register a live
+    /// session, so `has_live_session` returns false at the actor's recovery
+    /// re-check (the leaked-claim-without-live-session terminal path the user hit).
     async fn set_create_session_identity_already_active_without_live_session(
         &self,
         session_id: &SessionId,
@@ -1843,9 +1842,10 @@ impl SessionService for MockSessionService {
         }
         // Production-faithful "already active" failure: the inproc comms-claim
         // acquire fails INSIDE build_agent, before any live session handle is
-        // registered, so this returns the wrapped BuildError WITHOUT inserting
-        // into self.sessions — leaving has_live_session false at the actor's
-        // recovery re-check (the leaked-claim-without-live-session terminal path).
+        // registered, so this returns the typed build-time cause WITHOUT
+        // inserting into self.sessions — leaving has_live_session false at the
+        // actor's recovery re-check (the leaked-claim-without-live-session
+        // terminal path).
         if self
             .create_identity_already_active_no_live_sessions
             .read()
@@ -1855,10 +1855,7 @@ impl SessionService for MockSessionService {
             self.create_session_in_flight
                 .fetch_sub(1, Ordering::Relaxed);
             return Err(SessionError::Agent(
-                meerkat_core::error::AgentError::BuildError(format!(
-                    "Comms runtime failed: Failed to create inproc comms runtime: \
-                     Session identity already active: {session_id}"
-                )),
+                meerkat_core::error::AgentError::SessionIdentityInUse(session_id),
             ));
         }
         let n = self.session_counter.fetch_add(1, Ordering::Relaxed);
@@ -2043,9 +2040,7 @@ impl SessionService for MockSessionService {
             self.create_session_in_flight
                 .fetch_sub(1, Ordering::Relaxed);
             return Err(SessionError::Agent(
-                meerkat_core::error::AgentError::BuildError(format!(
-                    "Session identity already active: {session_id}"
-                )),
+                meerkat_core::error::AgentError::SessionIdentityInUse(session_id),
             ));
         }
 

--- a/meerkat/src/factory.rs
+++ b/meerkat/src/factory.rs
@@ -933,6 +933,11 @@ pub enum BuildAgentError {
     #[cfg(feature = "comms")]
     Comms(String),
 
+    /// Comms construction failed because the canonical session identity claim is live.
+    #[error("Session identity already active: {0}")]
+    #[cfg(feature = "comms")]
+    SessionIdentityInUse(meerkat_core::SessionId),
+
     /// Configuration error.
     #[error("Config error: {0}")]
     Config(String),
@@ -957,6 +962,18 @@ pub enum BuildAgentError {
     #[error("keep_alive requires comms_name to be set")]
     #[cfg(feature = "comms")]
     KeepAliveRequiresCommsName,
+}
+
+#[cfg(feature = "comms")]
+impl From<meerkat_comms::CommsRuntimeError> for BuildAgentError {
+    fn from(error: meerkat_comms::CommsRuntimeError) -> Self {
+        match error {
+            meerkat_comms::CommsRuntimeError::SessionIdentityInUse(session_id) => {
+                Self::SessionIdentityInUse(session_id)
+            }
+            other => Self::Comms(other.to_string()),
+        }
+    }
 }
 
 /// Resolver that delegates to [`ModelRegistry`] to look up model-specific
@@ -4461,7 +4478,7 @@ impl AgentFactory {
                     }
                 };
             let mut runtime =
-                crate::build_session_scoped_comms_runtime_from_config_scoped_with_silent_intents(
+                crate::sdk::build_session_scoped_comms_runtime_from_config_scoped_with_silent_intents_typed(
                     config,
                     _realm_scope_root.as_path(),
                     self.user_config_root.as_deref(),
@@ -4478,7 +4495,7 @@ impl AgentFactory {
                     session_claim_handle,
                 )
                 .await
-                .map_err(BuildAgentError::Comms)?;
+                ?;
             if let Some(blob_store) = build_config.blob_store_override.clone() {
                 runtime.set_blob_store(blob_store);
             }
@@ -4511,7 +4528,7 @@ impl AgentFactory {
                     .map(|realm| realm.as_str().to_string()),
                 silent_intents,
             )
-            .map_err(|e| BuildAgentError::Comms(e.to_string()))?;
+            .map_err(BuildAgentError::from)?;
             runtime.require_peer_comms_machine_authority();
             if let Some(ref meta) = build_config.peer_meta {
                 runtime.set_peer_meta(meta.clone());

--- a/meerkat/src/sdk.rs
+++ b/meerkat/src/sdk.rs
@@ -4,6 +4,8 @@ use std::path::Path;
 use std::sync::Arc;
 use std::{cmp, collections::HashSet};
 
+#[cfg(feature = "comms")]
+use crate::BuildAgentError;
 use crate::{AgentFactory, AgentToolDispatcher, Config, HookEngine, HooksConfig};
 #[cfg(feature = "comms")]
 use crate::{CommsRuntime, CoreCommsConfig};
@@ -546,6 +548,50 @@ pub async fn build_session_scoped_comms_runtime_from_config_scoped_with_silent_i
     silent_intents: std::sync::Arc<std::collections::HashSet<String>>,
     session_claim_handle: std::sync::Arc<dyn meerkat_core::handles::SessionClaimHandle>,
 ) -> Result<CommsRuntime, String> {
+    build_session_scoped_comms_runtime_from_config_scoped_with_silent_intents_typed(
+        config,
+        base_dir,
+        user_config_root,
+        comms_name,
+        peer_meta,
+        inproc_namespace,
+        session_id,
+        silent_intents,
+        session_claim_handle,
+    )
+    .await
+    .map_err(|error| match error {
+        BuildAgentError::Comms(message) => message,
+        other => other.to_string(),
+    })
+}
+
+#[cfg(feature = "comms")]
+fn session_scoped_comms_error(
+    context: &'static str,
+    error: meerkat_comms::CommsRuntimeError,
+) -> BuildAgentError {
+    match error {
+        meerkat_comms::CommsRuntimeError::SessionIdentityInUse(session_id) => {
+            BuildAgentError::SessionIdentityInUse(session_id)
+        }
+        other => BuildAgentError::Comms(format!("{context}: {other}")),
+    }
+}
+
+#[cfg(feature = "comms")]
+#[allow(clippy::implicit_hasher, clippy::too_many_arguments)]
+pub(crate) async fn build_session_scoped_comms_runtime_from_config_scoped_with_silent_intents_typed(
+    config: &Config,
+    base_dir: impl AsRef<Path>,
+    user_config_root: Option<&Path>,
+    comms_name: &str,
+    peer_meta: Option<meerkat_core::PeerMeta>,
+    inproc_namespace: Option<String>,
+    session_id: &meerkat_core::SessionId,
+    silent_intents: std::sync::Arc<std::collections::HashSet<String>>,
+    session_claim_handle: std::sync::Arc<dyn meerkat_core::handles::SessionClaimHandle>,
+) -> Result<CommsRuntime, BuildAgentError> {
     let event_listen_tcp = config
         .comms
         .event_address
@@ -554,28 +600,32 @@ pub async fn build_session_scoped_comms_runtime_from_config_scoped_with_silent_i
             addr.parse()
                 .map_err(|e| format!("Invalid event_address '{addr}': {e}"))
         })
-        .transpose()?;
+        .transpose()
+        .map_err(BuildAgentError::Config)?;
 
     let runtime = match config.comms.mode {
         CommsRuntimeMode::Inproc => CommsRuntime::inproc_only_session_scoped_with_silent_intents(
             comms_name,
             inproc_namespace.clone(),
-            canonical_session_comms_identity_root(user_config_root)?,
+            canonical_session_comms_identity_root(user_config_root)
+                .map_err(BuildAgentError::Config)?,
             session_id,
             silent_intents.clone(),
             session_claim_handle,
         )
         .await
-        .map_err(|e| format!("Failed to create inproc comms runtime: {e}"))?,
+        .map_err(|error| {
+            session_scoped_comms_error("Failed to create inproc comms runtime", error)
+        })?,
         CommsRuntimeMode::Tcp => {
-            let address = config
-                .comms
-                .address
-                .as_ref()
-                .ok_or_else(|| "comms.address is required when comms.mode = tcp".to_string())?;
-            let listen_tcp = address
-                .parse()
-                .map_err(|e| format!("Invalid comms TCP address '{address}': {e}"))?;
+            let address = config.comms.address.as_ref().ok_or_else(|| {
+                BuildAgentError::Config(
+                    "comms.address is required when comms.mode = tcp".to_string(),
+                )
+            })?;
+            let listen_tcp = address.parse().map_err(|e| {
+                BuildAgentError::Config(format!("Invalid comms TCP address '{address}': {e}"))
+            })?;
             let comms = CoreCommsConfig {
                 enabled: true,
                 name: comms_name.to_string(),
@@ -593,18 +643,18 @@ pub async fn build_session_scoped_comms_runtime_from_config_scoped_with_silent_i
                 silent_intents.clone(),
             )
             .await
-            .map_err(|e| format!("Failed to create comms runtime: {e}"))?;
-            rt.start_listeners()
-                .await
-                .map_err(|e| format!("Failed to start comms listeners: {e}"))?;
+            .map_err(|error| session_scoped_comms_error("Failed to create comms runtime", error))?;
+            rt.start_listeners().await.map_err(|error| {
+                session_scoped_comms_error("Failed to start comms listeners", error)
+            })?;
             rt
         }
         CommsRuntimeMode::Uds => {
-            let address = config
-                .comms
-                .address
-                .as_ref()
-                .ok_or_else(|| "comms.address is required when comms.mode = uds".to_string())?;
+            let address = config.comms.address.as_ref().ok_or_else(|| {
+                BuildAgentError::Config(
+                    "comms.address is required when comms.mode = uds".to_string(),
+                )
+            })?;
             let comms = CoreCommsConfig {
                 enabled: true,
                 name: comms_name.to_string(),
@@ -621,10 +671,10 @@ pub async fn build_session_scoped_comms_runtime_from_config_scoped_with_silent_i
                 silent_intents.clone(),
             )
             .await
-            .map_err(|e| format!("Failed to create comms runtime: {e}"))?;
-            rt.start_listeners()
-                .await
-                .map_err(|e| format!("Failed to start comms listeners: {e}"))?;
+            .map_err(|error| session_scoped_comms_error("Failed to create comms runtime", error))?;
+            rt.start_listeners().await.map_err(|error| {
+                session_scoped_comms_error("Failed to start comms listeners", error)
+            })?;
             rt
         }
     };

--- a/meerkat/src/service_factory.rs
+++ b/meerkat/src/service_factory.rs
@@ -27,7 +27,7 @@ use tokio_with_wasm::alias::sync::mpsc;
 
 #[cfg(feature = "session-store")]
 use crate::PersistenceBundle;
-use crate::{AgentBuildConfig, AgentFactory, DynAgent};
+use crate::{AgentBuildConfig, AgentFactory, BuildAgentError, DynAgent};
 use meerkat_client::LlmClient;
 
 /// Wrapper around [`DynAgent`] implementing [`SessionAgent`].
@@ -38,6 +38,16 @@ pub struct FactoryAgent {
     /// to fire `AdvanceSessionContext` on every canonical session-truth
     /// mutation (W2-E / issue #264). `None` on `StandaloneEphemeral` builds.
     session_context: Option<Arc<dyn meerkat_core::handles::SessionContextHandle>>,
+}
+
+fn build_agent_error_to_agent_error(error: BuildAgentError) -> meerkat_core::error::AgentError {
+    match error {
+        #[cfg(feature = "comms")]
+        BuildAgentError::SessionIdentityInUse(session_id) => {
+            meerkat_core::error::AgentError::SessionIdentityInUse(session_id)
+        }
+        other => meerkat_core::error::AgentError::BuildError(other.to_string()),
+    }
 }
 
 impl FactoryAgent {
@@ -890,9 +900,7 @@ impl SessionAgentBuilder for FactoryAgentBuilder {
             .factory
             .build_agent(build_config, &config)
             .await
-            .map_err(|e| {
-                SessionError::Agent(meerkat_core::error::AgentError::BuildError(e.to_string()))
-            })?;
+            .map_err(|e| SessionError::Agent(build_agent_error_to_agent_error(e)))?;
 
         Ok(FactoryAgent {
             agent,

--- a/meerkat/src/surface/runtime_backed.rs
+++ b/meerkat/src/surface/runtime_backed.rs
@@ -21,7 +21,7 @@ use tokio::sync::mpsc;
 
 #[cfg(all(test, feature = "jsonl-store", not(target_arch = "wasm32")))]
 use crate::JsonlStore;
-#[cfg(test)]
+#[cfg(all(test, feature = "jsonl-store", not(target_arch = "wasm32")))]
 use crate::MachineSessionArchiveProtocol;
 use crate::{
     CreateSessionRequest, FactoryAgentBuilder, MachineServiceTurnCommitProtocol,

--- a/sdks/python/meerkat/client.py
+++ b/sdks/python/meerkat/client.py
@@ -1857,20 +1857,23 @@ class MeerkatClient:
                     "INVALID_RESPONSE",
                     "Invalid mob/members response: entry missing member_ref",
                 )
+            agent_identity = entry.get("agent_identity")
+            if not isinstance(agent_identity, str) or not agent_identity:
+                raise MeerkatError(
+                    "INVALID_RESPONSE",
+                    "Invalid mob/members response: entry missing agent_identity",
+                )
+            role = entry.get("role")
+            if not isinstance(role, str) or not role:
+                raise MeerkatError(
+                    "INVALID_RESPONSE",
+                    "Invalid mob/members response: entry missing role",
+                )
             normalized.append(
                 {
-                    "agent_identity": (
-                        str(entry.get("agent_identity", ""))
-                        if entry.get("agent_identity") is not None
-                        else ""
-                    ),
+                    "agent_identity": agent_identity,
                     "member_ref": member_ref,
-                    "profile": str(
-                        entry.get("profile_name")
-                        or entry.get("profile")
-                        or entry.get("role")
-                        or ""
-                    ),
+                    "profile": role,
                     **(
                         {"peer_id": str(entry["peer_id"])}
                         if entry.get("peer_id") is not None
@@ -2496,15 +2499,16 @@ class MeerkatClient:
                 "INVALID_RESPONSE",
                 "Invalid mob/spawn_helper response: missing member_ref",
             )
+        resolved_identity = result.get("agent_identity")
+        if not isinstance(resolved_identity, str) or not resolved_identity:
+            raise MeerkatError(
+                "INVALID_RESPONSE",
+                "Invalid mob/spawn_helper response: missing agent_identity",
+            )
         return {
             "output": str(result["output"]) if result.get("output") is not None else None,
             "tokens_used": int(result.get("tokens_used", 0)),
-            "agent_identity": (
-                result["agent_identity"]
-                if isinstance(result.get("agent_identity"), str)
-                and result["agent_identity"]
-                else (agent_identity or "")
-            ),
+            "agent_identity": resolved_identity,
             "member_ref": member_ref,
         }
 
@@ -2538,15 +2542,16 @@ class MeerkatClient:
                 "INVALID_RESPONSE",
                 "Invalid mob/fork_helper response: missing member_ref",
             )
+        resolved_identity = result.get("agent_identity")
+        if not isinstance(resolved_identity, str) or not resolved_identity:
+            raise MeerkatError(
+                "INVALID_RESPONSE",
+                "Invalid mob/fork_helper response: missing agent_identity",
+            )
         return {
             "output": str(result["output"]) if result.get("output") is not None else None,
             "tokens_used": int(result.get("tokens_used", 0)),
-            "agent_identity": (
-                result["agent_identity"]
-                if isinstance(result.get("agent_identity"), str)
-                and result["agent_identity"]
-                else (agent_identity or "")
-            ),
+            "agent_identity": resolved_identity,
             "member_ref": member_ref,
         }
 

--- a/sdks/python/tests/test_types.py
+++ b/sdks/python/tests/test_types.py
@@ -3137,7 +3137,7 @@ async def test_client_mob_lifecycle_and_send_methods_use_explicit_rpc_methods():
                     {
                         "agent_identity": "agent-a",
                         "member_ref": _make_member_ref("mob-1", "agent-a"),
-                        "profile": "planner",
+                        "role": "planner",
                     }
                 ]
             }
@@ -4384,6 +4384,84 @@ async def test_list_mob_members_rejects_non_list_members() -> None:
 
     with pytest.raises(MeerkatError) as excinfo:
         await client.list_mob_members("mob-1")
+    assert excinfo.value.code == "INVALID_RESPONSE"
+
+
+@pytest.mark.asyncio
+async def test_list_mob_members_requires_canonical_identity_and_role() -> None:
+    client = MeerkatClient()
+
+    async def missing_identity(_method, _params):
+        return {
+            "members": [
+                {
+                    "member_ref": _make_member_ref("mob-1", "worker-1"),
+                    "role": "worker",
+                }
+            ]
+        }
+
+    client._request = missing_identity  # type: ignore[method-assign]
+    with pytest.raises(MeerkatError, match="missing agent_identity") as excinfo:
+        await client.list_mob_members("mob-1")
+    assert excinfo.value.code == "INVALID_RESPONSE"
+
+    async def legacy_profile_alias(_method, _params):
+        return {
+            "members": [
+                {
+                    "agent_identity": "worker-1",
+                    "member_ref": _make_member_ref("mob-1", "worker-1"),
+                    "profile_name": "worker",
+                }
+            ]
+        }
+
+    client._request = legacy_profile_alias  # type: ignore[method-assign]
+    with pytest.raises(MeerkatError, match="missing role") as excinfo:
+        await client.list_mob_members("mob-1")
+    assert excinfo.value.code == "INVALID_RESPONSE"
+
+
+@pytest.mark.asyncio
+async def test_mob_helper_results_require_canonical_agent_identity() -> None:
+    client = MeerkatClient()
+
+    async def missing_spawn_identity(method, _params):
+        if method == "mob/spawn_helper":
+            return {
+                "tokens_used": 1,
+                "member_ref": _make_member_ref("mob-1", "helper-a"),
+            }
+        raise AssertionError(f"unexpected method {method}")
+
+    client._request = missing_spawn_identity  # type: ignore[method-assign]
+    with pytest.raises(MeerkatError, match="missing agent_identity") as excinfo:
+        await client.spawn_mob_helper(
+            "mob-1",
+            "help",
+            agent_identity="helper-a",
+            role_name="worker",
+        )
+    assert excinfo.value.code == "INVALID_RESPONSE"
+
+    async def missing_fork_identity(method, _params):
+        if method == "mob/fork_helper":
+            return {
+                "tokens_used": 1,
+                "member_ref": _make_member_ref("mob-1", "fork-a"),
+            }
+        raise AssertionError(f"unexpected method {method}")
+
+    client._request = missing_fork_identity  # type: ignore[method-assign]
+    with pytest.raises(MeerkatError, match="missing agent_identity") as excinfo:
+        await client.fork_mob_helper(
+            "mob-1",
+            "agent-a",
+            "help",
+            agent_identity="fork-a",
+            role_name="worker",
+        )
     assert excinfo.value.code == "INVALID_RESPONSE"
 
 

--- a/sdks/web/src/mob.ts
+++ b/sdks/web/src/mob.ts
@@ -1000,16 +1000,11 @@ export class Mob {
       if (!memberRef) {
         throw new Error('Invalid mob list_members entry: missing member_ref');
       }
-      const profile =
-        typeof member.role === 'string' && member.role.length > 0
-          ? member.role
-          : typeof member.profile === 'string' && member.profile.length > 0
-            ? member.profile
-            : typeof member.profile_name === 'string' && member.profile_name.length > 0
-              ? member.profile_name
-              : undefined;
+      const profile = typeof member.role === 'string' && member.role.length > 0
+        ? member.role
+        : undefined;
       if (!profile) {
-        throw new Error('Invalid mob list_members entry: missing profile');
+        throw new Error('Invalid mob list_members entry: missing role');
       }
       return {
         agent_identity: agentIdentity,

--- a/sdks/web/tests/e2e_wasm_runtime.test.mjs
+++ b/sdks/web/tests/e2e_wasm_runtime.test.mjs
@@ -540,7 +540,7 @@ test("MeerkatRuntime forwards canonical mob status/helper methods through the wa
         {
           agent_identity: "worker-1",
           member_ref: "ref-worker-1",
-          profile: "worker",
+          role: "worker",
         },
       ]);
     },
@@ -746,7 +746,7 @@ test("MeerkatRuntime forwards canonical mob status/helper methods through the wa
           {
             prompt: "Summarize the thread.",
             agent_identity: "helper-1",
-            profile_name: "worker",
+            role_name: "worker",
           },
         ],
         [
@@ -756,7 +756,7 @@ test("MeerkatRuntime forwards canonical mob status/helper methods through the wa
             source_member_id: "worker-1",
             prompt: "Review the draft.",
             agent_identity: "fork-1",
-            profile_name: "worker",
+            role_name: "worker",
             fork_context: { mode: "full_history" },
           },
         ],

--- a/sdks/web/tests/mob_payload.unit.mjs
+++ b/sdks/web/tests/mob_payload.unit.mjs
@@ -1,4 +1,5 @@
 import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
 import test from 'node:test';
 
 import { Mob } from '../dist/mob.js';
@@ -6,10 +7,15 @@ import { MeerkatRuntime } from '../dist/runtime.js';
 import { Session, serializePromptContentInput } from '../dist/session.js';
 import { isKnownEvent } from '../dist/types.js';
 
+const WEB_PACKAGE_JSON_URL = new URL('../package.json', import.meta.url);
+const { version: CURRENT_WASM_VERSION } = JSON.parse(
+  await readFile(WEB_PACKAGE_JSON_URL, 'utf8'),
+);
+
 function makeSubscriptionRuntime(overrides = {}) {
   return {
     default: async () => undefined,
-    runtime_version: () => '0.7.0-alpha.0',
+    runtime_version: () => CURRENT_WASM_VERSION,
     init_runtime_from_config: () => JSON.stringify({ status: 'initialized', model: 'claude-sonnet-4-5', providers: ['anthropic'] }),
     destroy_runtime: () => undefined,
     async mob_create(definitionJson) {
@@ -88,7 +94,7 @@ async function runtimeWithMobList(payload) {
     {
       async default() {},
       runtime_version() {
-        return '0.7.0-alpha.0';
+        return CURRENT_WASM_VERSION;
       },
       init_runtime_from_config() {
         return JSON.stringify({ status: 'initialized', model: 'claude-sonnet-4-5', providers: ['anthropic'] });
@@ -1232,6 +1238,37 @@ test('Session.destroy re-throws non-already-gone typed errors', () => {
     async () => '{}',
   );
   assert.throws(() => session.destroy(), /SESSION_BUSY/);
+});
+
+test('Mob.listMembers rejects legacy profile aliases without canonical role', async () => {
+  const mob = new Mob('mob-web-unit', {
+    async mob_list_members() {
+      return JSON.stringify([
+        {
+          agent_identity: 'worker-1',
+          member_ref: 'ref-worker-1',
+          profile_name: 'worker',
+        },
+      ]);
+    },
+  });
+
+  await assert.rejects(() => mob.listMembers(), /missing role/);
+});
+
+test('Mob.listMembers rejects missing canonical agent_identity', async () => {
+  const mob = new Mob('mob-web-unit', {
+    async mob_list_members() {
+      return JSON.stringify([
+        {
+          member_ref: 'ref-worker-1',
+          role: 'worker',
+        },
+      ]);
+    },
+  });
+
+  await assert.rejects(() => mob.listMembers(), /missing agent_identity/);
 });
 
 // Regression: the WASM helper deserializers (MobSpawnHelperOptions /


### PR DESCRIPTION
## Summary
- make Python/Web mob roster parsing fail closed on canonical `agent_identity`, `member_ref`, and `role`
- preserve typed `SessionIdentityInUse(SessionId)` from comms construction through agent/session errors
- replace mob revival/provisioner error-message classifiers with typed variant matches

## Validation
- `make fmt-check`
- `make check`
- `./scripts/repo-cargo clippy -p meerkat --all-targets --features comms,session-store -- -D warnings`
- `PYTHONPATH=sdks/python python3 -m pytest sdks/python/tests/test_types.py sdks/python/tests/test_audit_parity.py`
- `npm test` in `sdks/web`
- `./scripts/repo-cargo test -p meerkat-mob test_revival_already_active_without_live_session_is_typed_terminal`
- `make buildbuddy-e2e-smoke-turbo-s` (BuildBuddy invocation `a4495846-75c8-4035-99a3-a3da691fc0eb`, 56/56 passed)
- two adversarial subagent reviews approved the diff after fixes
