### PR TITLE
CI: GHA-only lanes, ~17m warm — retire the GCP BuildBuddy CI fleet

### DIFF
--- a/.claude/skills/meerkat-architecture/SKILL.md
+++ b/.claude/skills/meerkat-architecture/SKILL.md
@@ -45,8 +45,14 @@ Architectural split:
   checked-in lockfile plus vendored generated BUILD bytes after Bazel exits.
   Persistent BUILD regeneration and module-lock updates are explicit maintenance
   steps, not normal local BuildBuddy lane behavior.
-- `.github/workflows/ci.yml` selects exactly one backend. Cargo and BuildBuddy
-  reusable workflows remain separate so CI lanes stay visible and comparable.
+- `.github/workflows/ci.yml` runs a single Cargo lane on free GitHub-hosted
+  runners (`cargo.yml`: change classification, lint+governance, tests,
+  generation ratchets, Web SDK/wasm, cargo-deny — parallel jobs, shared
+  rust-cache). Expensive low-churn lanes (feature matrices, minimal-feature,
+  surface modularity, e2e-system) run in `nightly.yml`. The GCP BuildBuddy CI
+  lane was retired 2026-07-03 (`buildbuddy.yml` is inert, pending deletion);
+  BuildBuddy remains an OPTIONAL local backend (`MEERKAT_BUILDBUDDY=1`) and
+  the hosted RELEASE binary flow is unchanged.
 
 Test lane authority belongs in Rust, not shell glue. The canonical e2e lane
 catalog is `tests/integration/src/e2e_lanes.rs`; scripts and Bazel targets

--- a/.github/actions/setup-rust-ci/action.yml
+++ b/.github/actions/setup-rust-ci/action.yml
@@ -6,6 +6,10 @@ runs:
   steps:
     - name: Install Rust
       uses: dtolnay/rust-toolchain@1.94.0
+      with:
+        # The CI lanes run fmt/clippy directly; the dtolnay action installs a
+        # minimal profile, so name the components explicitly.
+        components: rustfmt, clippy
 
     - name: Pin Rust toolchain binaries
       shell: bash

--- a/.github/workflows/buildbuddy.yml
+++ b/.github/workflows/buildbuddy.yml
@@ -1,5 +1,13 @@
 name: GCP BuildBuddy CI
 
+# RETIRED FROM CI ROUTING (2026-07-03): ci.yml no longer calls this workflow;
+# CI runs on free GitHub-hosted runners via cargo.yml + nightly.yml. This file
+# is `workflow_call`-only, so with no caller it is inert. It is kept as a
+# manual fallback during the transition (restore by re-adding the ci.yml job
+# or `git revert`). DELETE this file — together with the GCP control-plane /
+# executor-pool scripts it drives — once a few releases have shipped cleanly
+# on the GHA-only lane.
+
 on:
   workflow_call:
     inputs:

--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -1,17 +1,31 @@
 name: Cargo CI
 
+# The only CI lane. Runs entirely on free GitHub-hosted standard runners.
+#
+# Job layout (parallel, sharing one rust-cache key):
+#   changes          — path classification (docs-only changes skip Rust jobs)
+#   lint-governance  — fmt, workspace clippy, typed governance gates
+#   test             — unit + integration-fast + deterministic e2e lane
+#   ratchets         — version/schema/SDK/surface generation ratchets
+#   sdk-wasm         — Web SDK build+tests, wasm32 runtime check
+#   audit            — cargo-deny security/license audit
+#   gate             — aggregate (branch protection targets ci.yml's "CI gate")
+#
+# The heavy low-yield lanes (feature matrices, minimal-feature build,
+# surface-modularity, e2e-system, per-package clippy) run in nightly.yml.
+
 on:
   workflow_call:
     inputs:
       base_sha:
-        description: Base revision for changed-path Cargo gating.
+        description: Base revision for changed-path gating.
         required: false
         default: ""
         type: string
   workflow_dispatch:
     inputs:
       base_sha:
-        description: Optional base revision for changed-path Cargo gating.
+        description: Optional base revision for changed-path gating.
         required: false
         default: ""
         type: string
@@ -23,16 +37,181 @@ env:
   CARGO_TERM_COLOR: always
   CARGO_HOME: /tmp/meerkat-cargo-home
   RUSTUP_TOOLCHAIN: 1.94.0
+  # Keep repo-cargo's per-worktree redirection out of CI: pin the target dir
+  # where Swatinem/rust-cache caches it (scripts/repo-cargo respects a
+  # pre-set CARGO_TARGET_DIR).
+  CARGO_TARGET_DIR: ${{ github.workspace }}/target
+  # CI never reuses incremental state across compiles within a job, and
+  # debuginfo in test binaries only bloats the cache; both off for speed.
+  CARGO_INCREMENTAL: "0"
+  CARGO_PROFILE_DEV_DEBUG: "0"
+  CARGO_PROFILE_TEST_DEBUG: "0"
 
 jobs:
-  cargo:
-    name: GHA Cargo
-    runs-on: ${{ fromJSON(vars.MEERKAT_CI_RUNNER || '"ubuntu-latest"') }}
+  changes:
+    name: Change classification
+    runs-on: ubuntu-latest
+    outputs:
+      code_changed: ${{ steps.classify.outputs.code_changed }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
+
+      - name: Classify changed paths
+        id: classify
+        env:
+          BASE_SHA: ${{ inputs.base_sha || '' }}
+        run: |
+          set -euo pipefail
+          code_changed=true
+          if [[ -n "${BASE_SHA}" && "${BASE_SHA}" != "0000000000000000000000000000000000000000" ]] \
+            && git cat-file -e "${BASE_SHA}^{commit}" 2>/dev/null; then
+            # Docs-only changes (docs trees, markdown, agent config) skip the
+            # Rust jobs entirely. Anything else — or an unknown base — runs
+            # the full lane (fail open into MORE CI, never less).
+            if ! git diff --name-only "${BASE_SHA}...HEAD" | grep -qvE \
+              '^(docs/|docs-internal/|\.claude/|CHANGELOG\.md|README\.md|.*\.md$)'; then
+              code_changed=false
+            fi
+          fi
+          echo "code_changed=${code_changed}" >> "$GITHUB_OUTPUT"
+          echo "code_changed=${code_changed}"
+
+  lint-governance:
+    name: Lint + governance gates
+    needs: changes
+    if: ${{ needs.changes.outputs.code_changed == 'true' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Rust
+        uses: ./.github/actions/setup-rust-ci
+
+      - name: Cache cargo
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: ci
+
+      - name: Format check
+        run: make fmt-check
+
+      - name: Clippy (workspace, all features, all targets)
+        run: make lint
+
+      - name: Surface/backend gates
+        run: make legacy-surface-gate session-control-gate deprecated-backend-gate bridge-no-responsestatus-gate
+
+      - name: Dogma skill docs mirror
+        run: make sync-meerkat-dogma-skill-docs
+
+      - name: Typed governance gates (rmat-audit set)
+        run: make rmat-audit
+
+      - name: Seam inventory (strict)
+        run: make seam-inventory
+
+      - name: Runtime authority bypass audit
+        run: make runtime-authority-bypass
+
+      - name: Machine authority docs gate
+        run: make machine-authority-docs-gate
+
+      - name: Machine poster coverage
+        run: make verify-machine-poster-coverage
+
+      - name: Generated headers audit
+        run: make audit-generated-headers
+
+  test:
+    name: Tests (unit + int + e2e-fast)
+    needs: changes
+    if: ${{ needs.changes.outputs.code_changed == 'true' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Rust
+        uses: ./.github/actions/setup-rust-ci
+
+      - name: Cache cargo
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: ci
+
+      - name: Install nextest
+        uses: taiki-e/install-action@nextest
+        env:
+          HOME: ${{ runner.temp }}/install-action-home-${{ github.job }}
+
+      - name: Unit tests
+        run: make test-unit
+
+      - name: Integration-fast tests
+        run: make test-int
+
+      - name: Deterministic e2e lane
+        run: make e2e-fast
+
+  ratchets:
+    name: Generation ratchets
+    needs: changes
+    if: ${{ needs.changes.outputs.code_changed == 'true' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Rust
+        uses: ./.github/actions/setup-rust-ci
+
+      - name: Cache cargo
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: ci
+
+      - name: Docs validation
+        run: make docs-check
+
+      - name: Verify version parity
+        run: make verify-version-parity
+
+      - name: Verify schema freshness
+        run: make verify-schema-freshness
+
+      - name: Verify SDK codegen freshness
+        run: make verify-sdk-codegen-freshness
+
+      - name: Verify SDK event inventory
+        run: make verify-sdk-event-inventory
+
+      - name: Verify RPC surface alignment
+        run: make verify-rpc-surface-alignment
+
+      - name: Verify REST surface alignment
+        run: make verify-rest-surface-alignment
+
+      - name: Verify SDK wrapper freshness
+        run: make verify-sdk-wrapper-freshness
+
+      - name: Verify generated machine kernels are not stale
+        run: make machine-check-drift
+
+      - name: Check Rust release packaging
+        run: make check-rust-release-packaging
+
+  sdk-wasm:
+    name: Web SDK + wasm32
+    needs: changes
+    if: ${{ needs.changes.outputs.code_changed == 'true' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
 
       - name: Setup Rust
         uses: ./.github/actions/setup-rust-ci
@@ -58,48 +237,66 @@ jobs:
           install -m 0755 "/tmp/wasm-pack-v${version}-x86_64-unknown-linux-musl/wasm-pack" "$HOME/.cargo/bin/wasm-pack"
           wasm-pack --version
 
-      - name: Cache cargo registry
+      - name: Cache cargo
         uses: Swatinem/rust-cache@v2
-
-      - name: Install nextest
-        uses: taiki-e/install-action@nextest
-        env:
-          HOME: ${{ runner.temp }}/install-action-home-${{ github.job }}
-
-      - name: Cargo changed-path gate
-        env:
-          BASE_SHA: ${{ inputs.base_sha || '' }}
-        run: |
-          args=()
-          if [[ -n "${BASE_SHA}" && "${BASE_SHA}" != "0000000000000000000000000000000000000000" ]]; then
-            args+=(--base "${BASE_SHA}")
-          fi
-          scripts/cargo-agent-gate "${args[@]}" --committed
-
-      # Generation / drift ratchets (Dogma Rule 9). These previously ran only in
-      # the owner-gated BuildBuddy lane, so contributor PRs through this cargo
-      # lane could land schema/SDK/kernel/surface drift with green CI. Run them
-      # here so the ratchets bind every contributor, not just the owner.
-      - name: Verify version parity
-        run: make verify-version-parity
-
-      - name: Verify schema freshness
-        run: make verify-schema-freshness
-
-      - name: Verify SDK codegen freshness
-        run: make verify-sdk-codegen-freshness
-
-      - name: Verify RPC surface alignment
-        run: make verify-rpc-surface-alignment
-
-      - name: Verify REST surface alignment
-        run: make verify-rest-surface-alignment
-
-      - name: Verify generated machine kernels are not stale
-        run: make machine-check-drift
+        with:
+          shared-key: ci-wasm
 
       - name: Web SDK build and tests
         run: make test-sdk-web
 
       - name: WASM runtime check
         run: make wasm-check
+
+  audit:
+    name: Security audit
+    needs: changes
+    if: ${{ needs.changes.outputs.code_changed == 'true' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Rust
+        uses: ./.github/actions/setup-rust-ci
+
+      - name: Install cargo-deny
+        uses: taiki-e/install-action@cargo-deny
+        env:
+          HOME: ${{ runner.temp }}/install-action-home-${{ github.job }}
+
+      - name: Cargo deny
+        run: make audit
+
+  gate:
+    name: Cargo lane gate
+    if: ${{ always() }}
+    needs:
+      - changes
+      - lint-governance
+      - test
+      - ratchets
+      - sdk-wasm
+      - audit
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check lane results
+        shell: bash
+        env:
+          RESULTS: >-
+            ${{ needs.changes.result }}
+            ${{ needs.lint-governance.result }}
+            ${{ needs.test.result }}
+            ${{ needs.ratchets.result }}
+            ${{ needs.sdk-wasm.result }}
+            ${{ needs.audit.result }}
+        run: |
+          echo "Job results: ${RESULTS}"
+          for result in ${RESULTS}; do
+            case "${result}" in
+              failure|cancelled)
+                echo "::error::A cargo lane job failed or was cancelled."
+                exit 1
+                ;;
+            esac
+          done

--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -46,7 +46,10 @@ permissions:
 
 env:
   CARGO_TERM_COLOR: always
-  CARGO_HOME: /tmp/meerkat-cargo-home
+  # Stable per-VM Cargo home: hosted runners are fresh per job, and cache
+  # reuse (rust-cache + sccache) requires registry source paths that do not
+  # change between runs.
+  CARGO_HOME: /home/runner/.cargo
   RUSTUP_TOOLCHAIN: 1.94.0
   # Keep repo-cargo's per-worktree redirection out of CI: pin the target dir
   # where Swatinem/rust-cache caches it (scripts/repo-cargo respects a

--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -1,18 +1,29 @@
 name: Cargo CI
 
-# The only CI lane. Runs entirely on free GitHub-hosted standard runners.
+# The only CI lane. Runs entirely on free GitHub-hosted standard runners with
+# a ~10-minute wall-clock target: many small parallel jobs, sccache
+# (content-addressed compile cache) + mold (fast linker), and path gating so
+# work scales with what actually changed.
 #
-# Job layout (parallel, sharing one rust-cache key):
-#   changes          — path classification (docs-only changes skip Rust jobs)
-#   lint-governance  — fmt, workspace clippy, typed governance gates
-#   test             — unit + integration-fast + deterministic e2e lane
-#   ratchets         — version/schema/SDK/surface generation ratchets
-#   sdk-wasm         — Web SDK build+tests, wasm32 runtime check
-#   audit            — cargo-deny security/license audit
-#   gate             — aggregate (branch protection targets ci.yml's "CI gate")
+# Per-push jobs:
+#   changes         — path classification (docs-only skips Rust; SDK-relevant
+#                     paths enable the full Web SDK suite)
+#   fmt-governance  — fmt + surface gates + typed governance gates
+#   clippy          — workspace clippy, all features, lib/bin targets
+#                     (--all-targets multiplies build volume several-fold for
+#                     test-only lint yield; it runs nightly)
+#   test (x3)       — unit + integration-fast, nextest hash-partitioned
+#   e2e-fast        — deterministic end-to-end lane (real binaries)
+#   ratchets        — version/schema/SDK/surface generation ratchets
+#   wasm-check      — wasm32 cargo check (every code change)
+#   sdk-web         — full Web SDK suite (wasm-pack + wasm-opt + node tests);
+#                     only when SDK-relevant paths changed
+#   audit           — cargo-deny security/license audit
+#   gate            — aggregate (branch protection targets ci.yml's "CI gate")
 #
-# The heavy low-yield lanes (feature matrices, minimal-feature build,
-# surface-modularity, e2e-system, per-package clippy) run in nightly.yml.
+# Deferred to nightly.yml: feature matrices, minimal-feature build,
+# surface-modularity, e2e-system, clippy --all-targets, release packaging,
+# unconditional Web SDK suite.
 
 on:
   workflow_call:
@@ -46,6 +57,12 @@ env:
   CARGO_INCREMENTAL: "0"
   CARGO_PROFILE_DEV_DEBUG: "0"
   CARGO_PROFILE_TEST_DEBUG: "0"
+  # sccache is content-addressed, so it survives fresh-checkout mtimes (which
+  # defeat cargo's own fingerprints for workspace crates) and is shared
+  # across the divergent CARGO_TARGET_DIRs the xtask gate scripts use.
+  SCCACHE_GHA_ENABLED: "true"
+  # Cache-service hiccups must degrade to plain compiles, never fail a job.
+  SCCACHE_IGNORE_SERVER_IO_ERROR: "1"
 
 jobs:
   changes:
@@ -53,6 +70,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       code_changed: ${{ steps.classify.outputs.code_changed }}
+      sdk_changed: ${{ steps.classify.outputs.sdk_changed }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -66,30 +84,35 @@ jobs:
         run: |
           set -euo pipefail
           code_changed=true
+          sdk_changed=true
           if [[ -n "${BASE_SHA}" && "${BASE_SHA}" != "0000000000000000000000000000000000000000" ]] \
             && git cat-file -e "${BASE_SHA}^{commit}" 2>/dev/null; then
+            changed=$(git diff --name-only "${BASE_SHA}...HEAD")
             # Docs-only changes (docs trees, markdown, agent config) skip the
             # Rust jobs entirely. Anything else — or an unknown base — runs
             # the full lane (fail open into MORE CI, never less).
-            if ! git diff --name-only "${BASE_SHA}...HEAD" | grep -qvE \
-              '^(docs/|docs-internal/|\.claude/|CHANGELOG\.md|README\.md|.*\.md$)'; then
+            if ! grep -qvE '^(docs/|docs-internal/|\.claude/|CHANGELOG\.md|README\.md|.*\.md$)' <<<"${changed}"; then
               code_changed=false
+            fi
+            # The full Web SDK suite (wasm-pack + wasm-opt + node tests) is
+            # inherently slow; run it per push only when SDK-relevant
+            # surfaces changed. wasm-check still runs on every code change,
+            # and nightly runs the full suite unconditionally.
+            if ! grep -qE '^(sdks/|meerkat-web-runtime/|meerkat-contracts/|meerkat-core/|artifacts/schemas/|Cargo\.(toml|lock)|Makefile|\.github/)' <<<"${changed}"; then
+              sdk_changed=false
             fi
           fi
           echo "code_changed=${code_changed}" >> "$GITHUB_OUTPUT"
-          echo "code_changed=${code_changed}"
+          echo "sdk_changed=${sdk_changed}" >> "$GITHUB_OUTPUT"
+          echo "code_changed=${code_changed} sdk_changed=${sdk_changed}"
 
-  lint-governance:
-    name: Lint + governance gates
+  fmt-governance:
+    name: Format + governance gates
     needs: changes
     if: ${{ needs.changes.outputs.code_changed == 'true' }}
     runs-on: ubuntu-latest
     env:
-      # sccache is content-addressed, so it survives fresh-checkout mtimes
-      # (which defeat cargo's own fingerprints for workspace crates) and is
-      # shared across the different CARGO_TARGET_DIRs the xtask gates use.
       RUSTC_WRAPPER: sccache
-      SCCACHE_GHA_ENABLED: "true"
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -108,13 +131,10 @@ jobs:
         with:
           # One cache key PER JOB: with a single shared key only the first
           # job to save wins and every other job stays cold forever.
-          shared-key: ci-lint
+          shared-key: ci-governance
 
       - name: Format check
         run: make fmt-check
-
-      - name: Clippy (workspace, all features, all targets)
-        run: make lint
 
       - name: Surface/backend gates
         run: make legacy-surface-gate session-control-gate deprecated-backend-gate bridge-no-responsestatus-gate
@@ -140,17 +160,45 @@ jobs:
       - name: Generated headers audit
         run: make audit-generated-headers
 
-  test:
-    name: Tests (unit + int + e2e-fast)
+  clippy:
+    name: Clippy (workspace, all features)
     needs: changes
     if: ${{ needs.changes.outputs.code_changed == 'true' }}
     runs-on: ubuntu-latest
     env:
-      # sccache is content-addressed, so it survives fresh-checkout mtimes
-      # (which defeat cargo's own fingerprints for workspace crates) and is
-      # shared across the different CARGO_TARGET_DIRs the xtask gates use.
       RUSTC_WRAPPER: sccache
-      SCCACHE_GHA_ENABLED: "true"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Rust
+        uses: ./.github/actions/setup-rust-ci
+
+      - name: Setup sccache
+        uses: mozilla-actions/sccache-action@v0.0.9
+
+      - name: Setup mold linker
+        uses: rui314/setup-mold@v1
+
+      - name: Cache cargo
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: ci-clippy
+
+      - name: Clippy (lib/bin targets; --all-targets runs nightly)
+        run: ./scripts/repo-cargo clippy --workspace --all-features -- -D warnings
+
+  test:
+    name: Tests (shard ${{ matrix.partition }}/3)
+    needs: changes
+    if: ${{ needs.changes.outputs.code_changed == 'true' }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        partition: [1, 2, 3]
+    env:
+      RUSTC_WRAPPER: sccache
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -174,11 +222,41 @@ jobs:
         env:
           HOME: ${{ runner.temp }}/install-action-home-${{ github.job }}
 
-      - name: Unit tests
-        run: make test-unit
+      - name: Unit tests (shard)
+        run: ./scripts/repo-cargo unit --partition "hash:${{ matrix.partition }}/3"
 
-      - name: Integration-fast tests
-        run: make test-int
+      - name: Integration-fast tests (shard)
+        run: ./scripts/repo-cargo int --partition "hash:${{ matrix.partition }}/3"
+
+  e2e-fast:
+    name: Deterministic e2e lane
+    needs: changes
+    if: ${{ needs.changes.outputs.code_changed == 'true' }}
+    runs-on: ubuntu-latest
+    env:
+      RUSTC_WRAPPER: sccache
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Rust
+        uses: ./.github/actions/setup-rust-ci
+
+      - name: Setup sccache
+        uses: mozilla-actions/sccache-action@v0.0.9
+
+      - name: Setup mold linker
+        uses: rui314/setup-mold@v1
+
+      - name: Cache cargo
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: ci-e2e
+
+      - name: Install nextest
+        uses: taiki-e/install-action@nextest
+        env:
+          HOME: ${{ runner.temp }}/install-action-home-${{ github.job }}
 
       - name: Deterministic e2e lane
         run: make e2e-fast
@@ -189,11 +267,7 @@ jobs:
     if: ${{ needs.changes.outputs.code_changed == 'true' }}
     runs-on: ubuntu-latest
     env:
-      # sccache is content-addressed, so it survives fresh-checkout mtimes
-      # (which defeat cargo's own fingerprints for workspace crates) and is
-      # shared across the different CARGO_TARGET_DIRs the xtask gates use.
       RUSTC_WRAPPER: sccache
-      SCCACHE_GHA_ENABLED: "true"
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -243,17 +317,41 @@ jobs:
       # 4-core runner. It is release hygiene, re-verified by release_validate
       # at release time, and runs nightly instead of per push.
 
-  sdk-wasm:
-    name: Web SDK + wasm32
+  wasm-check:
+    name: wasm32 check
     needs: changes
     if: ${{ needs.changes.outputs.code_changed == 'true' }}
     runs-on: ubuntu-latest
     env:
-      # sccache is content-addressed, so it survives fresh-checkout mtimes
-      # (which defeat cargo's own fingerprints for workspace crates) and is
-      # shared across the different CARGO_TARGET_DIRs the xtask gates use.
       RUSTC_WRAPPER: sccache
-      SCCACHE_GHA_ENABLED: "true"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Rust
+        uses: ./.github/actions/setup-rust-ci
+
+      - name: Add wasm32 target
+        run: rustup target add wasm32-unknown-unknown
+
+      - name: Setup sccache
+        uses: mozilla-actions/sccache-action@v0.0.9
+
+      - name: Cache cargo
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: ci-wasm-check
+
+      - name: WASM runtime check
+        run: make wasm-check
+
+  sdk-web:
+    name: Web SDK build + tests
+    needs: changes
+    if: ${{ needs.changes.outputs.code_changed == 'true' && needs.changes.outputs.sdk_changed == 'true' }}
+    runs-on: ubuntu-latest
+    env:
+      RUSTC_WRAPPER: sccache
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -285,19 +383,13 @@ jobs:
       - name: Setup sccache
         uses: mozilla-actions/sccache-action@v0.0.9
 
-      - name: Setup mold linker
-        uses: rui314/setup-mold@v1
-
       - name: Cache cargo
         uses: Swatinem/rust-cache@v2
         with:
-          shared-key: ci-wasm
+          shared-key: ci-sdk-web
 
       - name: Web SDK build and tests
         run: make test-sdk-web
-
-      - name: WASM runtime check
-        run: make wasm-check
 
   audit:
     name: Security audit
@@ -324,10 +416,13 @@ jobs:
     if: ${{ always() }}
     needs:
       - changes
-      - lint-governance
+      - fmt-governance
+      - clippy
       - test
+      - e2e-fast
       - ratchets
-      - sdk-wasm
+      - wasm-check
+      - sdk-web
       - audit
     runs-on: ubuntu-latest
     steps:
@@ -336,10 +431,13 @@ jobs:
         env:
           RESULTS: >-
             ${{ needs.changes.result }}
-            ${{ needs.lint-governance.result }}
+            ${{ needs.fmt-governance.result }}
+            ${{ needs.clippy.result }}
             ${{ needs.test.result }}
+            ${{ needs.e2e-fast.result }}
             ${{ needs.ratchets.result }}
-            ${{ needs.sdk-wasm.result }}
+            ${{ needs.wasm-check.result }}
+            ${{ needs.sdk-web.result }}
             ${{ needs.audit.result }}
         run: |
           echo "Job results: ${RESULTS}"

--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -352,6 +352,11 @@ jobs:
     runs-on: ubuntu-latest
     env:
       RUSTC_WRAPPER: sccache
+      # Dev profile: skips wasm-opt (which dominates the release build — it
+      # chews through the opt-level=0 binary for many minutes) and compiles
+      # fast. This job runs the node unit tests, which never execute the
+      # wasm binary; nightly builds the release profile unconditionally.
+      MEERKAT_WEB_WASM_PROFILE: dev
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -84,12 +84,24 @@ jobs:
     needs: changes
     if: ${{ needs.changes.outputs.code_changed == 'true' }}
     runs-on: ubuntu-latest
+    env:
+      # sccache is content-addressed, so it survives fresh-checkout mtimes
+      # (which defeat cargo's own fingerprints for workspace crates) and is
+      # shared across the different CARGO_TARGET_DIRs the xtask gates use.
+      RUSTC_WRAPPER: sccache
+      SCCACHE_GHA_ENABLED: "true"
     steps:
       - name: Checkout
         uses: actions/checkout@v6
 
       - name: Setup Rust
         uses: ./.github/actions/setup-rust-ci
+
+      - name: Setup sccache
+        uses: mozilla-actions/sccache-action@v0.0.9
+
+      - name: Setup mold linker
+        uses: rui314/setup-mold@v1
 
       - name: Cache cargo
         uses: Swatinem/rust-cache@v2
@@ -133,12 +145,24 @@ jobs:
     needs: changes
     if: ${{ needs.changes.outputs.code_changed == 'true' }}
     runs-on: ubuntu-latest
+    env:
+      # sccache is content-addressed, so it survives fresh-checkout mtimes
+      # (which defeat cargo's own fingerprints for workspace crates) and is
+      # shared across the different CARGO_TARGET_DIRs the xtask gates use.
+      RUSTC_WRAPPER: sccache
+      SCCACHE_GHA_ENABLED: "true"
     steps:
       - name: Checkout
         uses: actions/checkout@v6
 
       - name: Setup Rust
         uses: ./.github/actions/setup-rust-ci
+
+      - name: Setup sccache
+        uses: mozilla-actions/sccache-action@v0.0.9
+
+      - name: Setup mold linker
+        uses: rui314/setup-mold@v1
 
       - name: Cache cargo
         uses: Swatinem/rust-cache@v2
@@ -164,12 +188,24 @@ jobs:
     needs: changes
     if: ${{ needs.changes.outputs.code_changed == 'true' }}
     runs-on: ubuntu-latest
+    env:
+      # sccache is content-addressed, so it survives fresh-checkout mtimes
+      # (which defeat cargo's own fingerprints for workspace crates) and is
+      # shared across the different CARGO_TARGET_DIRs the xtask gates use.
+      RUSTC_WRAPPER: sccache
+      SCCACHE_GHA_ENABLED: "true"
     steps:
       - name: Checkout
         uses: actions/checkout@v6
 
       - name: Setup Rust
         uses: ./.github/actions/setup-rust-ci
+
+      - name: Setup sccache
+        uses: mozilla-actions/sccache-action@v0.0.9
+
+      - name: Setup mold linker
+        uses: rui314/setup-mold@v1
 
       - name: Cache cargo
         uses: Swatinem/rust-cache@v2
@@ -212,6 +248,12 @@ jobs:
     needs: changes
     if: ${{ needs.changes.outputs.code_changed == 'true' }}
     runs-on: ubuntu-latest
+    env:
+      # sccache is content-addressed, so it survives fresh-checkout mtimes
+      # (which defeat cargo's own fingerprints for workspace crates) and is
+      # shared across the different CARGO_TARGET_DIRs the xtask gates use.
+      RUSTC_WRAPPER: sccache
+      SCCACHE_GHA_ENABLED: "true"
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -239,6 +281,12 @@ jobs:
           tar -xzf "/tmp/${archive}" -C /tmp
           install -m 0755 "/tmp/wasm-pack-v${version}-x86_64-unknown-linux-musl/wasm-pack" "$HOME/.cargo/bin/wasm-pack"
           wasm-pack --version
+
+      - name: Setup sccache
+        uses: mozilla-actions/sccache-action@v0.0.9
+
+      - name: Setup mold linker
+        uses: rui314/setup-mold@v1
 
       - name: Cache cargo
         uses: Swatinem/rust-cache@v2

--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -94,7 +94,9 @@ jobs:
       - name: Cache cargo
         uses: Swatinem/rust-cache@v2
         with:
-          shared-key: ci
+          # One cache key PER JOB: with a single shared key only the first
+          # job to save wins and every other job stays cold forever.
+          shared-key: ci-lint
 
       - name: Format check
         run: make fmt-check
@@ -141,7 +143,7 @@ jobs:
       - name: Cache cargo
         uses: Swatinem/rust-cache@v2
         with:
-          shared-key: ci
+          shared-key: ci-test
 
       - name: Install nextest
         uses: taiki-e/install-action@nextest
@@ -172,7 +174,7 @@ jobs:
       - name: Cache cargo
         uses: Swatinem/rust-cache@v2
         with:
-          shared-key: ci
+          shared-key: ci-ratchets
 
       - name: Docs validation
         run: make docs-check
@@ -200,9 +202,10 @@ jobs:
 
       - name: Verify generated machine kernels are not stale
         run: make machine-check-drift
-
-      - name: Check Rust release packaging
-        run: make check-rust-release-packaging
+      # check-rust-release-packaging dry-run-packages every release crate
+      # (each `cargo package` compiles the crate in isolation) — ~1h on a
+      # 4-core runner. It is release hygiene, re-verified by release_validate
+      # at release time, and runs nightly instead of per push.
 
   sdk-wasm:
     name: Web SDK + wasm32

--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -12,7 +12,7 @@ name: Cargo CI
 #   clippy          — workspace clippy, all features, lib/bin targets
 #                     (--all-targets multiplies build volume several-fold for
 #                     test-only lint yield; it runs nightly)
-#   test (x3)       — unit + integration-fast, nextest hash-partitioned
+#   test (x6)       — unit + integration-fast, nextest hash-partitioned
 #   e2e-fast        — deterministic end-to-end lane (real binaries)
 #   ratchets        — version/schema/SDK/surface generation ratchets
 #   wasm-check      — wasm32 cargo check (every code change)
@@ -189,14 +189,14 @@ jobs:
         run: ./scripts/repo-cargo clippy --workspace --all-features -- -D warnings
 
   test:
-    name: Tests (shard ${{ matrix.partition }}/3)
+    name: Tests (shard ${{ matrix.partition }}/6)
     needs: changes
     if: ${{ needs.changes.outputs.code_changed == 'true' }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        partition: [1, 2, 3]
+        partition: [1, 2, 3, 4, 5, 6]
     env:
       RUSTC_WRAPPER: sccache
     steps:
@@ -223,10 +223,10 @@ jobs:
           HOME: ${{ runner.temp }}/install-action-home-${{ github.job }}
 
       - name: Unit tests (shard)
-        run: ./scripts/repo-cargo unit --partition "hash:${{ matrix.partition }}/3"
+        run: ./scripts/repo-cargo unit --partition "hash:${{ matrix.partition }}/6"
 
       - name: Integration-fast tests (shard)
-        run: ./scripts/repo-cargo int --partition "hash:${{ matrix.partition }}/3"
+        run: ./scripts/repo-cargo int --partition "hash:${{ matrix.partition }}/6"
 
   e2e-fast:
     name: Deterministic e2e lane

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,16 @@
 name: CI
 
+# Single-lane CI on GitHub-hosted runners (free for this public repo).
+#
+# The former GCP BuildBuddy lane (control-plane + 12-executor RBE fleet spun
+# up per run) was retired on 2026-07-03 for cost: every push routed ~360
+# vCPUs of STANDARD-provisioned c3d compute plus a 24/7 control plane. The
+# cargo lane below covers the same gate set; the expensive low-yield lanes
+# (feature matrices, e2e-system, per-package no-unification clippy) moved to
+# the nightly workflow. `buildbuddy.yml` is kept unreferenced as a manual
+# fallback during the transition and should be deleted once a few releases
+# have gone through cleanly.
+
 on:
   push:
     branches:
@@ -13,21 +24,7 @@ on:
       - synchronize
       - reopened
       - ready_for_review
-  workflow_dispatch:
-    inputs:
-      lane:
-        description: CI lane to run.
-        required: true
-        default: cargo
-        type: choice
-        options:
-          - cargo
-          - gcp-buildbuddy
-      mode:
-        description: GCP BuildBuddy mode.
-        required: false
-        default: full-fresh
-        type: string
+  workflow_dispatch: {}
 
 concurrency:
   group: ci-${{ github.event.pull_request.number || github.ref }}
@@ -35,16 +32,10 @@ concurrency:
 
 permissions:
   contents: read
-  id-token: write
 
 jobs:
   cargo:
     name: GHA Cargo
-    if: >-
-      ${{
-        (github.event_name == 'workflow_dispatch' && inputs.lane == 'cargo') ||
-        (github.event_name != 'workflow_dispatch' && github.actor != 'lukacf')
-      }}
     uses: ./.github/workflows/cargo.yml
     with:
       base_sha: >-
@@ -54,67 +45,20 @@ jobs:
           ''
         }}
 
-  gcp-buildbuddy:
-    name: GCP BuildBuddy
-    if: >-
-      ${{
-        github.actor == 'lukacf' &&
-        ((github.event_name == 'workflow_dispatch' && inputs.lane == 'gcp-buildbuddy') ||
-         github.event_name == 'push' ||
-         github.event_name == 'pull_request')
-      }}
-    uses: ./.github/workflows/buildbuddy.yml
-    with:
-      mode: ${{ inputs.mode || 'full-fresh' }}
-      machine_authority_base_sha: >-
-        ${{
-          github.event_name == 'pull_request' && github.event.pull_request.base.sha ||
-          github.event_name == 'push' && github.event.before ||
-          ''
-        }}
-      machine_authority_head_sha: ${{ github.sha }}
-    secrets: inherit
-
-  unauthorized-gcp-buildbuddy:
-    name: GCP BuildBuddy authorization
-    if: ${{ github.event_name == 'workflow_dispatch' && inputs.lane == 'gcp-buildbuddy' && github.actor != 'lukacf' }}
-    runs-on: ubuntu-latest
-    steps:
-      - name: Reject unauthorized GCP BuildBuddy run
-        run: |
-          echo "::error::Only lukacf can run the secret-backed GCP BuildBuddy lane."
-          exit 1
-
   gate:
     name: CI gate
     if: ${{ always() }}
     needs:
       - cargo
-      - gcp-buildbuddy
-      - unauthorized-gcp-buildbuddy
     runs-on: ubuntu-latest
     steps:
-      - name: Check selected CI backend
+      - name: Check CI result
         shell: bash
         env:
           CARGO_RESULT: ${{ needs.cargo.result }}
-          GCP_BUILDBUDDY_RESULT: ${{ needs.gcp-buildbuddy.result }}
-          UNAUTHORIZED_GCP_BUILDBUDDY_RESULT: ${{ needs.unauthorized-gcp-buildbuddy.result }}
         run: |
           echo "GHA Cargo result: ${CARGO_RESULT}"
-          echo "GCP BuildBuddy result: ${GCP_BUILDBUDDY_RESULT}"
-          echo "GCP BuildBuddy authorization result: ${UNAUTHORIZED_GCP_BUILDBUDDY_RESULT}"
-
-          for result in "${CARGO_RESULT}" "${GCP_BUILDBUDDY_RESULT}" "${UNAUTHORIZED_GCP_BUILDBUDDY_RESULT}"; do
-            case "${result}" in
-              failure|cancelled)
-                echo "::error::A CI backend failed or was cancelled."
-                exit 1
-                ;;
-            esac
-          done
-
-          if [[ "${CARGO_RESULT}" != "success" && "${GCP_BUILDBUDDY_RESULT}" != "success" ]]; then
-            echo "::error::No CI backend completed successfully."
+          if [[ "${CARGO_RESULT}" != "success" ]]; then
+            echo "::error::CI did not complete successfully."
             exit 1
           fi

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,15 +1,19 @@
 name: Nightly
 
-# Expensive, low-churn lanes that used to run on every push via the GCP
-# BuildBuddy fleet. They rarely fail independently of the per-push lane, so
-# they run once a day on free hosted runners instead (plus on demand).
+# Expensive, low-churn lanes that used to run on every push (first on the GCP
+# BuildBuddy fleet, then in the per-push cargo lane). They rarely fail
+# independently of the per-push lane, so they run once a day on free hosted
+# runners instead (plus on demand).
 #
 # Coverage rationale:
+#   clippy-full       — clippy --all-targets --all-features (per push runs
+#                       lib/bin targets only; test-target lints land here)
 #   feature-matrix    — feature-unification bugs the all-features lane hides
 #   minimal/modular   — minimal-feature builds + surface modularity contracts
-#   per-crate clippy  — no-feature-unification lint fidelity (the Bazel
-#                       per-crate clippy equivalent; has caught real bugs)
 #   e2e-system        — real-binary/local-resource lane
+#   sdk-web           — full Web SDK suite (per push it is path-gated to
+#                       SDK-relevant changes)
+#   release-packaging — per-crate `cargo package` dry-run (release hygiene)
 #   audit             — daily cargo-deny advisory sweep
 
 on:
@@ -28,11 +32,15 @@ env:
   CARGO_INCREMENTAL: "0"
   CARGO_PROFILE_DEV_DEBUG: "0"
   CARGO_PROFILE_TEST_DEBUG: "0"
+  SCCACHE_GHA_ENABLED: "true"
+  SCCACHE_IGNORE_SERVER_IO_ERROR: "1"
 
 jobs:
-  feature-matrix:
-    name: Feature matrix (lint + test)
+  clippy-full:
+    name: Clippy (all targets, all features)
     runs-on: ubuntu-latest
+    env:
+      RUSTC_WRAPPER: sccache
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -40,10 +48,42 @@ jobs:
       - name: Setup Rust
         uses: ./.github/actions/setup-rust-ci
 
+      - name: Setup sccache
+        uses: mozilla-actions/sccache-action@v0.0.9
+
+      - name: Setup mold linker
+        uses: rui314/setup-mold@v1
+
       - name: Cache cargo
         uses: Swatinem/rust-cache@v2
         with:
-          shared-key: nightly
+          shared-key: nightly-clippy-full
+
+      - name: Clippy (workspace, all features, all targets)
+        run: make lint
+
+  feature-matrix:
+    name: Feature matrix (lint + test)
+    runs-on: ubuntu-latest
+    env:
+      RUSTC_WRAPPER: sccache
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Rust
+        uses: ./.github/actions/setup-rust-ci
+
+      - name: Setup sccache
+        uses: mozilla-actions/sccache-action@v0.0.9
+
+      - name: Setup mold linker
+        uses: rui314/setup-mold@v1
+
+      - name: Cache cargo
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: nightly-matrix
 
       - name: Install nextest
         uses: taiki-e/install-action@nextest
@@ -59,12 +99,20 @@ jobs:
   minimal-and-modularity:
     name: Minimal features + surface modularity
     runs-on: ubuntu-latest
+    env:
+      RUSTC_WRAPPER: sccache
     steps:
       - name: Checkout
         uses: actions/checkout@v6
 
       - name: Setup Rust
         uses: ./.github/actions/setup-rust-ci
+
+      - name: Setup sccache
+        uses: mozilla-actions/sccache-action@v0.0.9
+
+      - name: Setup mold linker
+        uses: rui314/setup-mold@v1
 
       - name: Cache cargo
         uses: Swatinem/rust-cache@v2
@@ -85,6 +133,8 @@ jobs:
   e2e-system:
     name: System e2e lane
     runs-on: ubuntu-latest
+    env:
+      RUSTC_WRAPPER: sccache
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -92,10 +142,16 @@ jobs:
       - name: Setup Rust
         uses: ./.github/actions/setup-rust-ci
 
+      - name: Setup sccache
+        uses: mozilla-actions/sccache-action@v0.0.9
+
+      - name: Setup mold linker
+        uses: rui314/setup-mold@v1
+
       - name: Cache cargo
         uses: Swatinem/rust-cache@v2
         with:
-          shared-key: nightly
+          shared-key: nightly-e2e-system
 
       - name: Install nextest
         uses: taiki-e/install-action@nextest
@@ -105,15 +161,67 @@ jobs:
       - name: Real-binary system lane
         run: make e2e-system
 
-  release-packaging:
-    name: Release packaging dry-run
+  sdk-web:
+    name: Web SDK build + tests
     runs-on: ubuntu-latest
+    env:
+      RUSTC_WRAPPER: sccache
     steps:
       - name: Checkout
         uses: actions/checkout@v6
 
       - name: Setup Rust
         uses: ./.github/actions/setup-rust-ci
+
+      - name: Add wasm32 target
+        run: rustup target add wasm32-unknown-unknown
+
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: "22"
+
+      - name: Install wasm-pack
+        shell: bash
+        run: |
+          set -euo pipefail
+          version="0.13.1"
+          archive="wasm-pack-v${version}-x86_64-unknown-linux-musl.tar.gz"
+          curl --fail --location --retry 5 --retry-delay 2 \
+            "https://github.com/wasm-bindgen/wasm-pack/releases/download/v${version}/${archive}" \
+            --output "/tmp/${archive}"
+          tar -xzf "/tmp/${archive}" -C /tmp
+          install -m 0755 "/tmp/wasm-pack-v${version}-x86_64-unknown-linux-musl/wasm-pack" "$HOME/.cargo/bin/wasm-pack"
+          wasm-pack --version
+
+      - name: Setup sccache
+        uses: mozilla-actions/sccache-action@v0.0.9
+
+      - name: Cache cargo
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: nightly-sdk-web
+
+      - name: Web SDK build and tests
+        run: make test-sdk-web
+
+  release-packaging:
+    name: Release packaging dry-run
+    runs-on: ubuntu-latest
+    env:
+      RUSTC_WRAPPER: sccache
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Rust
+        uses: ./.github/actions/setup-rust-ci
+
+      - name: Setup sccache
+        uses: mozilla-actions/sccache-action@v0.0.9
+
+      - name: Setup mold linker
+        uses: rui314/setup-mold@v1
 
       - name: Cache cargo
         uses: Swatinem/rust-cache@v2

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,124 @@
+name: Nightly
+
+# Expensive, low-churn lanes that used to run on every push via the GCP
+# BuildBuddy fleet. They rarely fail independently of the per-push lane, so
+# they run once a day on free hosted runners instead (plus on demand).
+#
+# Coverage rationale:
+#   feature-matrix    — feature-unification bugs the all-features lane hides
+#   minimal/modular   — minimal-feature builds + surface modularity contracts
+#   per-crate clippy  — no-feature-unification lint fidelity (the Bazel
+#                       per-crate clippy equivalent; has caught real bugs)
+#   e2e-system        — real-binary/local-resource lane
+#   audit             — daily cargo-deny advisory sweep
+
+on:
+  schedule:
+    - cron: "17 2 * * *"
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+env:
+  CARGO_TERM_COLOR: always
+  CARGO_HOME: /tmp/meerkat-cargo-home
+  RUSTUP_TOOLCHAIN: 1.94.0
+  CARGO_TARGET_DIR: ${{ github.workspace }}/target
+  CARGO_INCREMENTAL: "0"
+  CARGO_PROFILE_DEV_DEBUG: "0"
+  CARGO_PROFILE_TEST_DEBUG: "0"
+
+jobs:
+  feature-matrix:
+    name: Feature matrix (lint + test)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Rust
+        uses: ./.github/actions/setup-rust-ci
+
+      - name: Cache cargo
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: nightly
+
+      - name: Install nextest
+        uses: taiki-e/install-action@nextest
+        env:
+          HOME: ${{ runner.temp }}/install-action-home-${{ github.job }}
+
+      - name: Feature matrix clippy
+        run: make lint-feature-matrix
+
+      - name: Feature matrix tests
+        run: make test-feature-matrix
+
+  minimal-and-modularity:
+    name: Minimal features + surface modularity
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Rust
+        uses: ./.github/actions/setup-rust-ci
+
+      - name: Cache cargo
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: nightly-minimal
+
+      - name: Install nextest
+        uses: taiki-e/install-action@nextest
+        env:
+          HOME: ${{ runner.temp }}/install-action-home-${{ github.job }}
+
+      - name: Minimal feature tests
+        run: make test-minimal
+
+      - name: Surface modularity tests
+        run: make test-surface-modularity
+
+  e2e-system:
+    name: System e2e lane
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Rust
+        uses: ./.github/actions/setup-rust-ci
+
+      - name: Cache cargo
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: nightly
+
+      - name: Install nextest
+        uses: taiki-e/install-action@nextest
+        env:
+          HOME: ${{ runner.temp }}/install-action-home-${{ github.job }}
+
+      - name: Real-binary system lane
+        run: make e2e-system
+
+  audit:
+    name: Security audit
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Rust
+        uses: ./.github/actions/setup-rust-ci
+
+      - name: Install cargo-deny
+        uses: taiki-e/install-action@cargo-deny
+        env:
+          HOME: ${{ runner.temp }}/install-action-home-${{ github.job }}
+
+      - name: Cargo deny
+        run: make audit

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -105,6 +105,24 @@ jobs:
       - name: Real-binary system lane
         run: make e2e-system
 
+  release-packaging:
+    name: Release packaging dry-run
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Rust
+        uses: ./.github/actions/setup-rust-ci
+
+      - name: Cache cargo
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: nightly-packaging
+
+      - name: Check Rust release packaging
+        run: make check-rust-release-packaging
+
   audit:
     name: Security audit
     runs-on: ubuntu-latest

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -26,7 +26,10 @@ permissions:
 
 env:
   CARGO_TERM_COLOR: always
-  CARGO_HOME: /tmp/meerkat-cargo-home
+  # Stable per-VM Cargo home: hosted runners are fresh per job, and cache
+  # reuse (rust-cache + sccache) requires registry source paths that do not
+  # change between runs.
+  CARGO_HOME: /home/runner/.cargo
   RUSTUP_TOOLCHAIN: 1.94.0
   CARGO_TARGET_DIR: ${{ github.workspace }}/target
   CARGO_INCREMENTAL: "0"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -310,7 +310,7 @@ make audit       # Security audit via cargo-deny
 - `changes` — path classification (docs-only changes skip the Rust jobs; SDK-relevant paths enable `sdk-web`)
 - `fmt-governance` — fmt, surface/backend gates, dogma-docs mirror, rmat-audit set, seam-inventory, runtime-authority-bypass, machine-authority docs gate, poster coverage, generated-headers audit
 - `clippy` — workspace clippy, all features, lib/bin targets (`--all-targets` runs nightly)
-- `test` ×3 — `cargo unit` + `cargo int` sharded via nextest `--partition hash:N/3`
+- `test` ×6 — `cargo unit` + `cargo int` sharded via nextest `--partition hash:N/6`
 - `e2e-fast` — deterministic end-to-end lane
 - `ratchets` — docs-check, version parity, schema/SDK codegen freshness, SDK event inventory, RPC/REST surface alignment, SDK wrapper freshness, machine-kernel staleness
 - `wasm-check` — wasm32 cargo check (every code change)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -310,11 +310,11 @@ make audit       # Security audit via cargo-deny
 - `changes` — path classification (docs-only changes skip the Rust jobs)
 - `lint-governance` — fmt, workspace clippy, surface/backend gates, dogma-docs mirror, rmat-audit set, seam-inventory, runtime-authority-bypass, machine-authority docs gate, poster coverage, generated-headers audit
 - `test` — `test-unit` + `test-int` + `e2e-fast`
-- `ratchets` — docs-check, version parity, schema/SDK codegen freshness, SDK event inventory, RPC/REST surface alignment, SDK wrapper freshness, machine-kernel staleness, release packaging
+- `ratchets` — docs-check, version parity, schema/SDK codegen freshness, SDK event inventory, RPC/REST surface alignment, SDK wrapper freshness, machine-kernel staleness
 - `sdk-wasm` — Web SDK build+tests, wasm32 runtime check
 - `audit` — cargo-deny
 
-**Nightly** (`.github/workflows/nightly.yml`, cron + dispatch) — the expensive low-churn lanes: `lint-feature-matrix`, `test-feature-matrix`, `test-minimal`, `test-surface-modularity`, `e2e-system`, cargo-deny sweep.
+**Nightly** (`.github/workflows/nightly.yml`, cron + dispatch) — the expensive low-churn lanes: `lint-feature-matrix`, `test-feature-matrix`, `test-minimal`, `test-surface-modularity`, `e2e-system`, `check-rust-release-packaging`, cargo-deny sweep.
 
 The former GCP BuildBuddy CI lane (`buildbuddy.yml`) was retired from routing on 2026-07-03 (cost); the file is inert (`workflow_call`-only, no caller) and pending deletion. The BuildBuddy-hosted RELEASE flow (remote.buildbuddy.io + King Windows executors) is unaffected.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -306,15 +306,18 @@ make audit       # Security audit via cargo-deny
 
 ### GitHub Workflows
 
-**CI** (`.github/workflows/ci.yml`) — runs on push to main, PRs, feature branches, and manual dispatch, entirely on free GitHub-hosted runners. It calls `cargo.yml` (the only lane), then `gate` aggregates status. `cargo.yml` runs parallel jobs sharing one rust-cache key:
-- `changes` — path classification (docs-only changes skip the Rust jobs)
-- `lint-governance` — fmt, workspace clippy, surface/backend gates, dogma-docs mirror, rmat-audit set, seam-inventory, runtime-authority-bypass, machine-authority docs gate, poster coverage, generated-headers audit
-- `test` — `test-unit` + `test-int` + `e2e-fast`
+**CI** (`.github/workflows/ci.yml`) — runs on push to main, PRs, feature branches, and manual dispatch, entirely on free GitHub-hosted runners with a ~10-minute wall-clock target (sccache + mold + per-job rust-cache keys). It calls `cargo.yml` (the only lane), then `gate` aggregates status. `cargo.yml` runs parallel jobs:
+- `changes` — path classification (docs-only changes skip the Rust jobs; SDK-relevant paths enable `sdk-web`)
+- `fmt-governance` — fmt, surface/backend gates, dogma-docs mirror, rmat-audit set, seam-inventory, runtime-authority-bypass, machine-authority docs gate, poster coverage, generated-headers audit
+- `clippy` — workspace clippy, all features, lib/bin targets (`--all-targets` runs nightly)
+- `test` ×3 — `cargo unit` + `cargo int` sharded via nextest `--partition hash:N/3`
+- `e2e-fast` — deterministic end-to-end lane
 - `ratchets` — docs-check, version parity, schema/SDK codegen freshness, SDK event inventory, RPC/REST surface alignment, SDK wrapper freshness, machine-kernel staleness
-- `sdk-wasm` — Web SDK build+tests, wasm32 runtime check
+- `wasm-check` — wasm32 cargo check (every code change)
+- `sdk-web` — full Web SDK suite (only when SDK-relevant paths changed)
 - `audit` — cargo-deny
 
-**Nightly** (`.github/workflows/nightly.yml`, cron + dispatch) — the expensive low-churn lanes: `lint-feature-matrix`, `test-feature-matrix`, `test-minimal`, `test-surface-modularity`, `e2e-system`, `check-rust-release-packaging`, cargo-deny sweep.
+**Nightly** (`.github/workflows/nightly.yml`, cron + dispatch) — the expensive low-churn lanes: `lint` (clippy `--all-targets`), `lint-feature-matrix`, `test-feature-matrix`, `test-minimal`, `test-surface-modularity`, `e2e-system`, `test-sdk-web` (unconditional), `check-rust-release-packaging`, cargo-deny sweep.
 
 The former GCP BuildBuddy CI lane (`buildbuddy.yml`) was retired from routing on 2026-07-03 (cost); the file is inert (`workflow_call`-only, no caller) and pending deletion. The BuildBuddy-hosted RELEASE flow (remote.buildbuddy.io + King Windows executors) is unaffected.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -306,9 +306,17 @@ make audit       # Security audit via cargo-deny
 
 ### GitHub Workflows
 
-**CI** (`.github/workflows/ci.yml`) — runs on push to main, PRs, feature branches, and manual dispatch. It dispatches one of two lanes, then `gate` aggregates status:
-- `cargo` (`.github/workflows/cargo.yml`) — GHA Cargo lane (changed-path gate, version parity, schema/SDK codegen freshness, RPC/REST surface alignment, machine-kernel staleness)
-- `gcp-buildbuddy` (`.github/workflows/buildbuddy.yml`) — secret-backed GCP BuildBuddy lane (control-plane/executor spin-up, prebuild/static/native/governance/wasm/minimal-feature/feature/audit submit jobs); restricted to the repo owner
+**CI** (`.github/workflows/ci.yml`) — runs on push to main, PRs, feature branches, and manual dispatch, entirely on free GitHub-hosted runners. It calls `cargo.yml` (the only lane), then `gate` aggregates status. `cargo.yml` runs parallel jobs sharing one rust-cache key:
+- `changes` — path classification (docs-only changes skip the Rust jobs)
+- `lint-governance` — fmt, workspace clippy, surface/backend gates, dogma-docs mirror, rmat-audit set, seam-inventory, runtime-authority-bypass, machine-authority docs gate, poster coverage, generated-headers audit
+- `test` — `test-unit` + `test-int` + `e2e-fast`
+- `ratchets` — docs-check, version parity, schema/SDK codegen freshness, SDK event inventory, RPC/REST surface alignment, SDK wrapper freshness, machine-kernel staleness, release packaging
+- `sdk-wasm` — Web SDK build+tests, wasm32 runtime check
+- `audit` — cargo-deny
+
+**Nightly** (`.github/workflows/nightly.yml`, cron + dispatch) — the expensive low-churn lanes: `lint-feature-matrix`, `test-feature-matrix`, `test-minimal`, `test-surface-modularity`, `e2e-system`, cargo-deny sweep.
+
+The former GCP BuildBuddy CI lane (`buildbuddy.yml`) was retired from routing on 2026-07-03 (cost); the file is inert (`workflow_call`-only, no caller) and pending deletion. The BuildBuddy-hosted RELEASE flow (remote.buildbuddy.io + King Windows executors) is unaffected.
 
 **Release** (`.github/workflows/release.yml`) — runs on `v*` tag push or manual dispatch:
 

--- a/scripts/ci-pin-rust-toolchain-env
+++ b/scripts/ci-pin-rust-toolchain-env
@@ -20,10 +20,12 @@ if ! command -v rustup >/dev/null 2>&1; then
 fi
 
 if [[ "${GITHUB_ACTIONS:-}" == "true" ]]; then
-  cargo_home="${CARGO_HOME:-/tmp/meerkat-cargo-home}"
-  if [[ "${cargo_home}" == "/tmp/meerkat-cargo-home" ]]; then
-    cargo_home="/tmp/meerkat-cargo-home/${GITHUB_RUN_ID:-run}-${GITHUB_RUN_ATTEMPT:-1}-${GITHUB_JOB:-job}"
-  fi
+  # Hosted runners give every job a fresh VM, so a STABLE Cargo home is
+  # required: rust-cache/sccache reuse depends on registry source paths that
+  # do not change between runs. (The retired self-hosted runner needed a
+  # per-run path here for isolation; that inverted into a cache-killer on
+  # hosted runners — every dep compile hash embedded the run id.)
+  cargo_home="${CARGO_HOME:-${HOME}/.cargo}"
   mkdir -p "${cargo_home}"
 else
   cargo_home="${CARGO_HOME:-}"

--- a/scripts/repo-cargo
+++ b/scripts/repo-cargo
@@ -104,9 +104,6 @@ if [[ -n "${CARGO_TARGET_DIR:-}" ]]; then
   target_dir_was_set=true
 fi
 cargo_home="${CARGO_HOME:-${cache_root}/${repo_key}/cargo-home}"
-if [[ "${GITHUB_ACTIONS:-}" == "true" && "${cargo_home}" == "/tmp/meerkat-cargo-home" ]]; then
-  cargo_home="${cargo_home}/${lane_key}"
-fi
 export CARGO_HOME="${cargo_home}"
 export CARGO_TARGET_DIR="${CARGO_TARGET_DIR:-${cache_root}/${repo_key}/targets/${target_cache_schema}/${toolchain_key}/${lane_key}}"
 

--- a/scripts/rust-lane-doctor
+++ b/scripts/rust-lane-doctor
@@ -177,12 +177,16 @@ else
   bad "Cargo or BuildBuddy CI can fall back to runner Rust binaries"
 fi
 
-if grep -q 'CARGO_HOME: /tmp/meerkat-cargo-home' .github/workflows/cargo.yml &&
-  grep -q 'CARGO_HOME: /tmp/meerkat-cargo-home' .github/workflows/buildbuddy.yml &&
-  grep -Fq '${GITHUB_JOB:-job}' scripts/ci-pin-rust-toolchain-env; then
-  pass "CI and BuildBuddy workflows isolate Cargo home per GitHub job before cache restore"
+# Hosted runners give every job a fresh VM; the Cargo home must be STABLE
+# across runs so rust-cache/sccache can reuse registry sources. (The old
+# per-run /tmp isolation was for the retired shared self-hosted runner and
+# invalidated every dep compile hash on hosted runners.)
+if grep -q 'CARGO_HOME: /home/runner/.cargo' .github/workflows/cargo.yml &&
+  grep -q 'CARGO_HOME: /home/runner/.cargo' .github/workflows/nightly.yml &&
+  ! grep -Fq '${GITHUB_JOB:-job}' scripts/ci-pin-rust-toolchain-env; then
+  pass "CI workflows use a stable per-VM Cargo home (cacheable across runs)"
 else
-  bad "CI or BuildBuddy workflow can share mutable Cargo home across parallel jobs"
+  bad "CI Cargo home is unstable across runs (breaks sccache/rust-cache reuse)"
 fi
 
 selector_selftest_output="$(./scripts/rust-selector-selftest.mjs 2>&1 || true)"

--- a/xtask/BUILD.bazel
+++ b/xtask/BUILD.bazel
@@ -284,7 +284,6 @@ rust_test(
     data = [
         ":package_runfiles",
         "//:github_workflows",
-        "//:repo_governance_files",
         "tests/rustfmt_host.sh",
         "@@rules_rust++rust+rustfmt_nightly-2026-04-16__aarch64-apple-darwin_tools//:rustfmt_bin",
         "@@rules_rust++rust+rustfmt_nightly-2026-04-16__aarch64-apple-darwin_tools//:rustc_lib",

--- a/xtask/tests/ci_gate_requires_rmat.rs
+++ b/xtask/tests/ci_gate_requires_rmat.rs
@@ -74,11 +74,14 @@ fn cargo_workflow_covers_the_full_per_push_gate_set() {
         vec![
             "audit",
             "changes",
+            "clippy",
+            "e2e-fast",
+            "fmt-governance",
             "gate",
-            "lint-governance",
             "ratchets",
-            "sdk-wasm",
+            "sdk-web",
             "test",
+            "wasm-check",
         ],
     );
 
@@ -99,10 +102,13 @@ fn cargo_workflow_covers_the_full_per_push_gate_set() {
 
     // Full-workspace verification (the changed-crates-only gate missed
     // dependent-crate breakage; do not reintroduce it as the only test gate).
+    // Unit/int run as sharded nextest partitions of the same workspace-wide
+    // lanes the `unit`/`int` cargo aliases define; clippy covers the whole
+    // workspace with all features (test-target lints run nightly).
     for lane in [
-        "make lint",
-        "make test-unit",
-        "make test-int",
+        "clippy --workspace --all-features",
+        "repo-cargo unit --partition",
+        "repo-cargo int --partition",
         "make e2e-fast",
         "make verify-schema-freshness",
         "make verify-sdk-codegen-freshness",
@@ -138,11 +144,14 @@ fn nightly_covers_the_deferred_heavy_lanes() {
     // `make ci` target set — these are the targets deliberately moved off
     // the hot path, not dropped.
     for lane in [
+        "make lint",
         "make lint-feature-matrix",
         "make test-feature-matrix",
         "make test-minimal",
         "make test-surface-modularity",
         "make e2e-system",
+        "make test-sdk-web",
+        "make check-rust-release-packaging",
     ] {
         assert!(nightly.contains(lane), "nightly must run `{lane}`");
     }

--- a/xtask/tests/ci_gate_requires_rmat.rs
+++ b/xtask/tests/ci_gate_requires_rmat.rs
@@ -1,5 +1,13 @@
 #![allow(clippy::expect_used, clippy::panic)]
 
+//! Pinning tests for the CI workflow contract.
+//!
+//! CI runs a single Cargo lane on free GitHub-hosted runners (the GCP
+//! BuildBuddy lane was retired 2026-07-03). These tests ratchet the load-
+//! bearing invariants: the typed governance gates (rmat-audit set) bind every
+//! run, the per-push lane plus the nightly workflow cover the full `make ci`
+//! target set, and the retired BuildBuddy workflow stays inert until deleted.
+
 use std::path::{Path, PathBuf};
 
 fn workflow_yml_path(name: &str) -> PathBuf {
@@ -17,92 +25,166 @@ fn read_workflow(path: &Path) -> serde_yaml::Value {
         .unwrap_or_else(|e| panic!("cannot parse {} as YAML: {e}", path.display()))
 }
 
+fn job_names(doc: &serde_yaml::Value, path: &Path) -> Vec<String> {
+    let jobs = doc
+        .get("jobs")
+        .and_then(|j| j.as_mapping())
+        .unwrap_or_else(|| panic!("{} must have a jobs mapping", path.display()));
+    let mut defined: Vec<String> = jobs
+        .keys()
+        .filter_map(|k| k.as_str().map(str::to_owned))
+        .collect();
+    defined.sort_unstable();
+    defined
+}
+
 #[test]
-fn ci_exposes_only_default_cargo_and_owner_gated_gcp_buildbuddy() {
+fn ci_runs_a_single_free_cargo_lane() {
     let ci_yml = workflow_yml_path("ci.yml");
     let ci = std::fs::read_to_string(&ci_yml)
         .unwrap_or_else(|e| panic!("read {}: {e}", ci_yml.display()));
     let doc = read_workflow(&ci_yml);
-    let jobs = doc
-        .get("jobs")
-        .and_then(|j| j.as_mapping())
-        .expect("jobs mapping");
-    let mut defined: Vec<_> = jobs.keys().filter_map(|k| k.as_str()).collect();
-    defined.sort_unstable();
 
     assert_eq!(
-        defined,
-        vec![
-            "cargo",
-            "gate",
-            "gcp-buildbuddy",
-            "unauthorized-gcp-buildbuddy"
-        ],
-        "{} should expose only the default Cargo lane, the owner-gated GCP BuildBuddy lane, and the aggregating gate",
+        job_names(&doc, &ci_yml),
+        vec!["cargo", "gate"],
+        "{} should expose only the Cargo lane and the aggregating gate",
         ci_yml.display(),
     );
-    assert!(ci.contains("github.actor == 'lukacf'"));
     assert!(ci.contains("uses: ./.github/workflows/cargo.yml"));
-    assert!(ci.contains("uses: ./.github/workflows/buildbuddy.yml"));
-    assert!(!ci.contains("buildbuddy-hosted"));
+    assert!(
+        !ci.contains("uses: ./.github/workflows/buildbuddy.yml"),
+        "the retired GCP BuildBuddy lane must not be routed from CI"
+    );
+    assert!(
+        !ci.contains("github.actor"),
+        "CI must not route by actor — one lane for everyone"
+    );
 }
 
 #[test]
-fn cargo_workflow_is_a_single_changed_path_gate() {
+fn cargo_workflow_covers_the_full_per_push_gate_set() {
     let cargo_yml = workflow_yml_path("cargo.yml");
     let cargo = std::fs::read_to_string(&cargo_yml)
         .unwrap_or_else(|e| panic!("read {}: {e}", cargo_yml.display()));
     let doc = read_workflow(&cargo_yml);
-    let jobs = doc
-        .get("jobs")
-        .and_then(|j| j.as_mapping())
-        .expect("jobs mapping");
-    let mut defined: Vec<_> = jobs.keys().filter_map(|k| k.as_str()).collect();
-    defined.sort_unstable();
 
-    assert_eq!(defined, vec!["cargo"]);
-    assert!(cargo.contains("scripts/cargo-agent-gate"));
-    assert!(cargo.contains("--committed"));
-    assert!(!cargo.contains("buildbuddy"));
+    assert_eq!(
+        job_names(&doc, &cargo_yml),
+        vec![
+            "audit",
+            "changes",
+            "gate",
+            "lint-governance",
+            "ratchets",
+            "sdk-wasm",
+            "test",
+        ],
+    );
+
+    // The typed governance gates must bind every CI run — this is the
+    // original intent of this test module and must survive lane reshuffles.
+    for gate in [
+        "make rmat-audit",
+        "make seam-inventory",
+        "make runtime-authority-bypass",
+        "make machine-authority-docs-gate",
+        "make audit-generated-headers",
+    ] {
+        assert!(
+            cargo.contains(gate),
+            "cargo lane must run `{gate}` on every push"
+        );
+    }
+
+    // Full-workspace verification (the changed-crates-only gate missed
+    // dependent-crate breakage; do not reintroduce it as the only test gate).
+    for lane in [
+        "make lint",
+        "make test-unit",
+        "make test-int",
+        "make e2e-fast",
+        "make verify-schema-freshness",
+        "make verify-sdk-codegen-freshness",
+        "make audit",
+    ] {
+        assert!(cargo.contains(lane), "cargo lane must run `{lane}`");
+    }
+
+    assert!(
+        !cargo.contains("buildbuddy"),
+        "the cargo lane must not depend on BuildBuddy"
+    );
+    assert!(
+        !cargo.contains("self-hosted"),
+        "the cargo lane runs on free GitHub-hosted runners only"
+    );
 }
 
 #[test]
-fn buildbuddy_workflow_is_gcp_only() {
-    let buildbuddy_yml = workflow_yml_path("buildbuddy.yml");
-    let buildbuddy = std::fs::read_to_string(&buildbuddy_yml)
-        .unwrap_or_else(|e| panic!("read {}: {e}", buildbuddy_yml.display()));
-    let doc = read_workflow(&buildbuddy_yml);
-    let jobs = doc
-        .get("jobs")
-        .and_then(|j| j.as_mapping())
-        .expect("jobs mapping");
-    let mut defined: Vec<_> = jobs.keys().filter_map(|k| k.as_str()).collect();
-    defined.sort_unstable();
+fn nightly_covers_the_deferred_heavy_lanes() {
+    let nightly_yml = workflow_yml_path("nightly.yml");
+    let nightly = std::fs::read_to_string(&nightly_yml)
+        .unwrap_or_else(|e| panic!("read {}: {e}", nightly_yml.display()));
+    let doc = read_workflow(&nightly_yml);
 
+    // schedule + manual dispatch (serde_yaml parses the bare `on:` key as a
+    // boolean, so assert on the raw text).
+    assert!(nightly.contains("schedule:"), "nightly must run on a cron");
+    assert!(nightly.contains("workflow_dispatch"));
+    drop(doc);
+
+    // Together with the per-push cargo lane this must cover the complete
+    // `make ci` target set — these are the targets deliberately moved off
+    // the hot path, not dropped.
+    for lane in [
+        "make lint-feature-matrix",
+        "make test-feature-matrix",
+        "make test-minimal",
+        "make test-surface-modularity",
+        "make e2e-system",
+    ] {
+        assert!(nightly.contains(lane), "nightly must run `{lane}`");
+    }
+}
+
+#[test]
+fn buildbuddy_workflow_is_retired_and_inert() {
+    let ci_yml = workflow_yml_path("ci.yml");
+    let cargo_yml = workflow_yml_path("cargo.yml");
+    let nightly_yml = workflow_yml_path("nightly.yml");
+    let buildbuddy_yml = workflow_yml_path("buildbuddy.yml");
+    if !buildbuddy_yml.exists() {
+        // Fully deleted — the retirement completed; nothing to pin.
+        return;
+    }
+
+    // workflow_call-only: without a caller the workflow can never run.
+    // (YAML 1.1 parses the bare `on` key as boolean true.)
+    let doc = read_workflow(&buildbuddy_yml);
+    let triggers = doc
+        .get("on")
+        .or_else(|| doc.get(serde_yaml::Value::Bool(true)))
+        .and_then(|t| t.as_mapping())
+        .unwrap_or_else(|| panic!("{} must have an `on:` mapping", buildbuddy_yml.display()));
+    let mut names: Vec<&str> = triggers.keys().filter_map(|k| k.as_str()).collect();
+    names.sort_unstable();
     assert_eq!(
-        defined,
-        vec![
-            "audit-submit",
-            "control-plane-up",
-            "executors-down",
-            "executors-up",
-            "feature-submit",
-            "gate",
-            "governance-submit",
-            "minimal-feature-submit",
-            "native-submit",
-            "prebuild-submit",
-            "static-submit",
-            "wasm-check-submit",
-            "wasm-feature-changes",
-            "wasm-sdk-submit",
-        ],
+        names,
+        vec!["workflow_call"],
+        "retired buildbuddy.yml must stay workflow_call-only (inert without a caller)"
     );
-    assert!(buildbuddy.contains("MEERKAT_BAZEL_BACKEND: gcp-buildbuddy"));
-    assert!(buildbuddy.contains("CI_STARTED_AT_EPOCH:"));
-    assert!(buildbuddy.contains("Check GCP CI duration SLO"));
-    assert!(buildbuddy.contains("run-buildbuddy-ci-lane-batch"));
-    assert!(buildbuddy.contains("profile: submitter"));
-    assert!(!buildbuddy.contains("buildbuddy-hosted"));
-    assert!(!buildbuddy.contains("profile: native"));
+    for caller in [&ci_yml, &cargo_yml, &nightly_yml] {
+        let text = std::fs::read_to_string(caller)
+            .unwrap_or_else(|e| panic!("read {}: {e}", caller.display()));
+        // Prose may mention the file (retirement notes); a `uses:` reference
+        // is what would revive it.
+        assert!(
+            !text.lines().any(|line| {
+                line.trim_start().starts_with("uses:") && line.contains("buildbuddy.yml")
+            }),
+            "{} must not call the retired BuildBuddy workflow",
+            caller.display()
+        );
+    }
 }


### PR DESCRIPTION
Retires the per-push GCP BuildBuddy CI lane and the self-hosted runner. CI now runs entirely on free GitHub-hosted standard runners, at roughly **17 minutes wall clock warm** (target ≤20m), down from ~34m on the GCP fleet — at $0/run instead of an executor-fleet spin-up per push.

## Lane architecture

**Per push** (`cargo.yml`, all jobs parallel):

| Job | Warm time | What it runs |
|-----|-----------|--------------|
| changes | 0.7m | path classification: docs-only skips Rust; SDK paths enable `sdk-web` |
| fmt-governance | 3.2m | fmt-check, surface/backend gates, dogma mirror, rmat-audit set, seam-inventory, runtime-authority-bypass, machine-authority docs, poster coverage, generated headers |
| clippy | 6.9m | `clippy --workspace --all-features` (lib/bin; `--all-targets` nightly) |
| test ×6 | 8–16m | `cargo unit` + `cargo int`, nextest `--partition hash:N/6` |
| e2e-fast | 3.5m | deterministic e2e lane |
| ratchets | 3.9m | version parity, schema/SDK codegen freshness, RPC/REST alignment, machine drift |
| wasm-check | 5.7m | wasm32 check + clippy (every code change) |
| sdk-web | 2–14m | full Web SDK suite, dev-profile wasm (path-gated to SDK-relevant changes) |
| audit | 0.5m | cargo-deny |

**Nightly** (`nightly.yml`, cron + dispatch): clippy `--all-targets --all-features`, feature matrices, minimal-feature, surface-modularity, e2e-system, unconditional release-profile Web SDK suite, release packaging dry-run, cargo-deny sweep. Together with the per-push lane this covers the full `make ci` target set; `xtask/tests/ci_gate_requires_rmat.rs` pins the split.

## What made it fast

1. **Stable `CARGO_HOME`** — `repo-cargo` and `ci-pin-rust-toolchain-env` suffixed it with the GitHub run id (isolation for the retired shared self-hosted runner). On hosted per-job VMs that invalidated every dep compile hash: sccache hit 13–19%, rust-cache never restored. Pinned to `/home/runner/.cargo`; `rust-lane-doctor` now asserts stability instead of isolation.
2. **sccache (GHA backend) + mold** on all compiling jobs — content-addressed compile caching survives fresh-checkout mtimes that defeat cargo's own workspace fingerprints. `SCCACHE_IGNORE_SERVER_IO_ERROR=1` so cache hiccups degrade to plain compiles.
3. **6-way nextest sharding** of unit+int; per-job rust-cache keys (a single shared key lets only the first saver win).
4. **Dev-profile wasm** for the per-push Web SDK job (skips wasm-opt, which dominated the release build); release profile stays in nightly and the release flow.
5. **`--all-targets` clippy and `cargo package` dry-runs moved to nightly** — several-fold build volume for test-only lint yield and ~1h of packaging respectively.

## Notes

- First run on `main` after merge reseeds caches (GHA cache is branch-scoped); subsequent runs and all PR branches inherit main's caches.
- `buildbuddy.yml` is inert (`workflow_call`-only, no caller), kept as a manual fallback during transition; delete with `scripts/gcp-buildbuddy-*` after a few clean releases. The BuildBuddy-hosted **release** flow is unaffected.

## Post-merge decommission

- [ ] Delete repo var `MEERKAT_CI_RUNNER` (unused)
- [ ] Stop `meerkat-bb-control` (delete after a stable week)
- [ ] Stop `meerkat-gh-runner-0` (delete after the next release ships cleanly)
- [ ] After a few clean releases: delete `buildbuddy.yml` + `scripts/gcp-buildbuddy-*`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
