### PR TITLE
release: cap Windows binary-build parallelism and raise rustc stack

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -410,6 +410,17 @@ jobs:
           CARGO_TARGET_DIR: target
         run: |
           set -euo pipefail
+          # Windows: even with the expanded pagefile, four concurrent opt-3
+          # rustc processes exceed the runner's commit capacity (v0.7.16 tag
+          # run: LLVM "out of memory" on meerkat-mcp), and rustc's own worker
+          # stacks overflow on the deeply recursive LLVM passes of the large
+          # crates (0xc0000409 on meerkat-runtime). Halve build parallelism
+          # and raise rustc's thread stack size on Windows only; other lanes
+          # keep cargo defaults.
+          if [[ "${{ runner.os }}" == "Windows" ]]; then
+            export CARGO_BUILD_JOBS=2
+            export RUST_MIN_STACK=33554432
+          fi
           # Package names (for cargo build -p) — binary names differ via [[bin]]
           PACKAGES=("rkat" "meerkat-rpc" "meerkat-rest" "meerkat-mcp-server")
           for pkg in "${PACKAGES[@]}"; do


### PR DESCRIPTION
## Summary

The v0.7.16 tag run failed its Windows binary build even with the expanded pagefile (#831) and the machine-schema opt-level pin (#832) — the OOM moved to the next crates in the graph:

- `meerkat-mcp`: `rustc-LLVM ERROR: out of memory` / `Allocation failed` → `STATUS_ILLEGAL_INSTRUCTION` (four concurrent opt-3 rustc processes exceed the runner's commit capacity even at 24GB pagefile)
- `meerkat-runtime`: `STATUS_STACK_BUFFER_OVERRUN` (rustc worker-thread stack overflow on the deeply recursive LLVM passes)

Fix, Windows lane only, following #831's pipeline-mitigation shape (no profile/codegen change for shipped binaries on any platform):

- `CARGO_BUILD_JOBS=2` — halves peak concurrent LLVM commit
- `RUST_MIN_STACK=33554432` — 32MB rustc worker stacks for the stack-overrun class

## Recovery plan

After merge: `gh workflow run release.yml --ref main -f publish_release_assets_only=true -f release_tag=v0.7.16 -f release_backend=buildbuddy` to rebuild the v0.7.16 binaries with the fixed lane and publish the GitHub release assets (registries already published from the tag run).

🤖 Generated with [Claude Code](https://claude.com/claude-code)