### PR TITLE
feat: add bounded realtime seed windows

### DIFF
--- a/.claude/skills/meerkat-platform/SKILL.md
+++ b/.claude/skills/meerkat-platform/SKILL.md
@@ -219,14 +219,23 @@ surface, not the old live-adapter/docs-refresh snapshot:
 - Live (audio/video) channels are exposed through the caller-initiated `live/*` surface, not the previous attachment-status family. Capability detection still uses `ModelCapabilities.realtime` to decide whether a model can back a live channel; channel lifecycle is caller-initiated through the `live/*` JSON-RPC methods (and SDK equivalents) below. The previous `session/realtime_attachment_status`, `mob/member_status.realtime_attachment_status`, `realtime/open_info`, and `RealtimeAttachmentStatus` enum have been removed.
 ### Live channels (audio/video)
 
-Live is the single subsystem for audio and other realtime modalities. Pick a realtime-capable model (today the only catalog realtime row is `gpt-realtime-2`; older realtime catalog rows are retired) and open a channel explicitly. `live/open` returns a typed `LiveOpenResult` with the negotiated transport bootstrap (e.g. WebSocket URL for `rkat-rpc`'s `--live-ws` listener at `/live/ws`) and a `WireLiveChannelCapabilities` advert describing supported input/output modalities, continuity mode, and tool semantics.
+Live is the single subsystem for audio and other realtime modalities. Pick a realtime-capable model (today the only catalog realtime row is `gpt-realtime-2`; older realtime catalog rows are retired) and open a channel explicitly. `live/open` returns a typed `LiveOpenResult` with the negotiated transport bootstrap (e.g. WebSocket URL for `rkat-rpc`'s `--live-ws` listener at `/live/ws`) and a `WireLiveChannelCapabilities` advert describing supported input/output modalities, continuity mode, and tool semantics. Its optional positive `seed_max_chars` parameter requests a core-owned whole-turn seed suffix; omission preserves the full canonical seed.
 
 | Surface | Open channel | Observe / control |
 |---------|--------------|-------------------|
 | JSON-RPC | `live/open` (returns `LiveOpenResult` with transport bootstrap + capabilities) | `live/status`, `live/refresh`, `live/send_input`, `live/commit_input`, `live/interrupt`, `live/truncate`, `live/close` |
-| Python SDK | `client.live_open(session_id)` | `client.live_status / live_refresh / live_send_input_text / live_send_input_audio / live_send_input_image / live_send_input_video_frame / live_commit_input / live_interrupt / live_truncate / live_close` |
-| TypeScript SDK | `client.liveOpen({ session_id: sessionId })` | `client.liveStatus / liveRefresh / liveSendInput / liveSendInputImage / liveSendInputVideoFrame / liveCommitInput / liveInterrupt / liveTruncate / liveClose` |
+| Python SDK | `client.live_open(session_id, seed_max_chars=...)` | `client.live_status / live_refresh / live_send_input_text / live_send_input_audio / live_send_input_image / live_send_input_video_frame / live_commit_input / live_interrupt / live_truncate / live_close` |
+| TypeScript SDK | `client.liveOpen({ session_id: sessionId, seed_max_chars: ... })` or `LiveChannel.session(..., { seedMaxChars: ... })` | `client.liveStatus / liveRefresh / liveSendInput / liveSendInputImage / liveSendInputVideoFrame / liveCommitInput / liveInterrupt / liveTruncate / liveClose` |
 | Rust | `meerkat_live::LiveAdapterHost` + `meerkat_core::live_adapter` adapter trait, exercised through `SessionRuntime` | typed observations and capability reads through the live host |
+
+Seed-window contract: `seed_max_chars` must be positive; zero is rejected by
+server validation. Core counts serialized seed messages and selects complete
+recent turns rather than slicing a turn. The resolved root prompt is never
+dropped and must fit the window; an existing compaction-summary head may be
+retained. Any truncation must return degraded continuity. Runtime system
+context and full canonical image identity, tombstone, and accounting sidecars
+remain outside the message window, so this is not a hard cap on the provider's
+entire instruction payload.
 
 Live image input requires a caller-stable, session-scoped `idempotency_key` on
 both `LiveInputChunkWire::Image` and `RealtimeImageChunk`. The convenience

--- a/.claude/skills/meerkat-platform/references/api_reference.md
+++ b/.claude/skills/meerkat-platform/references/api_reference.md
@@ -320,7 +320,7 @@ rkat blob get <BLOB-ID> --output meerkat.png
 
 ### Live channels (caller-initiated)
 
-- `live/open` — open a live audio/text channel with model-gated image input
+- `live/open` — open a live audio/text channel with model-gated image input; optional positive `seed_max_chars` bounds serialized whole-turn seed messages
 - `live/status` — get the status of a live channel
 - `live/close` — close a live channel
 - `live/send_input` — send an audio, text, or model-supported image chunk to a live channel
@@ -330,6 +330,15 @@ rkat blob get <BLOB-ID> --output meerkat.png
 - `live/refresh` — apply mutable session config (instructions/tools/audio) to an open live channel
 
 Set `model: "gpt-realtime-2"` on `session/create` and call `live/open` to open a live channel; capability is gated on `ModelCapabilities.realtime`. Check the returned `capabilities.image_in` boolean before calling `live/send_input` with `{ "kind": "image", "idempotency_key": "turn-42-diagram", "mime": "image/png", "data": "<base64>" }`. Image input is staged context for the next text, audio, or explicitly committed response. `status: "sent"` is queue acceptance only; wait for `user_content_committed` with the matching key for durable success. An exact same-key replay returns the prior receipt without resending provider input; different MIME/bytes reject with `image_input_idempotency_conflict`. Commit staged text/audio before submitting an image (`image_input_requires_commit`). Canonical live image history is capped at 40 MiB decoded in aggregate; new input that would cross it rejects before provider send as `image_input_history_budget_exceeded`. Legacy/out-of-band overflow, missing blobs, and content-address mismatches fail `live/open`; reconnect never trims accepted image context.
+
+`live/open.seed_max_chars` is optional. Omission preserves the full canonical
+seed. A positive value bounds serialized seed messages and requests a recent
+whole-turn suffix; zero is rejected. The resolved root prompt is never dropped
+and must fit, an existing compaction-summary head may be retained, and any
+truncation reports degraded continuity. Runtime system context and full
+canonical image identity, tombstone, and accounting sidecars stay outside the
+message window.
+
 The `live/*` methods require at least one configured live transport: `rkat-rpc --live-ws <addr>` for WebSocket and/or the WebRTC listener flags for WebRTC.
 
 ### Auth (realm/binding model)
@@ -542,7 +551,7 @@ Client methods:
 
 Live channel helpers:
 
-- `live_open(session_id)` → `LiveOpenResult`
+- `live_open(session_id, seed_max_chars=None)` → `LiveOpenResult`
 - `live_status(session_id)` / `live_close(session_id)`
 - `live_send_input_text(session_id, text)` / `live_send_input_audio(session_id, data)`
 - `live_commit_input(session_id)` / `live_interrupt(session_id)` / `live_truncate(session_id, ...)`
@@ -631,7 +640,8 @@ Client methods:
 
 Live channel helpers:
 
-- `liveOpen(params)` / `liveStatus(params)` / `liveClose(params)`
+- `liveOpen({ session_id, seed_max_chars? })` / `liveStatus(params)` / `liveClose(params)`
+- `LiveChannel.session(client, sessionId, { seedMaxChars? })` — session-bound convenience wrapper
 - `liveSendInput(params)` / `liveSendInputImage(params)` / `liveSendInputVideoFrame(params)`
 - `liveCommitInput(params)` / `liveInterrupt(params)` / `liveTruncate(params)`
 - `liveRefresh(params)`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ via cargo-semver-checks against the published baselines).
 
 ### Breaking
 
+- `meerkat_contracts::LiveOpenParams` gained the optional
+  `seed_max_chars` field. Downstream Rust struct literals must initialize it;
+  omitting the field on the wire preserves the complete-history realtime seed,
+  while a positive value requests a bounded complete-turn suffix.
 - `meerkat_contracts::RealtimeInputKind` gained the exhaustive `Image`
   variant and `meerkat_contracts::RealtimeInputChunk` gained the exhaustive
   `ImageChunk(RealtimeImageChunk)` variant. Downstream Rust matches over
@@ -51,11 +55,12 @@ via cargo-semver-checks against the published baselines).
   `(&RealtimeExternalSessionTarget, &RealtimeSessionOpenConfig)` instead of
   separate identity and turning-mode arguments. `RealtimeSessionOpenConfig`
   struct literals must also initialize `user_content_identities`,
-  `user_content_tombstones`, and `transcript_rewrite_generation`.
+  `user_content_tombstones`, `canonical_user_image_decoded_bytes`, and
+  `transcript_rewrite_generation`.
 - `meerkat_core::LiveProjectionSnapshot` struct literals must initialize the
-  new `user_content_identities`, `user_content_tombstones`, and
-  `transcript_rewrite_generation` fields used by exact-retry and live rewrite
-  guards.
+  new `user_content_identities`, `user_content_tombstones`,
+  `canonical_user_image_decoded_bytes`, and `transcript_rewrite_generation`
+  fields used by exact-retry, image-budget, and live rewrite guards.
 - `WireLiveAdapterObservation::RealtimeTranscript.event` now uses the
   public-safe `WireRealtimeTranscriptEvent` Rust type instead of the internal
   `RealtimeTranscriptEvent`. Its serialized/schema shape preserves the public

--- a/artifacts/schemas/wire-types.json
+++ b/artifacts/schemas/wire-types.json
@@ -24335,6 +24335,15 @@
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "description": "Request payload for `live/open`.\n\nR3-1 (P1): `turning_mode` lets callers pick between the provider-managed\n(server-VAD) flow and the explicit-commit flow. The G9 typed text-only\n`live/commit_input { response_modality: text }` path requires\n`ExplicitCommit` because the OpenAI realtime API rejects\n`input_audio_buffer.commit` unless the session was opened with explicit\ncommit semantics (server VAD owns commits otherwise). Pre-R3-1 the\nhandler hard-coded `ProviderManaged`, which made the typed text-only\npath unreachable on a public channel — calling it killed the channel\ninstead of producing sideband text.\n\nDefault (`None`) preserves the prior wire shape: callers that omit the\nfield get `ProviderManaged`, matching the legacy behavior.",
     "properties": {
+      "seed_max_chars": {
+        "description": "Optional serialized-character budget for the history seed messages\nsent to the realtime provider when the channel opens.\n\nOmitted means full-seed compatibility: project the complete canonical\nhistory. A positive value requests a core-owned, whole-turn suffix\nwindow. The resolved root prompt must fit and is never dropped; an\nexisting compaction-summary head may be retained. If any history is\nomitted, the open result reports degraded continuity rather than\npretending the bounded replay was complete.\n\nRuntime system context and canonical multimodal identity, tombstone,\nand accounting state remain full sidecars outside this message window.\n`0` is valid at this serde-only wire layer so it can round-trip, but the\n`live/open` server validation rejects it; callers must send a positive\nvalue when the field is present.",
+        "format": "uint",
+        "minimum": 1,
+        "type": [
+          "integer",
+          "null"
+        ]
+      },
       "session_id": {
         "type": "string"
       },

--- a/docs/api/rpc.mdx
+++ b/docs/api/rpc.mdx
@@ -112,7 +112,7 @@ subset.
 | `session/input_status` | Session | `SessionInputStateParams` | `SessionInputStateResult` | Read an input's stored runtime state (terminal outcome, run association) by input id or idempotency key |
 | `turn/start` | Turn | `StartTurnParams` | `WireRunResult` | Start a new turn on existing session |
 | `turn/interrupt` | Turn | `InterruptParams` | `InterruptResult` | Cancel in-flight turn |
-| `live/open` | Live | `LiveOpenParams` | `LiveOpenResult` | Open a live audio/text channel with model-gated image input |
+| `live/open` | Live | `LiveOpenParams` | `LiveOpenResult` | Open a live channel; optionally bound its serialized seed messages |
 | `live/webrtc/answer` | Live | `LiveWebrtcAnswerParams` | `LiveWebrtcAnswerResult` | Answer a browser WebRTC offer for an already-open live channel |
 | `live/status` | Live | `LiveChannelParams` | `LiveStatusResult` | Get the status of a live channel |
 | `live/close` | Live | `LiveChannelParams` | `LiveCloseResult` | Close a live channel |
@@ -1172,6 +1172,30 @@ Create a session on a realtime-capable model and call `live/open`:
 
 `live/open` returns a `LiveOpenResult` with transport bootstrap (e.g. WebSocket URL), `WireLiveChannelCapabilities`, and `WireLiveContinuityMode`.
 
+<ParamField body="session_id" type="string" required>
+  Session whose canonical history seeds the live channel.
+</ParamField>
+
+<ParamField body="turning_mode" type="provider_managed | explicit_commit | null" default="null">
+  Optional input-turning mode. Omitted preserves provider-managed behavior.
+</ParamField>
+
+<ParamField body="transport" type="websocket | webrtc | null" default="null">
+  Optional live transport. Omitted uses the server default.
+</ParamField>
+
+<ParamField body="seed_max_chars" type="usize | null" default="null">
+  Optional positive serialized-character budget for the core-owned seed
+  message window. Omitted preserves the complete canonical history. When
+  present, core selects a recent whole-turn suffix. The resolved root prompt
+  is never dropped and must fit; an existing compaction-summary head may also
+  be retained. Any truncation returns degraded continuity. Zero is rejected.
+</ParamField>
+
+Runtime system context and the canonical multimodal sidecars remain outside
+the message window. Image identity, tombstones, and aggregate accounting stay
+complete even when older seed messages are omitted.
+
 ### live/status
 
 Read the current state of a live channel.
@@ -1259,7 +1283,7 @@ transport details.
 
 | Method | Purpose |
 |--------|---------|
-| `live/open` | Open a live audio/text channel with model-gated image input |
+| `live/open` | Open a live channel; optional positive `seed_max_chars` bounds serialized whole-turn seed messages |
 | `live/webrtc/answer` | Answer a browser WebRTC offer for an already-open live channel |
 | `live/status` | Get the status of a live channel |
 | `live/close` | Close a live channel |

--- a/docs/architecture/multi-host-mobs-plan.md
+++ b/docs/architecture/multi-host-mobs-plan.md
@@ -689,7 +689,7 @@ Gates: `make machine-codegen` / `machine-check-drift` / `machine-verify`, `runti
 ### 16.4 Wire deltas (meerkat-contracts; rides the §7 V4 protocol bump)
 
 New `BridgeCommand` variants (member-addressed, V4-required, `deny_unknown_fields`):
-- `OpenMemberLiveChannel(BridgeLiveOpenPayload { supervisor, epoch, protocol_version, turning_mode: Option<RealtimeTurningMode>, transport: Option<LiveOpenTransport> })` — mirrors `LiveOpenParams` minus `session_id` (wire/live.rs:123-129; identity addressing replaces it).
+- `OpenMemberLiveChannel(BridgeLiveOpenPayload { supervisor, epoch, protocol_version, turning_mode: Option<RealtimeTurningMode>, transport: Option<LiveOpenTransport>, seed_max_chars: Option<usize> })` — mirrors `LiveOpenParams` minus `session_id` (wire/live.rs:123-129; identity addressing replaces it).
 - `CloseMemberLiveChannel(BridgeLiveChannelPayload { supervisor, epoch, protocol_version, channel_id })`
 - `MemberLiveChannelStatus(BridgeLiveChannelPayload)`
 - `ControlMemberLiveChannel(BridgeLiveControlPayload { supervisor, epoch, protocol_version, channel_id, verb: BridgeLiveControlVerb })` with `BridgeLiveControlVerb = CommitInput | Interrupt | Truncate(mirror of live/truncate params) | Refresh`.

--- a/docs/guides/realtime.mdx
+++ b/docs/guides/realtime.mdx
@@ -115,6 +115,56 @@ which accommodates the documented 20 MiB decoded-image ceiling plus base64
 and envelope overhead.
 </Note>
 
+### Bounding the initial seed
+
+By default, `live/open` projects the full canonical history into the
+new realtime provider session. Long-lived sessions can request a smaller seed
+with the optional positive `seed_max_chars` parameter:
+
+<CodeGroup>
+```json JSON-RPC
+{
+  "jsonrpc": "2.0",
+  "id": 2,
+  "method": "live/open",
+  "params": {
+    "session_id": "01936f8a-7b2c-7000-8000-000000000001",
+    "seed_max_chars": 24000
+  }
+}
+```
+
+```python Python SDK
+result = await client.live_open(session.id, seed_max_chars=24_000)
+```
+
+```typescript TypeScript SDK
+const result = await client.liveOpen({
+  session_id: session.id,
+  seed_max_chars: 24_000,
+});
+
+const channel = LiveChannel.session(client, session.id, {
+  seedMaxChars: 24_000,
+});
+```
+</CodeGroup>
+
+The core counts the serialized projected seed messages and selects a recent
+whole-turn suffix; it never slices an individual turn just to fill the budget.
+The resolved root prompt is never dropped and must fit the requested window,
+or `live/open` rejects the request. An existing compaction summary may be
+retained as the head before the suffix.
+
+If selection omits any history, `LiveOpenResult.continuity` reports
+`mode: "degraded"`. Omitting `seed_max_chars` preserves the full-seed behavior.
+The value must be positive; the server rejects zero.
+
+Runtime system context and canonical multimodal sidecars are outside the seed
+message window. Image identity, tombstones, and aggregate accounting remain
+complete even when older seed messages are omitted, so retries and future
+image admission continue to use full canonical truth.
+
 ### Configuration defaults
 
 The session's default model can be set in config (`~/.rkat/config.toml` or project-local) via `default_model`. Any session created without an explicit `model` parameter inherits the configured default — so setting `default_model = "gpt-realtime-2"` makes live channels available by default. See the [Configuration guide](/concepts/configuration).
@@ -138,7 +188,7 @@ Use `live/status` to read the current state of a live channel:
 
 | Method | Purpose |
 |--------|---------|
-| `live/open` | Open a live channel on a session; returns `LiveOpenResult` with transport bootstrap and capabilities |
+| `live/open` | Open a live channel on a session; optionally bound its serialized seed messages with positive `seed_max_chars` |
 | `live/status` | Read live channel status |
 | `live/send_input` | Send an audio, text, or model-supported image chunk to a live channel |
 | `live/commit_input` | Commit pending input on a live channel (turn boundary) |

--- a/docs/sdks/python/overview.mdx
+++ b/docs/sdks/python/overview.mdx
@@ -110,7 +110,12 @@ client = MeerkatClient()
 await client.connect(live_ws=True)
 try:
     session = await client.create_session("Open a live channel")
-    channel = LiveChannel.session(client, session.id, turning_mode="explicit_commit")
+    channel = LiveChannel.session(
+        client,
+        session.id,
+        turning_mode="explicit_commit",
+        seed_max_chars=24_000,
+    )
 
     opened = await channel.open()
     # Connect to opened["transport"]["url"] externally.
@@ -121,7 +126,7 @@ finally:
     await client.close()
 ```
 
-- `await client.live_open(session_id, turning_mode=None)`
+- `await client.live_open(session_id, turning_mode=None, transport=None, seed_max_chars=None)`
 - `await client.live_status(channel_id)`
 - `await client.live_close(channel_id)`
 - `await client.live_send_input_text(channel_id, text)`
@@ -137,6 +142,12 @@ Image keys are required, caller-stable, and session-scoped. The helper returns
 after queue acceptance; wait for `user_content_committed` with the matching key
 before treating the image as durable context. See [Live Channels](/guides/realtime#sending-image-input)
 for replay, conflict, and reconnect limits.
+
+`seed_max_chars` is an optional positive serialized-character budget for a
+core-selected whole-turn seed suffix. Omit it for the full canonical seed. The
+resolved root must fit. Runtime context and complete image identity, tombstone,
+and accounting sidecars remain outside the window; any truncation reports
+degraded continuity. Zero is rejected by the server.
 
 ### Mob APIs
 

--- a/docs/sdks/python/reference.mdx
+++ b/docs/sdks/python/reference.mdx
@@ -209,7 +209,12 @@ from meerkat import LiveChannel, MeerkatClient
 client = MeerkatClient()
 await client.connect(live_ws=True)
 session = await client.create_session("Open a live channel")
-channel = LiveChannel.session(client, session.id, turning_mode="explicit_commit")
+channel = LiveChannel.session(
+    client,
+    session.id,
+    turning_mode="explicit_commit",
+    seed_max_chars=24_000,
+)
 opened = await channel.open()
 await channel.send_input_text("hello")
 await channel.commit_input(response_modality="text")
@@ -220,7 +225,7 @@ await client.close()
 
 Direct `MeerkatClient` helper names mirror the RPC methods:
 
-- `live_open(session_id, turning_mode=None)`
+- `live_open(session_id, turning_mode=None, transport=None, seed_max_chars=None)`
 - `live_status(channel_id)`
 - `live_close(channel_id)`
 - `live_send_input_text(channel_id, text)`
@@ -235,6 +240,12 @@ Direct `MeerkatClient` helper names mirror the RPC methods:
 `live_send_input_image` requires a caller-stable, session-scoped key. Its
 return value proves queue acceptance only; durable success is the later
 `user_content_committed` observation carrying that same key.
+
+Pass a positive `seed_max_chars` to bound serialized seed messages and request
+a core-owned whole-turn suffix at open time. Omission preserves the complete
+seed; zero is rejected. The resolved root must fit; an existing compaction
+summary may be retained, and any truncation reports degraded continuity.
+Canonical image identity, tombstone, and accounting sidecars remain complete.
 
 ## Capability and error model
 

--- a/docs/sdks/typescript/overview.mdx
+++ b/docs/sdks/typescript/overview.mdx
@@ -158,6 +158,7 @@ await client.connect({ liveWs: true });
 const session = await client.createSession("Open a live channel");
 const channel = LiveChannel.session(client, session.id, {
   turningMode: "explicit_commit",
+  seedMaxChars: 24_000,
 });
 
 const openResult = await channel.open();
@@ -177,6 +178,13 @@ await channel.close();
 Image keys are required, caller-stable, and session-scoped. See
 [Live Channels](/guides/realtime#sending-image-input) for same-key replay,
 conflict handling, and reconnect hydration limits.
+
+`seedMaxChars` maps to `live/open.seed_max_chars`. Use a positive value to
+bound serialized seed messages and request a core-selected whole-turn suffix;
+omit it for the complete canonical seed. The resolved root must fit; an existing
+compaction summary may be retained, and any truncation reports
+degraded continuity. Canonical image identity, tombstone, and accounting
+sidecars remain complete. The server rejects zero.
 
 ### Mob methods
 

--- a/docs/sdks/typescript/reference.mdx
+++ b/docs/sdks/typescript/reference.mdx
@@ -153,6 +153,7 @@ The `Session` methods are thin conveniences over canonical runtime calls:
 ```typescript
 const channel = LiveChannel.session(client, session.id, {
   turningMode: "explicit_commit",
+  seedMaxChars: 24_000,
 });
 
 const opened: LiveOpenResult = await channel.open();
@@ -172,6 +173,13 @@ using the transport appropriate for your app.
 
 The direct helper has the same required identity:
 `client.liveSendInputImage(channelId, idempotencyKey, mime, dataBase64)`.
+
+`LiveChannelOptions.seedMaxChars` forwards as `LiveOpenParams.seed_max_chars`.
+It must be positive, bounds serialized seed messages, and requests a
+core-owned whole-turn suffix; omission preserves the complete canonical seed.
+The resolved root must fit. Runtime context and complete image identity,
+tombstone, and accounting sidecars remain outside the window. Any truncation
+reports degraded continuity, and the server rejects zero.
 
 ### Usage
 

--- a/meerkat-contracts/src/wire/live.rs
+++ b/meerkat-contracts/src/wire/live.rs
@@ -126,6 +126,24 @@ pub struct LiveOpenParams {
     pub turning_mode: Option<RealtimeTurningMode>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub transport: Option<LiveOpenTransport>,
+    /// Optional serialized-character budget for the history seed messages
+    /// sent to the realtime provider when the channel opens.
+    ///
+    /// Omitted means full-seed compatibility: project the complete canonical
+    /// history. A positive value requests a core-owned, whole-turn suffix
+    /// window. The resolved root prompt must fit and is never dropped; an
+    /// existing compaction-summary head may be retained. If any history is
+    /// omitted, the open result reports degraded continuity rather than
+    /// pretending the bounded replay was complete.
+    ///
+    /// Runtime system context and canonical multimodal identity, tombstone,
+    /// and accounting state remain full sidecars outside this message window.
+    /// `0` is valid at this serde-only wire layer so it can round-trip, but the
+    /// `live/open` server validation rejects it; callers must send a positive
+    /// value when the field is present.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "schema", schemars(range(min = 1)))]
+    pub seed_max_chars: Option<usize>,
 }
 
 /// Transport requested by `live/open`.
@@ -2108,12 +2126,17 @@ mod tests {
             session_id: "session-1".into(),
             turning_mode: None,
             transport: None,
+            seed_max_chars: None,
         };
         let j = serde_json::to_value(&v).expect("round-trip should succeed");
         // R3-1: omitted `turning_mode` elides on the wire (back-compat).
         assert!(
             j.get("turning_mode").is_none(),
             "default `turning_mode` must elide the field on the wire"
+        );
+        assert!(
+            j.get("seed_max_chars").is_none(),
+            "omitted `seed_max_chars` must preserve the legacy full-seed wire shape"
         );
         let back: LiveOpenParams = serde_json::from_value(j).expect("round-trip should succeed");
         assert_eq!(v, back);
@@ -2127,6 +2150,7 @@ mod tests {
             session_id: "session-1".into(),
             turning_mode: Some(RealtimeTurningMode::ExplicitCommit),
             transport: None,
+            seed_max_chars: None,
         };
         let j = serde_json::to_value(&v).expect("round-trip should succeed");
         assert_eq!(j["turning_mode"], "explicit_commit");
@@ -2140,6 +2164,7 @@ mod tests {
             session_id: "session-1".into(),
             turning_mode: Some(RealtimeTurningMode::ProviderManaged),
             transport: None,
+            seed_max_chars: None,
         };
         let j = serde_json::to_value(&v).expect("round-trip should succeed");
         assert_eq!(j["turning_mode"], "provider_managed");
@@ -2153,9 +2178,38 @@ mod tests {
             session_id: "session-1".into(),
             turning_mode: None,
             transport: Some(LiveOpenTransport::Webrtc),
+            seed_max_chars: None,
         };
         let j = serde_json::to_value(&v).expect("round-trip should succeed");
         assert_eq!(j["transport"], "webrtc");
+        let back: LiveOpenParams = serde_json::from_value(j).expect("round-trip should succeed");
+        assert_eq!(v, back);
+    }
+
+    #[test]
+    fn live_open_params_seed_max_chars_round_trip() {
+        let v = LiveOpenParams {
+            session_id: "session-1".into(),
+            turning_mode: None,
+            transport: None,
+            seed_max_chars: Some(24_000),
+        };
+        let j = serde_json::to_value(&v).expect("round-trip should succeed");
+        assert_eq!(j["seed_max_chars"], 24_000);
+        let back: LiveOpenParams = serde_json::from_value(j).expect("round-trip should succeed");
+        assert_eq!(v, back);
+    }
+
+    #[test]
+    fn live_open_params_zero_seed_budget_round_trips_for_server_validation() {
+        let v = LiveOpenParams {
+            session_id: "session-1".into(),
+            turning_mode: None,
+            transport: None,
+            seed_max_chars: Some(0),
+        };
+        let j = serde_json::to_value(&v).expect("round-trip should succeed");
+        assert_eq!(j["seed_max_chars"], 0);
         let back: LiveOpenParams = serde_json::from_value(j).expect("round-trip should succeed");
         assert_eq!(v, back);
     }

--- a/meerkat-core/src/image_content.rs
+++ b/meerkat-core/src/image_content.rs
@@ -295,6 +295,18 @@ pub async fn hydrate_user_images_for_realtime_projection(
     messages: &mut [Message],
     max_decoded_bytes: usize,
 ) -> Result<(), RealtimeUserImageHydrationError> {
+    hydrate_user_images_for_realtime_projection_with_usage(blob_store, messages, max_decoded_bytes)
+        .await
+        .map(|_| ())
+}
+
+/// Hydrate realtime user images and return the full canonical decoded-byte
+/// usage independently of any later provider seed selection.
+pub async fn hydrate_user_images_for_realtime_projection_with_usage(
+    blob_store: &dyn BlobStore,
+    messages: &mut [Message],
+    max_decoded_bytes: usize,
+) -> Result<usize, RealtimeUserImageHydrationError> {
     struct HydratedImage {
         message_index: usize,
         block_index: usize,
@@ -417,7 +429,7 @@ pub async fn hydrate_user_images_for_realtime_projection(
             },
         };
     }
-    Ok(())
+    Ok(decoded_total)
 }
 
 fn decoded_realtime_image_len(

--- a/meerkat-core/src/live_adapter.rs
+++ b/meerkat-core/src/live_adapter.rs
@@ -797,6 +797,11 @@ pub struct LiveProjectionSnapshot {
     /// provider receives input.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub user_content_tombstones: Vec<RealtimeUserContentTombstone>,
+    /// Full canonical decoded-image usage, independent of the selected replay
+    /// seed. A bounded seed may omit old image messages while future image
+    /// admission must still enforce the canonical aggregate ceiling.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub canonical_user_image_decoded_bytes: Option<usize>,
     /// Canonical transcript revision at projection time. A changed revision
     /// cannot be hot-applied to a provider conversation that already contains
     /// the old causal history.
@@ -1331,6 +1336,7 @@ mod tests {
                 runtime_system_context: vec![],
                 user_content_identities: vec![],
                 user_content_tombstones: vec![],
+                canonical_user_image_decoded_bytes: None,
                 transcript_rewrite_generation: 0,
             },
         };
@@ -1368,6 +1374,7 @@ mod tests {
             }],
             user_content_identities: vec![],
             user_content_tombstones: vec![],
+            canonical_user_image_decoded_bytes: None,
             transcript_rewrite_generation: 0,
         };
         let json = serde_json::to_string(&snapshot).unwrap();
@@ -1910,6 +1917,7 @@ mod tests {
             runtime_system_context: vec![],
             user_content_identities: vec![],
             user_content_tombstones: vec![],
+            canonical_user_image_decoded_bytes: None,
             transcript_rewrite_generation: 0,
         };
         assert_eq!(s1.snapshot_version, 1);

--- a/meerkat-core/src/session.rs
+++ b/meerkat-core/src/session.rs
@@ -3182,6 +3182,18 @@ impl Session {
         blob_store: &dyn crate::BlobStore,
         max_decoded_bytes: usize,
     ) -> Result<(), crate::image_content::RealtimeUserImageHydrationError> {
+        self.hydrate_realtime_user_images_with_usage(blob_store, max_decoded_bytes)
+            .await
+            .map(|_| ())
+    }
+
+    /// Hydrate realtime user-message images and return the full canonical
+    /// decoded-byte usage for seed-independent future-image admission.
+    pub async fn hydrate_realtime_user_images_with_usage(
+        &mut self,
+        blob_store: &dyn crate::BlobStore,
+        max_decoded_bytes: usize,
+    ) -> Result<usize, crate::image_content::RealtimeUserImageHydrationError> {
         let previous_digest = if self
             .metadata
             .contains_key(SESSION_TRANSCRIPT_HISTORY_STATE_KEY)
@@ -3191,18 +3203,19 @@ impl Session {
             None
         };
         let messages = Arc::make_mut(&mut self.messages);
-        crate::image_content::hydrate_user_images_for_realtime_projection(
-            blob_store,
-            messages,
-            max_decoded_bytes,
-        )
-        .await?;
+        let decoded_total =
+            crate::image_content::hydrate_user_images_for_realtime_projection_with_usage(
+                blob_store,
+                messages,
+                max_decoded_bytes,
+            )
+            .await?;
         if let Some(previous_digest) = previous_digest
             && transcript_messages_digest(self.messages()).ok().as_ref() != Some(&previous_digest)
         {
             self.refresh_transcript_head_after_message_mutation();
         }
-        Ok(())
+        Ok(decoded_total)
     }
 
     /// Explicitly update the timestamp

--- a/meerkat-live/src/host.rs
+++ b/meerkat-live/src/host.rs
@@ -3881,6 +3881,7 @@ mod tests {
             runtime_system_context: vec![],
             user_content_identities: vec![],
             user_content_tombstones: vec![],
+            canonical_user_image_decoded_bytes: None,
             transcript_rewrite_generation: 0,
         };
 

--- a/meerkat-llm-core/src/realtime_session.rs
+++ b/meerkat-llm-core/src/realtime_session.rs
@@ -263,6 +263,15 @@ pub struct RealtimeSessionOpenConfig {
     /// Durable conflict markers for caller keys whose canonical image was
     /// removed by a same-session transcript rewrite.
     pub user_content_tombstones: Vec<RealtimeUserContentTombstone>,
+    /// Full canonical decoded-image usage at projection time.
+    ///
+    /// This is deliberately independent of `seed_messages`: a caller-selected
+    /// seed window may omit old image messages, but the live adapter must still
+    /// enforce future image admission against the complete canonical history.
+    /// `None` is reserved for direct/legacy Rust callers that did not obtain the
+    /// projection from a session service; adapters then derive usage from the
+    /// supplied seed for backward compatibility.
+    pub canonical_user_image_decoded_bytes: Option<usize>,
     /// Canonical transcript revision used to detect same-session history
     /// rewrites that cannot be applied to an already-seeded provider
     /// conversation in place.
@@ -294,6 +303,7 @@ impl RealtimeSessionOpenConfig {
             runtime_system_context: Vec::new(),
             user_content_identities: Vec::new(),
             user_content_tombstones: Vec::new(),
+            canonical_user_image_decoded_bytes: None,
             transcript_rewrite_generation: 0,
             response_nudge_timeout_ms: None,
             response_nudge_max_attempts: None,
@@ -356,6 +366,13 @@ impl RealtimeSessionOpenConfig {
         tombstones: Vec<RealtimeUserContentTombstone>,
     ) -> Self {
         self.user_content_tombstones = tombstones;
+        self
+    }
+
+    /// Carry full canonical image usage separately from the selected seed.
+    #[must_use]
+    pub fn with_canonical_user_image_decoded_bytes(mut self, decoded_bytes: usize) -> Self {
+        self.canonical_user_image_decoded_bytes = Some(decoded_bytes);
         self
     }
 

--- a/meerkat-openai/src/live.rs
+++ b/meerkat-openai/src/live.rs
@@ -658,6 +658,30 @@ fn openai_realtime_seed_user_image_decoded_bytes(
     Ok(total)
 }
 
+/// Resolve the full canonical image-history charge independently of the
+/// selected provider replay seed. A seed window may omit old image messages;
+/// that must not lower the aggregate admission baseline for future images.
+fn openai_realtime_canonical_user_image_decoded_bytes(
+    seed_messages: &[Message],
+    canonical_decoded_bytes: Option<usize>,
+    max_decoded_bytes: usize,
+) -> Result<usize, LlmError> {
+    let selected_decoded_bytes =
+        openai_realtime_seed_user_image_decoded_bytes(seed_messages, max_decoded_bytes)?;
+    let canonical_decoded_bytes = canonical_decoded_bytes.unwrap_or(selected_decoded_bytes);
+    if canonical_decoded_bytes < selected_decoded_bytes {
+        return Err(LlmError::InvalidConfig {
+            message: "canonical realtime image usage is smaller than the selected seed".to_string(),
+        });
+    }
+    if canonical_decoded_bytes > max_decoded_bytes {
+        return Err(LlmError::InvalidInputShape {
+            message: "image_input_history_budget_exceeded".to_string(),
+        });
+    }
+    Ok(canonical_decoded_bytes)
+}
+
 fn openai_realtime_history_events(
     seed_messages: &[Message],
     runtime_system_context: &[PendingSystemContextAppend],
@@ -2196,9 +2220,11 @@ impl OpenAiRealtimeSession {
         &mut self,
         seed_messages: &[Message],
         runtime_system_context: &[PendingSystemContextAppend],
+        canonical_user_image_decoded_bytes: Option<usize>,
     ) -> Result<(), LlmError> {
-        let committed_user_image_bytes = openai_realtime_seed_user_image_decoded_bytes(
+        let committed_user_image_bytes = openai_realtime_canonical_user_image_decoded_bytes(
             seed_messages,
+            canonical_user_image_decoded_bytes,
             self.user_image_history_budget_bytes,
         )?;
         let mut seed_events =
@@ -4281,10 +4307,12 @@ impl RealtimeSessionFactory for OpenAiRealtimeSessionFactory {
         // Hold the take-once runtime lease (or fresh direct-factory fallback)
         // until every canonical seed item has received provider ACK.
         let _open_projection_lease = self.take_or_acquire_open_projection_lease(open_config)?;
-        openai_realtime_seed_user_image_decoded_bytes(
-            &open_config.seed_messages,
-            self.user_image_history_budget_bytes,
-        )?;
+        let canonical_user_image_decoded_bytes =
+            openai_realtime_canonical_user_image_decoded_bytes(
+                &open_config.seed_messages,
+                open_config.canonical_user_image_decoded_bytes,
+                self.user_image_history_budget_bytes,
+            )?;
         let raw = self.raw_factory.open_session(open_config).await?;
         let mut session = OpenAiRealtimeSession::new(raw, open_config.turning_mode);
         session.user_image_history_budget_bytes = self.user_image_history_budget_bytes;
@@ -4307,6 +4335,7 @@ impl RealtimeSessionFactory for OpenAiRealtimeSessionFactory {
             .seed_history_projection(
                 &open_config.seed_messages,
                 &open_config.runtime_system_context,
+                Some(canonical_user_image_decoded_bytes),
             )
             .await?;
         Ok(Box::new(session))
@@ -4323,8 +4352,9 @@ impl RealtimeSessionFactory for OpenAiRealtimeSessionFactory {
         // cannot pin process admission indefinitely. No fresh fallback lease
         // is needed because this path materializes no seed events.
         let _carried_open_projection_lease = open_config.take_open_projection_lease();
-        let committed_user_image_bytes = openai_realtime_seed_user_image_decoded_bytes(
+        let committed_user_image_bytes = openai_realtime_canonical_user_image_decoded_bytes(
             &open_config.seed_messages,
+            open_config.canonical_user_image_decoded_bytes,
             self.user_image_history_budget_bytes,
         )?;
         let target = OpenAiLiveCallTarget::new(target.provider_session_id.clone())?;
@@ -4368,10 +4398,12 @@ impl RealtimeSessionFactory for OpenAiRealtimeSessionFactory {
         // event/data-URL materialization so the factory surface cannot bypass
         // aggregate memory custody.
         let _open_projection_lease = self.take_or_acquire_open_projection_lease(open_config)?;
-        openai_realtime_seed_user_image_decoded_bytes(
-            &open_config.seed_messages,
-            self.user_image_history_budget_bytes,
-        )?;
+        let canonical_user_image_decoded_bytes =
+            openai_realtime_canonical_user_image_decoded_bytes(
+                &open_config.seed_messages,
+                open_config.canonical_user_image_decoded_bytes,
+                self.user_image_history_budget_bytes,
+            )?;
         let raw = self.raw_factory.open_session(open_config).await?;
         let mut session = OpenAiRealtimeSession::new(raw, open_config.turning_mode);
         session.user_image_history_budget_bytes = self.user_image_history_budget_bytes;
@@ -4399,6 +4431,7 @@ impl RealtimeSessionFactory for OpenAiRealtimeSessionFactory {
             .seed_history_projection(
                 &open_config.seed_messages,
                 &open_config.runtime_system_context,
+                Some(canonical_user_image_decoded_bytes),
             )
             .await?;
         Ok(Arc::new(OpenAiLiveAdapter::new(session)) as Arc<dyn LiveAdapter>)
@@ -6150,7 +6183,11 @@ async fn execute_openai_live_command_with_budget(
             // system instructions (peer terminal, ops_lifecycle, etc.)
             // are emitted alongside seed history.
             session
-                .seed_history_projection(&snapshot.seed_messages, &snapshot.runtime_system_context)
+                .seed_history_projection(
+                    &snapshot.seed_messages,
+                    &snapshot.runtime_system_context,
+                    snapshot.canonical_user_image_decoded_bytes,
+                )
                 .await?;
             Ok(())
         }
@@ -6739,6 +6776,81 @@ mod tests {
         ));
     }
 
+    #[test]
+    fn windowed_seed_retains_full_canonical_user_image_usage() {
+        use base64::Engine as _;
+
+        let max_decoded_bytes =
+            meerkat_core::image_content::MAX_REALTIME_USER_IMAGE_PROJECTION_BYTES;
+        assert_eq!(
+            openai_realtime_canonical_user_image_decoded_bytes(&[], Some(16), max_decoded_bytes,)
+                .expect("an empty replay seed must retain the full canonical image charge"),
+            16
+        );
+
+        let selected_seed = vec![Message::User(meerkat_core::UserMessage::with_blocks(vec![
+            ContentBlock::Image {
+                media_type: "image/png".to_string(),
+                data: ImageData::Inline {
+                    data: base64::engine::general_purpose::STANDARD.encode(b"\x89PNG\r\n\x1a\n"),
+                },
+            },
+        ]))];
+        assert_eq!(
+            openai_realtime_canonical_user_image_decoded_bytes(
+                &selected_seed,
+                Some(24),
+                max_decoded_bytes,
+            )
+            .expect("a smaller replay seed must not lower the canonical image charge"),
+            24
+        );
+    }
+
+    #[test]
+    fn canonical_user_image_usage_cannot_be_smaller_than_selected_seed() {
+        use base64::Engine as _;
+
+        let selected_seed = vec![Message::User(meerkat_core::UserMessage::with_blocks(vec![
+            ContentBlock::Image {
+                media_type: "image/png".to_string(),
+                data: ImageData::Inline {
+                    data: base64::engine::general_purpose::STANDARD.encode(b"\x89PNG\r\n\x1a\n"),
+                },
+            },
+        ]))];
+        let error = openai_realtime_canonical_user_image_decoded_bytes(
+            &selected_seed,
+            Some(7),
+            meerkat_core::image_content::MAX_REALTIME_USER_IMAGE_PROJECTION_BYTES,
+        )
+        .expect_err("the canonical charge must cover every image in the selected seed");
+
+        assert!(matches!(
+            error,
+            LlmError::InvalidConfig { ref message }
+                if message == "canonical realtime image usage is smaller than the selected seed"
+        ));
+    }
+
+    #[test]
+    fn canonical_user_image_usage_cannot_exceed_projection_budget() {
+        let max_decoded_bytes =
+            meerkat_core::image_content::MAX_REALTIME_USER_IMAGE_PROJECTION_BYTES;
+        let error = openai_realtime_canonical_user_image_decoded_bytes(
+            &[],
+            Some(max_decoded_bytes + 1),
+            max_decoded_bytes,
+        )
+        .expect_err("the full canonical charge must remain within the 40 MiB projection budget");
+
+        assert!(matches!(
+            error,
+            LlmError::InvalidInputShape { ref message }
+                if message == "image_input_history_budget_exceeded"
+        ));
+    }
+
     #[tokio::test]
     async fn seed_image_history_over_budget_rejects_before_any_provider_item() {
         use base64::Engine as _;
@@ -6762,7 +6874,7 @@ mod tests {
         ]))];
 
         let error = session
-            .seed_history_projection(&seed, &[])
+            .seed_history_projection(&seed, &[], None)
             .await
             .expect_err("an eight-byte image must not fit a seven-byte replay budget");
         assert!(matches!(
@@ -7117,6 +7229,7 @@ mod tests {
             runtime_system_context: Vec::new(),
             user_content_identities: Vec::new(),
             user_content_tombstones: Vec::new(),
+            canonical_user_image_decoded_bytes: None,
             transcript_rewrite_generation: 0,
         }
     }
@@ -9187,6 +9300,7 @@ mod tests {
             runtime_system_context: Vec::new(),
             user_content_identities: Vec::new(),
             user_content_tombstones: Vec::new(),
+            canonical_user_image_decoded_bytes: None,
             transcript_rewrite_generation: 4,
         };
         execute_openai_live_command(
@@ -10213,7 +10327,7 @@ mod tests {
             RealtimeTurningMode::ProviderManaged,
         );
         session
-            .seed_history_projection(&seed_messages, &[])
+            .seed_history_projection(&seed_messages, &[], None)
             .await
             .expect("seed history projection");
         assert_eq!(seen.lock().await.len(), 1);
@@ -12358,6 +12472,7 @@ mod tests {
             runtime_system_context: Vec::new(),
             user_content_identities: Vec::new(),
             user_content_tombstones: Vec::new(),
+            canonical_user_image_decoded_bytes: None,
             transcript_rewrite_generation: 0,
         };
         adapter
@@ -12524,6 +12639,7 @@ mod tests {
                 runtime_system_context: runtime_system_context.clone(),
                 user_content_identities: Vec::new(),
                 user_content_tombstones: Vec::new(),
+                canonical_user_image_decoded_bytes: None,
                 transcript_rewrite_generation: 0,
             };
             adapter
@@ -12648,6 +12764,7 @@ mod tests {
             runtime_system_context: Vec::new(),
             user_content_identities: Vec::new(),
             user_content_tombstones: Vec::new(),
+            canonical_user_image_decoded_bytes: None,
             transcript_rewrite_generation: 0,
         };
         adapter
@@ -12766,6 +12883,7 @@ mod tests {
             runtime_system_context: Vec::new(),
             user_content_identities: Vec::new(),
             user_content_tombstones: Vec::new(),
+            canonical_user_image_decoded_bytes: None,
             transcript_rewrite_generation: 0,
         };
         adapter
@@ -12881,6 +12999,7 @@ mod tests {
             runtime_system_context: Vec::new(),
             user_content_identities: Vec::new(),
             user_content_tombstones: Vec::new(),
+            canonical_user_image_decoded_bytes: None,
             transcript_rewrite_generation: 0,
         };
         adapter
@@ -12957,6 +13076,7 @@ mod tests {
             runtime_system_context: Vec::new(),
             user_content_identities: Vec::new(),
             user_content_tombstones: Vec::new(),
+            canonical_user_image_decoded_bytes: None,
             transcript_rewrite_generation: 0,
         };
         adapter
@@ -13042,6 +13162,7 @@ mod tests {
             runtime_system_context: Vec::new(),
             user_content_identities: Vec::new(),
             user_content_tombstones: Vec::new(),
+            canonical_user_image_decoded_bytes: None,
             transcript_rewrite_generation: 0,
         };
         adapter
@@ -14397,6 +14518,7 @@ mod tests {
             runtime_system_context: Vec::new(),
             user_content_identities: Vec::new(),
             user_content_tombstones: Vec::new(),
+            canonical_user_image_decoded_bytes: None,
             transcript_rewrite_generation: 0,
         };
 
@@ -14531,6 +14653,7 @@ mod tests {
             runtime_system_context: Vec::new(),
             user_content_identities: Vec::new(),
             user_content_tombstones: Vec::new(),
+            canonical_user_image_decoded_bytes: None,
             transcript_rewrite_generation: 0,
         };
         let error = adapter

--- a/meerkat-rpc/src/handlers/live.rs
+++ b/meerkat-rpc/src/handlers/live.rs
@@ -8,6 +8,9 @@ use std::sync::Arc;
 #[cfg(feature = "live-webrtc")]
 use std::time::{SystemTime, UNIX_EPOCH};
 
+use meerkat::session_runtime::live_orchestration::{
+    LiveSeedProjectionError, RealtimeSessionOpenProjectionError,
+};
 use meerkat_client::realtime_session::RealtimeSessionFactory;
 use meerkat_client::realtime_session::RealtimeSessionOpenConfig;
 use meerkat_contracts::{
@@ -746,6 +749,7 @@ fn build_live_projection_snapshot(
         runtime_system_context: open_config.runtime_system_context.clone(),
         user_content_identities: open_config.user_content_identities.clone(),
         user_content_tombstones: open_config.user_content_tombstones.clone(),
+        canonical_user_image_decoded_bytes: open_config.canonical_user_image_decoded_bytes,
         transcript_rewrite_generation: open_config.transcript_rewrite_generation,
     }
 }
@@ -756,15 +760,59 @@ fn build_live_projection_snapshot(
 ///   conversation.
 /// - `TranscriptOnly` if seed messages are present — the adapter has been
 ///   handed canonical history to seed its provider session, so continuity
-///   exists at the transcript level. Provider-native resume (full
+///   exists at the transcript level.
+/// - `Degraded` whenever the seed projection reports known gaps, including
+///   when a tight window retains no replay messages.
+///
+/// Provider-native resume (full
 ///   provider-side continuation of the previous response) is not yet
 ///   wired; that becomes `Provider` once `LiveAudioConfig` and
 ///   provider-resume metadata are threaded through the snapshot.
-fn continuity_from_snapshot(snapshot: &LiveProjectionSnapshot) -> LiveContinuityMode {
-    if snapshot.seed_messages.is_empty() {
+fn continuity_from_snapshot(
+    snapshot: &LiveProjectionSnapshot,
+    seed_status: meerkat::session_runtime::live_orchestration::LiveSeedProjectionStatus,
+) -> LiveContinuityMode {
+    if seed_status.has_known_gaps() {
+        LiveContinuityMode::Degraded
+    } else if snapshot.seed_messages.is_empty() {
         LiveContinuityMode::Fresh
     } else {
         LiveContinuityMode::TranscriptOnly
+    }
+}
+
+fn live_seed_window_from_params(
+    id: Option<RpcId>,
+    seed_max_chars: Option<usize>,
+) -> Result<Option<meerkat::session_runtime::live_orchestration::LiveSeedWindow>, Box<RpcResponse>>
+{
+    match seed_max_chars {
+        Some(max_chars) => {
+            meerkat::session_runtime::live_orchestration::LiveSeedWindow::new(max_chars)
+                .map(Some)
+                .map_err(|projection_error| {
+                    Box::new(RpcResponse::error(
+                        id,
+                        error::INVALID_PARAMS,
+                        projection_error.to_string(),
+                    ))
+                })
+        }
+        None => Ok(None),
+    }
+}
+
+fn live_open_projection_error_code(error: &RealtimeSessionOpenProjectionError) -> i32 {
+    match error {
+        RealtimeSessionOpenProjectionError::Seed(
+            LiveSeedProjectionError::ZeroWindow | LiveSeedProjectionError::RootExceedsWindow { .. },
+        ) => crate::error::INVALID_PARAMS,
+        RealtimeSessionOpenProjectionError::Session(_)
+        | RealtimeSessionOpenProjectionError::Seed(
+            LiveSeedProjectionError::Session(_)
+            | LiveSeedProjectionError::Serialization(_)
+            | LiveSeedProjectionError::SizeOverflow,
+        ) => crate::error::INTERNAL_ERROR,
     }
 }
 
@@ -977,19 +1025,24 @@ pub async fn handle_live_open(
     let turning_mode = parsed
         .turning_mode
         .unwrap_or(RealtimeTurningMode::ProviderManaged);
-    let prepared_open_config = match runtime
-        .live_open_config_for_session(&session_id, turning_mode)
+    // Validate the caller-controlled window before minting a candidate
+    // channel id or asking machine authority to admit a live open.
+    let seed_window = match live_seed_window_from_params(id.clone(), parsed.seed_max_chars) {
+        Ok(seed_window) => seed_window,
+        Err(response) => return *response,
+    };
+    let prepared_projection = match runtime
+        .live_open_projection_for_session(&session_id, turning_mode, seed_window)
         .await
     {
-        Ok(config) => config,
+        Ok(projection) => projection,
         Err(err) => {
-            return RpcResponse::error(
-                id,
-                error::INTERNAL_ERROR,
-                format!("failed to build session config: {err}"),
-            );
+            let code = live_open_projection_error_code(&err);
+            return RpcResponse::error(id, code, format!("failed to build session config: {err}"));
         }
     };
+    let seed_status = prepared_projection.seed_status;
+    let prepared_open_config = prepared_projection.open_config;
     let live_open_identity = prepared_open_config.llm_identity.clone();
 
     let candidate_channel_id = LiveChannelId::random_uuid();
@@ -1157,7 +1210,7 @@ pub async fn handle_live_open(
                     open_config,
                     resolved_audio_config.clone(),
                 );
-                continuity = continuity_from_snapshot(&snapshot);
+                continuity = continuity_from_snapshot(&snapshot, seed_status);
             }
             Err(err) => {
                 close_live_channel_after_open_failure(host, runtime, &session_id, &channel_id)
@@ -2334,6 +2387,7 @@ mod tests {
             session_id: "sess-123".into(),
             turning_mode: None,
             transport: None,
+            seed_max_chars: None,
         };
         assert_eq!(round_trip(&v), v);
     }
@@ -2346,6 +2400,7 @@ mod tests {
             session_id: "sess-123".into(),
             turning_mode: Some(RealtimeTurningMode::ExplicitCommit),
             transport: None,
+            seed_max_chars: Some(24_000),
         };
         assert_eq!(round_trip(&v), v);
     }
@@ -2379,14 +2434,13 @@ mod tests {
     }
 
     #[test]
-    fn continuity_from_snapshot_never_synthesizes_provider_native_resume() {
+    fn continuity_from_snapshot_tracks_seed_completeness_without_provider_resume() {
         // T12: `ProviderNativeResume { provider_session_id }` is reserved
-        // for a future provider that surfaces a resume id. No provider
-        // Meerkat ships today does, so the open-time helper must only emit
-        // `Fresh` (empty seed) or `TranscriptOnly` (any seed messages) —
-        // never `ProviderNativeResume` and never `Degraded` (the latter is
-        // only set on canonical-replay failure further up the open path).
-        use meerkat_core::Provider;
+        // for a future provider that surfaces a resume id. A complete seed
+        // is `Fresh` when empty and `TranscriptOnly` when non-empty. A
+        // windowed seed has known canonical-history gaps and must be
+        // `Degraded`, even when the retained provider seed is empty.
+        use meerkat::session_runtime::live_orchestration::LiveSeedProjectionStatus;
         use meerkat_core::live_adapter::LiveProjectionSnapshot;
         use meerkat_core::types::{Message, SessionId, UserMessage};
 
@@ -2402,20 +2456,72 @@ mod tests {
             runtime_system_context: Vec::new(),
             user_content_identities: Vec::new(),
             user_content_tombstones: Vec::new(),
+            canonical_user_image_decoded_bytes: None,
             transcript_rewrite_generation: 0,
         };
         assert_eq!(
-            super::continuity_from_snapshot(&empty),
+            super::continuity_from_snapshot(&empty, LiveSeedProjectionStatus::Complete),
             LiveContinuityMode::Fresh
         );
 
         let seeded = LiveProjectionSnapshot {
             seed_messages: vec![Message::User(UserMessage::text("hi".to_string()))],
-            ..empty
+            ..empty.clone()
         };
         assert_eq!(
-            super::continuity_from_snapshot(&seeded),
+            super::continuity_from_snapshot(&seeded, LiveSeedProjectionStatus::Complete),
             LiveContinuityMode::TranscriptOnly
+        );
+
+        let windowed = LiveSeedProjectionStatus::Windowed {
+            dropped_messages: 3,
+            included_compaction_summary: false,
+        };
+        assert_eq!(
+            super::continuity_from_snapshot(&empty, windowed),
+            LiveContinuityMode::Degraded,
+            "known gaps must stay degraded even when no replay messages fit"
+        );
+        assert_eq!(
+            super::continuity_from_snapshot(&seeded, windowed),
+            LiveContinuityMode::Degraded,
+            "a retained suffix must not conceal omitted canonical history"
+        );
+    }
+
+    #[test]
+    fn zero_live_seed_window_is_invalid_params_before_channel_creation() {
+        let response = *super::live_seed_window_from_params(Some(RpcId::Num(30)), Some(0))
+            .expect_err("zero is not a valid live seed window");
+        let rpc_error = response.error.expect("typed JSON-RPC error");
+        assert_eq!(rpc_error.code, error::INVALID_PARAMS);
+        assert_eq!(
+            rpc_error.message,
+            "live seed window must be greater than zero"
+        );
+    }
+
+    #[test]
+    fn typed_live_seed_projection_errors_map_without_string_reclassification() {
+        use meerkat::session_runtime::live_orchestration::{
+            LiveSeedProjectionError, RealtimeSessionOpenProjectionError,
+        };
+
+        let too_small =
+            RealtimeSessionOpenProjectionError::Seed(LiveSeedProjectionError::RootExceedsWindow {
+                required_chars: 11,
+                max_chars: 10,
+            });
+        assert_eq!(
+            super::live_open_projection_error_code(&too_small),
+            error::INVALID_PARAMS
+        );
+
+        let internal =
+            RealtimeSessionOpenProjectionError::Seed(LiveSeedProjectionError::SizeOverflow);
+        assert_eq!(
+            super::live_open_projection_error_code(&internal),
+            error::INTERNAL_ERROR
         );
     }
 
@@ -2913,6 +3019,7 @@ mod tests {
             runtime_system_context: vec![],
             user_content_identities: vec![],
             user_content_tombstones: vec![],
+            canonical_user_image_decoded_bytes: None,
             transcript_rewrite_generation: 0,
         };
         let acceptance = host
@@ -3093,6 +3200,7 @@ mod tests {
                 runtime_system_context: vec![],
                 user_content_identities: vec![],
                 user_content_tombstones: vec![],
+                canonical_user_image_decoded_bytes: None,
                 transcript_rewrite_generation: 0,
             };
             snapshot.snapshot_version = host

--- a/meerkat-rpc/src/session_runtime.rs
+++ b/meerkat-rpc/src/session_runtime.rs
@@ -167,7 +167,8 @@ impl ArchiveRuntimeMobState for RpcMobStateAdapter {
 // `meerkat::session_runtime::live_orchestration`. Re-exported here so
 // the existing call-sites and tests resolve the same symbols.
 use meerkat::session_runtime::live_orchestration::{
-    LiveConfigPropagationReport, build_live_projection_snapshot_for_runtime,
+    LiveConfigPropagationReport, LiveSeedWindow, RealtimeSessionOpenProjection,
+    RealtimeSessionOpenProjectionError, build_live_projection_snapshot_for_runtime,
     live_channel_requires_close_for_identity_change, realtime_projection_messages,
     realtime_projection_root_system_message, realtime_projection_runtime_system_context,
 };
@@ -3061,6 +3062,21 @@ impl SessionRuntime {
         turning_mode: meerkat_contracts::RealtimeTurningMode,
     ) -> Result<RealtimeSessionOpenConfig, SessionError> {
         self.realtime_session_open_config(session_id, turning_mode)
+            .await
+    }
+
+    /// Build a live-open projection with an optional caller-selected seed
+    /// window while preserving the full canonical sidecars.
+    pub async fn live_open_projection_for_session(
+        &self,
+        session_id: &SessionId,
+        turning_mode: meerkat_contracts::RealtimeTurningMode,
+        seed_window: Option<LiveSeedWindow>,
+    ) -> Result<RealtimeSessionOpenProjection, RealtimeSessionOpenProjectionError> {
+        let snapshot = self.realm_context_snapshot();
+        let cleanup = self.archive_runtime_cleanup();
+        self.live_orchestrator(&snapshot, cleanup)
+            .live_open_projection_for_session(session_id, turning_mode, seed_window)
             .await
     }
 

--- a/meerkat-session/src/persistent.rs
+++ b/meerkat-session/src/persistent.rs
@@ -3832,6 +3832,19 @@ impl<B: SessionAgentBuilder + 'static> PersistentSessionService<B> {
         &self,
         id: &SessionId,
     ) -> Result<Session, SessionError> {
+        self.export_realtime_open_session_snapshot_with_image_usage(id)
+            .await
+            .map(|(session, _)| session)
+    }
+
+    /// Export the authoritative realtime-open snapshot together with the full
+    /// canonical decoded-image usage. Seed-window projection may omit old
+    /// messages, but image admission must continue to account for every
+    /// committed canonical image independently of the selected replay seed.
+    pub async fn export_realtime_open_session_snapshot_with_image_usage(
+        &self,
+        id: &SessionId,
+    ) -> Result<(Session, usize), SessionError> {
         self.export_realtime_open_session_snapshot_with_image_budget(
             id,
             MAX_REALTIME_USER_IMAGE_PROJECTION_BYTES,
@@ -3843,7 +3856,7 @@ impl<B: SessionAgentBuilder + 'static> PersistentSessionService<B> {
         &self,
         id: &SessionId,
         max_image_bytes: usize,
-    ) -> Result<Session, SessionError> {
+    ) -> Result<(Session, usize), SessionError> {
         // A provider ACK may have reached the durable metadata-only image
         // anchor immediately before a crash. Resolve that anchor before
         // constructing provider seed history: deferring recovery until the
@@ -3862,15 +3875,15 @@ impl<B: SessionAgentBuilder + 'static> PersistentSessionService<B> {
                 ));
             }
         }
-        session
-            .hydrate_realtime_user_images(self.blob_store.as_ref(), max_image_bytes)
+        let canonical_user_image_decoded_bytes = session
+            .hydrate_realtime_user_images_with_usage(self.blob_store.as_ref(), max_image_bytes)
             .await
             .map_err(|err| {
                 SessionError::Agent(meerkat_core::error::AgentError::InternalError(format!(
                     "failed to hydrate realtime history images before provider projection: {err}"
                 )))
             })?;
-        Ok(session)
+        Ok((session, canonical_user_image_decoded_bytes))
     }
 
     /// Export the authoritative session for an in-place realtime refresh.
@@ -15569,10 +15582,11 @@ mod tests {
             .await
             .expect("commit durable runtime snapshot");
 
-        let realtime_snapshot = service
-            .export_realtime_open_session_snapshot(&created.session_id)
+        let (realtime_snapshot, canonical_user_image_decoded_bytes) = service
+            .export_realtime_open_session_snapshot_with_image_usage(&created.session_id)
             .await
             .expect("realtime provider projection should hydrate durable image bytes");
+        assert_eq!(canonical_user_image_decoded_bytes, 24);
         assert!(matches!(
             realtime_snapshot.messages(),
             [Message::User(user), Message::ToolResults { results, .. }]

--- a/meerkat/src/session_runtime/live_orchestration.rs
+++ b/meerkat/src/session_runtime/live_orchestration.rs
@@ -492,15 +492,23 @@ pub enum RealtimeSessionOpenProjectionError {
     Seed(#[from] LiveSeedProjectionError),
 }
 
-fn realtime_projection_messages_full(session: &Session) -> Result<Vec<Message>, SessionError> {
+fn realtime_projection_messages_full_with_root_resolution(
+    session: &Session,
+) -> Result<(Vec<Message>, bool), SessionError> {
     let mut projected = session.messages().to_vec();
-    if let Some(root_system) = realtime_projection_root_system_message(session)? {
+    let resolved_root = realtime_projection_root_system_message(session)?;
+    let has_resolved_root = resolved_root.is_some();
+    if let Some(root_system) = resolved_root {
         match projected.first() {
             Some(Message::System(_) | Message::SystemNotice(_)) => projected[0] = root_system,
             _ => projected.insert(0, root_system),
         }
     }
-    Ok(projected)
+    Ok((projected, has_resolved_root))
+}
+
+fn realtime_projection_messages_full(session: &Session) -> Result<Vec<Message>, SessionError> {
+    realtime_projection_messages_full_with_root_resolution(session).map(|(projected, _)| projected)
 }
 
 /// Project a session's complete transcript for realtime delivery. This keeps
@@ -532,7 +540,8 @@ pub fn realtime_projection_messages_with_window(
     session: &Session,
     window: LiveSeedWindow,
 ) -> Result<LiveSeedMessageProjection, LiveSeedProjectionError> {
-    let projected = realtime_projection_messages_full(session)?;
+    let (projected, has_resolved_root) =
+        realtime_projection_messages_full_with_root_resolution(session)?;
     let costs = projected
         .iter()
         .map(serialized_message_chars)
@@ -545,10 +554,7 @@ pub fn realtime_projection_messages_with_window(
         });
     }
 
-    let root_len = usize::from(matches!(
-        projected.first(),
-        Some(Message::System(_) | Message::SystemNotice(_))
-    ));
+    let root_len = usize::from(has_resolved_root);
     let root_chars = checked_message_chars(&costs, 0..root_len)?;
     if root_chars > window.max_chars() {
         return Err(LiveSeedProjectionError::RootExceedsWindow {
@@ -1756,7 +1762,9 @@ mod prompt_truth_tests {
         AssistantBlock, BlockAssistantMessage, Message, SessionId, StopReason, SystemMessage,
         UserMessage,
     };
-    use meerkat_core::{Provider, Session, SessionBuildState, SessionLlmIdentity};
+    use meerkat_core::{
+        Provider, Session, SessionBuildState, SessionLlmIdentity, SystemPromptOverride,
+    };
     use meerkat_llm_core::realtime_session::RealtimeSessionOpenConfig;
 
     fn test_identity() -> SessionLlmIdentity {
@@ -1797,6 +1805,22 @@ mod prompt_truth_tests {
         session
     }
 
+    fn disabled_root_test_session() -> Session {
+        let mut session = Session::new();
+        session
+            .set_build_state(SessionBuildState {
+                system_prompt: SystemPromptOverride::Disable,
+                ..Default::default()
+            })
+            .expect("test build state must serialize");
+        session.push_batch(vec![
+            Message::System(SystemMessage::new("stale disabled root")),
+            Message::User(UserMessage::text("current user turn")),
+            assistant_text("current assistant turn"),
+        ]);
+        session
+    }
+
     #[test]
     fn live_seed_window_rejects_zero() {
         assert!(matches!(
@@ -1825,6 +1849,34 @@ mod prompt_truth_tests {
 
         assert_eq!(projection.messages, full);
         assert_eq!(projection.status, LiveSeedProjectionStatus::Complete);
+    }
+
+    #[test]
+    fn live_seed_window_does_not_charge_a_disabled_stale_system_lead_as_root() {
+        let session = disabled_root_test_session();
+        let full = realtime_projection_messages(&session).expect("full projection");
+        let tail_budget = full[1..]
+            .iter()
+            .map(serialized_message_chars)
+            .collect::<Result<Vec<_>, _>>()
+            .expect("serialized tail costs")
+            .into_iter()
+            .sum::<usize>();
+
+        let projection = realtime_projection_messages_with_window(
+            &session,
+            LiveSeedWindow::new(tail_budget).expect("positive window"),
+        )
+        .expect("a disabled stale lead must not cause root-too-small rejection");
+
+        assert_eq!(projection.messages, full[1..]);
+        assert_eq!(
+            projection.status,
+            LiveSeedProjectionStatus::Windowed {
+                dropped_messages: 1,
+                included_compaction_summary: false,
+            }
+        );
     }
 
     #[test]

--- a/meerkat/src/session_runtime/live_orchestration.rs
+++ b/meerkat/src/session_runtime/live_orchestration.rs
@@ -35,6 +35,7 @@ use meerkat_core::{
     PendingSystemContextAppend, Session, SessionLlmIdentity, SessionToolVisibilityState,
 };
 use meerkat_llm_core::realtime_session::RealtimeSessionOpenConfig;
+use std::num::NonZeroUsize;
 
 use crate::session_runtime::errors::LiveOpenPrecheckError;
 
@@ -107,6 +108,7 @@ pub fn build_live_projection_snapshot_for_runtime(
         runtime_system_context: open_config.runtime_system_context.clone(),
         user_content_identities: open_config.user_content_identities.clone(),
         user_content_tombstones: open_config.user_content_tombstones.clone(),
+        canonical_user_image_decoded_bytes: open_config.canonical_user_image_decoded_bytes,
         transcript_rewrite_generation: open_config.transcript_rewrite_generation,
     }
 }
@@ -386,14 +388,111 @@ pub fn realtime_projection_root_system_message(
     if content.trim().is_empty() {
         Ok(None)
     } else {
-        Ok(Some(Message::System(SystemMessage::new(content))))
+        // Projection must not mint ephemeral metadata: seed-window sizing is
+        // a pure function of canonical session state. Reuse the durable lead
+        // timestamp when there is one, otherwise the stable session creation
+        // timestamp. `SystemMessage::new` would stamp wall-clock time and make
+        // an exact-boundary window nondeterministic across identical opens.
+        let created_at = match session.messages().first() {
+            Some(Message::System(system)) => system.created_at,
+            Some(Message::SystemNotice(notice)) => notice.created_at,
+            _ => session.created_at().into(),
+        };
+        Ok(Some(Message::System(SystemMessage {
+            content,
+            mutation_kind: meerkat_core::SystemPromptMutationKind::Unspecified,
+            created_at,
+        })))
     }
 }
 
-/// Project a session's transcript for realtime delivery: prepend or
-/// rewrite the lead message with [`realtime_projection_root_system_message`]
-/// when one is available.
-pub fn realtime_projection_messages(session: &Session) -> Result<Vec<Message>, SessionError> {
+/// Caller-selected bound for the canonical transcript seed used by a live
+/// provider open. The count is over the serialized projected messages, after
+/// root-prompt resolution and image hydration.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct LiveSeedWindow {
+    max_chars: NonZeroUsize,
+}
+
+impl LiveSeedWindow {
+    pub fn new(max_chars: usize) -> Result<Self, LiveSeedProjectionError> {
+        NonZeroUsize::new(max_chars)
+            .map(|max_chars| Self { max_chars })
+            .ok_or(LiveSeedProjectionError::ZeroWindow)
+    }
+
+    #[must_use]
+    pub fn max_chars(self) -> usize {
+        self.max_chars.get()
+    }
+}
+
+/// Completeness of a provider replay seed relative to canonical history.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LiveSeedProjectionStatus {
+    Complete,
+    Windowed {
+        dropped_messages: usize,
+        included_compaction_summary: bool,
+    },
+}
+
+impl LiveSeedProjectionStatus {
+    #[must_use]
+    pub fn has_known_gaps(self) -> bool {
+        matches!(self, Self::Windowed { .. })
+    }
+}
+
+/// Selected realtime seed plus the typed completeness fact consumed by the
+/// live/open continuity projection.
+#[derive(Debug, Clone)]
+pub struct LiveSeedMessageProjection {
+    pub messages: Vec<Message>,
+    pub status: LiveSeedProjectionStatus,
+}
+
+/// Failures selecting a bounded live seed before any channel/provider state is
+/// minted.
+#[derive(Debug, thiserror::Error)]
+pub enum LiveSeedProjectionError {
+    #[error(transparent)]
+    Session(#[from] SessionError),
+    #[error("live seed window must be greater than zero")]
+    ZeroWindow,
+    #[error(
+        "live seed root requires {required_chars} serialized characters, exceeding the requested {max_chars}-character window"
+    )]
+    RootExceedsWindow {
+        required_chars: usize,
+        max_chars: usize,
+    },
+    #[error("failed to serialize live seed projection: {0}")]
+    Serialization(#[from] serde_json::Error),
+    #[error("live seed projection size overflowed usize")]
+    SizeOverflow,
+}
+
+/// Provider-neutral open projection: the mechanical provider config plus the
+/// canonical seed-completeness fact used by public continuity reporting.
+#[derive(Debug, Clone)]
+pub struct RealtimeSessionOpenProjection {
+    pub open_config: RealtimeSessionOpenConfig,
+    pub seed_status: LiveSeedProjectionStatus,
+}
+
+/// Typed failure at the live-open projection boundary. Surfaces classify seed
+/// policy rejection directly instead of recovering its class from strings or
+/// JSON-shaped session errors.
+#[derive(Debug, thiserror::Error)]
+pub enum RealtimeSessionOpenProjectionError {
+    #[error(transparent)]
+    Session(#[from] SessionError),
+    #[error(transparent)]
+    Seed(#[from] LiveSeedProjectionError),
+}
+
+fn realtime_projection_messages_full(session: &Session) -> Result<Vec<Message>, SessionError> {
     let mut projected = session.messages().to_vec();
     if let Some(root_system) = realtime_projection_root_system_message(session)? {
         match projected.first() {
@@ -402,6 +501,162 @@ pub fn realtime_projection_messages(session: &Session) -> Result<Vec<Message>, S
         }
     }
     Ok(projected)
+}
+
+/// Project a session's complete transcript for realtime delivery. This keeps
+/// the pre-seed-window behavior for Rust callers that do not request a bound.
+pub fn realtime_projection_messages(session: &Session) -> Result<Vec<Message>, SessionError> {
+    realtime_projection_messages_full(session)
+}
+
+fn serialized_message_chars(message: &Message) -> Result<usize, LiveSeedProjectionError> {
+    Ok(serde_json::to_string(message)?.chars().count())
+}
+
+fn checked_message_chars(
+    costs: &[usize],
+    mut range: std::ops::Range<usize>,
+) -> Result<usize, LiveSeedProjectionError> {
+    range.try_fold(0usize, |total, index| {
+        total
+            .checked_add(costs[index])
+            .ok_or(LiveSeedProjectionError::SizeOverflow)
+    })
+}
+
+/// Select a bounded, deterministic projection. Existing typed compaction
+/// summary content is the optional head; the tail is retained only at complete
+/// conversational-turn boundaries, with contiguous injected context glued to
+/// the user message it accompanied.
+pub fn realtime_projection_messages_with_window(
+    session: &Session,
+    window: LiveSeedWindow,
+) -> Result<LiveSeedMessageProjection, LiveSeedProjectionError> {
+    let projected = realtime_projection_messages_full(session)?;
+    let costs = projected
+        .iter()
+        .map(serialized_message_chars)
+        .collect::<Result<Vec<_>, _>>()?;
+    let total_chars = checked_message_chars(&costs, 0..costs.len())?;
+    if total_chars <= window.max_chars() {
+        return Ok(LiveSeedMessageProjection {
+            messages: projected,
+            status: LiveSeedProjectionStatus::Complete,
+        });
+    }
+
+    let root_len = usize::from(matches!(
+        projected.first(),
+        Some(Message::System(_) | Message::SystemNotice(_))
+    ));
+    let root_chars = checked_message_chars(&costs, 0..root_len)?;
+    if root_chars > window.max_chars() {
+        return Err(LiveSeedProjectionError::RootExceedsWindow {
+            required_chars: root_chars,
+            max_chars: window.max_chars(),
+        });
+    }
+
+    let mut selected = vec![false; projected.len()];
+    selected
+        .iter_mut()
+        .take(root_len)
+        .for_each(|keep| *keep = true);
+    let mut remaining = window.max_chars() - root_chars;
+
+    let summary_index = (root_len..projected.len()).rev().find(|index| {
+        matches!(
+            &projected[*index],
+            Message::User(user) if user.transcript_role.is_compaction_summary()
+        )
+    });
+    let included_compaction_summary = summary_index.is_some_and(|index| {
+        if costs[index] <= remaining {
+            selected[index] = true;
+            remaining -= costs[index];
+            true
+        } else {
+            false
+        }
+    });
+    let tail_start = summary_index.map_or(root_len, |index| index + 1);
+
+    let mut turn_starts = Vec::new();
+    for index in tail_start..projected.len() {
+        if matches!(
+            &projected[index],
+            Message::User(user) if user.transcript_role.is_conversational()
+        ) {
+            let mut start = index;
+            while start > tail_start
+                && matches!(
+                    &projected[start - 1],
+                    Message::User(user) if user.transcript_role.is_injected_context()
+                )
+            {
+                start -= 1;
+            }
+            turn_starts.push(start);
+        }
+    }
+
+    if !turn_starts.is_empty() {
+        let mut retained_suffix_start = None;
+        for turn_index in (0..turn_starts.len()).rev() {
+            let start = turn_starts[turn_index];
+            let end = turn_starts
+                .get(turn_index + 1)
+                .copied()
+                .unwrap_or(projected.len());
+            let turn_chars = checked_message_chars(&costs, start..end)?;
+            if turn_chars > remaining {
+                break;
+            }
+            remaining -= turn_chars;
+            retained_suffix_start = Some(start);
+        }
+        if let Some(start) = retained_suffix_start {
+            selected
+                .iter_mut()
+                .take(projected.len())
+                .skip(start)
+                .for_each(|keep| *keep = true);
+        }
+    }
+
+    let retained_count = selected.iter().filter(|keep| **keep).count();
+    let dropped_messages = projected.len().saturating_sub(retained_count);
+    let messages = projected
+        .into_iter()
+        .zip(selected)
+        .filter_map(|(message, keep)| keep.then_some(message))
+        .collect();
+    Ok(LiveSeedMessageProjection {
+        messages,
+        status: LiveSeedProjectionStatus::Windowed {
+            dropped_messages,
+            included_compaction_summary,
+        },
+    })
+}
+
+#[cfg(all(
+    feature = "session-store",
+    feature = "live",
+    not(target_arch = "wasm32")
+))]
+fn open_projection_error_to_compat_session_error(
+    error: RealtimeSessionOpenProjectionError,
+) -> SessionError {
+    match error {
+        RealtimeSessionOpenProjectionError::Session(error)
+        | RealtimeSessionOpenProjectionError::Seed(LiveSeedProjectionError::Session(error)) => {
+            error
+        }
+        RealtimeSessionOpenProjectionError::Seed(error) => {
+            SessionError::Agent(AgentError::InternalError(error.to_string()))
+        }
+    }
 }
 
 /// Project a session's runtime system context into the realtime
@@ -487,11 +742,14 @@ mod orchestrator {
 
     use super::{
         LiveChannelCloseFailure, LiveChannelRefreshFailure, LiveConfigPropagationReport,
-        LiveHotSwapSkipReason, build_live_projection_snapshot_for_runtime,
-        live_channel_identity_swap_context, live_channel_identity_swap_reason,
-        live_channel_requires_close_for_identity_change, precheck_identity,
-        realtime_projection_messages, realtime_projection_root_system_message,
-        realtime_projection_runtime_system_context, should_apply_global_model_hot_swap,
+        LiveHotSwapSkipReason, LiveSeedMessageProjection, LiveSeedProjectionStatus, LiveSeedWindow,
+        RealtimeSessionOpenProjection, RealtimeSessionOpenProjectionError,
+        build_live_projection_snapshot_for_runtime, live_channel_identity_swap_context,
+        live_channel_identity_swap_reason, live_channel_requires_close_for_identity_change,
+        open_projection_error_to_compat_session_error, precheck_identity,
+        realtime_projection_messages, realtime_projection_messages_with_window,
+        realtime_projection_root_system_message, realtime_projection_runtime_system_context,
+        should_apply_global_model_hot_swap,
     };
 
     use crate::service_factory::FactoryAgentBuilder;
@@ -761,13 +1019,14 @@ mod orchestrator {
             Ok(())
         }
 
-        /// Project the owning live session into the provider-backed
-        /// realtime open seam.
-        pub async fn realtime_session_open_config(
+        /// Project the owning live session into the provider-backed realtime
+        /// open seam, optionally selecting a bounded canonical seed.
+        pub async fn realtime_session_open_projection(
             &self,
             session_id: &SessionId,
             turning_mode: meerkat_contracts::RealtimeTurningMode,
-        ) -> Result<RealtimeSessionOpenConfig, SessionError> {
+            seed_window: Option<LiveSeedWindow>,
+        ) -> Result<RealtimeSessionOpenProjection, RealtimeSessionOpenProjectionError> {
             // Acquire process-wide custody before the persistent service can
             // hydrate blob-backed image history. The take-once slot carried on
             // the returned config transfers this same lease through provider
@@ -778,45 +1037,68 @@ mod orchestrator {
                     SessionError::Agent(AgentError::InternalError(error.to_string()))
                 })?;
             Box::pin(self.recover_live_session_for_realtime_open(session_id)).await?;
-            let session = match self
+            let (session, canonical_user_image_decoded_bytes) = match self
                 .service
-                .export_realtime_open_session_snapshot(session_id)
+                .export_realtime_open_session_snapshot_with_image_usage(session_id)
                 .await
             {
-                Ok(session) => session,
+                Ok(snapshot) => snapshot,
                 Err(SessionError::NotFound { .. }) => {
                     Box::pin(self.recover_live_session_for_realtime_open(session_id)).await?;
                     self.service
-                        .export_realtime_open_session_snapshot(session_id)
+                        .export_realtime_open_session_snapshot_with_image_usage(session_id)
                         .await?
                 }
-                Err(error) => return Err(error),
+                Err(error) => return Err(error.into()),
             };
             let llm_identity = self.service.live_session_llm_identity(session_id).await?;
             let visible_tools = self.service.live_visible_tool_defs(session_id).await?;
             let transcript_rewrite_generation = session
                 .transcript_rewrite_generation()
                 .map_err(|err| SessionError::Agent(AgentError::InternalError(err.to_string())))?;
-            Ok(RealtimeSessionOpenConfig::new(
-                turning_mode,
-                llm_identity,
-                visible_tools,
-                realtime_projection_messages(&session)?,
-            )
-            .with_open_projection_lease(open_projection_lease)
-            .with_runtime_system_context(realtime_projection_runtime_system_context(&session)?)
-            .with_user_content_identities(session.realtime_user_content_identities())
-            .with_user_content_tombstones(session.realtime_user_content_tombstones())
-            .with_transcript_rewrite_generation(transcript_rewrite_generation)
-            .with_system_prompt(
-                match realtime_projection_root_system_message(&session)? {
+            let seed_projection = match seed_window {
+                Some(window) => realtime_projection_messages_with_window(&session, window)?,
+                None => LiveSeedMessageProjection {
+                    messages: realtime_projection_messages(&session)?,
+                    status: LiveSeedProjectionStatus::Complete,
+                },
+            };
+            let open_config =
+                RealtimeSessionOpenConfig::new(
+                    turning_mode,
+                    llm_identity,
+                    visible_tools,
+                    seed_projection.messages,
+                )
+                .with_open_projection_lease(open_projection_lease)
+                .with_runtime_system_context(realtime_projection_runtime_system_context(&session)?)
+                .with_user_content_identities(session.realtime_user_content_identities())
+                .with_user_content_tombstones(session.realtime_user_content_tombstones())
+                .with_canonical_user_image_decoded_bytes(canonical_user_image_decoded_bytes)
+                .with_transcript_rewrite_generation(transcript_rewrite_generation)
+                .with_system_prompt(match realtime_projection_root_system_message(&session)? {
                     Some(Message::System(system)) => Some(system.content),
                     // `realtime_projection_root_system_message` only ever yields a
                     // `Message::System` (or `None`); any other shape means there is
                     // no root system prompt to project onto the typed field.
                     _ => None,
-                },
-            ))
+                });
+            Ok(RealtimeSessionOpenProjection {
+                open_config,
+                seed_status: seed_projection.status,
+            })
+        }
+
+        /// Compatibility wrapper retaining the pre-window full-history config.
+        pub async fn realtime_session_open_config(
+            &self,
+            session_id: &SessionId,
+            turning_mode: meerkat_contracts::RealtimeTurningMode,
+        ) -> Result<RealtimeSessionOpenConfig, SessionError> {
+            self.realtime_session_open_projection(session_id, turning_mode, None)
+                .await
+                .map(|projection| projection.open_config)
+                .map_err(open_projection_error_to_compat_session_error)
         }
 
         /// Build a live open config for a session that may be deferred
@@ -827,6 +1109,17 @@ mod orchestrator {
             turning_mode: meerkat_contracts::RealtimeTurningMode,
         ) -> Result<RealtimeSessionOpenConfig, SessionError> {
             self.realtime_session_open_config(session_id, turning_mode)
+                .await
+        }
+
+        /// Build a live-open projection with an optional per-open seed window.
+        pub async fn live_open_projection_for_session(
+            &self,
+            session_id: &SessionId,
+            turning_mode: meerkat_contracts::RealtimeTurningMode,
+            seed_window: Option<LiveSeedWindow>,
+        ) -> Result<RealtimeSessionOpenProjection, RealtimeSessionOpenProjectionError> {
+            self.realtime_session_open_projection(session_id, turning_mode, seed_window)
                 .await
         }
 
@@ -1454,9 +1747,16 @@ mod orchestrator {
 
 #[cfg(test)]
 mod prompt_truth_tests {
-    use super::build_live_projection_snapshot_for_runtime;
-    use meerkat_core::types::{Message, SessionId, SystemMessage, UserMessage};
-    use meerkat_core::{Provider, SessionLlmIdentity};
+    use super::{
+        LiveSeedProjectionError, LiveSeedProjectionStatus, LiveSeedWindow,
+        build_live_projection_snapshot_for_runtime, realtime_projection_messages,
+        realtime_projection_messages_with_window, serialized_message_chars,
+    };
+    use meerkat_core::types::{
+        AssistantBlock, BlockAssistantMessage, Message, SessionId, StopReason, SystemMessage,
+        UserMessage,
+    };
+    use meerkat_core::{Provider, Session, SessionBuildState, SessionLlmIdentity};
     use meerkat_llm_core::realtime_session::RealtimeSessionOpenConfig;
 
     fn test_identity() -> SessionLlmIdentity {
@@ -1467,6 +1767,179 @@ mod prompt_truth_tests {
             self_hosted_server_id: None,
             auth_binding: None,
         }
+    }
+
+    fn assistant_text(content: &str) -> Message {
+        Message::BlockAssistant(BlockAssistantMessage::new(
+            vec![AssistantBlock::Text {
+                text: content.to_string(),
+                meta: None,
+            }],
+            StopReason::EndTurn,
+        ))
+    }
+
+    fn window_test_session() -> Session {
+        let mut session = Session::new();
+        session
+            .set_build_state(SessionBuildState::default())
+            .expect("test build state must serialize");
+        session.push_batch(vec![
+            Message::System(SystemMessage::new("resolved root")),
+            Message::User(UserMessage::compaction_summary("prior history summary")),
+            Message::User(UserMessage::injected_context("old injected context")),
+            Message::User(UserMessage::text("old user turn")),
+            assistant_text("old assistant turn"),
+            Message::User(UserMessage::injected_context("new injected context")),
+            Message::User(UserMessage::text("new user turn")),
+            assistant_text("new assistant turn"),
+        ]);
+        session
+    }
+
+    #[test]
+    fn live_seed_window_rejects_zero() {
+        assert!(matches!(
+            LiveSeedWindow::new(0),
+            Err(LiveSeedProjectionError::ZeroWindow)
+        ));
+    }
+
+    #[test]
+    fn live_seed_window_preserves_full_projection_when_it_fits() {
+        let session = window_test_session();
+        let full = realtime_projection_messages(&session).expect("full projection");
+        let full_chars = full
+            .iter()
+            .map(serialized_message_chars)
+            .collect::<Result<Vec<_>, _>>()
+            .expect("serialized costs")
+            .into_iter()
+            .sum();
+
+        let projection = realtime_projection_messages_with_window(
+            &session,
+            LiveSeedWindow::new(full_chars).expect("positive window"),
+        )
+        .expect("bounded projection");
+
+        assert_eq!(projection.messages, full);
+        assert_eq!(projection.status, LiveSeedProjectionStatus::Complete);
+    }
+
+    #[test]
+    fn live_seed_window_is_deterministic_at_an_exact_boundary() {
+        let session = window_test_session();
+        let full = realtime_projection_messages(&session).expect("full projection");
+        let full_chars = full
+            .iter()
+            .map(serialized_message_chars)
+            .collect::<Result<Vec<_>, _>>()
+            .expect("serialized costs")
+            .into_iter()
+            .sum::<usize>();
+        let window = LiveSeedWindow::new(full_chars - 1).expect("positive boundary window");
+
+        let first = realtime_projection_messages_with_window(&session, window)
+            .expect("first bounded projection");
+        let second = realtime_projection_messages_with_window(&session, window)
+            .expect("second bounded projection");
+
+        assert_eq!(first.messages, second.messages);
+        assert_eq!(first.status, second.status);
+        assert!(first.status.has_known_gaps());
+    }
+
+    #[test]
+    fn live_seed_window_keeps_root_summary_and_newest_complete_turn() {
+        let session = window_test_session();
+        let full = realtime_projection_messages(&session).expect("full projection");
+        let costs = full
+            .iter()
+            .map(serialized_message_chars)
+            .collect::<Result<Vec<_>, _>>()
+            .expect("serialized costs");
+        let budget = costs[0] + costs[1] + costs[5..].iter().sum::<usize>();
+
+        let projection = realtime_projection_messages_with_window(
+            &session,
+            LiveSeedWindow::new(budget).expect("positive window"),
+        )
+        .expect("bounded projection");
+
+        let mut expected = full[..2].to_vec();
+        expected.extend_from_slice(&full[5..]);
+        assert_eq!(projection.messages, expected);
+        let selected_chars = projection
+            .messages
+            .iter()
+            .map(serialized_message_chars)
+            .collect::<Result<Vec<_>, _>>()
+            .expect("selected serialized costs")
+            .into_iter()
+            .sum::<usize>();
+        assert!(selected_chars <= budget);
+        assert_eq!(
+            projection.status,
+            LiveSeedProjectionStatus::Windowed {
+                dropped_messages: 3,
+                included_compaction_summary: true,
+            }
+        );
+    }
+
+    #[test]
+    fn live_seed_window_never_keeps_a_partial_newest_turn() {
+        let session = window_test_session();
+        let full = realtime_projection_messages(&session).expect("full projection");
+        let costs = full
+            .iter()
+            .map(serialized_message_chars)
+            .collect::<Result<Vec<_>, _>>()
+            .expect("serialized costs");
+        let latest_turn_chars = costs[5..].iter().sum::<usize>();
+        let budget = costs[0] + costs[1] + latest_turn_chars - 1;
+
+        let projection = realtime_projection_messages_with_window(
+            &session,
+            LiveSeedWindow::new(budget).expect("positive window"),
+        )
+        .expect("bounded projection");
+
+        assert_eq!(projection.messages.len(), 2);
+        assert!(matches!(projection.messages[0], Message::System(_)));
+        assert!(matches!(
+            &projection.messages[1],
+            Message::User(user) if user.transcript_role.is_compaction_summary()
+        ));
+        assert_eq!(
+            projection.status,
+            LiveSeedProjectionStatus::Windowed {
+                dropped_messages: 6,
+                included_compaction_summary: true,
+            }
+        );
+    }
+
+    #[test]
+    fn live_seed_window_fails_when_resolved_root_cannot_fit() {
+        let session = window_test_session();
+        let full = realtime_projection_messages(&session).expect("full projection");
+        let root_chars = serialized_message_chars(&full[0]).expect("root cost");
+
+        let error = realtime_projection_messages_with_window(
+            &session,
+            LiveSeedWindow::new(root_chars - 1).expect("positive window"),
+        )
+        .expect_err("root must not be silently dropped");
+
+        assert!(matches!(
+            error,
+            LiveSeedProjectionError::RootExceedsWindow {
+                required_chars,
+                max_chars,
+            } if required_chars == root_chars && max_chars == root_chars - 1
+        ));
     }
 
     /// R10: the runtime-side snapshot builder must surface the typed

--- a/sdks/python/meerkat/client.py
+++ b/sdks/python/meerkat/client.py
@@ -3419,6 +3419,7 @@ class MeerkatClient:
         session_id: str,
         turning_mode: Literal["provider_managed", "explicit_commit"] | None = None,
         transport: Literal["websocket", "webrtc"] | None = None,
+        seed_max_chars: int | None = None,
     ) -> dict[str, Any]:
         """Open a live audio/text channel with model-gated image input.
 
@@ -3444,12 +3445,23 @@ class MeerkatClient:
         opened with explicit-commit semantics. Defaults to ``None``,
         which omits the field on the wire — the server treats omitted as
         ``"provider_managed"`` for back-compat.
+
+        ``seed_max_chars`` optionally bounds serialized provider seed messages
+        and requests a core-owned, whole-turn suffix. Omitting it preserves
+        the full canonical seed. The resolved root prompt is never dropped
+        and must fit; an existing compaction summary may be retained as the
+        head. Any truncation is reported as degraded continuity. Runtime
+        system context and canonical image identity, tombstone, and accounting
+        sidecars remain complete outside the message window. When provided,
+        the value must be positive; the server rejects zero.
         """
         params: dict[str, Any] = {"session_id": session_id}
         if turning_mode is not None:
             params["turning_mode"] = turning_mode
         if transport is not None:
             params["transport"] = transport
+        if seed_max_chars is not None:
+            params["seed_max_chars"] = seed_max_chars
         return await self._request("live/open", params)
 
     async def live_webrtc_answer(

--- a/sdks/python/meerkat/generated/types.py
+++ b/sdks/python/meerkat/generated/types.py
@@ -3056,6 +3056,7 @@ instead of producing sideband text.
 Default (`None`) preserves the prior wire shape: callers that omit the
 field get `ProviderManaged`, matching the legacy behavior."""
     session_id: str
+    seed_max_chars: Optional[int] = None
     transport: Optional[Literal['websocket', 'webrtc']] = None
     turning_mode: Optional[RealtimeTurningMode] = None
 

--- a/sdks/python/meerkat/live.py
+++ b/sdks/python/meerkat/live.py
@@ -52,11 +52,13 @@ class LiveChannel:
         *,
         turning_mode: Literal["provider_managed", "explicit_commit"] | None = None,
         transport: Literal["websocket", "webrtc"] | None = None,
+        seed_max_chars: int | None = None,
     ) -> None:
         self._client = client
         self._session_id = session_id
         self._turning_mode = turning_mode
         self._transport = transport
+        self._seed_max_chars = seed_max_chars
         self._channel_id: str | None = None
 
     @classmethod
@@ -67,13 +69,19 @@ class LiveChannel:
         *,
         turning_mode: Literal["provider_managed", "explicit_commit"] | None = None,
         transport: Literal["websocket", "webrtc"] | None = None,
+        seed_max_chars: int | None = None,
     ) -> LiveChannel:
-        """Create a ``LiveChannel`` bound to a standalone session."""
+        """Create a ``LiveChannel`` bound to a standalone session.
+
+        ``seed_max_chars`` requests a positive serialized whole-turn seed
+        message window at open time. Omit it to preserve full-seed behavior.
+        """
         return cls(
             client,
             session_id,
             turning_mode=turning_mode,
             transport=transport,
+            seed_max_chars=seed_max_chars,
         )
 
     @property
@@ -99,11 +107,17 @@ class LiveChannel:
         Stores the returned ``channel_id`` for subsequent operations.
         Returns the full ``LiveOpenResult`` dict (``channel_id``,
         ``transport``, ``capabilities``, ``continuity``).
+
+        If ``seed_max_chars`` was supplied at construction time, the server
+        may seed a whole-turn suffix. Any truncation is surfaced as degraded
+        continuity. The resolved root is never dropped and must fit; runtime
+        context and canonical image sidecars stay outside the message window.
         """
         result = await self._client.live_open(
             self._session_id,
             turning_mode=self._turning_mode,
             transport=self._transport,
+            seed_max_chars=self._seed_max_chars,
         )
         self._channel_id = result.get("channel_id") or result.get("channelId")
         return result

--- a/sdks/python/tests/test_types.py
+++ b/sdks/python/tests/test_types.py
@@ -4996,12 +4996,11 @@ async def test_client_live_close_rejects_missing_or_unknown_generated_status():
 
 
 @pytest.mark.asyncio
-async def test_client_live_open_omits_turning_mode_when_default():
-    """R4-2 (P2): when the caller does not pass ``turning_mode``, the
-    Python SDK must omit the field on the wire — the server's
-    ``LiveOpenParams.turning_mode`` is ``Option<RealtimeTurningMode>``
-    with ``#[serde(skip_serializing_if = "Option::is_none")]`` and treats
-    omitted as ``ProviderManaged`` for back-compat with R3-1-era clients.
+async def test_client_live_open_omits_optional_open_parameters_when_default():
+    """Optional open controls must elide when absent.
+
+    The server treats omitted ``turning_mode`` as ``ProviderManaged`` and
+    omitted ``seed_max_chars`` as the legacy full canonical seed.
     """
     client = MeerkatClient()
 
@@ -5032,6 +5031,67 @@ async def test_client_live_open_omits_turning_mode_when_default():
 
     assert captured == [("live/open", {"session_id": "session-42"})]
     assert "turning_mode" not in captured[0][1]
+    assert "seed_max_chars" not in captured[0][1]
+
+
+@pytest.mark.asyncio
+async def test_client_live_open_passes_seed_max_chars():
+    """The direct helper forwards the snake-case wire budget unchanged."""
+    client = MeerkatClient()
+
+    captured: list[tuple[str, dict[str, object]]] = []
+
+    async def fake_request(method, params):
+        captured.append((method, params))
+        return {
+            "channel_id": "live_seeded",
+            "transport": {"transport": "websocket", "url": "ws://x", "token": "t"},
+            "capabilities": {},
+            "continuity": {"mode": "degraded"},
+        }
+
+    client._request = fake_request  # type: ignore[method-assign]
+
+    await client.live_open("session-seeded", seed_max_chars=24_000)
+
+    assert captured == [
+        (
+            "live/open",
+            {"session_id": "session-seeded", "seed_max_chars": 24_000},
+        )
+    ]
+
+
+@pytest.mark.asyncio
+async def test_live_channel_passes_seed_max_chars_on_open():
+    """The session-bound wrapper carries its camel-free Python option through."""
+    from meerkat import LiveChannel
+
+    client = MeerkatClient()
+    captured: list[tuple[str, object, object, object]] = []
+
+    async def fake_live_open(
+        session_id,
+        turning_mode=None,
+        transport=None,
+        seed_max_chars=None,
+    ):
+        captured.append((session_id, turning_mode, transport, seed_max_chars))
+        return {
+            "channel_id": "live_seeded",
+            "transport": {"transport": "websocket", "url": "ws://x", "token": "t"},
+            "capabilities": {},
+            "continuity": {"mode": "degraded"},
+        }
+
+    client.live_open = fake_live_open  # type: ignore[method-assign]
+    channel = LiveChannel.session(client, "session-seeded", seed_max_chars=12_000)
+
+    result = await channel.open()
+
+    assert captured == [("session-seeded", None, None, 12_000)]
+    assert channel.channel_id == "live_seeded"
+    assert result["continuity"] == {"mode": "degraded"}
 
 
 @pytest.mark.asyncio

--- a/sdks/typescript/src/generated/types.ts
+++ b/sdks/typescript/src/generated/types.ts
@@ -2861,6 +2861,7 @@ export interface RealtimeImageChunk {
 }
 
 export interface LiveOpenParams {
+  seed_max_chars?: number;
   session_id: string;
   transport?: "websocket" | "webrtc";
   turning_mode?: RealtimeTurningMode;

--- a/sdks/typescript/src/live.ts
+++ b/sdks/typescript/src/live.ts
@@ -64,6 +64,15 @@ export interface LiveChannelOptions {
   readonly turningMode?: RealtimeTurningMode;
   /** Transport to request from `live/open`. Missing uses the server default. */
   readonly transport?: LiveOpenTransport;
+  /**
+   * Positive serialized-character budget for a core-owned, whole-turn seed
+   * message window. Missing preserves the full canonical seed. The resolved
+   * root is never dropped and must fit; runtime context and canonical image
+   * sidecars stay outside the window. Truncation reports degraded continuity.
+   *
+   * Zero is invalid and is rejected by the server.
+   */
+  readonly seedMaxChars?: number;
 }
 
 export class LiveChannel {
@@ -71,6 +80,7 @@ export class LiveChannel {
   readonly sessionId: string;
   readonly turningMode?: RealtimeTurningMode;
   readonly transport?: LiveOpenTransport;
+  readonly seedMaxChars?: number;
 
   /** The channel id assigned by the server after `open()`. */
   private _channelId: string | undefined;
@@ -84,6 +94,7 @@ export class LiveChannel {
     this.sessionId = sessionId;
     this.turningMode = options?.turningMode;
     this.transport = options?.transport;
+    this.seedMaxChars = options?.seedMaxChars;
   }
 
   /**
@@ -108,14 +119,21 @@ export class LiveChannel {
    *
    * The returned {@link LiveOpenResult} contains `transport` (URL + token
    * for the caller to connect externally), `capabilities`, and `continuity`.
+   * When `seedMaxChars` is set, any whole-turn truncation is surfaced as
+   * degraded continuity; full canonical image sidecars remain attached.
    */
   async open(): Promise<LiveOpenResult> {
-    const params: LiveOpenParams = { session_id: this.sessionId };
+    const params: LiveOpenParams = {
+      session_id: this.sessionId,
+    };
     if (this.turningMode != null) {
       params.turning_mode = this.turningMode;
     }
     if (this.transport != null) {
       params.transport = this.transport;
+    }
+    if (this.seedMaxChars != null) {
+      params.seed_max_chars = this.seedMaxChars;
     }
     const result = await this.client.liveOpen(params);
     this._channelId = result.channel_id;

--- a/sdks/typescript/tests/live.test.js
+++ b/sdks/typescript/tests/live.test.js
@@ -1,0 +1,49 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { LiveChannel } from "../dist/live.js";
+
+test("LiveChannel forwards seedMaxChars as seed_max_chars", async () => {
+  const calls = [];
+  const client = {
+    async liveOpen(params) {
+      calls.push(params);
+      return {
+        channel_id: "live_seeded",
+        transport: { transport: "websocket", url: "ws://x", token: "t" },
+        capabilities: {},
+        continuity: { mode: "degraded" },
+      };
+    },
+  };
+
+  const channel = LiveChannel.session(client, "session-seeded", {
+    seedMaxChars: 24_000,
+  });
+  const result = await channel.open();
+
+  assert.deepEqual(calls, [
+    { session_id: "session-seeded", seed_max_chars: 24_000 },
+  ]);
+  assert.equal(channel.channelId, "live_seeded");
+  assert.deepEqual(result.continuity, { mode: "degraded" });
+});
+
+test("LiveChannel omits the seed field by default", async () => {
+  const calls = [];
+  const client = {
+    async liveOpen(params) {
+      calls.push(params);
+      return {
+        channel_id: "live_full_seed",
+        transport: { transport: "websocket", url: "ws://x", token: "t" },
+        capabilities: {},
+        continuity: { mode: "transcript_only" },
+      };
+    },
+  };
+
+  await LiveChannel.session(client, "session-full-seed").open();
+
+  assert.deepEqual(calls, [{ session_id: "session-full-seed" }]);
+});

--- a/sdks/typescript/tests/public-types.test.ts
+++ b/sdks/typescript/tests/public-types.test.ts
@@ -1162,11 +1162,18 @@ void liveChannel;
 const liveOpts: LiveChannelOptions = { turningMode: "explicit_commit" };
 void liveOpts;
 
+// The convenience wrapper exposes the bounded serialized seed as camelCase.
+const liveSeedWindowOpts: LiveChannelOptions = { seedMaxChars: 24_000 };
+// @ts-expect-error seedMaxChars is numeric; the server validates positivity.
+const liveInvalidSeedWindowOpts: LiveChannelOptions = { seedMaxChars: "24000" };
+void liveSeedWindowOpts;
+void liveInvalidSeedWindowOpts;
+
 // LiveChannel with options
 const liveChannelWithOpts: LiveChannel = LiveChannel.session(
   mockClient,
   "session_456",
-  { turningMode: "provider_managed" },
+  { turningMode: "provider_managed", seedMaxChars: 24_000 },
 );
 void liveChannelWithOpts;
 


### PR DESCRIPTION
## Summary

- add optional `live/open.seed_max_chars` projection policy while preserving the complete-history default
- retain the resolved root, an affordable existing compaction summary, and the newest complete conversational turns; report any omitted history as degraded continuity
- preserve full identity, tombstone, rewrite-generation, and canonical image-budget sidecars across a bounded provider seed
- expose the contract through generated and handwritten Python/TypeScript surfaces, with updated schema, docs, and changelog

## Validation

- `make check`
- `make lint`
- `make fmt-check`
- `make docs-check`
- `make verify-schema-freshness`
- `make verify-sdk-codegen-freshness`
- `make verify-sdk-event-inventory`
- `make verify-rpc-surface-alignment`
- `make verify-sdk-wrapper-freshness`
- focused Rust coverage: 9 projection tests, 2 typed RPC mapping tests, 3 OpenAI canonical-image accounting tests, persistent hydration/accounting, and 6 wire round trips
- focused SDK coverage: 6 Python live-open tests and 2 TypeScript runtime forwarding tests
- three independent adversarial review lanes: GREEN (architecture, safety/invariants, public surfaces)
- repository pre-push gate passed, including changed-crate Clippy, machine/codegen verification, generated-header and Bazel freshness, and the deterministic workspace lane

## Complexity Delta

- Docs/scripts/tests: focused boundary tests plus RPC, SDK, guide, reference, and platform-skill updates
- Non-test implementation: provider-neutral seed selection, typed projection errors, continuity plumbing, and seed-independent canonical image accounting
- Generated/schema churn: one optional wire field in JSON Schema and generated Python/TypeScript contracts
