### PR TITLE
fix(sdk): omit collectionFault when absent instead of emitting an undefined-valued key

### DIFF
--- a/sdks/typescript/src/client.ts
+++ b/sdks/typescript/src/client.ts
@@ -3791,7 +3791,12 @@ export class MeerkatClient {
         ),
       },
       quarantined,
-      collectionFault: data.collection_fault ?? undefined,
+      // Omit the key entirely when absent: emitting `collectionFault:
+      // undefined` makes strict deep-equality (and honest JSON round-trips)
+      // diverge from the wire shape.
+      ...(data.collection_fault !== undefined && data.collection_fault !== null
+        ? { collectionFault: data.collection_fault }
+        : {}),
     };
   }
 


### PR DESCRIPTION
Unblocks the v0.7.22 release: the release-validation SDK smoke (strict deep-equality on the BuildBuddy lane) failed on `parseRunResult includes skillDiagnostics` because #846's parser emits `collectionFault: undefined` for run results without a collection fault. A present-but-undefined key diverges from the wire shape; omit it when absent. TS suite green locally (skills tests 21/21, tsc clean).

Nothing of 0.7.22 published (validation gate failed first), so after merge the v0.7.22 tag will be re-pointed at the fixed commit and the release re-triggered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)