### PR TITLE
build: compile meerkat-machine-schema at opt-level 0 in release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -186,12 +186,14 @@ split-debuginfo = "off"
 codegen-units = 16
 strip = "symbols"
 
-# The generated machine catalog blows past rustc's resource envelope at
-# opt-level 3: STATUS_STACK_BUFFER_OVERRUN (rustc stack overflow) on Windows
-# and SIGKILL (OOM) on hosted macOS runners during release binary builds.
-# The crate is schema data + validation, not a runtime hot path.
+# The generated machine catalog blows past rustc's resource envelope when
+# optimized: opt-level 3 aborts on Windows (0xc0000409) and OOM-kills hosted
+# macOS runners; even opt-level 2 peaks at ~50GB rustc RSS, far beyond the
+# 16GB GitHub-hosted runners' commit limit. Tests already compile this crate
+# at opt-level 0 daily. The crate is schema data + validation, not a runtime
+# hot path, so release keeps it unoptimized.
 [profile.release.package.meerkat-machine-schema]
-opt-level = 2
+opt-level = 0
 
 
 [workspace.lints.rust]

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -509,7 +509,7 @@
           "REPO_MAPPING:rules_rust+,rules_cc rules_cc+",
           "REPO_MAPPING:rules_rust+,rules_rust rules_rust+",
           "FILE:@@//Cargo.lock a26332fc8993d26f8c5db027818a1ca3372b2cfffcd08b32b2168136114a4e65",
-          "FILE:@@//Cargo.toml cd02506645377477f91e447cea0d4dc109e3b181a821296d9379c8c6fbe21406",
+          "FILE:@@//Cargo.toml 924aa5c6a15901e819e8b77c150034cdd3684e86c9abe818a9dced3a3145ef66",
           "FILE:@@//meerkat-machine-derive/Cargo.toml f91da732cdc018477e0db4a1e89ea66cbbf1659bc4eae29782f9b6ba2ac487a6",
           "FILE:@@//meerkat-agent-build-authority/Cargo.toml 60ea4aff0eab73a475d3e58856bde5eb49f855fa2068df3f9cdda23768f68261",
           "FILE:@@//meerkat-core/Cargo.toml 8346cc54de287995949e82966ec509531184a273083b30ff2f72a756b6df66c3",


### PR DESCRIPTION
## Problem

The opt-level=2 pin from #829 did not fix the hosted Windows release lane: the v0.7.15 re-run still aborted compiling `meerkat-machine-schema` with `memory allocation of 176896 bytes failed` (0xc0000409) — an rustc OOM abort, not a stack overflow.

Measured locally, rustc peaks **above 46GB RSS** compiling this crate at opt-level 2 (I killed it past the 46GB mark after an hour, still climbing). No 16GB hosted runner — Windows, macOS, or Linux without generous overcommit — can absorb that, and no realistic pagefile bridges the gap (#831 helps commit headroom but cannot conjure 50GB). Local `wasm-pack --release` builds of `meerkat-web-runtime` pay the same cost, since the profile override applies there too.

## Fix

Pin the crate to `opt-level = 0` in the release profile:

| opt-level | wall clock | rustc peak RSS |
|-----------|-----------|----------------|
| 2 | >60 min (killed, unfinished) | >46GB and climbing |
| 0 | **41s** | **6.8GB** |

Tests already compile this crate at opt-level 0 every day (test/dev profile default). The crate is generated schema catalog data + validation — not a runtime hot path — and its rustc had `embed-bitcode=no`, so no downstream LTO stage re-optimizes it.

The #831 pagefile expansion stays as commit-headroom margin for the rest of the workspace.

MODULE.bazel.lock regenerated for the Cargo.toml change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)