### PR TITLE
release: pin overrun crates to opt-level 1 on the Windows lane only

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -412,14 +412,21 @@ jobs:
           set -euo pipefail
           # Windows: even with the expanded pagefile, four concurrent opt-3
           # rustc processes exceed the runner's commit capacity (v0.7.16 tag
-          # run: LLVM "out of memory" on meerkat-mcp), and rustc's own worker
-          # stacks overflow on the deeply recursive LLVM passes of the large
-          # crates (0xc0000409 on meerkat-runtime). Halve build parallelism
-          # and raise rustc's thread stack size on Windows only; other lanes
-          # keep cargo defaults.
+          # run: LLVM "out of memory" on meerkat-mcp), and LLVM worker
+          # threads overflow their stacks on the deeply recursive opt-3
+          # passes over the large generated-heavy crates (0xc0000409 on
+          # meerkat-runtime — RUST_MIN_STACK does not reach LLVM's workers,
+          # proven by the v0.7.16 recovery run). Halve build parallelism and
+          # pin the two proven-overrun crates to opt-level 1 via a
+          # config-level profile override, Windows lane only — shipped
+          # Linux/macOS binaries keep full release codegen.
           if [[ "${{ runner.os }}" == "Windows" ]]; then
             export CARGO_BUILD_JOBS=2
-            export RUST_MIN_STACK=33554432
+            mkdir -p .cargo
+            {
+              printf '\n[profile.release.package.meerkat-runtime]\nopt-level = 1\n'
+              printf '\n[profile.release.package.meerkat-mcp]\nopt-level = 1\n'
+            } >> .cargo/config.toml
           fi
           # Package names (for cargo build -p) — binary names differ via [[bin]]
           PACKAGES=("rkat" "meerkat-rpc" "meerkat-rest" "meerkat-mcp-server")


### PR DESCRIPTION
## Summary

Second round of the Windows release-lane fix. The v0.7.16 recovery run (with #833's `CARGO_BUILD_JOBS=2` + `RUST_MIN_STACK=32MB`) proved the stack overrun is inside LLVM's worker threads, which `RUST_MIN_STACK` does not reach: `meerkat-runtime` died with the identical `0xc0000409 STATUS_STACK_BUFFER_OVERRUN` at opt-level 3.

The only reliable lever for this class is opt level (the #832 precedent), but `meerkat-runtime` and `meerkat-mcp` are runtime hot paths — a global `Cargo.toml` pin would degrade shipped Linux/macOS binaries too. So the Windows build step now appends config-level per-package profile overrides (stable Cargo feature) pinning the two proven-overrun crates to opt-level 1 before building, **Windows lane only**. Keeps the `CARGO_BUILD_JOBS=2` commit-capacity cap (it fixed the `meerkat-mcp` LLVM OOM); drops the ineffective `RUST_MIN_STACK`.

## Recovery plan

After merge: `gh workflow run release.yml --ref main -f publish_release_assets_only=true -f release_tag=v0.7.16 -f release_backend=buildbuddy` (registries + Web SDK for v0.7.16 already published; only the GitHub release assets remain).

🤖 Generated with [Claude Code](https://claude.com/claude-code)