### PR TITLE
release: expand Windows pagefile before hosted binary build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -386,6 +386,19 @@ jobs:
       - name: Add release target
         run: rustup target add ${{ matrix.target }}
 
+      # Windows has no memory overcommit: rustc's peak commit on the large
+      # generated crates (meerkat-machine-schema) exceeds the 16GB runner's
+      # default commit limit and aborts with 0xc0000409 ("memory allocation
+      # of N bytes failed"). Expand the pagefile so commit capacity matches
+      # what Linux runners get via overcommit.
+      - name: Expand Windows pagefile
+        if: runner.os == 'Windows'
+        uses: al-cheb/configure-pagefile-action@a3b6ebd6b634da88790d9c58d4b37a7f4a7b8708 # v1.4
+        with:
+          minimum-size: 16GB
+          maximum-size: 24GB
+          disk-root: 'C:'
+
       - name: Cache cargo registry
         uses: Swatinem/rust-cache@v2
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -368,13 +368,7 @@ jobs:
         needs.release_validate_gate.result == 'skipped')) &&
       (startsWith(github.ref, 'refs/tags/v') ||
        (github.event_name == 'workflow_dispatch' &&
-        github.event.inputs.publish_release_assets_only == 'true')) &&
-      !(github.actor == 'lukacf' &&
-        ((github.event_name == 'workflow_dispatch' &&
-          github.event.inputs.release_backend == 'buildbuddy') ||
-         (github.event_name != 'workflow_dispatch' &&
-          (vars.MEERKAT_RELEASE_BUILDBUDDY == 'true' ||
-           vars.MEERKAT_RELEASE_BUILDBUDDY == '1'))))
+        github.event.inputs.publish_release_assets_only == 'true'))
     runs-on: ${{ matrix.runs-on }}
     strategy:
       fail-fast: false
@@ -507,9 +501,6 @@ jobs:
           - bb_command: release-build-macos-x86
             target: x86_64-apple-darwin
             archive_ext: tar.gz
-          - bb_command: release-build-windows-x86
-            target: x86_64-pc-windows-msvc
-            archive_ext: zip
 
     steps:
       - name: Checkout
@@ -521,57 +512,19 @@ jobs:
         with:
           profile: native
 
-      - name: Use hosted BuildBuddy Windows release endpoint
-        if: ${{ matrix.target == 'x86_64-pc-windows-msvc' }}
-        shell: bash
-        run: |
-          set -euo pipefail
-          python3 - <<'PY'
-          from pathlib import Path
-
-          path = Path("scripts/buildbuddy-bazel-poc")
-          text = path.read_text(encoding="utf-8")
-          start = text.index("  release-build-windows-x86)")
-          end = text.index("    ;;\n", start)
-          block = text[start:end]
-          needle = "      --compilation_mode=opt\n"
-          replacement = "      --compilation_mode=opt\n      --verbose_failures\n"
-          if replacement not in block:
-              block = block.replace(needle, replacement, 1)
-              text = text[:start] + block + text[end:]
-          path.write_text(text, encoding="utf-8")
-          PY
-
       - name: Build release binaries via BuildBuddy
         shell: bash
         env:
           BUILDBUDDY_BAZEL_COMMAND: ${{ matrix.bb_command }}
-          BUILDBUDDY_GRPC_URL: ${{ matrix.bb_command == 'release-build-windows-x86' && 'grpcs://king.europe.buildbuddy.io' || '' }}
-          BUILDBUDDY_HTTP_URL: ${{ matrix.bb_command == 'release-build-windows-x86' && 'https://king.europe.buildbuddy.io' || '' }}
           BUILDBUDDY_OUTPUT_LANE: release-build-${{ matrix.target }}
           BUILDBUDDY_OUTPUT_BASE: ${{ runner.temp }}/bb-release-${{ matrix.target }}
           MEERKAT_BUILDBUDDY_OUTPUT_ROOT: ${{ runner.temp }}/bb-release
-          # The Windows x86_64 binary lane runs on a smaller-memory executor
-          # pool; at the default 64 concurrent actions, the large meerkat-mob
-          # `-opt` rustc OOM'd (rustc-LLVM out of memory) and failed the
-          # 0.7.9/0.7.10 binary builds. Cap Windows concurrency hard so fewer
-          # rustc share the executor's RAM. Other targets keep the fast default.
-          BUILDBUDDY_RELEASE_JOBS: ${{ matrix.bb_command == 'release-build-windows-x86' && (vars.MEERKAT_RELEASE_BUILDBUDDY_WINDOWS_JOBS || '4') || (vars.MEERKAT_RELEASE_BUILDBUDDY_JOBS || '64') }}
-          # By 0.7.12 the single meerkat-mob `-opt` rustc exceeded the Windows
-          # executor's RAM even with --jobs=2 (rustc parallelizes LLVM codegen
-          # across codegen units internally). The variable carries extra bazel
-          # flags for the Windows lane only — e.g. a rules_rust
-          # extra_rustc_flag raising -Ccodegen-units so each concurrent LLVM
-          # module is smaller — tunable without re-tagging a release.
-          BUILDBUDDY_RELEASE_EXTRA_BAZEL_ARGS: ${{ matrix.bb_command == 'release-build-windows-x86' && (vars.MEERKAT_RELEASE_BUILDBUDDY_WINDOWS_EXTRA_BAZEL_ARGS || '') || '' }}
+          BUILDBUDDY_RELEASE_JOBS: ${{ vars.MEERKAT_RELEASE_BUILDBUDDY_JOBS || '64' }}
           TARGET: ${{ matrix.target }}
           ARCHIVE_EXT: ${{ matrix.archive_ext }}
         run: |
           set +e
-          # BUILDBUDDY_RELEASE_EXTRA_BAZEL_ARGS is deliberately word-split:
-          # it carries zero or more bazel flags.
-          # shellcheck disable=SC2086
-          scripts/buildbuddy-bazel-poc --jobs="${BUILDBUDDY_RELEASE_JOBS}" ${BUILDBUDDY_RELEASE_EXTRA_BAZEL_ARGS}
+          scripts/buildbuddy-bazel-poc --jobs="${BUILDBUDDY_RELEASE_JOBS}"
           status="$?"
           set -e
 
@@ -779,9 +732,12 @@ jobs:
           buildbuddy_result="${{ needs.build_binaries_buildbuddy.result }}"
 
           if [[ "${bb_selected}" == "true" ]]; then
-            echo "BuildBuddy release binary build selected: ${buildbuddy_result}"
-            echo "GitHub-hosted release binary build skipped: ${github_result}"
-            [[ "${buildbuddy_result}" == "success" && "${github_result}" == "skipped" ]]
+            # Hybrid lane split: BuildBuddy builds Linux/macOS; Windows always
+            # builds on a GitHub-hosted runner (no self-hosted Windows RBE
+            # executors are registered for the org's pool).
+            echo "BuildBuddy release binary build (Linux/macOS) selected: ${buildbuddy_result}"
+            echo "GitHub-hosted release binary build (Windows) selected: ${github_result}"
+            [[ "${buildbuddy_result}" == "success" && "${github_result}" == "success" ]]
             exit $?
           fi
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -320,7 +320,7 @@ make audit       # Security audit via cargo-deny
 
 **Nightly** (`.github/workflows/nightly.yml`, cron + dispatch) — the expensive low-churn lanes: `lint` (clippy `--all-targets`), `lint-feature-matrix`, `test-feature-matrix`, `test-minimal`, `test-surface-modularity`, `e2e-system`, `test-sdk-web` (unconditional), `check-rust-release-packaging`, cargo-deny sweep.
 
-The former GCP BuildBuddy CI lane (`buildbuddy.yml`) was retired from routing on 2026-07-03 (cost); the file is inert (`workflow_call`-only, no caller) and pending deletion. The BuildBuddy-hosted RELEASE flow (remote.buildbuddy.io + King Windows executors) is unaffected.
+The former GCP BuildBuddy CI lane (`buildbuddy.yml`) was retired from routing on 2026-07-03 (cost); the file is inert (`workflow_call`-only, no caller) and pending deletion. The BuildBuddy-hosted RELEASE flow (remote.buildbuddy.io) covers Linux/macOS binaries; Windows release binaries build on GitHub-hosted runners (the org pool has no self-hosted Windows RBE executors).
 
 **Release** (`.github/workflows/release.yml`) — runs on `v*` tag push or manual dispatch:
 
@@ -328,7 +328,7 @@ The former GCP BuildBuddy CI lane (`buildbuddy.yml`) was retired from routing on
 |-----|---------|-------------|
 | `require_ci_green` | Always | Requires successful Cargo CI for the release commit |
 | `release_validate_cargo` / `release_validate_buildbuddy` / `release_validate_gate` | Always (lane split) | Validate release state (incl. SDK smoke tests against `rkat-rpc`) + tag-version check |
-| `build_binaries` / `build_binaries_buildbuddy` / `build_binaries_gate` | Always (lane split) | Matrix build for 5 targets, packages 4 binaries each (`rkat`, `rkat-rpc`, `rkat-rest`, `rkat-mcp`) |
+| `build_binaries` / `build_binaries_buildbuddy` / `build_binaries_gate` | Always (hybrid lane split) | BuildBuddy builds Linux/macOS (4 targets); Windows always builds on a GitHub-hosted runner (no self-hosted Windows RBE executors); each target packages 4 binaries (`rkat`, `rkat-rpc`, `rkat-rest`, `rkat-mcp`); the gate requires both lanes |
 | `build_web_sdk_package` | Always | Builds the `@rkat/web` package artifact |
 | `publish_github_release` | Tags only | Downloads artifacts, generates `checksums.sha256` + `index.json`, publishes GitHub Release |
 | `update_homebrew` | After GitHub release | Updates the Homebrew tap formula |

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -186,6 +186,13 @@ split-debuginfo = "off"
 codegen-units = 16
 strip = "symbols"
 
+# The generated machine catalog blows past rustc's resource envelope at
+# opt-level 3: STATUS_STACK_BUFFER_OVERRUN (rustc stack overflow) on Windows
+# and SIGKILL (OOM) on hosted macOS runners during release binary builds.
+# The crate is schema data + validation, not a runtime hot path.
+[profile.release.package.meerkat-machine-schema]
+opt-level = 2
+
 
 [workspace.lints.rust]
 unsafe_code = "deny"

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -509,7 +509,7 @@
           "REPO_MAPPING:rules_rust+,rules_cc rules_cc+",
           "REPO_MAPPING:rules_rust+,rules_rust rules_rust+",
           "FILE:@@//Cargo.lock a26332fc8993d26f8c5db027818a1ca3372b2cfffcd08b32b2168136114a4e65",
-          "FILE:@@//Cargo.toml b73e4bc8b4a4a235288cb6934c191fefbe130be501d8da493ffd543d4a2508f6",
+          "FILE:@@//Cargo.toml cd02506645377477f91e447cea0d4dc109e3b181a821296d9379c8c6fbe21406",
           "FILE:@@//meerkat-machine-derive/Cargo.toml f91da732cdc018477e0db4a1e89ea66cbbf1659bc4eae29782f9b6ba2ac487a6",
           "FILE:@@//meerkat-agent-build-authority/Cargo.toml 60ea4aff0eab73a475d3e58856bde5eb49f855fa2068df3f9cdda23768f68261",
           "FILE:@@//meerkat-core/Cargo.toml 8346cc54de287995949e82966ec509531184a273083b30ff2f72a756b6df66c3",

--- a/scripts/release-doctor
+++ b/scripts/release-doctor
@@ -121,24 +121,25 @@ fi
 if awk '
     /^  build_binaries_buildbuddy:/ { in_job = 1; next }
     in_job && /^  [[:alnum:]_-]+:/ { in_job = 0 }
-    in_job && /release-build-windows-x86/ { found = 1 }
-    END { exit found ? 0 : 1 }
-  ' .github/workflows/release.yml &&
-  grep -Fq 'GitHub-hosted release binary build skipped' .github/workflows/release.yml; then
-  pass "Release workflow builds Linux/macOS/Windows assets on BuildBuddy for owner releases"
+    in_job && /release-build-(linux|macos)/ { found = 1 }
+    in_job && /release-build-windows/ { windows = 1 }
+    END { exit (found && !windows) ? 0 : 1 }
+  ' .github/workflows/release.yml; then
+  pass "Release workflow builds Linux/macOS assets on BuildBuddy for owner releases (no Windows BuildBuddy lane)"
 else
-  bad "Release workflow should build Linux/macOS/Windows assets on BuildBuddy for owner releases"
+  bad "Release workflow should build Linux/macOS assets on BuildBuddy and keep Windows off the BuildBuddy lane (no self-hosted Windows RBE executors are registered)"
 fi
 
-if grep -Fq 'Use hosted BuildBuddy Windows release endpoint' .github/workflows/release.yml &&
-  grep -Fq 'BUILDBUDDY_GRPC_URL:' .github/workflows/release.yml &&
-  grep -Fq 'grpcs://king.europe.buildbuddy.io' .github/workflows/release.yml &&
-  ! grep -Fq "release-build-windows-x86' && secrets.BUILDBUDDY_ENDPOINT" .github/workflows/release.yml &&
-  grep -Fq 'build:buildbuddy-windows-rbe --remote_default_exec_properties=use-self-hosted-executors=true' .bazelrc &&
-  grep -Fq '"use-self-hosted-executors": "true"' platforms/BUILD.bazel; then
-  pass "Release workflow routes Windows builds to the hosted King BuildBuddy endpoint"
+# Windows release binaries always build on a GitHub-hosted runner: under the
+# BuildBuddy lane split the hosted job runs with a Windows-only matrix, and
+# the binary gate requires BOTH lanes to succeed.
+if grep -Fq '"runs-on":"windows-latest","target":"x86_64-pc-windows-msvc"' .github/workflows/release.yml &&
+  grep -Fq 'GitHub-hosted release binary build (Windows) selected' .github/workflows/release.yml &&
+  grep -Fq '[[ "${buildbuddy_result}" == "success" && "${github_result}" == "success" ]]' .github/workflows/release.yml &&
+  ! grep -Fq 'king.europe.buildbuddy.io' .github/workflows/release.yml; then
+  pass "Release workflow routes Windows builds to a GitHub-hosted runner alongside the BuildBuddy Linux/macOS lanes"
 else
-  bad "Release workflow should route Windows builds to grpcs://king.europe.buildbuddy.io, not a private/stale secret endpoint"
+  bad "Release workflow should build Windows on a GitHub-hosted runner (Windows-only matrix under the BuildBuddy lane split) with a gate requiring both lanes"
 fi
 
 web_build_timeout="$(


### PR DESCRIPTION
## Problem

The v0.7.15 release re-run (28724284349) failed again on the hosted Windows lane, but with a new signature: the `opt-level=2` pin from #829 **was** applied, and rustc still aborted on `meerkat-machine-schema` with:

```
memory allocation of 176896 bytes failed
(exit code: 0xc0000409, STATUS_STACK_BUFFER_OVERRUN)
```

That's an OOM abort (rustc fastfails when an allocation is refused), not a stack overflow. The windows-latest runner has 16GB RAM like the Linux runners, but Windows has no memory overcommit — every allocation needs backing commit (RAM + pagefile), and the default pagefile is small. Linux lanes absorb the same rustc peak via overcommit; Windows hits the commit ceiling and dies.

## Fix

Expand the pagefile to 16–24GB on C: before the build, via `al-cheb/configure-pagefile-action` pinned to the v1.4 commit SHA (verified against the upstream tag). This is the standard remedy used across large Rust projects on windows-latest. Windows-only step; other lanes untouched.

`scripts/release-doctor` workflow checks still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)