### PR TITLE
fix: attention overlays inject fresh at apply time with newest-session arbitration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- Scheduled prompt delivery no longer snapshots the WorkGraph attention
+  projection at enqueue time (facade schedule host and CLI schedule host).
+  A queued prompt behind a running turn that mutated its work item carried a
+  projection that failed exact-currency validation at apply, deterministically
+  failing the scheduled delivery. The runtime executors inject a fresh
+  projection at apply time — the single canonical injection point — so the
+  enqueue-time composition was removed outright.
+- WorkGraph attention overlays now arbitrate newest-session-wins on the
+  canonical apply-time injection path. The arbitration guard previously ran
+  only on the (removed) enqueue-time composition path, so during mob member
+  respawn overlap both the old and new session matched the same owner-key
+  binding and both received the attention overlay. The session-listing
+  arbitration is now threaded through every injection surface (CLI, REST,
+  RPC, MCP, mob provisioner, runtime executors); a session not yet visible in
+  the listing (mid-creation) is treated as the newest carrier of its labels.
+
+### Testing
+
+- Pinned the apply-time attention injection on `CliRuntimeExecutor` and the
+  newest-session arbitration semantics (overlap denial + mid-creation allow).
+- Pinned the non-wasm fail-closed factory contract: WorkGraph enabled without
+  a supplied dispatcher refuses to build with the typed `Config` error.
+- Pinned the SQLite UNIQUE-violation → typed `Conflict` mapping for duplicate
+  work item and attention binding inserts.
+
 ## [0.7.22] - 2026-07-07
 
 Meerkat 0.7.22 fixes the runtime-loop self-deadlock that was the root

--- a/meerkat-cli/src/main.rs
+++ b/meerkat-cli/src/main.rs
@@ -10913,7 +10913,7 @@ impl SurfaceScheduleSessionHost for CliScheduleSessionHost {
         let mut scheduled_instructions = dispatch.additional_instructions.clone();
         scheduled_instructions.push(SCHEDULED_PROMPT_VISIBLE_COMPLETION_INSTRUCTION.to_string());
 
-        let mut turn_metadata = meerkat_core::lifecycle::run_primitive::RuntimeTurnMetadata {
+        let turn_metadata = meerkat_core::lifecycle::run_primitive::RuntimeTurnMetadata {
             handling_mode: None,
             keep_alive: None,
             skill_references: scheduled_skill_keys(&dispatch.skill_refs)?,
@@ -10944,15 +10944,11 @@ impl SurfaceScheduleSessionHost for CliScheduleSessionHost {
             auth_binding: None,
             transcript_identity: Default::default(),
         };
-        turn_metadata.turn_tool_overlay =
-            meerkat::surface::compose_workgraph_attention_turn_overlay_for_session(
-                self.service.as_ref(),
-                Some(&self.workgraph_service),
-                session_id,
-                turn_metadata.turn_tool_overlay.take(),
-            )
-            .await
-            .map_err(|error| meerkat::ScheduleDomainError::Internal(error.to_string()))?;
+        // The attention overlay is deliberately NOT composed here: a queued
+        // prompt can sit behind a running turn that mutates the work item,
+        // and a projection snapshotted at enqueue time would fail exact-
+        // currency validation at apply. CliRuntimeExecutor::apply injects a
+        // fresh projection at apply time instead.
         let mut prompt_input =
             PromptInput::from_content_input(dispatch.prompt, Some(turn_metadata));
         prompt_input.header.source = InputOrigin::System;
@@ -17072,6 +17068,7 @@ default_model = "gemma"
         session_id: SessionId,
         saw_event_tx: std::sync::atomic::AtomicBool,
         pre_turn_context_appends: Mutex<Vec<meerkat_core::PendingSystemContextAppend>>,
+        captured_turn_tool_overlay: Mutex<Option<meerkat_core::service::TurnToolOverlay>>,
     }
 
     impl CapturingEventTurnService {
@@ -17080,6 +17077,7 @@ default_model = "gemma"
                 session_id,
                 saw_event_tx: std::sync::atomic::AtomicBool::new(false),
                 pre_turn_context_appends: Mutex::new(Vec::new()),
+                captured_turn_tool_overlay: Mutex::new(None),
             }
         }
     }
@@ -17117,6 +17115,11 @@ default_model = "gemma"
                 .lock()
                 .expect("pre-turn context appends lock poisoned") =
                 req.runtime.pre_turn_context_appends;
+            *self
+                .captured_turn_tool_overlay
+                .lock()
+                .expect("captured turn tool overlay lock poisoned") =
+                req.runtime.turn_tool_overlay.clone();
             if let Some(tx) = req.event_tx {
                 self.saw_event_tx
                     .store(true, std::sync::atomic::Ordering::Release);
@@ -17615,6 +17618,73 @@ default_model = "gemma"
                 .saw_event_tx
                 .load(std::sync::atomic::Ordering::Acquire),
             "runtime-backed executor must forward the caller event sender"
+        );
+    }
+
+    /// Pin (post-#850 fixups): CliRuntimeExecutor::apply is the CLI's canonical
+    /// attention-overlay injection point. A session-scoped active binding must
+    /// surface as a turn tool overlay carrying the projection dispatch context
+    /// on the request the executor hands to the session service. Reverting the
+    /// apply-time injection call silently drops attention from CLI turns.
+    #[tokio::test]
+    async fn test_cli_runtime_executor_injects_attention_overlay_at_apply() {
+        let session_id = SessionId::new();
+        let service = Arc::new(CapturingEventTurnService::new(session_id.clone()));
+        let runtime_adapter = Arc::new(meerkat_runtime::MeerkatMachine::ephemeral());
+        let workgraph_service = meerkat::WorkGraphService::new(std::sync::Arc::new(
+            meerkat::MemoryWorkGraphStore::new(),
+        ));
+        workgraph_service
+            .create_goal(meerkat::GoalCreateRequest {
+                realm_id: None,
+                namespace: None,
+                title: "cli attention pin".to_string(),
+                description: None,
+                target: meerkat::GoalAttentionTarget::Session {
+                    session_id: session_id.clone(),
+                },
+                mode: meerkat::WorkAttentionMode::Coordinate,
+                completion_policy: meerkat::WorkCompletionPolicy::SelfAttest,
+                delegated_authority: meerkat::AttentionDelegatedAuthority::AddEvidence,
+                projection_policy: meerkat::AttentionProjectionPolicy::default(),
+            })
+            .await
+            .expect("create session-scoped goal");
+
+        let mut executor = CliRuntimeExecutor {
+            service: service.clone(),
+            #[cfg(feature = "session-store")]
+            persistent_service: None,
+            session_id: session_id.clone(),
+            runtime_adapter,
+            workgraph_service: Some(workgraph_service),
+            event_tx: None,
+        };
+        let primitive = meerkat_core::lifecycle::run_primitive::RunPrimitive::ImmediateAppend(
+            meerkat_core::lifecycle::run_primitive::ConversationAppend {
+                role: meerkat_core::lifecycle::run_primitive::ConversationAppendRole::User,
+                content: meerkat_core::lifecycle::run_primitive::CoreRenderable::Text {
+                    text: "hello".to_string(),
+                },
+            },
+        );
+        let run_id = meerkat_core::lifecycle::RunId::new();
+
+        meerkat_core::lifecycle::CoreExecutor::apply(&mut executor, run_id, primitive)
+            .await
+            .expect("runtime-backed CLI turn should succeed");
+
+        let overlay = service
+            .captured_turn_tool_overlay
+            .lock()
+            .expect("captured turn tool overlay lock poisoned")
+            .clone()
+            .expect("apply must inject the attention turn overlay for an active binding");
+        assert!(
+            overlay
+                .dispatch_context
+                .contains_key("workgraph.attention_projection"),
+            "injected overlay must carry the attention projection dispatch context"
         );
     }
 

--- a/meerkat-rest/src/lib.rs
+++ b/meerkat-rest/src/lib.rs
@@ -1693,6 +1693,7 @@ async fn apply_runtime_turn(
             if let Err(error) =
                 meerkat::surface::inject_workgraph_attention_turn_overlay_from_labels(
                     &context.workgraph_service,
+                    context.session_service.as_ref(),
                     session_id,
                     attention_labels,
                     &mut recovered_turn_req,

--- a/meerkat-rpc/src/session_runtime.rs
+++ b/meerkat-rpc/src/session_runtime.rs
@@ -5635,6 +5635,7 @@ impl SessionRuntime {
                 if let Err(error) =
                     meerkat::surface::inject_workgraph_attention_turn_overlay_from_labels(
                         workgraph_service,
+                        self.service.as_ref(),
                         session_id,
                         attention_labels,
                         &mut start_request,
@@ -5707,6 +5708,7 @@ impl SessionRuntime {
             if let Err(error) =
                 meerkat::surface::inject_workgraph_attention_turn_overlay_from_labels(
                     workgraph_service,
+                    self.service.as_ref(),
                     session_id,
                     attention_labels,
                     &mut start_request,
@@ -6141,6 +6143,7 @@ impl SessionRuntime {
                 if let Err(error) =
                     meerkat::surface::inject_workgraph_attention_turn_overlay_from_labels(
                         workgraph_service,
+                        self.service.as_ref(),
                         session_id,
                         attention_labels,
                         &mut start_request,

--- a/meerkat-workgraph/src/store.rs
+++ b/meerkat-workgraph/src/store.rs
@@ -1875,6 +1875,107 @@ mod tests {
         assert_eq!(events.len(), 1);
     }
 
+    /// Pins the SQLite UNIQUE-violation mapping for duplicate item inserts:
+    /// a second insert of an existing item id must surface as the typed
+    /// `Conflict`, not a generic `Store` error.
+    #[cfg(not(target_arch = "wasm32"))]
+    #[tokio::test]
+    async fn sqlite_store_duplicate_item_insert_maps_to_conflict() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("workgraph.sqlite3");
+        let store = std::sync::Arc::new(crate::SqliteWorkGraphStore::open(&path).expect("open"));
+        let service =
+            WorkGraphService::with_scope(store.clone(), "realm", WorkNamespace::default());
+        let item = service
+            .create(CreateWorkItemRequest {
+                realm_id: None,
+                namespace: None,
+                title: "unique item".to_string(),
+                description: None,
+                priority: Default::default(),
+                completion_policy: Default::default(),
+                labels: BTreeSet::new(),
+                due_at: None,
+                not_before: None,
+                snoozed_until: None,
+                external_refs: Vec::new(),
+                evidence_refs: Vec::new(),
+                status: None,
+            })
+            .await
+            .expect("create");
+
+        let event = WorkGraphEvent::graph(
+            item.realm_id.clone(),
+            item.namespace.clone(),
+            WorkGraphEventKind::Created,
+            item.created_at,
+            json!({ "item_id": item.id }),
+        );
+        let error = store
+            .insert_item(item, event)
+            .await
+            .expect_err("duplicate item insert must fail");
+        assert!(
+            matches!(error, WorkGraphError::Conflict(_)),
+            "duplicate item insert must map to Conflict, got: {error:?}"
+        );
+    }
+
+    /// Pins the SQLite UNIQUE-violation mapping for duplicate attention
+    /// binding inserts (via the compound goal insert): the typed `Conflict`,
+    /// not a generic `Store` error.
+    #[cfg(not(target_arch = "wasm32"))]
+    #[tokio::test]
+    async fn sqlite_store_duplicate_attention_insert_maps_to_conflict() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("workgraph.sqlite3");
+        let store = std::sync::Arc::new(crate::SqliteWorkGraphStore::open(&path).expect("open"));
+        let service =
+            WorkGraphService::with_scope(store.clone(), "realm", WorkNamespace::default());
+        let goal = service
+            .create_goal(GoalCreateRequest {
+                realm_id: None,
+                namespace: None,
+                title: "unique goal".to_string(),
+                description: None,
+                target: GoalAttentionTarget::Session {
+                    session_id: meerkat_core::SessionId::new(),
+                },
+                mode: WorkAttentionMode::Coordinate,
+                completion_policy: WorkCompletionPolicy::SelfAttest,
+                delegated_authority: AttentionDelegatedAuthority::AddEvidence,
+                projection_policy: AttentionProjectionPolicy::default(),
+            })
+            .await
+            .expect("create goal");
+
+        let mut fresh_item = goal.item.clone();
+        fresh_item.id = WorkItemId::generated();
+        let item_event = WorkGraphEvent::graph(
+            fresh_item.realm_id.clone(),
+            fresh_item.namespace.clone(),
+            WorkGraphEventKind::Created,
+            fresh_item.created_at,
+            json!({ "item_id": fresh_item.id }),
+        );
+        let attention_event = WorkGraphEvent::graph(
+            goal.attention.work_ref.realm_id.clone(),
+            goal.attention.work_ref.namespace.clone(),
+            WorkGraphEventKind::AttentionCreated,
+            goal.attention.updated_at,
+            json!({ "binding_id": goal.attention.binding_id }),
+        );
+        let error = store
+            .insert_goal(fresh_item, item_event, goal.attention, attention_event)
+            .await
+            .expect_err("duplicate attention insert must fail");
+        assert!(
+            matches!(error, WorkGraphError::Conflict(_)),
+            "duplicate attention insert must map to Conflict, got: {error:?}"
+        );
+    }
+
     #[cfg(not(target_arch = "wasm32"))]
     #[tokio::test]
     async fn sqlite_persistence_survives_restart() {

--- a/meerkat/src/surface.rs
+++ b/meerkat/src/surface.rs
@@ -118,6 +118,7 @@ pub async fn inject_workgraph_attention_turn_overlay(
     })?;
     inject_workgraph_attention_turn_overlay_from_labels(
         workgraph_service,
+        session_service,
         session_id,
         &session.state.labels,
         request,
@@ -125,36 +126,9 @@ pub async fn inject_workgraph_attention_turn_overlay(
     .await
 }
 
-pub async fn compose_workgraph_attention_turn_overlay_for_session(
-    session_service: &dyn meerkat_core::SessionService,
-    workgraph_service: Option<&crate::WorkGraphService>,
-    session_id: &meerkat_core::SessionId,
-    existing_overlay: Option<meerkat_core::service::TurnToolOverlay>,
-) -> Result<Option<meerkat_core::service::TurnToolOverlay>, WorkGraphAttentionTurnOverlayError> {
-    let Some(workgraph_service) = workgraph_service else {
-        return Ok(existing_overlay);
-    };
-    if workgraph_service.store().kind() == crate::WorkGraphStoreKind::Disabled {
-        return Ok(existing_overlay);
-    }
-    let session = session_service.read(session_id).await.map_err(|source| {
-        WorkGraphAttentionTurnOverlayError::SessionRead {
-            session_id: session_id.clone(),
-            source,
-        }
-    })?;
-    compose_workgraph_attention_turn_overlay_from_labels(
-        workgraph_service,
-        Some(session_service),
-        session_id,
-        &session.state.labels,
-        existing_overlay,
-    )
-    .await
-}
-
 pub async fn inject_workgraph_attention_turn_overlay_from_labels(
     workgraph_service: &crate::WorkGraphService,
+    session_service: &dyn meerkat_core::SessionService,
     session_id: &meerkat_core::SessionId,
     labels: &BTreeMap<String, String>,
     request: &mut meerkat_core::StartTurnRequest,
@@ -167,7 +141,7 @@ pub async fn inject_workgraph_attention_turn_overlay_from_labels(
         .or_else(|| request.runtime.turn_tool_overlay.clone());
     let Some(overlay) = compose_workgraph_attention_turn_overlay_from_labels(
         workgraph_service,
-        None,
+        Some(session_service),
         session_id,
         labels,
         existing_overlay,
@@ -296,6 +270,17 @@ async fn attention_binding_resolves_to_session(
                 .cmp(&left.session_id.to_string())
         })
     });
+    // A session not yet visible in the listing is mid-creation: it is
+    // definitionally the newest session carrying these labels, so the
+    // attention overlay may bind to it. Otherwise the newest listed live
+    // session wins, so overlapping respawn generations resolve
+    // deterministically instead of both receiving the attention overlay.
+    if !summaries
+        .iter()
+        .any(|summary| summary.session_id == *session_id)
+    {
+        return Ok(true);
+    }
     Ok(summaries
         .first()
         .is_none_or(|summary| summary.session_id == *session_id))
@@ -1081,6 +1066,243 @@ mod tests {
         assert_eq!(
             overlay.dispatch_context["workgraph.attention_projection"],
             serde_json::json!({"binding_id": "b"})
+        );
+    }
+
+    /// Minimal SessionService fake for owner-key attention arbitration: `read`
+    /// serves the configured labels for any known session and `list` applies
+    /// the label filter over the configured summaries, mirroring the real
+    /// live-session listing the arbitration guard consults.
+    struct RespawnOverlapSessionService {
+        summaries: Vec<meerkat_core::service::SessionSummary>,
+        labels: BTreeMap<String, String>,
+    }
+
+    #[async_trait::async_trait]
+    impl meerkat_core::SessionService for RespawnOverlapSessionService {
+        async fn create_session(
+            &self,
+            _req: meerkat_core::service::CreateSessionRequest,
+        ) -> Result<meerkat_core::RunResult, meerkat_core::service::SessionError> {
+            Err(meerkat_core::service::SessionError::Agent(
+                meerkat_core::AgentError::InternalError(
+                    "not used by arbitration tests".to_string(),
+                ),
+            ))
+        }
+
+        async fn start_turn(
+            &self,
+            id: &meerkat_core::SessionId,
+            _req: meerkat_core::StartTurnRequest,
+        ) -> Result<meerkat_core::RunResult, meerkat_core::service::SessionError> {
+            Err(meerkat_core::service::SessionError::NotFound { id: id.clone() })
+        }
+
+        async fn interrupt(
+            &self,
+            _id: &meerkat_core::SessionId,
+        ) -> Result<(), meerkat_core::service::SessionError> {
+            Ok(())
+        }
+
+        async fn read(
+            &self,
+            id: &meerkat_core::SessionId,
+        ) -> Result<meerkat_core::service::SessionView, meerkat_core::service::SessionError>
+        {
+            Ok(meerkat_core::service::SessionView {
+                state: meerkat_core::service::SessionInfo {
+                    session_id: id.clone(),
+                    created_at: std::time::SystemTime::UNIX_EPOCH,
+                    updated_at: std::time::SystemTime::UNIX_EPOCH,
+                    message_count: 0,
+                    is_active: false,
+                    model: "claude-sonnet-4-5".to_string(),
+                    provider: meerkat_core::Provider::Anthropic,
+                    last_assistant_text: None,
+                    labels: self.labels.clone(),
+                },
+                billing: meerkat_core::service::SessionUsage {
+                    total_tokens: 0,
+                    usage: meerkat_core::Usage::default(),
+                },
+            })
+        }
+
+        async fn list(
+            &self,
+            query: meerkat_core::service::SessionQuery,
+        ) -> Result<Vec<meerkat_core::service::SessionSummary>, meerkat_core::service::SessionError>
+        {
+            Ok(self
+                .summaries
+                .iter()
+                .filter(|summary| {
+                    query.labels.as_ref().is_none_or(|filter| {
+                        filter.iter().all(|(key, value)| {
+                            summary.labels.get(key).is_some_and(|label| label == value)
+                        })
+                    })
+                })
+                .cloned()
+                .collect())
+        }
+
+        async fn archive(
+            &self,
+            _id: &meerkat_core::SessionId,
+        ) -> Result<(), meerkat_core::service::SessionError> {
+            Ok(())
+        }
+    }
+
+    fn respawn_summary(
+        session_id: meerkat_core::SessionId,
+        created_at: std::time::SystemTime,
+        labels: &BTreeMap<String, String>,
+    ) -> meerkat_core::service::SessionSummary {
+        meerkat_core::service::SessionSummary {
+            session_id,
+            created_at,
+            updated_at: created_at,
+            message_count: 0,
+            total_tokens: 0,
+            is_active: true,
+            labels: labels.clone(),
+        }
+    }
+
+    fn mob_owner_labels() -> BTreeMap<String, String> {
+        BTreeMap::from([
+            ("mob_id".to_string(), "alpha".to_string()),
+            ("agent_identity".to_string(), "reviewer".to_string()),
+        ])
+    }
+
+    async fn owner_scoped_workgraph_service() -> crate::WorkGraphService {
+        let service =
+            crate::WorkGraphService::new(std::sync::Arc::new(crate::MemoryWorkGraphStore::new()));
+        service
+            .create_goal(crate::GoalCreateRequest {
+                realm_id: None,
+                namespace: None,
+                title: "arbitrated goal".to_string(),
+                description: None,
+                target: crate::GoalAttentionTarget::Owner {
+                    owner_key: crate::WorkOwnerKey::agent("mob/alpha/agent/reviewer")
+                        .expect("owner key"),
+                },
+                mode: crate::WorkAttentionMode::Coordinate,
+                completion_policy: crate::WorkCompletionPolicy::SelfAttest,
+                delegated_authority: crate::AttentionDelegatedAuthority::AddEvidence,
+                projection_policy: crate::AttentionProjectionPolicy::default(),
+            })
+            .await
+            .expect("create owner-scoped goal");
+        service
+    }
+
+    fn empty_start_turn_request() -> meerkat_core::StartTurnRequest {
+        meerkat_core::StartTurnRequest {
+            injected_context: Vec::new(),
+            prompt: meerkat_core::ContentInput::Text(String::new()),
+            system_prompt: None,
+            event_tx: None,
+            runtime: meerkat_core::service::StartTurnRuntimeSemantics::new(
+                meerkat_core::types::HandlingMode::Queue,
+                None,
+                Vec::new(),
+                None,
+            ),
+        }
+    }
+
+    /// Respawn-overlap arbitration on the canonical apply-time injection
+    /// path: when two live sessions carry the same mob owner labels, only
+    /// the newest receives the attention overlay.
+    #[tokio::test]
+    async fn attention_overlay_binds_only_to_newest_labeled_session() {
+        let labels = mob_owner_labels();
+        let older_id = meerkat_core::SessionId::new();
+        let newer_id = meerkat_core::SessionId::new();
+        let base = std::time::SystemTime::UNIX_EPOCH + std::time::Duration::from_secs(1_000_000);
+        let session_service = RespawnOverlapSessionService {
+            summaries: vec![
+                respawn_summary(older_id.clone(), base, &labels),
+                respawn_summary(
+                    newer_id.clone(),
+                    base + std::time::Duration::from_secs(60),
+                    &labels,
+                ),
+            ],
+            labels: labels.clone(),
+        };
+        let workgraph_service = owner_scoped_workgraph_service().await;
+
+        let mut older_request = empty_start_turn_request();
+        inject_workgraph_attention_turn_overlay(
+            &session_service,
+            Some(&workgraph_service),
+            &older_id,
+            &mut older_request,
+        )
+        .await
+        .expect("inject for older session");
+        assert!(
+            older_request.runtime.turn_tool_overlay.is_none(),
+            "the older overlapping session must not receive the attention overlay"
+        );
+
+        let mut newer_request = empty_start_turn_request();
+        inject_workgraph_attention_turn_overlay(
+            &session_service,
+            Some(&workgraph_service),
+            &newer_id,
+            &mut newer_request,
+        )
+        .await
+        .expect("inject for newest session");
+        let overlay = newer_request
+            .runtime
+            .turn_tool_overlay
+            .expect("newest session must receive the attention overlay");
+        assert!(
+            overlay
+                .dispatch_context
+                .contains_key("workgraph.attention_projection"),
+            "attention overlay must carry the projection dispatch context"
+        );
+    }
+
+    /// A session that is not yet visible in the session listing is
+    /// mid-creation and definitionally the newest carrier of its labels, so
+    /// creation-time injection (RPC/REST create-and-start paths) still binds.
+    #[tokio::test]
+    async fn attention_overlay_allows_unlisted_mid_creation_session() {
+        let labels = mob_owner_labels();
+        let listed_id = meerkat_core::SessionId::new();
+        let mid_creation_id = meerkat_core::SessionId::new();
+        let base = std::time::SystemTime::UNIX_EPOCH + std::time::Duration::from_secs(1_000_000);
+        let session_service = RespawnOverlapSessionService {
+            summaries: vec![respawn_summary(listed_id, base, &labels)],
+            labels: labels.clone(),
+        };
+        let workgraph_service = owner_scoped_workgraph_service().await;
+
+        let mut request = empty_start_turn_request();
+        inject_workgraph_attention_turn_overlay_from_labels(
+            &workgraph_service,
+            &session_service,
+            &mid_creation_id,
+            &labels,
+            &mut request,
+        )
+        .await
+        .expect("inject for mid-creation session");
+        assert!(
+            request.runtime.turn_tool_overlay.is_some(),
+            "a mid-creation session absent from the listing is the newest by construction"
         );
     }
 

--- a/meerkat/src/surface/runtime_schedule_host.rs
+++ b/meerkat/src/surface/runtime_schedule_host.rs
@@ -527,7 +527,7 @@ impl<B: SessionAgentBuilder + 'static> SurfaceScheduleSessionHost
     ) -> Result<crate::DeliveryDispatch, ScheduleDomainError> {
         self.ensure_runtime_session_registered(session_id).await?;
 
-        let mut turn_metadata = meerkat_core::lifecycle::run_primitive::RuntimeTurnMetadata {
+        let turn_metadata = meerkat_core::lifecycle::run_primitive::RuntimeTurnMetadata {
             handling_mode: None,
             keep_alive: None,
             skill_references: (!dispatch.skill_refs.is_empty()).then(|| {
@@ -559,15 +559,12 @@ impl<B: SessionAgentBuilder + 'static> SurfaceScheduleSessionHost
             auth_binding: None,
             transcript_identity: Default::default(),
         };
-        turn_metadata.turn_tool_overlay =
-            super::compose_workgraph_attention_turn_overlay_for_session(
-                self.service.as_ref(),
-                self.workgraph_service.as_ref(),
-                session_id,
-                turn_metadata.turn_tool_overlay.take(),
-            )
-            .await
-            .map_err(schedule_internal)?;
+        // The attention overlay is deliberately NOT composed here: a queued
+        // prompt can sit behind a running turn that mutates the work item,
+        // and a projection snapshotted at enqueue time would fail exact-
+        // currency validation at apply. The runtime executor (wired with
+        // this host's workgraph service) injects a fresh projection at
+        // apply time instead.
         let mut prompt_input =
             meerkat_runtime::PromptInput::from_content_input(dispatch.prompt, Some(turn_metadata));
         prompt_input.header.source = meerkat_runtime::InputOrigin::System;

--- a/meerkat/tests/factory_build_agent.rs
+++ b/meerkat/tests/factory_build_agent.rs
@@ -1288,6 +1288,70 @@ async fn build_agent_with_resume_uses_stored_metadata() {
     );
 }
 
+/// Fail-closed contract (post-#850): a WorkGraph-enabled non-wasm build with
+/// no supplied dispatcher (and no surface-installed default) must refuse to
+/// build with the typed Config error instead of silently falling back to an
+/// in-memory store.
+#[cfg(not(target_arch = "wasm32"))]
+#[tokio::test]
+async fn build_agent_workgraph_enabled_without_dispatcher_fails_closed() {
+    let temp = tempfile::tempdir().unwrap();
+    let factory = temp_factory(&temp);
+    let config = Config::default();
+
+    let mut session = Session::new();
+    session
+        .set_session_metadata(SessionMetadata {
+            schema_version: meerkat_core::SESSION_METADATA_SCHEMA_VERSION,
+            model: "claude-sonnet-4-5".to_string(),
+            max_tokens: 4096,
+            structured_output_retries: 2,
+            provider: Provider::Anthropic,
+            provider_params: None,
+            self_hosted_server_id: None,
+            tooling: SessionTooling {
+                builtins: ToolCategoryOverride::Disable,
+                shell: ToolCategoryOverride::Disable,
+                comms: ToolCategoryOverride::Disable,
+                mob: ToolCategoryOverride::Disable,
+                memory: ToolCategoryOverride::Disable,
+                schedule: ToolCategoryOverride::Disable,
+                workgraph: ToolCategoryOverride::Enable,
+                image_generation: ToolCategoryOverride::Inherit,
+                web_search: ToolCategoryOverride::Inherit,
+                tool_access_policy: None,
+                active_skills: None,
+            },
+            keep_alive: false,
+            comms_name: None,
+            peer_meta: None,
+            realm_id: None,
+            instance_id: None,
+            backend: None,
+            config_generation: None,
+            auth_binding: None,
+            mob_member_binding: None,
+        })
+        .unwrap();
+
+    let build_config = AgentBuildConfig {
+        llm_client_override: Some(Arc::new(MockLlmClient)),
+        resume_session: Some(session),
+        provider: Some(Provider::Anthropic),
+        max_tokens: Some(1024),
+        realm_id: Some(meerkat_core::RealmId::parse("dev").expect("valid realm")),
+        ..AgentBuildConfig::new("claude-sonnet-4-5")
+    };
+
+    let Err(error) = factory.build_agent(build_config, &config).await else {
+        panic!("WorkGraph enable without a dispatcher must fail the build closed");
+    };
+    assert!(
+        error.to_string().contains("without a supplied dispatcher"),
+        "expected the typed fail-closed Config error, got: {error}"
+    );
+}
+
 #[tokio::test]
 async fn build_agent_with_resume_preserves_explicit_override_masked_fields() {
     let temp = tempfile::tempdir().unwrap();

--- a/sdks/typescript/tests/types.test.js
+++ b/sdks/typescript/tests/types.test.js
@@ -1324,54 +1324,6 @@ describe("WorkGraph parsers", () => {
       created_at: timestamp,
       updated_at: timestamp,
     };
-    const reassignedAttention = {
-      ...attention,
-      binding_id: "attention-2",
-      target: {
-        kind: "lowered_owner",
-        owner_key: {
-          kind: "agent",
-          id: "mob/family-dentist/agent/planner",
-        },
-      },
-      machine_state: { revision: 2 },
-    };
-    const supersededAttention = {
-      ...attention,
-      status: { state: "superseded" },
-      machine_state: { revision: 2 },
-    };
-    const authorityProjection = {
-      binding_id: "attention-1",
-      work_ref: {
-        realm_id: "homecore",
-        namespace: "family/appointments",
-        item_id: "prep-dentist-ride",
-      },
-      mode: "coordinate",
-      binding_revision: 1,
-      item_revision: 1,
-      authority: {
-        can_get: true,
-        can_add_evidence: true,
-        can_release: false,
-        can_update: true,
-        can_block: false,
-        can_create: true,
-        can_link: true,
-        can_link_parent: false,
-        can_link_related: true,
-        can_link_derived_from: true,
-        can_close_if_policy_allows: false,
-        can_close_own_review_item: false,
-      },
-      text: {
-        title: "Prep A for non-preferred dentist car",
-        rendered: "projection",
-        truncated: false,
-      },
-    };
-
     const clientFor = (entry) => {
       const client = new MeerkatClient();
       client.request = async () => ({ attention: [entry] });


### PR DESCRIPTION
Two behavioral fixes to the #850 post-review fixups, surfaced by the 0.7.23 pre-release adversarial review (verified findings, both red-checked):

**1. Scheduled deliveries no longer snapshot the attention projection at enqueue.** The facade schedule host and CLI schedule host composed the overlay at dispatch time; a queued prompt behind a running turn that mutated its work item (e.g. `workgraph_add_evidence` bumping the item revision) carried a stale projection that failed exact-currency validation at apply — deterministically failing the scheduled delivery. The runtime executors (already wired with the workgraph service by the fixups) inject a fresh projection at apply time, so the enqueue-time composition was redundant on both paths. Removed outright, along with the now caller-less `compose_workgraph_attention_turn_overlay_for_session` — one canonical injection path.

**2. Newest-session arbitration now runs on the canonical apply-time path.** The arbitration guard added in the fixups only executed on the (now removed) enqueue-time path; every real turn surface called the `_from_labels` injector with `session_service: None`, short-circuiting the guard. During mob member respawn overlap, both generations matched the same owner-key binding and both received the attention overlay. `inject_workgraph_attention_turn_overlay_from_labels` now requires the session service (all four RPC/REST create-and-start callers pass theirs) and arbitrates newest-live-session-wins; a session not yet visible in the listing (mid-creation) is definitionally the newest carrier of its labels and still binds. Red-verified: the overlap-denial test fails on the pre-fix `None` threading.

**Coverage pins from the review's confirmed test-gap findings:**
- `test_cli_runtime_executor_injects_attention_overlay_at_apply` — reverting the CLI apply-time injection now fails a test
- `attention_overlay_binds_only_to_newest_labeled_session` / `attention_overlay_allows_unlisted_mid_creation_session`
- `build_agent_workgraph_enabled_without_dispatcher_fails_closed` — pins the non-wasm fail-closed factory contract
- `sqlite_store_duplicate_{item,attention}_insert_maps_to_conflict` — pins UNIQUE → typed `Conflict`
- Removed the three orphaned reassign-era fixtures from the TS SDK types test

Local verification: check+clippy (`-D warnings`, all targets) over all touched crates, full workspace unit lane (7338 pass), full test runs for meerkat/rkat/rpc/rest/workgraph (1643 pass), wasm-check, TS `types.test.js` 201/201, pre-push unit + e2e-fast green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)