### PR TITLE
fix(core/session): survive cold-restart resume with explicit prompts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,39 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- Cold-restart resume no longer loses the transcript when the host re-sends
+  an explicit per-request system prompt (the SDK-gateway shape: member specs
+  carry `SystemPromptOverride::Set` on every build). The factory build used
+  to blind-replace the resumed session's leading System message with the
+  re-assembled base prompt, discarding every runtime-applied system-context
+  append (comms rosters, host context) and re-stamping the typed
+  `mutation_kind` — so the resumed projection was no longer a continuation
+  of the persisted transcript revision, the continuity preflight failed
+  closed on the very first post-resume persist, the live session was
+  discarded, and downstream hosts fell back to fresh empty spawns (silent
+  history loss on every restart, including sessions freshly written by the
+  same version). Resume now reconciles instead of replacing
+  (`Session::reconcile_resumed_system_prompt`): a base the persisted System
+  message already carries — identical, or extended only by runtime
+  system-context appends — is preserved byte-for-byte (digest unchanged),
+  and a genuinely changed base is committed as a typed transcript rewrite
+  (`resume-system-prompt-refresh`) that preserves the runtime-appended tail
+  (reconstructed byte-exactly from the new
+  `SessionBuildState.assembled_system_prompt` record, with an
+  applied-append re-render fallback), so the first post-resume persist
+  proves a transcript graph edge from the persisted head instead of failing
+  closed. The rewrite-chain continuation walker also no longer aborts as a
+  cycle when a same-length rewrite commit sits exactly at the persisted
+  head (`find_transcript_rewrite_commit_chain_extending_session` skips
+  commits that cannot advance the cursor), which previously rejected the
+  first post-resume turn after such a rewrite. Regression coverage: resume
+  with a runtime-context-appended prompt (unchanged and changed explicit
+  base) over durable sqlite realm stores, mob cold-restart revival with a
+  context-appended member prompt, and unit pins on the reconciliation
+  outcomes.
+
 ## [0.7.14] - 2026-07-04
 
 Meerkat 0.7.14 makes cold-restart resume survivable (content-addressed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   base) over durable sqlite realm stores, mob cold-restart revival with a
   context-appended member prompt, and unit pins on the reconciliation
   outcomes.
+- Reconciliation hardening from the adversarial review of the fix above: an
+  all-context System prompt (empty/`Disable` base plus runtime appends) is
+  carried onto a new base instead of being misread as an "empty tail"; when
+  an unverifiable tail must be dropped, the orphaned applied-append records
+  and their idempotency keys are cleared (with a warning) so keyed re-sends
+  can restore the context instead of deduplicating forever; a shortened
+  explicit base whose removed remainder merely looks like a context tail
+  (the separator is ordinary markdown) is applied through the audited
+  rewrite instead of silently ignored — byte-exact verification against the
+  recorded prior base runs first, and the structural fast path is admitted
+  by the canonical `SessionDocumentMachine` from the typed
+  `RuntimeContextAppend` provenance, not shape alone. The rewrite-chain
+  walker's plain-append fallback no longer accepts untyped leading-System
+  replacements via the system-refresh equivalence (that equivalence now
+  bridges commit PARENT bookkeeping only), and the empty-chain acceptance
+  re-checks graph-head/message-digest agreement. `run_boundary_snapshot_save_guard`
+  adopts a first runtime-boundary commit that carries a validated typed
+  rewrite graph (resume/import over fresh runtime state); the plain
+  `SessionStore::save` first-save seeding rejection is unchanged. Both
+  resume rewrite sites drive `authorize_system_prompt_mutation` (the
+  generated durable-config authority) instead of hand-stamping the mutation
+  provenance, and the append-path block rendering is shared with the
+  resume-time tail verification so the two compositions cannot drift.
 
 ## [0.7.14] - 2026-07-04
 

--- a/meerkat-core/src/lib.rs
+++ b/meerkat-core/src/lib.rs
@@ -285,8 +285,9 @@ pub use service::{
 pub use session::{
     AuthorizedSessionToolVisibilityState, ConsumedDeferredTurnInputs, DeferredFirstTurnPhase,
     DeferredToolLoadAuthority, InheritedToolVisibilityAuthority, PendingDeferredPrompt,
-    PendingSystemContextAppend, PendingToolResultsMessage, SESSION_BUILD_STATE_KEY,
-    SESSION_DEFERRED_TURN_STATE_KEY, SESSION_LIFECYCLE_TERMINAL_KEY,
+    PendingSystemContextAppend, PendingToolResultsMessage,
+    RESUME_SYSTEM_PROMPT_REFRESH_REWRITE_REASON, ResumedSystemPromptReconciliation,
+    SESSION_BUILD_STATE_KEY, SESSION_DEFERRED_TURN_STATE_KEY, SESSION_LIFECYCLE_TERMINAL_KEY,
     SESSION_METADATA_SCHEMA_VERSION, SESSION_SYSTEM_CONTEXT_STATE_KEY,
     SESSION_TOOL_VISIBILITY_STATE_KEY, SESSION_TRANSCRIPT_HISTORY_STATE_KEY, SESSION_VERSION,
     SYSTEM_CONTEXT_SEPARATOR, SeenSystemContextKey, SeenSystemContextState, Session,

--- a/meerkat-core/src/session.rs
+++ b/meerkat-core/src/session.rs
@@ -2303,6 +2303,82 @@ fn render_system_context_block(append: &PendingSystemContextAppend) -> String {
 /// classification key. Nothing reads this back to make a semantic decision.
 const SYSTEM_CONTEXT_RENDER_LABEL: &str = "[Runtime System Context]";
 
+/// Render a sequence of system-context appends into the
+/// [`SYSTEM_CONTEXT_SEPARATOR`]-joined block text that
+/// [`Session::append_system_context_blocks`] concatenates onto the system
+/// prompt. The single composition rule — shared by the append path and the
+/// resume-time tail verification so the two can never drift apart.
+fn render_system_context_blocks_joined(appends: &[PendingSystemContextAppend]) -> String {
+    appends
+        .iter()
+        .map(render_system_context_block)
+        .collect::<Vec<_>>()
+        .join(SYSTEM_CONTEXT_SEPARATOR)
+}
+
+/// Compose a system prompt from a base and a verified runtime-context tail
+/// (leading [`SYSTEM_CONTEXT_SEPARATOR`] included; empty = no tail),
+/// mirroring [`Session::append_system_context_blocks`]' rule that an empty
+/// base renders the blocks without a separator prefix.
+fn compose_system_prompt_with_context_tail(base: &str, tail: &str) -> String {
+    if tail.is_empty() {
+        return base.to_string();
+    }
+    if base.is_empty() {
+        return tail
+            .strip_prefix(SYSTEM_CONTEXT_SEPARATOR)
+            .unwrap_or(tail)
+            .to_string();
+    }
+    format!("{base}{tail}")
+}
+
+/// Drive the canonical [`session_document::SessionDocumentMachine`]
+/// persist-append admission for the resume fast path: may the persisted
+/// System prompt be admitted as a runtime-context-append continuation of the
+/// freshly assembled base?
+///
+/// Mirrors the save-guard shell (`session_store::system_context_is_append`):
+/// this extracts only pure structural observations plus the typed
+/// [`crate::types::SystemPromptMutationKind`] provenance; the machine owns
+/// the verdict. A machine error fails closed — the caller falls back to the
+/// audited rewrite path.
+fn persisted_prompt_is_admitted_context_append_continuation(
+    assembled_base: &str,
+    persisted_content: &str,
+    persisted_mutation_kind: crate::types::SystemPromptMutationKind,
+) -> bool {
+    let content_identical = persisted_content == assembled_base;
+    let content_extends = persisted_content.starts_with(assembled_base);
+    let appended_starts_with_separator = content_extends
+        && persisted_content[assembled_base.len()..].starts_with(SYSTEM_CONTEXT_SEPARATOR);
+    let mut authority = session_document::SessionDocumentMachineAuthority::new();
+    match authority.resolve_system_context_persist_append_admission(
+        true,
+        content_identical,
+        content_extends,
+        appended_starts_with_separator,
+        persisted_mutation_kind.is_runtime_context_append(),
+    ) {
+        Ok(effects) => effects.into_iter().any(|effect| {
+            matches!(
+                effect,
+                session_document::SessionDocumentEffect::SystemContextPersistAppendAdmissionResolved {
+                    admission: session_document::SystemContextPersistAppendAdmission::Admit,
+                }
+            )
+        }),
+        Err(error) => {
+            tracing::warn!(
+                error = %error,
+                "session document authority refused resume prompt continuation admission; \
+                 falling back to audited rewrite"
+            );
+            false
+        }
+    }
+}
+
 /// Shell adapter that drives the canonical
 /// [`session_document::SessionDocumentMachine`] system-context region and
 /// mirrors its emitted decisions onto the bulky `SessionSystemContextState`.
@@ -3273,11 +3349,7 @@ impl Session {
             return;
         }
 
-        let rendered = new_appends
-            .iter()
-            .map(render_system_context_block)
-            .collect::<Vec<_>>()
-            .join(SYSTEM_CONTEXT_SEPARATOR);
+        let rendered = render_system_context_blocks_joined(&new_appends);
 
         let next = match self.messages.first() {
             Some(Message::System(sys)) if !sys.content.is_empty() => {
@@ -3330,110 +3402,194 @@ impl Session {
         assembled_base: String,
         actor: Option<String>,
     ) -> Result<ResumedSystemPromptReconciliation, TranscriptEditError> {
-        use crate::types::{SystemMessage, SystemPromptMutationKind};
-
-        let persisted_content = match self.messages.first() {
-            Some(Message::System(system)) => Some(system.content.clone()),
+        let persisted = match self.messages.first() {
+            Some(Message::System(system)) => Some((system.content.clone(), system.mutation_kind)),
             _ => None,
         };
 
-        let Some(persisted_content) = persisted_content else {
+        let Some((persisted_content, persisted_mutation_kind)) = persisted else {
             if assembled_base.is_empty() {
                 return Ok(ResumedSystemPromptReconciliation::NoChange);
             }
             // The persisted transcript never had a system prompt; introducing
             // one changes the transcript, so it flows through the same typed
             // rewrite path (an insert rewrite over the empty leading span).
-            let replacement = Message::System(SystemMessage::with_mutation_kind(
-                assembled_base,
-                SystemPromptMutationKind::ExplicitBuild,
-            ));
-            self.commit_transcript_rewrite(
-                TranscriptRewriteSelection::MessageRange { start: 0, end: 0 },
-                vec![replacement],
-                TranscriptRewriteReason::new(RESUME_SYSTEM_PROMPT_REFRESH_REWRITE_REASON),
-                actor,
-                None,
-            )?;
+            self.commit_resume_system_prompt_rewrite(assembled_base, false, actor)?;
             return Ok(ResumedSystemPromptReconciliation::RewrittenBase);
         };
 
-        // Continuation fast path: the persisted prompt already carries this
-        // base. `base + SYSTEM_CONTEXT_SEPARATOR + …` is exactly the shape
-        // `append_system_context_blocks` produces for runtime context appends.
-        if persisted_content == assembled_base
-            || (persisted_content.starts_with(&assembled_base)
-                && persisted_content[assembled_base.len()..].starts_with(SYSTEM_CONTEXT_SEPARATOR))
-        {
+        if persisted_content == assembled_base {
             return Ok(ResumedSystemPromptReconciliation::PreservedContinuation);
         }
 
-        // The base diverged. Preserve the runtime-appended context tail when
-        // it is verifiable — first byte-exactly against the prior build's
-        // recorded assembled base, then against a re-render of the durable
-        // applied-append records; otherwise the tail is not reconstructible
-        // and only the new base is written.
-        let prior_base_tail = self
+        // Byte-exact reconciliation first: when the persisted content splits
+        // into a VERIFIED base + runtime-appended tail, the expected content
+        // for this build is `assembled_base + tail` — equal means the base is
+        // unchanged (preserve untouched), different means the base changed
+        // (audited rewrite that carries the tail). This runs before the
+        // structural fast path so a shortened base whose removed remainder
+        // merely looks like a context tail (the separator is ordinary
+        // markdown) is applied instead of silently ignored.
+        if let Some(tail) = self.verified_runtime_context_tail(&persisted_content) {
+            let expected = compose_system_prompt_with_context_tail(&assembled_base, &tail);
+            if expected == persisted_content {
+                return Ok(ResumedSystemPromptReconciliation::PreservedContinuation);
+            }
+            self.commit_resume_system_prompt_rewrite(expected, true, actor)?;
+            return Ok(ResumedSystemPromptReconciliation::RewrittenBase);
+        }
+
+        // No verifiable tail record (rows written before the assembled base
+        // was recorded, or applied-append state swept by the runtime path).
+        // The canonical SessionDocumentMachine persist-append admission
+        // decides — from the structural observations plus the typed mutation
+        // provenance — whether the persisted prompt is a runtime-context-
+        // append continuation of the assembled base. Machine refusal fails
+        // closed into the audited rewrite below.
+        if persisted_prompt_is_admitted_context_append_continuation(
+            &assembled_base,
+            &persisted_content,
+            persisted_mutation_kind,
+        ) {
+            return Ok(ResumedSystemPromptReconciliation::PreservedContinuation);
+        }
+
+        // The base diverged and the runtime-context tail is not
+        // reconstructible: only the new base can be written. Dropping the
+        // appended context silently would leave the durable applied/seen
+        // records claiming those appends are applied — keyed re-sends would
+        // be deduplicated forever — so clear the orphaned records to keep the
+        // context restorable by the host.
+        let dropping_applied_context = persisted_mutation_kind.is_runtime_context_append()
+            || self
+                .system_context_state()
+                .is_some_and(|state| !state.applied.is_empty());
+        self.commit_resume_system_prompt_rewrite(assembled_base, true, actor)?;
+        if dropping_applied_context {
+            tracing::warn!(
+                session_id = %self.id,
+                "resume base-prompt refresh dropped an unverifiable runtime system-context tail; \
+                 clearing applied-append records so keyed re-sends can restore the context"
+            );
+            self.clear_applied_system_context_records();
+        }
+        Ok(ResumedSystemPromptReconciliation::RewrittenBase)
+    }
+
+    /// Split the persisted System content into a VERIFIED runtime-appended
+    /// tail (leading [`SYSTEM_CONTEXT_SEPARATOR`] included; empty when the
+    /// content is exactly a verified base).
+    ///
+    /// Verification sources, strongest first: byte-exact against the prior
+    /// build's recorded assembled base
+    /// ([`SessionBuildState::assembled_system_prompt`]), then a re-render of
+    /// the durable applied-append records. `None` means the tail is not
+    /// reconstructible from durable facts.
+    fn verified_runtime_context_tail(&self, persisted_content: &str) -> Option<String> {
+        if let Some(prior_base) = self
             .build_state()
             .and_then(|state| state.assembled_system_prompt)
-            .and_then(|prior_base| {
-                if persisted_content == prior_base {
-                    return Some(String::new());
-                }
-                let appended = persisted_content.strip_prefix(prior_base.as_str())?;
-                appended
-                    .starts_with(SYSTEM_CONTEXT_SEPARATOR)
-                    .then(|| appended.to_string())
-            });
-        let verified_tail = prior_base_tail.or_else(|| {
-            let rendered_tail = self
-                .system_context_state()
-                .map(|state| {
-                    state
-                        .applied
-                        .iter()
-                        .map(render_system_context_block)
-                        .collect::<Vec<_>>()
-                        .join(SYSTEM_CONTEXT_SEPARATOR)
-                })
-                .unwrap_or_default();
-            if rendered_tail.is_empty() {
-                None
-            } else if persisted_content == rendered_tail {
-                Some(String::new())
-            } else if persisted_content
-                .ends_with(&format!("{SYSTEM_CONTEXT_SEPARATOR}{rendered_tail}"))
-            {
-                Some(format!("{SYSTEM_CONTEXT_SEPARATOR}{rendered_tail}"))
-            } else {
-                None
+        {
+            if persisted_content == prior_base {
+                return Some(String::new());
             }
-        });
-        let replacement_content = match verified_tail {
-            None => assembled_base,
-            Some(tail) if tail.is_empty() => assembled_base,
-            Some(tail) if assembled_base.is_empty() => tail
-                .strip_prefix(SYSTEM_CONTEXT_SEPARATOR)
-                .map(str::to_string)
-                .unwrap_or(tail),
-            Some(tail) => format!("{assembled_base}{tail}"),
-        };
-        if replacement_content == persisted_content {
-            return Ok(ResumedSystemPromptReconciliation::PreservedContinuation);
+            if let Some(appended) = persisted_content.strip_prefix(prior_base.as_str())
+                && appended.starts_with(SYSTEM_CONTEXT_SEPARATOR)
+            {
+                return Some(appended.to_string());
+            }
+            // The record does not split this content (e.g. it predates the
+            // last prompt mutation); fall through to the render verification.
         }
+        let rendered_tail = self
+            .system_context_state()
+            .map(|state| render_system_context_blocks_joined(&state.applied))
+            .unwrap_or_default();
+        if rendered_tail.is_empty() {
+            return None;
+        }
+        if persisted_content == rendered_tail {
+            // The entire persisted prompt is verified runtime context (a
+            // promptless/empty-base build whose appends compose without a
+            // separator prefix) — the tail is the whole content, not empty.
+            return Some(format!("{SYSTEM_CONTEXT_SEPARATOR}{rendered_tail}"));
+        }
+        let with_separator = format!("{SYSTEM_CONTEXT_SEPARATOR}{rendered_tail}");
+        persisted_content
+            .ends_with(&with_separator)
+            .then_some(with_separator)
+    }
 
-        let replacement = Message::System(SystemMessage::with_mutation_kind(
-            replacement_content,
-            SystemPromptMutationKind::ExplicitBuild,
+    /// Commit a resume-time base-prompt refresh through the generated
+    /// durable-config authority and the canonical typed rewrite path.
+    fn commit_resume_system_prompt_rewrite(
+        &mut self,
+        content: String,
+        replacing_existing: bool,
+        actor: Option<String>,
+    ) -> Result<(), TranscriptEditError> {
+        let authorized = session_durable_config_authority::authorize_system_prompt_mutation(
+            content,
+            session_durable_config_authority::SessionSystemPromptSource::ExplicitBuild,
+            replacing_existing,
+        )
+        .map_err(|err| {
+            TranscriptEditError::HistoryStateMalformed(format!(
+                "generated session durable-config authority rejected resume system prompt refresh: {err}"
+            ))
+        })?;
+        let mutation_kind = authorized.mutation_kind();
+        let (content, _replacing_existing) = authorized.into_parts();
+        let replacement = Message::System(crate::types::SystemMessage::with_mutation_kind(
+            content,
+            mutation_kind,
         ));
+        let end = usize::from(replacing_existing);
         self.commit_transcript_rewrite(
-            TranscriptRewriteSelection::MessageRange { start: 0, end: 1 },
+            TranscriptRewriteSelection::MessageRange { start: 0, end },
             vec![replacement],
             TranscriptRewriteReason::new(RESUME_SYSTEM_PROMPT_REFRESH_REWRITE_REASON),
             actor,
             None,
         )?;
-        Ok(ResumedSystemPromptReconciliation::RewrittenBase)
+        Ok(())
+    }
+
+    /// Clear applied-append records (and their idempotency keys) after a
+    /// resume rewrite dropped their rendered blocks from the System prompt,
+    /// so the same keyed appends re-apply instead of deduplicating forever.
+    fn clear_applied_system_context_records(&mut self) {
+        let mut state = match self.try_system_context_state() {
+            Ok(Some(state)) => state,
+            Ok(None) => return,
+            Err(error) => {
+                tracing::warn!(
+                    session_id = %self.id,
+                    error = %error,
+                    "failed to read system-context state while clearing orphaned applied records"
+                );
+                return;
+            }
+        };
+        if state.applied.is_empty() {
+            return;
+        }
+        let dropped_keys: Vec<String> = state
+            .applied
+            .iter()
+            .filter_map(|append| append.idempotency_key.clone())
+            .collect();
+        state.applied.clear();
+        for key in &dropped_keys {
+            state.seen.remove(key);
+        }
+        if let Err(error) = self.set_system_context_state(state) {
+            tracing::warn!(
+                session_id = %self.id,
+                error = %error,
+                "failed to persist cleared applied system-context records after resume prompt refresh"
+            );
+        }
     }
 
     /// Get the last assistant message text content.
@@ -7787,6 +7943,165 @@ mod tests {
         assert_eq!(
             state.commits[0].reason.kind,
             RESUME_SYSTEM_PROMPT_REFRESH_REWRITE_REASON
+        );
+    }
+
+    fn leading_system_content(session: &Session) -> String {
+        match session.messages().first() {
+            Some(Message::System(system)) => system.content.clone(),
+            other => panic!("expected leading system message, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn reconcile_resumed_system_prompt_preserves_full_context_prompt_from_empty_base() {
+        // Promptless/empty-base build: appends compose as the WHOLE System
+        // content with no separator prefix. A resume with a non-empty
+        // explicit base must carry the verified all-context tail onto the
+        // new base instead of discarding it as an "empty tail".
+        let mut session = Session::new();
+        session.push(Message::User(UserMessage::text("hello".to_string())));
+        session.append_system_context_blocks(std::slice::from_ref(&roster_append()));
+        let all_context_content = leading_system_content(&session);
+        assert!(all_context_content.contains("peer roster: lead-1, w-1"));
+
+        let outcome = session
+            .reconcile_resumed_system_prompt("new base prompt".to_string(), None)
+            .expect("reconcile");
+
+        assert_eq!(outcome, ResumedSystemPromptReconciliation::RewrittenBase);
+        assert_eq!(
+            leading_system_content(&session),
+            format!("new base prompt{SYSTEM_CONTEXT_SEPARATOR}{all_context_content}"),
+            "the all-context prompt must survive as the runtime tail of the new base"
+        );
+    }
+
+    #[test]
+    fn reconcile_resumed_system_prompt_preserves_context_only_prompt_on_empty_base_resume() {
+        // Empty-base → empty-base resume: the all-context prompt IS the
+        // expected composition; it must be preserved untouched.
+        let mut session = Session::new();
+        session.push(Message::User(UserMessage::text("hello".to_string())));
+        session.append_system_context_blocks(std::slice::from_ref(&roster_append()));
+        let digest_before = transcript_messages_digest(session.messages()).unwrap();
+
+        let outcome = session
+            .reconcile_resumed_system_prompt(String::new(), None)
+            .expect("reconcile");
+
+        assert_eq!(
+            outcome,
+            ResumedSystemPromptReconciliation::PreservedContinuation
+        );
+        assert_eq!(
+            transcript_messages_digest(session.messages()).unwrap(),
+            digest_before
+        );
+    }
+
+    #[test]
+    fn reconcile_resumed_system_prompt_applies_shortened_base_with_recorded_prior() {
+        // The separator is ordinary markdown: a base prompt may legitimately
+        // contain it. Shortening the base must be APPLIED (audited rewrite),
+        // not silently classified as a preserved context-append continuation.
+        let full_base = format!("part one{SYSTEM_CONTEXT_SEPARATOR}part two");
+        let mut session = Session::new();
+        session.set_system_prompt(full_base.clone());
+        session.push(Message::User(UserMessage::text("hello".to_string())));
+        session
+            .set_build_state(SessionBuildState {
+                assembled_system_prompt: Some(full_base),
+                ..Default::default()
+            })
+            .expect("build state");
+
+        let outcome = session
+            .reconcile_resumed_system_prompt("part one".to_string(), None)
+            .expect("reconcile");
+
+        assert_eq!(outcome, ResumedSystemPromptReconciliation::RewrittenBase);
+        assert_eq!(leading_system_content(&session), "part one");
+    }
+
+    #[test]
+    fn reconcile_resumed_system_prompt_applies_shortened_base_without_context_provenance() {
+        // No recorded prior base, no applied records, and the persisted
+        // prompt's mutation provenance is not a runtime context append: the
+        // machine rejects the structural-extends continuation, so the
+        // shortened base is applied instead of silently ignored.
+        let full_base = format!("part one{SYSTEM_CONTEXT_SEPARATOR}part two");
+        let mut session = Session::new();
+        session.set_system_prompt(full_base);
+        session.push(Message::User(UserMessage::text("hello".to_string())));
+
+        let outcome = session
+            .reconcile_resumed_system_prompt("part one".to_string(), None)
+            .expect("reconcile");
+
+        assert_eq!(outcome, ResumedSystemPromptReconciliation::RewrittenBase);
+        assert_eq!(leading_system_content(&session), "part one");
+    }
+
+    #[test]
+    fn reconcile_resumed_system_prompt_preserves_appended_prompt_without_applied_records() {
+        // The runtime persistence path sweeps applied records and pre-0.7.15
+        // rows have no recorded assembled base. The typed
+        // RuntimeContextAppend provenance on the persisted message still
+        // admits the continuation through the machine fast path.
+        let mut session = resumed_session_with_context_appended_prompt("base prompt");
+        session
+            .set_system_context_state(SessionSystemContextState::default())
+            .expect("sweep applied records");
+        let digest_before = transcript_messages_digest(session.messages()).unwrap();
+
+        let outcome = session
+            .reconcile_resumed_system_prompt("base prompt".to_string(), None)
+            .expect("reconcile");
+
+        assert_eq!(
+            outcome,
+            ResumedSystemPromptReconciliation::PreservedContinuation
+        );
+        assert_eq!(
+            transcript_messages_digest(session.messages()).unwrap(),
+            digest_before
+        );
+    }
+
+    #[test]
+    fn reconcile_resumed_system_prompt_clears_orphaned_applied_records_on_tail_drop() {
+        let mut session = resumed_session_with_context_appended_prompt("base prompt");
+        // An out-of-band prompt mutation makes the applied records'
+        // re-render no longer reproduce the persisted content (and no
+        // assembled base was recorded): the tail is unverifiable and must be
+        // dropped by the rewrite.
+        session.set_system_prompt(format!(
+            "mutated base{SYSTEM_CONTEXT_SEPARATOR}stale-looking tail"
+        ));
+
+        let outcome = session
+            .reconcile_resumed_system_prompt("new base prompt".to_string(), None)
+            .expect("reconcile");
+
+        assert_eq!(outcome, ResumedSystemPromptReconciliation::RewrittenBase);
+        assert_eq!(leading_system_content(&session), "new base prompt");
+        let state = session.system_context_state().unwrap_or_default();
+        assert!(
+            state.applied.is_empty(),
+            "orphaned applied records must be cleared so the context stays restorable"
+        );
+        assert!(
+            state.seen.is_empty(),
+            "orphaned idempotency keys must be cleared so keyed re-sends re-apply"
+        );
+
+        // A host re-send of the same keyed append restores the context
+        // instead of deduplicating against the dropped application.
+        session.append_system_context_blocks(std::slice::from_ref(&roster_append()));
+        assert!(
+            leading_system_content(&session).contains("peer roster: lead-1, w-1"),
+            "re-sent keyed context must re-apply after the drop"
         );
     }
 

--- a/meerkat-core/src/session.rs
+++ b/meerkat-core/src/session.rs
@@ -124,6 +124,27 @@ impl TranscriptRewriteReason {
     }
 }
 
+/// Typed rewrite-commit reason for a resume-time base-prompt refresh
+/// committed by [`Session::reconcile_resumed_system_prompt`].
+pub const RESUME_SYSTEM_PROMPT_REFRESH_REWRITE_REASON: &str = "resume-system-prompt-refresh";
+
+/// Typed outcome of [`Session::reconcile_resumed_system_prompt`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ResumedSystemPromptReconciliation {
+    /// The persisted System message already carries the assembled base prompt
+    /// (identical, or extended only by runtime system-context appends). The
+    /// transcript was left untouched, so the resumed projection digests to
+    /// the persisted revision.
+    PreservedContinuation,
+    /// The assembled base prompt diverged from the persisted System message;
+    /// the replacement was committed as a typed transcript rewrite so the
+    /// first post-resume persist proves a graph edge from the persisted head.
+    RewrittenBase,
+    /// The resumed transcript has no leading System message and the assembled
+    /// prompt is empty — nothing to reconcile.
+    NoChange,
+}
+
 impl std::fmt::Display for TranscriptRewriteReason {
     /// Human-facing projection consumed by revision-list reads. The typed
     /// `{kind, note}` pair stays the owner; this rendering is derived only.
@@ -1680,6 +1701,14 @@ pub struct SessionBuildState {
     pub mob_tool_authority_context: Option<MobToolAuthorityContext>,
     #[serde(default, skip_serializing_if = "is_default_call_timeout_override")]
     pub call_timeout_override: crate::CallTimeoutOverride,
+    /// Exact assembled base-prompt bytes the last build applied (or verified)
+    /// for this session. Runtime system-context appends extend the leading
+    /// System message past this base; recording the base lets a later resume
+    /// split the persisted content into `base + appended tail` byte-exactly
+    /// (see [`Session::reconcile_resumed_system_prompt`]) instead of
+    /// re-deriving append renders.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub assembled_system_prompt: Option<String>,
 }
 
 /// Deferred create-time prompt staged for the next turn.
@@ -3269,6 +3298,142 @@ impl Session {
         if let Err(err) = self.set_system_context_state(state) {
             tracing::warn!(error = %err, "failed to persist applied system-context state");
         }
+    }
+
+    /// Reconcile a resumed session's persisted system prompt with a freshly
+    /// assembled base prompt.
+    ///
+    /// A resumed transcript is durable state: its leading [`Message::System`]
+    /// carries the base prompt PLUS every runtime system-context append the
+    /// runtime durably applied (comms rosters, host context — rendered by
+    /// [`Session::append_system_context_blocks`]). Blind-replacing that
+    /// message with a re-assembled base prompt discards the runtime-applied
+    /// context and produces a projection that is no longer a continuation of
+    /// the persisted transcript revision — the append-only save guard then
+    /// rejects the very first post-resume persist and the live session is
+    /// discarded (the upstream cold-restart transcript-loss report).
+    ///
+    /// Reconciliation instead of replacement:
+    /// - If the persisted System content IS the assembled base — identical, or
+    ///   extended only by [`SYSTEM_CONTEXT_SEPARATOR`]-joined runtime context
+    ///   appends — the transcript is left untouched (byte-for-byte, including
+    ///   the typed `mutation_kind`), so the resumed projection digests to the
+    ///   persisted revision.
+    /// - If the base genuinely changed, the new System message (new base plus
+    ///   the reconstructed runtime-append tail, when the persisted tail is
+    ///   verifiable from the durable applied-append records) is committed
+    ///   through [`Session::commit_transcript_rewrite`] — the canonical typed
+    ///   rewrite path — so the first post-resume persist proves a transcript
+    ///   graph edge from the persisted head instead of failing closed.
+    pub fn reconcile_resumed_system_prompt(
+        &mut self,
+        assembled_base: String,
+        actor: Option<String>,
+    ) -> Result<ResumedSystemPromptReconciliation, TranscriptEditError> {
+        use crate::types::{SystemMessage, SystemPromptMutationKind};
+
+        let persisted_content = match self.messages.first() {
+            Some(Message::System(system)) => Some(system.content.clone()),
+            _ => None,
+        };
+
+        let Some(persisted_content) = persisted_content else {
+            if assembled_base.is_empty() {
+                return Ok(ResumedSystemPromptReconciliation::NoChange);
+            }
+            // The persisted transcript never had a system prompt; introducing
+            // one changes the transcript, so it flows through the same typed
+            // rewrite path (an insert rewrite over the empty leading span).
+            let replacement = Message::System(SystemMessage::with_mutation_kind(
+                assembled_base,
+                SystemPromptMutationKind::ExplicitBuild,
+            ));
+            self.commit_transcript_rewrite(
+                TranscriptRewriteSelection::MessageRange { start: 0, end: 0 },
+                vec![replacement],
+                TranscriptRewriteReason::new(RESUME_SYSTEM_PROMPT_REFRESH_REWRITE_REASON),
+                actor,
+                None,
+            )?;
+            return Ok(ResumedSystemPromptReconciliation::RewrittenBase);
+        };
+
+        // Continuation fast path: the persisted prompt already carries this
+        // base. `base + SYSTEM_CONTEXT_SEPARATOR + …` is exactly the shape
+        // `append_system_context_blocks` produces for runtime context appends.
+        if persisted_content == assembled_base
+            || (persisted_content.starts_with(&assembled_base)
+                && persisted_content[assembled_base.len()..].starts_with(SYSTEM_CONTEXT_SEPARATOR))
+        {
+            return Ok(ResumedSystemPromptReconciliation::PreservedContinuation);
+        }
+
+        // The base diverged. Preserve the runtime-appended context tail when
+        // it is verifiable — first byte-exactly against the prior build's
+        // recorded assembled base, then against a re-render of the durable
+        // applied-append records; otherwise the tail is not reconstructible
+        // and only the new base is written.
+        let prior_base_tail = self
+            .build_state()
+            .and_then(|state| state.assembled_system_prompt)
+            .and_then(|prior_base| {
+                if persisted_content == prior_base {
+                    return Some(String::new());
+                }
+                let appended = persisted_content.strip_prefix(prior_base.as_str())?;
+                appended
+                    .starts_with(SYSTEM_CONTEXT_SEPARATOR)
+                    .then(|| appended.to_string())
+            });
+        let verified_tail = prior_base_tail.or_else(|| {
+            let rendered_tail = self
+                .system_context_state()
+                .map(|state| {
+                    state
+                        .applied
+                        .iter()
+                        .map(render_system_context_block)
+                        .collect::<Vec<_>>()
+                        .join(SYSTEM_CONTEXT_SEPARATOR)
+                })
+                .unwrap_or_default();
+            if rendered_tail.is_empty() {
+                None
+            } else if persisted_content == rendered_tail {
+                Some(String::new())
+            } else if persisted_content
+                .ends_with(&format!("{SYSTEM_CONTEXT_SEPARATOR}{rendered_tail}"))
+            {
+                Some(format!("{SYSTEM_CONTEXT_SEPARATOR}{rendered_tail}"))
+            } else {
+                None
+            }
+        });
+        let replacement_content = match verified_tail {
+            None => assembled_base,
+            Some(tail) if tail.is_empty() => assembled_base,
+            Some(tail) if assembled_base.is_empty() => tail
+                .strip_prefix(SYSTEM_CONTEXT_SEPARATOR)
+                .map(str::to_string)
+                .unwrap_or(tail),
+            Some(tail) => format!("{assembled_base}{tail}"),
+        };
+        if replacement_content == persisted_content {
+            return Ok(ResumedSystemPromptReconciliation::PreservedContinuation);
+        }
+
+        let replacement = Message::System(SystemMessage::with_mutation_kind(
+            replacement_content,
+            SystemPromptMutationKind::ExplicitBuild,
+        ));
+        self.commit_transcript_rewrite(
+            TranscriptRewriteSelection::MessageRange { start: 0, end: 1 },
+            vec![replacement],
+            TranscriptRewriteReason::new(RESUME_SYSTEM_PROMPT_REFRESH_REWRITE_REASON),
+            actor,
+            None,
+        )?;
+        Ok(ResumedSystemPromptReconciliation::RewrittenBase)
     }
 
     /// Get the last assistant message text content.
@@ -7489,6 +7654,140 @@ mod tests {
             .system_context_state()
             .expect("append should persist typed context state");
         assert_eq!(state.applied, vec![append]);
+    }
+
+    fn roster_append() -> PendingSystemContextAppend {
+        PendingSystemContextAppend {
+            content: crate::lifecycle::run_primitive::CoreRenderable::text(
+                "peer roster: lead-1, w-1".to_string(),
+            ),
+            source: Some("comms:roster".to_string()),
+            idempotency_key: Some("comms:roster:v1".to_string()),
+            source_kind: SystemContextSource::Normal,
+            peer_response_terminal: None,
+            accepted_at: SystemTime::UNIX_EPOCH,
+        }
+    }
+
+    fn resumed_session_with_context_appended_prompt(base: &str) -> Session {
+        let mut session = Session::new();
+        session.set_system_prompt(base.to_string());
+        session.push(Message::User(UserMessage::text("hello".to_string())));
+        session.append_system_context_blocks(std::slice::from_ref(&roster_append()));
+        session
+    }
+
+    #[test]
+    fn reconcile_resumed_system_prompt_preserves_identical_base() {
+        let mut session = Session::new();
+        session.set_system_prompt("base prompt".to_string());
+        session.push(Message::User(UserMessage::text("hello".to_string())));
+        let digest_before = transcript_messages_digest(session.messages()).unwrap();
+
+        let outcome = session
+            .reconcile_resumed_system_prompt("base prompt".to_string(), None)
+            .expect("reconcile");
+
+        assert_eq!(
+            outcome,
+            ResumedSystemPromptReconciliation::PreservedContinuation
+        );
+        assert_eq!(
+            transcript_messages_digest(session.messages()).unwrap(),
+            digest_before,
+            "identical base must leave the transcript revision unchanged"
+        );
+    }
+
+    #[test]
+    fn reconcile_resumed_system_prompt_preserves_context_appended_base() {
+        let mut session = resumed_session_with_context_appended_prompt("base prompt");
+        let digest_before = transcript_messages_digest(session.messages()).unwrap();
+
+        let outcome = session
+            .reconcile_resumed_system_prompt("base prompt".to_string(), None)
+            .expect("reconcile");
+
+        assert_eq!(
+            outcome,
+            ResumedSystemPromptReconciliation::PreservedContinuation
+        );
+        assert_eq!(
+            transcript_messages_digest(session.messages()).unwrap(),
+            digest_before,
+            "a base extended only by runtime context appends must stay untouched"
+        );
+        let system = match session.messages().first() {
+            Some(Message::System(system)) => system.clone(),
+            other => panic!("expected system message, got {other:?}"),
+        };
+        assert!(system.content.contains("peer roster: lead-1, w-1"));
+        assert!(
+            system.mutation_kind.is_runtime_context_append(),
+            "the persisted mutation provenance must survive reconciliation"
+        );
+    }
+
+    #[test]
+    fn reconcile_resumed_system_prompt_rewrites_changed_base_preserving_tail() {
+        let mut session = resumed_session_with_context_appended_prompt("base prompt");
+
+        let outcome = session
+            .reconcile_resumed_system_prompt("new base prompt".to_string(), None)
+            .expect("reconcile");
+
+        assert_eq!(outcome, ResumedSystemPromptReconciliation::RewrittenBase);
+        let system_content = match session.messages().first() {
+            Some(Message::System(system)) => system.content.clone(),
+            other => panic!("expected system message, got {other:?}"),
+        };
+        assert!(
+            system_content.starts_with("new base prompt"),
+            "the changed base must be applied: {system_content}"
+        );
+        assert!(
+            system_content.contains("peer roster: lead-1, w-1"),
+            "the runtime-applied context tail must survive the base change: {system_content}"
+        );
+        let state = session
+            .transcript_history_state()
+            .expect("history state deserializes")
+            .expect("rewrite must record transcript history");
+        assert_eq!(state.commits.len(), 1);
+        assert_eq!(
+            state.commits[0].reason.kind,
+            RESUME_SYSTEM_PROMPT_REFRESH_REWRITE_REASON
+        );
+        assert_eq!(
+            state.head,
+            transcript_messages_digest(session.messages()).unwrap(),
+            "the committed head must match the rewritten transcript"
+        );
+    }
+
+    #[test]
+    fn reconcile_resumed_system_prompt_inserts_prompt_on_promptless_transcript() {
+        let mut session = Session::new();
+        session.push(Message::User(UserMessage::text("hello".to_string())));
+
+        let outcome = session
+            .reconcile_resumed_system_prompt("late prompt".to_string(), None)
+            .expect("reconcile");
+
+        assert_eq!(outcome, ResumedSystemPromptReconciliation::RewrittenBase);
+        assert!(matches!(
+            session.messages().first(),
+            Some(Message::System(system)) if system.content == "late prompt"
+        ));
+        let state = session
+            .transcript_history_state()
+            .expect("history state deserializes")
+            .expect("insert must record transcript history");
+        assert_eq!(state.commits.len(), 1);
+        assert_eq!(
+            state.commits[0].reason.kind,
+            RESUME_SYSTEM_PROMPT_REFRESH_REWRITE_REASON
+        );
     }
 
     #[test]

--- a/meerkat-core/src/session_recovery.rs
+++ b/meerkat-core/src/session_recovery.rs
@@ -807,6 +807,7 @@ mod tests {
                     ),
                 ),
                 call_timeout_override: CallTimeoutOverride::Value(Duration::from_secs(42)),
+                assembled_system_prompt: None,
             })
             .expect("session build state");
         let mut deferred = SessionDeferredTurnState::default();

--- a/meerkat-core/src/session_store.rs
+++ b/meerkat-core/src/session_store.rs
@@ -562,6 +562,29 @@ pub fn run_boundary_snapshot_save_guard(
                 return Ok(());
             }
             let Some(previous) = previous else {
+                // First runtime-boundary commit for a session this authority
+                // has never snapshotted: adoption of a resumed/imported
+                // session. A typed rewrite graph carried in is audited by its
+                // own commits — validate every one against its retained
+                // bodies and require the graph head to match the incoming
+                // digest. Plain `SessionStore::save` keeps rejecting such
+                // seeds (the trait-level append-only contract); adoption is a
+                // runtime-authority decision, not an ordinary row write.
+                let incoming_revision = transcript_messages_digest(incoming.messages())
+                    .map_err(SessionStoreError::from)?;
+                if let Some(state) = incoming.transcript_history_state().map_err(|err| {
+                    SessionStoreError::InvalidTranscriptRewrite {
+                        id: incoming.id().clone(),
+                        reason: format!("incoming transcript history state is malformed: {err}"),
+                    }
+                })? && !state.commits.is_empty()
+                    && state.head == incoming_revision
+                {
+                    for commit in &state.commits {
+                        validate_transcript_rewrite_commit_bodies(incoming, commit, &state)?;
+                    }
+                    return Ok(());
+                }
                 return Err(append_error);
             };
             let incoming_revision =
@@ -594,6 +617,20 @@ pub fn run_boundary_snapshot_save_guard(
             let Some(commit) = commits.first() else {
                 if state.commits.is_empty() {
                     return Err(append_error);
+                }
+                // Empty chain: the persisted row is already at (or past) the
+                // last rewrite and the incoming head extends it by plain
+                // appends. Unlike the non-empty chain below, no bridge guard
+                // runs here, so re-check the graph-head/message-digest
+                // agreement explicitly before accepting.
+                if state.head != incoming_revision {
+                    return Err(SessionStoreError::InvalidTranscriptRewrite {
+                        id: incoming.id().clone(),
+                        reason: format!(
+                            "incoming transcript graph head {} does not match current message digest {incoming_revision}",
+                            state.head
+                        ),
+                    });
                 }
                 for commit in &state.commits {
                     validate_transcript_rewrite_commit_bodies(incoming, commit, &state)?;
@@ -815,6 +852,7 @@ pub fn find_transcript_rewrite_commit_chain_extending_session<'a>(
                     &commit.parent_revision,
                     cursor_messages,
                     cursor,
+                    true,
                 )?;
             if parent_extends_cursor {
                 selected = Some(commit);
@@ -828,6 +866,7 @@ pub fn find_transcript_rewrite_commit_chain_extending_session<'a>(
                 incoming_revision,
                 cursor_messages,
                 cursor,
+                false,
             )? {
                 return Ok(Some(chain));
             }
@@ -859,6 +898,7 @@ fn revision_body_preserves_append_continuation_prefix(
     revision: &str,
     ancestor_messages: &[Message],
     ancestor_revision: &str,
+    allow_leading_system_refresh: bool,
 ) -> Result<bool, SessionStoreError> {
     if revision == ancestor_revision {
         return Ok(true);
@@ -877,15 +917,19 @@ fn revision_body_preserves_append_continuation_prefix(
             return Ok(true);
         }
     }
-    Ok(
-        messages_preserve_conversation_tail_with_system_context_append(
-            &body.messages,
-            ancestor_messages,
-        )? || messages_preserve_tail_after_leading_system_refresh(
-            &body.messages,
-            ancestor_messages,
-        )?,
-    )
+    if messages_preserve_conversation_tail_with_system_context_append(
+        &body.messages,
+        ancestor_messages,
+    )? {
+        return Ok(true);
+    }
+    // The untyped leading-System-refresh equivalence bridges bookkeeping
+    // divergence between a persisted row and a rewrite commit's recorded
+    // PARENT body only. It must not prove the final plain-append
+    // continuation: that would admit an unaudited System replacement (a
+    // recorded refresh body with no typed commit) as an ordinary append.
+    Ok(allow_leading_system_refresh
+        && messages_preserve_tail_after_leading_system_refresh(&body.messages, ancestor_messages)?)
 }
 
 fn messages_preserve_tail_after_leading_system_refresh(
@@ -1978,6 +2022,99 @@ mod tests {
             Err(SessionStoreError::InvalidTranscriptRewrite { reason, .. })
                 if reason.contains("first save would seed transcript history state")
         ));
+        Ok(())
+    }
+
+    #[test]
+    fn run_boundary_guard_adopts_commit_carrying_history_on_first_commit()
+    -> Result<(), Box<dyn std::error::Error>> {
+        // A runtime authority adopting a session it never snapshotted
+        // (resume/import over fresh runtime state) may receive a session that
+        // already carries a typed rewrite graph — e.g. a resume-time
+        // base-prompt refresh. The commits are the audit: the run-boundary
+        // guard accepts the validated graph, while the plain trait-level
+        // `SessionStore::save` contract keeps rejecting first-save seeds.
+        let mut incoming = Session::new();
+        incoming.set_system_prompt("old base".to_string());
+        incoming.push(Message::User(UserMessage::text("hello".to_string())));
+        incoming.commit_transcript_rewrite(
+            crate::TranscriptRewriteSelection::MessageRange { start: 0, end: 1 },
+            vec![Message::System(SystemMessage::with_mutation_kind(
+                "new base".to_string(),
+                crate::types::SystemPromptMutationKind::ExplicitBuild,
+            ))],
+            crate::TranscriptRewriteReason::new("resume-system-prompt-refresh"),
+            None,
+            None,
+        )?;
+
+        assert!(run_boundary_snapshot_save_guard(&incoming, None).is_ok());
+        assert!(matches!(
+            append_only_save_guard(&incoming, None),
+            Err(SessionStoreError::InvalidTranscriptRewrite { .. })
+        ));
+        Ok(())
+    }
+
+    #[test]
+    fn run_boundary_guard_rejects_untyped_leading_system_refresh_after_head_rewrite()
+    -> Result<(), Box<dyn std::error::Error>> {
+        // A same-length rewrite commit sitting exactly at the persisted head
+        // (the resume-refresh shape) must not widen acceptance to UNTYPED
+        // leading-System replacements: a plain set_system_prompt records a
+        // refresh body via the head refresh but carries no commit, and the
+        // chain walker's fallback must not admit it as an ordinary append
+        // continuation via the leading-system-refresh equivalence.
+        let mut previous = Session::new();
+        previous.set_system_prompt("original base".to_string());
+        previous.push(Message::User(UserMessage::text("hello".to_string())));
+        previous.commit_transcript_rewrite(
+            crate::TranscriptRewriteSelection::MessageRange { start: 0, end: 1 },
+            vec![Message::System(SystemMessage::with_mutation_kind(
+                "refreshed base".to_string(),
+                crate::types::SystemPromptMutationKind::ExplicitBuild,
+            ))],
+            crate::TranscriptRewriteReason::new("resume-system-prompt-refresh"),
+            None,
+            None,
+        )?;
+
+        let mut incoming = previous.clone();
+        incoming.set_system_prompt("untyped hijack".to_string());
+
+        assert!(matches!(
+            run_boundary_snapshot_save_guard(&incoming, Some(&previous)),
+            Err(SessionStoreError::TranscriptContinuityViolation { .. })
+        ));
+        Ok(())
+    }
+
+    #[test]
+    fn run_boundary_guard_accepts_plain_append_after_head_rewrite()
+    -> Result<(), Box<dyn std::error::Error>> {
+        // The empty-chain acceptance the cycle-skip exists for: the persisted
+        // row is already AT the rewrite revision and the incoming snapshot
+        // extends it by ordinary appends.
+        let mut previous = Session::new();
+        previous.set_system_prompt("original base".to_string());
+        previous.push(Message::User(UserMessage::text("hello".to_string())));
+        previous.commit_transcript_rewrite(
+            crate::TranscriptRewriteSelection::MessageRange { start: 0, end: 1 },
+            vec![Message::System(SystemMessage::with_mutation_kind(
+                "refreshed base".to_string(),
+                crate::types::SystemPromptMutationKind::ExplicitBuild,
+            ))],
+            crate::TranscriptRewriteReason::new("resume-system-prompt-refresh"),
+            None,
+            None,
+        )?;
+
+        let mut incoming = previous.clone();
+        incoming.push(Message::User(UserMessage::text(
+            "post-rewrite turn".to_string(),
+        )));
+
+        assert!(run_boundary_snapshot_save_guard(&incoming, Some(&previous)).is_ok());
         Ok(())
     }
 

--- a/meerkat-core/src/session_store.rs
+++ b/meerkat-core/src/session_store.rs
@@ -796,6 +796,16 @@ pub fn find_transcript_rewrite_commit_chain_extending_session<'a>(
         };
         let mut selected = None;
         for commit in &state.commits {
+            // A commit whose revision is already the cursor cannot advance
+            // the walk — selecting it only revisits the cursor and aborts as
+            // a cycle. Same-length rewrites (e.g. a resume-time system-prompt
+            // refresh) can otherwise be spuriously selected here because
+            // their parent body also "extends" the cursor under the
+            // system-refresh equivalence; plain append continuation from
+            // this cursor is proven by the fallback below instead.
+            if commit.revision == cursor {
+                continue;
+            }
             if !transcript_history_revision_extends(state, incoming_revision, &commit.revision) {
                 continue;
             }

--- a/meerkat-mob/tests/cold_restart_mob_resume.rs
+++ b/meerkat-mob/tests/cold_restart_mob_resume.rs
@@ -325,6 +325,33 @@ async fn run_cold_restart_scenario(reuse_runtime_store: bool, lead_mode: MobRunt
         "lifetime1",
     )
     .await;
+
+    // Upstream 0.7.21 transcript-loss shape: a runtime system-context append
+    // (comms roster) lands on the worker's System message before the cold
+    // stop. The resumed projection must continue this appended prompt instead
+    // of failing the continuity preflight and fresh-spawning.
+    let roster_append = meerkat_core::PendingSystemContextAppend {
+        content: meerkat_core::lifecycle::run_primitive::CoreRenderable::Text {
+            text: "peer roster: lead-1, w-1".to_string(),
+        },
+        source: Some("comms:roster".to_string()),
+        idempotency_key: Some("comms:roster:v1".to_string()),
+        source_kind: meerkat_core::session::SystemContextSource::Normal,
+        peer_response_terminal: None,
+        accepted_at: std::time::SystemTime::now(),
+    };
+    service_1
+        .apply_runtime_system_context_for_turn(&w1_sid, vec![roster_append])
+        .await
+        .expect("apply runtime system context to worker");
+    send_and_wait(
+        &handle_1,
+        service_1.as_ref(),
+        "w-1",
+        "PRE_RESTART_W1_TURN2 token-omega",
+        "lifetime1",
+    )
+    .await;
     if lead_mode == MobRuntimeMode::TurnDriven {
         send_and_wait(
             &handle_1,
@@ -429,10 +456,26 @@ async fn run_cold_restart_scenario(reuse_runtime_store: bool, lead_mode: MobRunt
     wait_for_history_contains_all(
         service_2.as_ref(),
         &w1_sid,
-        &["PRE_RESTART_W1_TURN"],
+        &["PRE_RESTART_W1_TURN", "PRE_RESTART_W1_TURN2"],
         "post-resume-w1-history",
     )
     .await;
+
+    // The runtime-appended system context must have survived the resume
+    // byte-for-byte on the worker's leading System message.
+    let w1_resumed = service_2
+        .load_authoritative_session(&w1_sid)
+        .await
+        .expect("load resumed worker session")
+        .expect("worker session must survive restart");
+    let w1_prompt = match w1_resumed.messages().first() {
+        Some(meerkat_core::Message::System(system)) => system.content.clone(),
+        other => panic!("expected leading system message on resumed worker, got {other:?}"),
+    };
+    assert!(
+        w1_prompt.contains("peer roster: lead-1, w-1"),
+        "runtime-applied system context must survive the mob cold restart: {w1_prompt}"
+    );
 
     // First post-restart member turn: this drives the resumed projection into
     // the save guard against the persisted pre-restart row.

--- a/meerkat/src/factory.rs
+++ b/meerkat/src/factory.rs
@@ -5305,6 +5305,17 @@ impl AgentFactory {
             shell_env: build_config.shell_env.clone(),
             mob_tool_authority_context: build_config.mob_tool_authority_context.clone(),
             call_timeout_override: build_config.call_timeout_override.clone(),
+            // Record the exact assembled base-prompt bytes (or carry the
+            // prior build's record through an Inherit resume) so a later
+            // resume can split the persisted System content into base +
+            // runtime-appended tail byte-exactly.
+            assembled_system_prompt: system_prompt.clone().or_else(|| {
+                build_config
+                    .resume_session
+                    .as_ref()
+                    .and_then(|session| session.build_state())
+                    .and_then(|state| state.assembled_system_prompt)
+            }),
         };
 
         // Resolve the structured-output retry budget exactly once, here at the
@@ -5465,6 +5476,40 @@ impl AgentFactory {
         if let Some(state) = initial_visibility_state {
             builder = builder.with_initial_tool_visibility_state(state);
         }
+        // Resume continuity: an explicit per-request prompt on a resumed,
+        // established transcript must not blind-replace the persisted System
+        // message — that discards runtime-applied system context and produces
+        // a projection that is no longer a continuation of the persisted
+        // transcript revision, so the append-only continuity guard rejects
+        // the very first post-resume persist and the live session is
+        // discarded (cold-restart transcript loss for runtime-backed hosts).
+        // Reconcile instead: a base the persisted prompt already carries is
+        // preserved byte-for-byte; a genuinely changed base is committed as a
+        // typed transcript rewrite so the persist proves a graph edge from
+        // the persisted head.
+        let system_prompt = match system_prompt {
+            Some(assembled)
+                if build_config.resume_session.is_some() && !resume_session_is_precreated_empty =>
+            {
+                let reconciliation = session
+                    .reconcile_resumed_system_prompt(
+                        assembled,
+                        Some("agent-factory/resume".to_string()),
+                    )
+                    .map_err(|err| {
+                        BuildAgentError::Config(format!(
+                            "failed to reconcile resumed system prompt: {err}"
+                        ))
+                    })?;
+                tracing::debug!(
+                    session_id = %session.id(),
+                    ?reconciliation,
+                    "reconciled explicit system prompt against resumed transcript"
+                );
+                None
+            }
+            other => other,
+        };
         if let Some(system_prompt) = system_prompt {
             builder = builder.system_prompt(system_prompt);
         }

--- a/meerkat/tests/cold_restart_resume.rs
+++ b/meerkat/tests/cold_restart_resume.rs
@@ -221,6 +221,197 @@ mod tests {
         );
     }
 
+    /// Upstream report (0.7.14/0.7.21): every cold restart of a runtime-backed
+    /// session lost the transcript when the host re-sent its explicit
+    /// per-request system prompt on resume (the SDK-gateway shape: member
+    /// specs carry `SystemPromptOverride::Set` on every build).
+    ///
+    /// During the first lifetime the runtime appends system context (comms
+    /// roster, host context) onto the persisted System message
+    /// (`mutation_kind = RuntimeContextAppend`). The resume build used to
+    /// blind-replace `messages[0]` with the re-assembled base prompt, so the
+    /// resumed projection diverged from the persisted revision, the
+    /// continuity preflight failed closed, and the live session was
+    /// discarded — silent history loss for the caller.
+    #[tokio::test]
+    async fn cold_restart_resume_survives_runtime_context_appended_prompt() {
+        let temp = tempfile::tempdir().expect("tempdir");
+
+        // First host lifetime: create with an explicit prompt, run a turn,
+        // append runtime system context, run another turn so the appended
+        // prompt is committed to both stores.
+        let session_id = {
+            let (service, adapter) = build_service(temp.path()).await;
+            let session = Session::new();
+            let session_id = session.id().clone();
+            materialize(&service, &adapter, session).await;
+            run_prompt(&adapter, &session_id, "first turn before restart").await;
+
+            let append = meerkat_core::PendingSystemContextAppend {
+                content: meerkat_core::lifecycle::run_primitive::CoreRenderable::Text {
+                    text: "peer roster: lead-1, w-1".to_string(),
+                },
+                source: Some("comms:roster".to_string()),
+                idempotency_key: Some("comms:roster:v1".to_string()),
+                source_kind: meerkat_core::session::SystemContextSource::Normal,
+                peer_response_terminal: None,
+                accepted_at: std::time::SystemTime::now(),
+            };
+            service
+                .apply_runtime_system_context_for_turn(&session_id, vec![append])
+                .await
+                .expect("apply runtime system context");
+            run_prompt(&adapter, &session_id, "turn after context append").await;
+            session_id
+        };
+
+        // Second host lifetime: resume with the SAME explicit prompt the
+        // gateway would re-send. The persisted System message carries the
+        // runtime context append; the rebuilt projection must continue it.
+        let (service, adapter) = build_service(temp.path()).await;
+        let resume_source = service
+            .load_authoritative_session(&session_id)
+            .await
+            .expect("authoritative load after restart")
+            .expect("session should survive restart");
+        materialize(&service, &adapter, resume_source).await;
+        run_prompt(&adapter, &session_id, "second turn after restart").await;
+
+        let final_session = service
+            .load_authoritative_session(&session_id)
+            .await
+            .expect("authoritative load after resumed turn")
+            .expect("session should still exist");
+        let texts = user_texts(&final_session);
+        assert!(
+            texts
+                .iter()
+                .any(|t| t.contains("first turn before restart")),
+            "history from before the restart must survive: {texts:?}"
+        );
+        assert!(
+            texts
+                .iter()
+                .any(|t| t.contains("second turn after restart")),
+            "the post-restart turn must be recorded: {texts:?}"
+        );
+        let system_prompt = match final_session.messages().first() {
+            Some(meerkat_core::Message::System(system)) => system.content.clone(),
+            other => panic!("expected leading system message, got {other:?}"),
+        };
+        assert!(
+            system_prompt.contains("peer roster: lead-1, w-1"),
+            "runtime-applied system context must survive the resume: {system_prompt}"
+        );
+    }
+
+    /// Companion to the runtime-context-append regression: when the host
+    /// re-sends a *different* explicit base prompt on resume (definition
+    /// edit), the transcript must still resume — the base-prompt change is
+    /// committed as a typed transcript rewrite (auditable, guard-admitted)
+    /// instead of a blind replace that fails the continuity preflight, and
+    /// the runtime-applied context tail survives onto the new base.
+    #[tokio::test]
+    async fn cold_restart_resume_survives_changed_explicit_prompt() {
+        let temp = tempfile::tempdir().expect("tempdir");
+
+        let session_id = {
+            let (service, adapter) = build_service(temp.path()).await;
+            let session = Session::new();
+            let session_id = session.id().clone();
+            materialize(&service, &adapter, session).await;
+            run_prompt(&adapter, &session_id, "first turn before restart").await;
+
+            let append = meerkat_core::PendingSystemContextAppend {
+                content: meerkat_core::lifecycle::run_primitive::CoreRenderable::Text {
+                    text: "peer roster: lead-1, w-1".to_string(),
+                },
+                source: Some("comms:roster".to_string()),
+                idempotency_key: Some("comms:roster:v1".to_string()),
+                source_kind: meerkat_core::session::SystemContextSource::Normal,
+                peer_response_terminal: None,
+                accepted_at: std::time::SystemTime::now(),
+            };
+            service
+                .apply_runtime_system_context_for_turn(&session_id, vec![append])
+                .await
+                .expect("apply runtime system context");
+            run_prompt(&adapter, &session_id, "turn after context append").await;
+            session_id
+        };
+
+        // Second host lifetime: the host's definition changed, so it re-sends
+        // a different explicit base prompt.
+        let (service, adapter) = build_service(temp.path()).await;
+        let resume_source = service
+            .load_authoritative_session(&session_id)
+            .await
+            .expect("authoritative load after restart")
+            .expect("session should survive restart");
+        let mut request = create_request();
+        request.system_prompt =
+            meerkat::SystemPromptOverride::Set("cold restart resume contract v2".to_string());
+        let service_for_executor = Arc::clone(&service);
+        let adapter_for_executor = Arc::clone(&adapter);
+        Box::pin(materialize_session(
+            &service,
+            &adapter,
+            resume_source,
+            request,
+            move |session_id| {
+                default_persistent_executor(service_for_executor, adapter_for_executor, session_id)
+            },
+        ))
+        .await
+        .expect("materialize session with changed prompt");
+        run_prompt(&adapter, &session_id, "second turn after restart").await;
+
+        let final_session = service
+            .load_authoritative_session(&session_id)
+            .await
+            .expect("authoritative load after resumed turn")
+            .expect("session should still exist");
+        let texts = user_texts(&final_session);
+        assert!(
+            texts
+                .iter()
+                .any(|t| t.contains("first turn before restart")),
+            "history from before the restart must survive: {texts:?}"
+        );
+        assert!(
+            texts
+                .iter()
+                .any(|t| t.contains("second turn after restart")),
+            "the post-restart turn must be recorded: {texts:?}"
+        );
+        let system_prompt = match final_session.messages().first() {
+            Some(meerkat_core::Message::System(system)) => system.content.clone(),
+            other => panic!("expected leading system message, got {other:?}"),
+        };
+        assert!(
+            system_prompt.contains("cold restart resume contract v2"),
+            "the changed explicit base prompt must be applied: {system_prompt}"
+        );
+        assert!(
+            system_prompt.contains("peer roster: lead-1, w-1"),
+            "runtime-applied system context must survive the base change: {system_prompt}"
+        );
+        let history = final_session
+            .transcript_history_state()
+            .expect("transcript history state must deserialize")
+            .expect("base-prompt change must record transcript history");
+        assert!(
+            history.commits.iter().any(|commit| commit.reason.kind
+                == meerkat_core::RESUME_SYSTEM_PROMPT_REFRESH_REWRITE_REASON),
+            "base-prompt change must be recorded as a typed rewrite commit: {:?}",
+            history
+                .commits
+                .iter()
+                .map(|commit| &commit.reason.kind)
+                .collect::<Vec<_>>()
+        );
+    }
+
     #[tokio::test]
     async fn cold_restart_resume_continues_persisted_history() {
         let temp = tempfile::tempdir().expect("tempdir");


### PR DESCRIPTION
Upstream report (0.7.14 sdk / 0.7.21 mobkit): every cold restart of a
runtime-backed (session-owned) agent lost its transcript. Reconcile
claimed outcome=resumed, but each resume failed the session-store
projection continuity preflight ("incoming transcript is not a
continuation of persisted revision"), the live session was discarded,
and the downstream bridge fresh-spawned an empty replacement — on every
restart, including sessions freshly written by the same version.

Root cause: on resume with an explicit per-request prompt (the
SDK-gateway shape — member specs re-send SystemPromptOverride::Set on
every build), AgentFactory::build_agent re-assembled the base prompt
and blind-replaced the resumed session's leading System message. That
discarded every runtime-applied system-context append (comms rosters,
host context) and re-stamped the typed mutation_kind, so the resumed
projection no longer digested to a continuation of the persisted
revision and meerkat rejected its own resumed projection. meerkat-mob's
own resume passes SystemPromptOverride::Inherit, which is why the
existing mob cold-restart coverage never caught the explicit-prompt
surface.

Fix, at the composition seam:

- Session::reconcile_resumed_system_prompt (meerkat-core): a resumed,
  established transcript is authoritative. If the persisted System
  message already carries the assembled base — identical, or extended
  only by SYSTEM_CONTEXT_SEPARATOR-joined runtime context appends — it
  is preserved byte-for-byte (mutation_kind included), so the resumed
  projection digests to the persisted revision. A genuinely changed
  base is committed through the canonical typed rewrite path
  (reason "resume-system-prompt-refresh"), preserving the
  runtime-appended tail when it is verifiable byte-exactly against the
  prior build's recorded assembled base (new
  SessionBuildState.assembled_system_prompt, carried forward across
  Inherit resumes) or against a re-render of the durable applied-append
  records.
- AgentFactory::build_agent routes explicit prompts on resumed
  non-empty sessions through the reconciliation instead of
  builder.system_prompt() replacement, and records the assembled
  base-prompt bytes in the persisted build state.
- find_transcript_rewrite_commit_chain_extending_session
  (meerkat-core): skip commits whose revision is already the walk
  cursor. A same-length rewrite commit sitting exactly at the persisted
  head was spuriously selected (its parent body also "extends" the
  cursor under the leading-system-refresh equivalence), turning the
  walk into a cycle that rejected the first post-resume turn's boundary
  commit with "incoming append-only save would change retained
  transcript revision graph".

Regression coverage:

- meerkat/tests/cold_restart_resume.rs: resume with a
  runtime-context-appended prompt and the same explicit base (the
  reported shape — previously failed the continuity preflight at
  materialize time), and resume with a changed explicit base (typed
  rewrite recorded, appended tail preserved, post-restart turn lands).
- meerkat-mob/tests/cold_restart_mob_resume.rs: the cold-restart
  scenarios now append runtime system context to a member before the
  cold stop and assert the appended prompt survives revival
  byte-for-byte.
- meerkat-core session unit tests pin all reconciliation outcomes
  (preserved identical, preserved appended, rewritten-with-tail,
  insert-on-promptless).

The mob layer keeps its existing non-destructive contract on resume
failure (restore diagnostics + retry, never a fresh spawn over a
durable session); the silent empty-spawn fallback named in the report
lives in the downstream mobkit bridge, not in this repository.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01JQ4bMwefdNQsgTLZKSPPkn