### PR TITLE
fix wasm surface e2e artifact assertions

### DIFF
--- a/meerkat-cli/tests/cli_mobpack_live_smoke.rs
+++ b/meerkat-cli/tests/cli_mobpack_live_smoke.rs
@@ -1063,8 +1063,9 @@ async fn e2e_smoke_wasm_surface_gate() -> Result<(), Box<dyn std::error::Error>>
     let out_dir = project_dir.join("web-out");
     for file in [
         "index.html",
-        "runtime.js",
-        "runtime_bg.wasm",
+        "meerkat-bootstrap.js",
+        "meerkat_web_runtime.js",
+        "meerkat_web_runtime_bg.wasm",
         "mobpack.bin",
         "manifest.web.toml",
     ] {


### PR DESCRIPTION
## Summary
- Update the WASM surface e2e harness to assert the current mob web build artifact names.
- The CLI emits the wasm-pack basenames plus meerkat-bootstrap.js, matching docs and unit coverage.

## Validation
- git diff --check
- ./scripts/repo-cargo test -p rkat --features integration-real-tests --test cli_mobpack_live_smoke e2e_smoke_wasm_surface_gate -- --ignored --nocapture