### PR TITLE
fix: runtime-loop stop paths never run executor cleanup under the session mutation gate (ask 21c)

### DIFF
--- a/meerkat-runtime/src/control_plane.rs
+++ b/meerkat-runtime/src/control_plane.rs
@@ -94,11 +94,14 @@ pub(crate) async fn apply_executor_effect(
 /// channel closure must still route through the canonical stop/terminalize
 /// path (StopRuntimeExecutor + [`terminalize_async_stop`] + waiter resolution)
 /// instead of silently exiting as if a stop effect had already been applied.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug)]
 pub(crate) enum EffectDrainOutcome {
-    /// A stop effect was applied (and terminalized) during this drain. The
-    /// loop should stop, terminalization has already run.
-    AppliedStop,
+    /// A stop effect was received but NOT applied: stop realization awaits
+    /// executor cleanup that may re-enter the machine (e.g. a mob executor
+    /// unregistering its session), so it must never run under the session
+    /// mutation gate the drain callers hold. The caller drops its authority
+    /// guard first, then applies the returned effect.
+    StopEffectPending(RuntimeEffect),
     /// No effects were pending; the channel remains open. The loop may
     /// continue processing queued work.
     Empty,
@@ -118,9 +121,15 @@ pub(crate) async fn drain_ready_executor_effects(
     loop {
         match effect_rx.try_recv() {
             Ok(effect) => {
-                if apply_executor_effect(driver, completions, executor, effect).await? {
-                    return Ok(EffectDrainOutcome::AppliedStop);
+                if effect.is_stop() {
+                    // Never applied here: the caller holds the session
+                    // mutation gate during drains, and the stop path's
+                    // cleanup can re-enter the machine (unregister), which
+                    // acquires the same gate — a self-deadlock that parked
+                    // the loop task forever and wedged whole mobs.
+                    return Ok(EffectDrainOutcome::StopEffectPending(effect));
                 }
+                apply_executor_effect(driver, completions, executor, effect).await?;
             }
             Err(mpsc::error::TryRecvError::Empty) => return Ok(EffectDrainOutcome::Empty),
             Err(mpsc::error::TryRecvError::Disconnected) => {
@@ -341,8 +350,11 @@ mod tests {
     async fn drain_ready_executor_effects_channel_closed_is_distinct_from_applied_stop() {
         let driver = shared_driver();
 
-        // Applied-stop case: a stop effect is delivered, then the sender is
-        // dropped. The drain applies the stop and reports `AppliedStop`.
+        // Stop-pending case: a stop effect is delivered, then the sender is
+        // dropped. The drain must NOT apply the stop (its cleanup can
+        // re-enter the machine and deadlock on the session mutation gate
+        // the drain callers hold); it surfaces the effect for the caller to
+        // apply after releasing its authority guard.
         {
             let stop_calls = Arc::new(AtomicUsize::new(0));
             let mut executor = RecordingExecutor {
@@ -362,12 +374,19 @@ mod tests {
 
             let outcome = drain_ready_executor_effects(&driver, None, &mut executor, &mut rx)
                 .await
-                .expect("drain with applied stop should succeed");
+                .expect("drain with pending stop should succeed");
+            let EffectDrainOutcome::StopEffectPending(effect) = outcome else {
+                panic!("a stop effect must surface as StopEffectPending, got {outcome:?}");
+            };
             assert_eq!(
-                outcome,
-                EffectDrainOutcome::AppliedStop,
-                "an applied stop effect must report AppliedStop"
+                stop_calls.load(Ordering::SeqCst),
+                0,
+                "the drain must never apply the stop itself"
             );
+            let should_stop = apply_executor_effect(&driver, None, &mut executor, effect)
+                .await
+                .expect("caller applies the pending stop guard-free");
+            assert!(should_stop);
             assert_eq!(stop_calls.load(Ordering::SeqCst), 1);
         }
 
@@ -389,15 +408,9 @@ mod tests {
             let outcome = drain_ready_executor_effects(&driver, None, &mut executor, &mut rx)
                 .await
                 .expect("drain on closed channel should succeed");
-            assert_eq!(
-                outcome,
-                EffectDrainOutcome::ChannelClosed,
-                "a closed effect channel must be distinguishable from an applied stop"
-            );
-            assert_ne!(
-                outcome,
-                EffectDrainOutcome::AppliedStop,
-                "channel closure must NOT masquerade as an applied stop"
+            assert!(
+                matches!(outcome, EffectDrainOutcome::ChannelClosed),
+                "a closed effect channel must be distinguishable from a pending stop: {outcome:?}"
             );
             assert_eq!(
                 stop_calls.load(Ordering::SeqCst),

--- a/meerkat-runtime/src/effect.rs
+++ b/meerkat-runtime/src/effect.rs
@@ -34,6 +34,14 @@ pub(crate) enum RuntimeEffectInner {
 }
 
 impl RuntimeEffect {
+    /// Whether realizing this effect stops the runtime executor. Stop
+    /// realization awaits executor cleanup that may re-enter the machine
+    /// (e.g. a mob executor unregistering its session), so callers must
+    /// NEVER apply a stop effect while holding the session mutation gate.
+    pub(crate) fn is_stop(&self) -> bool {
+        matches!(self.inner, RuntimeEffectInner::StopRuntimeExecutor { .. })
+    }
+
     fn from_fact(fact: RuntimeEffectFact) -> Self {
         let inner = match fact {
             RuntimeEffectFact::CancelAfterBoundary { reason } => {

--- a/meerkat-runtime/src/meerkat_machine/traits.rs
+++ b/meerkat-runtime/src/meerkat_machine/traits.rs
@@ -641,8 +641,25 @@ impl MeerkatMachine {
         );
         let (session_id, driver, completions, wake_tx) = self.lookup_entry(runtime_id).await?;
         let gate = self.session_mutation_gate(&session_id).await;
+        // Bounded acquisition (defense in depth for the stop-under-gate
+        // deadlock class): the gate is only ever held for short critical
+        // sections, so a long wait means another task is parked while
+        // holding it — a bug in THAT task. Fail with a typed busy error so
+        // callers (e.g. a single-task mob actor) fast-fail instead of
+        // wedging every subsequent command behind an unbounded lock wait.
         let _gate_guard = match gate {
-            Some(ref gate) => Some(gate.lock().await),
+            Some(ref gate) => Some(
+                crate::tokio::time::timeout(
+                    std::time::Duration::from_secs(30),
+                    gate.lock(),
+                )
+                .await
+                .map_err(|_| {
+                    RuntimeControlPlaneError::Internal(format!(
+                        "retire for session {session_id} timed out acquiring the session                          mutation gate after 30s; the gate holder is likely deadlocked                          (stop-under-gate class) — retire can be retried"
+                    ))
+                })?,
+            ),
             None => None,
         };
 

--- a/meerkat-runtime/src/meerkat_machine_tests.rs
+++ b/meerkat-runtime/src/meerkat_machine_tests.rs
@@ -6293,6 +6293,224 @@ async fn cancel_after_boundary_on_attached_runtime_calls_live_handle_and_queues_
     );
 }
 
+/// Ask 21c defensive class tests (meerkat-studio P0): executor cleanup that
+/// re-enters the machine (the mob executor unregisters its session in
+/// `cleanup_after_runtime_stop_terminalized`) must never run while the
+/// runtime-loop task holds the session mutation gate — that is a
+/// single-task self-deadlock that parks the loop forever, leaves the
+/// session registered forever (the producer of the ask 20/21/21b strand
+/// family), and wedges every caller that later touches the gate (bricking
+/// whole mobs). Each test drives a DIFFERENT stop entry path with a
+/// machine-re-entrant executor under a hard timeout: a hang is a fail.
+mod stop_under_gate_deadlock_class {
+    use super::*;
+
+    struct ReentrantCleanupExecutor {
+        machine: Arc<MeerkatMachine>,
+        session_id: SessionId,
+        cleanup_ran: Arc<AtomicUsize>,
+        block_apply: Option<(Arc<Notify>, Arc<Notify>)>,
+        fail_checkpoint: bool,
+    }
+
+    #[async_trait::async_trait]
+    impl CoreExecutor for ReentrantCleanupExecutor {
+        async fn apply(
+            &mut self,
+            run_id: RunId,
+            primitive: RunPrimitive,
+        ) -> Result<CoreApplyOutput, CoreExecutorError> {
+            if let Some((started, release)) = &self.block_apply {
+                started.notify_waiters();
+                release.notified().await;
+            }
+            Ok(CoreApplyOutput {
+                receipt: RunBoundaryReceiptDraft {
+                    run_id,
+                    boundary: RunApplyBoundary::RunStart,
+                    contributing_input_ids: primitive.contributing_input_ids().to_vec(),
+                    conversation_digest: None,
+                    message_count: 0,
+                },
+                session_snapshot: if self.fail_checkpoint {
+                    Some(vec![1, 2, 3])
+                } else {
+                    None
+                },
+                terminal: None,
+            })
+        }
+
+        async fn checkpoint_committed_session_snapshot(
+            &mut self,
+            _session_snapshot: &[u8],
+        ) -> Result<(), CoreExecutorError> {
+            if self.fail_checkpoint {
+                return Err(CoreExecutorError::control_failed_runtime(
+                    "synthetic checkpoint failure",
+                ));
+            }
+            Ok(())
+        }
+
+        async fn cancel_after_boundary(
+            &mut self,
+            _reason: String,
+        ) -> Result<(), CoreExecutorError> {
+            Ok(())
+        }
+
+        async fn stop_runtime_executor(
+            &mut self,
+            _reason: String,
+        ) -> Result<(), CoreExecutorError> {
+            Ok(())
+        }
+
+        async fn cleanup_after_runtime_stop_terminalized(
+            &mut self,
+        ) -> Result<(), CoreExecutorError> {
+            // The mob executor shape: post-stop cleanup re-enters the
+            // machine, whose first await is the SAME session mutation gate
+            // the loop task must therefore not be holding.
+            self.cleanup_ran.fetch_add(1, Ordering::SeqCst);
+            self.machine.unregister_session(&self.session_id).await;
+            Ok(())
+        }
+    }
+
+    async fn register(
+        machine: &Arc<MeerkatMachine>,
+        session_id: &SessionId,
+        cleanup_ran: &Arc<AtomicUsize>,
+        block_apply: Option<(Arc<Notify>, Arc<Notify>)>,
+        fail_checkpoint: bool,
+    ) {
+        machine
+            .register_session_with_executor(
+                session_id.clone(),
+                Box::new(ReentrantCleanupExecutor {
+                    machine: Arc::clone(machine),
+                    session_id: session_id.clone(),
+                    cleanup_ran: Arc::clone(cleanup_ran),
+                    block_apply,
+                    fail_checkpoint,
+                }),
+            )
+            .await
+            .expect("runtime executor registration should succeed");
+    }
+
+    /// Path 1: explicit stop on an idle attached loop (stop effect via the
+    /// select! direct-effect arm).
+    #[tokio::test]
+    async fn explicit_stop_with_reentrant_cleanup_completes() {
+        let machine = Arc::new(MeerkatMachine::ephemeral());
+        let session_id = SessionId::new();
+        let cleanup_ran = Arc::new(AtomicUsize::new(0));
+        register(&machine, &session_id, &cleanup_ran, None, false).await;
+
+        tokio::time::timeout(Duration::from_secs(5), async {
+            machine
+                .stop_runtime_executor(&session_id, "class test: explicit stop")
+                .await
+                .expect("stop should be accepted");
+            while cleanup_ran.load(Ordering::SeqCst) == 0 {
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+            while machine.contains_session(&session_id).await {
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .expect(
+            "stop with machine-re-entrant cleanup must complete: a hang means a stop path \
+             ran executor cleanup while holding the session mutation gate",
+        );
+    }
+
+    /// Path 2: stop requested while a turn is mid-apply (stop effect drained
+    /// by process_queue after the apply returns — the drain must surface the
+    /// stop instead of applying it under the queue authority guard).
+    #[tokio::test]
+    async fn mid_apply_stop_with_reentrant_cleanup_completes() {
+        let machine = Arc::new(MeerkatMachine::ephemeral());
+        let session_id = SessionId::new();
+        let cleanup_ran = Arc::new(AtomicUsize::new(0));
+        let apply_started = Arc::new(Notify::new());
+        let release_apply = Arc::new(Notify::new());
+        register(
+            &machine,
+            &session_id,
+            &cleanup_ran,
+            Some((Arc::clone(&apply_started), Arc::clone(&release_apply))),
+            false,
+        )
+        .await;
+
+        let (outcome, _completion) = machine
+            .accept_input_with_completion(&session_id, make_prompt("turn to stop mid-apply"))
+            .await
+            .expect("prompt should be accepted");
+        assert!(outcome.is_accepted());
+        tokio::time::timeout(Duration::from_secs(1), apply_started.notified())
+            .await
+            .expect("turn should start running");
+
+        tokio::time::timeout(Duration::from_secs(5), async {
+            machine
+                .stop_runtime_executor(&session_id, "class test: mid-apply stop")
+                .await
+                .expect("stop should be accepted");
+            release_apply.notify_waiters();
+            while cleanup_ran.load(Ordering::SeqCst) == 0 {
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+            while machine.contains_session(&session_id).await {
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .expect(
+            "mid-apply stop with machine-re-entrant cleanup must complete: a hang means the \
+             effect drain applied the stop under the queue authority guard",
+        );
+    }
+
+    /// Path 3: checkpoint-failure stop (the terminal-authority-guard family
+    /// — the same guard the field deadlock parked on in the
+    /// terminal-failure arm).
+    #[tokio::test]
+    async fn checkpoint_failure_stop_with_reentrant_cleanup_completes() {
+        let machine = Arc::new(MeerkatMachine::ephemeral());
+        let session_id = SessionId::new();
+        let cleanup_ran = Arc::new(AtomicUsize::new(0));
+        register(&machine, &session_id, &cleanup_ran, None, true).await;
+
+        tokio::time::timeout(Duration::from_secs(5), async {
+            let (outcome, _completion) = machine
+                .accept_input_with_completion(
+                    &session_id,
+                    make_prompt("turn whose checkpoint fails"),
+                )
+                .await
+                .expect("prompt should be accepted");
+            assert!(outcome.is_accepted());
+            while cleanup_ran.load(Ordering::SeqCst) == 0 {
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+            while machine.contains_session(&session_id).await {
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .expect(
+            "checkpoint-failure stop with machine-re-entrant cleanup must complete: a hang \
+             means the stop ran under the terminal authority guard",
+        );
+    }
+}
+
 /// M1 regression (meerkat-studio P0): a boundary handle that (wrongly)
 /// re-enters `MeerkatMachine::cancel_after_boundary` from inside the
 /// machine's own dispatch used to recurse unboundedly — each lap re-staged

--- a/meerkat-runtime/src/runtime_loop.rs
+++ b/meerkat-runtime/src/runtime_loop.rs
@@ -765,7 +765,7 @@ pub(crate) fn spawn_runtime_loop_with_completions(
                 maybe_effect = effect_rx.recv() => {
                     match maybe_effect {
                         Some(effect) => {
-                            let _authority_guard = match authority_binding
+                            let authority_guard = match authority_binding
                                 .lock_current_driver_authority(
                                     &driver,
                                     "runtime loop direct executor effect",
@@ -775,6 +775,14 @@ pub(crate) fn spawn_runtime_loop_with_completions(
                                 Ok(guard) => guard,
                                 Err(_) => break,
                             };
+                            if effect.is_stop() {
+                                // Stop realization awaits executor cleanup
+                                // that may re-enter the machine (unregister),
+                                // which acquires this same gate — applying it
+                                // under the guard self-deadlocks the loop
+                                // task and wedges every caller of the gate.
+                                drop(authority_guard);
+                            }
                             match crate::control_plane::apply_executor_effect(
                                 &driver,
                                 completions.as_ref(),
@@ -1152,7 +1160,29 @@ async fn process_queue(
         )
         .await
         {
-            Ok(crate::control_plane::EffectDrainOutcome::AppliedStop) => return true,
+            Ok(crate::control_plane::EffectDrainOutcome::StopEffectPending(effect)) => {
+                // The drain never applies stops: realize it here AFTER the
+                // authority guard is released (cleanup may re-enter the
+                // machine and acquire the same session mutation gate).
+                drop(effect_authority_guard);
+                return match crate::control_plane::apply_executor_effect(
+                    driver,
+                    completions,
+                    executor,
+                    effect,
+                )
+                .await
+                {
+                    Ok(should_stop) => should_stop,
+                    Err(error) => {
+                        tracing::error!(
+                            error = %error,
+                            "failed to apply pending stop-runtime-executor effect"
+                        );
+                        true
+                    }
+                };
+            }
             Ok(crate::control_plane::EffectDrainOutcome::Empty) => {}
             Ok(crate::control_plane::EffectDrainOutcome::ChannelClosed) => {
                 // The effect sender was dropped: the control plane is gone.
@@ -1359,6 +1389,9 @@ async fn process_queue(
                         .await
                         {
                             tracing::error!(error = %err, "failed to record primitive rejection terminal event");
+                            // Stop paths must never run under the session
+                            // mutation gate (cleanup can re-enter the machine).
+                            drop(queue_authority_guard);
                             let should_stop = stop_runtime_loop_executor_from_dsl_effect(
                                 driver,
                                 completions,
@@ -1399,6 +1432,7 @@ async fn process_queue(
                     .await
                     {
                         tracing::error!(error = %err, "failed to record turn-state preparation terminal event");
+                        drop(queue_authority_guard);
                         let should_stop = stop_runtime_loop_executor_from_dsl_effect(
                             driver,
                             completions,
@@ -1483,6 +1517,7 @@ async fn process_queue(
                                 Some(completion_error),
                             )
                             .await;
+                            drop(terminal_authority_guard);
                             let should_stop = stop_runtime_loop_executor_from_dsl_effect(
                                 driver,
                                 completions,
@@ -1517,6 +1552,7 @@ async fn process_queue(
                                 Some(completion_error),
                             )
                             .await;
+                            drop(terminal_authority_guard);
                             let should_stop = stop_runtime_loop_executor_from_dsl_effect(
                                 driver,
                                 completions,
@@ -1594,6 +1630,12 @@ async fn process_queue(
                         };
                         if let Err(err) = fail_result {
                             tracing::error!(error = %err, "failed to record runtime terminal event");
+                            // The field deadlock (ask 21c): stopping here
+                            // while holding the authority guard parked the
+                            // loop task forever inside its own unregister —
+                            // same pattern as the ChannelClosed arm's
+                            // explicit drop.
+                            drop(terminal_authority_guard);
                             let should_stop = stop_runtime_loop_executor_from_dsl_effect(
                                 driver,
                                 completions,
@@ -1650,6 +1692,7 @@ async fn process_queue(
                     let mut completions = completions.lock().await;
                     fail_completion_waiters(&mut completions, &input_ids, reason.clone());
                 }
+                drop(queue_authority_guard);
                 return stop_runtime_loop_executor_from_dsl_effect(
                     driver,
                     completions,


### PR DESCRIPTION
Fixes the root producer of the entire ask 20/21/21b/21c family (meerkat-studio P0 blocking 0.7.21 adoption).

## Root cause
The runtime-loop task acquired the per-session mutation gate for terminal/effect handling and — still holding it — entered stop realization. `cleanup_after_runtime_stop_terminalized` re-enters the machine (the mob executor unregisters its session), and `unregister_session_inner`'s first await is the SAME non-reentrant gate: the task parks forever (B waits on B). Consequences: a forever-leaked registered session (the exact state asks 20/21/21b kept hitting downstream), and on 0.7.21 the new archive arm gate-locking against the parked task wedged the entire single-task MobActor.

## Fix (structural — stops are guard-free by construction)
- `drain_ready_executor_effects` never applies stop effects: it surfaces `StopEffectPending` and the caller applies after dropping its authority guard. The select! direct-effect arm gets the same split via `RuntimeEffect::is_stop`.
- Every `stop_runtime_loop_executor_from_dsl_effect` site drops its live guard first — the terminal-failure arm (the field deadlock at the studio's traced frames), plus primitive-rejection, turn-state-prep, commit-failure, checkpoint-failure, and ProjectionMismatch arms — matching the ChannelClosed arm's existing explicit-drop precedent. Full audit of all 9 call sites.
- Defense in depth (studio direction 3): `retire_runtime_control_plane` acquires the gate with a 30s bound and a typed error naming the deadlock class — a future regression fast-fails a mob command instead of wedging the actor.

## Defensive class tests (the whack-a-mole ender)
`stop_under_gate_deadlock_class`: a mob-shaped executor whose cleanup re-enters `unregister_session`, driven through three distinct stop entry paths (explicit stop via the select arm; mid-apply stop via the queue effect drain; checkpoint-failure stop via the terminal-authority-guard family — the same family as the field's terminal-failure arm), each under a hard 5s timeout. **Red-verified**: against the unfixed code these tests deadlock and time out. Any future stop-under-gate regression on any path fails loudly instead of shipping.

Also updated the control-plane drain contract tests to the non-applying semantics.

## Downstream convergence
With unregister actually completing, never-run member disposal converges through the existing 21/21b arms (runtime unregistered at archive time → NotFound propagates → disposal tolerance → Ok) instead of manufacturing the permanently-registered state — this should also resolve the identity-first construction still failing with the original 21b error on 0.7.21.

## Acceptance
meerkat-side: runtime+mob+session 2618 tests green, clippy clean. The mobkit acceptance repros (`studio_k1_retire_respawn_succeed_on_persistent_ensure_member_crew` with a per-test timeout, and `doctrine_member_rpcs_route_identity_owned_members_through_identity_authority`) are the field gates on the 0.7.22 upgrade.

🤖 Generated with [Claude Code](https://claude.com/claude-code)