### PR TITLE
feat: 0.7.25 sweep batch 1 — M2 revival tools, M4 restart-first-class status, ask 26 reply seam, ask 24 metadata seam, ask 15 addendum

### DIFF
--- a/meerkat-cli/src/main.rs
+++ b/meerkat-cli/src/main.rs
@@ -11357,6 +11357,20 @@ impl meerkat_mob::MobSessionService for MobCliSessionService {
         .await
     }
 
+    async fn load_persisted_session_metadata(
+        &self,
+        session_id: &SessionId,
+    ) -> Result<
+        Option<meerkat_core::PersistedSessionMetadataView>,
+        meerkat_core::service::SessionError,
+    > {
+        <meerkat::PersistentSessionService<FactoryAgentBuilder> as meerkat_mob::MobSessionService>::load_persisted_session_metadata(
+            &self.inner,
+            session_id,
+        )
+        .await
+    }
+
     async fn execution_snapshot(
         &self,
         session_id: &SessionId,

--- a/meerkat-comms/src/agent/dispatcher.rs
+++ b/meerkat-comms/src/agent/dispatcher.rs
@@ -93,7 +93,7 @@ impl AgentToolDispatcher for NoOpDispatcher {
 fn is_comms_tool(name: &str) -> bool {
     matches!(
         name,
-        "send" | "send_message" | "send_request" | "send_response" | "peers"
+        "send" | "send_message" | "reply_to_peer" | "send_request" | "send_response" | "peers"
     )
 }
 
@@ -504,6 +504,35 @@ mod tests {
         ));
         let view = router.trusted_peers_view();
         (router, view)
+    }
+
+    /// `reply_to_peer` routes through the comms dispatch path (never falling
+    /// through to an inner dispatcher's NotFound) and fails closed with the
+    /// typed no-capability error when the turn carries no reply context.
+    #[tokio::test]
+    async fn reply_to_peer_routes_as_comms_tool() {
+        assert!(is_comms_tool("reply_to_peer"));
+
+        let (router, trusted_peers) = test_router();
+        let dispatcher = CommsToolDispatcher::new(router, trusted_peers);
+        let args_raw = serde_json::value::RawValue::from_string(
+            serde_json::json!({"body": "on it", "handling_mode": "queue"}).to_string(),
+        )
+        .expect("valid args");
+        let call = ToolCallView {
+            id: "reply-1",
+            name: "reply_to_peer",
+            args: &args_raw,
+        };
+
+        let result = dispatcher.dispatch(call).await;
+        let Err(ToolError::ExecutionFailed { message }) = result else {
+            panic!("expected comms-routed execution failure, got {result:?}");
+        };
+        assert!(
+            message.starts_with("no_reply_capability"),
+            "expected typed no_reply_capability error, got: {message}"
+        );
     }
 
     #[test]

--- a/meerkat-comms/src/event_injector.rs
+++ b/meerkat-comms/src/event_injector.rs
@@ -160,6 +160,24 @@ impl meerkat_core::event_injector::SubscribableInjector for CommsEventInjector {
             events: rx,
         })
     }
+
+    fn inject_with_interaction_id(
+        &self,
+        interaction_id: meerkat_core::InteractionId,
+        content: ContentInput,
+        source: PlainEventSource,
+        handling_mode: HandlingMode,
+        render_metadata: Option<RenderMetadata>,
+    ) -> Result<(), EventInjectorError> {
+        CommsEventInjector::inject_with_interaction_id(
+            self,
+            interaction_id.0,
+            content,
+            source,
+            handling_mode,
+            render_metadata,
+        )
+    }
 }
 
 #[cfg(test)]

--- a/meerkat-comms/src/mcp/tools.rs
+++ b/meerkat-comms/src/mcp/tools.rs
@@ -22,8 +22,9 @@ use meerkat_contracts::{
 use meerkat_core::BlobId;
 use meerkat_core::agent::CommsRuntime as CoreCommsRuntime;
 use meerkat_core::comms::{
-    CommsCommand, InputStreamMode, PeerCapabilitySet, PeerDirectoryEntry, PeerDirectorySource,
-    PeerId, PeerName, PeerRoute, PeerSendability, SendError, SendReceipt,
+    COMMS_PEER_REPLY_DISPATCH_CONTEXT_KEY, CommsCommand, InputStreamMode, PeerCapabilitySet,
+    PeerDirectoryEntry, PeerDirectorySource, PeerId, PeerName, PeerReplyCapability,
+    PeerReplyDispatchContext, PeerRoute, PeerSendability, SendError, SendReceipt,
 };
 use meerkat_core::interaction::{InteractionId, ResponseStatus};
 use meerkat_core::tool_catalog::ToolUnavailableReason;
@@ -69,6 +70,33 @@ pub struct SendMessageInput {
     #[serde(default)]
     pub display_name: Option<String>,
     /// Message body
+    pub body: String,
+    /// Optional multimodal blocks. Use image_ref entries such as
+    /// {"type":"image_ref","source":"current_turn","index":0} to forward
+    /// images from the current admitted user turn, or
+    /// {"type":"image_ref","source":"blob","blob_id":"sha256:...","media_type":"image/png"}
+    /// to forward a generated/blob-backed image without inlining bytes in the tool call.
+    #[serde(default)]
+    pub blocks: Option<Vec<CommsToolContentBlock>>,
+    /// "queue" for next turn boundary (normal), "steer" for urgent preemption
+    pub handling_mode: HandlingMode,
+}
+
+/// Reply to the peer message that triggered the current turn.
+///
+/// Pre-addressed: the runtime minted a typed reply capability for this turn's
+/// incoming peer message(s), so no `peer_id` is supplied — only content.
+///
+/// Example: `{"body": "Done — the migration completed.", "handling_mode": "queue"}`
+#[derive(Debug, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct ReplyToPeerInput {
+    /// Optional delivery selector, only needed when more than one peer
+    /// message arrived in this turn. Set it to one of the delivery ids listed
+    /// by an `ambiguous_reply` error.
+    #[serde(default)]
+    pub reply_to: Option<String>,
+    /// Reply body
     pub body: String,
     /// Optional multimodal blocks. Use image_ref entries such as
     /// {"type":"image_ref","source":"current_turn","index":0} to forward
@@ -234,6 +262,11 @@ pub fn tools_list() -> Vec<Value> {
             "inputSchema": schema_for::<SendMessageInput>()
         }),
         json!({
+            "name": "reply_to_peer",
+            "description": format!("{}{}{}", "Reply to the peer message that triggered the current turn. The reply is pre-addressed: the runtime already knows which peer sent the triggering message, so you do not supply a peer_id.\n\nWhen to use: Use reply_to_peer to answer a peer message you received this turn. Use send_message with an explicit peer_id for unsolicited outreach, and use send_response only for typed request/response contracts (send_request traffic).\n\nreply_to (optional): Only needed when more than one peer message arrived in this turn. On an ambiguous call the error lists the available delivery ids; retry with reply_to set to one of them.\n\nhandling_mode:\n- \"queue\": The reply is delivered at the peer's next turn boundary. Use for ordinary collaboration.\n- \"steer\": The peer processes your reply immediately, interrupting its current work. Use only for urgent or time-sensitive collaboration.", COMMS_BLOCKS_DESCRIPTION, "\n\nExamples:\n1. Reply to the turn's peer message:\n   {\"body\": \"Done — the database migration completed successfully.\", \"handling_mode\": \"queue\"}\n2. Disambiguate between multiple deliveries in one turn:\n   {\"reply_to\": \"<delivery-id-from-ambiguous_reply-error>\", \"body\": \"Acknowledged.\", \"handling_mode\": \"queue\"}\n\nFailure handling:\n- no_reply_capability: This turn was not triggered by a peer message; there is nothing to reply to. Use peers + send_message instead.\n- ambiguous_reply: Multiple peer messages arrived this turn. Retry with reply_to set to one of the listed delivery ids.\n- unknown_reply_to: The reply_to value does not match any of this turn's deliveries. Use one of the listed delivery ids.\n- peer_not_found_or_not_trusted / peer_unreachable: Same as send_message — the sending peer is no longer trusted or reachable."),
+            "inputSchema": schema_for::<ReplyToPeerInput>()
+        }),
+        json!({
             "name": "send_request",
             "description": format!("{}{}{}{}", "Send a typed structured request to a peer and expect a correlated response. The peer will reply using send_response with the same request ID.\n\nWhen to use: Use send_request for typed comms request contracts such as checksum_token or supervisor.bridge. The response will arrive as an incoming message with the original request ID in its in_reply_to field, so you can match it. If you just need to share information without expecting a reply, use send_message instead.\n\nhandling_mode:\n- \"queue\": The request is delivered at the peer's next turn boundary. Use when the peer can handle it after finishing its current task.\n- \"steer\": The peer processes your request immediately, interrupting its current work. Use only for requests that block your own progress.", SEND_REQUEST_CONTRACTS_DESCRIPTION, COMMS_BLOCKS_DESCRIPTION, "\n\nExamples:\n1. checksum_token image review request:\n   {\"peer_id\":\"<peer-id-from-peers>\",\"display_name\":\"reviewer\",\"intent\":\"checksum_token\",\"params\":{\"subject\":\"image_receipt_check\"},\"blocks\":[{\"type\":\"text\",\"text\":\"Please inspect this generated image and return a receipt token with an image receipt.\"},{\"type\":\"image_ref\",\"source\":\"blob\",\"blob_id\":\"sha256:generated-image\",\"media_type\":\"image/png\"}],\"handling_mode\":\"queue\"}\n2. supervisor bridge request/reply:\n  {\"peer_id\": \"<peer-id-from-peers>\", \"display_name\": \"member\", \"intent\": \"supervisor.bridge\", \"params\": {\"command\": \"observe_member\", \"supervisor\": {\"name\": \"supervisor\", \"peer_id\": \"<supervisor-peer-id>\", \"address\": \"inproc://supervisor\", \"pubkey\": [0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]}, \"epoch\": 1, \"protocol_version\": 2}, \"handling_mode\": \"queue\"}\n  The peer receives this and sends back with your peer_id:\n  {\"peer_id\": \"<your-peer-id>\", \"in_reply_to\": \"<request-id>\", \"status\": \"completed\", \"result\": {\"result\": \"ack\", \"ok\": true}}\n\nFailure handling:\n- peer_not_found_or_not_trusted: The peer_id does not match a trusted peer. Call peers first to pick a peer_id.\n- peer_unreachable: The peer exists but is offline or the transport failed. Retry after a delay or inform the user.\n- Missing response: There is no built-in timeout. If the peer does not respond, it may have failed or dropped the request. Re-send or check with the peer via send_message."),
             "inputSchema": schema_for::<SendRequestInput>()
@@ -272,6 +305,34 @@ pub async fn handle_tools_call_with_context(
     }
 
     match name {
+        "reply_to_peer" => {
+            let input: ReplyToPeerInput = serde_json::from_value(args.clone())
+                .map_err(|e| format!("Invalid arguments: {e}"))?;
+            let reply_context = peer_reply_dispatch_context(dispatch_context)?;
+            let capability =
+                select_reply_capability(&reply_context.deliveries, input.reply_to.as_deref())?;
+            // Trust is re-validated at dispatch time: a capability minted at
+            // turn admission does not outlive a trust revocation.
+            let to = peer_route(ctx, capability.peer_id, capability.display_name.as_deref())?;
+            let blocks = resolve_message_blocks(&input.body, input.blocks, dispatch_context)?;
+            // Single content authority: mirrors send_message — when blocks are
+            // present they own the content and `body` is projected from their
+            // text blocks so the two cannot diverge.
+            let body = match &blocks {
+                Some(blocks) => project_body_from_blocks(blocks),
+                None => input.body,
+            };
+            let command = CommsCommand::PeerMessage {
+                to,
+                body,
+                blocks,
+                // Agent tools carry no per-send taint override: the outbound
+                // declaration is inherited from the runtime-level host config.
+                content_taint: None,
+                handling_mode: input.handling_mode,
+            };
+            dispatch(ctx, command).await
+        }
         "send_message" => {
             let input: SendMessageInput = serde_json::from_value(args.clone())
                 .map_err(|e| format!("Invalid arguments: {e}"))?;
@@ -526,6 +587,67 @@ fn project_peer_response_command(
         content_taint,
         handling_mode,
     })
+}
+
+/// Read the typed peer-reply dispatch context minted by the runtime for this
+/// turn. Absent key => the turn was not triggered by a peer message; a
+/// present-but-malformed value fails closed with a distinct typed code
+/// instead of being coerced or ignored.
+fn peer_reply_dispatch_context(
+    dispatch_context: &ToolDispatchContext,
+) -> Result<PeerReplyDispatchContext, String> {
+    let value = dispatch_context
+        .turn_metadata(COMMS_PEER_REPLY_DISPATCH_CONTEXT_KEY)
+        .ok_or_else(|| {
+            "no_reply_capability: this turn was not triggered by a peer message; \
+             use peers + send_message instead"
+                .to_string()
+        })?;
+    let context: PeerReplyDispatchContext = serde_json::from_value(value.clone())
+        .map_err(|err| format!("invalid_reply_context: malformed peer reply context: {err}"))?;
+    if context.deliveries.is_empty() {
+        return Err(
+            "no_reply_capability: this turn carries no peer message deliveries".to_string(),
+        );
+    }
+    Ok(context)
+}
+
+/// Select the delivery to reply to. One delivery with no selector resolves to
+/// it; multiple deliveries require an explicit `reply_to`; a selector must
+/// match one of the turn's delivery ids.
+fn select_reply_capability<'a>(
+    deliveries: &'a [PeerReplyCapability],
+    reply_to: Option<&str>,
+) -> Result<&'a PeerReplyCapability, String> {
+    match reply_to {
+        Some(selector) => deliveries
+            .iter()
+            .find(|capability| capability.in_reply_to.to_string() == selector)
+            .ok_or_else(|| {
+                format!(
+                    "unknown_reply_to: no peer delivery in this turn matches '{selector}'; \
+                     available delivery ids: [{}]",
+                    delivery_ids(deliveries)
+                )
+            }),
+        None => match deliveries {
+            [single] => Ok(single),
+            _ => Err(format!(
+                "ambiguous_reply: multiple peer messages arrived this turn; \
+                 set reply_to to one of the delivery ids: [{}]",
+                delivery_ids(deliveries)
+            )),
+        },
+    }
+}
+
+fn delivery_ids(deliveries: &[PeerReplyCapability]) -> String {
+    deliveries
+        .iter()
+        .map(|capability| capability.in_reply_to.to_string())
+        .collect::<Vec<_>>()
+        .join(", ")
 }
 
 fn peer_name(value: &str, field: &str) -> Result<PeerName, String> {
@@ -1088,11 +1210,12 @@ mod tests {
     }
 
     #[test]
-    fn test_tools_list_has_four_tools() {
+    fn test_tools_list_has_five_tools() {
         let tools = tools_list();
-        assert_eq!(tools.len(), 4);
+        assert_eq!(tools.len(), 5);
         let names: Vec<&str> = tools.iter().map(|t| t["name"].as_str().unwrap()).collect();
         assert!(names.contains(&"send_message"));
+        assert!(names.contains(&"reply_to_peer"));
         assert!(names.contains(&"send_request"));
         assert!(names.contains(&"send_response"));
         assert!(names.contains(&"peers"));
@@ -1154,6 +1277,245 @@ mod tests {
                 .unwrap()
                 .contains_key("blocks")
         );
+    }
+
+    /// The pre-addressed reply tool takes no peer identity: body and
+    /// handling_mode are required, reply_to and blocks optional, and unknown
+    /// fields (e.g. a smuggled peer_id) are rejected at the schema level.
+    #[test]
+    fn test_reply_to_peer_schema_is_pre_addressed() {
+        let schema = schema_for::<ReplyToPeerInput>();
+        let required = schema["required"].as_array().unwrap();
+        let required_names: Vec<&str> = required.iter().map(|v| v.as_str().unwrap()).collect();
+        assert!(
+            required_names.contains(&"handling_mode"),
+            "reply_to_peer must require handling_mode, got required: {required_names:?}"
+        );
+        assert!(required_names.contains(&"body"));
+        assert!(!required_names.contains(&"reply_to"));
+        assert!(!required_names.contains(&"blocks"));
+        let properties = schema["properties"].as_object().unwrap();
+        assert!(properties.contains_key("reply_to"));
+        assert!(properties.contains_key("blocks"));
+        assert!(
+            !properties.contains_key("peer_id"),
+            "reply_to_peer is pre-addressed; it must not expose a peer_id input"
+        );
+        assert_eq!(
+            schema["additionalProperties"],
+            Value::Bool(false),
+            "deny_unknown_fields must project as additionalProperties: false"
+        );
+    }
+
+    fn reply_capability(peer_id: PeerId, interaction: u128) -> PeerReplyCapability {
+        PeerReplyCapability {
+            in_reply_to: InteractionId(uuid::Uuid::from_u128(interaction)),
+            peer_id,
+            display_name: Some("sender-agent".to_string()),
+            kind: meerkat_core::comms::PeerReplyDeliveryKind::Message,
+        }
+    }
+
+    fn reply_dispatch_context(deliveries: Vec<PeerReplyCapability>) -> ToolDispatchContext {
+        let context = PeerReplyDispatchContext { deliveries };
+        ToolDispatchContext::default().with_turn_metadata(std::collections::BTreeMap::from([(
+            COMMS_PEER_REPLY_DISPATCH_CONTEXT_KEY.to_string(),
+            serde_json::to_value(&context).expect("reply context serializes"),
+        )]))
+    }
+
+    #[tokio::test]
+    async fn reply_to_peer_dispatches_peer_message_to_capability_peer() {
+        let peer_keypair = Keypair::generate();
+        let (mut ctx, peer_id) = make_trusted_runtime_less_context(&peer_keypair).await;
+        let runtime = Arc::new(RecordingRuntime::new());
+        ctx.runtime = Some(RuntimeCommsCommandHandle::new(runtime.clone()));
+        let dispatch_context = reply_dispatch_context(vec![reply_capability(peer_id, 7)]);
+
+        handle_tools_call_with_context(
+            &ctx,
+            "reply_to_peer",
+            &json!({"body": "on it", "handling_mode": "queue"}),
+            &dispatch_context,
+        )
+        .await
+        .expect("single-delivery reply must dispatch without a selector");
+
+        let sent = runtime.sent.lock();
+        let [
+            CommsCommand::PeerMessage {
+                to,
+                body,
+                blocks,
+                handling_mode,
+                ..
+            },
+        ] = sent.as_slice()
+        else {
+            panic!("expected one peer message, got {sent:?}");
+        };
+        assert_eq!(to.peer_id, peer_id);
+        assert_eq!(body, "on it");
+        assert!(blocks.is_none());
+        assert_eq!(*handling_mode, HandlingMode::Queue);
+    }
+
+    #[tokio::test]
+    async fn reply_to_peer_without_capability_returns_no_reply_capability() {
+        let peer_keypair = Keypair::generate();
+        let (mut ctx, _peer_id) = make_trusted_runtime_less_context(&peer_keypair).await;
+        let runtime = Arc::new(RecordingRuntime::new());
+        ctx.runtime = Some(RuntimeCommsCommandHandle::new(runtime.clone()));
+
+        let err = handle_tools_call_with_context(
+            &ctx,
+            "reply_to_peer",
+            &json!({"body": "on it", "handling_mode": "queue"}),
+            &ToolDispatchContext::default(),
+        )
+        .await
+        .expect_err("a turn without a peer delivery must not reply");
+
+        assert!(
+            err.starts_with("no_reply_capability"),
+            "expected typed no_reply_capability error, got: {err}"
+        );
+        assert_eq!(runtime.sent_len(), 0, "nothing may be dispatched");
+    }
+
+    #[tokio::test]
+    async fn reply_to_peer_with_multiple_deliveries_requires_selector() {
+        let peer_keypair = Keypair::generate();
+        let (mut ctx, peer_id) = make_trusted_runtime_less_context(&peer_keypair).await;
+        let runtime = Arc::new(RecordingRuntime::new());
+        ctx.runtime = Some(RuntimeCommsCommandHandle::new(runtime.clone()));
+        let first = reply_capability(peer_id, 1);
+        let second = reply_capability(peer_id, 2);
+        let dispatch_context = reply_dispatch_context(vec![first.clone(), second.clone()]);
+
+        let err = handle_tools_call_with_context(
+            &ctx,
+            "reply_to_peer",
+            &json!({"body": "on it", "handling_mode": "queue"}),
+            &dispatch_context,
+        )
+        .await
+        .expect_err("two deliveries without a selector must be ambiguous");
+
+        assert!(
+            err.starts_with("ambiguous_reply"),
+            "expected typed ambiguous_reply error, got: {err}"
+        );
+        assert!(
+            err.contains(&first.in_reply_to.to_string())
+                && err.contains(&second.in_reply_to.to_string()),
+            "ambiguous error must list the delivery ids so the caller can retry: {err}"
+        );
+        assert_eq!(runtime.sent_len(), 0, "nothing may be dispatched");
+
+        // Retrying with an explicit selector resolves the ambiguity.
+        handle_tools_call_with_context(
+            &ctx,
+            "reply_to_peer",
+            &json!({
+                "reply_to": second.in_reply_to.to_string(),
+                "body": "on it",
+                "handling_mode": "queue"
+            }),
+            &dispatch_context,
+        )
+        .await
+        .expect("explicit selector must resolve the ambiguity");
+        assert_eq!(runtime.sent_len(), 1);
+    }
+
+    #[tokio::test]
+    async fn reply_to_peer_with_unknown_selector_returns_unknown_reply_to() {
+        let peer_keypair = Keypair::generate();
+        let (mut ctx, peer_id) = make_trusted_runtime_less_context(&peer_keypair).await;
+        let runtime = Arc::new(RecordingRuntime::new());
+        ctx.runtime = Some(RuntimeCommsCommandHandle::new(runtime.clone()));
+        let dispatch_context = reply_dispatch_context(vec![reply_capability(peer_id, 7)]);
+
+        let err = handle_tools_call_with_context(
+            &ctx,
+            "reply_to_peer",
+            &json!({
+                "reply_to": uuid::Uuid::from_u128(999).to_string(),
+                "body": "on it",
+                "handling_mode": "queue"
+            }),
+            &dispatch_context,
+        )
+        .await
+        .expect_err("a selector outside the turn's deliveries must fail");
+
+        assert!(
+            err.starts_with("unknown_reply_to"),
+            "expected typed unknown_reply_to error, got: {err}"
+        );
+        assert_eq!(runtime.sent_len(), 0, "nothing may be dispatched");
+    }
+
+    /// Trust is re-validated at dispatch time: a capability naming a peer that
+    /// is not (or no longer) trusted must fail closed, never route on the
+    /// minted identity alone.
+    #[tokio::test]
+    async fn reply_to_peer_revalidates_trust_at_dispatch() {
+        let peer_keypair = Keypair::generate();
+        let (mut ctx, _trusted_peer) = make_trusted_runtime_less_context(&peer_keypair).await;
+        let runtime = Arc::new(RecordingRuntime::new());
+        ctx.runtime = Some(RuntimeCommsCommandHandle::new(runtime.clone()));
+        let untrusted_peer = PeerId::new();
+        let dispatch_context = reply_dispatch_context(vec![reply_capability(untrusted_peer, 7)]);
+
+        let err = handle_tools_call_with_context(
+            &ctx,
+            "reply_to_peer",
+            &json!({"body": "on it", "handling_mode": "queue"}),
+            &dispatch_context,
+        )
+        .await
+        .expect_err("an untrusted capability peer must fail closed");
+
+        assert!(
+            err.starts_with("peer_not_found_or_not_trusted"),
+            "expected typed trust error, got: {err}"
+        );
+        assert_eq!(runtime.sent_len(), 0, "nothing may be dispatched");
+    }
+
+    /// A present-but-malformed reply context is a distinct fail-closed error,
+    /// never coerced into "no capability" or a successful dispatch.
+    #[tokio::test]
+    async fn reply_to_peer_rejects_malformed_reply_context() {
+        let peer_keypair = Keypair::generate();
+        let (mut ctx, _peer_id) = make_trusted_runtime_less_context(&peer_keypair).await;
+        let runtime = Arc::new(RecordingRuntime::new());
+        ctx.runtime = Some(RuntimeCommsCommandHandle::new(runtime.clone()));
+        let dispatch_context =
+            ToolDispatchContext::default().with_turn_metadata(std::collections::BTreeMap::from([
+                (
+                    COMMS_PEER_REPLY_DISPATCH_CONTEXT_KEY.to_string(),
+                    json!({"deliveries": [], "unexpected": true}),
+                ),
+            ]));
+
+        let err = handle_tools_call_with_context(
+            &ctx,
+            "reply_to_peer",
+            &json!({"body": "on it", "handling_mode": "queue"}),
+            &dispatch_context,
+        )
+        .await
+        .expect_err("unknown fields in the reply context must fail closed");
+
+        assert!(
+            err.starts_with("invalid_reply_context"),
+            "expected typed invalid_reply_context error, got: {err}"
+        );
+        assert_eq!(runtime.sent_len(), 0, "nothing may be dispatched");
     }
 
     #[test]

--- a/meerkat-core/src/agent/runner.rs
+++ b/meerkat-core/src/agent/runner.rs
@@ -2254,6 +2254,73 @@ mod skill_activation_effect_tests {
         );
     }
 
+    /// Ask-15 addendum pin: a committed turn's interaction id survives the
+    /// full persist → reload cycle on the transcript messages (the exact
+    /// read a console session-history backfill performs), so backfilled
+    /// frames can be stamped with the same id as the live
+    /// `InteractionComplete` frames.
+    #[tokio::test]
+    async fn transcript_interaction_id_survives_session_persist_reload() {
+        let mut agent = build_agent_with_engine(SucceedingSkillEngine).await;
+        let interaction_id = crate::interaction::InteractionId(uuid::Uuid::from_u128(0xfeed_f00d));
+        let transcript_identity = crate::types::TranscriptMessageIdentity {
+            interaction_id: Some(interaction_id),
+            run_id: None,
+        };
+
+        let (tx, _rx) = mpsc::channel::<AgentEvent>(8);
+        agent
+            .run_with_events_and_typed_turn_appends(
+                "Commit me durably.".to_string().into(),
+                Vec::new(),
+                Vec::new(),
+                Some(transcript_identity),
+                tx,
+            )
+            .await
+            .expect("mock turn should complete");
+
+        // Persist + reload: the canonical session wire round-trip every
+        // session store implementation flows through.
+        let persisted = serde_json::to_value(agent.session())
+            .expect("session should serialize for persistence");
+        let reloaded: crate::session::Session =
+            serde_json::from_value(persisted).expect("persisted session should reload");
+
+        let user = reloaded
+            .messages()
+            .iter()
+            .find_map(|message| match message {
+                Message::User(message) => Some(message),
+                _ => None,
+            })
+            .expect("reloaded transcript should carry the user message");
+        assert_eq!(
+            user.identity.interaction_id,
+            Some(interaction_id),
+            "the reloaded user message must carry the committed interaction id"
+        );
+
+        let assistant = reloaded
+            .messages()
+            .iter()
+            .rev()
+            .find_map(|message| match message {
+                Message::BlockAssistant(message) => Some(message),
+                _ => None,
+            })
+            .expect("reloaded transcript should carry the assistant message");
+        assert_eq!(
+            assistant.identity.interaction_id,
+            Some(interaction_id),
+            "the reloaded assistant message must carry the committed interaction id"
+        );
+        assert!(
+            assistant.identity.run_id.is_some(),
+            "the reloaded assistant message must keep the resolving run id"
+        );
+    }
+
     #[tokio::test]
     async fn append_assistant_blocks_effect_stamps_active_transcript_identity_and_run_id() {
         let mut agent = build_agent_with_engine(SucceedingSkillEngine).await;

--- a/meerkat-core/src/comms.rs
+++ b/meerkat-core/src/comms.rs
@@ -1737,6 +1737,53 @@ pub enum SendReceipt {
     },
 }
 
+/// Turn-scoped dispatch-context key carrying the typed peer-reply capability.
+///
+/// The runtime mints a [`PeerReplyDispatchContext`] under this key on the
+/// per-turn tool overlay when the turn was triggered by one or more peer
+/// message deliveries; the comms `reply_to_peer` tool reads it back at
+/// dispatch time. The value under this key is always the serialized
+/// [`PeerReplyDispatchContext`] — no other producer may write this key.
+pub const COMMS_PEER_REPLY_DISPATCH_CONTEXT_KEY: &str = "comms.peer_reply";
+
+/// Delivery kind a peer-reply capability was minted for.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum PeerReplyDeliveryKind {
+    /// A one-way peer message delivery (the `PeerMessage` input grouping).
+    Message,
+}
+
+/// Typed capability to reply to one peer delivery that triggered this turn.
+///
+/// Minted by the runtime at batch admission — never by tool input — so the
+/// `reply_to_peer` tool is pre-addressed: the model supplies no peer identity,
+/// only content. Trust is still re-validated at dispatch time.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PeerReplyCapability {
+    /// Interaction id of the triggering delivery (the reply selector).
+    pub in_reply_to: InteractionId,
+    /// Canonical routing identity of the sending peer.
+    pub peer_id: PeerId,
+    /// Optional display label admitted at peer ingress. Presentation
+    /// metadata only; routing uses `peer_id`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub display_name: Option<String>,
+    /// Delivery kind the capability was minted for.
+    pub kind: PeerReplyDeliveryKind,
+}
+
+/// Turn-scoped peer-reply dispatch context: every peer message delivery in
+/// the admitted batch that can be answered with `reply_to_peer`, in batch
+/// delivery order.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct PeerReplyDispatchContext {
+    /// Reply capabilities in batch delivery order.
+    pub deliveries: Vec<PeerReplyCapability>,
+}
+
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]

--- a/meerkat-core/src/event_injector.rs
+++ b/meerkat-core/src/event_injector.rs
@@ -84,6 +84,24 @@ pub trait SubscribableInjector: EventInjector {
         handling_mode: HandlingMode,
         render_metadata: Option<RenderMetadata>,
     ) -> Result<InteractionSubscription, EventInjectorError>;
+
+    /// Inject an event stamped with a caller-chosen interaction id, without
+    /// reserving a subscriber channel.
+    ///
+    /// Unlike [`EventInjector::inject`] (fresh, unrelated interaction id
+    /// minted downstream), the injected event carries `interaction_id`, so
+    /// the transcript identity stamped at runtime admission joins with the
+    /// caller's live interaction frames — the seam mob work-lane delivery
+    /// uses to persist a host-supplied interaction id onto committed
+    /// transcript messages (mobkit ask-15 addendum).
+    fn inject_with_interaction_id(
+        &self,
+        interaction_id: crate::interaction::InteractionId,
+        content: ContentInput,
+        source: PlainEventSource,
+        handling_mode: HandlingMode,
+        render_metadata: Option<RenderMetadata>,
+    ) -> Result<(), EventInjectorError>;
 }
 
 #[cfg(test)]

--- a/meerkat-core/src/lib.rs
+++ b/meerkat-core/src/lib.rs
@@ -285,7 +285,7 @@ pub use service::{
 pub use session::{
     AuthorizedSessionToolVisibilityState, ConsumedDeferredTurnInputs, DeferredFirstTurnPhase,
     DeferredToolLoadAuthority, InheritedToolVisibilityAuthority, PendingDeferredPrompt,
-    PendingSystemContextAppend, PendingToolResultsMessage,
+    PendingSystemContextAppend, PendingToolResultsMessage, PersistedSessionMetadataView,
     RESUME_SYSTEM_PROMPT_REFRESH_REWRITE_REASON, ResumedSystemPromptReconciliation,
     SESSION_BUILD_STATE_KEY, SESSION_DEFERRED_TURN_STATE_KEY, SESSION_LIFECYCLE_TERMINAL_KEY,
     SESSION_METADATA_SCHEMA_VERSION, SESSION_SYSTEM_CONTEXT_STATE_KEY,
@@ -293,12 +293,13 @@ pub use session::{
     SYSTEM_CONTEXT_SEPARATOR, SeenSystemContextKey, SeenSystemContextState, Session,
     SessionBuildState, SessionDeferredTurnState, SessionLifecycleTerminal, SessionLlmIdentity,
     SessionLlmIdentityOverride, SessionLlmIdentityOverrideError, SessionLlmRequestPolicy,
-    SessionMeta, SessionMetadata, SessionSystemContextState, SessionToolVisibilityState,
-    SessionTooling, SystemContextStageError, SystemContextStateHandle, ToolCategoryOverride,
-    ToolVisibilityWitness, TranscriptHistoryState, TranscriptRevisionBody, TranscriptRewriteRecord,
-    VIEW_IMAGE_TOOL_NAME, WitnessedToolFilter, capability_base_filter_for_image_tool_results,
-    resolve_session_llm_identity_override, session_metadata_schema_version, session_version,
-    transcript_messages_digest,
+    SessionMeta, SessionMetadata, SessionMetadataDocument, SessionSystemContextState,
+    SessionToolVisibilityState, SessionTooling, SystemContextStageError, SystemContextStateHandle,
+    ToolCategoryOverride, ToolVisibilityWitness, TranscriptHistoryState, TranscriptRevisionBody,
+    TranscriptRewriteRecord, VIEW_IMAGE_TOOL_NAME, WitnessedToolFilter,
+    capability_base_filter_for_image_tool_results, resolve_session_llm_identity_override,
+    session_metadata_document_from_slice, session_metadata_schema_version, session_version,
+    transcript_messages_digest, try_lifecycle_terminal_from_map, try_session_metadata_from_map,
 };
 pub use session_recovery::{
     BUILD_ONLY_RECOVERY_OVERRIDE_ERROR, RecoveredSessionBuild, RecoveryBackendKind,

--- a/meerkat-core/src/service/mod.rs
+++ b/meerkat-core/src/service/mod.rs
@@ -1395,6 +1395,92 @@ impl TurnToolOverlay {
         self.dispatch_context.clear();
         self
     }
+
+    /// Compose an additional overlay into an optional existing overlay.
+    ///
+    /// This is the canonical composition path for every producer that layers
+    /// per-turn overlays (WorkGraph attention, runtime peer-reply
+    /// capabilities): allow-lists intersect, deny-lists union, and
+    /// dispatch-context entries merge key-wise. The same key carrying two
+    /// distinct values is a typed conflict — never a silent overwrite.
+    pub fn compose(
+        existing: Option<Self>,
+        overlay: Self,
+    ) -> Result<Self, TurnToolOverlayComposeError> {
+        let Some(existing) = existing else {
+            return Ok(overlay);
+        };
+        let allowed_tools = intersect_allowed_tools(existing.allowed_tools, overlay.allowed_tools);
+        let blocked_tools = union_blocked_tools(existing.blocked_tools, overlay.blocked_tools);
+        let dispatch_context =
+            merge_turn_dispatch_context(existing.dispatch_context, overlay.dispatch_context)?;
+        Ok(Self {
+            allowed_tools,
+            blocked_tools,
+            dispatch_context,
+        })
+    }
+}
+
+/// Typed error composing two per-turn tool overlays.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum TurnToolOverlayComposeError {
+    /// Both overlays carry the same dispatch-context key with distinct values.
+    #[error("conflicting turn tool overlay dispatch context for {key}")]
+    ConflictingDispatchContext { key: String },
+}
+
+fn intersect_allowed_tools(
+    left: Option<Vec<crate::types::ToolName>>,
+    right: Option<Vec<crate::types::ToolName>>,
+) -> Option<Vec<crate::types::ToolName>> {
+    match (left, right) {
+        (Some(left), Some(right)) => {
+            let right = right.into_iter().collect::<BTreeSet<_>>();
+            Some(
+                left.into_iter()
+                    .filter(|name| right.contains(name))
+                    .collect::<BTreeSet<_>>()
+                    .into_iter()
+                    .collect(),
+            )
+        }
+        (Some(left), None) => Some(left),
+        (None, Some(right)) => Some(right),
+        (None, None) => None,
+    }
+}
+
+fn union_blocked_tools(
+    left: Option<Vec<crate::types::ToolName>>,
+    right: Option<Vec<crate::types::ToolName>>,
+) -> Option<Vec<crate::types::ToolName>> {
+    let blocked = left
+        .into_iter()
+        .flatten()
+        .chain(right.into_iter().flatten())
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .collect::<Vec<_>>();
+    (!blocked.is_empty()).then_some(blocked)
+}
+
+fn merge_turn_dispatch_context(
+    mut existing: BTreeMap<String, serde_json::Value>,
+    overlay: BTreeMap<String, serde_json::Value>,
+) -> Result<BTreeMap<String, serde_json::Value>, TurnToolOverlayComposeError> {
+    for (key, value) in overlay {
+        match existing.get(&key) {
+            Some(current) if current != &value => {
+                return Err(TurnToolOverlayComposeError::ConflictingDispatchContext { key });
+            }
+            Some(_) => {}
+            None => {
+                existing.insert(key, value);
+            }
+        }
+    }
+    Ok(existing)
 }
 
 /// Public caller-safe per-turn tool overlay.
@@ -2079,6 +2165,96 @@ impl dyn SessionService {
 )]
 mod tests {
     use super::*;
+
+    /// Canonical overlay composition: allow-lists intersect, deny-lists
+    /// union, and dispatch-context entries from distinct producers (e.g. the
+    /// WorkGraph attention key and the comms peer-reply key) coexist.
+    #[test]
+    fn turn_tool_overlay_compose_preserves_distinct_dispatch_context_keys() {
+        let existing = TurnToolOverlay {
+            allowed_tools: Some(vec![
+                crate::types::ToolName::from("workgraph_get"),
+                crate::types::ToolName::from("send_message"),
+            ]),
+            blocked_tools: Some(vec![crate::types::ToolName::from("blocked_by_flow")]),
+            dispatch_context: BTreeMap::from([(
+                "workgraph.attention_projection".to_string(),
+                serde_json::json!({"binding_id": "b"}),
+            )]),
+        };
+        let overlay = TurnToolOverlay {
+            allowed_tools: None,
+            blocked_tools: None,
+            dispatch_context: BTreeMap::from([(
+                crate::comms::COMMS_PEER_REPLY_DISPATCH_CONTEXT_KEY.to_string(),
+                serde_json::json!({"deliveries": []}),
+            )]),
+        };
+
+        let composed = TurnToolOverlay::compose(Some(existing), overlay)
+            .unwrap_or_else(|err| unreachable!("distinct keys must compose: {err}"));
+
+        assert_eq!(
+            composed.allowed_tools,
+            Some(vec![
+                crate::types::ToolName::from("workgraph_get"),
+                crate::types::ToolName::from("send_message"),
+            ]),
+            "an overlay without an allow-list must pass the existing allow-list through unchanged"
+        );
+        assert_eq!(
+            composed.blocked_tools,
+            Some(vec![crate::types::ToolName::from("blocked_by_flow")])
+        );
+        assert_eq!(
+            composed.dispatch_context["workgraph.attention_projection"],
+            serde_json::json!({"binding_id": "b"})
+        );
+        assert_eq!(
+            composed.dispatch_context[crate::comms::COMMS_PEER_REPLY_DISPATCH_CONTEXT_KEY],
+            serde_json::json!({"deliveries": []})
+        );
+    }
+
+    #[test]
+    fn turn_tool_overlay_compose_without_existing_returns_overlay() {
+        let overlay = TurnToolOverlay {
+            allowed_tools: None,
+            blocked_tools: None,
+            dispatch_context: BTreeMap::from([(
+                crate::comms::COMMS_PEER_REPLY_DISPATCH_CONTEXT_KEY.to_string(),
+                serde_json::json!({"deliveries": []}),
+            )]),
+        };
+
+        let composed = TurnToolOverlay::compose(None, overlay.clone())
+            .unwrap_or_else(|err| unreachable!("no existing overlay must compose: {err}"));
+        assert_eq!(composed, overlay);
+    }
+
+    #[test]
+    fn turn_tool_overlay_compose_refuses_conflicting_dispatch_context_key() {
+        let make = |value: serde_json::Value| TurnToolOverlay {
+            allowed_tools: None,
+            blocked_tools: None,
+            dispatch_context: BTreeMap::from([(
+                crate::comms::COMMS_PEER_REPLY_DISPATCH_CONTEXT_KEY.to_string(),
+                value,
+            )]),
+        };
+
+        let err = TurnToolOverlay::compose(
+            Some(make(serde_json::json!({"deliveries": [1]}))),
+            make(serde_json::json!({"deliveries": [2]})),
+        )
+        .expect_err("distinct values under the same key must be a typed conflict");
+        assert_eq!(
+            err,
+            TurnToolOverlayComposeError::ConflictingDispatchContext {
+                key: crate::comms::COMMS_PEER_REPLY_DISPATCH_CONTEXT_KEY.to_string(),
+            }
+        );
+    }
 
     struct UnsupportedSessionService;
 

--- a/meerkat-core/src/session.rs
+++ b/meerkat-core/src/session.rs
@@ -1028,6 +1028,80 @@ impl<'de> Deserialize<'de> for Session {
     }
 }
 
+/// Serde helper for the metadata-only partial decode of a persisted session
+/// envelope.
+///
+/// LOCKSTEP with [`SessionSerde`]: this struct must decode exactly the field
+/// names and serde shapes that `SessionSerde` persists for `version`, `id`,
+/// and `metadata` (`rename_all = "snake_case"`, `#[serde(default)]` on
+/// `metadata`). The `session_metadata_document_lockstep_with_full_envelope`
+/// pin test fails if the two drift.
+#[derive(Deserialize)]
+#[serde(rename_all = "snake_case")]
+struct SessionMetadataDocumentSerde {
+    version: u32,
+    id: SessionId,
+    #[serde(default)]
+    metadata: serde_json::Map<String, serde_json::Value>,
+}
+
+/// Metadata-only projection of a persisted session envelope.
+///
+/// Produced by [`session_metadata_document_from_slice`] without materializing
+/// the transcript. Exposes ONLY the two session-authority facts the metadata
+/// read seam is allowed to observe ([`SESSION_METADATA_KEY`] and
+/// [`SESSION_LIFECYCLE_TERMINAL_KEY`]) — deliberately no raw metadata-map
+/// accessor, so the partial decode can never grow into an untyped side
+/// channel around [`Session`]'s authority-gated reads.
+#[derive(Debug, Clone)]
+pub struct SessionMetadataDocument {
+    session_id: SessionId,
+    metadata: serde_json::Map<String, serde_json::Value>,
+}
+
+impl SessionMetadataDocument {
+    /// Session identity carried by the envelope.
+    pub fn session_id(&self) -> &SessionId {
+        &self.session_id
+    }
+
+    /// Raw projected [`SESSION_METADATA_KEY`] value, for divergence
+    /// comparison against another projection of the same fact.
+    pub fn session_metadata_value(&self) -> Option<&serde_json::Value> {
+        self.metadata.get(SESSION_METADATA_KEY)
+    }
+
+    /// Raw projected [`SESSION_LIFECYCLE_TERMINAL_KEY`] value, for divergence
+    /// comparison against another projection of the same fact.
+    pub fn lifecycle_terminal_value(&self) -> Option<&serde_json::Value> {
+        self.metadata.get(SESSION_LIFECYCLE_TERMINAL_KEY)
+    }
+
+    /// Decode the typed metadata view through the canonical map-level
+    /// decoders, failing closed on corrupt values.
+    pub fn try_into_view(self) -> Result<PersistedSessionMetadataView, serde_json::Error> {
+        PersistedSessionMetadataView::try_from_metadata_map(self.session_id, &self.metadata)
+    }
+}
+
+/// Partially decode a persisted session envelope into its metadata-only
+/// document, without materializing the transcript.
+///
+/// Fail-closed on the envelope format version through the generated
+/// persistence version authority — exactly like the full [`Session`]
+/// deserializer.
+pub fn session_metadata_document_from_slice(
+    bytes: &[u8],
+) -> Result<SessionMetadataDocument, serde_json::Error> {
+    let serde_repr: SessionMetadataDocumentSerde = serde_json::from_slice(bytes)?;
+    session_persistence_version_authority::restore_session_envelope_version(serde_repr.version)
+        .map_err(<serde_json::Error as serde::de::Error>::custom)?;
+    Ok(SessionMetadataDocument {
+        session_id: serde_repr.id,
+        metadata: serde_repr.metadata,
+    })
+}
+
 /// Metadata key used to store durable system-context control state.
 pub const SESSION_SYSTEM_CONTEXT_STATE_KEY: &str = "session_system_context_state";
 
@@ -3743,18 +3817,7 @@ impl Session {
 
     /// Try to load SessionMetadata through generated restore authority.
     pub fn try_session_metadata(&self) -> Result<Option<SessionMetadata>, serde_json::Error> {
-        let Some(value) = self.metadata.get(SESSION_METADATA_KEY) else {
-            return Ok(None);
-        };
-        let mut metadata = serde_json::from_value::<SessionMetadata>(value.clone())?;
-        metadata.schema_version =
-            session_persistence_version_authority::restore_session_metadata_schema_version(
-                metadata.schema_version,
-            )
-            .map_err(<serde_json::Error as serde::de::Error>::custom)?;
-        session_durable_config_authority::restore_session_metadata(metadata)
-            .map(Some)
-            .map_err(<serde_json::Error as serde::de::Error>::custom)
+        try_session_metadata_from_map(&self.metadata)
     }
 
     /// Store durable system-context control state in the session metadata map.
@@ -3857,10 +3920,7 @@ impl Session {
     pub fn try_lifecycle_terminal(
         &self,
     ) -> Result<Option<SessionLifecycleTerminal>, serde_json::Error> {
-        match self.metadata.get(SESSION_LIFECYCLE_TERMINAL_KEY) {
-            Some(value) => serde_json::from_value(value.clone()).map(Some),
-            None => Ok(None),
-        }
+        try_lifecycle_terminal_from_map(&self.metadata)
     }
 
     /// Load the typed session lifecycle-terminal fact, failing closed on a
@@ -4800,6 +4860,93 @@ impl From<&Session> for SessionMeta {
             total_tokens: session.total_tokens(),
             metadata: session.metadata.clone(),
         }
+    }
+}
+
+/// Decode the typed [`SESSION_METADATA_KEY`] fact from a session metadata map
+/// through the generated restore authority.
+///
+/// Canonical single decoder: [`Session::try_session_metadata`] and every
+/// metadata-only read seam ([`PersistedSessionMetadataView`]) delegate here so
+/// the full-session and metadata-only decode paths can never drift.
+///
+/// Fail-closed: a present-but-corrupt value is an error, never "absent".
+pub fn try_session_metadata_from_map(
+    metadata: &serde_json::Map<String, serde_json::Value>,
+) -> Result<Option<SessionMetadata>, serde_json::Error> {
+    let Some(value) = metadata.get(SESSION_METADATA_KEY) else {
+        return Ok(None);
+    };
+    let mut metadata = serde_json::from_value::<SessionMetadata>(value.clone())?;
+    metadata.schema_version =
+        session_persistence_version_authority::restore_session_metadata_schema_version(
+            metadata.schema_version,
+        )
+        .map_err(<serde_json::Error as serde::de::Error>::custom)?;
+    session_durable_config_authority::restore_session_metadata(metadata)
+        .map(Some)
+        .map_err(<serde_json::Error as serde::de::Error>::custom)
+}
+
+/// Decode the typed [`SESSION_LIFECYCLE_TERMINAL_KEY`] fact from a session
+/// metadata map.
+///
+/// Canonical single decoder: [`Session::try_lifecycle_terminal`] and every
+/// metadata-only read seam delegate here. An absent key means no terminal
+/// fact; a present-but-corrupt value fails closed.
+pub fn try_lifecycle_terminal_from_map(
+    metadata: &serde_json::Map<String, serde_json::Value>,
+) -> Result<Option<SessionLifecycleTerminal>, serde_json::Error> {
+    match metadata.get(SESSION_LIFECYCLE_TERMINAL_KEY) {
+        Some(value) => serde_json::from_value(value.clone()).map(Some),
+        None => Ok(None),
+    }
+}
+
+/// Typed metadata-only view of a persisted session row or snapshot.
+///
+/// The metadata read seam's currency (mobkit ask-24 clause 3): carries the
+/// session identity plus the two typed session-authority metadata facts,
+/// decoded fail-closed through the canonical map-level decoders. Consumers
+/// that only need ownership/policy/lifecycle facts read this view instead of
+/// materializing the full session document.
+#[derive(Debug, Clone)]
+pub struct PersistedSessionMetadataView {
+    pub session_id: SessionId,
+    pub session_metadata: Option<SessionMetadata>,
+    pub lifecycle_terminal: Option<SessionLifecycleTerminal>,
+}
+
+impl PersistedSessionMetadataView {
+    /// Build the view from a persisted metadata map (e.g. a
+    /// [`SessionMeta`] row projection).
+    ///
+    /// Fail-closed: corrupt values under either reserved key are an error,
+    /// never treated as absent.
+    pub fn try_from_metadata_map(
+        session_id: SessionId,
+        metadata: &serde_json::Map<String, serde_json::Value>,
+    ) -> Result<Self, serde_json::Error> {
+        Ok(Self {
+            session_id,
+            session_metadata: try_session_metadata_from_map(metadata)?,
+            lifecycle_terminal: try_lifecycle_terminal_from_map(metadata)?,
+        })
+    }
+
+    /// Project the view from a fully materialized session document.
+    pub fn try_from_session(session: &Session) -> Result<Self, serde_json::Error> {
+        Ok(Self {
+            session_id: session.id().clone(),
+            session_metadata: session.try_session_metadata()?,
+            lifecycle_terminal: session.try_lifecycle_terminal()?,
+        })
+    }
+
+    /// Typed durable mob member identity carried on the session metadata,
+    /// if any.
+    pub fn mob_member_binding(&self) -> Option<&crate::MobMemberBinding> {
+        self.session_metadata.as_ref()?.mob_member_binding.as_ref()
     }
 }
 
@@ -9182,5 +9329,133 @@ mod tests {
             }
             other => unreachable!("expected BlockAssistant, got {other:?}"),
         }
+    }
+
+    fn metadata_seam_session_metadata() -> SessionMetadata {
+        SessionMetadata {
+            schema_version: SESSION_METADATA_SCHEMA_VERSION,
+            model: "test-model".to_string(),
+            max_tokens: 1024,
+            structured_output_retries: 2,
+            provider: Provider::Anthropic,
+            self_hosted_server_id: None,
+            provider_params: None,
+            tooling: SessionTooling::default(),
+            keep_alive: false,
+            comms_name: Some("team/reviewer/alice".to_string()),
+            peer_meta: None,
+            realm_id: None,
+            instance_id: None,
+            backend: None,
+            config_generation: None,
+            auth_binding: None,
+            mob_member_binding: Some(crate::MobMemberBinding {
+                mob_id: "team".to_string(),
+                role: "reviewer".to_string(),
+                member: "alice".to_string(),
+            }),
+        }
+    }
+
+    /// Lockstep pin: the metadata-only partial decode must read the exact
+    /// envelope that `SessionSerde` writes. If a field rename or serde-shape
+    /// change lands on the full envelope without the partial decoder
+    /// following, this test fails.
+    #[test]
+    fn session_metadata_document_lockstep_with_full_envelope() {
+        let mut session = Session::new();
+        session.push(Message::User(UserMessage::text("hello".to_string())));
+        session
+            .set_session_metadata(metadata_seam_session_metadata())
+            .expect("session metadata should persist");
+        session
+            .set_lifecycle_terminal(SessionLifecycleTerminal::Archived)
+            .expect("lifecycle terminal should persist");
+
+        let bytes = serde_json::to_vec(&session).expect("session should serialize");
+        let document = session_metadata_document_from_slice(&bytes)
+            .expect("partial decode must accept the canonical envelope");
+
+        assert_eq!(document.session_id(), session.id());
+        assert_eq!(
+            document.session_metadata_value(),
+            session.metadata().get(SESSION_METADATA_KEY),
+            "partial decode must project the identical raw session-metadata value"
+        );
+        assert_eq!(
+            document.lifecycle_terminal_value(),
+            session.metadata().get(SESSION_LIFECYCLE_TERMINAL_KEY),
+            "partial decode must project the identical raw lifecycle-terminal value"
+        );
+
+        let view = document
+            .try_into_view()
+            .expect("typed view must decode from the partial document");
+        let full_view =
+            PersistedSessionMetadataView::try_from_session(&session).expect("full-session view");
+        assert_eq!(view.session_id, full_view.session_id);
+        assert_eq!(
+            view.session_metadata.as_ref().map(|m| m.model.clone()),
+            full_view.session_metadata.as_ref().map(|m| m.model.clone())
+        );
+        assert_eq!(
+            view.mob_member_binding(),
+            full_view.mob_member_binding(),
+            "typed binding must be identical across the two decode paths"
+        );
+        assert_eq!(
+            view.lifecycle_terminal,
+            Some(SessionLifecycleTerminal::Archived)
+        );
+        assert_eq!(
+            full_view.lifecycle_terminal,
+            Some(SessionLifecycleTerminal::Archived)
+        );
+    }
+
+    /// The metadata-only partial decode fails closed on an unsupported
+    /// envelope version — same contract as the full deserializer.
+    #[test]
+    fn session_metadata_document_fails_closed_on_envelope_version() {
+        let session = Session::new();
+        let mut value = serde_json::to_value(&session).expect("session should serialize");
+        value["version"] = serde_json::json!(SESSION_VERSION + 999);
+        let bytes = serde_json::to_vec(&value).expect("mangled envelope should serialize");
+
+        session_metadata_document_from_slice(&bytes)
+            .expect_err("an unsupported envelope version must fail the partial decode closed");
+    }
+
+    /// Corrupt values under either reserved key are a read FAULT for the
+    /// metadata view — never coalesced into "absent".
+    #[test]
+    fn persisted_session_metadata_view_fails_closed_on_corrupt_values() {
+        let session_id = SessionId::new();
+
+        let mut corrupt_metadata = serde_json::Map::new();
+        corrupt_metadata.insert(SESSION_METADATA_KEY.to_string(), serde_json::json!(42));
+        PersistedSessionMetadataView::try_from_metadata_map(session_id.clone(), &corrupt_metadata)
+            .expect_err("corrupt session_metadata must fail the view decode closed");
+
+        let mut corrupt_terminal = serde_json::Map::new();
+        corrupt_terminal.insert(
+            SESSION_LIFECYCLE_TERMINAL_KEY.to_string(),
+            serde_json::json!("definitely-not-a-terminal"),
+        );
+        PersistedSessionMetadataView::try_from_metadata_map(session_id, &corrupt_terminal)
+            .expect_err("corrupt lifecycle terminal must fail the view decode closed");
+    }
+
+    /// Absent reserved keys decode as typed absence through the view.
+    #[test]
+    fn persisted_session_metadata_view_reads_absent_facts_as_none() {
+        let view = PersistedSessionMetadataView::try_from_metadata_map(
+            SessionId::new(),
+            &serde_json::Map::new(),
+        )
+        .expect("empty metadata map must decode");
+        assert!(view.session_metadata.is_none());
+        assert!(view.lifecycle_terminal.is_none());
+        assert!(view.mob_member_binding().is_none());
     }
 }

--- a/meerkat-core/src/session_store.rs
+++ b/meerkat-core/src/session_store.rs
@@ -1466,6 +1466,25 @@ pub trait SessionStore: Send + Sync {
     /// List sessions matching filter.
     async fn list(&self, filter: SessionFilter) -> Result<Vec<SessionMeta>, SessionStoreError>;
 
+    /// Load only the summary metadata row for a session.
+    ///
+    /// Metadata-only read seam (mobkit ask-24 clause 3): callers that need
+    /// session-level metadata facts (the reserved `session_*` authority keys
+    /// carried on [`SessionMeta::metadata`]) but not the transcript can avoid
+    /// materializing the full session document.
+    ///
+    /// Default: full [`load`](Self::load) projected through
+    /// [`SessionMeta::from`] — correct for every backend, with no
+    /// partial-read benefit. Backends with a row-level metadata projection
+    /// (SQLite) override this with a real partial read that survives a
+    /// corrupt or unreadable full session document.
+    async fn load_meta(&self, id: &SessionId) -> Result<Option<SessionMeta>, SessionStoreError> {
+        Ok(self
+            .load(id)
+            .await?
+            .map(|session| SessionMeta::from(&session)))
+    }
+
     /// Delete a session.
     async fn delete(&self, id: &SessionId) -> Result<(), SessionStoreError>;
 

--- a/meerkat-mob-mcp/src/agent_tools.rs
+++ b/meerkat-mob-mcp/src/agent_tools.rs
@@ -2457,6 +2457,17 @@ mod tests {
                 events: rx,
             })
         }
+
+        fn inject_with_interaction_id(
+            &self,
+            _interaction_id: InteractionId,
+            body: ContentInput,
+            source: PlainEventSource,
+            handling_mode: HandlingMode,
+            render_metadata: Option<RenderMetadata>,
+        ) -> Result<(), EventInjectorError> {
+            self.inject(body, source, handling_mode, render_metadata)
+        }
     }
 
     impl TestCommsRegistry {

--- a/meerkat-mob-mcp/src/agent_tools.rs
+++ b/meerkat-mob-mcp/src/agent_tools.rs
@@ -646,14 +646,16 @@ impl AgentMobToolSurface {
     ///
     /// `Inherit`/absent resolves to this (parent) session's effective policy
     /// from `SessionMetadata.tooling.tool_access_policy` — the same field the
-    /// factory stamps at build. Every backend exposes the parent through
-    /// `load_persisted_session`: the persistent service reads the durable
-    /// snapshot and the ephemeral service exports the LIVE session (a
-    /// restricted ephemeral parent must never mint unrestricted children
-    /// because its policy was invisible to the read seam). A metadata READ
-    /// FAULT fails the spawn closed rather than silently minting an ungated
-    /// child; a genuinely absent parent session (host/operator-authored
-    /// spawn) resolves to unrestricted.
+    /// factory stamps at build. Every backend exposes the parent through the
+    /// metadata-only `load_persisted_session_metadata` seam: the persistent
+    /// service projects the durable metadata row and the ephemeral service
+    /// derives the view from the LIVE session (a restricted ephemeral parent
+    /// must never mint unrestricted children because its policy was invisible
+    /// to the read seam). A metadata READ FAULT — including corrupt durable
+    /// metadata, which the seam surfaces as `Err`, never `Ok(None)` — fails
+    /// the spawn closed rather than silently minting an ungated child; a
+    /// genuinely absent parent session (host/operator-authored spawn)
+    /// resolves to unrestricted.
     async fn resolve_child_tool_access_policy(
         &self,
         tool_name: &str,
@@ -668,28 +670,20 @@ impl AgentMobToolSurface {
         ) {
             return Ok(effective_child_tool_access_policy(requested, None));
         }
-        let parent_session = self
+        let parent_view = self
             .state
             .session_service()
-            .load_persisted_session(&self.owner_bridge_session_id)
+            .load_persisted_session_metadata(&self.owner_bridge_session_id)
             .await
             .map_err(|error| {
                 ToolError::execution_failed(format!(
-                    "tool '{tool_name}' parent tool access policy read failed: {error}"
+                    "tool '{tool_name}' parent tool access policy read failed; \
+                     refusing to resolve the child tool access policy: {error}"
                 ))
             })?;
-        let parent_effective = match parent_session.as_ref() {
-            Some(session) => session
-                .try_session_metadata()
-                .map_err(|error| {
-                    ToolError::execution_failed(format!(
-                        "tool '{tool_name}' parent session metadata is corrupt; \
-                         refusing to resolve the child tool access policy: {error}"
-                    ))
-                })?
-                .and_then(|metadata| metadata.tooling.tool_access_policy),
-            None => None,
-        };
+        let parent_effective = parent_view
+            .and_then(|view| view.session_metadata)
+            .and_then(|metadata| metadata.tooling.tool_access_policy);
         Ok(effective_child_tool_access_policy(
             requested,
             parent_effective,

--- a/meerkat-mob-mcp/src/agent_tools.rs
+++ b/meerkat-mob-mcp/src/agent_tools.rs
@@ -539,6 +539,7 @@ impl AgentMobToolSurface {
                 let comms_tools: std::collections::HashSet<String> = [
                     "send",
                     "send_message",
+                    "reply_to_peer",
                     "send_request",
                     "send_response",
                     "peers",
@@ -4825,6 +4826,7 @@ mod tests {
         [
             "send",
             "send_message",
+            "reply_to_peer",
             "send_request",
             "send_response",
             "peers",
@@ -4942,7 +4944,7 @@ mod tests {
         };
         let resolved = surface.resolve_spawn_tooling(&tooling).await.unwrap();
         let names = inherited_allow_names(resolved);
-        assert_eq!(names.len(), 8, "should inherit all 8 parent tools");
+        assert_eq!(names.len(), 9, "should inherit all 9 parent tools");
         assert!(names.contains("send"));
         assert!(names.contains("read_file"));
         assert!(names.contains("bash"));
@@ -4957,7 +4959,7 @@ mod tests {
         };
         let resolved = surface.resolve_spawn_tooling(&tooling).await.unwrap();
         let names = inherited_allow_names(resolved);
-        assert_eq!(names.len(), 7, "hidden parent tools must not be inherited");
+        assert_eq!(names.len(), 8, "hidden parent tools must not be inherited");
         assert!(names.contains("read_file"));
         assert!(!names.contains("bash"));
     }
@@ -4991,7 +4993,7 @@ mod tests {
         };
         let resolved = surface.resolve_spawn_tooling(&tooling).await.unwrap();
         let names = inherited_allow_names(resolved);
-        assert_eq!(names.len(), 6);
+        assert_eq!(names.len(), 7);
         assert!(!names.contains("bash"));
         assert!(!names.contains("write_file"));
         assert!(names.contains("read_file"));
@@ -5032,9 +5034,10 @@ mod tests {
         let tooling = meerkat_mob::SpawnTooling::Minimal;
         let resolved = surface.resolve_spawn_tooling(&tooling).await.unwrap();
         let names = inherited_allow_names(resolved);
-        assert_eq!(names.len(), 5);
+        assert_eq!(names.len(), 6);
         assert!(names.contains("send"));
         assert!(names.contains("send_message"));
+        assert!(names.contains("reply_to_peer"));
         assert!(names.contains("send_request"));
         assert!(names.contains("send_response"));
         assert!(names.contains("peers"));

--- a/meerkat-mob-mcp/src/lib.rs
+++ b/meerkat-mob-mcp/src/lib.rs
@@ -187,14 +187,15 @@ pub struct KickoffMemberSnapshot {
     pub snapshot: meerkat_mob::MobMemberSnapshot,
 }
 
-fn persisted_mob_binding(session: &meerkat_core::Session) -> Option<meerkat_mob::MobId> {
-    // Read the typed durable identity directly. Old persisted rows written
-    // before `mob_member_binding` existed deserialize as `None` and are simply
-    // not owned (back-read safe) — they re-acquire a typed binding on the next
-    // build/resume. No comms_name string-split, no `mob:{id}` realm
-    // format-string, no magic-key peer_meta cross-check.
-    let metadata = session.session_metadata()?;
-    let binding = metadata.mob_member_binding.as_ref()?;
+fn persisted_mob_binding(
+    view: &meerkat_core::PersistedSessionMetadataView,
+) -> Option<meerkat_mob::MobId> {
+    // Read the typed durable identity directly off the metadata view. Old
+    // persisted rows written before `mob_member_binding` existed decode as
+    // `None` and are simply not owned (back-read safe) — they re-acquire a
+    // typed binding on the next build/resume. No comms_name string-split, no
+    // `mob:{id}` realm format-string, no magic-key peer_meta cross-check.
+    let binding = view.mob_member_binding()?;
     Some(meerkat_mob::MobId::from(binding.mob_id.as_str()))
 }
 
@@ -1145,9 +1146,11 @@ impl MobMcpState {
 
     #[doc(hidden)]
     pub async fn owns_persisted_bridge_session(&self, bridge_session_id: &SessionId) -> bool {
-        let Some(session) = self
+        // Ownership routing needs only the typed identity facts on session
+        // metadata — read the metadata-only seam, never the full document.
+        let Some(view) = self
             .session_service()
-            .load_persisted_session(bridge_session_id)
+            .load_persisted_session_metadata(bridge_session_id)
             .await
             .ok()
             .flatten()
@@ -1155,7 +1158,7 @@ impl MobMcpState {
             return false;
         };
 
-        let Some(mob_id) = persisted_mob_binding(&session) else {
+        let Some(mob_id) = persisted_mob_binding(&view) else {
             return false;
         };
         match self.handle_for(&mob_id).await {
@@ -4740,6 +4743,12 @@ mod tests {
         counter: AtomicU64,
         start_turn_delay_ms: AtomicU64,
         start_turn_calls: AtomicU64,
+        /// Counting-wrapper guard state: full-document reads through
+        /// `load_persisted_session`.
+        persisted_full_loads: AtomicU64,
+        /// Counting-wrapper guard state: metadata-only reads through
+        /// `load_persisted_session_metadata`.
+        persisted_metadata_loads: AtomicU64,
         runtime_adapter: Arc<meerkat_runtime::MeerkatMachine>,
     }
 
@@ -4754,6 +4763,8 @@ mod tests {
                 counter: AtomicU64::new(0),
                 start_turn_delay_ms: AtomicU64::new(0),
                 start_turn_calls: AtomicU64::new(0),
+                persisted_full_loads: AtomicU64::new(0),
+                persisted_metadata_loads: AtomicU64::new(0),
                 runtime_adapter: Arc::new(meerkat_runtime::MeerkatMachine::ephemeral()),
             }
         }
@@ -5086,12 +5097,37 @@ mod tests {
             &self,
             session_id: &SessionId,
         ) -> Result<Option<Session>, SessionError> {
+            self.persisted_full_loads.fetch_add(1, Ordering::Relaxed);
             Ok(self
                 .persisted_sessions
                 .read()
                 .await
                 .get(session_id)
                 .cloned())
+        }
+
+        async fn load_persisted_session_metadata(
+            &self,
+            session_id: &SessionId,
+        ) -> Result<Option<meerkat_core::PersistedSessionMetadataView>, SessionError> {
+            self.persisted_metadata_loads
+                .fetch_add(1, Ordering::Relaxed);
+            let Some(session) = self
+                .persisted_sessions
+                .read()
+                .await
+                .get(session_id)
+                .cloned()
+            else {
+                return Ok(None);
+            };
+            meerkat_core::PersistedSessionMetadataView::try_from_session(&session)
+                .map(Some)
+                .map_err(|err| {
+                    SessionError::Agent(meerkat_core::error::AgentError::InternalError(format!(
+                        "session {session_id} durable metadata failed typed restore: {err}"
+                    )))
+                })
         }
 
         async fn apply_runtime_turn(
@@ -5701,6 +5737,63 @@ mod tests {
         assert!(
             state.owns_persisted_bridge_session(&persisted_id).await,
             "persisted mob members must still route through mob ownership after restart even before a live handle is rehydrated"
+        );
+    }
+
+    /// Counting-wrapper guard (mobkit ask-24 clause 3): the persisted
+    /// ownership probe reads the metadata seam ONLY — exactly one
+    /// metadata-view load and ZERO full session-document loads. Regresses if
+    /// `owns_persisted_bridge_session` (or anything on its path) reaches for
+    /// `load_persisted_session` again.
+    #[tokio::test]
+    async fn test_owns_persisted_bridge_session_reads_metadata_seam_without_full_load() {
+        let svc = Arc::new(MockSessionSvc::new());
+        let session_service: Arc<dyn meerkat_mob::MobSessionService> = svc.clone();
+        let state = Arc::new(MobMcpState::new(session_service));
+
+        let mut persisted = Session::new();
+        let persisted_id = persisted.id().clone();
+        let _ = persisted.set_session_metadata(SessionMetadata {
+            schema_version: meerkat_core::SESSION_METADATA_SCHEMA_VERSION,
+            model: "claude-sonnet-4-5".to_string(),
+            max_tokens: 4096,
+            structured_output_retries: 2,
+            provider: Provider::Anthropic,
+            self_hosted_server_id: None,
+            provider_params: None,
+            tooling: SessionTooling {
+                comms: ToolCategoryOverride::Enable,
+                ..SessionTooling::default()
+            },
+            keep_alive: false,
+            comms_name: Some("team/reviewer/alice".to_string()),
+            peer_meta: None,
+            realm_id: None,
+            instance_id: None,
+            backend: None,
+            config_generation: None,
+            auth_binding: None,
+            mob_member_binding: Some(meerkat_core::MobMemberBinding {
+                mob_id: "team".to_string(),
+                role: "reviewer".to_string(),
+                member: "alice".to_string(),
+            }),
+        });
+        svc.insert_persisted_session(persisted).await;
+
+        assert!(
+            state.owns_persisted_bridge_session(&persisted_id).await,
+            "the metadata seam must resolve ownership for a bound persisted session"
+        );
+        assert_eq!(
+            svc.persisted_full_loads.load(Ordering::Relaxed),
+            0,
+            "the ownership probe must not materialize the full session document"
+        );
+        assert_eq!(
+            svc.persisted_metadata_loads.load(Ordering::Relaxed),
+            1,
+            "the ownership probe reads exactly one metadata view"
         );
     }
 

--- a/meerkat-mob-mcp/src/lib.rs
+++ b/meerkat-mob-mcp/src/lib.rs
@@ -4524,6 +4524,17 @@ mod tests {
                 events: rx,
             })
         }
+
+        fn inject_with_interaction_id(
+            &self,
+            _interaction_id: InteractionId,
+            body: ContentInput,
+            source: PlainEventSource,
+            handling_mode: HandlingMode,
+            render_metadata: Option<RenderMetadata>,
+        ) -> Result<(), EventInjectorError> {
+            self.inject(body, source, handling_mode, render_metadata)
+        }
     }
 
     impl MockComms {

--- a/meerkat-mob/src/event.rs
+++ b/meerkat-mob/src/event.rs
@@ -538,6 +538,12 @@ pub struct MemberSpawnedEvent {
     /// Application-defined labels for this member.
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub labels: BTreeMap<String, String>,
+    /// Per-spawn effective profile override (from `SpawnTooling::Profile`
+    /// resolution) active at spawn. Durable so roster replay repopulates
+    /// `RosterEntry.effective_profile_override` across process restarts;
+    /// `None` means the definition profile keyed by `role` is authoritative.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub effective_profile_override: Option<crate::profile::Profile>,
     /// Typed continuity evidence emitted at spawn finalization.
     #[serde(default, skip_serializing_if = "crate::event::is_ephemeral_continuity")]
     pub continuity_intent: crate::runtime::SpawnContinuityIntent,
@@ -563,6 +569,7 @@ impl MemberSpawnedEvent {
             role,
             runtime_mode: MobRuntimeMode::AutonomousHost,
             labels: BTreeMap::new(),
+            effective_profile_override: None,
             continuity_intent: crate::runtime::SpawnContinuityIntent::Ephemeral,
             bridge_member_ref: None,
         }
@@ -1299,6 +1306,94 @@ mod tests {
         event.runtime_mode = MobRuntimeMode::TurnDriven;
         event.labels = labels;
         roundtrip(&MobEventKind::MemberSpawned(event));
+    }
+
+    fn override_profile_with_mcp_servers() -> Profile {
+        Profile {
+            model: "claude-sonnet-4-5".to_string(),
+            provider: None,
+            self_hosted_server_id: None,
+            image_generation_provider: None,
+            auto_compact_threshold: None,
+            resume_overrides: Vec::new(),
+            skills: vec![],
+            tools: ToolConfig {
+                mcp_servers: vec![meerkat_core::mcp_config::McpServerConfig::stdio(
+                    "planner",
+                    "/bin/echo",
+                    vec![],
+                    std::collections::HashMap::new(),
+                )],
+                ..ToolConfig::default()
+            },
+            peer_description: "A worker".to_string(),
+            external_addressable: false,
+            backend: None,
+            runtime_mode: MobRuntimeMode::AutonomousHost,
+            max_inline_peer_notifications: None,
+            output_schema: None,
+            provider_params: None,
+        }
+    }
+
+    #[test]
+    fn test_member_spawned_effective_profile_override_roundtrip() {
+        let identity = AgentIdentity::from("coder");
+        let mut event = MemberSpawnedEvent::new(
+            identity.clone(),
+            Generation::INITIAL,
+            FenceToken::new(7),
+            AgentRuntimeId::initial(identity),
+            ProfileName::from("worker"),
+        );
+        event.effective_profile_override = Some(override_profile_with_mcp_servers());
+        roundtrip(&MobEventKind::MemberSpawned(event));
+    }
+
+    #[test]
+    fn test_member_spawned_without_override_serializes_without_the_field() {
+        let identity = AgentIdentity::from("coder");
+        let event = MemberSpawnedEvent::new(
+            identity.clone(),
+            Generation::INITIAL,
+            FenceToken::new(7),
+            AgentRuntimeId::initial(identity),
+            ProfileName::from("worker"),
+        );
+        let serialized =
+            serde_json::to_string(&MobEventKind::MemberSpawned(event)).expect("serialize");
+        assert!(
+            !serialized.contains("effective_profile_override"),
+            "None override must keep the wire shape byte-identical to pre-wave-2 events: {serialized}"
+        );
+    }
+
+    #[test]
+    fn test_member_spawned_pre_wave2_event_without_override_deserializes_to_none() {
+        let event: MobEvent = serde_json::from_value(json!({
+            "cursor": 1,
+            "timestamp": "2026-02-19T00:00:00Z",
+            "mob_id": "test-mob",
+            "kind": {
+                "type": "member_spawned",
+                "agent_identity": "researcher",
+                "generation": 0,
+                "fence_token": 1,
+                "agent_runtime_id": {
+                    "identity": "researcher",
+                    "generation": 0
+                },
+                "role": "worker",
+                "runtime_mode": "autonomous_host"
+            },
+        }))
+        .expect("pre-wave-2 stored event must stay readable");
+        match event.kind {
+            MobEventKind::MemberSpawned(member_spawned) => {
+                assert_eq!(member_spawned.effective_profile_override, None);
+            }
+            other => panic!("expected MemberSpawned, got {other:?}"),
+        }
     }
 
     #[test]

--- a/meerkat-mob/src/ids.rs
+++ b/meerkat-mob/src/ids.rs
@@ -385,6 +385,17 @@ pub struct WorkSpec {
     /// reject it fail-closed with a typed [`crate::MobError`].
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub injected_context: Vec<meerkat_core::types::ContentInput>,
+    /// Host-supplied interaction identity for this unit of work.
+    ///
+    /// Ask-15 addendum: the delivery path carries this id to
+    /// `RuntimeTurnMetadata.transcript_identity` (turn-driven dispatch) or
+    /// stamps it onto the injected inbox event (autonomous dispatch), so the
+    /// transcript messages committed for this turn persist the SAME
+    /// interaction id the host's live `interaction_complete` frames carry —
+    /// history backfill can then join persisted and live frames without
+    /// content heuristics. Serde-additive: absent on old stored shapes.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub interaction_id: Option<meerkat_core::interaction::InteractionId>,
 }
 
 impl WorkSpec {
@@ -396,6 +407,7 @@ impl WorkSpec {
             content: content.into(),
             origin,
             injected_context: Vec::new(),
+            interaction_id: None,
         }
     }
 
@@ -405,6 +417,17 @@ impl WorkSpec {
         injected_context: Vec<meerkat_core::types::ContentInput>,
     ) -> Self {
         self.injected_context = injected_context;
+        self
+    }
+
+    /// Attach a host-supplied interaction id so the committed transcript
+    /// messages for this turn persist the same identity the host's live
+    /// interaction frames carry.
+    pub fn with_interaction_id(
+        mut self,
+        interaction_id: meerkat_core::interaction::InteractionId,
+    ) -> Self {
+        self.interaction_id = Some(interaction_id);
         self
     }
 }
@@ -431,6 +454,32 @@ impl WorkOrigin {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn work_spec_interaction_id_is_serde_additive() {
+        // Absent field (the pre-ask-15 stored shape) deserializes to None,
+        // and None is skipped on serialization so old readers see the old
+        // shape unchanged.
+        let json = serde_json::to_value(WorkSpec::new(
+            "do the thing".to_string(),
+            WorkOrigin::Internal,
+        ))
+        .unwrap();
+        assert!(
+            json.get("interaction_id").is_none(),
+            "None must not serialize (serde-additive)"
+        );
+        let spec: WorkSpec = serde_json::from_value(json).unwrap();
+        assert!(spec.interaction_id.is_none());
+
+        // A carried id round-trips.
+        let id = meerkat_core::interaction::InteractionId(Uuid::new_v4());
+        let keyed =
+            WorkSpec::new("do the thing".to_string(), WorkOrigin::External).with_interaction_id(id);
+        let json = serde_json::to_value(&keyed).unwrap();
+        let parsed: WorkSpec = serde_json::from_value(json).unwrap();
+        assert_eq!(parsed.interaction_id, Some(id));
+    }
 
     #[test]
     fn test_run_id_roundtrip_json() {

--- a/meerkat-mob/src/roster.rs
+++ b/meerkat-mob/src/roster.rs
@@ -186,7 +186,10 @@ impl Roster {
                     peer_id: None,
                     transport_public_key: None,
                     labels: member_spawned.labels.clone(),
-                    effective_profile_override: None,
+                    // Durable single owner: replay repopulates the per-spawn
+                    // override so restarts without a SpawnMemberCustomizer
+                    // keep per-spawn declarative tooling.
+                    effective_profile_override: member_spawned.effective_profile_override.clone(),
                 });
             }
             MobEventKind::MemberRetired { agent_identity, .. } => {

--- a/meerkat-mob/src/runtime/actor.rs
+++ b/meerkat-mob/src/runtime/actor.rs
@@ -4815,23 +4815,28 @@ impl MobActor {
 
         // Raw observation only: the live runtime is gone; is the durable
         // snapshot still materializable? The verdict belongs to MobMachine.
-        let stored_session = if self.session_service.supports_persistent_sessions() {
+        // Presence is probed over the metadata-only read seam — the full
+        // document is loaded later, and only on the machine-authorized
+        // revival path.
+        let stored_session_present = if self.session_service.supports_persistent_sessions() {
             self.session_service
-                .load_persisted_session(bridge_session_id)
+                .load_persisted_session_metadata(bridge_session_id)
                 .await
                 .map_err(MobError::SessionError)?
+                .is_some()
         } else {
-            None
+            false
         };
-        let (observation, reason) = match stored_session.as_ref() {
-            Some(_) => (
+        let (observation, reason) = if stored_session_present {
+            (
                 mob_dsl::MemberLiveMaterializationObservationKind::DurableSnapshotPresent,
                 format!("live session materialization missing for '{bridge_session_id}'"),
-            ),
-            None => (
+            )
+        } else {
+            (
                 mob_dsl::MemberLiveMaterializationObservationKind::DurableSnapshotMissing,
                 format!("missing bridge session snapshot for '{bridge_session_id}'"),
-            ),
+            )
         };
 
         let transition = self.apply_dsl_signal_collect_transition(
@@ -4889,21 +4894,33 @@ impl MobActor {
                 })
             }
             mob_dsl::MemberRevivalVerdictKind::ReviveAuthorized => {
-                let Some(stored_session) = stored_session else {
-                    return Err(MobError::Internal(
-                        "MobMachine authorized member revival without a durable snapshot observation"
-                            .into(),
-                    ));
-                };
-                match self
-                    .materialize_revived_member_session(
-                        entry,
-                        member_ref,
-                        bridge_session_id,
-                        stored_session,
-                    )
+                // Full-load only now that the machine authorized exactly one
+                // materialization attempt. A snapshot that vanished between
+                // the metadata presence probe and this load resolves through
+                // the SAME machine-owned failure path as any other
+                // materialization error — the revival obligation is never
+                // left dangling.
+                let materialization = match self
+                    .session_service
+                    .load_persisted_session(bridge_session_id)
                     .await
                 {
+                    Ok(Some(stored_session)) => {
+                        self.materialize_revived_member_session(
+                            entry,
+                            member_ref,
+                            bridge_session_id,
+                            stored_session,
+                        )
+                        .await
+                    }
+                    Ok(None) => Err(MobError::Internal(format!(
+                        "durable snapshot for bridge session '{bridge_session_id}' vanished \
+                         between the metadata presence probe and revival materialization"
+                    ))),
+                    Err(error) => Err(MobError::SessionError(error)),
+                };
+                match materialization {
                     Ok(()) => {
                         self.apply_dsl_signal(
                             mob_dsl::MobMachineSignal::ResolveMemberRevivalSucceeded {

--- a/meerkat-mob/src/runtime/actor.rs
+++ b/meerkat-mob/src/runtime/actor.rs
@@ -129,10 +129,38 @@ struct SubmitWorkDispatchRequest {
     /// Deliverable on queue-mode turn-driven dispatch (local and remote);
     /// autonomous inbox delivery and steer dispatch reject it fail-closed.
     injected_context: Vec<ContentInput>,
+    /// Host-supplied interaction identity for the delivered turn. Stamped
+    /// into `RuntimeTurnMetadata.transcript_identity` on turn-driven
+    /// dispatch and onto the injected inbox event on autonomous dispatch,
+    /// so the committed transcript messages persist the id the host's live
+    /// interaction frames carry (mobkit ask-15 addendum).
+    interaction_id: Option<meerkat_core::interaction::InteractionId>,
     handling_mode: meerkat_core::types::HandlingMode,
     render_metadata: Option<meerkat_core::types::RenderMetadata>,
     ack_mode: crate::mob_machine::SubmitWorkAckMode,
     operation_id: Option<meerkat_core::ops::OperationId>,
+}
+
+/// Canonical turn-metadata carrier for submit-work delivery: render metadata
+/// and the host-supplied transcript interaction identity travel together;
+/// an empty pair stays `None` so metadata-less requests keep their shape.
+fn submit_work_turn_metadata(
+    render_metadata: Option<meerkat_core::types::RenderMetadata>,
+    interaction_id: Option<meerkat_core::interaction::InteractionId>,
+) -> Option<meerkat_core::lifecycle::run_primitive::RuntimeTurnMetadata> {
+    if render_metadata.is_none() && interaction_id.is_none() {
+        return None;
+    }
+    Some(
+        meerkat_core::lifecycle::run_primitive::RuntimeTurnMetadata {
+            render_metadata,
+            transcript_identity: meerkat_core::types::TranscriptMessageIdentity {
+                interaction_id,
+                run_id: None,
+            },
+            ..Default::default()
+        },
+    )
 }
 
 #[derive(Debug, Clone)]
@@ -17962,6 +17990,7 @@ impl MobActor {
             content,
             origin,
             injected_context,
+            interaction_id,
             handling_mode,
             render_metadata,
             ack_mode,
@@ -18167,6 +18196,7 @@ impl MobActor {
                 SubmitWorkDispatchRequest {
                     content,
                     injected_context,
+                    interaction_id,
                     handling_mode,
                     render_metadata,
                     ack_mode,
@@ -18284,6 +18314,8 @@ impl MobActor {
                     // Spawn kickoff is mob-internal coordination content; the
                     // injected-context slot belongs to the submit-work lane.
                     injected_context: Vec::new(),
+                    // Mob-internal kickoff carries no host interaction id.
+                    interaction_id: None,
                     handling_mode: meerkat_core::types::HandlingMode::Queue,
                     render_metadata: None,
                     ack_mode: crate::mob_machine::SubmitWorkAckMode::IngressAccepted,
@@ -18421,6 +18453,7 @@ impl MobActor {
         let SubmitWorkDispatchRequest {
             content,
             injected_context,
+            interaction_id,
             handling_mode,
             render_metadata,
             ack_mode,
@@ -18546,12 +18579,7 @@ impl MobActor {
                             handling_mode,
                             None,
                             Vec::new(),
-                            render_metadata.map(|render_metadata| {
-                                meerkat_core::lifecycle::run_primitive::RuntimeTurnMetadata {
-                                    render_metadata: Some(render_metadata),
-                                    ..Default::default()
-                                }
-                            }),
+                            submit_work_turn_metadata(render_metadata, interaction_id),
                         ),
                     };
                     return Ok(SubmitWorkDispatchCompletion::AwaitTurnAdmission {
@@ -18573,19 +18601,32 @@ impl MobActor {
                         capability: crate::error::MobMemberCapability::InteractionEventInjector,
                         context: "autonomous direct turn delivery",
                     })?;
-                injector
-                    .inject(
+                // A host-supplied interaction id rides the injected inbox
+                // event so the comms classification (and therefore the
+                // runtime transcript identity) carries the SAME id as the
+                // host's live interaction frames instead of minting a fresh
+                // unrelated one.
+                let inject_result = match interaction_id {
+                    Some(interaction_id) => injector.inject_with_interaction_id(
+                        interaction_id,
                         content,
                         meerkat_core::PlainEventSource::Rpc,
                         handling_mode,
                         render_metadata,
-                    )
-                    .map_err(|error| {
-                        MobError::Internal(format!(
-                            "autonomous dispatch inject failed for '{}': {}",
-                            entry.agent_identity, error
-                        ))
-                    })?;
+                    ),
+                    None => injector.inject(
+                        content,
+                        meerkat_core::PlainEventSource::Rpc,
+                        handling_mode,
+                        render_metadata,
+                    ),
+                };
+                inject_result.map_err(|error| {
+                    MobError::Internal(format!(
+                        "autonomous dispatch inject failed for '{}': {}",
+                        entry.agent_identity, error
+                    ))
+                })?;
                 Ok(SubmitWorkDispatchCompletion::Completed)
             }
             crate::MobRuntimeMode::TurnDriven => {
@@ -18623,12 +18664,7 @@ impl MobActor {
                         handling_mode,
                         None,
                         Vec::new(),
-                        render_metadata.map(|render_metadata| {
-                            meerkat_core::lifecycle::run_primitive::RuntimeTurnMetadata {
-                                render_metadata: Some(render_metadata),
-                                ..Default::default()
-                            }
-                        }),
+                        submit_work_turn_metadata(render_metadata, interaction_id),
                     ),
                 };
                 tracing::debug!(

--- a/meerkat-mob/src/runtime/actor.rs
+++ b/meerkat-mob/src/runtime/actor.rs
@@ -1003,6 +1003,9 @@ pub(super) struct PendingSpawn {
     /// Effective profile override from `SpawnTooling::Profile` resolution.
     /// Persisted in the roster so respawn/restore can use it.
     pub(super) effective_profile_override: Option<crate::profile::Profile>,
+    /// Per-spawn external-tool overlay carried to the finalize commit so the
+    /// actor retention map is updated in the same block as the roster insert.
+    pub(super) per_spawn_external_tools: Option<Arc<dyn AgentToolDispatcher>>,
     pub(super) authorized_profile_material: AuthorizedSpawnProfileMaterial,
     pub(super) continuity_intent: super::handle::SpawnContinuityIntent,
     pub(super) progress: Arc<std::sync::Mutex<PendingSpawnProgress>>,
@@ -1150,6 +1153,7 @@ struct SpawnFinalizeCtx {
     auto_wire_parent: bool,
     restore_wiring: Option<RestoreWiringPlan>,
     effective_profile_override: Option<crate::profile::Profile>,
+    per_spawn_external_tools: Option<Arc<dyn AgentToolDispatcher>>,
     authorized_profile_material: AuthorizedSpawnProfileMaterial,
     continuity_intent: super::handle::SpawnContinuityIntent,
 }
@@ -1282,6 +1286,15 @@ pub(super) struct MobActor {
     /// authority inside the actor.
     pub(super) phase_watch_tx: tokio::sync::watch::Sender<MobState>,
     pub(super) default_external_tools_provider: Option<crate::ExternalToolsProvider>,
+    /// Per-spawn external-tool overlays (`SpawnMemberSpec.external_tools`)
+    /// retained for the member's lifetime so machine-authorized revival
+    /// recomposes the same dispatcher stack the spawn used. Entries are
+    /// written only in the spawn/respawn commit path (provisioning failure
+    /// never inserts), replaced or cleared by respawn replacement semantics,
+    /// and removed at disposal. RwLock: `dispose_remove_from_roster` runs on
+    /// `&self`.
+    pub(super) per_spawn_external_tools:
+        tokio::sync::RwLock<BTreeMap<AgentIdentity, Arc<dyn AgentToolDispatcher>>>,
     pub(super) spawn_member_customizer: Option<Arc<dyn super::SpawnMemberCustomizer>>,
     pub(super) realm_profile_store: Option<Arc<dyn crate::store::RealmProfileStore>>,
     /// Typed composition binding for the `meerkat_mob_seam` composition
@@ -5032,7 +5045,15 @@ impl MobActor {
             &profile,
             "revive_member_profile_authority",
         )?;
-        let external_tools = self.external_tools_for_profile(&profile, None)?;
+        // Revival inputs must equal spawn-time inputs: recompose the retained
+        // per-spawn overlay alongside profile bundles and mob-default tools.
+        let per_spawn_overlay = self
+            .per_spawn_external_tools
+            .read()
+            .await
+            .get(&agent_identity)
+            .cloned();
+        let external_tools = self.external_tools_for_profile(&profile, per_spawn_overlay)?;
         let mut config = build::build_resumed_agent_config(build::BuildResumedAgentConfigParams {
             base: build::BuildAgentConfigParams {
                 mob_id: &self.definition.id,
@@ -9030,6 +9051,7 @@ impl MobActor {
                         owner_bridge_session_id.clone(),
                         auto_wire_parent,
                         effective_profile_override.clone(),
+                        per_spawn_external_tools.clone(),
                         authorized_profile_material.clone(),
                         continuity_intent.clone(),
                     ));
@@ -9120,6 +9142,7 @@ impl MobActor {
                         owner_bridge_session_id.clone(),
                         auto_wire_parent,
                         effective_profile_override.clone(),
+                        per_spawn_external_tools.clone(),
                         authorized_profile_material.clone(),
                         continuity_intent.clone(),
                     ));
@@ -9285,6 +9308,7 @@ impl MobActor {
                 owner_bridge_session_id.clone(),
                 auto_wire_parent,
                 effective_profile_override,
+                per_spawn_external_tools,
                 authorized_profile_material,
                 continuity_intent,
             ))
@@ -9304,6 +9328,7 @@ impl MobActor {
             spawn_owner_bridge_session_id,
             auto_wire_parent,
             effective_profile_override,
+            per_spawn_external_tools,
             authorized_profile_material,
             continuity_intent,
         ) = match prepare_result {
@@ -9375,6 +9400,7 @@ impl MobActor {
                 auto_wire_parent,
                 None,
                 effective_profile_override,
+                per_spawn_external_tools,
                 authorized_profile_material,
                 continuity_intent,
             ))
@@ -9462,6 +9488,7 @@ impl MobActor {
             auto_wire_parent,
             restore_wiring: None,
             effective_profile_override,
+            per_spawn_external_tools,
             authorized_profile_material,
             continuity_intent,
             progress: pending_progress.clone(),
@@ -9655,6 +9682,7 @@ impl MobActor {
                 auto_wire_parent,
                 restore_wiring,
                 effective_profile_override,
+                per_spawn_external_tools,
                 authorized_profile_material,
                 continuity_intent,
                 progress: _,
@@ -9721,6 +9749,7 @@ impl MobActor {
                             auto_wire_parent,
                             restore_wiring,
                             effective_profile_override,
+                            per_spawn_external_tools,
                             authorized_profile_material,
                             continuity_intent,
                         ))
@@ -9837,7 +9866,8 @@ impl MobActor {
             agent_identity,
         )?;
         let runtime_mode = normalize_runtime_mode_for_binding(runtime_mode, &selected_binding);
-        let external_tools = self.external_tools_for_profile(&profile, per_spawn_external_tools)?;
+        let external_tools =
+            self.external_tools_for_profile(&profile, per_spawn_external_tools.clone())?;
         let labels = labels.unwrap_or_default();
         let mut config = build::build_agent_config(build::BuildAgentConfigParams {
             mob_id: &self.definition.id,
@@ -9925,6 +9955,7 @@ impl MobActor {
             auto_wire_parent: false,
             restore_wiring: None,
             effective_profile_override: override_profile.clone(),
+            per_spawn_external_tools: per_spawn_external_tools.clone(),
             authorized_profile_material: authorized_profile_material.clone(),
             continuity_intent: continuity_intent.clone(),
             progress: Arc::new(std::sync::Mutex::new(PendingSpawnProgress::default())),
@@ -10018,6 +10049,7 @@ impl MobActor {
                 false,
                 None,
                 override_profile, // policy spawns usually use definition profiles; customizers may supply an override
+                per_spawn_external_tools,
                 authorized_profile_material,
                 continuity_intent,
             ))
@@ -10111,6 +10143,7 @@ impl MobActor {
         auto_wire_parent: bool,
         restore_wiring: Option<RestoreWiringPlan>,
         effective_profile_override: Option<crate::profile::Profile>,
+        per_spawn_external_tools: Option<Arc<dyn AgentToolDispatcher>>,
         authorized_profile_material: AuthorizedSpawnProfileMaterial,
         continuity_intent: super::handle::SpawnContinuityIntent,
     ) -> Result<FinalizeSpawnOutcome, MobError> {
@@ -10134,6 +10167,7 @@ impl MobActor {
             auto_wire_parent,
             restore_wiring,
             effective_profile_override,
+            per_spawn_external_tools,
             authorized_profile_material,
             continuity_intent,
         });
@@ -10375,6 +10409,10 @@ impl MobActor {
                     event.runtime_mode = runtime_mode;
                     event.labels = labels.clone();
                     event.continuity_intent = continuity_intent.clone();
+                    // Durable per-spawn declarative provenance: replay
+                    // repopulates RosterEntry.effective_profile_override so
+                    // restarts keep per-spawn tooling without a customizer.
+                    event.effective_profile_override = ctx.effective_profile_override.clone();
                     event
                 }),
             })
@@ -10467,6 +10505,7 @@ impl MobActor {
             auto_wire_parent,
             restore_wiring,
             effective_profile_override,
+            per_spawn_external_tools,
             authorized_profile_material: _,
             continuity_intent: _,
         } = *ctx;
@@ -10563,6 +10602,17 @@ impl MobActor {
                 labels: labels.clone(),
                 effective_profile_override: effective_profile_override.clone(),
             });
+        }
+        {
+            // Same commit as the roster insert: retain the per-spawn overlay
+            // so machine-authorized revival recomposes it. `None` clears any
+            // prior incarnation's overlay (respawn replacement semantics).
+            let mut per_spawn = self.per_spawn_external_tools.write().await;
+            if let Some(dispatcher) = per_spawn_external_tools {
+                per_spawn.insert(identity.clone(), dispatcher);
+            } else {
+                per_spawn.remove(&identity);
+            }
         }
 
         // Row #314: record the machine-owned external-member rebind capability
@@ -14627,7 +14677,7 @@ impl MobActor {
             "MobActor::handle_respawn authorized replacement profile material"
         );
         let external_tools =
-            self.external_tools_for_profile(&profile, replacement_external_tools)?;
+            self.external_tools_for_profile(&profile, replacement_external_tools.clone())?;
         let mut config = build::build_agent_config(build::BuildAgentConfigParams {
             mob_id: &self.definition.id,
             profile_name: &snapshot.profile_name,
@@ -14735,6 +14785,7 @@ impl MobActor {
                 || !snapshot.restore_wiring.external_peers.is_empty())
             .then_some(snapshot.restore_wiring.clone()),
             effective_profile_override: replacement_profile_override.clone(),
+            per_spawn_external_tools: replacement_external_tools.clone(),
             authorized_profile_material: replacement_authorized_profile_material.clone(),
             continuity_intent: replacement_continuity_intent.clone(),
             progress: Arc::new(std::sync::Mutex::new(PendingSpawnProgress::default())),
@@ -14904,6 +14955,7 @@ impl MobActor {
                         || !snapshot.restore_wiring.external_peers.is_empty())
                     .then_some(snapshot.restore_wiring.clone()),
                     replacement_profile_override,
+                    replacement_external_tools,
                     replacement_authorized_profile_material,
                     replacement_continuity_intent,
                 ))
@@ -15746,6 +15798,13 @@ impl MobActor {
         let mut roster = self.roster.write().await;
         roster.remove_member(&ctx.agent_identity);
         drop(roster);
+        // Disposal ends the member's lifetime: drop the retained per-spawn
+        // overlay so host dispatchers are released and a later spawn of the
+        // same identity cannot revive with a stale tool surface.
+        self.per_spawn_external_tools
+            .write()
+            .await
+            .remove(&ctx.agent_identity);
         self.restore_diagnostics
             .write()
             .await

--- a/meerkat-mob/src/runtime/builder.rs
+++ b/meerkat-mob/src/runtime/builder.rs
@@ -2419,6 +2419,7 @@ impl MobBuilder {
             wiring.dsl_authority.state().topology_epoch,
         ));
 
+        let mut per_spawn_external_tools_seed = BTreeMap::new();
         if resumed_state == MobState::Running {
             Self::reconcile_resume(
                 &definition,
@@ -2437,6 +2438,7 @@ impl MobBuilder {
                 &spawn_member_customizer,
                 storage.realm_profiles.clone(),
                 storage.runtime_metadata.clone(),
+                &mut per_spawn_external_tools_seed,
             )
             .await?;
         }
@@ -2471,6 +2473,7 @@ impl MobBuilder {
             default_external_tools_provider,
             spawn_member_customizer,
             storage.realm_profiles.clone(),
+            per_spawn_external_tools_seed,
             realtime_session_factory,
         ))
     }
@@ -2634,6 +2637,7 @@ impl MobBuilder {
         spawn_member_customizer: &Option<Arc<dyn super::SpawnMemberCustomizer>>,
         realm_profile_store: Option<Arc<dyn crate::store::RealmProfileStore>>,
         runtime_metadata: Arc<dyn crate::store::MobRuntimeMetadataStore>,
+        per_spawn_external_tools_seed: &mut BTreeMap<AgentIdentity, Arc<dyn AgentToolDispatcher>>,
     ) -> Result<(), MobError> {
         let pending_supervisor_accepted_peer_ids: std::collections::BTreeSet<String> =
             supervisor_bridge
@@ -2740,6 +2744,11 @@ impl MobBuilder {
                     "spawn customizer cannot change resume restore profile for '{}' from '{}' to '{}'",
                     entry.agent_identity, entry.role, restore_spec.role_name
                 )));
+            }
+            // Seed the actor's retention map so a later machine-authorized
+            // revival recomposes the customizer-supplied per-spawn overlay.
+            if let Some(tools) = restore_spec.external_tools.clone() {
+                per_spawn_external_tools_seed.insert(entry.agent_identity.clone(), tools);
             }
             let restore_profile_override = restore_spec.override_profile.clone();
             let restore_labels = restore_spec
@@ -3654,6 +3663,7 @@ impl MobBuilder {
             default_external_tools_provider,
             spawn_member_customizer,
             realm_profile_store,
+            BTreeMap::new(),
             realtime_session_factory,
         ))
     }
@@ -3673,6 +3683,7 @@ impl MobBuilder {
         default_external_tools_provider: Option<crate::ExternalToolsProvider>,
         spawn_member_customizer: Option<Arc<dyn super::SpawnMemberCustomizer>>,
         realm_profile_store: Option<Arc<dyn crate::store::RealmProfileStore>>,
+        per_spawn_external_tools: BTreeMap<AgentIdentity, Arc<dyn AgentToolDispatcher>>,
         realtime_session_factory: Option<Arc<dyn meerkat_client::RealtimeSessionFactory>>,
     ) -> MobHandle {
         let run_store = authority_validating_mob_run_store(run_store);
@@ -3817,6 +3828,7 @@ impl MobBuilder {
             machine_state_watch_tx,
             phase_watch_tx: phase_watch_tx_actor,
             default_external_tools_provider,
+            per_spawn_external_tools: tokio::sync::RwLock::new(per_spawn_external_tools),
             spawn_member_customizer,
             realm_profile_store,
             composition_binding,

--- a/meerkat-mob/src/runtime/builder.rs
+++ b/meerkat-mob/src/runtime/builder.rs
@@ -876,24 +876,27 @@ async fn latest_persisted_session_for_member(
         role.as_str(),
         agent_identity.as_str(),
     )?;
+
+    // Candidate matching runs over the metadata-only read seam: the member
+    // identity facts (typed binding, comms name) live on session metadata, so
+    // scanning the realm never materializes full transcripts.
     let mut best: Option<(
         meerkat_core::time_compat::SystemTime,
         meerkat_core::types::SessionId,
-        meerkat_core::Session,
     )> = None;
 
     for summary in listed_sessions {
         if &summary.session_id == missing_session_id {
             continue;
         }
-        let Some(session) = session_service
-            .load_persisted_session(&summary.session_id)
+        let Some(view) = session_service
+            .load_persisted_session_metadata(&summary.session_id)
             .await?
         else {
             continue;
         };
         if !persisted_session_matches_member(
-            &session,
+            view.session_metadata.as_ref(),
             mob_id,
             role,
             agent_identity,
@@ -903,23 +906,33 @@ async fn latest_persisted_session_for_member(
         }
         let replace = best
             .as_ref()
-            .is_none_or(|(updated_at, _, _)| summary.updated_at > *updated_at);
+            .is_none_or(|(updated_at, _)| summary.updated_at > *updated_at);
         if replace {
-            best = Some((summary.updated_at, summary.session_id.clone(), session));
+            best = Some((summary.updated_at, summary.session_id.clone()));
         }
     }
 
-    Ok(best.map(|(_, session_id, session)| (session_id, session)))
+    let Some((_, winner_session_id)) = best else {
+        return Ok(None);
+    };
+    // Full-load ONLY the winner. A winner that vanishes between the metadata
+    // match and the full load reads as "no replacement" (`Ok(None)`) — the
+    // caller records the member's restore failure exactly as if no candidate
+    // had matched.
+    Ok(session_service
+        .load_persisted_session(&winner_session_id)
+        .await?
+        .map(|session| (winner_session_id, session)))
 }
 
 fn persisted_session_matches_member(
-    session: &meerkat_core::Session,
+    metadata: Option<&meerkat_core::SessionMetadata>,
     mob_id: &crate::ids::MobId,
     role: &crate::ids::ProfileName,
     agent_identity: &crate::ids::AgentIdentity,
     canonical_comms_name: &str,
 ) -> bool {
-    let Some(metadata) = session.session_metadata() else {
+    let Some(metadata) = metadata else {
         return false;
     };
     if metadata.mob_member_binding.as_ref().is_some_and(|binding| {

--- a/meerkat-mob/src/runtime/handle.rs
+++ b/meerkat-mob/src/runtime/handle.rs
@@ -1898,7 +1898,11 @@ pub struct SpawnMemberSpec {
     /// provide binding authority; build paths that require a binding must reject
     /// the spawn instead of promoting an ambient fallback.
     pub auth_binding: Option<meerkat_core::AuthBindingRef>,
-    /// Per-spawn external tool overlay. In-process only and not persisted.
+    /// Per-spawn external tool overlay. In-process only; retained by the mob
+    /// actor for the member's lifetime so machine-authorized revival
+    /// recomposes it (replaced or cleared by respawn replacement semantics,
+    /// dropped at retire). Not persisted: re-supply across process restarts
+    /// via `SpawnMemberCustomizer` (`SpawnSource::Resume`).
     pub external_tools: Option<Arc<dyn AgentToolDispatcher>>,
     /// Typed prompt replacement for this spawn.
     pub system_prompt_override: Option<SpawnSystemPromptOverride>,

--- a/meerkat-mob/src/runtime/handle.rs
+++ b/meerkat-mob/src/runtime/handle.rs
@@ -2472,6 +2472,7 @@ impl MobHandle {
                     content: spec.content,
                     origin: spec.origin,
                     injected_context: spec.injected_context,
+                    interaction_id: spec.interaction_id,
                     handling_mode,
                     render_metadata,
                     ack_mode,

--- a/meerkat-mob/src/runtime/session_service.rs
+++ b/meerkat-mob/src/runtime/session_service.rs
@@ -272,6 +272,35 @@ pub trait MobSessionService:
         Ok(None)
     }
 
+    /// Load the persisted session METADATA view when available.
+    ///
+    /// Metadata-only sibling of [`Self::load_persisted_session`] (mobkit
+    /// ask-24 clause 3): ownership routing, policy resolution, and presence
+    /// probes that only need session-authority metadata facts must not force
+    /// a full transcript materialization. Visibility parity with
+    /// `load_persisted_session` is part of the contract: whenever that method
+    /// returns `Ok(None)` (absent or archived), this one does too.
+    ///
+    /// Default: derives from `load_persisted_session`, so every backend
+    /// exposes the seam with identical visibility. Persistent services
+    /// override this with the metadata-only authoritative read. Corrupt
+    /// durable metadata is a read FAULT (`Err`), never `Ok(None)`.
+    async fn load_persisted_session_metadata(
+        &self,
+        session_id: &SessionId,
+    ) -> Result<Option<meerkat_core::PersistedSessionMetadataView>, SessionError> {
+        let Some(session) = self.load_persisted_session(session_id).await? else {
+            return Ok(None);
+        };
+        meerkat_core::PersistedSessionMetadataView::try_from_session(&session)
+            .map(Some)
+            .map_err(|err| {
+                SessionError::Agent(meerkat_core::error::AgentError::InternalError(format!(
+                    "session {session_id} durable metadata failed typed restore: {err}"
+                )))
+            })
+    }
+
     /// Archive a mob-owned session through the strongest lifecycle authority
     /// this service exposes. Runtime-backed persistent services override this
     /// to require a concrete `MeerkatMachine` archive protocol before writing
@@ -715,6 +744,30 @@ where
             return Ok(None);
         }
         Ok(Some(session))
+    }
+
+    /// Metadata-only authoritative read. Same visibility contract as
+    /// [`Self::load_persisted_session`] — the archived filter runs through
+    /// `session_archived_by_authority_with_terminal`, the terminal-fact
+    /// sibling of the full-session overload, so archived sessions read as
+    /// `None` on both seams.
+    async fn load_persisted_session_metadata(
+        &self,
+        session_id: &SessionId,
+    ) -> Result<Option<meerkat_core::PersistedSessionMetadataView>, SessionError> {
+        let Some(view) = self.load_authoritative_session_metadata(session_id).await? else {
+            return Ok(None);
+        };
+        if self
+            .session_archived_by_authority_with_terminal(
+                session_id,
+                view.lifecycle_terminal.as_ref(),
+            )
+            .await?
+        {
+            return Ok(None);
+        }
+        Ok(Some(view))
     }
 
     async fn session_known_to_archive_authority(

--- a/meerkat-mob/src/runtime/state.rs
+++ b/meerkat-mob/src/runtime/state.rs
@@ -256,6 +256,11 @@ pub(super) struct SubmitWorkPayload {
     /// dispatch carrier only — the MobMachine DSL admits identity facts
     /// (runtime id, fence, work id, origin), never content payloads.
     pub injected_context: Vec<ContentInput>,
+    /// Host-supplied interaction identity riding with the work content.
+    /// Shell dispatch carrier only (content-adjacent metadata, like
+    /// `render_metadata`); stamped into the turn's transcript identity at
+    /// delivery so the committed transcript joins the host's live frames.
+    pub interaction_id: Option<meerkat_core::interaction::InteractionId>,
     pub handling_mode: meerkat_core::types::HandlingMode,
     pub render_metadata: Option<meerkat_core::types::RenderMetadata>,
     pub ack_mode: crate::mob_machine::SubmitWorkAckMode,

--- a/meerkat-mob/src/runtime/tests.rs
+++ b/meerkat-mob/src/runtime/tests.rs
@@ -1265,6 +1265,17 @@ struct MockSessionService {
     /// from the request's active lowering carrier (typed appends in runtime
     /// mode, the `injected_context` field + prompt in direct mode).
     start_turn_user_channel: RwLock<Vec<(SessionId, Vec<(bool, String)>)>>,
+    /// Per turn request: the typed runtime turn metadata carrier, so tests
+    /// can assert transcript identity stamping on the delivery path.
+    start_turn_metadata: RwLock<
+        Vec<(
+            SessionId,
+            Option<meerkat_core::lifecycle::run_primitive::RuntimeTurnMetadata>,
+        )>,
+    >,
+    /// Interaction ids received through the SubscribableInjector's
+    /// caller-chosen-id entry point (autonomous submit-work delivery).
+    injected_interaction_ids: Arc<std::sync::Mutex<Vec<InteractionId>>>,
     keep_alive_prompts: RwLock<Vec<(SessionId, String)>>,
     interrupt_calls: AtomicU64,
     cancel_after_boundary_supported: AtomicBool,
@@ -1333,6 +1344,8 @@ impl MockSessionService {
             keep_alive_turns_complete_immediately: std::sync::atomic::AtomicBool::new(false),
             start_turn_prompts: RwLock::new(Vec::new()),
             start_turn_user_channel: RwLock::new(Vec::new()),
+            start_turn_metadata: RwLock::new(Vec::new()),
+            injected_interaction_ids: Arc::new(std::sync::Mutex::new(Vec::new())),
             keep_alive_prompts: RwLock::new(Vec::new()),
             interrupt_calls: AtomicU64::new(0),
             cancel_after_boundary_supported: AtomicBool::new(true),
@@ -1448,6 +1461,22 @@ impl MockSessionService {
 
     async fn recorded_start_turn_user_channel(&self) -> Vec<(SessionId, Vec<(bool, String)>)> {
         self.start_turn_user_channel.read().await.clone()
+    }
+
+    async fn recorded_start_turn_metadata(
+        &self,
+    ) -> Vec<(
+        SessionId,
+        Option<meerkat_core::lifecycle::run_primitive::RuntimeTurnMetadata>,
+    )> {
+        self.start_turn_metadata.read().await.clone()
+    }
+
+    fn recorded_injected_interaction_ids(&self) -> Vec<InteractionId> {
+        self.injected_interaction_ids
+            .lock()
+            .expect("injected interaction id mutex")
+            .clone()
     }
 
     async fn recorded_external_tools_flags(&self) -> Vec<bool> {
@@ -2138,6 +2167,10 @@ impl SessionService for MockSessionService {
             .write()
             .await
             .push((id.clone(), user_channel));
+        self.start_turn_metadata
+            .write()
+            .await
+            .push((id.clone(), req.runtime.turn_metadata.clone()));
         // Determine keep-alive by checking if a notifier was registered for this session
         // (created in create_session when build.keep_alive is true).
         let is_keep_alive = self.keep_alive_notifiers.read().await.contains_key(id);
@@ -2456,6 +2489,7 @@ struct CountingInjector {
     fail: bool,
     fail_inject: bool,
     completed_result: String,
+    interaction_ids: Arc<std::sync::Mutex<Vec<InteractionId>>>,
 }
 
 impl EventInjector for CountingInjector {
@@ -2523,6 +2557,22 @@ impl SubscribableInjector for CountingInjector {
             events: rx,
         })
     }
+
+    fn inject_with_interaction_id(
+        &self,
+        interaction_id: InteractionId,
+        body: meerkat_core::types::ContentInput,
+        source: PlainEventSource,
+        handling_mode: meerkat_core::types::HandlingMode,
+        render_metadata: Option<meerkat_core::types::RenderMetadata>,
+    ) -> Result<(), EventInjectorError> {
+        self.inject(body, source, handling_mode, render_metadata)?;
+        self.interaction_ids
+            .lock()
+            .expect("interaction id mutex")
+            .push(interaction_id);
+        Ok(())
+    }
 }
 
 #[async_trait]
@@ -2571,6 +2621,7 @@ impl SessionServiceCommsExt for MockSessionService {
             fail,
             fail_inject,
             completed_result,
+            interaction_ids: self.injected_interaction_ids.clone(),
         }))
     }
 
@@ -2612,6 +2663,7 @@ impl SessionServiceCommsExt for MockSessionService {
             fail,
             fail_inject,
             completed_result,
+            interaction_ids: self.injected_interaction_ids.clone(),
         }))
     }
 }
@@ -33235,6 +33287,109 @@ async fn test_turn_driven_submit_work_delivers_injected_context_before_work_cont
         ],
         "injected context must reach the member turn request as typed \
          injected-context entries before the work content, in order"
+    );
+}
+
+/// Ask-15 addendum (turn-driven): a host-supplied `WorkSpec.interaction_id`
+/// is stamped into the delivered turn's
+/// `RuntimeTurnMetadata.transcript_identity`, so the runner persists it onto
+/// the committed transcript messages and history backfill can join them with
+/// the host's live interaction frames.
+#[tokio::test]
+async fn test_turn_driven_submit_work_interaction_id_stamps_transcript_identity() {
+    let (handle, service) = create_test_mob(sample_definition()).await;
+    let member_id = AgentIdentity::from("worker-interaction-id");
+    handle
+        .spawn_with_options(
+            ProfileName::from("worker"),
+            member_id.clone(),
+            None,
+            Some(crate::MobRuntimeMode::TurnDriven),
+            None,
+        )
+        .await
+        .expect("spawn turn-driven worker");
+    let entry = handle
+        .get_member(&member_id)
+        .await
+        .unwrap()
+        .expect("member exists");
+
+    let interaction_id = InteractionId(uuid::Uuid::new_v4());
+    handle
+        .submit_work(
+            entry.agent_runtime_id.clone(),
+            entry.fence_token,
+            WorkRef::new(),
+            WorkSpec::new("summarize the findings".to_string(), WorkOrigin::Internal)
+                .with_interaction_id(interaction_id),
+        )
+        .await
+        .expect("submit work with interaction id");
+
+    wait_for_start_turn_call_count(
+        &service,
+        1,
+        "turn-driven work with an interaction id should start a turn",
+    )
+    .await;
+
+    let records = service.recorded_start_turn_metadata().await;
+    let (_, metadata) = records.last().expect("one turn request recorded");
+    let metadata = metadata
+        .as_ref()
+        .expect("submit-work delivery must carry runtime turn metadata");
+    assert_eq!(
+        metadata.transcript_identity.interaction_id,
+        Some(interaction_id),
+        "the host-supplied interaction id must ride the turn's transcript identity"
+    );
+    assert_eq!(
+        metadata.transcript_identity.run_id, None,
+        "the concrete run id is stamped later by the runner, not the work lane"
+    );
+}
+
+/// Ask-15 addendum (autonomous): a host-supplied `WorkSpec.interaction_id`
+/// rides the injected inbox event, so the comms classification (and the
+/// runtime transcript identity derived from it) carries the SAME id as the
+/// host's live interaction frames instead of a fresh unrelated one.
+#[tokio::test]
+async fn test_autonomous_submit_work_interaction_id_reaches_inbox_injection() {
+    let (handle, service) = create_test_mob(sample_definition()).await;
+    let member_id = AgentIdentity::from("lead-interaction-id");
+    handle
+        .spawn_with_options(
+            ProfileName::from("lead"),
+            member_id.clone(),
+            None,
+            Some(crate::MobRuntimeMode::AutonomousHost),
+            None,
+        )
+        .await
+        .expect("spawn autonomous lead");
+    let entry = handle
+        .get_member(&member_id)
+        .await
+        .unwrap()
+        .expect("member exists");
+
+    let interaction_id = InteractionId(uuid::Uuid::new_v4());
+    handle
+        .submit_work(
+            entry.agent_runtime_id.clone(),
+            entry.fence_token,
+            WorkRef::new(),
+            WorkSpec::new("do the thing".to_string(), WorkOrigin::External)
+                .with_interaction_id(interaction_id),
+        )
+        .await
+        .expect("submit keyed autonomous work");
+
+    assert_eq!(
+        service.recorded_injected_interaction_ids(),
+        vec![interaction_id],
+        "the autonomous inbox delivery must carry the host-supplied interaction id"
     );
 }
 

--- a/meerkat-mob/src/runtime/tests.rs
+++ b/meerkat-mob/src/runtime/tests.rs
@@ -1218,6 +1218,9 @@ struct MockSessionService {
     create_requests: RwLock<Vec<CreateSessionRecord>>,
     /// Records whether each create_session had external_tools configured.
     create_with_external_tools: RwLock<Vec<bool>>,
+    /// Records the declarative MCP server names per create_session call,
+    /// in call order.
+    mcp_server_names: RwLock<Vec<(SessionId, Vec<String>)>>,
     /// External tool dispatcher captured per session.
     external_tools_by_session: RwLock<HashMap<SessionId, Arc<dyn AgentToolDispatcher>>>,
     /// Optional per-comms-name behavior overrides.
@@ -1313,6 +1316,7 @@ impl MockSessionService {
             prompts: RwLock::new(Vec::new()),
             create_requests: RwLock::new(Vec::new()),
             create_with_external_tools: RwLock::new(Vec::new()),
+            mcp_server_names: RwLock::new(Vec::new()),
             external_tools_by_session: RwLock::new(HashMap::new()),
             comms_behaviors: RwLock::new(HashMap::new()),
             missing_comms_sessions: RwLock::new(HashSet::new()),
@@ -1452,6 +1456,10 @@ impl MockSessionService {
 
     async fn recorded_external_tools_flags(&self) -> Vec<bool> {
         self.create_with_external_tools.read().await.clone()
+    }
+
+    async fn recorded_mcp_server_names(&self) -> Vec<(SessionId, Vec<String>)> {
+        self.mcp_server_names.read().await.clone()
     }
 
     async fn external_tool_names(&self, session_id: &SessionId) -> Vec<String> {
@@ -2060,6 +2068,22 @@ impl SessionService for MockSessionService {
                     .as_ref()
                     .and_then(|build| build.budget_limits.clone()),
             });
+
+        let mcp_server_names: Vec<String> = req
+            .build
+            .as_ref()
+            .map(|build| {
+                build
+                    .mcp_servers
+                    .iter()
+                    .map(|server| server.name.clone())
+                    .collect()
+            })
+            .unwrap_or_default();
+        self.mcp_server_names
+            .write()
+            .await
+            .push((session_id.clone(), mcp_server_names));
 
         // Record the prompt for test inspection
         self.prompts
@@ -36981,6 +37005,341 @@ async fn test_per_spawn_external_tools_are_not_restored_from_storage() {
         flags.last().copied(),
         Some(false),
         "per-spawn trait-object dispatchers must be supplied again by the upper layer on restore"
+    );
+}
+
+fn sample_definition_with_turn_driven_worker() -> MobDefinition {
+    let mut definition = sample_definition();
+    definition
+        .profiles
+        .get_mut(&ProfileName::from("worker"))
+        .expect("worker profile")
+        .as_inline_mut()
+        .expect("worker profile should be inline")
+        .runtime_mode = crate::MobRuntimeMode::TurnDriven;
+    definition
+}
+
+/// M2 Wave-1 regression (D1): the per-spawn external-tools overlay must be
+/// retained by the actor and recomposed when machine-authorized revival
+/// rebuilds a discarded live session. Before the retention map,
+/// `materialize_revived_member_session` passed `None` to
+/// `external_tools_for_profile` and revived members silently lost their
+/// per-spawn tools.
+#[tokio::test]
+async fn test_revival_recomposes_per_spawn_external_tools_overlay() {
+    let (handle, service) = create_test_mob(sample_definition_with_turn_driven_worker()).await;
+
+    let mut spec = SpawnMemberSpec::new("worker", "w-1");
+    spec.external_tools = Some(Arc::new(MultiToolDispatcher::new(&["per_spawn_probe"])));
+    let spawned = handle.spawn_spec(spec).await.expect("spawn worker");
+    let bridge_session_id = handle
+        .resolve_bridge_session_id(&spawned.agent_identity)
+        .await
+        .expect("bridge session id");
+    assert!(
+        service
+            .external_tool_names(&bridge_session_id)
+            .await
+            .contains(&"per_spawn_probe".to_string()),
+        "sanity: the original create must expose the per-spawn overlay"
+    );
+
+    MobSessionService::discard_live_session(service.as_ref(), &bridge_session_id)
+        .await
+        .expect("discard live session");
+
+    handle
+        .member(&AgentIdentity::from("w-1"))
+        .await
+        .expect("member handle")
+        .internal_turn(ContentInput::from("come back online".to_string()))
+        .await
+        .expect("machine-authorized revival must rebuild the live session");
+
+    let revived_tool_names = service.external_tool_names(&bridge_session_id).await;
+    assert!(
+        revived_tool_names.contains(&"per_spawn_probe".to_string()),
+        "revival must recompose the retained per-spawn overlay: {revived_tool_names:?}"
+    );
+}
+
+/// M2 Wave-2 regression (D2): per-spawn declarative tooling carried on
+/// `SpawnMemberSpec.override_profile` must survive a cold process restart
+/// WITHOUT a `SpawnMemberCustomizer`. Before `MemberSpawnedEvent` carried
+/// `effective_profile_override`, roster replay projected `None` and the
+/// restore rebuilt the member from the definition profile, silently dropping
+/// per-spawn MCP servers.
+#[tokio::test]
+async fn test_cold_restart_restores_per_spawn_profile_override_without_customizer() {
+    let definition = sample_definition();
+    let mut override_profile = definition
+        .profiles
+        .get(&ProfileName::from("worker"))
+        .expect("worker profile")
+        .as_inline()
+        .expect("worker profile should be inline")
+        .clone();
+    override_profile.tools.mcp_servers = vec![meerkat_core::mcp_config::McpServerConfig::stdio(
+        "planner",
+        "/bin/echo",
+        vec![],
+        HashMap::new(),
+    )];
+
+    let service = Arc::new(MockSessionService::new());
+    let _ = service.enable_runtime_adapter();
+    let storage = MobStorage::in_memory();
+    let events = storage.events.clone();
+    let runtime_metadata = storage.runtime_metadata.clone();
+    let handle = MobBuilder::new(definition, storage)
+        .with_session_service(service.clone())
+        .create()
+        .await
+        .expect("create mob");
+
+    let mut spec = SpawnMemberSpec::new("worker", "w-override");
+    spec.override_profile = Some(override_profile);
+    let spawned = handle
+        .spawn_spec(spec)
+        .await
+        .expect("spawn override worker");
+    let old_session_id = handle
+        .resolve_bridge_session_id(&spawned.agent_identity)
+        .await
+        .expect("bridge session id");
+
+    handle.stop().await.expect("stop");
+    MobSessionService::discard_live_session(service.as_ref(), &old_session_id)
+        .await
+        .expect("discard live session");
+
+    // Cold restart: rebuild the mob from durable storage with NO customizer.
+    let resumed = MobBuilder::for_resume(MobStorage::with_events_and_runtime_metadata(
+        events,
+        runtime_metadata,
+    ))
+    .with_session_service(service.clone())
+    .resume()
+    .await
+    .expect("resume");
+
+    let entry = resumed
+        .get_member(&AgentIdentity::from("w-override"))
+        .await
+        .expect("get member")
+        .expect("restored member");
+    let restored_override = entry
+        .effective_profile_override
+        .expect("replayed MemberSpawned must repopulate effective_profile_override");
+    assert_eq!(restored_override.tools.mcp_servers.len(), 1);
+    assert_eq!(restored_override.tools.mcp_servers[0].name, "planner");
+
+    let mcp_creates = service.recorded_mcp_server_names().await;
+    let (_, last_names) = mcp_creates
+        .last()
+        .expect("restore must re-create the member session");
+    assert!(
+        last_names.contains(&"planner".to_string()),
+        "restored member build must carry the per-spawn declarative MCP servers: {mcp_creates:?}"
+    );
+}
+
+struct RespawnOverlayCustomizer;
+
+impl SpawnMemberCustomizer for RespawnOverlayCustomizer {
+    fn customize_spawn(
+        &self,
+        ctx: &SpawnCustomizationContext,
+        spec: &mut SpawnMemberSpec,
+    ) -> Result<(), MobError> {
+        if ctx.spawn_source == SpawnSource::Respawn {
+            spec.external_tools = Some(Arc::new(MultiToolDispatcher::new(&["respawn_tool"])));
+        }
+        Ok(())
+    }
+}
+
+/// Respawn replacement semantics for the retention map: the replacement
+/// spawn's overlay replaces the retired incarnation's entry, so a later
+/// machine-authorized revival composes the replacement tools, not the
+/// original spawn's.
+#[tokio::test]
+async fn test_respawn_replaces_retained_per_spawn_external_tools_for_revival() {
+    let service = Arc::new(MockSessionService::new());
+    let _ = service.enable_runtime_adapter();
+    let handle = MobBuilder::new(
+        sample_definition_with_turn_driven_worker(),
+        MobStorage::in_memory(),
+    )
+    .with_session_service(service.clone())
+    .with_spawn_member_customizer(Arc::new(RespawnOverlayCustomizer))
+    .create()
+    .await
+    .expect("create mob");
+
+    let mut spec = SpawnMemberSpec::new("worker", "w-1");
+    spec.external_tools = Some(Arc::new(MultiToolDispatcher::new(&["tool_a"])));
+    handle.spawn_spec(spec).await.expect("spawn worker");
+
+    handle
+        .respawn(AgentIdentity::from("w-1"), None)
+        .await
+        .expect("respawn worker");
+    let respawn_session_id = handle
+        .resolve_bridge_session_id(&AgentIdentity::from("w-1"))
+        .await
+        .expect("respawn bridge session");
+
+    MobSessionService::discard_live_session(service.as_ref(), &respawn_session_id)
+        .await
+        .expect("discard live session");
+    handle
+        .member(&AgentIdentity::from("w-1"))
+        .await
+        .expect("member handle")
+        .internal_turn(ContentInput::from("revive replacement".to_string()))
+        .await
+        .expect("revival after respawn");
+
+    let revived_tool_names = service.external_tool_names(&respawn_session_id).await;
+    assert!(
+        revived_tool_names.contains(&"respawn_tool".to_string()),
+        "revival after respawn must compose the replacement overlay: {revived_tool_names:?}"
+    );
+    assert!(
+        !revived_tool_names.contains(&"tool_a".to_string()),
+        "the retired incarnation's overlay must not leak into the replacement's revival: {revived_tool_names:?}"
+    );
+}
+
+/// Retention cleanup / no leak: the old incarnation's disposal
+/// (`dispose_remove_from_roster`) drops the retained overlay, and a
+/// replacement spawned WITHOUT external_tools keeps it absent (`None` =
+/// replacement semantics), so the new incarnation revives without the old
+/// tool. Direct fresh spawn of a retired identity is machine-rejected for
+/// the live actor (`identity_to_runtime` tombstones retired identities;
+/// only recovery replay clears them), so respawn is the live-path
+/// identity-reuse route this guards.
+#[tokio::test]
+async fn test_respawn_without_replacement_overlay_clears_retained_per_spawn_tools() {
+    let (handle, service) = create_test_mob(sample_definition_with_turn_driven_worker()).await;
+
+    let mut spec = SpawnMemberSpec::new("worker", "w-1");
+    spec.external_tools = Some(Arc::new(MultiToolDispatcher::new(&["stale_tool"])));
+    handle.spawn_spec(spec).await.expect("spawn worker");
+
+    handle
+        .respawn(AgentIdentity::from("w-1"), None)
+        .await
+        .expect("respawn worker without a replacement overlay");
+    let respawn_session_id = handle
+        .resolve_bridge_session_id(&AgentIdentity::from("w-1"))
+        .await
+        .expect("respawn bridge session");
+
+    MobSessionService::discard_live_session(service.as_ref(), &respawn_session_id)
+        .await
+        .expect("discard live session");
+    handle
+        .member(&AgentIdentity::from("w-1"))
+        .await
+        .expect("member handle")
+        .internal_turn(ContentInput::from("revive fresh incarnation".to_string()))
+        .await
+        .expect("revival of fresh incarnation");
+
+    let revived_tool_names = service.external_tool_names(&respawn_session_id).await;
+    assert!(
+        !revived_tool_names.contains(&"stale_tool".to_string()),
+        "disposal must drop the retained overlay; the fresh incarnation revives clean: {revived_tool_names:?}"
+    );
+}
+
+struct ResumeOverlayCustomizer;
+
+impl SpawnMemberCustomizer for ResumeOverlayCustomizer {
+    fn customize_spawn(
+        &self,
+        ctx: &SpawnCustomizationContext,
+        spec: &mut SpawnMemberSpec,
+    ) -> Result<(), MobError> {
+        if ctx.spawn_source == SpawnSource::Resume {
+            spec.external_tools = Some(Arc::new(MultiToolDispatcher::new(&[
+                "customizer_resume_probe",
+            ])));
+        }
+        Ok(())
+    }
+}
+
+/// Restore-seeded retention: tools attached by a `SpawnMemberCustomizer` at
+/// `SpawnSource::Resume` seed the actor's retention map, so a later
+/// machine-authorized revival in the restored incarnation recomposes them
+/// (guards the reconcile_resume -> MobActor construction seeding).
+#[tokio::test]
+async fn test_restore_seeded_per_spawn_tools_survive_machine_authorized_revival() {
+    let service = Arc::new(MockSessionService::new());
+    let _ = service.enable_runtime_adapter();
+    let storage = MobStorage::in_memory();
+    let events = storage.events.clone();
+    let runtime_metadata = storage.runtime_metadata.clone();
+    let handle = MobBuilder::new(sample_definition_with_turn_driven_worker(), storage)
+        .with_session_service(service.clone())
+        .create()
+        .await
+        .expect("create mob");
+    let spawned = handle
+        .spawn_spec(SpawnMemberSpec::new("worker", "w-1"))
+        .await
+        .expect("spawn worker");
+    let old_session_id = handle
+        .resolve_bridge_session_id(&spawned.agent_identity)
+        .await
+        .expect("bridge session id");
+
+    handle.stop().await.expect("stop");
+    MobSessionService::discard_live_session(service.as_ref(), &old_session_id)
+        .await
+        .expect("discard live session");
+
+    let resumed = MobBuilder::for_resume(MobStorage::with_events_and_runtime_metadata(
+        events,
+        runtime_metadata,
+    ))
+    .with_session_service(service.clone())
+    .with_spawn_member_customizer(Arc::new(ResumeOverlayCustomizer))
+    .resume()
+    .await
+    .expect("resume");
+
+    let restored_session_id = resumed
+        .resolve_bridge_session_id(&AgentIdentity::from("w-1"))
+        .await
+        .expect("restored bridge session");
+    assert!(
+        service
+            .external_tool_names(&restored_session_id)
+            .await
+            .contains(&"customizer_resume_probe".to_string()),
+        "sanity: the restore build must compose the customizer overlay"
+    );
+
+    MobSessionService::discard_live_session(service.as_ref(), &restored_session_id)
+        .await
+        .expect("discard restored live session");
+    resumed
+        .member(&AgentIdentity::from("w-1"))
+        .await
+        .expect("member handle")
+        .internal_turn(ContentInput::from("revive restored member".to_string()))
+        .await
+        .expect("revival after restore");
+
+    let revived_tool_names = service.external_tool_names(&restored_session_id).await;
+    assert!(
+        revived_tool_names.contains(&"customizer_resume_probe".to_string()),
+        "customizer-restored tools must survive machine-authorized revival: {revived_tool_names:?}"
     );
 }
 

--- a/meerkat-runtime/src/driver/ephemeral.rs
+++ b/meerkat-runtime/src/driver/ephemeral.rs
@@ -3477,6 +3477,9 @@ impl crate::traits::RuntimeDriver for EphemeralRuntimeDriver {
     fn stored_input_state(&self, input_id: &InputId) -> Option<StoredInputState> {
         EphemeralRuntimeDriver::stored_input_state(self, input_id)
     }
+    fn stored_input_states_snapshot(&self) -> Result<Vec<StoredInputState>, RuntimeDriverError> {
+        EphemeralRuntimeDriver::stored_input_states_snapshot(self)
+    }
     fn input_id_for_idempotency_key(&self, idempotency_key: &str) -> Option<InputId> {
         EphemeralRuntimeDriver::input_id_for_idempotency_key(self, idempotency_key)
     }

--- a/meerkat-runtime/src/driver/persistent.rs
+++ b/meerkat-runtime/src/driver/persistent.rs
@@ -949,6 +949,10 @@ impl RuntimeDriver for PersistentRuntimeDriver {
         self.inner.stored_input_state(input_id)
     }
 
+    fn stored_input_states_snapshot(&self) -> Result<Vec<StoredInputState>, RuntimeDriverError> {
+        self.inner.stored_input_states_snapshot()
+    }
+
     fn input_id_for_idempotency_key(&self, idempotency_key: &str) -> Option<InputId> {
         self.inner.input_id_for_idempotency_key(idempotency_key)
     }

--- a/meerkat-runtime/src/input.rs
+++ b/meerkat-runtime/src/input.rs
@@ -753,6 +753,49 @@ fn peer_display_label(peer: &PeerInput) -> Option<String> {
         .map(ToOwned::to_owned)
 }
 
+/// Mint the typed peer-reply capability for a runtime input, when one exists.
+///
+/// Only peer *message* deliveries — the [`InputKind::PeerMessage`] grouping
+/// (`PeerConvention::Message` or a bare peer input) — mint a reply capability.
+/// Request/response conventions have their own correlated reply channel
+/// (`send_response`) and mint none. A peer input whose origin `peer_id` is not
+/// a canonical [`meerkat_core::comms::PeerId`] cannot mint a routable
+/// capability: that is a producer bug, logged loudly and dropped rather than
+/// smuggled into the tool seam. A delivery without a stamped correlation id
+/// (the comms bridge stamps one on every classified peer ingress) carries no
+/// reply selector and mints none.
+pub(crate) fn peer_reply_capability(
+    input: &Input,
+) -> Option<meerkat_core::comms::PeerReplyCapability> {
+    if input.kind() != InputKind::PeerMessage {
+        return None;
+    }
+    let Input::Peer(peer) = input else {
+        return None;
+    };
+    let InputOrigin::Peer { peer_id, .. } = &peer.header.source else {
+        return None;
+    };
+    let peer_id = match meerkat_core::comms::PeerId::parse(peer_id) {
+        Ok(peer_id) => peer_id,
+        Err(error) => {
+            tracing::error!(
+                peer_id,
+                error = %error,
+                "dropping peer reply capability with non-canonical peer_id"
+            );
+            return None;
+        }
+    };
+    let correlation_id = peer.header.correlation_id.as_ref()?;
+    Some(meerkat_core::comms::PeerReplyCapability {
+        in_reply_to: meerkat_core::InteractionId(correlation_id.0),
+        peer_id,
+        display_name: peer_display_label(peer),
+        kind: meerkat_core::comms::PeerReplyDeliveryKind::Message,
+    })
+}
+
 /// Rendered prompt-text projection for a peer input.
 pub(crate) fn peer_prompt_text(peer: &PeerInput) -> String {
     peer_projection_from_peer_input(peer)
@@ -1349,6 +1392,121 @@ mod tests {
         assert_eq!(json["input_type"], "peer");
         let parsed: Input = serde_json::from_value(json).unwrap();
         assert!(matches!(parsed, Input::Peer(_)));
+    }
+
+    fn peer_input_with(
+        peer_id: &str,
+        convention: Option<PeerConvention>,
+        correlation_id: Option<CorrelationId>,
+    ) -> Input {
+        let mut header = make_header();
+        header.source = InputOrigin::Peer {
+            peer_id: peer_id.into(),
+            display_identity: Some("  display-agent  ".into()),
+            runtime_id: None,
+        };
+        header.correlation_id = correlation_id;
+        Input::Peer(PeerInput {
+            injected_context: Vec::new(),
+            sender_taint: None,
+            header,
+            convention,
+            content: "hi there".into(),
+            payload: None,
+            handling_mode: None,
+        })
+    }
+
+    /// Only the `InputKind::PeerMessage` grouping mints a reply capability:
+    /// request/response conventions and non-peer inputs mint none, and a
+    /// message delivery without a stamped correlation id has no selector.
+    #[test]
+    fn non_message_conventions_mint_no_reply_capability() {
+        let peer_id = "018f6f79-7a82-7c4e-a552-a3b86f963005";
+        let correlation = CorrelationId::from_uuid(uuid::Uuid::from_u128(9));
+
+        let message = peer_input_with(
+            peer_id,
+            Some(PeerConvention::Message),
+            Some(correlation.clone()),
+        );
+        let capability = peer_reply_capability(&message)
+            .expect("message convention with correlation must mint a capability");
+        assert_eq!(
+            capability.peer_id,
+            meerkat_core::comms::PeerId::parse(peer_id).expect("canonical id")
+        );
+        assert_eq!(
+            capability.in_reply_to,
+            meerkat_core::InteractionId(uuid::Uuid::from_u128(9))
+        );
+        assert_eq!(
+            capability.display_name.as_deref(),
+            Some("display-agent"),
+            "display identity must be trimmed"
+        );
+        assert_eq!(
+            capability.kind,
+            meerkat_core::comms::PeerReplyDeliveryKind::Message
+        );
+
+        let bare = peer_input_with(peer_id, None, Some(correlation.clone()));
+        assert!(
+            peer_reply_capability(&bare).is_some(),
+            "bare peer input groups as PeerMessage and must mint"
+        );
+
+        let request = peer_input_with(
+            peer_id,
+            Some(PeerConvention::Request {
+                request_id: "req-1".into(),
+                intent: "review".into(),
+            }),
+            Some(correlation.clone()),
+        );
+        assert!(peer_reply_capability(&request).is_none());
+
+        let progress = peer_input_with(
+            peer_id,
+            Some(PeerConvention::ResponseProgress {
+                request_id: "req-1".into(),
+                phase: ResponseProgressPhase::Accepted,
+            }),
+            Some(correlation.clone()),
+        );
+        assert!(peer_reply_capability(&progress).is_none());
+
+        let terminal = peer_input_with(
+            peer_id,
+            Some(PeerConvention::ResponseTerminal {
+                request_id: "req-1".into(),
+                status: ResponseTerminalStatus::Completed,
+            }),
+            Some(correlation),
+        );
+        assert!(peer_reply_capability(&terminal).is_none());
+
+        let no_correlation = peer_input_with(peer_id, Some(PeerConvention::Message), None);
+        assert!(
+            peer_reply_capability(&no_correlation).is_none(),
+            "a delivery without a correlation id has no reply selector"
+        );
+
+        let prompt = Input::Prompt(PromptInput::new("hello", None));
+        assert!(peer_reply_capability(&prompt).is_none());
+    }
+
+    #[test]
+    fn non_canonical_peer_id_mints_no_reply_capability() {
+        let input = peer_input_with(
+            "peer-1",
+            Some(PeerConvention::Message),
+            Some(CorrelationId::from_uuid(uuid::Uuid::from_u128(9))),
+        );
+        assert!(
+            peer_reply_capability(&input).is_none(),
+            "a non-canonical peer id must fail the mint, never smuggle a raw string"
+        );
     }
 
     #[test]

--- a/meerkat-runtime/src/lib.rs
+++ b/meerkat-runtime/src/lib.rs
@@ -90,6 +90,7 @@ pub mod runtime_state;
 pub mod service_ext;
 pub(crate) mod silent_intent;
 pub mod store;
+pub mod terminal_status;
 pub mod traits;
 
 use meerkat_core::lifecycle::run_primitive::RuntimeTurnMetadata as RuntimeStampedTurnMetadata;

--- a/meerkat-runtime/src/meerkat_machine/dispatch_session.rs
+++ b/meerkat-runtime/src/meerkat_machine/dispatch_session.rs
@@ -1,4 +1,8 @@
 use super::*;
+use crate::input_state::StoredInputState;
+use crate::terminal_status::{
+    self, InteractionSelector, Sourced, TerminalWitnessSource, interaction_report,
+};
 use meerkat_core::ToolName;
 
 #[path = "../user_interrupt.rs"]
@@ -434,6 +438,70 @@ impl MeerkatMachine {
         ))
     }
 
+    /// Durable input-state witnesses for an UNREGISTERED session.
+    ///
+    /// Persistent machines answer from the RuntimeStore rows committed
+    /// atomically at every machine lifecycle boundary (rows are never
+    /// deleted, so terminal facts persist). A session with no lifecycle
+    /// record AND no input rows was never admitted and fails typed
+    /// `NotFound` — never an empty success. Ephemeral machines keep the
+    /// existing `NotReady` class: with no store there is no durable witness
+    /// to answer from.
+    pub(super) async fn durable_session_input_witnesses(
+        &self,
+        session_id: &SessionId,
+    ) -> Result<Vec<StoredInputState>, RuntimeDriverError> {
+        let Some(store) = self.store.as_ref() else {
+            return Err(RuntimeDriverError::NotReady {
+                state: RuntimeState::Destroyed,
+            });
+        };
+        let runtime_id = Self::logical_runtime_id(session_id);
+        let witnesses = store.load_input_states(&runtime_id).await.map_err(|err| {
+            RuntimeDriverError::Internal(format!(
+                "terminal-status witness read failed for {runtime_id}: {err}"
+            ))
+        })?;
+        if witnesses.is_empty() {
+            let lifecycle = store
+                .load_machine_lifecycle_record(&runtime_id)
+                .await
+                .map_err(|err| {
+                    RuntimeDriverError::Internal(format!(
+                        "terminal-status lifecycle read failed for {runtime_id}: {err}"
+                    ))
+                })?;
+            if lifecycle.is_none() {
+                return Err(RuntimeDriverError::NotFound { runtime_id });
+            }
+        }
+        Ok(witnesses)
+    }
+
+    /// Input-state witnesses for a session: the live DSL-backed snapshot when
+    /// the session is registered, the durable store rows otherwise. Both
+    /// sides feed the same pure evaluators in [`crate::terminal_status`].
+    pub(super) async fn session_input_witnesses(
+        &self,
+        session_id: &SessionId,
+    ) -> Result<(TerminalWitnessSource, Vec<StoredInputState>), RuntimeDriverError> {
+        let driver = {
+            let sessions = self.sessions.read().await;
+            sessions.get(session_id).map(|entry| entry.driver.clone())
+        };
+        if let Some(driver) = driver {
+            let driver = driver.lock().await;
+            return Ok((
+                TerminalWitnessSource::LiveRuntime,
+                driver.as_driver().stored_input_states_snapshot()?,
+            ));
+        }
+        Ok((
+            TerminalWitnessSource::DurableStore,
+            self.durable_session_input_witnesses(session_id).await?,
+        ))
+    }
+
     pub(super) async fn execute_meerkat_machine_session_command(
         &self,
         command: MeerkatMachineCommand,
@@ -612,17 +680,27 @@ impl MeerkatMachine {
             } => {
                 let driver = {
                     let sessions = self.sessions.read().await;
-                    let entry = sessions
-                        .get(&session_id)
-                        .ok_or(RuntimeDriverError::NotReady {
-                            state: RuntimeState::Destroyed,
-                        })?;
-                    entry.driver.clone()
+                    sessions.get(&session_id).map(|entry| entry.driver.clone())
                 };
-                let driver = driver.lock().await;
-                Ok(MeerkatMachineCommandResult::InputState(
-                    driver.as_driver().stored_input_state(&input_id),
-                ))
+                match driver {
+                    Some(driver) => {
+                        let driver = driver.lock().await;
+                        Ok(MeerkatMachineCommandResult::InputState(
+                            driver.as_driver().stored_input_state(&input_id),
+                        ))
+                    }
+                    // Restart-first-class fallback: an unregistered session on
+                    // a persistent machine answers from the durable
+                    // RuntimeStore witnesses without reviving the runtime.
+                    None => {
+                        let witnesses = self.durable_session_input_witnesses(&session_id).await?;
+                        Ok(MeerkatMachineCommandResult::InputState(
+                            witnesses
+                                .into_iter()
+                                .find(|stored| stored.state.input_id == input_id),
+                        ))
+                    }
+                }
             }
             MeerkatMachineCommand::InputStateByIdempotencyKey {
                 session_id,
@@ -630,20 +708,84 @@ impl MeerkatMachine {
             } => {
                 let driver = {
                     let sessions = self.sessions.read().await;
-                    let entry = sessions
-                        .get(&session_id)
-                        .ok_or(RuntimeDriverError::NotReady {
-                            state: RuntimeState::Destroyed,
-                        })?;
-                    entry.driver.clone()
+                    sessions.get(&session_id).map(|entry| entry.driver.clone())
                 };
-                let driver = driver.lock().await;
-                let driver = driver.as_driver();
-                Ok(MeerkatMachineCommandResult::InputState(
-                    driver
-                        .input_id_for_idempotency_key(&idempotency_key)
-                        .and_then(|input_id| driver.stored_input_state(&input_id)),
+                match driver {
+                    Some(driver) => {
+                        let driver = driver.lock().await;
+                        let driver = driver.as_driver();
+                        Ok(MeerkatMachineCommandResult::InputState(
+                            driver
+                                .input_id_for_idempotency_key(&idempotency_key)
+                                .and_then(|input_id| driver.stored_input_state(&input_id)),
+                        ))
+                    }
+                    // Restart-first-class fallback: the persisted shell key is
+                    // the exact fact recovery re-enters as the machine-owned
+                    // idempotency binding, so the durable witness and the live
+                    // admission map cannot diverge.
+                    None => {
+                        let witnesses = self.durable_session_input_witnesses(&session_id).await?;
+                        Ok(MeerkatMachineCommandResult::InputState(
+                            terminal_status::find_by_idempotency_key(&witnesses, &idempotency_key)
+                                .cloned(),
+                        ))
+                    }
+                }
+            }
+            MeerkatMachineCommand::InteractionTerminalStatus {
+                session_id,
+                selector,
+            } => {
+                let driver = {
+                    let sessions = self.sessions.read().await;
+                    sessions.get(&session_id).map(|entry| entry.driver.clone())
+                };
+                let sourced = match driver {
+                    Some(driver) => {
+                        let driver = driver.lock().await;
+                        let driver = driver.as_driver();
+                        let bundle = match &selector {
+                            InteractionSelector::InputId(input_id) => {
+                                driver.stored_input_state(input_id)
+                            }
+                            // Live path: the machine-owned admission map is
+                            // the authority for key -> input resolution.
+                            InteractionSelector::IdempotencyKey(key) => driver
+                                .input_id_for_idempotency_key(key)
+                                .and_then(|input_id| driver.stored_input_state(&input_id)),
+                        };
+                        bundle.map(|bundle| Sourced {
+                            source: TerminalWitnessSource::LiveRuntime,
+                            report: interaction_report(&bundle),
+                        })
+                    }
+                    None => {
+                        let witnesses = self.durable_session_input_witnesses(&session_id).await?;
+                        let bundle = match &selector {
+                            InteractionSelector::InputId(input_id) => witnesses
+                                .iter()
+                                .find(|stored| &stored.state.input_id == input_id),
+                            InteractionSelector::IdempotencyKey(key) => {
+                                terminal_status::find_by_idempotency_key(&witnesses, key)
+                            }
+                        };
+                        bundle.map(|bundle| Sourced {
+                            source: TerminalWitnessSource::DurableStore,
+                            report: interaction_report(bundle),
+                        })
+                    }
+                };
+                Ok(MeerkatMachineCommandResult::InteractionTerminalStatus(
+                    sourced,
                 ))
+            }
+            MeerkatMachineCommand::RunTerminalStatus { session_id, run_id } => {
+                let (source, witnesses) = self.session_input_witnesses(&session_id).await?;
+                Ok(MeerkatMachineCommandResult::RunTerminalStatus(Sourced {
+                    source,
+                    report: terminal_status::evaluate_run(&run_id, &witnesses),
+                }))
             }
             MeerkatMachineCommand::ListActiveInputs { session_id } => {
                 let driver = {

--- a/meerkat-runtime/src/meerkat_machine/mod.rs
+++ b/meerkat-runtime/src/meerkat_machine/mod.rs
@@ -2615,6 +2615,8 @@ impl MeerkatMachine {
                 | MeerkatMachineCommand::PrepareLocalSessionBindings { .. }
                 | MeerkatMachineCommand::InputState { .. }
                 | MeerkatMachineCommand::InputStateByIdempotencyKey { .. }
+                | MeerkatMachineCommand::InteractionTerminalStatus { .. }
+                | MeerkatMachineCommand::RunTerminalStatus { .. }
                 | MeerkatMachineCommand::ListActiveInputs { .. }
                 | MeerkatMachineCommand::ReconfigureSessionLlmIdentity { .. }
                 | MeerkatMachineCommand::StagePersistentFilter { .. }

--- a/meerkat-runtime/src/meerkat_machine/traits.rs
+++ b/meerkat-runtime/src/meerkat_machine/traits.rs
@@ -147,6 +147,58 @@ impl SessionServiceRuntimeExt for MeerkatMachine {
         }
     }
 
+    async fn interaction_terminal_status(
+        &self,
+        session_id: &SessionId,
+        selector: crate::terminal_status::InteractionSelector,
+    ) -> Result<
+        Option<crate::terminal_status::Sourced<crate::terminal_status::InteractionTerminalReport>>,
+        RuntimeDriverError,
+    > {
+        match self
+            .execute_meerkat_machine_command(
+                None,
+                MeerkatMachineCommand::InteractionTerminalStatus {
+                    session_id: session_id.clone(),
+                    selector,
+                },
+            )
+            .await
+            .map_err(MeerkatMachine::driver_error_from_command_error)?
+        {
+            MeerkatMachineCommandResult::InteractionTerminalStatus(report) => Ok(report),
+            other => Err(RuntimeDriverError::Internal(format!(
+                "unexpected MeerkatMachineCommandResult for SessionServiceRuntimeExt::interaction_terminal_status: {other:?}"
+            ))),
+        }
+    }
+
+    async fn run_terminal_status(
+        &self,
+        session_id: &SessionId,
+        run_id: &meerkat_core::lifecycle::RunId,
+    ) -> Result<
+        crate::terminal_status::Sourced<crate::terminal_status::RunTerminalReport>,
+        RuntimeDriverError,
+    > {
+        match self
+            .execute_meerkat_machine_command(
+                None,
+                MeerkatMachineCommand::RunTerminalStatus {
+                    session_id: session_id.clone(),
+                    run_id: run_id.clone(),
+                },
+            )
+            .await
+            .map_err(MeerkatMachine::driver_error_from_command_error)?
+        {
+            MeerkatMachineCommandResult::RunTerminalStatus(report) => Ok(report),
+            other => Err(RuntimeDriverError::Internal(format!(
+                "unexpected MeerkatMachineCommandResult for SessionServiceRuntimeExt::run_terminal_status: {other:?}"
+            ))),
+        }
+    }
+
     async fn list_active_inputs(
         &self,
         session_id: &SessionId,

--- a/meerkat-runtime/src/meerkat_machine_tests.rs
+++ b/meerkat-runtime/src/meerkat_machine_tests.rs
@@ -3028,6 +3028,541 @@ async fn input_terminal_status_by_idempotency_key_survives_restart() {
     );
 }
 
+/// Shared setup for the restart-first-class terminal-status lane: drive a
+/// keyed prompt to its `Consumed` terminal on a persistent machine, wait
+/// until the terminal facts (including the resolving run id) are visible
+/// through the machine seam, then drop the machine and the store handle.
+#[cfg(all(not(target_arch = "wasm32"), feature = "sqlite-store"))]
+async fn seed_terminal_keyed_prompt_store() -> (
+    tempfile::TempDir,
+    PathBuf,
+    SessionId,
+    IdempotencyKey,
+    InputId,
+    RunId,
+) {
+    struct CompletingExecutor;
+
+    #[async_trait::async_trait]
+    impl CoreExecutor for CompletingExecutor {
+        async fn apply(
+            &mut self,
+            run_id: RunId,
+            primitive: RunPrimitive,
+        ) -> Result<CoreApplyOutput, CoreExecutorError> {
+            Ok(CoreApplyOutput {
+                receipt: meerkat_core::lifecycle::RunBoundaryReceiptDraft {
+                    run_id,
+                    boundary: meerkat_core::lifecycle::RunApplyBoundary::RunStart,
+                    contributing_input_ids: primitive.contributing_input_ids().to_vec(),
+                    conversation_digest: None,
+                    message_count: 0,
+                },
+                session_snapshot: None,
+                terminal: None,
+            })
+        }
+
+        async fn cancel_after_boundary(
+            &mut self,
+            _reason: String,
+        ) -> Result<(), CoreExecutorError> {
+            Ok(())
+        }
+
+        async fn stop_runtime_executor(
+            &mut self,
+            _reason: String,
+        ) -> Result<(), CoreExecutorError> {
+            Ok(())
+        }
+    }
+
+    let dir = tempfile::TempDir::new().expect("temp dir");
+    let path = dir.path().join("runtime.sqlite3");
+    let store = Arc::new(
+        crate::store::SqliteRuntimeStore::new(path.clone()).expect("sqlite runtime store"),
+    ) as Arc<dyn crate::store::RuntimeStore>;
+    let session_id = SessionId::new();
+    let key = crate::identifiers::IdempotencyKey::new("terminal-status-restart-1");
+
+    let machine = Arc::new(MeerkatMachine::persistent(
+        Arc::clone(&store),
+        memory_blob_store(),
+    ));
+    machine
+        .register_session_with_executor(session_id.clone(), Box::new(CompletingExecutor))
+        .await
+        .expect("runtime executor registration should succeed");
+
+    let mut prompt = make_prompt("keyed interaction to reconcile after restart");
+    let prompt_id = prompt.id().clone();
+    if let Input::Prompt(inner) = &mut prompt {
+        inner.header.idempotency_key = Some(key.clone());
+    }
+    let (outcome, completion) = machine
+        .accept_input_with_completion(&session_id, prompt)
+        .await
+        .expect("keyed prompt should be accepted");
+    assert!(outcome.is_accepted());
+    let completion = completion.expect("queued prompt should register completion");
+    tokio::time::timeout(Duration::from_secs(2), completion.wait_authorized())
+        .await
+        .expect("keyed prompt should reach a terminal outcome before restart");
+
+    // Wait until the terminal state (with its resolving run id) is visible
+    // through the machine seam before simulating the restart.
+    let run_id = tokio::time::timeout(Duration::from_secs(2), async {
+        loop {
+            let stored =
+                <MeerkatMachine as SessionServiceRuntimeExt>::input_state_by_idempotency_key(
+                    &machine,
+                    &session_id,
+                    &key.to_string(),
+                )
+                .await
+                .expect("keyed lookup should succeed pre-restart");
+            if let Some(stored) = stored
+                && stored.seed.terminal_outcome.is_some()
+                && let Some(run_id) = stored.seed.last_run_id
+            {
+                break run_id;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .expect("keyed prompt should terminalize with a bound run id before restart");
+    drop(machine);
+    drop(store);
+
+    (dir, path, session_id, key, prompt_id, run_id)
+}
+
+/// M4 restart-first-class (G1): the terminal status of a keyed interaction is
+/// queryable after a host restart WITHOUT registering the session — the
+/// durable RuntimeStore witnesses answer directly.
+#[cfg(all(not(target_arch = "wasm32"), feature = "sqlite-store"))]
+#[tokio::test]
+async fn interaction_terminal_status_by_key_survives_restart_without_registration() {
+    let (_dir, path, session_id, key, prompt_id, run_id) = seed_terminal_keyed_prompt_store().await;
+
+    let restarted_store = Arc::new(
+        crate::store::SqliteRuntimeStore::new(path).expect("sqlite runtime store reopens"),
+    ) as Arc<dyn crate::store::RuntimeStore>;
+    let restarted = MeerkatMachine::persistent(restarted_store, memory_blob_store());
+    // Deliberately NOT registered: the query must answer from the store.
+    let sourced = <MeerkatMachine as SessionServiceRuntimeExt>::interaction_terminal_status(
+        &restarted,
+        &session_id,
+        crate::terminal_status::InteractionSelector::IdempotencyKey(key.to_string()),
+    )
+    .await
+    .expect("unregistered durable terminal-status query should succeed")
+    .expect("the persisted keyed interaction must resolve without registration");
+    assert_eq!(
+        sourced.source,
+        crate::terminal_status::TerminalWitnessSource::DurableStore,
+        "an unregistered session must be answered by the durable witness"
+    );
+    assert_eq!(sourced.report.input_id, prompt_id);
+    assert_eq!(
+        sourced.report.terminal,
+        Some(crate::input_state::InputTerminalOutcome::Consumed),
+    );
+    assert_eq!(sourced.report.resolving_run_id, Some(run_id));
+    assert_eq!(
+        sourced.report.idempotency_key,
+        Some(key),
+        "the durable report must carry the reconciliation key"
+    );
+}
+
+/// M4 restart-first-class (G1, shipped-surface fold-in): the EXISTING
+/// `input_state_by_idempotency_key` answers from the durable store for an
+/// unregistered session instead of failing `NotReady { Destroyed }`.
+#[cfg(all(not(target_arch = "wasm32"), feature = "sqlite-store"))]
+#[tokio::test]
+async fn input_state_by_idempotency_key_falls_back_to_store_when_unregistered() {
+    let (_dir, path, session_id, key, prompt_id, _run_id) =
+        seed_terminal_keyed_prompt_store().await;
+
+    let restarted_store = Arc::new(
+        crate::store::SqliteRuntimeStore::new(path).expect("sqlite runtime store reopens"),
+    ) as Arc<dyn crate::store::RuntimeStore>;
+    let restarted = MeerkatMachine::persistent(restarted_store, memory_blob_store());
+    let stored = <MeerkatMachine as SessionServiceRuntimeExt>::input_state_by_idempotency_key(
+        &restarted,
+        &session_id,
+        &key.to_string(),
+    )
+    .await
+    .expect("unregistered keyed lookup should fall back to the durable store")
+    .expect("the persisted binding must resolve without registration");
+    assert_eq!(stored.state.input_id, prompt_id);
+    assert_eq!(
+        stored.seed.terminal_outcome,
+        Some(crate::input_state::InputTerminalOutcome::Consumed),
+    );
+}
+
+/// M4 restart-first-class (G2): a run id captured before the restart resolves
+/// from the durable input witnesses without registration.
+#[cfg(all(not(target_arch = "wasm32"), feature = "sqlite-store"))]
+#[tokio::test]
+async fn run_terminal_status_resolves_from_durable_witnesses() {
+    let (_dir, path, session_id, _key, prompt_id, run_id) =
+        seed_terminal_keyed_prompt_store().await;
+
+    let restarted_store = Arc::new(
+        crate::store::SqliteRuntimeStore::new(path).expect("sqlite runtime store reopens"),
+    ) as Arc<dyn crate::store::RuntimeStore>;
+    let restarted = MeerkatMachine::persistent(restarted_store, memory_blob_store());
+    let sourced = <MeerkatMachine as SessionServiceRuntimeExt>::run_terminal_status(
+        &restarted,
+        &session_id,
+        &run_id,
+    )
+    .await
+    .expect("unregistered durable run-status query should succeed");
+    assert_eq!(
+        sourced.source,
+        crate::terminal_status::TerminalWitnessSource::DurableStore,
+    );
+    assert_eq!(
+        sourced.report.status,
+        crate::terminal_status::RunTerminalStatus::Resolved {
+            outcome: crate::terminal_status::RunResolutionClass::Consumed
+        },
+    );
+    assert_eq!(
+        sourced.report.witnesses.len(),
+        1,
+        "exactly the seeding input must witness the run"
+    );
+    assert_eq!(sourced.report.witnesses[0].input_id, prompt_id);
+}
+
+/// Unknown run on a known session reports `NoDurableWitness` with an empty
+/// witness set; an unknown session id fails typed `NotFound`.
+#[cfg(all(not(target_arch = "wasm32"), feature = "sqlite-store"))]
+#[tokio::test]
+async fn run_terminal_status_reports_no_durable_witness_for_unknown_run() {
+    let (_dir, path, session_id, _key, _prompt_id, _run_id) =
+        seed_terminal_keyed_prompt_store().await;
+
+    let restarted_store = Arc::new(
+        crate::store::SqliteRuntimeStore::new(path).expect("sqlite runtime store reopens"),
+    ) as Arc<dyn crate::store::RuntimeStore>;
+    let restarted = MeerkatMachine::persistent(restarted_store, memory_blob_store());
+
+    let fresh_run = RunId::new();
+    let sourced = <MeerkatMachine as SessionServiceRuntimeExt>::run_terminal_status(
+        &restarted,
+        &session_id,
+        &fresh_run,
+    )
+    .await
+    .expect("known session with unknown run should answer, not error");
+    assert_eq!(
+        sourced.report.status,
+        crate::terminal_status::RunTerminalStatus::NoDurableWitness,
+    );
+    assert!(sourced.report.witnesses.is_empty());
+
+    let unknown_session = SessionId::new();
+    let err = <MeerkatMachine as SessionServiceRuntimeExt>::run_terminal_status(
+        &restarted,
+        &unknown_session,
+        &fresh_run,
+    )
+    .await
+    .expect_err("a never-admitted session must fail typed NotFound");
+    assert!(
+        matches!(err, RuntimeDriverError::NotFound { .. }),
+        "expected NotFound, got {err:?}"
+    );
+}
+
+/// Live-runtime witness: an input staged to a run that has not terminalized
+/// reports `InFlight` from the live DSL snapshot.
+#[tokio::test]
+async fn run_terminal_status_reports_in_flight_on_live_runtime() {
+    struct PendingExecutor;
+
+    #[async_trait::async_trait]
+    impl CoreExecutor for PendingExecutor {
+        async fn apply(
+            &mut self,
+            _run_id: RunId,
+            _primitive: RunPrimitive,
+        ) -> Result<CoreApplyOutput, CoreExecutorError> {
+            std::future::pending::<()>().await;
+            Err(CoreExecutorError::Stopped)
+        }
+
+        async fn cancel_after_boundary(
+            &mut self,
+            _reason: String,
+        ) -> Result<(), CoreExecutorError> {
+            Ok(())
+        }
+
+        async fn stop_runtime_executor(
+            &mut self,
+            _reason: String,
+        ) -> Result<(), CoreExecutorError> {
+            Ok(())
+        }
+    }
+
+    let machine = Arc::new(MeerkatMachine::ephemeral());
+    let session_id = SessionId::new();
+    machine
+        .register_session_with_executor(session_id.clone(), Box::new(PendingExecutor))
+        .await
+        .expect("runtime executor registration should succeed");
+
+    let prompt = make_prompt("never finishes");
+    let prompt_id = prompt.id().clone();
+    let outcome =
+        <MeerkatMachine as SessionServiceRuntimeExt>::accept_input(&machine, &session_id, prompt)
+            .await
+            .expect("prompt should be accepted");
+    assert!(outcome.is_accepted());
+
+    // Poll until the run association binds (staging happens before the
+    // executor apply, which never completes).
+    let run_id = tokio::time::timeout(Duration::from_secs(2), async {
+        loop {
+            let stored = <MeerkatMachine as SessionServiceRuntimeExt>::input_state(
+                &machine,
+                &session_id,
+                &prompt_id,
+            )
+            .await
+            .expect("live input_state should succeed");
+            if let Some(run_id) = stored.and_then(|stored| stored.seed.last_run_id) {
+                break run_id;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .expect("staged prompt should bind a run id");
+
+    let sourced = <MeerkatMachine as SessionServiceRuntimeExt>::run_terminal_status(
+        &machine,
+        &session_id,
+        &run_id,
+    )
+    .await
+    .expect("live run-status query should succeed");
+    assert_eq!(
+        sourced.source,
+        crate::terminal_status::TerminalWitnessSource::LiveRuntime,
+    );
+    assert_eq!(
+        sourced.report.status,
+        crate::terminal_status::RunTerminalStatus::InFlight,
+    );
+}
+
+/// M4 cause class (G3): an abandoned interaction surfaces its typed abandon
+/// reason — not a string — through the terminal-status report.
+#[tokio::test]
+async fn interaction_terminal_status_carries_abandon_cause() {
+    let adapter = Arc::new(MeerkatMachine::ephemeral());
+    let session_id = SessionId::new();
+    adapter
+        .register_session(session_id.clone())
+        .await
+        .expect("register session");
+
+    let key = crate::identifiers::IdempotencyKey::new("abandon-cause-1");
+    let mut prompt = make_prompt("will be retired before running");
+    if let Input::Prompt(inner) = &mut prompt {
+        inner.header.idempotency_key = Some(key.clone());
+    }
+    let outcome =
+        <MeerkatMachine as SessionServiceRuntimeExt>::accept_input(&adapter, &session_id, prompt)
+            .await
+            .expect("keyed prompt should be accepted");
+    assert!(outcome.is_accepted());
+
+    let retire_report =
+        <MeerkatMachine as SessionServiceRuntimeExt>::retire_runtime(&adapter, &session_id)
+            .await
+            .expect("retire should abandon the queued prompt");
+    assert_eq!(retire_report.inputs_abandoned, 1);
+
+    let sourced = <MeerkatMachine as SessionServiceRuntimeExt>::interaction_terminal_status(
+        &adapter,
+        &session_id,
+        crate::terminal_status::InteractionSelector::IdempotencyKey(key.to_string()),
+    )
+    .await
+    .expect("live terminal-status query should succeed")
+    .expect("the abandoned interaction must resolve from its key");
+    assert_eq!(
+        sourced.source,
+        crate::terminal_status::TerminalWitnessSource::LiveRuntime,
+    );
+    assert_eq!(
+        sourced.report.terminal,
+        Some(crate::input_state::InputTerminalOutcome::Abandoned {
+            reason: crate::input_state::InputAbandonReason::Retired,
+        }),
+        "the typed abandon cause class must surface on the report"
+    );
+}
+
+/// Degradation pin: only persistent machines answer durably. An unregistered
+/// session on a store-less (ephemeral) machine keeps today's `NotReady`
+/// behavior class for both new query methods.
+#[tokio::test]
+async fn terminal_status_on_storeless_machine_unregistered_is_not_ready() {
+    let machine = MeerkatMachine::ephemeral();
+    let session_id = SessionId::new();
+
+    let err = <MeerkatMachine as SessionServiceRuntimeExt>::interaction_terminal_status(
+        &machine,
+        &session_id,
+        crate::terminal_status::InteractionSelector::InputId(InputId::new()),
+    )
+    .await
+    .expect_err("store-less machines cannot answer for unregistered sessions");
+    assert!(
+        matches!(
+            err,
+            RuntimeDriverError::NotReady {
+                state: RuntimeState::Destroyed
+            }
+        ),
+        "expected NotReady {{ Destroyed }}, got {err:?}"
+    );
+
+    let err = <MeerkatMachine as SessionServiceRuntimeExt>::run_terminal_status(
+        &machine,
+        &session_id,
+        &RunId::new(),
+    )
+    .await
+    .expect_err("store-less machines cannot answer for unregistered sessions");
+    assert!(
+        matches!(
+            err,
+            RuntimeDriverError::NotReady {
+                state: RuntimeState::Destroyed
+            }
+        ),
+        "expected NotReady {{ Destroyed }}, got {err:?}"
+    );
+}
+
+/// Never-admitted pin: an unregistered session id on a persistent machine
+/// with no lifecycle record and no input rows fails typed `NotFound` — never
+/// an empty success.
+#[cfg(all(not(target_arch = "wasm32"), feature = "sqlite-store"))]
+#[tokio::test]
+async fn terminal_status_never_admitted_session_is_not_found() {
+    let dir = tempfile::TempDir::new().expect("temp dir");
+    let store = Arc::new(
+        crate::store::SqliteRuntimeStore::new(dir.path().join("runtime.sqlite3"))
+            .expect("sqlite runtime store"),
+    ) as Arc<dyn crate::store::RuntimeStore>;
+    let machine = MeerkatMachine::persistent(store, memory_blob_store());
+    let session_id = SessionId::new();
+    let expected_runtime_id = runtime_id_for_session(&session_id);
+
+    let err = <MeerkatMachine as SessionServiceRuntimeExt>::interaction_terminal_status(
+        &machine,
+        &session_id,
+        crate::terminal_status::InteractionSelector::InputId(InputId::new()),
+    )
+    .await
+    .expect_err("a never-admitted session must fail typed NotFound");
+    match err {
+        RuntimeDriverError::NotFound { runtime_id } => {
+            assert_eq!(runtime_id, expected_runtime_id);
+        }
+        other => panic!("expected NotFound, got {other:?}"),
+    }
+
+    let err = <MeerkatMachine as SessionServiceRuntimeExt>::run_terminal_status(
+        &machine,
+        &session_id,
+        &RunId::new(),
+    )
+    .await
+    .expect_err("a never-admitted session must fail typed NotFound");
+    assert!(
+        matches!(err, RuntimeDriverError::NotFound { .. }),
+        "expected NotFound, got {err:?}"
+    );
+}
+
+/// One-canonical-evaluator agreement: after restart + re-registration, the
+/// live query and a store-handle-direct `evaluate_run` over
+/// `load_input_states` produce identical facts (only the source differs).
+#[cfg(all(not(target_arch = "wasm32"), feature = "sqlite-store"))]
+#[tokio::test]
+async fn live_and_durable_run_terminal_reports_agree_after_recovery() {
+    let (_dir, path, session_id, _key, prompt_id, run_id) =
+        seed_terminal_keyed_prompt_store().await;
+
+    let restarted_store = Arc::new(
+        crate::store::SqliteRuntimeStore::new(path).expect("sqlite runtime store reopens"),
+    ) as Arc<dyn crate::store::RuntimeStore>;
+    let restarted = MeerkatMachine::persistent(Arc::clone(&restarted_store), memory_blob_store());
+    restarted
+        .register_session(session_id.clone())
+        .await
+        .expect("session re-registration should recover persisted input states");
+
+    let live = <MeerkatMachine as SessionServiceRuntimeExt>::run_terminal_status(
+        &restarted,
+        &session_id,
+        &run_id,
+    )
+    .await
+    .expect("live run-status query should succeed");
+    assert_eq!(
+        live.source,
+        crate::terminal_status::TerminalWitnessSource::LiveRuntime,
+    );
+
+    let durable_witnesses = restarted_store
+        .load_input_states(&runtime_id_for_session(&session_id))
+        .await
+        .expect("store-handle-direct witness read should succeed");
+    let durable = crate::terminal_status::evaluate_run(&run_id, &durable_witnesses);
+
+    assert_eq!(live.report.status, durable.status);
+    let fact_projection = |report: &crate::terminal_status::RunTerminalReport| {
+        report
+            .witnesses
+            .iter()
+            .map(|witness| {
+                (
+                    witness.input_id.clone(),
+                    witness.phase,
+                    witness.terminal.clone(),
+                    witness.resolving_run_id.clone(),
+                    witness.attempt_count,
+                    witness.idempotency_key.clone(),
+                )
+            })
+            .collect::<Vec<_>>()
+    };
+    assert_eq!(
+        fact_projection(&live.report),
+        fact_projection(&durable),
+        "the single canonical evaluator must produce identical facts from both witnesses"
+    );
+    assert_eq!(live.report.witnesses[0].input_id, prompt_id);
+}
+
 /// Test peer-comms install target that accepts the generated install: the
 /// minimal comms runtime surface the field repro needs (the 0.7.19–0.7.23
 /// resume-strand class fired `PublishLocalEndpoint` through this seam).
@@ -24259,6 +24794,12 @@ fn summarize_runtime_parity_command_result(result: &MeerkatMachineCommandResult)
         MeerkatMachineCommandResult::Bindings(_) => "bindings".to_string(),
         MeerkatMachineCommandResult::InputState(state) => {
             format!("input_state_present:{}", state.is_some())
+        }
+        MeerkatMachineCommandResult::InteractionTerminalStatus(report) => {
+            format!("interaction_terminal_status_present:{}", report.is_some())
+        }
+        MeerkatMachineCommandResult::RunTerminalStatus(report) => {
+            format!("run_terminal_status:{:?}", report.report.status)
         }
         MeerkatMachineCommandResult::ActiveInputs(inputs) => {
             format!("active_inputs:{}", inputs.len())

--- a/meerkat-runtime/src/meerkat_machine_types.rs
+++ b/meerkat-runtime/src/meerkat_machine_types.rs
@@ -311,6 +311,21 @@ pub(crate) enum MeerkatMachineCommand {
         session_id: SessionId,
         idempotency_key: String,
     },
+    // Restart-first-class terminal-status read: same machine-owned authority
+    // read as `InputState`, but when the session is not registered a
+    // persistent machine answers from the durably committed input-state
+    // witnesses in the RuntimeStore instead of failing NotReady.
+    InteractionTerminalStatus {
+        session_id: SessionId,
+        selector: crate::terminal_status::InteractionSelector,
+    },
+    // Run-id-keyed terminal-status read over the same witnesses: the durable
+    // run-terminal truth is the set of inputs whose `last_run_id` references
+    // the run, evaluated by the canonical pure evaluator.
+    RunTerminalStatus {
+        session_id: SessionId,
+        run_id: RunId,
+    },
     ListActiveInputs {
         session_id: SessionId,
     },
@@ -491,6 +506,10 @@ pub(crate) enum MeerkatMachineCommandResult {
     OpsLifecycleRegistry(Option<Arc<crate::ops_lifecycle::RuntimeOpsLifecycleRegistry>>),
     Bindings(meerkat_core::SessionRuntimeBindings),
     InputState(Option<StoredInputState>),
+    InteractionTerminalStatus(
+        Option<crate::terminal_status::Sourced<crate::terminal_status::InteractionTerminalReport>>,
+    ),
+    RunTerminalStatus(crate::terminal_status::Sourced<crate::terminal_status::RunTerminalReport>),
     ActiveInputs(Vec<InputId>),
     LlmReconfigured(SessionLlmReconfigureReport),
     VisibilityRevision(meerkat_core::ToolScopeRevision),
@@ -1288,6 +1307,11 @@ impl MeerkatMachineCommandVariant {
             // Same machine-owned read route as `InputState` (the key
             // resolves through the generated admission map first).
             Self::InputStateByIdempotencyKey => Some(MeerkatMachineCatalogInput::InputState),
+            // Terminal-status queries are the same machine-owned read route
+            // as `InputState`: they evaluate the identical DSL-owned seed
+            // facts (live snapshot or their durable store witnesses).
+            Self::InteractionTerminalStatus => Some(MeerkatMachineCatalogInput::InputState),
+            Self::RunTerminalStatus => Some(MeerkatMachineCatalogInput::InputState),
             Self::ListActiveInputs => Some(MeerkatMachineCatalogInput::ListActiveInputs),
             Self::ReconfigureSessionLlmIdentity => {
                 Some(MeerkatMachineCatalogInput::ReconfigureSessionLlmIdentity)
@@ -1464,6 +1488,15 @@ const fn meerkat_machine_command_classification(
         // key resolves through the generated admission map, then the stored
         // input state is read identically.
         MeerkatMachineCommandVariant::InputStateByIdempotencyKey => {
+            MeerkatMachineCommandClassification::CatalogInput(
+                MeerkatMachineCatalogInput::InputState,
+            )
+        }
+        // Terminal-status reads evaluate the same DSL-owned seed facts as
+        // `InputState` (live snapshot for registered sessions, durable store
+        // witnesses otherwise) — same machine-owned read route.
+        MeerkatMachineCommandVariant::InteractionTerminalStatus
+        | MeerkatMachineCommandVariant::RunTerminalStatus => {
             MeerkatMachineCommandClassification::CatalogInput(
                 MeerkatMachineCatalogInput::InputState,
             )

--- a/meerkat-runtime/src/runtime_loop.rs
+++ b/meerkat-runtime/src/runtime_loop.rs
@@ -103,7 +103,73 @@ pub(crate) fn merge_batch_turn_metadata(
             }
         }
     }
+    // Batch-level peer-reply capability mint: every peer *message* delivery
+    // in the admitted batch contributes one typed reply capability. Minted
+    // AFTER the per-input fold so the scalar overlay merge above never sees a
+    // runtime-minted overlay (which would spuriously conflict across inputs).
+    let deliveries = inputs
+        .iter()
+        .filter_map(|(_, input)| crate::input::peer_reply_capability(input))
+        .collect::<Vec<_>>();
+    if !deliveries.is_empty() {
+        // `for_input` stamps `execution_kind` on every input, so a non-empty
+        // batch always folded into `Some`; a missing accumulator here is a
+        // logic error and fails closed with a typed error.
+        let Some(metadata) = acc.as_mut() else {
+            return Err(
+                meerkat_core::lifecycle::run_primitive::TurnMetadataMergeConflict {
+                    field: "turn_tool_overlay",
+                    reason: "peer reply capability minted for a batch with no metadata accumulator",
+                },
+            );
+        };
+        attach_peer_reply_capabilities(metadata, deliveries)?;
+    }
     Ok(acc.filter(|m| !m.is_empty()))
+}
+
+/// Attach the batch's typed peer-reply capabilities to the accumulated turn
+/// metadata by composing a dispatch-context-only overlay into its turn tool
+/// overlay. Mutates the single accumulator minted by [`for_input`] — this is
+/// NOT a second `RuntimeTurnMetadata` construction site.
+fn attach_peer_reply_capabilities(
+    metadata: &mut meerkat_core::lifecycle::run_primitive::RuntimeTurnMetadata,
+    deliveries: Vec<meerkat_core::comms::PeerReplyCapability>,
+) -> Result<(), meerkat_core::lifecycle::run_primitive::TurnMetadataMergeConflict> {
+    use meerkat_core::lifecycle::run_primitive::TurnMetadataMergeConflict;
+
+    let context = meerkat_core::comms::PeerReplyDispatchContext { deliveries };
+    let value = serde_json::to_value(&context).map_err(|error| {
+        tracing::error!(
+            error = %error,
+            "typed peer reply dispatch context failed to serialize"
+        );
+        TurnMetadataMergeConflict {
+            field: "turn_tool_overlay",
+            reason: "peer reply dispatch context failed to serialize",
+        }
+    })?;
+    let mut reply_overlay = meerkat_core::service::TurnToolOverlay::default();
+    reply_overlay.dispatch_context.insert(
+        meerkat_core::comms::COMMS_PEER_REPLY_DISPATCH_CONTEXT_KEY.to_string(),
+        value,
+    );
+    let composed = meerkat_core::service::TurnToolOverlay::compose(
+        metadata.turn_tool_overlay.take(),
+        reply_overlay,
+    )
+    .map_err(|error| {
+        tracing::error!(
+            error = %error,
+            "peer reply overlay composition conflicted with an existing dispatch-context entry"
+        );
+        TurnMetadataMergeConflict {
+            field: "turn_tool_overlay",
+            reason: "peer reply dispatch context conflicted with an existing overlay entry",
+        }
+    })?;
+    metadata.turn_tool_overlay = Some(composed);
+    Ok(())
 }
 
 fn completion_terminal_observation(
@@ -2748,6 +2814,189 @@ mod tests {
             .expect("metadata should still carry execution kind");
 
         assert!(metadata.transcript_identity.is_empty());
+    }
+
+    fn admission_semantics(input: &Input) -> crate::ingress_types::RuntimeInputSemantics {
+        crate::ingress_types::RuntimeInputSemantics::try_from_generated_admission(input, true)
+            .expect("generated admission semantics")
+    }
+
+    fn reply_context_from_overlay(
+        overlay: &meerkat_core::service::TurnToolOverlay,
+    ) -> meerkat_core::comms::PeerReplyDispatchContext {
+        let value = overlay
+            .dispatch_context
+            .get(meerkat_core::comms::COMMS_PEER_REPLY_DISPATCH_CONTEXT_KEY)
+            .expect("comms.peer_reply dispatch context entry");
+        serde_json::from_value(value.clone()).expect("typed peer reply dispatch context")
+    }
+
+    /// Ask 26 keystone: a turn triggered by a peer message mints a typed
+    /// reply-capability overlay on the batch turn metadata (dispatch-context
+    /// only — no tool visibility restriction).
+    #[test]
+    fn peer_message_turn_mints_typed_reply_capability_overlay() {
+        let peer_uuid = uuid::Uuid::from_u128(0x42);
+        let interaction_uuid = uuid::Uuid::from_u128(7);
+        let mut input = make_peer_message(&peer_uuid.to_string(), "hello");
+        if let Input::Peer(peer) = &mut input {
+            peer.header.correlation_id = Some(crate::CorrelationId::from_uuid(interaction_uuid));
+        }
+        let semantics = admission_semantics(&input);
+        let inputs = vec![(InputId::new(), input)];
+
+        let metadata = merge_batch_turn_metadata(&inputs, &[semantics])
+            .expect("single input metadata cannot conflict")
+            .expect("peer message batch carries metadata");
+
+        let overlay = metadata
+            .turn_tool_overlay
+            .expect("peer message turn must mint a reply-capability overlay");
+        assert_eq!(overlay.allowed_tools, None);
+        assert_eq!(overlay.blocked_tools, None);
+        let context = reply_context_from_overlay(&overlay);
+        assert_eq!(context.deliveries.len(), 1);
+        let capability = &context.deliveries[0];
+        assert_eq!(
+            capability.peer_id,
+            meerkat_core::comms::PeerId::from_uuid(peer_uuid)
+        );
+        assert_eq!(capability.in_reply_to, InteractionId(interaction_uuid));
+        assert_eq!(capability.display_name.as_deref(), Some("analyst-rt"));
+        assert_eq!(
+            capability.kind,
+            meerkat_core::comms::PeerReplyDeliveryKind::Message
+        );
+    }
+
+    /// A batch with two peer message deliveries mints both capabilities, in
+    /// batch delivery order.
+    #[test]
+    fn peer_message_batch_mints_one_capability_per_delivery() {
+        let first_peer = uuid::Uuid::from_u128(0xA1);
+        let second_peer = uuid::Uuid::from_u128(0xA2);
+        let mut first = make_peer_message(&first_peer.to_string(), "hello");
+        let mut second = make_peer_message(&second_peer.to_string(), "again");
+        if let Input::Peer(peer) = &mut first {
+            peer.header.correlation_id =
+                Some(crate::CorrelationId::from_uuid(uuid::Uuid::from_u128(1)));
+        }
+        if let Input::Peer(peer) = &mut second {
+            peer.header.correlation_id =
+                Some(crate::CorrelationId::from_uuid(uuid::Uuid::from_u128(2)));
+        }
+        let semantics = vec![admission_semantics(&first), admission_semantics(&second)];
+        let inputs = vec![(InputId::new(), first), (InputId::new(), second)];
+
+        let metadata = merge_batch_turn_metadata(&inputs, &semantics)
+            .expect("peer message batch must merge")
+            .expect("peer message batch carries metadata");
+
+        let overlay = metadata
+            .turn_tool_overlay
+            .expect("two-delivery batch must mint a reply-capability overlay");
+        let context = reply_context_from_overlay(&overlay);
+        assert_eq!(
+            context
+                .deliveries
+                .iter()
+                .map(|capability| (capability.peer_id, capability.in_reply_to))
+                .collect::<Vec<_>>(),
+            vec![
+                (
+                    meerkat_core::comms::PeerId::from_uuid(first_peer),
+                    InteractionId(uuid::Uuid::from_u128(1))
+                ),
+                (
+                    meerkat_core::comms::PeerId::from_uuid(second_peer),
+                    InteractionId(uuid::Uuid::from_u128(2))
+                ),
+            ],
+            "deliveries must preserve batch delivery order"
+        );
+    }
+
+    /// Non-message peer conventions and non-canonical peer ids mint no
+    /// overlay at the batch level.
+    #[test]
+    fn non_reply_eligible_batches_mint_no_overlay() {
+        let terminal =
+            make_terminal_peer_response(TEST_PEER_RESPONSE_ROUTE_ID, TEST_PEER_RESPONSE_REQUEST_ID);
+        let semantics = admission_semantics(&terminal);
+        let metadata = merge_batch_turn_metadata(&[(InputId::new(), terminal)], &[semantics])
+            .expect("terminal batch must merge")
+            .expect("terminal batch carries metadata");
+        assert!(
+            metadata.turn_tool_overlay.is_none(),
+            "terminal peer responses must not mint a reply capability"
+        );
+
+        let mut non_canonical = make_peer_message("peer-1", "hello");
+        if let Input::Peer(peer) = &mut non_canonical {
+            peer.header.correlation_id =
+                Some(crate::CorrelationId::from_uuid(uuid::Uuid::from_u128(3)));
+        }
+        let semantics = admission_semantics(&non_canonical);
+        let metadata = merge_batch_turn_metadata(&[(InputId::new(), non_canonical)], &[semantics])
+            .expect("non-canonical peer batch must merge")
+            .expect("non-canonical peer batch carries metadata");
+        assert!(
+            metadata.turn_tool_overlay.is_none(),
+            "a non-canonical peer id must not mint a reply capability"
+        );
+    }
+
+    /// The reply-capability overlay composes with a caller-supplied overlay
+    /// carrying an unrelated dispatch-context key (e.g. WorkGraph attention)
+    /// instead of replacing it.
+    #[test]
+    fn reply_capability_overlay_composes_with_existing_dispatch_context() {
+        let workgraph_overlay = meerkat_core::service::TurnToolOverlay {
+            allowed_tools: None,
+            blocked_tools: Some(vec![meerkat_core::types::ToolName::from("blocked_by_flow")]),
+            dispatch_context: std::collections::BTreeMap::from([(
+                "workgraph.attention_projection".to_string(),
+                serde_json::json!({"binding_id": "b"}),
+            )]),
+        };
+        let prompt = Input::Prompt(crate::input::PromptInput::new(
+            "carry the workgraph overlay",
+            Some(
+                meerkat_core::lifecycle::run_primitive::RuntimeTurnMetadata {
+                    turn_tool_overlay: Some(workgraph_overlay),
+                    ..Default::default()
+                },
+            ),
+        ));
+        let peer_uuid = uuid::Uuid::from_u128(0x51);
+        let mut peer = make_peer_message(&peer_uuid.to_string(), "hello");
+        if let Input::Peer(peer_input) = &mut peer {
+            peer_input.header.correlation_id =
+                Some(crate::CorrelationId::from_uuid(uuid::Uuid::from_u128(4)));
+        }
+        let semantics = vec![admission_semantics(&prompt), admission_semantics(&peer)];
+        let inputs = vec![(InputId::new(), prompt), (InputId::new(), peer)];
+
+        let metadata = merge_batch_turn_metadata(&inputs, &semantics)
+            .expect("prompt + peer message batch must merge")
+            .expect("batch carries metadata");
+
+        let overlay = metadata.turn_tool_overlay.expect("composed overlay");
+        assert_eq!(
+            overlay.blocked_tools,
+            Some(vec![meerkat_core::types::ToolName::from("blocked_by_flow")]),
+            "caller overlay facts must survive the reply-capability mint"
+        );
+        assert_eq!(
+            overlay.dispatch_context["workgraph.attention_projection"],
+            serde_json::json!({"binding_id": "b"})
+        );
+        let context = reply_context_from_overlay(&overlay);
+        assert_eq!(context.deliveries.len(), 1);
+        assert_eq!(
+            context.deliveries[0].peer_id,
+            meerkat_core::comms::PeerId::from_uuid(peer_uuid)
+        );
     }
 
     fn make_terminal_peer_response(peer_id: &str, request_id: &str) -> Input {

--- a/meerkat-runtime/src/service_ext.rs
+++ b/meerkat-runtime/src/service_ext.rs
@@ -4,7 +4,7 @@
 //! operations. It lives in meerkat-runtime (NOT in core) to maintain
 //! the separation: core owns SessionService, runtime owns runtime extensions.
 
-use meerkat_core::lifecycle::InputId;
+use meerkat_core::lifecycle::{InputId, RunId};
 use meerkat_core::types::SessionId;
 
 use crate::accept::AcceptOutcome;
@@ -16,6 +16,9 @@ use crate::meerkat_machine_types::{
     SessionLlmReconfigureRequest, SwitchTurnRequest,
 };
 use crate::runtime_state::RuntimeState;
+use crate::terminal_status::{
+    InteractionSelector, InteractionTerminalReport, RunTerminalReport, Sourced,
+};
 use crate::traits::{ResetReport, RetireReport, RuntimeDriverError};
 
 /// v9 runtime extensions for SessionService.
@@ -92,6 +95,34 @@ pub trait SessionServiceRuntimeExt: Send + Sync {
         session_id: &SessionId,
         idempotency_key: &str,
     ) -> Result<Option<StoredInputState>, RuntimeDriverError>;
+
+    /// Durable terminal-status query for one interaction.
+    ///
+    /// Registered sessions answer from live DSL truth; unregistered sessions
+    /// on a machine with a persistent RuntimeStore answer from the durably
+    /// committed input-state witnesses WITHOUT reviving the runtime. A
+    /// never-admitted session id fails typed `NotFound`; unregistered
+    /// sessions on a store-less (ephemeral) machine keep the `NotReady`
+    /// class. `Ok(None)` means the session is known but no input matches the
+    /// selector.
+    async fn interaction_terminal_status(
+        &self,
+        session_id: &SessionId,
+        selector: InteractionSelector,
+    ) -> Result<Option<Sourced<InteractionTerminalReport>>, RuntimeDriverError>;
+
+    /// Durable terminal-status query for a run.
+    ///
+    /// Evaluates the input-state witnesses whose `last_run_id` references
+    /// `run_id` (live snapshot when registered, durable store rows
+    /// otherwise) through the canonical pure evaluator. An unknown run on a
+    /// known session reports `NoDurableWitness` — callers must not read that
+    /// as `Failed` (re-staging rebinds `last_run_id`).
+    async fn run_terminal_status(
+        &self,
+        session_id: &SessionId,
+        run_id: &RunId,
+    ) -> Result<Sourced<RunTerminalReport>, RuntimeDriverError>;
 
     /// List all active (non-terminal) inputs for a session.
     async fn list_active_inputs(

--- a/meerkat-runtime/src/terminal_status.rs
+++ b/meerkat-runtime/src/terminal_status.rs
@@ -1,0 +1,409 @@
+//! Restart-first-class terminal-status evaluation over input-state witnesses.
+//!
+//! The durable truth for "did interaction X / run Y finish, and how?" is the
+//! set of per-input [`StoredInputState`] bundles: the DSL-owned seed carries
+//! `phase`, `last_run_id`, `terminal_outcome`, and `attempt_count`, and the
+//! runtime store commits those rows atomically at every machine lifecycle
+//! boundary (they are never deleted). This module owns the single canonical,
+//! pure evaluation used by BOTH witnesses — the live DSL-backed snapshot of a
+//! registered session and the durable store rows of an unregistered one — so
+//! the two sources cannot drift semantically.
+//!
+//! Honest limitation (run-status): an input that is re-staged to a later run
+//! rebinds `seed.last_run_id`, so a crashed-and-retried run can legitimately
+//! report [`RunTerminalStatus::NoDurableWitness`]. That is the durable truth;
+//! callers must not treat it as `Failed`.
+
+use chrono::{DateTime, Utc};
+use meerkat_core::lifecycle::{InputId, RunId};
+
+use crate::identifiers::IdempotencyKey;
+use crate::input_state::{
+    InputAbandonReason, InputLifecycleState, InputTerminalOutcome, StoredInputState,
+};
+
+/// Exactly-one lookup key for an interaction terminal-status query.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum InteractionSelector {
+    /// Look up by the canonical runtime input id.
+    InputId(InputId),
+    /// Look up by the caller-supplied idempotency key.
+    IdempotencyKey(String),
+}
+
+/// Which witness answered a terminal-status query.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TerminalWitnessSource {
+    /// The session is registered; facts were read from live DSL authority.
+    LiveRuntime,
+    /// The session is not registered; facts were read from the durably
+    /// committed input-state rows in the runtime store.
+    DurableStore,
+}
+
+/// Typed terminal-status report for a single interaction (input).
+#[derive(Debug, Clone, PartialEq)]
+pub struct InteractionTerminalReport {
+    pub input_id: InputId,
+    /// DSL-owned lifecycle phase at the time of the witness.
+    pub phase: InputLifecycleState,
+    /// `None` => not yet terminal; `phase` says where the input is.
+    pub terminal: Option<InputTerminalOutcome>,
+    /// The run the input last contributed to (`seed.last_run_id`).
+    pub resolving_run_id: Option<RunId>,
+    pub attempt_count: u32,
+    pub idempotency_key: Option<IdempotencyKey>,
+    pub updated_at: DateTime<Utc>,
+}
+
+/// How a run resolved, projected from its terminal input witnesses.
+#[derive(Debug, Clone, PartialEq)]
+pub enum RunResolutionClass {
+    /// At least one witness was consumed by the run.
+    Consumed,
+    /// No witness was consumed; the first abandoned witness (in admission
+    /// order) supplies the typed cause.
+    Abandoned { reason: InputAbandonReason },
+    /// Only superseded/coalesced witnesses reference the run.
+    Displaced,
+}
+
+/// Terminal status of a run, derived from durable input witnesses.
+#[derive(Debug, Clone, PartialEq)]
+pub enum RunTerminalStatus {
+    /// At least one non-terminal witness is still bound to the run.
+    InFlight,
+    /// Every witness bound to the run is terminal.
+    Resolved { outcome: RunResolutionClass },
+    /// No input's `last_run_id` references the run. NOTE: re-staging rebinds
+    /// `last_run_id`, so a retried run can legitimately land here.
+    NoDurableWitness,
+}
+
+/// Terminal-status report for a run.
+#[derive(Debug, Clone, PartialEq)]
+pub struct RunTerminalReport {
+    pub run_id: RunId,
+    pub status: RunTerminalStatus,
+    /// Inputs whose `seed.last_run_id` references the run, in admission order.
+    pub witnesses: Vec<InteractionTerminalReport>,
+}
+
+/// A report tagged with the witness source that produced it.
+#[derive(Debug, Clone, PartialEq)]
+pub struct Sourced<T> {
+    pub source: TerminalWitnessSource,
+    pub report: T,
+}
+
+/// Project one input-state bundle into its typed interaction report.
+///
+/// Pure and I/O-free: the single canonical projection used by both the live
+/// and the durable witness paths.
+#[must_use]
+pub fn interaction_report(bundle: &StoredInputState) -> InteractionTerminalReport {
+    InteractionTerminalReport {
+        input_id: bundle.state.input_id.clone(),
+        phase: bundle.seed.phase,
+        terminal: bundle.seed.terminal_outcome.clone(),
+        resolving_run_id: bundle.seed.last_run_id.clone(),
+        attempt_count: bundle.seed.attempt_count,
+        idempotency_key: bundle.state.idempotency_key.clone(),
+        updated_at: bundle.state.updated_at,
+    }
+}
+
+/// Resolve an idempotency key to its input bundle by exact match on the
+/// persisted shell key.
+///
+/// On the durable path this key IS the recovered authority fact: recovery
+/// re-enters the machine-owned idempotency binding from this exact field, so
+/// the durable witness and the live admission map cannot diverge.
+#[must_use]
+pub fn find_by_idempotency_key<'a>(
+    inputs: &'a [StoredInputState],
+    key: &str,
+) -> Option<&'a StoredInputState> {
+    inputs.iter().find(|stored| {
+        stored
+            .state
+            .idempotency_key
+            .as_ref()
+            .is_some_and(|stored_key| stored_key.0 == key)
+    })
+}
+
+/// Evaluate the terminal status of `run_id` over a set of input witnesses.
+///
+/// Witnesses are the inputs whose `seed.last_run_id` references the run,
+/// ordered by admission sequence. Precedence for resolved runs:
+/// `Consumed` > `Abandoned` (first witness in admission order supplies the
+/// cause) > `Displaced`. An empty witness set is `NoDurableWitness`.
+#[must_use]
+pub fn evaluate_run(run_id: &RunId, inputs: &[StoredInputState]) -> RunTerminalReport {
+    let mut witnesses: Vec<&StoredInputState> = inputs
+        .iter()
+        .filter(|stored| stored.seed.last_run_id.as_ref() == Some(run_id))
+        .collect();
+    // Admission order; inputs without an admission sequence sort last, then
+    // input id keeps the order deterministic.
+    witnesses.sort_by(|a, b| {
+        let a_key = (
+            a.seed.admission_sequence.is_none(),
+            a.seed.admission_sequence,
+        );
+        let b_key = (
+            b.seed.admission_sequence.is_none(),
+            b.seed.admission_sequence,
+        );
+        a_key
+            .cmp(&b_key)
+            .then_with(|| a.state.input_id.0.cmp(&b.state.input_id.0))
+    });
+
+    let status = if witnesses.is_empty() {
+        RunTerminalStatus::NoDurableWitness
+    } else if witnesses
+        .iter()
+        .any(|stored| stored.seed.terminal_outcome.is_none())
+    {
+        RunTerminalStatus::InFlight
+    } else if witnesses.iter().any(|stored| {
+        matches!(
+            stored.seed.terminal_outcome,
+            Some(InputTerminalOutcome::Consumed)
+        )
+    }) {
+        RunTerminalStatus::Resolved {
+            outcome: RunResolutionClass::Consumed,
+        }
+    } else if let Some(reason) =
+        witnesses
+            .iter()
+            .find_map(|stored| match &stored.seed.terminal_outcome {
+                Some(InputTerminalOutcome::Abandoned { reason }) => Some(reason.clone()),
+                _ => None,
+            })
+    {
+        RunTerminalStatus::Resolved {
+            outcome: RunResolutionClass::Abandoned { reason },
+        }
+    } else {
+        RunTerminalStatus::Resolved {
+            outcome: RunResolutionClass::Displaced,
+        }
+    };
+
+    RunTerminalReport {
+        run_id: run_id.clone(),
+        status,
+        witnesses: witnesses.into_iter().map(interaction_report).collect(),
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+    use crate::input_state::{InputState, InputStateSeed};
+
+    fn witness(
+        run_id: Option<&RunId>,
+        terminal: Option<InputTerminalOutcome>,
+        admission_sequence: Option<u64>,
+        idempotency_key: Option<&str>,
+    ) -> StoredInputState {
+        let input_id = InputId::new();
+        let mut state = InputState::new_accepted(input_id.clone());
+        state.idempotency_key = idempotency_key.map(IdempotencyKey::new);
+        let phase = match &terminal {
+            None => InputLifecycleState::Staged,
+            Some(InputTerminalOutcome::Consumed) => InputLifecycleState::Consumed,
+            Some(InputTerminalOutcome::Superseded { .. }) => InputLifecycleState::Superseded,
+            Some(InputTerminalOutcome::Coalesced { .. }) => InputLifecycleState::Coalesced,
+            Some(InputTerminalOutcome::Abandoned { .. }) => InputLifecycleState::Abandoned,
+        };
+        StoredInputState {
+            state,
+            seed: InputStateSeed {
+                phase,
+                last_run_id: run_id.cloned(),
+                last_boundary_sequence: None,
+                admission_sequence,
+                terminal_outcome: terminal,
+                attempt_count: 1,
+                recovery_lane: None,
+            },
+        }
+    }
+
+    fn abandoned(reason: InputAbandonReason) -> Option<InputTerminalOutcome> {
+        Some(InputTerminalOutcome::Abandoned { reason })
+    }
+
+    #[test]
+    fn consumed_takes_precedence_over_abandoned_and_displaced() {
+        let run_id = RunId::new();
+        let inputs = vec![
+            witness(
+                Some(&run_id),
+                abandoned(InputAbandonReason::Cancelled),
+                Some(1),
+                None,
+            ),
+            witness(
+                Some(&run_id),
+                Some(InputTerminalOutcome::Consumed),
+                Some(2),
+                None,
+            ),
+            witness(
+                Some(&run_id),
+                Some(InputTerminalOutcome::Superseded {
+                    superseded_by: InputId::new(),
+                }),
+                Some(3),
+                None,
+            ),
+        ];
+        let report = evaluate_run(&run_id, &inputs);
+        assert_eq!(
+            report.status,
+            RunTerminalStatus::Resolved {
+                outcome: RunResolutionClass::Consumed
+            }
+        );
+        assert_eq!(report.witnesses.len(), 3);
+    }
+
+    #[test]
+    fn abandoned_cause_is_first_abandoned_witness_in_admission_order() {
+        let run_id = RunId::new();
+        let inputs = vec![
+            witness(
+                Some(&run_id),
+                abandoned(InputAbandonReason::Stopped),
+                Some(9),
+                None,
+            ),
+            witness(
+                Some(&run_id),
+                abandoned(InputAbandonReason::Cancelled),
+                Some(2),
+                None,
+            ),
+        ];
+        let report = evaluate_run(&run_id, &inputs);
+        assert_eq!(
+            report.status,
+            RunTerminalStatus::Resolved {
+                outcome: RunResolutionClass::Abandoned {
+                    reason: InputAbandonReason::Cancelled
+                }
+            },
+            "the FIRST abandoned witness in admission order supplies the cause"
+        );
+    }
+
+    #[test]
+    fn all_superseded_or_coalesced_is_displaced() {
+        let run_id = RunId::new();
+        let inputs = vec![
+            witness(
+                Some(&run_id),
+                Some(InputTerminalOutcome::Superseded {
+                    superseded_by: InputId::new(),
+                }),
+                Some(1),
+                None,
+            ),
+            witness(
+                Some(&run_id),
+                Some(InputTerminalOutcome::Coalesced {
+                    aggregate_id: InputId::new(),
+                }),
+                Some(2),
+                None,
+            ),
+        ];
+        let report = evaluate_run(&run_id, &inputs);
+        assert_eq!(
+            report.status,
+            RunTerminalStatus::Resolved {
+                outcome: RunResolutionClass::Displaced
+            }
+        );
+    }
+
+    #[test]
+    fn one_non_terminal_witness_is_in_flight() {
+        let run_id = RunId::new();
+        let inputs = vec![
+            witness(
+                Some(&run_id),
+                Some(InputTerminalOutcome::Consumed),
+                Some(1),
+                None,
+            ),
+            witness(Some(&run_id), None, Some(2), None),
+        ];
+        let report = evaluate_run(&run_id, &inputs);
+        assert_eq!(report.status, RunTerminalStatus::InFlight);
+    }
+
+    #[test]
+    fn empty_witness_set_is_no_durable_witness() {
+        let run_id = RunId::new();
+        let other_run = RunId::new();
+        let inputs = vec![witness(
+            Some(&other_run),
+            Some(InputTerminalOutcome::Consumed),
+            Some(1),
+            None,
+        )];
+        let report = evaluate_run(&run_id, &inputs);
+        assert_eq!(report.status, RunTerminalStatus::NoDurableWitness);
+        assert!(report.witnesses.is_empty());
+    }
+
+    #[test]
+    fn find_by_idempotency_key_is_exact_match_only() {
+        let run_id = RunId::new();
+        let inputs = vec![
+            witness(
+                Some(&run_id),
+                Some(InputTerminalOutcome::Consumed),
+                Some(1),
+                Some("interaction-1"),
+            ),
+            witness(Some(&run_id), None, Some(2), None),
+        ];
+        assert!(find_by_idempotency_key(&inputs, "interaction-1").is_some());
+        assert!(
+            find_by_idempotency_key(&inputs, "interaction").is_none(),
+            "prefix must not match"
+        );
+        assert!(
+            find_by_idempotency_key(&inputs, "interaction-12").is_none(),
+            "superstring must not match"
+        );
+    }
+
+    #[test]
+    fn interaction_report_projects_seed_and_shell_facts() {
+        let run_id = RunId::new();
+        let stored = witness(
+            Some(&run_id),
+            Some(InputTerminalOutcome::Consumed),
+            Some(7),
+            Some("key-7"),
+        );
+        let report = interaction_report(&stored);
+        assert_eq!(report.input_id, stored.state.input_id);
+        assert_eq!(report.phase, InputLifecycleState::Consumed);
+        assert_eq!(report.terminal, Some(InputTerminalOutcome::Consumed));
+        assert_eq!(report.resolving_run_id, Some(run_id));
+        assert_eq!(report.attempt_count, 1);
+        assert_eq!(report.idempotency_key, Some(IdempotencyKey::new("key-7")));
+    }
+}

--- a/meerkat-runtime/src/traits.rs
+++ b/meerkat-runtime/src/traits.rs
@@ -149,6 +149,13 @@ pub trait RuntimeDriver: Send + Sync {
     /// Get the persisted shell+seed bundle for a specific input.
     fn stored_input_state(&self, input_id: &InputId) -> Option<StoredInputState>;
 
+    /// Snapshot of every ledger entry paired with its DSL-owned seed.
+    ///
+    /// The live-runtime witness set for terminal-status evaluation: the same
+    /// facts a persistent store commits at every lifecycle boundary, read
+    /// from the DSL authority instead of disk.
+    fn stored_input_states_snapshot(&self) -> Result<Vec<StoredInputState>, RuntimeDriverError>;
+
     /// Resolve the machine-owned idempotency-key binding to its input id.
     ///
     /// Read-only reconciliation mirror of the generated admission map — it

--- a/meerkat-session/src/persistent.rs
+++ b/meerkat-session/src/persistent.rs
@@ -7920,6 +7920,23 @@ mod tests {
                 events,
             })
         }
+
+        fn inject_with_interaction_id(
+            &self,
+            _interaction_id: meerkat_core::InteractionId,
+            content: meerkat_core::types::ContentInput,
+            source: meerkat_core::PlainEventSource,
+            handling_mode: meerkat_core::types::HandlingMode,
+            render_metadata: Option<meerkat_core::types::RenderMetadata>,
+        ) -> Result<(), meerkat_core::event_injector::EventInjectorError> {
+            meerkat_core::EventInjector::inject(
+                self,
+                content,
+                source,
+                handling_mode,
+                render_metadata,
+            )
+        }
     }
 
     struct NoopCommsRuntime {

--- a/meerkat-session/src/persistent.rs
+++ b/meerkat-session/src/persistent.rs
@@ -1649,6 +1649,22 @@ impl<B: SessionAgentBuilder + 'static> PersistentSessionService<B> {
         }
     }
 
+    /// Metadata-seam sibling of [`Self::session_archived_by_authority`]:
+    /// the same authority precedence (runtime `Retired` realization primary,
+    /// durable typed lifecycle-terminal projection fallback), driven by an
+    /// already-decoded terminal fact instead of a full session document.
+    pub async fn session_archived_by_authority_with_terminal(
+        &self,
+        id: &SessionId,
+        lifecycle_terminal: Option<&SessionLifecycleTerminal>,
+    ) -> Result<bool, SessionError> {
+        match Self::load_runtime_state_for_session(&self.runtime_store, id).await? {
+            Some(RuntimeState::Retired) => Ok(true),
+            Some(_) => Ok(false),
+            None => Ok(lifecycle_terminal.is_some_and(|terminal| terminal.is_archived())),
+        }
+    }
+
     fn runtime_id_for_session(id: &SessionId) -> LogicalRuntimeId {
         LogicalRuntimeId::for_session(id)
     }
@@ -1804,7 +1820,8 @@ impl<B: SessionAgentBuilder + 'static> PersistentSessionService<B> {
                                 self.runtime_projection_fallback_quarantined(id).await;
                             match self.store_projection_recovery_source_resolved(
                                 id,
-                                &session,
+                                session.session_metadata().is_some(),
+                                session.build_state().is_some(),
                                 runtime_projection_quarantined,
                             ) {
                                 Ok(true) => Some(session),
@@ -2468,18 +2485,26 @@ impl<B: SessionAgentBuilder + 'static> PersistentSessionService<B> {
         }
     }
 
+    /// Drive the canonical SessionDocumentMachine recovery-source verdict for
+    /// a store-only projection from typed observations.
+    ///
+    /// Takes the two metadata-presence observations as bools so both read
+    /// seams (the full-session path and the metadata-only path) feed the SAME
+    /// machine input from their respective projections — neither re-derives
+    /// the verdict.
     fn store_projection_recovery_source_resolved(
         &self,
         id: &SessionId,
-        session: &Session,
+        session_metadata_present: bool,
+        build_state_present: bool,
         runtime_projection_quarantined: bool,
     ) -> Result<bool, SessionError> {
         let mut authority = SessionDocumentMachineAuthority::new();
         let effects = authority
             .recover_session_from_store(
                 SessionDocumentKey::new(id.to_string()),
-                session.session_metadata().is_some(),
-                session.build_state().is_some(),
+                session_metadata_present,
+                build_state_present,
                 runtime_projection_quarantined,
             )
             .map_err(|err| {
@@ -6332,6 +6357,150 @@ impl<B: SessionAgentBuilder + 'static> PersistentSessionService<B> {
         id: &SessionId,
     ) -> Result<Option<Session>, SessionError> {
         self.load_authoritative_session_base(id).await
+    }
+
+    /// Load the authoritative durable session METADATA view without
+    /// materializing the full session document.
+    ///
+    /// Mirrors the authority precedence of
+    /// [`Self::load_authoritative_session`] WITHOUT re-deriving any machine
+    /// verdict:
+    ///
+    /// 1. Runtime `Retired`: the durable store row is the authoritative read
+    ///    source; its metadata projection wins.
+    /// 2. Runtime snapshot present: the snapshot's metadata document stands
+    ///    when the store row is absent or agrees on both projected facts
+    ///    (`SESSION_METADATA_KEY`, `SESSION_LIFECYCLE_TERMINAL_KEY`) — in
+    ///    that case the full path's read-source arbitration cannot change
+    ///    the metadata answer, whichever side it picks. ANY disagreement is
+    ///    AMBIGUOUS: this seam delegates to the full
+    ///    [`Self::load_authoritative_session`] path and projects its result —
+    ///    the full path stays the single divergence arbiter (stale-prefix
+    ///    continuity, machine read-source verdicts, quarantine).
+    /// 3. Store-only row: eligibility is the same canonical
+    ///    SessionDocumentMachine recovery-source verdict the full path
+    ///    drives, fed with the same typed observations (metadata/build-state
+    ///    presence, quarantine marker). Verdict parity with the full path:
+    ///    `Ok(true)` exposes the view; `Ok(false)` and machine drive errors
+    ///    read as absent.
+    ///
+    /// This seam skips transcript-rewrite replay and rewrite-audit
+    /// verification — sound because it exposes ONLY the two session-authority
+    /// metadata facts, which replay never mutates (rewrites replace messages
+    /// and advance transcript revisions; they never touch
+    /// `SESSION_METADATA_KEY` or `SESSION_LIFECYCLE_TERMINAL_KEY`). The
+    /// returned view deliberately has no raw metadata-map accessor.
+    ///
+    /// Fail-closed: a corrupt value under either reserved key is an error,
+    /// never `Ok(None)`.
+    pub async fn load_authoritative_session_metadata(
+        &self,
+        id: &SessionId,
+    ) -> Result<Option<meerkat_core::PersistedSessionMetadataView>, SessionError> {
+        use meerkat_core::session::{SESSION_LIFECYCLE_TERMINAL_KEY, SESSION_METADATA_KEY};
+
+        let corrupt_metadata_error = |err: serde_json::Error| {
+            SessionError::Agent(AgentError::InternalError(format!(
+                "session {id} durable metadata failed typed restore: {err}"
+            )))
+        };
+
+        // (1) Retired: the durable archived projection row wins.
+        if matches!(
+            Self::load_runtime_state_for_session(&self.runtime_store, id).await?,
+            Some(RuntimeState::Retired)
+        ) {
+            let Some(meta) = self
+                .store
+                .load_meta(id)
+                .await
+                .map_err(|e| SessionError::Store(Box::new(e)))?
+            else {
+                return Ok(None);
+            };
+            return meerkat_core::PersistedSessionMetadataView::try_from_metadata_map(
+                meta.id,
+                &meta.metadata,
+            )
+            .map(Some)
+            .map_err(corrupt_metadata_error);
+        }
+
+        // (2) Committed runtime snapshot present.
+        let runtime_id = Self::runtime_id_for_session(id);
+        let snapshot_bytes = self
+            .runtime_store
+            .load_session_snapshot(&runtime_id)
+            .await
+            .map_err(|err| {
+                SessionError::Agent(AgentError::InternalError(format!(
+                    "failed to load runtime session snapshot: {err}"
+                )))
+            })?;
+        if let Some(bytes) = snapshot_bytes {
+            let document =
+                meerkat_core::session_metadata_document_from_slice(&bytes).map_err(|err| {
+                    SessionError::Agent(AgentError::InternalError(format!(
+                        "failed to decode runtime session snapshot metadata document for \
+                         session {id}: {err}"
+                    )))
+                })?;
+            let store_meta = self
+                .store
+                .load_meta(id)
+                .await
+                .map_err(|e| SessionError::Store(Box::new(e)))?;
+            let store_agrees = match store_meta.as_ref() {
+                None => true,
+                Some(meta) => {
+                    document.session_metadata_value() == meta.metadata.get(SESSION_METADATA_KEY)
+                        && document.lifecycle_terminal_value()
+                            == meta.metadata.get(SESSION_LIFECYCLE_TERMINAL_KEY)
+                }
+            };
+            if store_agrees {
+                return document
+                    .try_into_view()
+                    .map(Some)
+                    .map_err(corrupt_metadata_error);
+            }
+            // AMBIGUOUS snapshot-vs-row metadata: the full authoritative load
+            // owns divergence arbitration; project its result.
+            let Some(session) = self.load_authoritative_session(id).await? else {
+                return Ok(None);
+            };
+            return meerkat_core::PersistedSessionMetadataView::try_from_session(&session)
+                .map(Some)
+                .map_err(corrupt_metadata_error);
+        }
+
+        // (3) Store-only projection: mirror the canonical recovery-source
+        // verdict from the metadata row's typed observations.
+        let Some(meta) = self
+            .store
+            .load_meta(id)
+            .await
+            .map_err(|e| SessionError::Store(Box::new(e)))?
+        else {
+            return Ok(None);
+        };
+        let runtime_projection_quarantined = self.runtime_projection_fallback_quarantined(id).await;
+        match self.store_projection_recovery_source_resolved(
+            id,
+            meta.metadata.contains_key(SESSION_METADATA_KEY),
+            meta.metadata
+                .contains_key(meerkat_core::SESSION_BUILD_STATE_KEY),
+            runtime_projection_quarantined,
+        ) {
+            Ok(true) => meerkat_core::PersistedSessionMetadataView::try_from_metadata_map(
+                meta.id,
+                &meta.metadata,
+            )
+            .map(Some)
+            .map_err(corrupt_metadata_error),
+            // Verdict parity with the full path (`Ok(false) | Err(_) => None`).
+            Ok(false) | Err(_) => Ok(None),
+        }
     }
 
     /// Export the full session from the live task and persist it to the store.
@@ -17757,6 +17926,382 @@ mod tests {
             matches!(read_error, SessionError::NotFound { ref id } if *id == legacy_id),
             "archived read must reject with the typed archived/NotFound contract: {read_error:?}"
         );
+    }
+
+    fn metadata_seam_service(
+        store: &Arc<dyn SessionStore>,
+        runtime_store: &Arc<dyn RuntimeStore>,
+    ) -> PersistentSessionService<DummyBuilder> {
+        PersistentSessionService::new(
+            DummyBuilder,
+            4,
+            Arc::clone(store),
+            Arc::clone(runtime_store),
+            memory_blob_store(),
+        )
+    }
+
+    async fn seed_runtime_snapshot(runtime_store: &Arc<dyn RuntimeStore>, session: &Session) {
+        let snapshot = serde_json::to_vec(session).expect("snapshot session should serialize");
+        runtime_store
+            .commit_session_snapshot(
+                &PersistentSessionService::<DummyBuilder>::runtime_id_for_session(session.id()),
+                meerkat_runtime::store::SessionDelta {
+                    session_snapshot: snapshot,
+                },
+            )
+            .await
+            .expect("test should seed a runtime session snapshot");
+    }
+
+    /// AMBIGUITY FAILS CLOSED INTO THE FULL PATH: when the frozen runtime
+    /// snapshot carries metadata A and the durable store head carries
+    /// metadata B, the metadata seam must not prefer either projection on
+    /// its own — it delegates to `load_authoritative_session`, whose
+    /// machine-owned read-source verdict stays the divergence arbiter, and
+    /// mirrors that answer exactly (in BOTH verdict directions).
+    #[tokio::test]
+    async fn test_metadata_seam_ambiguous_snapshot_vs_head_equals_full_path() {
+        // Direction 1: the store head provably extends the stale snapshot —
+        // the full path picks the head; the seam must mirror it.
+        let store: Arc<dyn SessionStore> = Arc::new(MemoryStore::new());
+        let runtime_store: Arc<dyn RuntimeStore> = Arc::new(InMemoryRuntimeStore::new());
+        let service = metadata_seam_service(&store, &runtime_store);
+
+        let mut snapshot_session = recoverable_store_row();
+        snapshot_session.push(Message::User(UserMessage::text("hello".to_string())));
+        let id = snapshot_session.id().clone();
+        seed_runtime_snapshot(&runtime_store, &snapshot_session).await;
+
+        let mut head = snapshot_session.clone();
+        head.push(Message::User(UserMessage::text("newer".to_string())));
+        let mut head_metadata = head.session_metadata().expect("head metadata");
+        head_metadata.model = "head-model".to_string();
+        head.set_session_metadata(head_metadata)
+            .expect("head metadata should persist");
+        store.save(&head).await.expect("seed store head");
+
+        let view = service
+            .load_authoritative_session_metadata(&id)
+            .await
+            .expect("metadata seam load should succeed")
+            .expect("session must resolve");
+        let full_view = meerkat_core::PersistedSessionMetadataView::try_from_session(
+            &service
+                .load_authoritative_session(&id)
+                .await
+                .expect("full path load should succeed")
+                .expect("session must resolve"),
+        )
+        .expect("full-path view should project");
+        assert_eq!(
+            view.session_metadata.as_ref().map(|m| m.model.as_str()),
+            full_view
+                .session_metadata
+                .as_ref()
+                .map(|m| m.model.as_str()),
+            "ambiguous snapshot-vs-head metadata must resolve exactly like the full path"
+        );
+        assert_eq!(
+            view.session_metadata.as_ref().map(|m| m.model.as_str()),
+            Some("head-model"),
+            "the machine verdict picks the extending store head here; the seam must mirror it"
+        );
+
+        // Direction 2: the store row does NOT extend the snapshot (equal
+        // transcripts, diverged metadata only) — the full path keeps the
+        // runtime snapshot; the seam must mirror that too, proving it
+        // delegates instead of preferring the row.
+        let store: Arc<dyn SessionStore> = Arc::new(MemoryStore::new());
+        let runtime_store: Arc<dyn RuntimeStore> = Arc::new(InMemoryRuntimeStore::new());
+        let service = metadata_seam_service(&store, &runtime_store);
+
+        let mut snapshot_session = recoverable_store_row();
+        snapshot_session.push(Message::User(UserMessage::text("hello".to_string())));
+        let id = snapshot_session.id().clone();
+        seed_runtime_snapshot(&runtime_store, &snapshot_session).await;
+
+        let mut row = snapshot_session.clone();
+        let mut row_metadata = row.session_metadata().expect("row metadata");
+        row_metadata.model = "row-model".to_string();
+        row.set_session_metadata(row_metadata)
+            .expect("row metadata should persist");
+        store.save(&row).await.expect("seed diverged store row");
+
+        let view = service
+            .load_authoritative_session_metadata(&id)
+            .await
+            .expect("metadata seam load should succeed")
+            .expect("session must resolve");
+        let full_view = meerkat_core::PersistedSessionMetadataView::try_from_session(
+            &service
+                .load_authoritative_session(&id)
+                .await
+                .expect("full path load should succeed")
+                .expect("session must resolve"),
+        )
+        .expect("full-path view should project");
+        assert_eq!(
+            view.session_metadata.as_ref().map(|m| m.model.as_str()),
+            full_view
+                .session_metadata
+                .as_ref()
+                .map(|m| m.model.as_str()),
+            "seam must mirror the full path in the snapshot-wins direction too"
+        );
+        assert_eq!(
+            view.session_metadata.as_ref().map(|m| m.model.as_str()),
+            Some("test-model"),
+            "the machine verdict keeps the runtime snapshot here; the seam must mirror it"
+        );
+    }
+
+    /// When snapshot and store row agree on both projected metadata facts,
+    /// the seam answers from the snapshot document without a full load.
+    #[tokio::test]
+    async fn test_metadata_seam_agreeing_snapshot_and_row_project_without_full_load() {
+        let store: Arc<dyn SessionStore> = Arc::new(MemoryStore::new());
+        let runtime_store: Arc<dyn RuntimeStore> = Arc::new(InMemoryRuntimeStore::new());
+        let service = metadata_seam_service(&store, &runtime_store);
+
+        let mut session = recoverable_store_row();
+        session.push(Message::User(UserMessage::text("hello".to_string())));
+        let id = session.id().clone();
+        seed_runtime_snapshot(&runtime_store, &session).await;
+        store.save(&session).await.expect("seed agreeing store row");
+
+        let view = service
+            .load_authoritative_session_metadata(&id)
+            .await
+            .expect("metadata seam load should succeed")
+            .expect("session must resolve");
+        assert_eq!(
+            view.session_metadata.as_ref().map(|m| m.model.as_str()),
+            Some("test-model")
+        );
+        assert_eq!(view.session_id, id);
+
+        // Snapshot present with NO store row at all: the snapshot is the sole
+        // truth and projects directly.
+        let store: Arc<dyn SessionStore> = Arc::new(MemoryStore::new());
+        let runtime_store: Arc<dyn RuntimeStore> = Arc::new(InMemoryRuntimeStore::new());
+        let service = metadata_seam_service(&store, &runtime_store);
+        seed_runtime_snapshot(&runtime_store, &session).await;
+        let view = service
+            .load_authoritative_session_metadata(&id)
+            .await
+            .expect("metadata seam load should succeed")
+            .expect("snapshot-only session must resolve");
+        assert_eq!(
+            view.session_metadata.as_ref().map(|m| m.model.as_str()),
+            Some("test-model")
+        );
+    }
+
+    /// Once the machine has retired the runtime, the durable store row is
+    /// the authoritative read source — the frozen pre-retirement snapshot
+    /// (which may carry stale metadata) must not answer.
+    #[tokio::test]
+    async fn test_metadata_seam_retired_row_wins_over_frozen_snapshot() {
+        let store: Arc<dyn SessionStore> = Arc::new(MemoryStore::new());
+        let runtime_store: Arc<dyn RuntimeStore> = Arc::new(InMemoryRuntimeStore::new());
+        let service = metadata_seam_service(&store, &runtime_store);
+
+        let mut snapshot_session = recoverable_store_row();
+        let id = snapshot_session.id().clone();
+        snapshot_session.push(Message::User(UserMessage::text("hello".to_string())));
+        seed_runtime_snapshot(&runtime_store, &snapshot_session).await;
+
+        let mut row = snapshot_session.clone();
+        let mut row_metadata = row.session_metadata().expect("row metadata");
+        row_metadata.model = "post-archive-model".to_string();
+        row.set_session_metadata(row_metadata)
+            .expect("row metadata should persist");
+        row.set_lifecycle_terminal(SessionLifecycleTerminal::Archived)
+            .expect("row terminal should persist");
+        store.save(&row).await.expect("seed archived store row");
+
+        let machine = meerkat_runtime::MeerkatMachine::persistent(
+            Arc::clone(&runtime_store),
+            memory_blob_store(),
+        );
+        machine
+            .register_session(id.clone())
+            .await
+            .expect("register session");
+        meerkat_runtime::RuntimeControlPlane::retire(
+            &machine,
+            &PersistentSessionService::<DummyBuilder>::runtime_id_for_session(&id),
+        )
+        .await
+        .expect("retire session");
+
+        let view = service
+            .load_authoritative_session_metadata(&id)
+            .await
+            .expect("metadata seam load should succeed")
+            .expect("retired session must resolve from the durable row");
+        assert_eq!(
+            view.session_metadata.as_ref().map(|m| m.model.as_str()),
+            Some("post-archive-model"),
+            "the retired read source is the durable row, not the frozen snapshot"
+        );
+        assert_eq!(
+            view.lifecycle_terminal,
+            Some(SessionLifecycleTerminal::Archived)
+        );
+        assert!(
+            service
+                .session_archived_by_authority_with_terminal(&id, view.lifecycle_terminal.as_ref())
+                .await
+                .expect("archived-by-authority read must not error"),
+            "runtime Retired must read as archived through the terminal overload"
+        );
+    }
+
+    /// Store-only rows mirror the canonical recovery-source verdict: a raw
+    /// row without session metadata or build state is NOT a recoverable
+    /// projection and must read as absent — exactly like the full path.
+    #[tokio::test]
+    async fn test_metadata_seam_store_only_verdict_parity() {
+        let store: Arc<dyn SessionStore> = Arc::new(MemoryStore::new());
+        let runtime_store: Arc<dyn RuntimeStore> = Arc::new(InMemoryRuntimeStore::new());
+        let service = metadata_seam_service(&store, &runtime_store);
+
+        // Ineligible raw row: no session metadata, no build state.
+        let mut raw = Session::new();
+        raw.push(Message::User(UserMessage::text("raw".to_string())));
+        let raw_id = raw.id().clone();
+        store.save(&raw).await.expect("seed raw store row");
+        assert!(
+            service
+                .load_authoritative_session_metadata(&raw_id)
+                .await
+                .expect("metadata seam load should succeed")
+                .is_none(),
+            "a non-recoverable store-only row must read as absent through the seam"
+        );
+        assert!(
+            service
+                .load_authoritative_session(&raw_id)
+                .await
+                .expect("full path load should succeed")
+                .is_none(),
+            "verdict parity: the full path reads the same row as absent"
+        );
+
+        // Eligible recoverable row: carries session metadata.
+        let recoverable = recoverable_store_row();
+        let recoverable_id = recoverable.id().clone();
+        store
+            .save(&recoverable)
+            .await
+            .expect("seed recoverable store row");
+        let view = service
+            .load_authoritative_session_metadata(&recoverable_id)
+            .await
+            .expect("metadata seam load should succeed")
+            .expect("recoverable store-only row must project through the seam");
+        assert_eq!(
+            view.session_metadata.as_ref().map(|m| m.model.as_str()),
+            Some("test-model")
+        );
+        assert!(
+            service
+                .load_authoritative_session(&recoverable_id)
+                .await
+                .expect("full path load should succeed")
+                .is_some(),
+            "verdict parity: the full path recovers the same row"
+        );
+    }
+
+    /// Corrupt metadata under the reserved key is a read FAULT for the seam
+    /// — `Err`, never `Ok(None)` (which would launder corruption into
+    /// "no such session").
+    #[tokio::test]
+    async fn test_metadata_seam_corrupt_session_metadata_fails_closed() {
+        let store: Arc<dyn SessionStore> = Arc::new(MemoryStore::new());
+        let runtime_store: Arc<dyn RuntimeStore> = Arc::new(InMemoryRuntimeStore::new());
+        let service = metadata_seam_service(&store, &runtime_store);
+
+        let session = recoverable_store_row();
+        let id = session.id().clone();
+        let mut value = serde_json::to_value(&session).expect("session should serialize");
+        value["metadata"][SESSION_METADATA_KEY] = serde_json::json!(42);
+        let corrupt: Session =
+            serde_json::from_value(value).expect("corrupt envelope should still deserialize");
+        store.save(&corrupt).await.expect("seed corrupt store row");
+
+        service
+            .load_authoritative_session_metadata(&id)
+            .await
+            .expect_err("corrupt session_metadata must surface as Err, never Ok(None)");
+    }
+
+    /// Seam parity across present / absent / archived: filtering the seam
+    /// through `session_archived_by_authority_with_terminal` yields exactly
+    /// the visibility of the full-path `load_authoritative_session` +
+    /// `session_archived_by_authority` composition (the persistent
+    /// `MobSessionService::load_persisted_session` contract).
+    #[tokio::test]
+    async fn test_metadata_seam_visibility_parity_across_present_absent_archived() {
+        let store: Arc<dyn SessionStore> = Arc::new(MemoryStore::new());
+        let runtime_store: Arc<dyn RuntimeStore> = Arc::new(InMemoryRuntimeStore::new());
+        let service = metadata_seam_service(&store, &runtime_store);
+
+        // Present.
+        let present = recoverable_store_row();
+        let present_id = present.id().clone();
+        store.save(&present).await.expect("seed present row");
+
+        // Archived (legacy store-only archived shape).
+        let archived = legacy_store_only_archived_row();
+        let archived_id = archived.id().clone();
+        store.save(&archived).await.expect("seed archived row");
+
+        // Absent.
+        let absent_id = SessionId::new();
+
+        for (id, expected_visible) in [
+            (&present_id, true),
+            (&archived_id, false),
+            (&absent_id, false),
+        ] {
+            let seam_visible = match service
+                .load_authoritative_session_metadata(id)
+                .await
+                .expect("metadata seam load should succeed")
+            {
+                Some(view) => !service
+                    .session_archived_by_authority_with_terminal(
+                        id,
+                        view.lifecycle_terminal.as_ref(),
+                    )
+                    .await
+                    .expect("terminal archived read should succeed"),
+                None => false,
+            };
+            let full_visible = match service
+                .load_authoritative_session(id)
+                .await
+                .expect("full path load should succeed")
+            {
+                Some(session) => !service
+                    .session_archived_by_authority(id, &session)
+                    .await
+                    .expect("full archived read should succeed"),
+                None => false,
+            };
+            assert_eq!(
+                seam_visible, full_visible,
+                "seam visibility must match the full path for session {id}"
+            );
+            assert_eq!(
+                seam_visible, expected_visible,
+                "unexpected visibility for session {id}"
+            );
+        }
     }
 
     #[tokio::test]

--- a/meerkat-store/src/sqlite_store.rs
+++ b/meerkat-store/src/sqlite_store.rs
@@ -124,6 +124,48 @@ pub fn write_session_snapshot_in_txn(
     Ok(())
 }
 
+/// Map a row of the canonical metadata projection column set
+/// (`session_id, created_at_ms, updated_at_ms, message_count, total_tokens,
+/// metadata_json`) into a [`SessionMeta`]. Shared by `list` and `load_meta`
+/// so the two projections cannot drift.
+fn session_meta_from_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<SessionMeta> {
+    let metadata_json = row.get::<_, JsonColumnBytes>(5)?.into_bytes();
+    let metadata = serde_json::from_slice(&metadata_json).map_err(|err| {
+        rusqlite::Error::FromSqlConversionFailure(5, rusqlite::types::Type::Text, Box::new(err))
+    })?;
+    let id = parse_session_id(row.get(0)?).map_err(|err| {
+        rusqlite::Error::FromSqlConversionFailure(0, rusqlite::types::Type::Text, Box::new(err))
+    })?;
+    // Derived projection counters are stored as i64. A negative
+    // or out-of-range value is an impossible durable state, so
+    // fail closed with a typed Corrupted error rather than
+    // laundering it to usize::MAX/u64::MAX (terminal-truth
+    // store-metadata cluster). The canonical truth is in
+    // session_json; the caller can recover via load().
+    let message_count = usize::try_from(row.get::<_, i64>(3)?).map_err(|_| {
+        rusqlite::Error::FromSqlConversionFailure(
+            3,
+            rusqlite::types::Type::Integer,
+            Box::new(StoreError::Corrupted(id.clone())),
+        )
+    })?;
+    let total_tokens = u64::try_from(row.get::<_, i64>(4)?).map_err(|_| {
+        rusqlite::Error::FromSqlConversionFailure(
+            4,
+            rusqlite::types::Type::Integer,
+            Box::new(StoreError::Corrupted(id.clone())),
+        )
+    })?;
+    Ok(SessionMeta {
+        id,
+        created_at: millis_to_system_time(row.get(1)?),
+        updated_at: millis_to_system_time(row.get(2)?),
+        message_count,
+        total_tokens,
+        metadata,
+    })
+}
+
 fn load_session_snapshot_in_txn(
     tx: &Transaction<'_>,
     id: &SessionId,
@@ -224,55 +266,38 @@ impl SqliteSessionStore {
             )?;
             let rows = stmt.query_map(
                 params![created_after, updated_after, limit, offset],
-                |row| {
-                    let metadata_json = row.get::<_, JsonColumnBytes>(5)?.into_bytes();
-                    let metadata = serde_json::from_slice(&metadata_json).map_err(|err| {
-                        rusqlite::Error::FromSqlConversionFailure(
-                            5,
-                            rusqlite::types::Type::Text,
-                            Box::new(err),
-                        )
-                    })?;
-                    let id = parse_session_id(row.get(0)?).map_err(|err| {
-                        rusqlite::Error::FromSqlConversionFailure(
-                            0,
-                            rusqlite::types::Type::Text,
-                            Box::new(err),
-                        )
-                    })?;
-                    // Derived projection counters are stored as i64. A negative
-                    // or out-of-range value is an impossible durable state, so
-                    // fail closed with a typed Corrupted error rather than
-                    // laundering it to usize::MAX/u64::MAX (terminal-truth
-                    // store-metadata cluster). The canonical truth is in
-                    // session_json; the caller can recover via load().
-                    let message_count = usize::try_from(row.get::<_, i64>(3)?).map_err(|_| {
-                        rusqlite::Error::FromSqlConversionFailure(
-                            3,
-                            rusqlite::types::Type::Integer,
-                            Box::new(StoreError::Corrupted(id.clone())),
-                        )
-                    })?;
-                    let total_tokens = u64::try_from(row.get::<_, i64>(4)?).map_err(|_| {
-                        rusqlite::Error::FromSqlConversionFailure(
-                            4,
-                            rusqlite::types::Type::Integer,
-                            Box::new(StoreError::Corrupted(id.clone())),
-                        )
-                    })?;
-                    Ok(SessionMeta {
-                        id,
-                        created_at: millis_to_system_time(row.get(1)?),
-                        updated_at: millis_to_system_time(row.get(2)?),
-                        message_count,
-                        total_tokens,
-                        metadata,
-                    })
-                },
+                session_meta_from_row,
             )?;
 
             rows.collect::<Result<Vec<_>, _>>()
                 .map_err(StoreError::from)
+        })
+        .await
+        .map_err(StoreError::Join)?
+    }
+
+    async fn load_meta_impl(&self, id: &SessionId) -> Result<Option<SessionMeta>, StoreError> {
+        let path = self.path.clone();
+        let session_id = id.to_string();
+        tokio::task::spawn_blocking(move || {
+            let conn = open_connection(&path)?;
+            conn.query_row(
+                r"
+                SELECT
+                    session_id,
+                    created_at_ms,
+                    updated_at_ms,
+                    message_count,
+                    total_tokens,
+                    metadata_json
+                FROM sessions
+                WHERE session_id = ?1
+                ",
+                params![session_id],
+                session_meta_from_row,
+            )
+            .optional()
+            .map_err(StoreError::from)
         })
         .await
         .map_err(StoreError::Join)?
@@ -392,6 +417,15 @@ impl SessionStore for SqliteSessionStore {
 
     async fn list(&self, filter: SessionFilter) -> Result<Vec<SessionMeta>, SessionStoreError> {
         self.list_impl(filter)
+            .await
+            .map_err(into_session_store_error)
+    }
+
+    /// Metadata-only partial read over the durable projection columns —
+    /// never touches `session_json`, so it survives a corrupt or unreadable
+    /// full session document.
+    async fn load_meta(&self, id: &SessionId) -> Result<Option<SessionMeta>, SessionStoreError> {
+        self.load_meta_impl(id)
             .await
             .map_err(into_session_store_error)
     }
@@ -643,6 +677,79 @@ mod tests {
                 .unwrap()
         );
         assert!(first.load(session.id()).await.unwrap().is_none());
+    }
+
+    /// The metadata projection columns are durable truth independent of the
+    /// full session document: a corrupt/unreadable `session_json` must fail
+    /// the full `load()` but MUST NOT take the metadata-only read seam down
+    /// with it. Under the trait-default `load_meta` (full load projected
+    /// through `SessionMeta::from`) this test is RED; the SQLite SQL
+    /// projection override makes it green.
+    #[tokio::test]
+    async fn load_meta_survives_corrupt_session_json() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("sessions.sqlite3");
+        let store = SqliteSessionStore::open(&path).unwrap();
+
+        let mut session = Session::new();
+        session.push(Message::User(UserMessage::text("hello".to_string())));
+        store.save(&session).await.unwrap();
+
+        // Corrupt the full document column directly on disk.
+        let conn = open_connection(&path).unwrap();
+        conn.execute(
+            "UPDATE sessions SET session_json = X'DEADBEEF' WHERE session_id = ?1",
+            params![session.id().to_string()],
+        )
+        .unwrap();
+        drop(conn);
+
+        store
+            .load(session.id())
+            .await
+            .expect_err("corrupt session_json must fail the full document load");
+
+        let meta = store
+            .load_meta(session.id())
+            .await
+            .expect("load_meta must project the metadata row without decoding session_json")
+            .expect("metadata row must still exist");
+        assert_eq!(meta.id, *session.id());
+        assert_eq!(meta.message_count, 1);
+    }
+
+    #[tokio::test]
+    async fn load_meta_matches_list_row_and_reads_absent_as_none() {
+        let (_dir, store) = temp_store();
+        let mut session = Session::new();
+        session.push(Message::User(UserMessage::text("hello".to_string())));
+        session.set_metadata("caller_key", serde_json::json!("caller_value"));
+        store.save(&session).await.unwrap();
+
+        let listed = store.list(SessionFilter::default()).await.unwrap();
+        assert_eq!(listed.len(), 1);
+        let meta = store
+            .load_meta(session.id())
+            .await
+            .unwrap()
+            .expect("metadata row exists");
+        assert_eq!(meta.id, listed[0].id);
+        assert_eq!(meta.message_count, listed[0].message_count);
+        assert_eq!(meta.total_tokens, listed[0].total_tokens);
+        assert_eq!(meta.metadata, listed[0].metadata);
+        assert_eq!(
+            meta.metadata.get("caller_key"),
+            Some(&serde_json::json!("caller_value"))
+        );
+
+        assert!(
+            store
+                .load_meta(&meerkat_core::SessionId::new())
+                .await
+                .unwrap()
+                .is_none(),
+            "an absent session reads as None, not an error"
+        );
     }
 
     #[tokio::test]

--- a/meerkat-tools/src/builtin/comms/surface.rs
+++ b/meerkat-tools/src/builtin/comms/surface.rs
@@ -65,11 +65,12 @@ impl CommsToolSurface {
 You can communicate with other agents using these tools:
 
 - **send_message**: Send a message to a peer. Always include `handling_mode` — use `"steer"` for normal collaboration.
+- **reply_to_peer**: Reply to the peer whose message triggered the current turn. Pre-addressed — no peer_id needed. Always include `handling_mode`. If several peer messages arrived this turn, set `reply_to` to one of the delivery ids listed by the ambiguity error.
 - **send_request**: Send a structured request (intent + params) and expect a correlated response. Always include `handling_mode`.
 - **send_response**: Reply to a previous request using its ID.
 - **peers**: List all visible peers. Always check peers first to see who is available.
 
-Use `send_message` for ordinary collaboration. Use `send_request` only when you need structured intent/params with a correlated reply."#
+Use `reply_to_peer` to answer an incoming peer message, `send_message` for ordinary outreach. Use `send_request` only when you need structured intent/params with a correlated reply."#
     }
 }
 

--- a/meerkat/src/surface.rs
+++ b/meerkat/src/surface.rs
@@ -65,7 +65,7 @@ use meerkat_contracts::{
 use meerkat_core::ConfigStoreMetadata;
 use meerkat_core::{AgentEvent, Config, PeerMeta};
 
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::BTreeMap;
 #[cfg(not(target_arch = "wasm32"))]
 use tokio::sync::mpsc;
 #[cfg(target_arch = "wasm32")]
@@ -95,6 +95,18 @@ pub enum WorkGraphAttentionTurnOverlayError {
     WorkGraph(#[from] crate::WorkGraphError),
     #[error("conflicting turn tool overlay dispatch context for {key}")]
     ConflictingDispatchContext { key: String },
+}
+
+impl From<meerkat_core::service::TurnToolOverlayComposeError>
+    for WorkGraphAttentionTurnOverlayError
+{
+    fn from(error: meerkat_core::service::TurnToolOverlayComposeError) -> Self {
+        match error {
+            meerkat_core::service::TurnToolOverlayComposeError::ConflictingDispatchContext {
+                key,
+            } => Self::ConflictingDispatchContext { key },
+        }
+    }
 }
 
 pub async fn inject_workgraph_attention_turn_overlay(
@@ -347,71 +359,12 @@ fn compose_turn_tool_overlay(
     existing: Option<meerkat_core::service::TurnToolOverlay>,
     attention: meerkat_core::service::TurnToolOverlay,
 ) -> Result<meerkat_core::service::TurnToolOverlay, WorkGraphAttentionTurnOverlayError> {
-    let Some(existing) = existing else {
-        return Ok(attention);
-    };
-    let allowed_tools = intersect_allowed_tools(existing.allowed_tools, attention.allowed_tools);
-    let blocked_tools = union_blocked_tools(existing.blocked_tools, attention.blocked_tools);
-    let dispatch_context =
-        merge_turn_dispatch_context(existing.dispatch_context, attention.dispatch_context)?;
-    Ok(meerkat_core::service::TurnToolOverlay {
-        allowed_tools,
-        blocked_tools,
-        dispatch_context,
-    })
-}
-
-fn intersect_allowed_tools(
-    left: Option<Vec<meerkat_core::types::ToolName>>,
-    right: Option<Vec<meerkat_core::types::ToolName>>,
-) -> Option<Vec<meerkat_core::types::ToolName>> {
-    match (left, right) {
-        (Some(left), Some(right)) => {
-            let right = right.into_iter().collect::<BTreeSet<_>>();
-            Some(
-                left.into_iter()
-                    .filter(|name| right.contains(name))
-                    .collect::<BTreeSet<_>>()
-                    .into_iter()
-                    .collect(),
-            )
-        }
-        (Some(left), None) => Some(left),
-        (None, Some(right)) => Some(right),
-        (None, None) => None,
-    }
-}
-
-fn union_blocked_tools(
-    left: Option<Vec<meerkat_core::types::ToolName>>,
-    right: Option<Vec<meerkat_core::types::ToolName>>,
-) -> Option<Vec<meerkat_core::types::ToolName>> {
-    let blocked = left
-        .into_iter()
-        .flatten()
-        .chain(right.into_iter().flatten())
-        .collect::<BTreeSet<_>>()
-        .into_iter()
-        .collect::<Vec<_>>();
-    (!blocked.is_empty()).then_some(blocked)
-}
-
-fn merge_turn_dispatch_context(
-    mut existing: BTreeMap<String, serde_json::Value>,
-    attention: BTreeMap<String, serde_json::Value>,
-) -> Result<BTreeMap<String, serde_json::Value>, WorkGraphAttentionTurnOverlayError> {
-    for (key, value) in attention {
-        match existing.get(&key) {
-            Some(current) if current != &value => {
-                return Err(WorkGraphAttentionTurnOverlayError::ConflictingDispatchContext { key });
-            }
-            Some(_) => {}
-            None => {
-                existing.insert(key, value);
-            }
-        }
-    }
-    Ok(existing)
+    // Single canonical composition path: core owns overlay composition
+    // semantics (`TurnToolOverlay::compose`); this surface only maps the typed
+    // conflict into its own error vocabulary.
+    Ok(meerkat_core::service::TurnToolOverlay::compose(
+        existing, attention,
+    )?)
 }
 
 /// Surface-specific facts used to build a read-only runtime host projection.

--- a/tests/integration/tests/phase2_mode_routing.rs
+++ b/tests/integration/tests/phase2_mode_routing.rs
@@ -87,6 +87,17 @@ impl SubscribableInjector for MockInjector {
             events: rx,
         })
     }
+
+    fn inject_with_interaction_id(
+        &self,
+        _interaction_id: InteractionId,
+        body: ContentInput,
+        source: PlainEventSource,
+        handling_mode: HandlingMode,
+        render_metadata: Option<RenderMetadata>,
+    ) -> Result<(), EventInjectorError> {
+        self.inject(body, source, handling_mode, render_metadata)
+    }
 }
 
 #[async_trait]


### PR DESCRIPTION
Four workstreams from the outstanding-asks sweep, each implemented from an adversarially-produced design, red-verified, and merged serially after cross-verification (workspace unit 7406/7406 on the integrated branch):

**M2 remainder (studio P1)** — parts 1+2 (typed `McpServerConfig` build seam + composite bind forwarding) already shipped in 0.7.19; this fixes the two real remainders: machine-authorized **revival now recomposes per-spawn external tools** (retention map on the mob actor, threaded through spawn/respawn/dispose; customizer-restored tools seeded at cold restore), and **`MemberSpawnedEvent` durably carries `effective_profile_override`** so per-spawn declarative MCP servers survive process restarts without a `SpawnMemberCustomizer` (roster replay no longer hardcodes `None`). Both red-verified.

**M4 (studio P2) + ask 15 addendum** — the terminal-status query is now **restart-first-class**: `session/input_status` (and the new `SessionServiceRuntimeExt::interaction_terminal_status`/`run_terminal_status` host APIs backed by a pure evaluator in `meerkat-runtime/src/terminal_status.rs`) answer from the durable RuntimeStore input-state rows without requiring a registered session — zero wire changes. The ask-15 addendum root fix: the mob work lane now threads the host interaction id (`WorkSpec.interaction_id` → dispatch → transcript identity / inbox injection), so history backfill can stamp `interaction_complete` frames. Release note: `input_state`/`session/input_status` now return `Ok`/typed `NotFound` for unregistered persistent sessions instead of `NotReady{Destroyed}` — liveness probes should use `runtime_state()`.

**Ask 26 (mobkit P2)** — typed peer-reply seam: peer-message turns mint a `PeerReplyCapability` set into the turn overlay dispatch context (batch-level, fail-closed, composes with the workgraph attention overlay via the newly lifted `TurnToolOverlay::compose` — one canonical compose path), and a pre-addressed **`reply_to_peer`** comms tool answers the delivery with typed errors (`no_reply_capability`/`ambiguous_reply`/`unknown_reply_to`), trust re-validated at send. Zero wire/contract changes.

**Ask 24 clause 3 (mobkit)** — metadata-only session read seam: `PersistedSessionMetadataView` + `SessionStore::load_meta` (SQLite SQL projection; JSONL/memory keep the derived default), `PersistentSessionService::load_authoritative_session_metadata` mirroring authority precedence with ambiguity **delegating to the full canonical load** (never re-deriving machine verdicts), `MobSessionService::load_persisted_session_metadata`, and consumer migrations (mob-mcp ownership probe, tool-access policy, builder candidate matching full-loads only the winner, revival presence probe). Red-verified including the corrupt-`session_json`-survival projection test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)