### PR TITLE
fix: chunk DSL schema() emission so the machine catalog compiles with sane memory

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -395,8 +395,11 @@ jobs:
         if: runner.os == 'Windows'
         uses: al-cheb/configure-pagefile-action@a3b6ebd6b634da88790d9c58d4b37a7f4a7b8708 # v1.4
         with:
-          minimum-size: 16GB
-          maximum-size: 24GB
+          # Fixed size: Windows grows demand-sized pagefiles too slowly for
+          # parallel rustc allocation bursts (the v0.7.16 tag run OOM-aborted
+          # mid-growth at 16GB->24GB), so preallocate the full capacity.
+          minimum-size: 32GB
+          maximum-size: 32GB
           disk-root: 'C:'
 
       - name: Cache cargo registry

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -186,16 +186,6 @@ split-debuginfo = "off"
 codegen-units = 16
 strip = "symbols"
 
-# The generated machine catalog blows past rustc's resource envelope when
-# optimized: opt-level 3 aborts on Windows (0xc0000409) and OOM-kills hosted
-# macOS runners; even opt-level 2 peaks at ~50GB rustc RSS, far beyond the
-# 16GB GitHub-hosted runners' commit limit. Tests already compile this crate
-# at opt-level 0 daily. The crate is schema data + validation, not a runtime
-# hot path, so release keeps it unoptimized.
-[profile.release.package.meerkat-machine-schema]
-opt-level = 0
-
-
 [workspace.lints.rust]
 unsafe_code = "deny"
 unexpected_cfgs = { level = "warn", check-cfg = ["cfg(meerkat_internal_agent_factory_build)", "cfg(meerkat_internal_generated_authority_bridge)"] }

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -509,7 +509,7 @@
           "REPO_MAPPING:rules_rust+,rules_cc rules_cc+",
           "REPO_MAPPING:rules_rust+,rules_rust rules_rust+",
           "FILE:@@//Cargo.lock a9494c5bf522636070e122fdeea2753ff9d99a6003cd9710ac92885aec39c415",
-          "FILE:@@//Cargo.toml 11ed727b18147ee6f4cef1a9cf319ac7c916822c3e9f664acf3d56f152e62430",
+          "FILE:@@//Cargo.toml badad7aa62717faf9723ab2d80c74fd0911f7d4957fe4c15351d4554a89da7f7",
           "FILE:@@//meerkat-machine-derive/Cargo.toml f91da732cdc018477e0db4a1e89ea66cbbf1659bc4eae29782f9b6ba2ac487a6",
           "FILE:@@//meerkat-agent-build-authority/Cargo.toml 60ea4aff0eab73a475d3e58856bde5eb49f855fa2068df3f9cdda23768f68261",
           "FILE:@@//meerkat-core/Cargo.toml 8346cc54de287995949e82966ec509531184a273083b30ff2f72a756b6df66c3",

--- a/meerkat-machine-dsl-core/src/gen_schema.rs
+++ b/meerkat-machine-dsl-core/src/gen_schema.rs
@@ -41,45 +41,58 @@ fn non_literal_amount_compile_error(field: &str, update_kind: &str) -> TokenStre
 /// This is the backward-compatibility bridge: codegen, RMAT, validation, and
 /// xtask all work with MachineSchema. The invoking crate must depend on
 /// `meerkat-machine-schema` — we just emit the constructor tokens.
+/// A schema list emitted as per-element helper functions plus an assembly
+/// expression, instead of one inline `vec![...]` literal.
+///
+/// Inlining every constructor into the single `schema()` body produces one
+/// function of >100k expanded lines for the large machines; rustc's
+/// optimizer scales super-linearly in function-body size and peaks above
+/// 46GB RSS compiling it at opt-level 2. Splitting each element into its own
+/// `#[inline(never)]` associated function keeps every MIR body small at any
+/// opt level.
+struct ChunkedList {
+    part_fns: Vec<TokenStream>,
+    vec_expr: TokenStream,
+}
+
+fn chunk_schema_list(
+    schema_crate: &TokenStream,
+    elem_ty: &str,
+    prefix: &str,
+    elems: &[TokenStream],
+) -> ChunkedList {
+    let ty = syn::Ident::new(elem_ty, proc_macro2::Span::call_site());
+    let mut part_fns = Vec::with_capacity(elems.len());
+    let mut calls = Vec::with_capacity(elems.len());
+    for (idx, elem) in elems.iter().enumerate() {
+        let name = syn::Ident::new(
+            &format!("__schema_{prefix}_{idx}"),
+            proc_macro2::Span::call_site(),
+        );
+        part_fns.push(quote! {
+            #[doc(hidden)]
+            #[inline(never)]
+            fn #name() -> #schema_crate::#ty {
+                #[allow(unused_imports)]
+                use #schema_crate::*;
+                #[allow(unused_imports)]
+                use #schema_crate::identity::*;
+                #elem
+            }
+        });
+        calls.push(quote! { Self::#name() });
+    }
+    ChunkedList {
+        part_fns,
+        vec_expr: quote! { vec![#(#calls),*] },
+    }
+}
+
 pub fn generate(def: &MachineDef) -> TokenStream {
     let machine_name = def.name.to_string();
     let version = def.version;
     let rust_crate = &def.rust_crate;
     let rust_module = &def.rust_module;
-
-    let phase_enum_name = def.phase_enum.name.to_string();
-    let phase_variants = gen_variants(&def.phase_enum.variants);
-
-    let state_fields = gen_state_fields(def);
-    let init_phase = def.init_phase.to_string();
-    let init_fields = gen_init_fields(def);
-    let terminal_phases: Vec<_> = def
-        .terminal_phases
-        .iter()
-        .map(std::string::ToString::to_string)
-        .collect();
-
-    let input_name = def.inputs.name.to_string();
-    let input_variants = gen_enum_variants(&def.inputs);
-
-    let surface_only: Vec<_> = def
-        .surface_only_inputs
-        .iter()
-        .map(std::string::ToString::to_string)
-        .collect();
-
-    let signal_name = def.signals.name.to_string();
-    let signal_variants = gen_enum_variants(&def.signals);
-
-    let effect_name = def.effects.name.to_string();
-    let effect_variants = gen_enum_variants(&def.effects);
-
-    let helpers = gen_helpers(def);
-    let invariants = gen_invariants(def);
-    let transitions = gen_transitions(def);
-    let dispositions = gen_dispositions(def);
-
-    let state_name = crate::gen_state::state_struct_name(def);
 
     // When rust_crate is "self", the DSL is invoked inside meerkat-machine-schema
     // itself, so imports use `crate::` instead of `meerkat_machine_schema::`.
@@ -88,6 +101,85 @@ pub fn generate(def: &MachineDef) -> TokenStream {
     } else {
         quote! { meerkat_machine_schema }
     };
+
+    let phase_enum_name = def.phase_enum.name.to_string();
+    let phase_variants = chunk_schema_list(
+        &schema_crate,
+        "VariantSchema",
+        "phase_variant",
+        &gen_variants(&def.phase_enum.variants),
+    );
+
+    let state_fields = chunk_schema_list(
+        &schema_crate,
+        "FieldSchema",
+        "state_field",
+        &gen_state_fields(def),
+    );
+    let init_phase = def.init_phase.to_string();
+    let init_fields = chunk_schema_list(
+        &schema_crate,
+        "FieldInit",
+        "init_field",
+        &gen_init_fields(def),
+    );
+    let terminal_phases: Vec<_> = def
+        .terminal_phases
+        .iter()
+        .map(std::string::ToString::to_string)
+        .collect();
+
+    let input_name = def.inputs.name.to_string();
+    let input_variants = chunk_schema_list(
+        &schema_crate,
+        "VariantSchema",
+        "input_variant",
+        &gen_enum_variants(&def.inputs),
+    );
+
+    let surface_only: Vec<_> = def
+        .surface_only_inputs
+        .iter()
+        .map(std::string::ToString::to_string)
+        .collect();
+
+    let signal_name = def.signals.name.to_string();
+    let signal_variants = chunk_schema_list(
+        &schema_crate,
+        "VariantSchema",
+        "signal_variant",
+        &gen_enum_variants(&def.signals),
+    );
+
+    let effect_name = def.effects.name.to_string();
+    let effect_variants = chunk_schema_list(
+        &schema_crate,
+        "VariantSchema",
+        "effect_variant",
+        &gen_enum_variants(&def.effects),
+    );
+
+    let helpers = chunk_schema_list(&schema_crate, "HelperSchema", "helper", &gen_helpers(def));
+    let invariants = chunk_schema_list(
+        &schema_crate,
+        "InvariantSchema",
+        "invariant",
+        &gen_invariants(def),
+    );
+    let transitions = chunk_schema_list(
+        &schema_crate,
+        "TransitionSchema",
+        "transition",
+        &gen_transitions(def),
+    );
+    let dispositions = chunk_schema_list(
+        &schema_crate,
+        "EffectDispositionRule",
+        "disposition",
+        &gen_dispositions(def),
+    );
+
+    let state_name = crate::gen_state::state_struct_name(def);
 
     let machine_id = typed_id("MachineId", &machine_name);
     let init_phase_id = typed_id("PhaseId", &init_phase);
@@ -100,8 +192,40 @@ pub fn generate(def: &MachineDef) -> TokenStream {
         .map(|variant| typed_id("InputVariantId", variant))
         .collect();
 
+    let phase_variant_fns = &phase_variants.part_fns;
+    let phase_variants_expr = &phase_variants.vec_expr;
+    let state_field_fns = &state_fields.part_fns;
+    let state_fields_expr = &state_fields.vec_expr;
+    let init_field_fns = &init_fields.part_fns;
+    let init_fields_expr = &init_fields.vec_expr;
+    let input_variant_fns = &input_variants.part_fns;
+    let input_variants_expr = &input_variants.vec_expr;
+    let signal_variant_fns = &signal_variants.part_fns;
+    let signal_variants_expr = &signal_variants.vec_expr;
+    let effect_variant_fns = &effect_variants.part_fns;
+    let effect_variants_expr = &effect_variants.vec_expr;
+    let helper_fns = &helpers.part_fns;
+    let helpers_expr = &helpers.vec_expr;
+    let invariant_fns = &invariants.part_fns;
+    let invariants_expr = &invariants.vec_expr;
+    let transition_fns = &transitions.part_fns;
+    let transitions_expr = &transitions.vec_expr;
+    let disposition_fns = &dispositions.part_fns;
+    let dispositions_expr = &dispositions.vec_expr;
+
     quote! {
         impl #state_name {
+            #(#phase_variant_fns)*
+            #(#state_field_fns)*
+            #(#init_field_fns)*
+            #(#input_variant_fns)*
+            #(#signal_variant_fns)*
+            #(#effect_variant_fns)*
+            #(#helper_fns)*
+            #(#invariant_fns)*
+            #(#transition_fns)*
+            #(#disposition_fns)*
+
             pub fn schema() -> #schema_crate::MachineSchema {
                 use #schema_crate::*;
                 use #schema_crate::identity::*;
@@ -116,35 +240,35 @@ pub fn generate(def: &MachineDef) -> TokenStream {
                     state: StateSchema {
                         phase: EnumSchema {
                             name: #phase_enum_name.into(),
-                            variants: vec![#(#phase_variants),*],
+                            variants: #phase_variants_expr,
                         },
-                        fields: vec![#(#state_fields),*],
+                        fields: #state_fields_expr,
                         init: InitSchema {
                             phase: #init_phase_id,
-                            fields: vec![#(#init_fields),*],
+                            fields: #init_fields_expr,
                         },
                         terminal_phases: vec![#(#terminal_phase_ids),*],
                     },
                     inputs: EnumSchema {
                         name: #input_name.into(),
-                        variants: vec![#(#input_variants),*],
+                        variants: #input_variants_expr,
                     },
                     surface_only_inputs: vec![#(#surface_only_ids),*],
                     runtime_internal_inputs: vec![],
                     signals: EnumSchema {
                         name: #signal_name.into(),
-                        variants: vec![#(#signal_variants),*],
+                        variants: #signal_variants_expr,
                     },
                     effects: EnumSchema {
                         name: #effect_name.into(),
-                        variants: vec![#(#effect_variants),*],
+                        variants: #effect_variants_expr,
                     },
-                    helpers: vec![#(#helpers),*],
+                    helpers: #helpers_expr,
                     derived: vec![],
                     command_plans: vec![],
-                    invariants: vec![#(#invariants),*],
-                    transitions: vec![#(#transitions),*],
-                    effect_dispositions: vec![#(#dispositions),*],
+                    invariants: #invariants_expr,
+                    transitions: #transitions_expr,
+                    effect_dispositions: #dispositions_expr,
                     // Named-type bindings are attached by the catalog
                     // wrapper (`catalog::dsl::mod::with_named_types`) so the
                     // DSL macro surface stays stable while the authoritative

--- a/meerkat-machine-schema/BUILD.bazel
+++ b/meerkat-machine-schema/BUILD.bazel
@@ -65,7 +65,6 @@ rust_library(
     crate_root = "src/lib.rs",
     crate_features = [],
     edition = "2024",
-    rustc_flags = ["-Copt-level=0"],
     compile_data = [
         "Cargo.toml",
     ],

--- a/meerkat-runtime/BUILD.bazel
+++ b/meerkat-runtime/BUILD.bazel
@@ -146,7 +146,6 @@ rust_library(
         "sqlite-store",
     ],
     edition = "2024",
-    rustc_flags = ["-Copt-level=0"],
     compile_data = [
         "Cargo.toml",
         "src/comms_drain.rs",
@@ -194,7 +193,6 @@ rust_library(
         "test-support",
     ],
     edition = "2024",
-    rustc_flags = ["-Copt-level=0"],
     compile_data = [
         "Cargo.toml",
         "src/comms_drain.rs",

--- a/scripts/generate-bazel-rust-builds.mjs
+++ b/scripts/generate-bazel-rust-builds.mjs
@@ -1583,14 +1583,6 @@ for (const pkg of localPackages.values()) {
           internalAttrs[rustcEnvIndex] = `    rustc_env = {\n${rustcEnv.join("\n")}\n    },`;
         }
       }
-      if (key === "meerkat-machine-schema" || key === "meerkat-runtime") {
-        const editionIndex = internalAttrs.indexOf(`    edition = "2024",`);
-        internalAttrs.splice(
-          editionIndex + 1,
-          0,
-          `    rustc_flags = ["-Copt-level=0"],`,
-        );
-      }
       rules.push(`rust_library(\n${internalAttrs.join("\n")}\n)`);
       if (shouldGenerateRuntimeAgentFactoryTestSupportVariantForKey(key)) {
         const internalTestSupportDepsWithOptionalExternal = rewriteRuntimeTestSupportDeps(


### PR DESCRIPTION
## The core issue (per Luka: not a runner problem)

The `machine!` proc macro emitted each machine's entire `MachineSchema` as **one function** — 135,718 expanded lines for MeerkatMachine — and rustc/LLVM scale super-linearly on giant single bodies. Compiling `meerkat-machine-schema` at opt-level 2 peaked **above 46GB RSS without finishing**. That's what killed every hosted Windows release lane, what the opt-level pins (#829/#832) merely masked, and what would OOM nearly any dev machine.

## Fix (generator level)

`gen_schema` now emits every schema list element (transitions, invariants, helpers, variants, fields, init fields, dispositions) as its own private `#[inline(never)]` associated function on the state struct; `schema()` assembles the calls. Element expressions, evaluation order, and counts are unchanged.

**Value-parity proof:** `make machine-check-drift` — generated kernel artifacts byte-identical. 362 tests green across dsl-core/schema/kernels/codegen/dsl-tests; clippy clean; full pre-push gate (workspace clippy + unit + e2e-fast) green. An adversarial review cleared name-collision, hygiene, evaluation-order, wasm32/`inline(never)`, and visibility angles, and caught the leftover Bazel injection removed below.

## Measured at full opt-level 3 after the fix

| crate | peak RSS | wall |
|---|---|---|
| meerkat-machine-schema | 6.1GB | 2m18s |
| meerkat-runtime | 6.2GB | 2m45s |
| meerkat-mob | 6.3GB | 2m57s |
| meerkat-mcp | 6.0GB | 2m14s |
| meerkat-contracts | 6.0GB | 1m58s |
| meerkat-core | 2.6GB | — |
| meerkat-machine-kernels | 2.2GB | — |

(before: machine-schema at opt2 = >46GB, killed after an hour, still climbing)

## Workarounds deleted now that the cause is fixed

- `[profile.release.package.meerkat-machine-schema]` override in Cargo.toml — release binaries ship fully optimized again
- Bazel `-Copt-level=0` injection for machine-schema **and meerkat-runtime** in `generate-bazel-rust-builds.mjs` (BUILD files regenerated, lock refreshed) — the BuildBuddy release lane was silently shipping those crates unoptimized
- Windows pagefile becomes fixed-size 32GB: demand growth expands too slowly for parallel rustc bursts (the v0.7.16 tag run OOM-aborted mid-growth at 16→24GB). Complements #833's `-j2` cap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)