### PR TITLE
[codex] fix dogma remediation gaps

### DIFF
--- a/.github/workflows/buildbuddy.yml
+++ b/.github/workflows/buildbuddy.yml
@@ -82,6 +82,7 @@ env:
   MEERKAT_GCP_BUILDBUDDY_CACHE_DISK_TYPE: ${{ vars.MEERKAT_GCP_BUILDBUDDY_CACHE_DISK_TYPE || 'pd-ssd' }}
   MEERKAT_GCP_BUILDBUDDY_DOWN_MODE: ${{ vars.MEERKAT_GCP_BUILDBUDDY_DOWN_MODE || 'stopped' }}
   MEERKAT_GCP_BUILDBUDDY_CI_MAX_SECONDS: ${{ vars.MEERKAT_GCP_BUILDBUDDY_CI_MAX_SECONDS || '1500' }}
+  MEERKAT_GCP_BUILDBUDDY_SDK_CI_MAX_SECONDS: ${{ vars.MEERKAT_GCP_BUILDBUDDY_SDK_CI_MAX_SECONDS || '2400' }}
   MEERKAT_BUILDBUDDY_EXECUTOR_POOL: ${{ vars.MEERKAT_BUILDBUDDY_EXECUTOR_POOL || 'meerkat-ci' }}
   MEERKAT_BUILDBUDDY_CI_IMAGE: ${{ vars.MEERKAT_BUILDBUDDY_CI_IMAGE || 'europe-west1-docker.pkg.dev/king-dnn-training-dev/meerkat-ci/meerkat-ci-rust:1.94.0' }}
   MEERKAT_HOST_CARGO_HOME: /usr/local/cargo
@@ -416,12 +417,13 @@ jobs:
     needs: [control-plane-up, executors-up, wasm-feature-changes]
     if: ${{ needs.wasm-feature-changes.outputs.sdk_changed == 'true' }}
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 45
     env:
       BUILDBUDDY_GRPC_URL: ${{ needs.control-plane-up.outputs.grpc_url }}
       BUILDBUDDY_HTTP_URL: ${{ needs.control-plane-up.outputs.http_url }}
       BUILDBUDDY_ENDPOINT: ${{ needs.control-plane-up.outputs.grpc_url }}
       CI_STARTED_AT_EPOCH: ${{ needs.control-plane-up.outputs.started_at_epoch }}
+      MEERKAT_GCP_BUILDBUDDY_CI_MAX_SECONDS: ${{ vars.MEERKAT_GCP_BUILDBUDDY_SDK_CI_MAX_SECONDS || '2400' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -625,7 +627,7 @@ jobs:
         shell: bash
         env:
           CI_STARTED_AT_EPOCH: ${{ needs.control-plane-up.outputs.started_at_epoch }}
-          MAX_SECONDS: ${{ vars.MEERKAT_GCP_BUILDBUDDY_CI_MAX_SECONDS || '1500' }}
+          MAX_SECONDS: ${{ needs.wasm-feature-changes.outputs.sdk_changed == 'true' && (vars.MEERKAT_GCP_BUILDBUDDY_SDK_CI_MAX_SECONDS || '2400') || (vars.MEERKAT_GCP_BUILDBUDDY_CI_MAX_SECONDS || '1500') }}
         run: |
           if ! [[ "${CI_STARTED_AT_EPOCH}" =~ ^[0-9]+$ ]]; then
             echo "::error::Missing or invalid GCP BuildBuddy CI start timestamp: '${CI_STARTED_AT_EPOCH}'"

--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -37,6 +37,27 @@ jobs:
       - name: Setup Rust
         uses: ./.github/actions/setup-rust-ci
 
+      - name: Add wasm32 target
+        run: rustup target add wasm32-unknown-unknown
+
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: "22"
+
+      - name: Install wasm-pack
+        shell: bash
+        run: |
+          set -euo pipefail
+          version="0.13.1"
+          archive="wasm-pack-v${version}-x86_64-unknown-linux-musl.tar.gz"
+          curl --fail --location --retry 5 --retry-delay 2 \
+            "https://github.com/wasm-bindgen/wasm-pack/releases/download/v${version}/${archive}" \
+            --output "/tmp/${archive}"
+          tar -xzf "/tmp/${archive}" -C /tmp
+          install -m 0755 "/tmp/wasm-pack-v${version}-x86_64-unknown-linux-musl/wasm-pack" "$HOME/.cargo/bin/wasm-pack"
+          wasm-pack --version
+
       - name: Cache cargo registry
         uses: Swatinem/rust-cache@v2
 
@@ -76,3 +97,9 @@ jobs:
 
       - name: Verify generated machine kernels are not stale
         run: make machine-check-drift
+
+      - name: Web SDK build and tests
+        run: make test-sdk-web
+
+      - name: WASM runtime check
+        run: make wasm-check

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ YELLOW := \033[0;33m
 RED := \033[0;31m
 NC := \033[0m
 
-.PHONY: all install-build-deps build test test-unit test-int e2e-fast e2e-build e2e-system e2e-live e2e-smoke e2e-auth test-int-real test-e2e test-all test-minimal test-feature-matrix-lib test-feature-matrix-surface test-feature-matrix test-surface-modularity test-sdk-python test-sdk-typescript test-sdk-suites lint lint-feature-matrix fmt fmt-check audit rust-lane-doctor agent-gate cargo-agent-gate buildbuddy-install buildbuddy-generate buildbuddy-lock-update buildbuddy-generate-check buildbuddy-doctor buildbuddy-build buildbuddy-check buildbuddy-clippy buildbuddy-lint buildbuddy-test buildbuddy-test-all buildbuddy-test-unit buildbuddy-test-int buildbuddy-e2e-fast buildbuddy-e2e-system buildbuddy-e2e-live buildbuddy-e2e-smoke buildbuddy-e2e-smoke-turbo-s buildbuddy-e2e-auth buildbuddy-agent-gate buildbuddy-ci-dispatch buildbuddy-fast buildbuddy-benchmark buildbuddy-ci buildbuddy-ci-warm buildbuddy-ci-full buildbuddy-ci-full-warm ci ci-smoke release-doctor release-preflight release-preflight-smoke release-workflow release-assets release-packages release-web-sdk publish-dry-run publish-dry-run-python publish-dry-run-typescript publish-dry-run-web release-dry-run release-dry-run-smoke clean doc docs-check release install-hooks coverage check help legacy-surface-gate legacy-surface-inventory session-control-gate deprecated-backend-gate deprecated-backend-inventory sync-meerkat-dogma-skill-docs verify-version-parity verify-schema-freshness verify-sdk-codegen-freshness verify-sdk-event-inventory verify-rpc-surface-alignment verify-rest-surface-alignment verify-sdk-wrapper-freshness verify-machine-poster-coverage check-rust-release-config check-rust-release-packaging check-published-facade-link bump-sdk-versions smoke-sdk-python-artifact smoke-sdk-typescript-artifact xtask-build machine-codegen machine-verify machine-check-drift machine-authority-docs-gate runtime-authority-bypass seam-inventory rmat-audit audit-generated-headers
+.PHONY: all install-build-deps build test test-unit test-int e2e-fast e2e-build e2e-system e2e-live e2e-smoke e2e-auth test-int-real test-e2e test-all test-minimal test-feature-matrix-lib test-feature-matrix-surface test-feature-matrix test-surface-modularity test-sdk-python test-sdk-typescript test-sdk-web test-sdk-suites wasm-check lint lint-feature-matrix fmt fmt-check audit rust-lane-doctor agent-gate cargo-agent-gate buildbuddy-install buildbuddy-generate buildbuddy-lock-update buildbuddy-generate-check buildbuddy-doctor buildbuddy-build buildbuddy-check buildbuddy-clippy buildbuddy-lint buildbuddy-test buildbuddy-test-all buildbuddy-test-unit buildbuddy-test-int buildbuddy-e2e-fast buildbuddy-e2e-system buildbuddy-e2e-live buildbuddy-e2e-smoke buildbuddy-e2e-smoke-turbo-s buildbuddy-e2e-auth buildbuddy-agent-gate buildbuddy-ci-dispatch buildbuddy-fast buildbuddy-benchmark buildbuddy-ci buildbuddy-ci-warm buildbuddy-ci-full buildbuddy-ci-full-warm ci ci-smoke release-doctor release-preflight release-preflight-smoke release-workflow release-assets release-packages release-web-sdk publish-dry-run publish-dry-run-python publish-dry-run-typescript publish-dry-run-web release-dry-run release-dry-run-smoke clean doc docs-check release install-hooks coverage check help legacy-surface-gate legacy-surface-inventory session-control-gate deprecated-backend-gate deprecated-backend-inventory sync-meerkat-dogma-skill-docs verify-version-parity verify-schema-freshness verify-sdk-codegen-freshness verify-sdk-event-inventory verify-rpc-surface-alignment verify-rest-surface-alignment verify-sdk-wrapper-freshness verify-machine-poster-coverage check-rust-release-config check-rust-release-packaging check-published-facade-link bump-sdk-versions smoke-sdk-python-artifact smoke-sdk-typescript-artifact xtask-build machine-codegen machine-verify machine-check-drift machine-authority-docs-gate runtime-authority-bypass seam-inventory rmat-audit audit-generated-headers
 
 # Default target
 all: ci
@@ -119,8 +119,23 @@ test-sdk-typescript:
 		npm run build && \
 		npm test)
 
+# Web SDK test suite
+test-sdk-web:
+	@echo "$(GREEN)Running Web SDK tests...$(NC)"
+	@(cd sdks/web && \
+		npm install --ignore-scripts && \
+		npm run build && \
+		npm test)
+
+# WASM runtime compile and lint gate
+wasm-check:
+	@echo "$(GREEN)Running WASM runtime check...$(NC)"
+	@rustup target add wasm32-unknown-unknown
+	RUSTFLAGS='--cfg getrandom_backend="wasm_js"' $(CARGO) check -p meerkat-web-runtime --target wasm32-unknown-unknown
+	RUSTFLAGS='--cfg getrandom_backend="wasm_js"' $(CARGO) clippy -p meerkat-web-runtime --target wasm32-unknown-unknown -- -D warnings
+
 # Combined SDK test suites
-test-sdk-suites: test-sdk-python test-sdk-typescript
+test-sdk-suites: test-sdk-python test-sdk-typescript test-sdk-web
 
 # Minimal builds without optional features
 test-minimal:

--- a/meerkat-mob/src/ids.rs
+++ b/meerkat-mob/src/ids.rs
@@ -186,7 +186,7 @@ string_newtype!(
 
 impl AgentIdentity {
     /// Returns `true` when this identity falls inside the reserved
-    /// flow-system namespace.
+    /// flow-owned member namespace.
     ///
     /// This is the single canonical predicate for "is this a system-owned
     /// identity the public spawn/wire surfaces must reject"; all admission and
@@ -194,7 +194,14 @@ impl AgentIdentity {
     /// from the underlying string prefix.
     pub(crate) fn is_system_reserved(&self) -> bool {
         self.as_str()
-            .starts_with(crate::runtime::FLOW_SYSTEM_MEMBER_ID_PREFIX)
+            .starts_with(crate::runtime::FLOW_MEMBER_ID_PREFIX)
+    }
+
+    /// Returns `true` when this identity falls inside the flow-owned member
+    /// namespace. Only MobMachine-owned flow provisioning may mint these
+    /// identities; public spawn surfaces must reject them.
+    pub(crate) fn is_flow_member_namespace(&self) -> bool {
+        self.is_system_reserved()
     }
 
     /// Constructs the reserved provenance identity used to attribute

--- a/meerkat-mob/src/runtime/actor.rs
+++ b/meerkat-mob/src/runtime/actor.rs
@@ -8836,6 +8836,7 @@ impl MobActor {
             let _ = reply_tx.send(Err(error));
             return;
         }
+        let allow_reserved_flow_identity = spawn_source.allows_reserved_flow_identity();
         let super::handle::SpawnMemberSpec {
             role_name: profile_name,
             identity,
@@ -8874,7 +8875,7 @@ impl MobActor {
             _ => None,
         };
         let prepare_result = async {
-            if agent_identity.is_system_reserved() {
+            if agent_identity.is_system_reserved() && !allow_reserved_flow_identity {
                 return Err(MobError::WiringError(format!(
                     "meerkat id '{agent_identity}' uses reserved system identifier namespace"
                 )));
@@ -10244,7 +10245,7 @@ impl MobActor {
             agent_identity = %agent_identity,
             "MobActor::finalize_spawn_from_pending resolving supervisor comms"
         );
-        let supervisor_private_trust_install = if agent_identity.as_str().starts_with("__flow_") {
+        let supervisor_private_trust_install = if agent_identity.is_flow_member_namespace() {
             tracing::debug!(
                 agent_identity = %agent_identity,
                 "MobActor::finalize_spawn_from_pending skipped supervisor private trust for run-scoped flow member"
@@ -10582,7 +10583,7 @@ impl MobActor {
         // compensating rollback in `rollback_failed_spawn` expects both
         // `wired_spawn_targets` and `planned_wiring_targets` populated so
         // partial-wire failures can unwind.
-        let mut planned_wiring_targets = if agent_identity.as_str().starts_with("__flow_") {
+        let mut planned_wiring_targets = if agent_identity.is_flow_member_namespace() {
             Vec::new()
         } else {
             Box::pin(self.spawn_wiring_targets(profile_name, agent_identity)).await
@@ -10704,7 +10705,7 @@ impl MobActor {
         }
 
         if runtime_mode == crate::MobRuntimeMode::TurnDriven
-            && !agent_identity.as_str().starts_with("__flow_")
+            && !agent_identity.is_flow_member_namespace()
         {
             // Turn-driven mob members still need a persistent comms drain:
             // async peer requests/responses arrive between user turns (think

--- a/meerkat-mob/src/runtime/handle.rs
+++ b/meerkat-mob/src/runtime/handle.rs
@@ -1754,6 +1754,7 @@ pub enum SpawnSource {
     AgentSpawnMember,
     HelperSpawn,
     BatchItem,
+    FlowProvisioning,
     PolicySpawn,
     Respawn,
     Resume,
@@ -1768,6 +1769,7 @@ impl SpawnSource {
             Self::AgentSpawnMember => "agent_spawn_member",
             Self::HelperSpawn => "helper_spawn",
             Self::BatchItem => "batch_item",
+            Self::FlowProvisioning => "flow_provisioning",
             Self::PolicySpawn => "policy_spawn",
             Self::Respawn => "respawn",
             Self::Resume => "resume",
@@ -1782,6 +1784,11 @@ impl SpawnSource {
             crate::launch::MemberLaunchMode::Fork { .. } => Self::Fork,
             crate::launch::MemberLaunchMode::Fresh => base,
         }
+    }
+
+    #[must_use]
+    pub(crate) fn allows_reserved_flow_identity(self) -> bool {
+        matches!(self, Self::FlowProvisioning)
     }
 }
 
@@ -3861,9 +3868,10 @@ impl MobHandle {
             if self.get_member(&identity).await?.is_some() {
                 continue;
             }
-            self.spawn_spec(
+            self.spawn_spec_internal_with_source(
                 SpawnMemberSpec::new(role, identity)
                     .with_runtime_mode(crate::MobRuntimeMode::TurnDriven),
+                SpawnSource::FlowProvisioning,
             )
             .await?;
         }

--- a/meerkat-mob/src/runtime/mod.rs
+++ b/meerkat-mob/src/runtime/mod.rs
@@ -50,6 +50,7 @@ pub(crate) type RuntimeAdapterOption = Option<Arc<meerkat_runtime::MeerkatMachin
 #[cfg(not(feature = "runtime-adapter"))]
 pub(crate) type RuntimeAdapterOption = Option<()>;
 
+pub(crate) const FLOW_MEMBER_ID_PREFIX: &str = "__flow_";
 pub(crate) const FLOW_SYSTEM_MEMBER_ID_PREFIX: &str = "__flow_system_";
 
 pub(crate) fn flow_system_member_id() -> AgentIdentity {

--- a/meerkat-mob/src/runtime/tests.rs
+++ b/meerkat-mob/src/runtime/tests.rs
@@ -27246,9 +27246,9 @@ async fn test_plain_text_step_output_can_skip_json_parsing() {
 }
 
 #[tokio::test]
-async fn test_spawn_rejects_reserved_flow_system_member_prefix() {
+async fn test_spawn_rejects_reserved_flow_member_prefix() {
     let (handle, _service) = create_test_mob(sample_definition()).await;
-    let reserved_member_identity = format!("{}test", crate::runtime::FLOW_SYSTEM_MEMBER_ID_PREFIX);
+    let reserved_member_identity = format!("{}worker_demo", crate::runtime::FLOW_MEMBER_ID_PREFIX);
     let err = handle
         .spawn(
             ProfileName::from("lead"),

--- a/meerkat-session/src/persistent.rs
+++ b/meerkat-session/src/persistent.rs
@@ -5582,6 +5582,12 @@ impl<B: SessionAgentBuilder + 'static> SessionService for PersistentSessionServi
         id: &SessionId,
         client: std::sync::Arc<dyn meerkat_core::AgentLlmClient>,
     ) -> Result<(), SessionError> {
+        if self.runtime_store.is_some() {
+            return Err(SessionError::Unsupported(
+                "set_session_client is disabled for runtime-backed sessions; use runtime turn metadata reconfiguration".to_string(),
+            ));
+        }
+
         self.inner.set_session_client(id, client).await
     }
 

--- a/meerkat-session/tests/persistence_compat.rs
+++ b/meerkat-session/tests/persistence_compat.rs
@@ -161,3 +161,233 @@ fn stored_input_state_version_is_pinned_to_current() {
     assert_eq!(SESSION_VERSION, 2);
     assert_eq!(SESSION_METADATA_SCHEMA_VERSION, 2);
 }
+
+#[cfg(all(feature = "session-store", not(target_arch = "wasm32")))]
+mod runtime_backed_llm_reconfigure_tests {
+    use std::sync::Arc;
+
+    use async_trait::async_trait;
+    use meerkat_core::error::AgentError;
+    use meerkat_core::generated::session_document::ObservedSessionTailKind;
+    use meerkat_core::service::{
+        CreateSessionRequest, DeferredPromptPolicy, InitialTurnPolicy, SessionError, SessionService,
+    };
+    use meerkat_core::types::{ContentInput, RunResult};
+    use meerkat_core::{
+        AgentLlmClient, LlmStreamResult, Message, Provider, Session, SessionLlmIdentity,
+        SessionLlmRequestPolicy, SystemContextStateError, SystemContextStateHandle,
+        SystemPromptOverride, ToolDef,
+    };
+    use meerkat_runtime::{InMemoryRuntimeStore, RuntimeStore};
+    use meerkat_session::{
+        PersistentSessionService, SessionAgent, SessionAgentBuilder, SessionSnapshot,
+    };
+    use meerkat_store::{MemoryBlobStore, MemoryStore, SessionStore};
+    use tokio::sync::mpsc;
+
+    struct NoopAgentLlmClient {
+        model: String,
+    }
+
+    #[async_trait]
+    impl AgentLlmClient for NoopAgentLlmClient {
+        async fn stream_response(
+            &self,
+            _messages: &[Message],
+            _tools: &[Arc<ToolDef>],
+            _max_tokens: u32,
+            _temperature: Option<f32>,
+            _provider_params: Option<&meerkat_core::ProviderParamsOverride>,
+        ) -> Result<LlmStreamResult, AgentError> {
+            Err(AgentError::ConfigError(
+                "noop integration test client should not be called".to_string(),
+            ))
+        }
+
+        fn provider(&self) -> Provider {
+            Provider::Other
+        }
+
+        fn model(&self) -> &str {
+            self.model.as_str()
+        }
+    }
+
+    struct DummyAgent {
+        session: Session,
+    }
+
+    #[async_trait]
+    impl SessionAgent for DummyAgent {
+        async fn run_with_events(
+            &mut self,
+            _prompt: ContentInput,
+            _event_tx: mpsc::Sender<meerkat_core::AgentEvent>,
+        ) -> Result<RunResult, AgentError> {
+            Err(AgentError::ConfigError(
+                "deferred integration test session should not run".to_string(),
+            ))
+        }
+
+        fn set_skill_references(&mut self, _refs: Option<Vec<meerkat_core::skills::SkillKey>>) {}
+
+        fn set_flow_tool_overlay(
+            &mut self,
+            _overlay: Option<meerkat_core::service::TurnToolOverlay>,
+        ) -> Result<(), AgentError> {
+            Ok(())
+        }
+
+        fn hot_swap_llm_identity(
+            &mut self,
+            _client: Arc<dyn AgentLlmClient>,
+            _identity: SessionLlmIdentity,
+            _request_policy: SessionLlmRequestPolicy,
+        ) -> Result<(), AgentError> {
+            Ok(())
+        }
+
+        fn cancel(&mut self) {}
+
+        fn session_id(&self) -> meerkat_core::SessionId {
+            self.session.id().clone()
+        }
+
+        fn snapshot(&self) -> SessionSnapshot {
+            SessionSnapshot {
+                created_at: self.session.created_at(),
+                updated_at: self.session.updated_at(),
+                message_count: self.session.messages().len(),
+                total_tokens: 0,
+                usage: Default::default(),
+                last_assistant_text: None,
+            }
+        }
+
+        fn session_clone(&self) -> Result<Session, SystemContextStateError> {
+            Ok(self.session.clone())
+        }
+
+        fn durable_llm_identity(&self) -> Option<SessionLlmIdentity> {
+            Some(test_llm_identity("noop"))
+        }
+
+        fn observed_session_tail(&self) -> ObservedSessionTailKind {
+            ObservedSessionTailKind::Empty
+        }
+
+        fn apply_runtime_system_context(
+            &mut self,
+            _appends: &[meerkat_core::PendingSystemContextAppend],
+        ) {
+        }
+
+        fn system_context_state(&self) -> SystemContextStateHandle {
+            SystemContextStateHandle::new(Default::default())
+                .expect("test system-context state should restore")
+        }
+    }
+
+    fn test_llm_identity(model: &str) -> SessionLlmIdentity {
+        SessionLlmIdentity {
+            model: model.to_string(),
+            provider: Provider::Other,
+            self_hosted_server_id: None,
+            provider_params: None,
+            auth_binding: None,
+        }
+    }
+
+    struct DummyBuilder;
+
+    #[async_trait]
+    impl SessionAgentBuilder for DummyBuilder {
+        type Agent = DummyAgent;
+
+        async fn build_agent(
+            &self,
+            req: &CreateSessionRequest,
+            _event_tx: mpsc::Sender<meerkat_core::AgentEvent>,
+        ) -> Result<Self::Agent, SessionError> {
+            let session = req
+                .build
+                .as_ref()
+                .and_then(|build| build.resume_session.clone())
+                .unwrap_or_default();
+            Ok(DummyAgent { session })
+        }
+    }
+
+    fn create_deferred_request(prompt: &str) -> CreateSessionRequest {
+        CreateSessionRequest {
+            model: "test".to_string(),
+            prompt: prompt.to_string().into(),
+            deferred_prompt_policy: DeferredPromptPolicy::Discard,
+            system_prompt: SystemPromptOverride::Inherit,
+            max_tokens: None,
+            event_tx: None,
+            initial_turn: InitialTurnPolicy::Defer,
+            build: None,
+            labels: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn runtime_backed_set_session_client_fails_closed() {
+        let store: Arc<dyn SessionStore> = Arc::new(MemoryStore::new());
+        let runtime_store: Arc<dyn RuntimeStore> = Arc::new(InMemoryRuntimeStore::new());
+        let service = PersistentSessionService::new(
+            DummyBuilder,
+            4,
+            Arc::clone(&store),
+            Some(Arc::clone(&runtime_store)),
+            Arc::new(MemoryBlobStore::new()),
+        );
+
+        let created = service
+            .create_session(create_deferred_request("seed"))
+            .await
+            .expect("create_session should succeed");
+        let err = service
+            .set_session_client(
+                &created.session_id,
+                Arc::new(NoopAgentLlmClient {
+                    model: "noop".to_string(),
+                }),
+            )
+            .await
+            .expect_err("runtime-backed raw client swap must be rejected");
+
+        assert!(
+            matches!(&err, SessionError::Unsupported(message) if message.contains("runtime turn metadata reconfiguration")),
+            "raw client swap should point callers at the runtime-owned reconfiguration seam: {err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn store_only_set_session_client_still_delegates() {
+        let store: Arc<dyn SessionStore> = Arc::new(MemoryStore::new());
+        let service = PersistentSessionService::new(
+            DummyBuilder,
+            4,
+            Arc::clone(&store),
+            None,
+            Arc::new(MemoryBlobStore::new()),
+        );
+
+        let created = service
+            .create_session(create_deferred_request("seed"))
+            .await
+            .expect("create_session should succeed");
+
+        service
+            .set_session_client(
+                &created.session_id,
+                Arc::new(NoopAgentLlmClient {
+                    model: "store-only-swap".to_string(),
+                }),
+            )
+            .await
+            .expect("store-only persistent sessions should preserve raw client swaps");
+    }
+}

--- a/scripts/buildbuddy-doctor
+++ b/scripts/buildbuddy-doctor
@@ -381,6 +381,7 @@ else
 fi
 
 if grep -Fq 'MEERKAT_GCP_BUILDBUDDY_CI_MAX_SECONDS' .github/workflows/buildbuddy.yml &&
+  grep -Fq 'MEERKAT_GCP_BUILDBUDDY_SDK_CI_MAX_SECONDS' .github/workflows/buildbuddy.yml &&
   grep -Fq 'buildbuddy-gcp-executors' .github/workflows/buildbuddy.yml &&
   grep -Fq 'queue: max' .github/workflows/buildbuddy.yml &&
   grep -Fq 'MEERKAT_GCP_BUILDBUDDY_WAIT_ON_DOWN' .github/workflows/buildbuddy.yml &&
@@ -422,6 +423,8 @@ if job_has_line .github/workflows/ci.yml cargo 'name: GHA Cargo' &&
   job_has_line .github/workflows/buildbuddy.yml governance-submit 'name: Governance submitter' &&
   job_has_line .github/workflows/buildbuddy.yml wasm-feature-changes 'name: WASM, SDK, and feature change detection' &&
   job_has_line .github/workflows/buildbuddy.yml wasm-sdk-submit 'name: SDK suites submitter' &&
+  job_has_line .github/workflows/buildbuddy.yml wasm-sdk-submit 'timeout-minutes: 45' &&
+  job_has_line .github/workflows/buildbuddy.yml wasm-sdk-submit "MEERKAT_GCP_BUILDBUDDY_CI_MAX_SECONDS: \${{ vars.MEERKAT_GCP_BUILDBUDDY_SDK_CI_MAX_SECONDS || '2400' }}" &&
   job_has_line .github/workflows/buildbuddy.yml wasm-check-submit 'name: WASM check submitter' &&
   job_has_line .github/workflows/buildbuddy.yml minimal-feature-submit 'name: Minimal feature submitter' &&
   job_has_line .github/workflows/buildbuddy.yml feature-submit 'name: Feature matrix submitter' &&
@@ -476,6 +479,7 @@ if job_has_line .github/workflows/ci.yml cargo 'name: GHA Cargo' &&
   ! job_has_line .github/workflows/buildbuddy.yml feature-submit 'rmat-audit' &&
   ! job_has_line .github/workflows/buildbuddy.yml feature-submit 'machine-authority' &&
   grep -Fq 'MEERKAT_BUILDBUDDY_BATCH_JOBS' .github/workflows/buildbuddy.yml &&
+  grep -Fq "MAX_SECONDS: \${{ needs.wasm-feature-changes.outputs.sdk_changed == 'true' && (vars.MEERKAT_GCP_BUILDBUDDY_SDK_CI_MAX_SECONDS || '2400') || (vars.MEERKAT_GCP_BUILDBUDDY_CI_MAX_SECONDS || '1500') }}" .github/workflows/buildbuddy.yml &&
   grep -Fq 'MEERKAT_BUILDBUDDY_BATCH_JOBS: ${{ inputs.batch_jobs || env.MEERKAT_BUILDBUDDY_BATCH_JOBS }}' .github/actions/run-buildbuddy-ci-lane-batch/action.yml &&
   grep -Fq 'Check GCP CI duration SLO' .github/workflows/buildbuddy.yml &&
   grep -Fq 'Active BuildBuddy lane heartbeat' scripts/buildbuddy-ci-lane-batch &&

--- a/scripts/cargo-agent-gate
+++ b/scripts/cargo-agent-gate
@@ -209,6 +209,8 @@ done < <(collect_changed_paths | awk 'NF' | sort -u)
 relevant=()
 governance=()
 generated_contract=()
+web_sdk=()
+wasm_runtime=()
 global=0
 if [[ "${#changed[@]}" -gt 0 ]]; then
   for path in "${changed[@]}"; do
@@ -224,10 +226,18 @@ if [[ "${#changed[@]}" -gt 0 ]]; then
     if scripts/generated-contract-ratchet-changed -- "${path}" >/dev/null 2>&1; then
       generated_contract+=("${path}")
     fi
+    case "${path}" in
+      sdks/web/*)
+        web_sdk+=("${path}")
+        ;;
+      meerkat-web-runtime/*)
+        wasm_runtime+=("${path}")
+        ;;
+    esac
   done
 fi
 
-if [[ "${#relevant[@]}" -eq 0 && "${#governance[@]}" -eq 0 && "${#generated_contract[@]}" -eq 0 ]]; then
+if [[ "${#relevant[@]}" -eq 0 && "${#governance[@]}" -eq 0 && "${#generated_contract[@]}" -eq 0 && "${#web_sdk[@]}" -eq 0 && "${#wasm_runtime[@]}" -eq 0 ]]; then
   echo "Cargo agent gate: no Rust build-relevant changes detected."
   exit 0
 fi
@@ -256,6 +266,28 @@ if [[ "${#generated_contract[@]}" -gt 0 ]]; then
     echo "DRY-RUN make verify-schema-freshness verify-sdk-codegen-freshness verify-sdk-event-inventory verify-rpc-surface-alignment verify-rest-surface-alignment"
   else
     make verify-schema-freshness verify-sdk-codegen-freshness verify-sdk-event-inventory verify-rpc-surface-alignment verify-rest-surface-alignment
+  fi
+fi
+
+if [[ "${#web_sdk[@]}" -gt 0 ]]; then
+  printf 'Cargo agent gate Web SDK paths:\n'
+  printf '  %s\n' "${web_sdk[@]}"
+  echo "Web SDK changed; running test-sdk-web."
+  if [[ "${dry_run}" -eq 1 ]]; then
+    echo "DRY-RUN make test-sdk-web"
+  else
+    make test-sdk-web
+  fi
+fi
+
+if [[ "${#wasm_runtime[@]}" -gt 0 ]]; then
+  printf 'Cargo agent gate WASM runtime paths:\n'
+  printf '  %s\n' "${wasm_runtime[@]}"
+  echo "WASM runtime changed; running wasm-check."
+  if [[ "${dry_run}" -eq 1 ]]; then
+    echo "DRY-RUN make wasm-check"
+  else
+    make wasm-check
   fi
 fi
 

--- a/scripts/machine-authority-changed
+++ b/scripts/machine-authority-changed
@@ -87,7 +87,7 @@ machine_authority_path() {
     meerkat-machine-codegen/*|meerkat-machine-derive/*|meerkat-machine-dsl/*|meerkat-machine-dsl-core/*|meerkat-machine-kernels/*|meerkat-machine-schema/*)
       return 0
       ;;
-    meerkat-runtime/src/meerkat_machine/*|meerkat-runtime/src/auth_machine/*|meerkat-mob/src/machines/*|meerkat-schedule/src/machines/*)
+    meerkat-runtime/src/meerkat_machine/*|meerkat-runtime/src/auth_machine/*|meerkat-mob/src/ids.rs|meerkat-mob/src/machines/*|meerkat-mob/src/runtime/*|meerkat-schedule/src/machines/*)
       return 0
       ;;
     meerkat-machine-kernels/src/generated/*|meerkat-core/src/generated/*|meerkat-mob/src/generated/*|meerkat-runtime/src/generated/*|meerkat-schedule/src/generated/*|*/src/generated/protocol_*.rs)

--- a/scripts/tests/xtask_scripts_dogma_gates.sh
+++ b/scripts/tests/xtask_scripts_dogma_gates.sh
@@ -69,6 +69,11 @@ if scripts/machine-authority-changed -- xtask/src/rmat_policy.rs >/dev/null; the
 else
   bad "machine-authority-changed did not flag xtask/src/rmat_policy.rs"
 fi
+if scripts/machine-authority-changed -- meerkat-mob/src/runtime/actor.rs >/dev/null; then
+  ok "machine-authority-changed exits 0 (changed) for mob runtime authority"
+else
+  bad "machine-authority-changed did not flag mob runtime authority"
+fi
 if scripts/machine-authority-changed -- docs/reference/machine-authority.mdx >/dev/null; then
   ok "machine-authority-changed exits 0 (changed) for machine-authority docs"
 else
@@ -157,6 +162,13 @@ if printf '%s' "$generated_machine_gate_out" | grep -Fq 'machine-check-drift mac
 else
   bad "cargo-agent-gate dry-run did not route generated machine catalog changes"
 fi
+mob_identity_gate_out=$(scripts/cargo-agent-gate --dry-run -- meerkat-mob/src/ids.rs 2>&1 || true)
+if printf '%s' "$mob_identity_gate_out" | grep -Fq 'machine-check-drift machine-authority-docs-gate runtime-authority-bypass seam-inventory rmat-audit' \
+  && ! printf '%s' "$mob_identity_gate_out" | grep -Fq 'no Rust build-relevant changes detected.'; then
+  ok "cargo-agent-gate dry-run routes mob identity authority changes to governance gate"
+else
+  bad "cargo-agent-gate dry-run did not route mob identity authority changes"
+fi
 generated_buildbuddy_gate_out=$(scripts/buildbuddy-agent-gate --dry-run -- meerkat-core/src/generated/protocol_runtime.rs 2>&1 || true)
 if printf '%s' "$generated_buildbuddy_gate_out" | grep -Fq 'machine-check-drift machine-authority-docs-gate seam-inventory rmat-audit' \
   && ! printf '%s' "$generated_buildbuddy_gate_out" | grep -Fq 'no build-relevant changes detected.'; then
@@ -190,6 +202,20 @@ if printf '%s' "$surface_gate_out" | grep -Fq 'verify-schema-freshness verify-sd
   ok "cargo-agent-gate dry-run routes public surface docs/router/mob-mcp changes to generated contract ratchets"
 else
   bad "cargo-agent-gate dry-run did not route public surface docs/router/mob-mcp changes"
+fi
+web_gate_out=$(scripts/cargo-agent-gate --dry-run -- sdks/web/src/runtime.ts 2>&1 || true)
+if printf '%s' "$web_gate_out" | grep -Fq 'test-sdk-web' \
+  && ! printf '%s' "$web_gate_out" | grep -Fq 'no Rust build-relevant changes detected.'; then
+  ok "cargo-agent-gate dry-run routes Web SDK changes to Web SDK tests"
+else
+  bad "cargo-agent-gate dry-run did not route Web SDK changes"
+fi
+wasm_gate_out=$(scripts/cargo-agent-gate --dry-run -- meerkat-web-runtime/src/lib.rs 2>&1 || true)
+if printf '%s' "$wasm_gate_out" | grep -Fq 'wasm-check' \
+  && ! printf '%s' "$wasm_gate_out" | grep -Fq 'no Rust build-relevant changes detected.'; then
+  ok "cargo-agent-gate dry-run routes web runtime changes to wasm-check"
+else
+  bad "cargo-agent-gate dry-run did not route web runtime changes"
 fi
 rest_gate_out=$(scripts/buildbuddy-agent-gate --dry-run -- meerkat-rest/src/lib.rs meerkat-rpc/src/session_runtime.rs 2>&1 || true)
 if printf '%s' "$rest_gate_out" | grep -Fq 'verify-schema-freshness verify-sdk-codegen-freshness verify-sdk-event-inventory verify-rpc-surface-alignment verify-rest-surface-alignment' \

--- a/sdks/python/meerkat/client.py
+++ b/sdks/python/meerkat/client.py
@@ -1958,6 +1958,17 @@ class MeerkatClient:
                 "Invalid mob/member_send response: missing member_ref",
             )
         receipt_handling_mode = result.get("handling_mode")
+        resolved_mob_id = result.get("mob_id")
+        if not isinstance(resolved_mob_id, str) or not resolved_mob_id:
+            raise MeerkatError(
+                "INVALID_RESPONSE",
+                "Invalid mob/member_send response: missing mob_id",
+            )
+        if resolved_mob_id != mob_id:
+            raise MeerkatError(
+                "INVALID_RESPONSE",
+                "Invalid mob/member_send response: mob_id mismatch",
+            )
         resolved_identity = result.get("agent_identity")
         if not isinstance(resolved_identity, str) or not resolved_identity:
             raise MeerkatError(
@@ -1965,6 +1976,7 @@ class MeerkatClient:
                 "Invalid mob/member_send response: missing agent_identity",
             )
         return {
+            "mob_id": resolved_mob_id,
             "agent_identity": resolved_identity,
             "member_ref": member_ref,
             "handling_mode": self._parse_wire_handling_mode(
@@ -2032,8 +2044,14 @@ class MeerkatClient:
                 "INVALID_RESPONSE",
                 "Invalid mob/spawn response: missing member_ref",
             )
+        resolved_mob_id = result.get("mob_id")
+        if not isinstance(resolved_mob_id, str) or not resolved_mob_id:
+            raise MeerkatError(
+                "INVALID_RESPONSE",
+                "Invalid mob/spawn response: missing mob_id",
+            )
         return {
-            "mob_id": str(result.get("mob_id", mob_id)),
+            "mob_id": resolved_mob_id,
             "agent_identity": resolved_identity,
             "member_ref": member_ref,
         }

--- a/sdks/python/meerkat/mob.py
+++ b/sdks/python/meerkat/mob.py
@@ -55,6 +55,7 @@ RenderMetadata = TypedDict(
 MemberDeliveryReceipt = TypedDict(
     "MemberDeliveryReceipt",
     {
+        "mob_id": str,
         "agent_identity": str,
         "member_ref": MobMemberRef,
         "handling_mode": Literal["queue", "steer"],

--- a/sdks/python/tests/test_types.py
+++ b/sdks/python/tests/test_types.py
@@ -1316,6 +1316,7 @@ def test_member_send_never_falls_back_to_requested_handling_mode():
         # Runtime echoes identity/member_ref but OMITS handling_mode entirely.
         # The client requested "steer" — it must not be substituted.
         return {
+            "mob_id": params["mob_id"],
             "agent_identity": params["agent_identity"],
             "member_ref": "m1",
         }
@@ -1344,6 +1345,7 @@ def test_member_send_returns_runtime_handling_mode():
 
     async def fake_request(method, params):
         return {
+            "mob_id": params["mob_id"],
             "agent_identity": params["agent_identity"],
             "member_ref": "m1",
             # Runtime resolved to "queue" though client asked for "steer".
@@ -3386,6 +3388,26 @@ async def test_client_mob_lifecycle_and_send_methods_use_explicit_rpc_methods():
 
 
 @pytest.mark.asyncio
+async def test_spawn_mob_member_rejects_missing_runtime_mob_id() -> None:
+    client = MeerkatClient()
+
+    async def fake_request(_method: str, _params: dict[str, object]) -> dict[str, object]:
+        return {
+            "agent_identity": "agent-a",
+            "member_ref": _make_member_ref("mob-1", "agent-a"),
+        }
+
+    client._request = fake_request  # type: ignore[method-assign]
+
+    with pytest.raises(MeerkatError, match="missing mob_id"):
+        await client.spawn_mob_member(
+            "mob-1",
+            profile="worker",
+            agent_identity="agent-a",
+        )
+
+
+@pytest.mark.asyncio
 async def test_mob_status_rejects_missing_status():
     client = MeerkatClient()
 
@@ -3487,6 +3509,7 @@ async def test_send_mob_member_content_uses_canonical_host_member_send_lane() ->
     async def fake_request(method: str, params: dict[str, object]) -> dict[str, object]:
         calls.append((method, params))
         return {
+            "mob_id": "mob-1",
             "agent_identity": "agent-a",
             "member_ref": _make_member_ref("mob-1", "agent-a"),
             "handling_mode": "steer",
@@ -3503,6 +3526,7 @@ async def test_send_mob_member_content_uses_canonical_host_member_send_lane() ->
     )
 
     assert receipt == {
+        "mob_id": "mob-1",
         "agent_identity": "agent-a",
         "member_ref": _make_member_ref("mob-1", "agent-a"),
         "handling_mode": "steer",
@@ -3531,6 +3555,58 @@ async def test_send_mob_member_content_rejects_malformed_receipt() -> None:
     client._request = fake_request  # type: ignore[method-assign]
 
     with pytest.raises(MeerkatError, match="missing member_ref"):
+        await client.send_mob_member_content("mob-1", "agent-a", "hello reviewer")
+
+
+@pytest.mark.asyncio
+async def test_send_mob_member_content_rejects_missing_runtime_identity() -> None:
+    client = MeerkatClient()
+
+    async def fake_request(_method: str, _params: dict[str, object]) -> dict[str, object]:
+        return {
+            "mob_id": "mob-1",
+            "member_ref": _make_member_ref("mob-1", "agent-a"),
+            "handling_mode": "queue",
+        }
+
+    client._request = fake_request  # type: ignore[method-assign]
+
+    with pytest.raises(MeerkatError, match="missing agent_identity"):
+        await client.send_mob_member_content("mob-1", "agent-a", "hello reviewer")
+
+
+@pytest.mark.asyncio
+async def test_send_mob_member_content_rejects_missing_runtime_mob_id() -> None:
+    client = MeerkatClient()
+
+    async def fake_request(_method: str, _params: dict[str, object]) -> dict[str, object]:
+        return {
+            "agent_identity": "agent-a",
+            "member_ref": _make_member_ref("mob-1", "agent-a"),
+            "handling_mode": "queue",
+        }
+
+    client._request = fake_request  # type: ignore[method-assign]
+
+    with pytest.raises(MeerkatError, match="missing mob_id"):
+        await client.send_mob_member_content("mob-1", "agent-a", "hello reviewer")
+
+
+@pytest.mark.asyncio
+async def test_send_mob_member_content_rejects_mismatched_runtime_mob_id() -> None:
+    client = MeerkatClient()
+
+    async def fake_request(_method: str, _params: dict[str, object]) -> dict[str, object]:
+        return {
+            "mob_id": "mob-2",
+            "agent_identity": "agent-a",
+            "member_ref": _make_member_ref("mob-1", "agent-a"),
+            "handling_mode": "queue",
+        }
+
+    client._request = fake_request  # type: ignore[method-assign]
+
+    with pytest.raises(MeerkatError, match="mob_id mismatch"):
         await client.send_mob_member_content("mob-1", "agent-a", "hello reviewer")
 
 

--- a/sdks/typescript/src/client.ts
+++ b/sdks/typescript/src/client.ts
@@ -1609,11 +1609,22 @@ export class MeerkatClient {
         "Invalid mob/member_send response: missing member_ref",
       );
     }
+    const resolvedMobId = MeerkatClient.parseRequiredString(
+      result.mob_id,
+      "Invalid mob/member_send response: missing mob_id",
+    );
+    if (resolvedMobId !== mobId) {
+      throw new MeerkatError(
+        "INVALID_RESPONSE",
+        "Invalid mob/member_send response: mob_id mismatch",
+      );
+    }
     return {
-      agentIdentity:
-        typeof result.agent_identity === "string" && result.agent_identity.length > 0
-          ? result.agent_identity
-          : agentIdentity,
+      mobId: resolvedMobId,
+      agentIdentity: MeerkatClient.parseRequiredString(
+        result.agent_identity,
+        "Invalid mob/member_send response: missing agent_identity",
+      ),
       memberRef,
       handlingMode: MeerkatClient.parseWireHandlingMode(
         result.handling_mode,
@@ -1638,11 +1649,14 @@ export class MeerkatClient {
       );
     }
     return {
-      mobId: String(result.mob_id ?? mobId),
-      agentIdentity:
-        typeof result.agent_identity === "string" && result.agent_identity.length > 0
-          ? result.agent_identity
-          : options.agentIdentity,
+      mobId: MeerkatClient.parseRequiredString(
+        result.mob_id,
+        "Invalid mob/spawn response: missing mob_id",
+      ),
+      agentIdentity: MeerkatClient.parseRequiredString(
+        result.agent_identity,
+        "Invalid mob/spawn response: missing agent_identity",
+      ),
       memberRef,
     };
   }
@@ -2208,16 +2222,10 @@ export class MeerkatClient {
       runtime_mode: options?.runtimeMode,
       backend: options?.backend,
     });
-    const resultIdentity =
-      typeof result.agent_identity === "string" && result.agent_identity.length > 0
-        ? result.agent_identity
-        : options?.agentIdentity;
-    if (!resultIdentity) {
-      throw new MeerkatError(
-        "INVALID_RESPONSE",
-        "Invalid mob/spawn_helper response: missing agent identity",
-      );
-    }
+    const resultIdentity = MeerkatClient.parseRequiredString(
+      result.agent_identity,
+      "Invalid mob/spawn_helper response: missing agent_identity",
+    );
     const memberRef =
       typeof result.member_ref === "string" && result.member_ref.length > 0
         ? result.member_ref
@@ -2267,16 +2275,10 @@ export class MeerkatClient {
       runtime_mode: options?.runtimeMode,
       backend: options?.backend,
     });
-    const resultIdentity =
-      typeof result.agent_identity === "string" && result.agent_identity.length > 0
-        ? result.agent_identity
-        : options?.agentIdentity;
-    if (!resultIdentity) {
-      throw new MeerkatError(
-        "INVALID_RESPONSE",
-        "Invalid mob/fork_helper response: missing agent identity",
-      );
-    }
+    const resultIdentity = MeerkatClient.parseRequiredString(
+      result.agent_identity,
+      "Invalid mob/fork_helper response: missing agent_identity",
+    );
     const memberRef =
       typeof result.member_ref === "string" && result.member_ref.length > 0
         ? result.member_ref
@@ -2564,6 +2566,13 @@ export class MeerkatClient {
 
   private static parseOptionalString(raw: unknown): string | undefined {
     return typeof raw === "string" ? raw : undefined;
+  }
+
+  private static parseRequiredString(raw: unknown, context: string): string {
+    if (typeof raw === "string" && raw.length > 0) {
+      return raw;
+    }
+    throw new MeerkatError("INVALID_RESPONSE", context);
   }
 
   private static parseOptionalNumber(raw: unknown): number | undefined {

--- a/sdks/typescript/src/mob.ts
+++ b/sdks/typescript/src/mob.ts
@@ -45,6 +45,7 @@ export interface MemberSendOptions {
 }
 
 export interface MemberDeliveryReceipt {
+  mobId: string;
   agentIdentity: string;
   memberRef: MobMemberRef;
   handlingMode: MobHandlingMode;

--- a/sdks/typescript/tests/types.test.js
+++ b/sdks/typescript/tests/types.test.js
@@ -2630,6 +2630,24 @@ describe("Parity wrappers", () => {
     assert.equal(calls[4].params.limit, 5);
   });
 
+  it("rejects mob spawn receipts missing server-owned identity fields", async () => {
+    const client = new MeerkatClient();
+    client.request = async () => ({
+      member_ref: makeMemberRef("mob-1", "worker-1"),
+    });
+
+    await assert.rejects(
+      () => client.spawnMobMember("mob-1", {
+        profile: "worker",
+        agentIdentity: "worker-1",
+      }),
+      (error) =>
+        error instanceof MeerkatError &&
+        error.code === "INVALID_RESPONSE" &&
+        String(error.message).includes("missing mob_id"),
+    );
+  });
+
   it("passes mob_turn_start tri-state overrides through unchanged", async () => {
     const client = new MeerkatClient();
     const calls = [];
@@ -2857,6 +2875,30 @@ describe("Parity wrappers", () => {
     assert.equal(spawnByRole.fenceToken, undefined);
     assert.equal(forkByRole.agentRuntimeId, undefined);
     assert.equal(forkByRole.fenceToken, undefined);
+  });
+
+  it("rejects helper receipts missing runtime-owned agent identity", async () => {
+    const client = new MeerkatClient();
+    client.request = async () => ({
+      output: "ok",
+      tokens_used: 1,
+      member_ref: makeMemberRef("mob-1", "caller-requested"),
+    });
+
+    await assert.rejects(
+      () => client.spawnMobHelper("mob-1", "help", { agentIdentity: "caller-requested" }),
+      (error) =>
+        error instanceof MeerkatError &&
+        error.code === "INVALID_RESPONSE" &&
+        String(error.message).includes("missing agent_identity"),
+    );
+    await assert.rejects(
+      () => client.forkMobHelper("mob-1", "source", "help", { agentIdentity: "caller-requested" }),
+      (error) =>
+        error instanceof MeerkatError &&
+        error.code === "INVALID_RESPONSE" &&
+        String(error.message).includes("missing agent_identity"),
+    );
   });
 });
 
@@ -3523,6 +3565,7 @@ describe("Mob member host ingress", () => {
     client.request = async (method, params) => {
       calls.push({ method, params });
       return {
+        mob_id: "mob-1",
         agent_identity: "reviewer-1",
         member_ref: expectedRef,
         handling_mode: "steer",
@@ -3541,6 +3584,7 @@ describe("Mob member host ingress", () => {
     );
 
     assert.deepEqual(receipt, {
+      mobId: "mob-1",
       agentIdentity: "reviewer-1",
       memberRef: expectedRef,
       handlingMode: "steer",
@@ -3571,6 +3615,58 @@ describe("Mob member host ingress", () => {
       /missing member_ref/,
     );
   });
+
+  it("rejects member-send receipts missing runtime-owned agent identity", async () => {
+    const client = new MeerkatClient();
+    client.request = async () => ({
+      mob_id: "mob-1",
+      member_ref: makeMemberRef("mob-1", "reviewer-1"),
+      handling_mode: "queue",
+    });
+
+    await assert.rejects(
+      () => new Mob(client, "mob-1").member("reviewer-1").send("hello reviewer"),
+      (error) =>
+        error instanceof MeerkatError &&
+        error.code === "INVALID_RESPONSE" &&
+        String(error.message).includes("missing agent_identity"),
+    );
+  });
+
+  it("rejects member-send receipts missing runtime-owned mob id", async () => {
+    const client = new MeerkatClient();
+    client.request = async () => ({
+      agent_identity: "reviewer-1",
+      member_ref: makeMemberRef("mob-1", "reviewer-1"),
+      handling_mode: "queue",
+    });
+
+    await assert.rejects(
+      () => new Mob(client, "mob-1").member("reviewer-1").send("hello reviewer"),
+      (error) =>
+        error instanceof MeerkatError &&
+        error.code === "INVALID_RESPONSE" &&
+        String(error.message).includes("missing mob_id"),
+    );
+  });
+
+  it("rejects member-send receipts with mismatched runtime-owned mob id", async () => {
+    const client = new MeerkatClient();
+    client.request = async () => ({
+      mob_id: "mob-2",
+      agent_identity: "reviewer-1",
+      member_ref: makeMemberRef("mob-1", "reviewer-1"),
+      handling_mode: "queue",
+    });
+
+    await assert.rejects(
+      () => new Mob(client, "mob-1").member("reviewer-1").send("hello reviewer"),
+      (error) =>
+        error instanceof MeerkatError &&
+        error.code === "INVALID_RESPONSE" &&
+        String(error.message).includes("mob_id mismatch"),
+    );
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -3582,6 +3678,7 @@ describe("Member-send handling-mode parse boundary (row 357)", () => {
     const client = new MeerkatClient();
     const expectedRef = makeMemberRef("mob-1", "reviewer-1");
     client.request = async () => ({
+      mob_id: "mob-1",
       agent_identity: "reviewer-1",
       member_ref: expectedRef,
       handling_mode: "queue",
@@ -3598,6 +3695,7 @@ describe("Member-send handling-mode parse boundary (row 357)", () => {
     const client = new MeerkatClient();
     const expectedRef = makeMemberRef("mob-1", "reviewer-1");
     client.request = async () => ({
+      mob_id: "mob-1",
       agent_identity: "reviewer-1",
       member_ref: expectedRef,
       // handling_mode intentionally absent
@@ -3616,6 +3714,7 @@ describe("Member-send handling-mode parse boundary (row 357)", () => {
     const client = new MeerkatClient();
     const expectedRef = makeMemberRef("mob-1", "reviewer-1");
     client.request = async () => ({
+      mob_id: "mob-1",
       agent_identity: "reviewer-1",
       member_ref: expectedRef,
       handling_mode: "interrupt",

--- a/sdks/web/scripts/build-wasm.mjs
+++ b/sdks/web/scripts/build-wasm.mjs
@@ -19,6 +19,8 @@ const WORKSPACE_DIR = path.resolve(SDK_DIR, "../..");
 const CACHE_MANIFEST = path.join(OUT_DIR, ".meerkat-wasm-build.json");
 const WASM_PACK_BIN =
   process.env.RKAT_WASM_PACK_BIN || process.env.WASM_PACK || "wasm-pack";
+const CARGO_BIN = process.env.CARGO || "cargo";
+const CARGO_BIN_DIR = path.isAbsolute(CARGO_BIN) ? path.dirname(CARGO_BIN) : "";
 const REQUIRED_OUTPUTS = [
   "meerkat_web_runtime.js",
   "meerkat_web_runtime_bg.wasm",
@@ -72,6 +74,18 @@ function pidIsAlive(pid) {
   } catch (error) {
     return error?.code === "EPERM";
   }
+}
+
+function wasmPackEnv(extraEnv = {}) {
+  const env = {
+    ...process.env,
+    ...extraEnv,
+  };
+  if (CARGO_BIN_DIR) {
+    env.CARGO = CARGO_BIN;
+    env.PATH = `${CARGO_BIN_DIR}${path.delimiter}${env.PATH || ""}`;
+  }
+  return env;
 }
 
 async function readLockOwner() {
@@ -243,7 +257,7 @@ async function collectPackageInputs(packageRoot) {
 }
 
 async function localCargoGraphInputs() {
-  const metadataText = await runCapture("cargo", ["metadata", "--format-version", "1"], {
+  const metadataText = await runCapture(CARGO_BIN, ["metadata", "--format-version", "1"], {
     cwd: WORKSPACE_DIR,
   });
   const metadata = JSON.parse(metadataText);
@@ -352,8 +366,7 @@ async function run() {
           cwd: SDK_DIR,
           stdio: "inherit",
           env: {
-            ...process.env,
-            ...RELEASE_CARGO_PROFILE_ENV,
+            ...wasmPackEnv(RELEASE_CARGO_PROFILE_ENV),
             CARGO_TARGET_WASM32_UNKNOWN_UNKNOWN_RUSTFLAGS: WASM_RUSTFLAGS,
           },
         },

--- a/specs/compositions/README.md
+++ b/specs/compositions/README.md
@@ -13,21 +13,13 @@ Each composition directory contains:
 - optional witness or liveness configs when the composition has additional
   proof lanes
 
-Canonical composition set:
-
-- `meerkat_mob_seam`
-- perimeter compositions retained after audit:
-  - `auth_lease_bundle`
-  - `schedule_bundle`
-  - `schedule_runtime_bundle`
-  - `schedule_mob_bundle`
-  - `workgraph_attention_bundle`
-
 Status:
 
-- internal routes inside `MeerkatMachine` and `MobMachine` are no longer
-  modeled as inter-machine compositions
-- `meerkat_mob_seam` is the sole inter-kernel composition
+- `specs/compositions/` is the canonical executable composition-spec home
+- the schema catalog and generated authority artifacts define the canonical
+  composition roster
+- internal routes inside `MeerkatMachine` and `MobMachine` are not modeled as
+  inter-machine compositions
 - the retained perimeter/workgraph compositions were audited during the two-kernel
   collapse:
   - `auth_lease_bundle` remains because it publishes auth lease lifecycle

--- a/specs/machines/README.md
+++ b/specs/machines/README.md
@@ -13,28 +13,11 @@ Each machine directory contains:
 - optional focused liveness or audit configs when the machine has additional
   proof lanes
 
-Canonical machine set:
-
-- `meerkat_machine`
-- `mob_machine`
-- `auth`
-- `occurrence_lifecycle`
-- `schedule_lifecycle`
-- `work_graph_lifecycle`
-- `work_attention_lifecycle`
-
 Status:
 
 - `specs/machines/` is the canonical executable spec home
-- the machine authority specs live at:
-  - `specs/machines/meerkat_machine/`
-  - `specs/machines/mob_machine/`
-  - `specs/machines/auth/`
-  - `specs/machines/occurrence_lifecycle/`
-  - `specs/machines/schedule_lifecycle/`
-  - `specs/machines/work_graph_lifecycle/`
-  - `specs/machines/work_attention_lifecycle/`
-- the schema catalog and generated authority artifacts must match these specs
+- the schema catalog and generated authority artifacts define the canonical
+  machine roster
 - where implementation or catalog coverage diverges, `mapping.md` calls that
   out explicitly
 - the checked-in `ci.cfg` files are the bounded CI TLC profiles

--- a/tools/buildbuddy/BUILD.bazel
+++ b/tools/buildbuddy/BUILD.bazel
@@ -169,7 +169,9 @@ sh_test(
     args = ["sdk-suites"],
     data = [
         "//:workspace_runfiles",
-    ] + RUST_TOOLCHAIN_DATA + SDK_TOOL_DATA,
+        "@wasm_pack_darwin_arm64//:wasm-pack",
+        "@wasm_pack_linux_x86_64//:wasm-pack",
+    ] + RUST_TOOLCHAIN_DATA + WASM_RUST_TOOLCHAIN_DATA + SDK_TOOL_DATA,
     exec_properties = CARGO_EQUIVALENT_EXEC_PROPERTIES,
     size = "enormous",
     timeout = "eternal",

--- a/tools/buildbuddy/full_lane_test.sh
+++ b/tools/buildbuddy/full_lane_test.sh
@@ -298,18 +298,35 @@ case "${lane}" in
     wait_parallel_jobs
     ;;
   sdk-suites)
-    configure_rust "${host_rust_toolchain}"
+    configure_rust_with_wasm_target
     configure_node
     configure_python
+    configure_wasm_pack
     "${CARGO}" build -p meerkat-rpc
-    (cd sdks/python &&
+    parallel_jobs_file="${TEST_TMPDIR}/sdk-suites-jobs.tsv"
+    : >"${parallel_jobs_file}"
+    run_parallel_job python-sdk bash -lc '
+      export PIP_CACHE_DIR="${TEST_TMPDIR}/pip-cache-python-sdk"
+      cd sdks/python &&
       "${PYTHON}" -m pip install --upgrade pip &&
       "${PYTHON}" -m pip install -e ".[dev]" &&
-      "${PYTHON}" -m pytest -q tests)
-    (cd sdks/typescript &&
+      "${PYTHON}" -m pytest -q tests
+    '
+    run_parallel_job typescript-sdk bash -lc '
+      export NPM_CONFIG_CACHE="${TEST_TMPDIR}/npm-cache-typescript-sdk"
+      cd sdks/typescript &&
       npm install --ignore-scripts &&
       npm run build &&
-      npm test)
+      npm test
+    '
+    run_parallel_job web-sdk bash -lc '
+      export NPM_CONFIG_CACHE="${TEST_TMPDIR}/npm-cache-web-sdk"
+      cd sdks/web &&
+      npm install --ignore-scripts &&
+      npm run build &&
+      npm test
+    '
+    wait_parallel_jobs
     make verify-sdk-wrapper-freshness CARGO="${CARGO}" PYTHON="${PYTHON}"
     ;;
   wasm-check)


### PR DESCRIPTION
## Summary
- closes the six retained 2026-07-01 dogma remediation rows
- reserves flow-member identities behind typed flow provisioning and rejects public `__flow_*` spawns
- fails closed on runtime-backed raw session client swaps
- extends public Cargo/BuildBuddy gates for Web SDK, wasm runtime, and mob authority paths
- makes TypeScript/Python mob receipt wrappers require runtime-owned fields
- removes stale canonical-looking spec roster mirrors

## Validation
- make agent-gate
- make test-sdk-web
- make wasm-check
- ./scripts/tests/xtask_scripts_dogma_gates.sh
- python3.11 -m pytest -q tests (in sdks/python)
- npm run build && node --test tests/types.test.js --test-name-pattern "member-send receipts|Mob member host ingress|Member-send handling-mode" (in sdks/typescript)
- RUST_LANE_ID=dogma-mob ./scripts/repo-cargo test -p meerkat-mob test_spawn_rejects_reserved_flow_member_prefix
- RUST_LANE_ID=dogma-session ./scripts/repo-cargo test -p meerkat-session --features session-store --test persistence_compat runtime_backed_set_session_client_fails_closed

## Adversarial Review
- runtime/session/mob reviewer: yellow only for future FlowProvisioning misuse risk, no blocker
- governance/SDK reviewer: initially red on member-send `mob_id` and Web SDK package build gaps; follow-up recheck green after fixes
