### PR TITLE
feat: semver-breaks release gate + pre-1.0 exact-pin versioning policy (studio M3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,25 @@
 # Changelog
 
 All notable changes to this project will be documented in this file.
+The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
-The format is based on [Keep a Changelog](https://keepachangelog.com/),
-and this project adheres to [Semantic Versioning](https://semver.org/).
+**Versioning policy (pre-1.0):** meerkat 0.x PATCH releases may contain
+breaking public-API changes — this project ships deliberate clean breaks
+instead of compatibility shims. Downstreams must EXACT-PIN the meerkat crate
+family (e.g. `meerkat = "=0.7.24"`) and bump deliberately. In exchange, every
+release that breaks public API declares it under a `### Breaking` heading
+naming the changed signatures (enforced by the `semver-breaks` release gate
+via cargo-semver-checks against the published baselines).
 
 ## [Unreleased]
+
+### Added
+
+- `semver-breaks` release-preflight gate (studio M3): cargo-semver-checks
+  runs against the last published crates.io baselines; detected public-API
+  breaks fail the release unless declared under a `### Breaking` changelog
+  heading. The exact-pin policy in this file's header is the other half of
+  the contract.
 
 ### Added
 

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ YELLOW := \033[0;33m
 RED := \033[0;31m
 NC := \033[0m
 
-.PHONY: all install-build-deps build test test-unit test-int e2e-fast e2e-build e2e-system e2e-live e2e-smoke e2e-auth test-int-real test-e2e test-all test-minimal test-feature-matrix-lib test-feature-matrix-surface test-feature-matrix test-surface-modularity test-sdk-python test-sdk-typescript test-sdk-web test-sdk-suites wasm-check lint lint-feature-matrix fmt fmt-check audit rust-lane-doctor agent-gate cargo-agent-gate buildbuddy-install buildbuddy-generate buildbuddy-lock-update buildbuddy-generate-check buildbuddy-doctor buildbuddy-build buildbuddy-check buildbuddy-clippy buildbuddy-lint buildbuddy-test buildbuddy-test-all buildbuddy-test-unit buildbuddy-test-int buildbuddy-e2e-fast buildbuddy-e2e-system buildbuddy-e2e-live buildbuddy-e2e-smoke buildbuddy-e2e-smoke-turbo-s buildbuddy-e2e-auth buildbuddy-agent-gate buildbuddy-ci-dispatch buildbuddy-fast buildbuddy-benchmark buildbuddy-ci buildbuddy-ci-warm buildbuddy-ci-full buildbuddy-ci-full-warm ci ci-smoke release-doctor release-preflight release-preflight-smoke release-workflow release-assets release-packages release-web-sdk publish-dry-run publish-dry-run-python publish-dry-run-typescript publish-dry-run-web release-dry-run release-dry-run-smoke clean doc docs-check release install-hooks coverage check help legacy-surface-gate legacy-surface-inventory session-control-gate deprecated-backend-gate deprecated-backend-inventory sync-meerkat-dogma-skill-docs verify-version-parity verify-schema-freshness verify-sdk-codegen-freshness verify-sdk-event-inventory verify-rpc-surface-alignment verify-rest-surface-alignment verify-sdk-wrapper-freshness verify-machine-poster-coverage check-rust-release-config check-rust-release-packaging check-published-facade-link bump-sdk-versions smoke-sdk-python-artifact smoke-sdk-typescript-artifact xtask-build machine-codegen machine-verify machine-check-drift machine-authority-docs-gate runtime-authority-bypass seam-inventory rmat-audit audit-generated-headers
+.PHONY: all install-build-deps build test test-unit test-int e2e-fast e2e-build e2e-system e2e-live e2e-smoke e2e-auth test-int-real test-e2e test-all test-minimal test-feature-matrix-lib test-feature-matrix-surface test-feature-matrix test-surface-modularity test-sdk-python test-sdk-typescript test-sdk-web test-sdk-suites wasm-check lint lint-feature-matrix fmt fmt-check audit rust-lane-doctor agent-gate cargo-agent-gate buildbuddy-install buildbuddy-generate buildbuddy-lock-update buildbuddy-generate-check buildbuddy-doctor buildbuddy-build buildbuddy-check buildbuddy-clippy buildbuddy-lint buildbuddy-test buildbuddy-test-all buildbuddy-test-unit buildbuddy-test-int buildbuddy-e2e-fast buildbuddy-e2e-system buildbuddy-e2e-live buildbuddy-e2e-smoke buildbuddy-e2e-smoke-turbo-s buildbuddy-e2e-auth buildbuddy-agent-gate buildbuddy-ci-dispatch buildbuddy-fast buildbuddy-benchmark buildbuddy-ci buildbuddy-ci-warm buildbuddy-ci-full buildbuddy-ci-full-warm ci ci-smoke release-doctor release-preflight release-preflight-smoke release-workflow release-assets release-packages release-web-sdk publish-dry-run publish-dry-run-python publish-dry-run-typescript publish-dry-run-web release-dry-run release-dry-run-smoke clean doc docs-check release install-hooks coverage check help legacy-surface-gate legacy-surface-inventory session-control-gate deprecated-backend-gate deprecated-backend-inventory sync-meerkat-dogma-skill-docs verify-version-parity verify-schema-freshness verify-sdk-codegen-freshness verify-sdk-event-inventory verify-rpc-surface-alignment verify-rest-surface-alignment verify-sdk-wrapper-freshness verify-machine-poster-coverage check-rust-release-config check-rust-release-packaging check-published-facade-link bump-sdk-versions smoke-sdk-python-artifact smoke-sdk-typescript-artifact xtask-build machine-codegen machine-verify machine-check-drift machine-authority-docs-gate runtime-authority-bypass seam-inventory rmat-audit audit-generated-headers semver-breaks
 
 # Default target
 all: ci
@@ -582,8 +582,15 @@ release-doctor:
 	@echo "$(GREEN)Checking release environment...$(NC)"
 	@scripts/release-doctor
 
+# Semver-break detection (M3 policy: exact-pin + break detection). 0.x patch
+# releases may break public API, but every break must be declared under a
+# '### Breaking' changelog heading; this gate enforces the declaration.
+semver-breaks:
+	@echo "$(GREEN)Checking public-API breaks vs published baselines...$(NC)"
+	@scripts/check-semver-breaks.sh
+
 # Full pre-release checklist
-release-preflight: release-doctor ci verify-schema-freshness check-rust-release-packaging
+release-preflight: release-doctor ci verify-schema-freshness check-rust-release-packaging semver-breaks
 	@echo ""
 	@echo "$(GREEN)Pre-release checklist:$(NC)"
 	@echo "  1. CHANGELOG.md [Unreleased] section populated?"

--- a/scripts/check-semver-breaks.sh
+++ b/scripts/check-semver-breaks.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# Semver-break detection gate (M3 policy: exact-pin + break detection).
+#
+# Policy: meerkat 0.x PATCH releases MAY contain breaking public-API changes
+# (pre-1.0 clean-break discipline). Downstreams must exact-pin (`=0.7.24`).
+# In exchange, every release that breaks public API must SAY SO: this gate
+# runs cargo-semver-checks against the last published crates.io baseline and
+# fails the release preflight when breaks exist without a `### Breaking`
+# section in the changelog's pending (topmost) release notes.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+if ! command -v cargo-semver-checks >/dev/null 2>&1; then
+    echo "error: cargo-semver-checks is required for the semver-breaks gate" >&2
+    echo "install: cargo install cargo-semver-checks --locked" >&2
+    exit 1
+fi
+
+# Check the full publishable workspace against the latest published baselines.
+# `--release-type patch` declares our intent (we ship patches); any detected
+# break is then a REPORTED violation we convert into a changelog obligation
+# rather than a hard stop.
+report_file="$(mktemp)"
+trap 'rm -f "$report_file"' EXIT
+breaks_found=0
+if ! cargo semver-checks check-release --workspace --release-type patch \
+    >"$report_file" 2>&1; then
+    breaks_found=1
+fi
+
+if [[ "$breaks_found" -eq 0 ]]; then
+    echo "semver-breaks: no public-API breaks vs the published baselines"
+    exit 0
+fi
+
+# Breaks exist: they are allowed by policy, but only when loudly declared.
+# The pending release notes are the topmost section of CHANGELOG.md —
+# `## [Unreleased]` when populated, otherwise the topmost stamped release.
+pending_section="$(awk '/^## \[/{count++} count==1{print} count==2{exit}' CHANGELOG.md)"
+if ! grep -q '^### Breaking' <<<"$pending_section"; then
+    echo "semver-breaks: public-API breaks detected vs published baselines:" >&2
+    echo >&2
+    grep -E "^(--- failure|Summary|.*semver requires)" "$report_file" >&2 || tail -40 "$report_file" >&2
+    echo >&2
+    echo "error: the pending CHANGELOG.md section has no '### Breaking' heading." >&2
+    echo "Policy (M3): 0.x patch releases may break public API, but every break" >&2
+    echo "must be declared under '### Breaking' with the changed signatures so" >&2
+    echo "exact-pinned downstreams can plan the bump. Add the section and rerun." >&2
+    exit 1
+fi
+
+echo "semver-breaks: public-API breaks detected and declared under '### Breaking':"
+grep -E "^(--- failure|Summary)" "$report_file" || true
+exit 0


### PR DESCRIPTION
Implements the M3 policy decision: 0.x patch releases may break public API (clean-break discipline), downstreams exact-pin, and every break must be declared — the new `semver-breaks` release-preflight gate runs cargo-semver-checks against published baselines and fails the release when breaks exist without a `### Breaking` changelog heading. Policy documented in the CHANGELOG header.

First live run already caught undeclared breaks pending for 0.7.25 (e.g. the `MultipleActiveBindings` variant removal from #854) — the `### Breaking` section lands with the release stamp.

🤖 Generated with [Claude Code](https://claude.com/claude-code)