### PR TITLE
chore: pin rustc 1.94.1; stamp 0.7.26 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,16 @@ release that breaks public API declares it under a `### Breaking` heading
 naming the changed signatures (enforced by the `semver-breaks` release gate
 via cargo-semver-checks against the published baselines).
 
-## [Unreleased]
+## [0.7.26] - 2026-07-09
+
+Meerkat 0.7.26 closes the field bugs reported against 0.7.25's first week:
+the torn-shutdown save wedge on classic (non-incremental) session stores,
+the cold-revival re-bind rejection that broke identity-first member
+revival, the misleading "session not found" laundering in front of it, and
+the whole-mob blast radius of a single member's composition-dispatch
+rejection. It also documents the 0.7.25 storage-layout migration and the
+durable runtime_state vocabulary, and hardens the release pipeline's
+Homebrew tap update against assets-only backfills of old tags.
 
 ### Fixed
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -2,7 +2,7 @@
 # Pin the Rust version for consistent builds across machines and CI
 
 [toolchain]
-channel = "1.94.0"
+channel = "1.94.1"
 
 components = [
     "rustfmt",


### PR DESCRIPTION
The `semver-breaks` gate's isolated crate builds resolve fresh dep versions, and current `aws-*` releases require rustc 1.94.1 — on the 1.94.0 pin, cargo-semver-checks couldn't rustdoc `meerkat-anthropic` (previously the facade at 0.7.25), and the gate conflated tool failure with detected breaks. With 1.94.1 the isolated builds succeed and every crate reports **no semver update required** — so 0.7.26 truthfully carries no `### Breaking` section.

Also stamps the 0.7.26 changelog (B-2 write-half rollback for classic stores, cold-revival re-bind + un-laundered bindings errors + mob blast-radius containment, storage-migration/runtime_state docs, Homebrew backfill guard).

Fast lane 9143/9143 and workspace clippy clean on 1.94.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)