### PR TITLE
windows release lane: scoped -Clto=off for meerkat-mob (permanent OOM fix)

### DIFF
--- a/meerkat-mob/BUILD.bazel
+++ b/meerkat-mob/BUILD.bazel
@@ -42,7 +42,10 @@ rust_library(
     edition = "2024",
     rustc_flags = [
         "-Ccodegen-units=256",
-    ],
+    ] + select({
+        "@platforms//os:windows": ["-Clto=off"],
+        "//conditions:default": [],
+    }),
     compile_data = [
         "Cargo.toml",
         "src/runtime/actor.rs",
@@ -96,7 +99,10 @@ rust_library(
     edition = "2024",
     rustc_flags = [
         "-Ccodegen-units=256",
-    ],
+    ] + select({
+        "@platforms//os:windows": ["-Clto=off"],
+        "//conditions:default": [],
+    }),
     compile_data = [
         "Cargo.toml",
         "src/runtime/actor.rs",

--- a/scripts/generate-bazel-rust-builds.mjs
+++ b/scripts/generate-bazel-rust-builds.mjs
@@ -1336,12 +1336,24 @@ for (const pkg of localPackages.values()) {
     // peak rustc memory stays bounded. opt-only (fastbuild/dev already split),
     // preserves -O optimization, applied to the main library the release
     // binary links.
+    const windowsOnlyRustcFlags = [];
     if (key === "meerkat-mob" && rule === "rust_library") {
       extraRustcFlags.push("-Ccodegen-units=256");
+      // Even at 256 codegen units, the crate's `-opt` local ThinLTO pass
+      // exhausted the Windows release executor's memory at 0.7.12 (rustc-LLVM
+      // out of memory, deterministic across retries incl. --jobs=1). Disable
+      // the local ThinLTO combine for this crate on Windows only; other
+      // platforms keep full optimization.
+      windowsOnlyRustcFlags.push("-Clto=off");
     }
-    if (extraRustcFlags.length) {
+    if (extraRustcFlags.length || windowsOnlyRustcFlags.length) {
       const editionIndex = attrs.indexOf(`    edition = "2024",`);
-      attrs.splice(editionIndex + 1, 0, `    rustc_flags = ${listExpr(extraRustcFlags)},`);
+      let rustcFlagsExpr = listExpr(extraRustcFlags);
+      if (windowsOnlyRustcFlags.length) {
+        const windowsList = `[${windowsOnlyRustcFlags.map((v) => q(v)).join(", ")}]`;
+        rustcFlagsExpr = `${rustcFlagsExpr} + select({\n        "@platforms//os:windows": ${windowsList},\n        "//conditions:default": [],\n    })`;
+      }
+      attrs.splice(editionIndex + 1, 0, `    rustc_flags = ${rustcFlagsExpr},`);
     }
     if (rule === "rust_binary" || rule === "rust_test") {
       const packageRunfilesDir = relative(root, dir) || ".";


### PR DESCRIPTION
## Summary

Permanent, scoped replacement for the `MEERKAT_RELEASE_BUILDBUDDY_WINDOWS_EXTRA_BAZEL_ARGS` repo variable currently carrying `-Clto=off` globally for the Windows release lane.

The v0.7.12 Windows x86_64 binary build OOM'd deterministically compiling the `meerkat_mob` rlib (`rustc-LLVM ERROR: out of memory`) across four attempts: `--jobs=4`, `--jobs=1`, and `-Ccodegen-units=64` via the var — despite the existing `-Ccodegen-units=256` mitigation from 0.7.9/0.7.10. PR #821 grew the crate past the self-hosted Windows executor's ceiling for the opt-mode **local ThinLTO combine**; `-Clto=off` (applied via the var) is what got the v0.7.12 binaries built (run 28631651807).

This change makes the fix durable and *scoped*: the BUILD generator emits `-Clto=off` for `meerkat-mob` on Windows only via `select()` — other platforms and all other crates keep full optimization, unlike the repo-variable form which disables local ThinLTO for every crate on the lane.

After merge, clear the repo variable so this policy has exactly one owner:
`gh variable set MEERKAT_RELEASE_BUILDBUDDY_WINDOWS_EXTRA_BAZEL_ARGS --body ""`

🤖 Generated with [Claude Code](https://claude.com/claude-code)