### PR TITLE
Fix dogma runtime identity and SDK parsing

### DIFF
--- a/artifacts/schemas/wire-types.json
+++ b/artifacts/schemas/wire-types.json
@@ -45125,10 +45125,12 @@
   "WireLiveAdapterErrorCode": {
     "$defs": {
       "WireLiveConfigRejectionReason": {
-        "description": "Wire mirror of\n[`meerkat_core::live_adapter::LiveConfigRejectionReason`]. R5-2 (P2\ndogma): pins the typed semantic-routing variants on the wire so SDKs\ncan distinguish a runtime-side identity swap from an adapter-side\ninput-modality rejection without string parsing.\n\nR6-5 (P3 dogma): closes the last typed-route-as-detail-string gap. The\nprevious wildcard fallback collapsed future core variants into\n`Other { detail: \"unknown_live_config_rejection_reason\" }`, which SDK\nconsumers had to pattern-match on the English `detail` to route — the\nexact \"typed route becomes detail string\" antipattern R3-6 + R5-3\nclosed for transport / observation / continuity / modality / status /\nerror_code. Future core variants now surface as `Unknown { debug }`\nwith the `{:?}` projection of the source variant preserved for\nserver-side observability.",
         "oneOf": [
           {
             "properties": {
+              "auth_binding_changed": {
+                "type": "boolean"
+              },
               "from_model": {
                 "type": "string"
               },
@@ -46047,10 +46049,12 @@
         ]
       },
       "WireLiveConfigRejectionReason": {
-        "description": "Wire mirror of\n[`meerkat_core::live_adapter::LiveConfigRejectionReason`]. R5-2 (P2\ndogma): pins the typed semantic-routing variants on the wire so SDKs\ncan distinguish a runtime-side identity swap from an adapter-side\ninput-modality rejection without string parsing.\n\nR6-5 (P3 dogma): closes the last typed-route-as-detail-string gap. The\nprevious wildcard fallback collapsed future core variants into\n`Other { detail: \"unknown_live_config_rejection_reason\" }`, which SDK\nconsumers had to pattern-match on the English `detail` to route — the\nexact \"typed route becomes detail string\" antipattern R3-6 + R5-3\nclosed for transport / observation / continuity / modality / status /\nerror_code. Future core variants now surface as `Unknown { debug }`\nwith the `{:?}` projection of the source variant preserved for\nserver-side observability.",
         "oneOf": [
           {
             "properties": {
+              "auth_binding_changed": {
+                "type": "boolean"
+              },
               "from_model": {
                 "type": "string"
               },

--- a/meerkat-contracts/src/wire/live.rs
+++ b/meerkat-contracts/src/wire/live.rs
@@ -1116,6 +1116,10 @@ pub enum WireLiveAdapterErrorCode {
 /// error_code. Future core variants now surface as `Unknown { debug }`
 /// with the `{:?}` projection of the source variant preserved for
 /// server-side observability.
+fn bool_is_false(value: &bool) -> bool {
+    !*value
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[serde(tag = "kind", rename_all = "snake_case")]
@@ -1126,6 +1130,8 @@ pub enum WireLiveConfigRejectionReason {
         from_provider: WireProvider,
         to_model: String,
         to_provider: WireProvider,
+        #[serde(default, skip_serializing_if = "bool_is_false")]
+        auth_binding_changed: bool,
     },
     NonRealtimeResolution {
         detail: String,
@@ -1193,11 +1199,13 @@ impl From<LiveConfigRejectionReason> for WireLiveConfigRejectionReason {
                 from_provider,
                 to_model,
                 to_provider,
+                auth_binding_changed,
             } => Self::ChannelIdentitySwap {
                 from_model,
                 from_provider: from_provider.into(),
                 to_model,
                 to_provider: to_provider.into(),
+                auth_binding_changed,
             },
             LiveConfigRejectionReason::NonRealtimeResolution { detail } => {
                 Self::NonRealtimeResolution { detail }
@@ -1276,11 +1284,13 @@ impl TryFrom<WireLiveConfigRejectionReason> for LiveConfigRejectionReason {
                 from_provider,
                 to_model,
                 to_provider,
+                auth_binding_changed,
             } => Ok(Self::ChannelIdentitySwap {
                 from_model,
                 from_provider: from_provider.try_into()?,
                 to_model,
                 to_provider: to_provider.try_into()?,
+                auth_binding_changed,
             }),
             WireLiveConfigRejectionReason::NonRealtimeResolution { detail } => {
                 Ok(Self::NonRealtimeResolution { detail })
@@ -2754,6 +2764,7 @@ mod tests {
                 from_provider: WireProvider::Anthropic,
                 to_model: "gpt-5.4".into(),
                 to_provider: WireProvider::OpenAi,
+                auth_binding_changed: false,
             },
             WireLiveConfigRejectionReason::Other {
                 detail: "anything".into(),
@@ -2847,10 +2858,12 @@ mod tests {
             from_provider: WireProvider::Anthropic,
             to_model: "gpt-5.4".into(),
             to_provider: WireProvider::OpenAi,
+            auth_binding_changed: false,
         };
         let j = serde_json::to_value(&v).expect("serialization should succeed");
         assert_eq!(j["from_provider"], "anthropic");
         assert_eq!(j["to_provider"], "openai");
+        assert!(j.get("auth_binding_changed").is_none());
         // Must NOT serialize as "open_a_i"
         assert_ne!(
             j["to_provider"], "open_a_i",

--- a/meerkat-core/src/live_adapter.rs
+++ b/meerkat-core/src/live_adapter.rs
@@ -481,6 +481,10 @@ pub enum LiveAdapterErrorCode {
 /// Wire shape: internally tagged on `kind` (snake_case) so SDK consumers
 /// can route on the discriminator. `#[non_exhaustive]` so future variants
 /// don't break existing callers.
+fn bool_is_false(value: &bool) -> bool {
+    !*value
+}
+
 #[cfg_attr(feature = "schema", derive(JsonSchema))]
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(tag = "kind", rename_all = "snake_case")]
@@ -488,13 +492,16 @@ pub enum LiveAdapterErrorCode {
 pub enum LiveConfigRejectionReason {
     /// Runtime detected the live channel's bound LLM identity diverges
     /// from the session's resolved identity (typically after a global
-    /// `config/patch` model/provider swap). The channel cannot rebind
+    /// `config/patch` model/provider swap, or a session-scoped auth binding
+    /// swap). The channel cannot rebind
     /// in place; the SDK must close + reopen against the new identity.
     ChannelIdentitySwap {
         from_model: String,
         from_provider: Provider,
         to_model: String,
         to_provider: Provider,
+        #[serde(default, skip_serializing_if = "bool_is_false")]
+        auth_binding_changed: bool,
     },
     /// Per-session post-`config/patch` precheck rejected the channel
     /// because the new resolved model is not realtime-capable, or the
@@ -562,10 +569,24 @@ impl std::fmt::Display for LiveConfigRejectionReason {
                 from_provider,
                 to_model,
                 to_provider,
+                auth_binding_changed,
             } => {
+                let kind = if *auth_binding_changed
+                    && from_model == to_model
+                    && from_provider == to_provider
+                {
+                    "auth_binding_swap"
+                } else {
+                    "model_swap"
+                };
+                let suffix = if *auth_binding_changed {
+                    "; auth_binding changed"
+                } else {
+                    ""
+                };
                 write!(
                     f,
-                    "model_swap: {from_model} ({from_provider:?}) -> {to_model} ({to_provider:?})"
+                    "{kind}: {from_model} ({from_provider:?}) -> {to_model} ({to_provider:?}){suffix}"
                 )
             }
             Self::NonRealtimeResolution { detail } => {
@@ -1992,6 +2013,7 @@ mod tests {
                 from_provider: Provider::OpenAI,
                 to_model: "test-realtime-2".into(),
                 to_provider: Provider::OpenAI,
+                auth_binding_changed: false,
             },
             LiveConfigRejectionReason::NonRealtimeResolution {
                 detail: "ModelNotRealtime { model: \"test-model-a\", provider: \"openai\" }".into(),

--- a/meerkat-live/src/host.rs
+++ b/meerkat-live/src/host.rs
@@ -3443,6 +3443,7 @@ mod tests {
                 from_provider: meerkat_core::Provider::OpenAI,
                 to_model: "b".to_string(),
                 to_provider: meerkat_core::Provider::OpenAI,
+                auth_binding_changed: false,
             },
         };
         host.signal_terminal_error(&ch, code).await.unwrap();

--- a/meerkat-rpc/src/session_runtime.rs
+++ b/meerkat-rpc/src/session_runtime.rs
@@ -3721,14 +3721,38 @@ impl SessionRuntime {
                 })?;
         }
 
-        match self
+        let report = match self
             .runtime_adapter
             .reconfigure_session_llm_identity(session_id, request.clone())
             .await
         {
-            Ok(_) => Ok(()),
-            Err(err) => Err(runtime_driver_error_to_rpc(err)),
+            Ok(report) => report,
+            Err(err) => return Err(runtime_driver_error_to_rpc(err)),
+        };
+
+        if live_channel_requires_close_for_identity_change(
+            &report.previous_identity,
+            &report.new_identity,
+        ) {
+            let snapshot = self.realm_context_snapshot();
+            let cleanup = self.archive_runtime_cleanup();
+            let close_report = self
+                .live_orchestrator(&snapshot, cleanup)
+                .close_live_channels_for_identity_change(session_id, &report.new_identity)
+                .await;
+            if !close_report.close_failed.is_empty() {
+                return Err(RpcError {
+                    code: error::INTERNAL_ERROR,
+                    message: format!(
+                        "failed to close stale live channel after LLM identity change for {session_id}: {:?}",
+                        close_report.close_failed
+                    ),
+                    data: None,
+                });
+            }
         }
+
+        Ok(())
     }
 
     pub async fn discard_live_session(&self, session_id: &SessionId) -> Result<(), SessionError> {
@@ -8901,6 +8925,25 @@ mod tests {
         assert!(
             live_channel_requires_close_for_identity_change(&prev, &new),
             "provider swap must require close+reopen even at same model_id"
+        );
+    }
+
+    #[test]
+    fn r11_close_required_when_auth_binding_swapped() {
+        let prev = SessionLlmIdentity {
+            model: "gpt-realtime-2".to_string(),
+            provider: meerkat_core::Provider::OpenAI,
+            self_hosted_server_id: None,
+            provider_params: None,
+            auth_binding: Some(test_auth_binding("dev", "openai_oauth_a")),
+        };
+        let new = SessionLlmIdentity {
+            auth_binding: Some(test_auth_binding("dev", "openai_oauth_b")),
+            ..prev.clone()
+        };
+        assert!(
+            live_channel_requires_close_for_identity_change(&prev, &new),
+            "auth_binding swap at the same model/provider must require close+reopen"
         );
     }
 
@@ -22680,6 +22723,152 @@ mod tests {
                 }
             }
             other => panic!("R11/CC1: expected Error observation, got {other:?}"),
+        }
+    }
+
+    /// Auth-binding swaps are credential identity swaps for live channels even
+    /// when model/provider stay unchanged. The open adapter resolved
+    /// credentials from the old binding at open/attach time; hot-swapping the
+    /// session identity must therefore close the channel so callers reopen with
+    /// fresh credentials instead of refreshing stale auth in place.
+    #[tokio::test]
+    async fn r11_hot_swap_closes_channel_on_auth_binding_swap() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let mut runtime = make_runtime(temp_factory(&temp), 10);
+        runtime.set_default_llm_client(Some(Arc::new(MockLlmClient)));
+
+        let session_id = runtime
+            .create_session(
+                realtime_build_config("gpt-realtime-2"),
+                None,
+                None,
+                Vec::new(),
+            )
+            .await
+            .expect("create_session for live channel");
+        let (event_tx, _rx) = mpsc::channel(100);
+        runtime
+            .start_turn(
+                &session_id,
+                "materialize for auth binding swap test".into(),
+                event_tx,
+                None,
+                None,
+                None,
+                None,
+            )
+            .await
+            .expect("materialize session via first turn");
+
+        let host = Arc::new(meerkat_live::LiveAdapterHost::new(Arc::new(
+            meerkat_live::NoOpProjectionSink,
+        )));
+        runtime.set_live_adapter_host(Arc::clone(&host));
+        let runtime = Arc::new(runtime);
+        let current_identity = runtime
+            .live_open_config_for_session(
+                &session_id,
+                meerkat_contracts::RealtimeTurningMode::ProviderManaged,
+            )
+            .await
+            .expect("live_open_config_for_session")
+            .llm_identity;
+        assert!(
+            current_identity.auth_binding.is_none(),
+            "test setup expects initial live identity to use env/default auth"
+        );
+        let candidate_channel_id = meerkat_live::LiveChannelId::random_uuid();
+        let open_authority = runtime
+            .runtime_adapter()
+            .resolve_live_open_admission(&session_id, &candidate_channel_id, &current_identity)
+            .await
+            .expect("live open admission");
+        let channel_id = host
+            .open_channel_with_authority(
+                open_authority
+                    .channel_open_authority()
+                    .expect("generated live open handoff"),
+            )
+            .await
+            .expect("open_channel");
+        let log: Arc<tokio::sync::Mutex<Vec<meerkat_core::live_adapter::LiveAdapterCommand>>> =
+            Arc::new(tokio::sync::Mutex::new(Vec::new()));
+        let adapter: Arc<dyn meerkat_core::live_adapter::LiveAdapter> =
+            Arc::new(R11RecordingAdapter {
+                log: Arc::clone(&log),
+            });
+        host.attach_adapter(&channel_id, adapter)
+            .await
+            .expect("attach_adapter");
+
+        let overrides = crate::handlers::turn::TurnOverrides {
+            auth_binding: Some(
+                meerkat_core::lifecycle::run_primitive::TurnMetadataOverride::Set(
+                    test_auth_binding("dev", "openai_oauth_b"),
+                ),
+            ),
+            ..Default::default()
+        };
+        runtime
+            .hot_swap_llm_client(&session_id, &overrides)
+            .await
+            .expect("auth-binding hot swap should close stale live channel");
+
+        let recorded = log.lock().await;
+        assert!(
+            recorded.is_empty(),
+            "auth-binding swap must close, not enqueue Refresh: {recorded:?}"
+        );
+        drop(recorded);
+        let status =
+            generated_live_public_status(&runtime, &session_id, host.as_ref(), &channel_id).await;
+        assert_eq!(
+            status,
+            meerkat_runtime::meerkat_machine::dsl::LiveChannelPublicStatus::Closed,
+            "auth-binding swap must close the channel; got status {status:?}"
+        );
+
+        let synthetic = drain_pending_synthetic(&host, &channel_id)
+            .await
+            .expect("auth-binding swap must enqueue a synthetic terminal obs");
+        match synthetic {
+            meerkat_core::live_adapter::LiveAdapterObservation::Error { code, message } => {
+                match code {
+                    meerkat_core::live_adapter::LiveAdapterErrorCode::ConfigRejected { reason } => {
+                        match &reason {
+                            meerkat_core::live_adapter::LiveConfigRejectionReason::ChannelIdentitySwap {
+                                from_model,
+                                to_model,
+                                auth_binding_changed,
+                                ..
+                            } => {
+                                assert_eq!(from_model, "gpt-realtime-2");
+                                assert_eq!(to_model, "gpt-realtime-2");
+                                assert!(
+                                    *auth_binding_changed,
+                                    "reason must identify auth_binding as the changed identity field"
+                                );
+                            }
+                            other => panic!(
+                                "expected ChannelIdentitySwap reason for auth-binding swap, got {other:?}"
+                            ),
+                        }
+                        let rendered = reason.to_string();
+                        assert!(
+                            rendered.contains("auth_binding_swap")
+                                && rendered.contains("auth_binding changed"),
+                            "Display projection must name the auth-binding swap; got: {rendered}"
+                        );
+                        assert_eq!(message, rendered);
+                    }
+                    other => {
+                        panic!(
+                            "expected ConfigRejected error code on auth-binding swap, got {other:?}"
+                        )
+                    }
+                }
+            }
+            other => panic!("expected Error observation, got {other:?}"),
         }
     }
 

--- a/meerkat/src/session_runtime/live_orchestration.rs
+++ b/meerkat/src/session_runtime/live_orchestration.rs
@@ -108,9 +108,9 @@ pub fn build_live_projection_snapshot_for_runtime(
     }
 }
 
-/// R11: pure helper deciding whether a `config/patch`-resolved live
-/// identity represents a model or provider swap relative to the identity
-/// the channel was opened with.
+/// Pure helper deciding whether a newly resolved live identity represents
+/// a channel-bound identity swap relative to the identity the channel was
+/// opened with.
 ///
 /// Returns `true` when the channel must be closed (so the SDK can reopen
 /// against the new identity); `false` when an in-place `Refresh` is safe.
@@ -119,17 +119,53 @@ pub fn build_live_projection_snapshot_for_runtime(
 /// authority. Missing generated identity is handled as a fail-closed channel
 /// close before this comparison is reached.
 ///
+/// Provider params are intentionally NOT checked here. Provider parameters
+/// are projected through in-place refresh semantics and do not necessarily
+/// require a new provider connection. The durable auth binding is checked
+/// because live adapters resolve credentials at open/attach time; a changed
+/// binding means the already-open provider session may be authenticated with
+/// stale credentials and must be closed + reopened.
+///
 /// Audio-rate change is intentionally NOT checked here. The OpenAI
 /// Refresh guard rejects it, but R11's typed runtime path is scoped to
-/// model + provider until `audio_config` is plumbed into the projection
-/// snapshot. Audio mismatches still surface as the existing async
+/// channel-bound LLM identity until `audio_config` is plumbed into the
+/// projection snapshot. Audio mismatches still surface as the existing async
 /// `LiveAdapterErrorCode::ConfigRejected` error from the adapter.
 #[must_use]
 pub fn live_channel_requires_close_for_identity_change(
     bound_identity: &SessionLlmIdentity,
     new_identity: &SessionLlmIdentity,
 ) -> bool {
-    bound_identity.model != new_identity.model || bound_identity.provider != new_identity.provider
+    bound_identity.model != new_identity.model
+        || bound_identity.provider != new_identity.provider
+        || bound_identity.auth_binding != new_identity.auth_binding
+}
+
+fn live_channel_identity_swap_reason(
+    bound_identity: &SessionLlmIdentity,
+    new_identity: &SessionLlmIdentity,
+) -> meerkat_core::live_adapter::LiveConfigRejectionReason {
+    meerkat_core::live_adapter::LiveConfigRejectionReason::ChannelIdentitySwap {
+        from_model: bound_identity.model.clone(),
+        from_provider: bound_identity.provider,
+        to_model: new_identity.model.clone(),
+        to_provider: new_identity.provider,
+        auth_binding_changed: bound_identity.auth_binding != new_identity.auth_binding,
+    }
+}
+
+fn live_channel_identity_swap_context(
+    bound_identity: &SessionLlmIdentity,
+    new_identity: &SessionLlmIdentity,
+) -> &'static str {
+    if bound_identity.model == new_identity.model
+        && bound_identity.provider == new_identity.provider
+        && bound_identity.auth_binding != new_identity.auth_binding
+    {
+        "auth_binding_swap"
+    } else {
+        "model_swap"
+    }
 }
 
 /// Decide whether `propagate_config_to_live_channels` should hot-swap a
@@ -436,6 +472,7 @@ mod orchestrator {
     use super::{
         LiveChannelCloseFailure, LiveChannelRefreshFailure, LiveConfigPropagationReport,
         LiveHotSwapSkipReason, build_live_projection_snapshot_for_runtime,
+        live_channel_identity_swap_context, live_channel_identity_swap_reason,
         live_channel_requires_close_for_identity_change, precheck_identity,
         realtime_projection_messages, realtime_projection_root_system_message,
         realtime_projection_runtime_system_context, should_apply_global_model_hot_swap,
@@ -897,6 +934,110 @@ mod orchestrator {
                 })
         }
 
+        /// Close active live channels for a session after its durable LLM
+        /// identity changes in a way the provider session cannot refresh in
+        /// place. This is the session-scoped sibling of
+        /// `propagate_config_to_live_channels`: both paths compare the
+        /// generated live-open bound identity against the new session identity
+        /// and close through generated live-close authority.
+        pub async fn close_live_channels_for_identity_change(
+            &self,
+            session_id: &SessionId,
+            new_identity: &SessionLlmIdentity,
+        ) -> LiveConfigPropagationReport {
+            let mut report = LiveConfigPropagationReport::default();
+            let Some(host) = self.host.as_ref() else {
+                return report;
+            };
+            let channels = host.active_channels().await;
+            for channel_id in channels {
+                let Some(channel_session_id) = self
+                    .runtime_adapter
+                    .live_session_for_active_channel(&channel_id)
+                    .await
+                else {
+                    continue;
+                };
+                if &channel_session_id != session_id {
+                    continue;
+                }
+                let bound_identity = match self
+                    .runtime_adapter
+                    .live_channel_bound_llm_identity(session_id, &channel_id)
+                    .await
+                {
+                    Ok(Some(identity)) => identity,
+                    Ok(None) => {
+                        let reason = meerkat_core::live_adapter::LiveConfigRejectionReason::Other {
+                            detail: "missing generated live-channel bound identity authority"
+                                .to_string(),
+                        };
+                        match self
+                            .close_live_channel_for_config_rejection(
+                                host,
+                                session_id,
+                                &channel_id,
+                                reason,
+                                "missing_generated_identity",
+                            )
+                            .await
+                        {
+                            Ok(()) => report.closed.push(session_id.clone()),
+                            Err(failure) => {
+                                report.close_failed.push((session_id.clone(), failure));
+                            }
+                        }
+                        continue;
+                    }
+                    Err(err) => {
+                        let reason = meerkat_core::live_adapter::LiveConfigRejectionReason::Other {
+                            detail: format!(
+                                "generated live-channel bound identity authority lookup failed: {err}"
+                            ),
+                        };
+                        match self
+                            .close_live_channel_for_config_rejection(
+                                host,
+                                session_id,
+                                &channel_id,
+                                reason,
+                                "generated_identity_lookup_failed",
+                            )
+                            .await
+                        {
+                            Ok(()) => report.closed.push(session_id.clone()),
+                            Err(failure) => {
+                                report.close_failed.push((session_id.clone(), failure));
+                            }
+                        }
+                        continue;
+                    }
+                };
+                if !live_channel_requires_close_for_identity_change(&bound_identity, new_identity) {
+                    report
+                        .skipped
+                        .push((session_id.clone(), LiveHotSwapSkipReason::NoOpOrOverride));
+                    continue;
+                }
+                let reason = live_channel_identity_swap_reason(&bound_identity, new_identity);
+                let context = live_channel_identity_swap_context(&bound_identity, new_identity);
+                match self
+                    .close_live_channel_for_config_rejection(
+                        host,
+                        session_id,
+                        &channel_id,
+                        reason,
+                        context,
+                    )
+                    .await
+                {
+                    Ok(()) => report.closed.push(session_id.clone()),
+                    Err(failure) => report.close_failed.push((session_id.clone(), failure)),
+                }
+            }
+            report
+        }
+
         /// Fan out `Refresh` (or `Close` if the new resolved model is no
         /// longer realtime-capable, or if the model/provider was
         /// swapped) to every active live channel. Per-channel faults are
@@ -1114,6 +1255,10 @@ mod orchestrator {
                     &bound_identity,
                     &open_config.llm_identity,
                 ) {
+                    let context = live_channel_identity_swap_context(
+                        &bound_identity,
+                        &open_config.llm_identity,
+                    );
                     tracing::info!(
                         target: "meerkat::session_runtime::live_orchestration",
                         %channel_id,
@@ -1122,24 +1267,23 @@ mod orchestrator {
                         new_model_id = %open_config.llm_identity.model,
                         old_provider_id = ?bound_identity.provider,
                         new_provider_id = ?open_config.llm_identity.provider,
-                        reason = "model_swap",
-                        "closing live channel: config patch swapped \
-                         model/provider; SDK must reopen against new identity"
+                        old_auth_binding = ?bound_identity.auth_binding,
+                        new_auth_binding = ?open_config.llm_identity.auth_binding,
+                        reason = context,
+                        "closing live channel: resolved live identity changed; \
+                         SDK must reopen against new identity"
                     );
-                    let reason =
-                        meerkat_core::live_adapter::LiveConfigRejectionReason::ChannelIdentitySwap {
-                            from_model: bound_identity.model.clone(),
-                            from_provider: bound_identity.provider,
-                            to_model: open_config.llm_identity.model.clone(),
-                            to_provider: open_config.llm_identity.provider,
-                        };
+                    let reason = live_channel_identity_swap_reason(
+                        &bound_identity,
+                        &open_config.llm_identity,
+                    );
                     match self
                         .close_live_channel_for_config_rejection(
                             host,
                             &session_id,
                             &channel_id,
                             reason,
-                            "model_swap",
+                            context,
                         )
                         .await
                     {

--- a/sdks/python/meerkat/client.py
+++ b/sdks/python/meerkat/client.py
@@ -608,17 +608,25 @@ class MeerkatClient:
         )
         if isinstance(caps_result, CapabilitiesResponse):  # pragma: no cover - typing aid
             caps_result = caps_result.__dict__
-        self._capabilities = [
-            Capability(
-                id=c.get("id", ""),
-                description=c.get("description", ""),
-                status=self._parse_wire_capability_status(
-                    c.get("status"),
-                    "Invalid capabilities/get response",
-                ),
+        context = "Invalid capabilities/get response"
+        capabilities = self._require_present_list_field(
+            caps_result, "capabilities", context
+        )
+        self._capabilities = []
+        for c in capabilities:
+            entry = self._require_dict(c, "capability", context)
+            self._capabilities.append(
+                Capability(
+                    id=self._require_string_field(entry, "id", context),
+                    description=self._require_string_field(
+                        entry, "description", context
+                    ),
+                    status=self._parse_wire_capability_status(
+                        entry.get("status"),
+                        context,
+                    ),
+                )
             )
-            for c in caps_result.get("capabilities", [])
-        ]
 
         # Register callback tools with the server if any were declared.
         if self._tool_registry:
@@ -1076,10 +1084,11 @@ class MeerkatClient:
         )
         params["initial_turn"] = "deferred"
         raw = await self._request("session/create", params)
+        context = "Invalid session/create deferred response"
         return DeferredSession(
             self,
-            session_id=raw.get("session_id", ""),
-            session_ref=raw.get("session_ref"),
+            session_id=self._require_string_field(raw, "session_id", context),
+            session_ref=self._optional_string_field(raw, "session_ref", context),
         )
 
     async def ask_help(
@@ -1134,9 +1143,14 @@ class MeerkatClient:
         if offset is not None:
             params["offset"] = offset
         result = await self._request("session/list", params)
+        sessions = self._require_present_list_field(
+            result, "sessions", "Invalid session/list response"
+        )
         return [
-            self._parse_session_summary(s)
-            for s in result.get("sessions", [])
+            self._parse_session_summary(
+                self._require_dict(s, f"sessions[{idx}]", "Invalid session/list response")
+            )
+            for idx, s in enumerate(sessions)
         ]
 
     async def read_session(self, session_id: str) -> SessionDetails:
@@ -1413,10 +1427,11 @@ class MeerkatClient:
             | RpcBlobPayload
         )
         raw = await self._request("blob/get", {"blob_id": blob_id})
+        context = "Invalid blob/get response"
         return BlobPayload(
-            blob_id=str(raw.get("blob_id", blob_id)),
-            media_type=str(raw.get("media_type", "")),
-            data_base64=str(raw.get("data", "")),
+            blob_id=self._require_string_field(raw, "blob_id", context),
+            media_type=self._require_string_field(raw, "media_type", context),
+            data_base64=self._require_string_field(raw, "data", context),
         )
 
     async def get_runtime_host_info(self) -> dict[str, Any]:
@@ -1884,8 +1899,13 @@ class MeerkatClient:
         definition: MobDefinitionInput | dict[str, Any],
     ) -> Mob:
         self.require_capability("mob")
-        result = await self._request("mob/create", {"definition": _wire_params(definition)})
-        return Mob(self, str(result.get("mob_id", "")))
+        result = await self._request(
+            "mob/create", {"definition": _wire_params(definition)}
+        )
+        return Mob(
+            self,
+            self._require_string_field(result, "mob_id", "Invalid mob/create response"),
+        )
 
     def mob(self, mob_id: str) -> Mob:
         return Mob(self, mob_id)
@@ -1893,7 +1913,13 @@ class MeerkatClient:
     async def list_mobs(self) -> list[dict[str, Any]]:
         self.require_capability("mob")
         result = await self._request("mob/list", {})
-        return self._require_list_field(result, "mobs", "Invalid mob/list response")
+        mobs = self._require_present_list_field(result, "mobs", "Invalid mob/list response")
+        parsed: list[dict[str, Any]] = []
+        for idx, mob in enumerate(mobs):
+            entry = self._require_dict(mob, f"mobs[{idx}]", "Invalid mob/list response")
+            self._require_string_field(entry, "mob_id", "Invalid mob/list response")
+            parsed.append(entry)
+        return parsed
 
     async def mob_status(self, mob_id: str) -> dict[str, Any]:
         result = await self._request("mob/status", {"mob_id": mob_id})
@@ -2692,8 +2718,21 @@ class MeerkatClient:
 
     async def list_mob_profiles(self) -> list[StoredMobProfile]:
         raw = await self._request("mob/profile/list", {})
-        profiles = raw.get("profiles", [])
-        return profiles if isinstance(profiles, list) else []
+        profiles = self._require_present_list_field(
+            raw, "profiles", "Invalid mob/profile/list response"
+        )
+        parsed: list[StoredMobProfile] = []
+        for idx, profile in enumerate(profiles):
+            entry = self._require_dict(
+                profile,
+                f"profiles[{idx}]",
+                "Invalid mob/profile/list response",
+            )
+            self._require_string_field(
+                entry, "name", "Invalid mob/profile/list response"
+            )
+            parsed.append(entry)  # type: ignore[arg-type]
+        return parsed
 
     async def update_mob_profile(
         self,
@@ -2829,9 +2868,14 @@ class MeerkatClient:
 
         Wraps the ``mob/cancel_work`` RPC (DELETE_ME C4).
         """
-        return await self._request(
+        result = await self._request(
             "mob/cancel_work", {"mob_id": mob_id, "work_ref": work_ref}
         )
+        context = "Invalid mob/cancel_work response"
+        return {
+            "mob_id": self._require_string_field(result, "mob_id", context),
+            "ok": self._require_bool_field(result, "ok", context),
+        }
 
     async def mob_cancel_all_work(self, member_ref: MobMemberRef) -> dict[str, Any]:
         """Cancel all in-flight work for a specific mob member.
@@ -2840,10 +2884,15 @@ class MeerkatClient:
         ``ensure_member``/``spawn_helper``/``fork_helper`` and member-list
         responses.
         """
-        return await self._request(
+        result = await self._request(
             "mob/cancel_all_work",
             {"member_ref": member_ref},
         )
+        context = "Invalid mob/cancel_all_work response"
+        return {
+            "mob_id": self._require_string_field(result, "mob_id", context),
+            "ok": self._require_bool_field(result, "ok", context),
+        }
 
     async def append_mob_system_context(
         self,
@@ -2878,11 +2927,20 @@ class MeerkatClient:
 
     async def list_mob_flows(self, mob_id: str) -> list[str]:
         result = await self._request("mob/flows", {"mob_id": mob_id})
-        return result.get("flows", [])
+        context = "Invalid mob/flows response"
+        self._require_string_field(result, "mob_id", context)
+        flows = self._require_present_list_field(result, "flows", context)
+        for idx, flow in enumerate(flows):
+            if not isinstance(flow, str) or not flow:
+                raise MeerkatError(
+                    "INVALID_RESPONSE",
+                    f"{context}: flows[{idx}] must be string",
+                )
+        return flows
 
     async def run_mob_flow(self, mob_id: str, flow_id: str, params: dict[str, Any] | None = None) -> str:
         result = await self._request("mob/flow_run", {"mob_id": mob_id, "flow_id": flow_id, "params": params or {}})
-        return str(result.get("run_id", ""))
+        return self._require_string_field(result, "run_id", "Invalid mob/flow_run response")
 
     async def run_mob(
         self,
@@ -2903,7 +2961,7 @@ class MeerkatClient:
             _wire_params(payload),
         )
         if isinstance(result, dict):
-            return str(result.get("run_id", ""))
+            return self._require_string_field(result, "run_id", "Invalid mob/run response")
         return result.run_id
 
     async def get_mob_flow_status(self, mob_id: str, run_id: str) -> dict[str, Any] | None:
@@ -4074,12 +4132,24 @@ class MeerkatClient:
         return value
 
     @staticmethod
+    def _require_present_string_field(raw: dict[str, Any], field: str, context: str) -> str:
+        value = raw.get(field)
+        if not isinstance(value, str):
+            raise MeerkatError("INVALID_RESPONSE", f"{context}: missing {field}")
+        return value
+
+    @staticmethod
     def _require_number_field(
         raw: dict[str, Any],
         field: str,
         context: str,
         display_field: str | None = None,
     ) -> int | float:
+        if field not in raw:
+            raise MeerkatError(
+                "INVALID_RESPONSE",
+                f"{context}: missing {display_field or field}",
+            )
         value = raw.get(field)
         if not isinstance(value, (int, float)) or isinstance(value, bool):
             raise MeerkatError(
@@ -4200,47 +4270,112 @@ class MeerkatClient:
         return value
 
     @staticmethod
-    def _parse_skill_diagnostics(raw: Any) -> SkillRuntimeDiagnostics | None:
-        if not isinstance(raw, dict):
-            return None
+    def _require_present_list_field(
+        raw: dict[str, Any], field: str, context: str
+    ) -> list[Any]:
+        if field not in raw:
+            raise MeerkatError("INVALID_RESPONSE", f"{context}: missing {field}")
+        return MeerkatClient._require_list_field(raw, field, context)
 
-        source_health_raw = raw.get("source_health")
-        source_health = SourceHealthSnapshot()
-        if isinstance(source_health_raw, dict):
-            source_health = SourceHealthSnapshot(
-                state=str(source_health_raw.get("state", "")),
-                invalid_ratio=float(source_health_raw.get("invalid_ratio", 0.0)),
-                invalid_count=int(source_health_raw.get("invalid_count", 0)),
-                total_count=int(source_health_raw.get("total_count", 0)),
-                failure_streak=int(source_health_raw.get("failure_streak", 0)),
-                handshake_failed=bool(source_health_raw.get("handshake_failed", False)),
-            )
+    @staticmethod
+    def _parse_skill_diagnostics(raw: Any) -> SkillRuntimeDiagnostics | None:
+        if raw is None:
+            return None
+        context = "Invalid run result"
+        data = MeerkatClient._require_dict(raw, "skill_diagnostics", context)
+
+        source_health_raw = MeerkatClient._require_dict(
+            data.get("source_health"),
+            "skill_diagnostics.source_health",
+            context,
+        )
+        source_health = SourceHealthSnapshot(
+            state=MeerkatClient._require_string_field(
+                source_health_raw, "state", context
+            ),
+            invalid_ratio=MeerkatClient._require_number_field(
+                source_health_raw,
+                "invalid_ratio",
+                context,
+                "skill_diagnostics.source_health.invalid_ratio",
+            ),
+            invalid_count=MeerkatClient._require_non_negative_integer_field(
+                source_health_raw,
+                "invalid_count",
+                context,
+                "skill_diagnostics.source_health.invalid_count",
+            ),
+            total_count=MeerkatClient._require_non_negative_integer_field(
+                source_health_raw,
+                "total_count",
+                context,
+                "skill_diagnostics.source_health.total_count",
+            ),
+            failure_streak=MeerkatClient._require_non_negative_integer_field(
+                source_health_raw,
+                "failure_streak",
+                context,
+                "skill_diagnostics.source_health.failure_streak",
+            ),
+            handshake_failed=MeerkatClient._require_bool_field(
+                source_health_raw, "handshake_failed", context
+            ),
+        )
 
         quarantined_items: list[SkillQuarantineDiagnostic] = []
-        raw_quarantined = raw.get("quarantined")
-        if isinstance(raw_quarantined, list):
-            for item in raw_quarantined:
-                if not isinstance(item, dict):
-                    raise MeerkatError(
-                        "INVALID_RESPONSE",
-                        "Invalid skill diagnostics: quarantined entry must be an object",
-                    )
-                quarantined_items.append(
-                    SkillQuarantineDiagnostic(
-                        source_uuid=str(item.get("source_uuid", "")),
-                        skill_id=str(item.get("skill_id", "")),
-                        location=str(item.get("location", "")),
-                        error_code=str(item.get("error_code", "")),
-                        error_class=str(item.get("error_class", "")),
-                        message=str(item.get("message", "")),
-                        first_seen_unix_secs=int(item.get("first_seen_unix_secs", 0)),
-                        last_seen_unix_secs=int(item.get("last_seen_unix_secs", 0)),
-                    )
+        raw_quarantined = MeerkatClient._require_present_list_field(
+            data, "quarantined", context
+        )
+        for idx, item in enumerate(raw_quarantined):
+            entry = MeerkatClient._require_dict(
+                item,
+                f"skill_diagnostics.quarantined[{idx}]",
+                context,
+            )
+            identity = MeerkatClient._require_dict(
+                entry.get("identity"),
+                f"skill_diagnostics.quarantined[{idx}].identity",
+                context,
+            )
+            quarantined_items.append(
+                SkillQuarantineDiagnostic(
+                    source_uuid=MeerkatClient._require_string_field(
+                        identity, "source_uuid", context
+                    ),
+                    skill_id=MeerkatClient._require_present_string_field(
+                        identity, "raw_id", context
+                    ),
+                    location=MeerkatClient._require_present_string_field(
+                        entry, "location", context
+                    ),
+                    error_code=MeerkatClient._require_present_string_field(
+                        entry, "error_code", context
+                    ),
+                    error_class=MeerkatClient._require_present_string_field(
+                        entry, "error_class", context
+                    ),
+                    message=MeerkatClient._require_present_string_field(
+                        entry, "message", context
+                    ),
+                    first_seen_unix_secs=MeerkatClient._require_non_negative_integer_field(
+                        entry,
+                        "first_seen_unix_secs",
+                        context,
+                        "skill_diagnostics.quarantined.first_seen_unix_secs",
+                    ),
+                    last_seen_unix_secs=MeerkatClient._require_non_negative_integer_field(
+                        entry,
+                        "last_seen_unix_secs",
+                        context,
+                        "skill_diagnostics.quarantined.last_seen_unix_secs",
+                    ),
                 )
+            )
 
         return SkillRuntimeDiagnostics(
             source_health=source_health,
             quarantined=quarantined_items,
+            collection_fault=data.get("collection_fault"),
         )
 
     @staticmethod
@@ -4291,37 +4426,65 @@ class MeerkatClient:
         raw_warnings = data.get("schema_warnings")
         schema_warnings: list[SchemaWarning] | None = None
         if raw_warnings is not None:
-            schema_warnings = [
-                SchemaWarning(
-                    provider=w.get("provider", ""),
-                    path=w.get("path", ""),
-                    message=w.get("message", ""),
+            warnings = MeerkatClient._require_list_field(
+                {"schema_warnings": raw_warnings},
+                "schema_warnings",
+                context,
+            )
+            schema_warnings = []
+            for idx, warning in enumerate(warnings):
+                entry = MeerkatClient._require_dict(
+                    warning, f"schema_warnings[{idx}]", context
                 )
-                for w in raw_warnings
-            ]
+                schema_warnings.append(
+                    SchemaWarning(
+                        provider=MeerkatClient._require_present_string_field(
+                            entry, "provider", context
+                        ),
+                        path=MeerkatClient._require_present_string_field(
+                            entry, "path", context
+                        ),
+                        message=MeerkatClient._require_present_string_field(
+                            entry, "message", context
+                        ),
+                    )
+                )
         raw_extraction_error = data.get("extraction_error")
         extraction_error = None
-        if isinstance(raw_extraction_error, dict):
+        if raw_extraction_error is not None:
+            extraction = MeerkatClient._require_dict(
+                raw_extraction_error,
+                "extraction_error",
+                context,
+            )
             extraction_error = ExtractionError(
-                last_output=str(raw_extraction_error.get("last_output", "")),
+                last_output=MeerkatClient._require_present_string_field(
+                    extraction,
+                    "last_output",
+                    context,
+                ),
                 attempts=MeerkatClient._require_number_field(
-                    raw_extraction_error,
+                    extraction,
                     "attempts",
                     context,
                     "extraction_error.attempts",
                 ),
-                reason=str(raw_extraction_error.get("reason", "")),
+                reason=MeerkatClient._require_present_string_field(
+                    extraction,
+                    "reason",
+                    context,
+                ),
             )
         return RunResult(
-            session_id=data.get("session_id", ""),
-            text=data.get("text", ""),
+            session_id=MeerkatClient._require_string_field(data, "session_id", context),
+            text=MeerkatClient._require_present_string_field(data, "text", context),
             turns=MeerkatClient._require_number_field(data, "turns", context),
             tool_calls=MeerkatClient._require_number_field(data, "tool_calls", context),
             usage=usage,
             terminal_cause_kind=data.get("terminal_cause_kind")
             if isinstance(data.get("terminal_cause_kind"), str)
             else None,
-            session_ref=data.get("session_ref"),
+            session_ref=MeerkatClient._optional_string_field(data, "session_ref", context),
             structured_output=data.get("structured_output"),
             extraction_error=extraction_error,
             schema_warnings=schema_warnings,
@@ -4707,15 +4870,27 @@ class MeerkatClient:
 
     @staticmethod
     def _parse_session_summary(s: dict[str, Any]) -> SessionSummary:
+        context = "Invalid session/list response entry"
+        labels_raw = s.get("labels")
+        if labels_raw is not None and not isinstance(labels_raw, dict):
+            raise MeerkatError("INVALID_RESPONSE", f"{context}: labels must be object")
         return SessionSummary(
-            session_id=str(s.get("session_id", "")),
-            session_ref=s.get("session_ref"),
-            created_at=MeerkatClient._parse_int(s.get("created_at"), 0),
-            updated_at=MeerkatClient._parse_int(s.get("updated_at"), 0),
-            message_count=MeerkatClient._parse_int(s.get("message_count"), 0),
-            total_tokens=MeerkatClient._parse_int(s.get("total_tokens"), 0),
-            labels=MeerkatClient._parse_string_map(s.get("labels")),
-            is_active=bool(s.get("is_active", False)),
+            session_id=MeerkatClient._require_string_field(s, "session_id", context),
+            session_ref=MeerkatClient._optional_string_field(s, "session_ref", context),
+            created_at=MeerkatClient._require_non_negative_integer_field(
+                s, "created_at", context
+            ),
+            updated_at=MeerkatClient._require_non_negative_integer_field(
+                s, "updated_at", context
+            ),
+            message_count=MeerkatClient._require_non_negative_integer_field(
+                s, "message_count", context
+            ),
+            total_tokens=MeerkatClient._require_non_negative_integer_field(
+                s, "total_tokens", context
+            ),
+            labels=MeerkatClient._parse_string_map(labels_raw),
+            is_active=MeerkatClient._require_bool_field(s, "is_active", context),
         )
 
     @staticmethod

--- a/sdks/python/meerkat/generated/types.py
+++ b/sdks/python/meerkat/generated/types.py
@@ -3529,22 +3529,9 @@ class WireLiveAdapterStatusUnknown(TypedDict, total=False):
 
 WireLiveAdapterStatus = WireLiveAdapterStatusIdle | WireLiveAdapterStatusOpening | WireLiveAdapterStatusReady | WireLiveAdapterStatusDegraded | WireLiveAdapterStatusClosing | WireLiveAdapterStatusClosed | WireLiveAdapterStatusUnknown
 
-# Wire mirror of
-# [`meerkat_core::live_adapter::LiveConfigRejectionReason`]. R5-2 (P2
-# dogma): pins the typed semantic-routing variants on the wire so SDKs
-# can distinguish a runtime-side identity swap from an adapter-side
-# input-modality rejection without string parsing.
-#
-# R6-5 (P3 dogma): closes the last typed-route-as-detail-string gap. The
-# previous wildcard fallback collapsed future core variants into
-# `Other { detail: "unknown_live_config_rejection_reason" }`, which SDK
-# consumers had to pattern-match on the English `detail` to route — the
-# exact "typed route becomes detail string" antipattern R3-6 + R5-3
-# closed for transport / observation / continuity / modality / status /
-# error_code. Future core variants now surface as `Unknown { debug }`
-# with the `{:?}` projection of the source variant preserved for
-# server-side observability.
+# Wire projection of LiveConfigRejectionReason (tagged on `kind`).
 class WireLiveConfigRejectionReasonChannelIdentitySwap(TypedDict, total=False):
+    auth_binding_changed: NotRequired[bool]
     from_model: Required[str]
     from_provider: Required[WireProvider]
     kind: Required[Literal['channel_identity_swap']]

--- a/sdks/python/meerkat/types.py
+++ b/sdks/python/meerkat/types.py
@@ -321,6 +321,7 @@ class SkillRuntimeDiagnostics:
 
     source_health: SourceHealthSnapshot = field(default_factory=SourceHealthSnapshot)
     quarantined: list[SkillQuarantineDiagnostic] = field(default_factory=list)
+    collection_fault: Any | None = None
 
 
 @dataclass(frozen=True, slots=True)

--- a/sdks/python/tests/test_types.py
+++ b/sdks/python/tests/test_types.py
@@ -694,8 +694,10 @@ def test_parse_run_result_skill_diagnostics():
             },
             "quarantined": [
                 {
-                    "source_uuid": "src-1",
-                    "skill_id": "extract/email",
+                    "identity": {
+                        "source_uuid": "src-1",
+                        "raw_id": "extract/email",
+                    },
                     "location": "project",
                     "error_code": "bad_frontmatter",
                     "error_class": "ValidationError",
@@ -704,12 +706,20 @@ def test_parse_run_result_skill_diagnostics():
                     "last_seen_unix_secs": 20,
                 }
             ],
+            "collection_fault": {
+                "reason_type": "source_unknown",
+                "message": "diagnostics source unavailable",
+            },
         },
     }
     result = MeerkatClient._parse_run_result(raw)
     assert result.skill_diagnostics is not None
     assert result.skill_diagnostics.source_health.state == "healthy"
     assert result.skill_diagnostics.quarantined[0].skill_id == "extract/email"
+    assert result.skill_diagnostics.collection_fault == {
+        "reason_type": "source_unknown",
+        "message": "diagnostics source unavailable",
+    }
 
 
 def test_parse_run_result_extraction_error():
@@ -733,6 +743,26 @@ def test_parse_run_result_extraction_error():
 
 
 def test_parse_run_result_rejects_malformed_counters():
+    with pytest.raises(MeerkatError, match="missing session_id"):
+        MeerkatClient._parse_run_result(
+            {
+                "text": "ok",
+                "turns": 1,
+                "tool_calls": 0,
+                "usage": {"input_tokens": 1, "output_tokens": 1},
+            }
+        )
+
+    MeerkatClient._parse_run_result(
+        {
+            "session_id": "s1",
+            "text": "",
+            "turns": 1,
+            "tool_calls": 0,
+            "usage": {"input_tokens": 1, "output_tokens": 1},
+        }
+    )
+
     with pytest.raises(MeerkatError, match="missing usage"):
         MeerkatClient._parse_run_result(
             {"session_id": "s1", "text": "ok", "turns": 1, "tool_calls": 0}
@@ -757,6 +787,90 @@ def test_parse_run_result_rejects_malformed_counters():
                 "turns": 1,
                 "tool_calls": 0,
                 "usage": {"input_tokens": "oops", "output_tokens": 1},
+            }
+        )
+
+    with pytest.raises(MeerkatError, match="missing provider"):
+        MeerkatClient._parse_run_result(
+            {
+                "session_id": "s1",
+                "text": "ok",
+                "turns": 1,
+                "tool_calls": 0,
+                "usage": {"input_tokens": 1, "output_tokens": 1},
+                "schema_warnings": [{"path": "$", "message": "warn"}],
+            }
+        )
+
+    with pytest.raises(MeerkatError, match="schema_warnings must be a list"):
+        MeerkatClient._parse_run_result(
+            {
+                "session_id": "s1",
+                "text": "ok",
+                "turns": 1,
+                "tool_calls": 0,
+                "usage": {"input_tokens": 1, "output_tokens": 1},
+                "schema_warnings": "warn",
+            }
+        )
+
+    with pytest.raises(MeerkatError, match="missing reason"):
+        MeerkatClient._parse_run_result(
+            {
+                "session_id": "s1",
+                "text": "ok",
+                "turns": 1,
+                "tool_calls": 0,
+                "usage": {"input_tokens": 1, "output_tokens": 1},
+                "extraction_error": {"last_output": "bad", "attempts": 1},
+            }
+        )
+
+    with pytest.raises(MeerkatError, match="missing extraction_error"):
+        MeerkatClient._parse_run_result(
+            {
+                "session_id": "s1",
+                "text": "ok",
+                "turns": 1,
+                "tool_calls": 0,
+                "usage": {"input_tokens": 1, "output_tokens": 1},
+                "extraction_error": "bad",
+            }
+        )
+
+    with pytest.raises(MeerkatError, match="missing skill_diagnostics.source_health"):
+        MeerkatClient._parse_run_result(
+            {
+                "session_id": "s1",
+                "text": "ok",
+                "turns": 1,
+                "tool_calls": 0,
+                "usage": {"input_tokens": 1, "output_tokens": 1},
+                "skill_diagnostics": {"quarantined": []},
+            }
+        )
+
+    with pytest.raises(
+        MeerkatError, match=r"missing skill_diagnostics.quarantined\[0\].identity"
+    ):
+        MeerkatClient._parse_run_result(
+            {
+                "session_id": "s1",
+                "text": "ok",
+                "turns": 1,
+                "tool_calls": 0,
+                "usage": {"input_tokens": 1, "output_tokens": 1},
+                "skill_diagnostics": {
+                    "source_health": {
+                        "state": "healthy",
+                        "invalid_ratio": 0,
+                        "invalid_count": 0,
+                        "total_count": 0,
+                        "failure_streak": 0,
+                        "handshake_failed": False,
+                    },
+                    "quarantined": [{"location": "project"}],
+                },
             }
         )
 
@@ -1187,6 +1301,19 @@ async def test_create_deferred_session_returns_runtime_backed_deferred_wrapper()
             {"prompt": "Hold until first turn", "initial_turn": "deferred"},
         )
     ]
+
+
+@pytest.mark.asyncio
+async def test_create_deferred_session_rejects_missing_session_id() -> None:
+    client = MeerkatClient()
+
+    async def fake_request(method: str, params: dict[str, object]) -> dict[str, object]:
+        return {"session_ref": "team/deferred"}
+
+    client._request = fake_request  # type: ignore[method-assign]
+
+    with pytest.raises(MeerkatError, match="missing session_id"):
+        await client.create_deferred_session("Hold until first turn")
 
 
 @pytest.mark.asyncio
@@ -2452,6 +2579,48 @@ async def test_client_list_sessions_parses_summary_shape():
 
 
 @pytest.mark.asyncio
+async def test_client_list_sessions_rejects_missing_required_summary_facts():
+    client = MeerkatClient()
+
+    async def missing_total_tokens(method, params):
+        return {
+            "sessions": [
+                {
+                    "session_id": "s1",
+                    "created_at": 10,
+                    "updated_at": 20,
+                    "message_count": 2,
+                    "is_active": True,
+                }
+            ]
+        }
+
+    client._request = missing_total_tokens  # type: ignore[method-assign]
+    with pytest.raises(MeerkatError, match="missing total_tokens"):
+        await client.list_sessions()
+
+    async def missing_sessions(method, params):
+        return {}
+
+    client._request = missing_sessions  # type: ignore[method-assign]
+    with pytest.raises(MeerkatError, match="missing sessions"):
+        await client.list_sessions()
+
+
+@pytest.mark.asyncio
+async def test_client_get_blob_rejects_missing_required_fields():
+    client = MeerkatClient()
+
+    async def fake_request(method, params):
+        return {"blob_id": "blob-1", "data": "AAAA"}
+
+    client._request = fake_request  # type: ignore[method-assign]
+
+    with pytest.raises(MeerkatError, match="missing media_type"):
+        await client.get_blob("blob-1")
+
+
+@pytest.mark.asyncio
 async def test_client_read_session_parses_details_shape():
     client = MeerkatClient()
 
@@ -3194,7 +3363,7 @@ async def test_client_mob_lifecycle_and_send_methods_use_explicit_rpc_methods():
                 },
             }
         if method == "mob/flows":
-            return {"flows": ["incident"]}
+            return {"mob_id": "mob-1", "flows": ["incident"]}
         if method == "mob/run":
             return {"run_id": "run-typed"}
         if method == "mob/flow_run":
@@ -3416,6 +3585,50 @@ async def test_client_mob_lifecycle_and_send_methods_use_explicit_rpc_methods():
 
 
 @pytest.mark.asyncio
+async def test_client_mob_wrappers_reject_malformed_success_responses():
+    client = MeerkatClient()
+    client.require_capability = lambda _cap: None  # type: ignore[method-assign]
+
+    async def empty_response(method, params):
+        return {}
+
+    client._request = empty_response  # type: ignore[method-assign]
+    with pytest.raises(MeerkatError, match="missing mob_id"):
+        await client.create_mob(definition={"id": "mob-1", "profiles": {}})
+    with pytest.raises(MeerkatError, match="missing mobs"):
+        await client.list_mobs()
+
+    async def fake_request(method, params):
+        if method == "mob/cancel_work":
+            return {"ok": True}
+        if method == "mob/cancel_all_work":
+            return {"mob_id": "mob-1"}
+        if method == "mob/profile/list":
+            return {}
+        if method == "mob/flows":
+            return {"mob_id": "mob-1", "flows": ["incident", 42]}
+        if method == "mob/flow_run":
+            return {}
+        if method == "mob/run":
+            return {}
+        return {}
+
+    client._request = fake_request  # type: ignore[method-assign]
+    with pytest.raises(MeerkatError, match="missing mob_id"):
+        await client.mob_cancel_work("mob-1", "work-1")
+    with pytest.raises(MeerkatError, match="ok must be boolean"):
+        await client.mob_cancel_all_work(_make_member_ref("mob-1", "agent-a"))
+    with pytest.raises(MeerkatError, match="missing profiles"):
+        await client.list_mob_profiles()
+    with pytest.raises(MeerkatError, match=r"flows\[1\] must be string"):
+        await client.list_mob_flows("mob-1")
+    with pytest.raises(MeerkatError, match="missing run_id"):
+        await client.run_mob_flow("mob-1", "incident")
+    with pytest.raises(MeerkatError, match="missing run_id"):
+        await client.run_mob("mob-1")
+
+
+@pytest.mark.asyncio
 async def test_spawn_mob_member_rejects_missing_runtime_mob_id() -> None:
     client = MeerkatClient()
 
@@ -3497,7 +3710,7 @@ async def test_mob_member_status_rejects_missing_tokens_used():
 
     client._request = fake_request  # type: ignore[method-assign]
 
-    with pytest.raises(MeerkatError, match="tokens_used must be number"):
+    with pytest.raises(MeerkatError, match="missing tokens_used"):
         await client.mob_member_status("mob-1", "agent-a")
 
 
@@ -3634,9 +3847,9 @@ async def test_mob_helper_wrappers_reject_missing_tokens_used():
 
     client._request = fake_request  # type: ignore[method-assign]
 
-    with pytest.raises(MeerkatError, match="tokens_used must be number"):
+    with pytest.raises(MeerkatError, match="missing tokens_used"):
         await client.spawn_mob_helper("mob-1", "help")
-    with pytest.raises(MeerkatError, match="tokens_used must be number"):
+    with pytest.raises(MeerkatError, match="missing tokens_used"):
         await client.fork_mob_helper("mob-1", "agent-a", "help")
 
 

--- a/sdks/typescript/src/client.ts
+++ b/sdks/typescript/src/client.ts
@@ -935,10 +935,11 @@ export class MeerkatClient {
     const params = MeerkatClient.buildCreateParams(prompt, options);
     params.initial_turn = "deferred";
     const raw = await this.request("session/create", params);
+    const context = "Invalid session/create deferred response";
     return new DeferredSession(
       this,
-      String(raw.session_id ?? ""),
-      raw.session_ref != null ? String(raw.session_ref) : undefined,
+      MeerkatClient.requireStringField(raw, "session_id", context),
+      MeerkatClient.optionalStringField(raw, "session_ref", context),
     );
   }
 
@@ -965,8 +966,11 @@ export class MeerkatClient {
     if (options?.limit !== undefined) params.limit = options.limit;
     if (options?.offset !== undefined) params.offset = options.offset;
     const result = await this.request("session/list", params);
-    const sessions = (result.sessions as Array<Record<string, unknown>>) ?? [];
-    return sessions.map((s) => MeerkatClient.parseSessionInfo(s));
+    const sessions = MeerkatClient.requireRecordArray(
+      result.sessions,
+      "Invalid session/list response",
+    );
+    return sessions.map((s) => MeerkatClient.parseSessionSummary(s));
   }
 
   async readSession(sessionId: string): Promise<SessionInfo> {
@@ -1301,10 +1305,11 @@ export class MeerkatClient {
   async getBlob(blobId: string): Promise<BlobPayload> {
     type _RpcSignature = [RpcBlobGetParams, RpcBlobPayload];
     const result = await this.request("blob/get", { blob_id: blobId });
+    const context = "Invalid blob/get response";
     return {
-      blobId: String(result.blob_id ?? blobId),
-      mediaType: String(result.media_type ?? ""),
-      dataBase64: String(result.data ?? ""),
+      blobId: MeerkatClient.requireStringField(result, "blob_id", context),
+      mediaType: MeerkatClient.requireStringField(result, "media_type", context),
+      dataBase64: MeerkatClient.requireStringField(result, "data", context),
     };
   }
 
@@ -1557,7 +1562,14 @@ export class MeerkatClient {
   async createMob(options: MobCreateOptions): Promise<Mob> {
     this.requireCapability("mob");
     const result = await this.request("mob/create", options);
-    return new Mob(this, String(result.mob_id ?? ""));
+    return new Mob(
+      this,
+      MeerkatClient.requireStringField(
+        result,
+        "mob_id",
+        "Invalid mob/create response",
+      ),
+    );
   }
 
   mob(mobId: string): Mob {
@@ -1568,12 +1580,13 @@ export class MeerkatClient {
     this.requireCapability("mob");
     const result = await this.request("mob/list", {});
     const mobs = MeerkatClient.requireRecordArray(result.mobs, "Invalid mob/list response");
+    const context = "Invalid mob/list response entry";
     return mobs.map((mob) => ({
-      mobId: String(mob.mob_id ?? mob.mobId ?? ""),
+      mobId: MeerkatClient.requireStringField(mob, "mob_id", context),
       status: MeerkatClient.requireStringField(
         mob,
         "status",
-        "Invalid mob/list response entry: missing status",
+        context,
       ),
     }));
   }
@@ -2116,10 +2129,10 @@ export class MeerkatClient {
       mob_id: mobId,
       work_ref: workRef,
     });
-    if (typeof result.ok !== "boolean") {
-      throw new Error("Invalid mob/cancel_work response: missing ok");
-    }
-    return { ok: result.ok };
+    const context = "Invalid mob/cancel_work response";
+    MeerkatClient.requireStringField(result, "mob_id", context);
+    const ok = MeerkatClient.requireBooleanField(result, "ok", context);
+    return { ok };
   }
 
   /**
@@ -2132,10 +2145,10 @@ export class MeerkatClient {
     const result = await this.request("mob/cancel_all_work", {
       member_ref: args.memberRef,
     });
-    if (typeof result.ok !== "boolean") {
-      throw new Error("Invalid mob/cancel_all_work response: missing ok");
-    }
-    return { ok: result.ok };
+    const context = "Invalid mob/cancel_all_work response";
+    MeerkatClient.requireStringField(result, "mob_id", context);
+    const ok = MeerkatClient.requireBooleanField(result, "ok", context);
+    return { ok };
   }
 
   async waitMobKickoff(
@@ -2447,9 +2460,10 @@ export class MeerkatClient {
 
   async listMobProfiles(): Promise<MobProfileLookupResult[]> {
     const raw = await this.request("mob/profile/list", {});
-    const profiles = Array.isArray(raw.profiles)
-      ? (raw.profiles as Array<Record<string, unknown>>)
-      : [];
+    const profiles = MeerkatClient.requireRecordArray(
+      raw.profiles,
+      "Invalid mob/profile/list response",
+    );
     return profiles.map((profile) => MeerkatClient.parseMobProfileLookup(profile));
   }
 
@@ -2487,7 +2501,9 @@ export class MeerkatClient {
 
   async listMobFlows(mobId: string): Promise<string[]> {
     const result = await this.request("mob/flows", { mob_id: mobId });
-    return (result.flows as string[]) ?? [];
+    const context = "Invalid mob/flows response";
+    MeerkatClient.requireStringField(result, "mob_id", context);
+    return MeerkatClient.requireStringArrayField(result, "flows", context);
   }
 
   async runMobFlow(mobId: string, flowId: string, params: Record<string, unknown> = {}): Promise<string> {
@@ -3395,12 +3411,27 @@ export class MeerkatClient {
     return value;
   }
 
+  private static requirePresentStringField(
+    raw: Record<string, unknown>,
+    field: string,
+    context: string,
+  ): string {
+    const value = raw[field];
+    if (typeof value !== "string") {
+      throw new MeerkatError("INVALID_RESPONSE", `${context}: missing ${field}`);
+    }
+    return value;
+  }
+
   private static requireNumberField(
     raw: Record<string, unknown>,
     field: string,
     context: string,
     displayField = field,
   ): number {
+    if (!(field in raw)) {
+      throw new MeerkatError("INVALID_RESPONSE", `${context}: missing ${displayField}`);
+    }
     const value = raw[field];
     if (typeof value !== "number" || !Number.isFinite(value)) {
       throw new MeerkatError("INVALID_RESPONSE", `${context}: ${displayField} must be number`);
@@ -3467,6 +3498,26 @@ export class MeerkatClient {
       throw new MeerkatError("INVALID_RESPONSE", `${context}: ${field} must be boolean`);
     }
     return value;
+  }
+
+  private static requireStringArrayField(
+    raw: Record<string, unknown>,
+    field: string,
+    context: string,
+  ): string[] {
+    const value = raw[field];
+    if (!Array.isArray(value)) {
+      throw new MeerkatError("INVALID_RESPONSE", `${context}: ${field} must be array`);
+    }
+    return value.map((item, index) => {
+      if (typeof item !== "string" || item.length === 0) {
+        throw new MeerkatError(
+          "INVALID_RESPONSE",
+          `${context}: ${field}[${index}] must be string`,
+        );
+      }
+      return item;
+    });
   }
 
   private static parseWireMobMemberStatus(
@@ -3658,36 +3709,89 @@ export class MeerkatClient {
   }
 
   private static parseSkillDiagnostics(raw: unknown): SkillRuntimeDiagnostics | undefined {
-    if (!raw || typeof raw !== "object") return undefined;
-    const data = raw as Record<string, unknown>;
-    const sourceHealthRaw = data.source_health as Record<string, unknown> | undefined;
-    const rawQuarantined = Array.isArray(data.quarantined)
-      ? data.quarantined
-      : [];
+    if (raw == null) return undefined;
+    const context = "Invalid run result";
+    const data = MeerkatClient.requireRecord(raw, "skill_diagnostics", context);
+    const sourceHealthRaw = MeerkatClient.requireRecord(
+      data.source_health,
+      "skill_diagnostics.source_health",
+      context,
+    );
+    if (!Array.isArray(data.quarantined)) {
+      throw new MeerkatError(
+        "INVALID_RESPONSE",
+        `${context}: missing skill_diagnostics.quarantined`,
+      );
+    }
 
-    const quarantined = rawQuarantined
-      .filter((item): item is Record<string, unknown> => typeof item === "object" && item !== null)
-      .map((item) => ({
-        sourceUuid: String(item.source_uuid ?? ""),
-        skillId: String(item.skill_id ?? ""),
-        location: String(item.location ?? ""),
-        errorCode: String(item.error_code ?? ""),
-        errorClass: String(item.error_class ?? ""),
-        message: String(item.message ?? ""),
-        firstSeenUnixSecs: Number(item.first_seen_unix_secs ?? 0),
-        lastSeenUnixSecs: Number(item.last_seen_unix_secs ?? 0),
-      }));
+    const quarantined = data.quarantined.map((item, index) => {
+      const record = MeerkatClient.requireRecord(
+        item,
+        `skill_diagnostics.quarantined[${index}]`,
+        context,
+      );
+      const identity = MeerkatClient.requireRecord(
+        record.identity,
+        `skill_diagnostics.quarantined[${index}].identity`,
+        context,
+      );
+      return {
+        sourceUuid: MeerkatClient.requireStringField(identity, "source_uuid", context),
+        skillId: MeerkatClient.requirePresentStringField(identity, "raw_id", context),
+        location: MeerkatClient.requirePresentStringField(record, "location", context),
+        errorCode: MeerkatClient.requirePresentStringField(record, "error_code", context),
+        errorClass: MeerkatClient.requirePresentStringField(record, "error_class", context),
+        message: MeerkatClient.requirePresentStringField(record, "message", context),
+        firstSeenUnixSecs: MeerkatClient.requireNonNegativeIntegerField(
+          record,
+          "first_seen_unix_secs",
+          context,
+          "skill_diagnostics.quarantined.first_seen_unix_secs",
+        ),
+        lastSeenUnixSecs: MeerkatClient.requireNonNegativeIntegerField(
+          record,
+          "last_seen_unix_secs",
+          context,
+          "skill_diagnostics.quarantined.last_seen_unix_secs",
+        ),
+      };
+    });
 
     return {
       sourceHealth: {
-        state: String(sourceHealthRaw?.state ?? ""),
-        invalidRatio: Number(sourceHealthRaw?.invalid_ratio ?? 0),
-        invalidCount: Number(sourceHealthRaw?.invalid_count ?? 0),
-        totalCount: Number(sourceHealthRaw?.total_count ?? 0),
-        failureStreak: Number(sourceHealthRaw?.failure_streak ?? 0),
-        handshakeFailed: Boolean(sourceHealthRaw?.handshake_failed ?? false),
+        state: MeerkatClient.requireStringField(sourceHealthRaw, "state", context),
+        invalidRatio: MeerkatClient.requireNumberField(
+          sourceHealthRaw,
+          "invalid_ratio",
+          context,
+          "skill_diagnostics.source_health.invalid_ratio",
+        ),
+        invalidCount: MeerkatClient.requireNonNegativeIntegerField(
+          sourceHealthRaw,
+          "invalid_count",
+          context,
+          "skill_diagnostics.source_health.invalid_count",
+        ),
+        totalCount: MeerkatClient.requireNonNegativeIntegerField(
+          sourceHealthRaw,
+          "total_count",
+          context,
+          "skill_diagnostics.source_health.total_count",
+        ),
+        failureStreak: MeerkatClient.requireNonNegativeIntegerField(
+          sourceHealthRaw,
+          "failure_streak",
+          context,
+          "skill_diagnostics.source_health.failure_streak",
+        ),
+        handshakeFailed: MeerkatClient.requireBooleanField(
+          sourceHealthRaw,
+          "handshake_failed",
+          context,
+        ),
       },
       quarantined,
+      collectionFault: data.collection_fault ?? undefined,
     };
   }
 
@@ -3732,33 +3836,49 @@ export class MeerkatClient {
         : undefined,
     };
 
-    const rawWarnings = data.schema_warnings as Array<Record<string, unknown>> | undefined;
-    const schemaWarnings: SchemaWarning[] | undefined = rawWarnings?.map(
-      (w): SchemaWarning => ({
-        provider: String(w.provider ?? ""),
-        path: String(w.path ?? ""),
-        message: String(w.message ?? ""),
-      }),
-    );
+    const rawWarnings = data.schema_warnings;
+    const schemaWarnings: SchemaWarning[] | undefined = rawWarnings == null
+      ? undefined
+      : MeerkatClient.requireRecordArray(rawWarnings, context).map(
+          (w): SchemaWarning => ({
+            provider: MeerkatClient.requirePresentStringField(w, "provider", context),
+            path: MeerkatClient.requirePresentStringField(w, "path", context),
+            message: MeerkatClient.requirePresentStringField(w, "message", context),
+          }),
+        );
     const rawExtractionError = data.extraction_error;
-    const extractionError =
-      rawExtractionError && typeof rawExtractionError === "object"
-        ? {
-            lastOutput: String((rawExtractionError as Record<string, unknown>).last_output ?? ""),
+    const extractionError = rawExtractionError == null
+      ? undefined
+      : (() => {
+          const extraction = MeerkatClient.requireRecord(
+            rawExtractionError,
+            "extraction_error",
+            context,
+          );
+          return {
+            lastOutput: MeerkatClient.requirePresentStringField(
+              extraction,
+              "last_output",
+              context,
+            ),
             attempts: MeerkatClient.requireNumberField(
-              rawExtractionError as Record<string, unknown>,
+              extraction,
               "attempts",
               context,
               "extraction_error.attempts",
             ),
-            reason: String((rawExtractionError as Record<string, unknown>).reason ?? ""),
-          }
-        : undefined;
+            reason: MeerkatClient.requirePresentStringField(
+              extraction,
+              "reason",
+              context,
+            ),
+          };
+        })();
 
     return {
-      sessionId: String(data.session_id ?? ""),
-      sessionRef: data.session_ref != null ? String(data.session_ref) : undefined,
-      text: String(data.text ?? ""),
+      sessionId: MeerkatClient.requireStringField(data, "session_id", context),
+      sessionRef: MeerkatClient.optionalStringField(data, "session_ref", context),
+      text: MeerkatClient.requirePresentStringField(data, "text", context),
       turns: MeerkatClient.requireNumberField(data, "turns", context),
       toolCalls: MeerkatClient.requireNumberField(data, "tool_calls", context),
       usage,
@@ -3773,30 +3893,61 @@ export class MeerkatClient {
     };
   }
 
-  static parseSessionInfo(data: Record<string, unknown>): SessionInfo {
-    const labelsRaw =
-      data.labels && typeof data.labels === "object"
-        ? (data.labels as Record<string, unknown>)
-        : {};
-    const labels = Object.fromEntries(
-      Object.entries(labelsRaw).map(([key, value]) => [key, String(value)]),
+  private static parseSessionLabels(
+    raw: unknown,
+    context: string,
+  ): Readonly<Record<string, string>> {
+    if (raw == null) {
+      return {};
+    }
+    if (typeof raw !== "object" || Array.isArray(raw)) {
+      throw new MeerkatError("INVALID_RESPONSE", `${context}: labels must be object`);
+    }
+    return Object.fromEntries(
+      Object.entries(raw as Record<string, unknown>).map(([key, value]) => [
+        key,
+        String(value),
+      ]),
     );
+  }
+
+  static parseSessionSummary(data: Record<string, unknown>): SessionInfo {
+    const context = "Invalid session/list response entry";
     return {
-      sessionId: String(data.session_id ?? ""),
-      sessionRef: data.session_ref != null ? String(data.session_ref) : undefined,
-      createdAt: Number(data.created_at ?? 0),
-      updatedAt: Number(data.updated_at ?? 0),
-      messageCount: Number(data.message_count ?? 0),
-      isActive: Boolean(data.is_active),
-      totalTokens: data.total_tokens != null ? Number(data.total_tokens) : undefined,
-      model: data.model != null ? String(data.model) : undefined,
-      provider: data.provider != null ? String(data.provider) : undefined,
-      lastAssistantText:
-        data.last_assistant_text != null ? String(data.last_assistant_text) : undefined,
+      sessionId: MeerkatClient.requireStringField(data, "session_id", context),
+      sessionRef: MeerkatClient.optionalStringField(data, "session_ref", context),
+      createdAt: MeerkatClient.requireNonNegativeIntegerField(data, "created_at", context),
+      updatedAt: MeerkatClient.requireNonNegativeIntegerField(data, "updated_at", context),
+      messageCount: MeerkatClient.requireNonNegativeIntegerField(data, "message_count", context),
+      isActive: MeerkatClient.requireBooleanField(data, "is_active", context),
+      totalTokens: MeerkatClient.requireNonNegativeIntegerField(data, "total_tokens", context),
+      labels: MeerkatClient.parseSessionLabels(data.labels, context),
+    };
+  }
+
+  static parseSessionInfo(data: Record<string, unknown>): SessionInfo {
+    const context = "Invalid session/read response";
+    return {
+      sessionId: MeerkatClient.requireStringField(data, "session_id", context),
+      sessionRef: MeerkatClient.optionalStringField(data, "session_ref", context),
+      createdAt: MeerkatClient.requireNonNegativeIntegerField(data, "created_at", context),
+      updatedAt: MeerkatClient.requireNonNegativeIntegerField(data, "updated_at", context),
+      messageCount: MeerkatClient.requireNonNegativeIntegerField(data, "message_count", context),
+      isActive: MeerkatClient.requireBooleanField(data, "is_active", context),
+      totalTokens: data.total_tokens != null
+        ? MeerkatClient.requireNonNegativeIntegerField(data, "total_tokens", context)
+        : undefined,
+      model: MeerkatClient.requireStringField(data, "model", context),
+      provider: MeerkatClient.requireStringField(data, "provider", context),
+      lastAssistantText: MeerkatClient.optionalStringField(
+        data,
+        "last_assistant_text",
+        context,
+      ),
       resolvedCapabilities: MeerkatClient.parseResolvedModelCapabilities(
         data.resolved_capabilities,
       ),
-      labels,
+      labels: MeerkatClient.parseSessionLabels(data.labels, context),
     };
   }
 
@@ -4136,15 +4287,17 @@ export class MeerkatClient {
   }
 
   static parseMobProfileLookup(data: Record<string, unknown>): MobProfileLookupResult {
+    const context = "Invalid mob/profile response";
+    const name = MeerkatClient.requireStringField(data, "name", context);
     if (Boolean(data.not_found)) {
       return {
         notFound: true,
-        name: String(data.name ?? ""),
+        name,
       };
     }
     return {
       notFound: false,
-      name: String(data.name ?? ""),
+      name,
       profile:
         data.profile && typeof data.profile === "object"
           ? (data.profile as MobProfile)

--- a/sdks/typescript/src/generated/types.ts
+++ b/sdks/typescript/src/generated/types.ts
@@ -3188,6 +3188,7 @@ export interface WireLiveAdapterStatusUnknown {
 export type WireLiveAdapterStatus = WireLiveAdapterStatusIdle | WireLiveAdapterStatusOpening | WireLiveAdapterStatusReady | WireLiveAdapterStatusDegraded | WireLiveAdapterStatusClosing | WireLiveAdapterStatusClosed | WireLiveAdapterStatusUnknown;
 
 export interface WireLiveConfigRejectionReasonChannelIdentitySwap {
+  auth_binding_changed?: boolean;
   from_model: string;
   from_provider: WireProvider;
   kind: "channel_identity_swap";

--- a/sdks/typescript/src/types.ts
+++ b/sdks/typescript/src/types.ts
@@ -94,6 +94,7 @@ export interface SkillQuarantineDiagnostic {
 export interface SkillRuntimeDiagnostics {
   readonly sourceHealth: SourceHealthSnapshot;
   readonly quarantined: readonly SkillQuarantineDiagnostic[];
+  readonly collectionFault?: unknown;
 }
 
 /** Structured skill identifier (source UUID + skill name). */

--- a/sdks/typescript/tests/types.test.js
+++ b/sdks/typescript/tests/types.test.js
@@ -1421,6 +1421,16 @@ describe("Session wrappers", () => {
     ]]);
   });
 
+  it("createDeferredSession rejects malformed success responses", async () => {
+    const client = new MeerkatClient();
+    client.request = async () => ({ session_ref: "team/deferred" });
+
+    await assert.rejects(
+      () => client.createDeferredSession("Hold until first turn"),
+      /missing session_id/,
+    );
+  });
+
   it("createSession forwards extended creation options", async () => {
     const client = new MeerkatClient();
     const seen = [];
@@ -1524,6 +1534,33 @@ describe("Session wrappers", () => {
     });
   });
 
+  it("listSessions rejects missing required session facts", async () => {
+    const client = new MeerkatClient();
+    client.request = async () => ({
+      sessions: [
+        {
+          session_id: "s1",
+          created_at: 10,
+          updated_at: 20,
+          message_count: 2,
+          is_active: true,
+          labels: {},
+        },
+      ],
+    });
+
+    await assert.rejects(
+      () => client.listSessions(),
+      /missing total_tokens/,
+    );
+
+    client.request = async () => ({});
+    await assert.rejects(
+      () => client.listSessions(),
+      /expected array/,
+    );
+  });
+
   it("drops malformed resolved capabilities instead of fabricating false defaults", async () => {
     const client = new MeerkatClient();
     client.request = async (method) => {
@@ -1534,6 +1571,8 @@ describe("Session wrappers", () => {
         updated_at: 20,
         message_count: 2,
         is_active: false,
+        model: "claude-sonnet-4-6",
+        provider: "anthropic",
         resolved_capabilities: {
           vision: true,
           image_input: true,
@@ -1549,6 +1588,19 @@ describe("Session wrappers", () => {
     const details = await client.readSession("s1");
 
     assert.equal(details.resolvedCapabilities, undefined);
+  });
+
+  it("getBlob rejects missing required blob fields", async () => {
+    const client = new MeerkatClient();
+    client.request = async () => ({
+      blob_id: "blob-1",
+      data: "AAAA",
+    });
+
+    await assert.rejects(
+      () => client.getBlob("blob-1"),
+      /missing media_type/,
+    );
   });
 
   it("session/deferred injectContext call public wrapper", async () => {
@@ -1755,8 +1807,10 @@ describe("RunResult parsing", () => {
         },
         quarantined: [
           {
-            source_uuid: "src-1",
-            skill_id: "extract/email",
+            identity: {
+              source_uuid: "src-1",
+              raw_id: "extract/email",
+            },
             location: "project",
             error_code: "bad_frontmatter",
             error_class: "ValidationError",
@@ -1765,6 +1819,10 @@ describe("RunResult parsing", () => {
             last_seen_unix_secs: 20,
           },
         ],
+        collection_fault: {
+          reason_type: "source_unknown",
+          message: "diagnostics source unavailable",
+        },
       },
     };
     const result = MeerkatClient.parseRunResult(raw);
@@ -1789,6 +1847,10 @@ describe("RunResult parsing", () => {
           lastSeenUnixSecs: 20,
         },
       ],
+      collectionFault: {
+        reason_type: "source_unknown",
+        message: "diagnostics source unavailable",
+      },
     });
   });
 
@@ -1805,6 +1867,24 @@ describe("RunResult parsing", () => {
   });
 
   it("rejects malformed run results instead of fabricating counters", () => {
+    assert.throws(
+      () => MeerkatClient.parseRunResult({
+        text: "ok",
+        turns: 1,
+        tool_calls: 0,
+        usage: { input_tokens: 1, output_tokens: 1 },
+      }),
+      /missing session_id/,
+    );
+    assert.doesNotThrow(
+      () => MeerkatClient.parseRunResult({
+        session_id: "s1",
+        text: "",
+        turns: 1,
+        tool_calls: 0,
+        usage: { input_tokens: 1, output_tokens: 1 },
+      }),
+    );
     assert.throws(
       () => MeerkatClient.parseRunResult({ session_id: "s1", text: "ok", turns: 1, tool_calls: 0 }),
       /missing usage/,
@@ -1828,6 +1908,84 @@ describe("RunResult parsing", () => {
         usage: { input_tokens: "oops", output_tokens: 1 },
       }),
       /usage.input_tokens must be number/,
+    );
+    assert.throws(
+      () => MeerkatClient.parseRunResult({
+        session_id: "s1",
+        text: "ok",
+        turns: 1,
+        tool_calls: 0,
+        usage: { input_tokens: 1, output_tokens: 1 },
+        schema_warnings: [{ path: "$", message: "warn" }],
+      }),
+      /missing provider/,
+    );
+    assert.throws(
+      () => MeerkatClient.parseRunResult({
+        session_id: "s1",
+        text: "ok",
+        turns: 1,
+        tool_calls: 0,
+        usage: { input_tokens: 1, output_tokens: 1 },
+        schema_warnings: "warn",
+      }),
+      /expected array/,
+    );
+    assert.throws(
+      () => MeerkatClient.parseRunResult({
+        session_id: "s1",
+        text: "ok",
+        turns: 1,
+        tool_calls: 0,
+        usage: { input_tokens: 1, output_tokens: 1 },
+        extraction_error: { last_output: "bad", attempts: 1 },
+      }),
+      /missing reason/,
+    );
+    assert.throws(
+      () => MeerkatClient.parseRunResult({
+        session_id: "s1",
+        text: "ok",
+        turns: 1,
+        tool_calls: 0,
+        usage: { input_tokens: 1, output_tokens: 1 },
+        extraction_error: "bad",
+      }),
+      /missing extraction_error/,
+    );
+    assert.throws(
+      () => MeerkatClient.parseRunResult({
+        session_id: "s1",
+        text: "ok",
+        turns: 1,
+        tool_calls: 0,
+        usage: { input_tokens: 1, output_tokens: 1 },
+        skill_diagnostics: {
+          quarantined: [],
+        },
+      }),
+      /missing skill_diagnostics.source_health/,
+    );
+    assert.throws(
+      () => MeerkatClient.parseRunResult({
+        session_id: "s1",
+        text: "ok",
+        turns: 1,
+        tool_calls: 0,
+        usage: { input_tokens: 1, output_tokens: 1 },
+        skill_diagnostics: {
+          source_health: {
+            state: "healthy",
+            invalid_ratio: 0,
+            invalid_count: 0,
+            total_count: 0,
+            failure_streak: 0,
+            handshake_failed: false,
+          },
+          quarantined: [{ location: "project" }],
+        },
+      }),
+      /missing skill_diagnostics\.quarantined\[0\]\.identity/,
     );
   });
 });
@@ -2636,6 +2794,61 @@ describe("Parity wrappers", () => {
     assert.equal(calls[4].params.limit, 5);
   });
 
+  it("rejects malformed mob wrapper success responses instead of fabricating defaults", async () => {
+    const client = new MeerkatClient();
+    client.requireCapability = () => {};
+
+    client.request = async () => ({});
+    await assert.rejects(
+      () => client.createMob({ definition: { id: "mob-1", profiles: {} } }),
+      /missing mob_id/,
+    );
+    await assert.rejects(
+      () => client.listMobs(),
+      /expected array/,
+    );
+
+    client.request = async (method) => {
+      if (method === "mob/cancel_work") {
+        return { ok: true };
+      }
+      if (method === "mob/cancel_all_work") {
+        return { mob_id: "mob-1" };
+      }
+      if (method === "mob/profile/list") {
+        return {};
+      }
+      if (method === "mob/flows") {
+        return { mob_id: "mob-1", flows: ["incident", 42] };
+      }
+      if (method === "mob/flow_run") {
+        return {};
+      }
+      return {};
+    };
+
+    await assert.rejects(
+      () => client.mobCancelWork("mob-1", "work-1"),
+      /missing mob_id/,
+    );
+    await assert.rejects(
+      () => client.mobCancelAllWork({ memberRef: makeMemberRef("mob-1", "worker-1") }),
+      /ok must be boolean/,
+    );
+    await assert.rejects(
+      () => client.listMobProfiles(),
+      /expected array/,
+    );
+    await assert.rejects(
+      () => client.listMobFlows("mob-1"),
+      /flows\[1\] must be string/,
+    );
+    await assert.rejects(
+      () => client.runMobFlow("mob-1", "incident"),
+      /missing run_id/,
+    );
+  });
+
   it("rejects mob spawn receipts missing server-owned identity fields", async () => {
     const client = new MeerkatClient();
     client.request = async () => ({
@@ -2920,14 +3133,14 @@ describe("Parity wrappers", () => {
       (error) =>
         error instanceof MeerkatError &&
         error.code === "INVALID_RESPONSE" &&
-        /tokens_used must be number/.test(String(error.message)),
+        /missing tokens_used/.test(String(error.message)),
     );
     await assert.rejects(
       () => client.forkMobHelper("mob-1", "source", "help"),
       (error) =>
         error instanceof MeerkatError &&
         error.code === "INVALID_RESPONSE" &&
-        /tokens_used must be number/.test(String(error.message)),
+        /missing tokens_used/.test(String(error.message)),
     );
   });
 
@@ -3543,7 +3756,7 @@ describe("Mob surface fail-closed status parsing (DOGMA Rule 6)", () => {
         (error) =>
           error instanceof MeerkatError &&
           error.code === "INVALID_RESPONSE" &&
-          /tokens_used must be number/.test(String(error.message)),
+          /missing tokens_used/.test(String(error.message)),
       );
     });
 


### PR DESCRIPTION
## Summary
- fail closed in Python/TypeScript SDK wrappers when successful responses omit runtime-owned facts
- close stale live realtime channels when durable LLM auth_binding changes, with typed auth_binding_changed rejection reason
- refresh generated wire/schema SDK types and add regression coverage for nested run-result diagnostics

## Validation
- python -m pytest sdks/python/tests/test_types.py
- npm run build && node --test tests/types.test.js
- ./scripts/repo-cargo fmt --check
- ./scripts/repo-cargo test -p meerkat-core live_adapter::tests::config_rejection_reason_round_trips_each_typed_variant
- ./scripts/repo-cargo test -p meerkat-contracts config_rejection_reason_round_trips_through_core
- ./scripts/repo-cargo test -p meerkat-rpc r11_close_required_when_auth_binding_swapped
- ./scripts/repo-cargo test -p meerkat-rpc r11_hot_swap_closes_channel_on_auth_binding_swap
- make verify-schema-freshness
- make verify-sdk-codegen-freshness
- make verify-sdk-wrapper-freshness verify-sdk-event-inventory
- pre-push hook suite passed during git push

## Adversarial gate
- Reviewer 1: GREEN on SDK/public parsing scope after final skill_diagnostics patch
- Reviewer 2: GREEN on live/realtime auth identity scope

## Local note
- Full sdks/typescript npm test previously reached provider-backed image scenarios and failed locally because no image generation executor was configured for Gemini; focused SDK unit/build tests pass.