### PR TITLE
fix: classic-store projection bridge consults the write-half rollback (B-2)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -891,7 +891,28 @@ jobs:
     needs: [publish_github_release]
     runs-on: ubuntu-latest
     steps:
+      # An assets-only backfill can target an OLD tag after a newer release
+      # has already shipped; pointing the tap at it would DOWNGRADE every
+      # `brew upgrade` user (field: the v0.7.24 backfill re-pointed the tap
+      # from 0.7.25 to 0.7.24). The tap must only ever track the repository's
+      # latest release.
+      - name: Require target tag to be the latest release
+        id: latest_guard
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.release_tag || github.ref_name }}
+        run: |
+          set -euo pipefail
+          LATEST=$(gh release view --repo "${GITHUB_REPOSITORY}" --json tagName --jq .tagName)
+          if [ "${LATEST}" != "${RELEASE_TAG}" ]; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "target ${RELEASE_TAG} is not the latest release (${LATEST}); leaving the tap untouched"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Checkout tap
+        if: steps.latest_guard.outputs.skip != 'true'
         uses: actions/checkout@v6
         with:
           repository: lukacf/homebrew-meerkat
@@ -899,6 +920,7 @@ jobs:
           path: homebrew-meerkat
 
       - name: Download checksums
+        if: steps.latest_guard.outputs.skip != 'true'
         env:
           RELEASE_TAG: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.release_tag || github.ref_name }}
         run: |
@@ -906,6 +928,7 @@ jobs:
           curl -fsSL "https://github.com/lukacf/meerkat/releases/download/${RELEASE_TAG}/checksums.sha256" -o checksums.sha256
 
       - name: Generate updated formula
+        if: steps.latest_guard.outputs.skip != 'true'
         env:
           VERSION: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.release_tag || github.ref_name }}
         run: |
@@ -979,6 +1002,7 @@ jobs:
           } > homebrew-meerkat/rkat.rb
 
       - name: Commit and push formula
+        if: steps.latest_guard.outputs.skip != 'true'
         working-directory: homebrew-meerkat
         env:
           VERSION: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.release_tag || github.ref_name }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,23 @@ release that breaks public API declares it under a `### Breaking` heading
 naming the changed signatures (enforced by the `semver-breaks` release gate
 via cargo-semver-checks against the published baselines).
 
+## [Unreleased]
+
+### Fixed
+
+- The torn-shutdown save wedge now also clears on CLASSIC (non-incremental)
+  session stores (field, identity-first gateways on meerkat 0.7.25: resume
+  saves rejected with "message count 165 is shorter than previously
+  persisted 167" retried forever). 0.7.24's write-half rollback
+  (`ResolveRuntimeProjectionRollback` → `RebuildToAuthority`) was consulted
+  on the incremental head-canonical save path and the audited
+  authoritative-projection path, but external `SessionStore` implementations
+  route plain projection saves through the storage-normalization bridge —
+  which re-threw `MonotonicityViolation` against a checkpointer-stamped
+  ahead row on every retry. The bridge now consults the same machine-owned
+  arbitration and converges via the CAS projection write; unstamped or
+  content-forked rows keep failing closed.
+
 ## [0.7.25] - 2026-07-08
 
 Meerkat 0.7.25 is the outstanding-asks sweep: O(delta) incremental session

--- a/meerkat-session/src/persistent.rs
+++ b/meerkat-session/src/persistent.rs
@@ -1414,6 +1414,35 @@ async fn save_session_projection_with_storage_normalization_bridge(
 ) -> Result<(), SessionStoreError> {
     match store.save(session).await {
         Ok(()) => Ok(()),
+        // Write half of the torn-shutdown wedge for CLASSIC (non-incremental)
+        // stores (field, meerkat 0.7.25 / identity-first gateways): the
+        // intra-turn checkpointer left a stamped row AHEAD of the committed
+        // authority, and this authority save trips the store's append-only
+        // guard. The incremental head-canonical path and the audited
+        // authoritative-projection path already consult the machine-owned
+        // rollback here; without this arm, external `SessionStore`
+        // implementations wedge permanently on resume (every retry re-throws
+        // MonotonicityViolation). The `SessionDocumentMachine` — not this
+        // shell — owns the disposition; `RebuildToAuthority` requires the
+        // row to be a faithful continuation of the authority AND to carry
+        // the checkpointer's own provenance stamp, so genuine forks and
+        // out-of-band divergence keep failing closed.
+        Err(error @ SessionStoreError::MonotonicityViolation { .. }) => {
+            let Some(previous) = store.load(session.id()).await? else {
+                return Err(error);
+            };
+            let previous_projection_token =
+                meerkat_core::session_store::session_projection_cas_token(&previous)?;
+            if runtime_projection_rollback_authorized(session, &previous)? {
+                return store
+                    .save_authoritative_projection_if_current_revision(
+                        session,
+                        Some(previous_projection_token),
+                    )
+                    .await;
+            }
+            Err(error)
+        }
         Err(
             error @ (SessionStoreError::TranscriptContinuityViolation { .. }
             | SessionStoreError::InvalidTranscriptRewrite { .. }),
@@ -19594,6 +19623,97 @@ mod tests {
             !runtime_projection_rollback_authorized(&authority, &forked_row)
                 .expect("rollback resolution should succeed"),
             "a stamped row that forks from the authority must not be rebuilt"
+        );
+    }
+
+    /// Bug B-2 class pin (field: identity-first gateways, meerkat 0.7.25):
+    /// the WRITE half of the torn-shutdown wedge must clear on CLASSIC
+    /// (non-incremental) stores too. The incremental head-canonical path and
+    /// the audited authoritative-projection path already consult the
+    /// machine-owned rollback; external `SessionStore` implementations route
+    /// plain projection saves through the storage-normalization bridge,
+    /// where a stamped ahead row previously re-threw MonotonicityViolation
+    /// on every resume save — permanently stranding the session.
+    #[tokio::test]
+    async fn classic_store_projection_bridge_converges_stamped_ahead_row() {
+        let store: Arc<dyn SessionStore> = Arc::new(MemoryStore::new());
+        let blob_store = memory_blob_store();
+
+        let mut authority = Session::new();
+        authority.push(Message::User(UserMessage::text(
+            "committed turn".to_string(),
+        )));
+
+        // The intra-turn checkpointer wrote ahead of the boundary commit and
+        // a host kill froze the row there.
+        let mut ahead_row = authority.clone();
+        ahead_row.push(Message::User(UserMessage::text(
+            "checkpointed but uncommitted".to_string(),
+        )));
+        ahead_row.set_runtime_checkpoint_provenance();
+        store
+            .save(&ahead_row)
+            .await
+            .expect("persist stamped ahead row");
+
+        save_session_projection_with_storage_normalization_bridge(
+            store.as_ref(),
+            blob_store.as_ref(),
+            &authority,
+        )
+        .await
+        .expect(
+            "the authority save must converge the stamped ahead row instead of wedging on \
+             MonotonicityViolation",
+        );
+
+        let persisted = store
+            .load(authority.id())
+            .await
+            .expect("load should succeed")
+            .expect("row should exist");
+        assert_eq!(
+            persisted.messages().len(),
+            authority.messages().len(),
+            "the row must be rebuilt onto committed truth (unacknowledged tail discarded)"
+        );
+        assert!(
+            !persisted.has_runtime_checkpoint_provenance(),
+            "the converged row is boundary-committed content, not a checkpointer write"
+        );
+    }
+
+    /// Sibling fail-closed pin: an ahead row WITHOUT the checkpointer's
+    /// stamp is out-of-band divergence — the classic-store bridge must keep
+    /// rejecting the shrink.
+    #[tokio::test]
+    async fn classic_store_projection_bridge_keeps_unstamped_shrink_fail_closed() {
+        let store: Arc<dyn SessionStore> = Arc::new(MemoryStore::new());
+        let blob_store = memory_blob_store();
+
+        let mut authority = Session::new();
+        authority.push(Message::User(UserMessage::text(
+            "committed turn".to_string(),
+        )));
+        let mut unstamped_row = authority.clone();
+        unstamped_row.push(Message::User(UserMessage::text(
+            "out-of-band appended".to_string(),
+        )));
+        store
+            .save(&unstamped_row)
+            .await
+            .expect("persist unstamped ahead row");
+
+        let error = save_session_projection_with_storage_normalization_bridge(
+            store.as_ref(),
+            blob_store.as_ref(),
+            &authority,
+        )
+        .await
+        .expect_err("an unstamped ahead row must keep the shrink fail-closed");
+        assert!(
+            matches!(error, SessionStoreError::MonotonicityViolation { .. }),
+            "expected MonotonicityViolation, got {error:?}"
         );
     }
 


### PR DESCRIPTION
## Field failure (Bug B-2, identity-first gateways on meerkat 0.7.25)

Resume saves rejected with `message count 165 is shorter than previously persisted 167` and retried forever — the exact torn-shutdown wedge 0.7.24 was built to clear, surviving in the deployment class that reported it (HomeCore, 2026-07-09; both continuity-store heads verified carrying `session_runtime_checkpoint_provenance_v1: true`).

## Root cause

0.7.24's write-half arbitration (`ResolveRuntimeProjectionRollback` → `RebuildToAuthority`) is consulted on the **incremental head-canonical** save path and the **audited authoritative-projection** path — but plain projection saves on **classic (non-incremental) stores** route through `save_session_projection_with_storage_normalization_bridge`, which only bridged `TranscriptContinuityViolation`/`InvalidTranscriptRewrite`. Both in-repo stores are incremental since #857, so the gap was invisible in-tree and bit exactly the external `SessionStore` implementations (mobkit's `ContinuitySessionStoreAdapter`) whose raw `append_only_save_guard` rejects the authority shrink against the checkpointer-stamped ahead row.

## Fix

The bridge now handles `MonotonicityViolation` with the same machine-owned arbitration (`runtime_projection_rollback_authorized`) and converges via the CAS projection write (`save_authoritative_projection_if_current_revision` — which mobkit's adapter already implements correctly). Unstamped or content-forked rows keep failing closed: the `SessionDocumentMachine`, not the shell, owns the disposition. No mobkit change needed; stranded field sessions converge on their next resume save.

## Tests (red-verified)

- `classic_store_projection_bridge_converges_stamped_ahead_row` — fails with the arm disabled
- `classic_store_projection_bridge_keeps_unstamped_shrink_fail_closed` — pins the fail-closed sibling
- meerkat-session all-features suite (349) + fast lane (9141) green

🤖 Generated with [Claude Code](https://claude.com/claude-code)