### PR TITLE
test: scope image wiring to provider builds

### DIFF
--- a/meerkat-cli/src/main.rs
+++ b/meerkat-cli/src/main.rs
@@ -16599,8 +16599,10 @@ default_model = "gemma"
         }
     }
 
+    #[cfg(any(feature = "openai", feature = "gemini"))]
     struct FakeImageGenerationExecutor;
 
+    #[cfg(any(feature = "openai", feature = "gemini"))]
     #[async_trait]
     impl meerkat_llm_core::ImageGenerationExecutor for FakeImageGenerationExecutor {
         async fn execute_image_generation(
@@ -21436,6 +21438,9 @@ capabilities = ["rpc"]
         );
     }
 
+    // These wiring contracts require a compiled image-provider profile. Slim
+    // provider-free builds intentionally have no image planner or image tool.
+    #[cfg(any(feature = "openai", feature = "gemini"))]
     #[tokio::test]
     async fn test_run_session_build_wires_generate_image_for_runtime_owned_one_shot() {
         let temp = tempfile::tempdir().expect("tempdir must be created");
@@ -21507,6 +21512,7 @@ capabilities = ["rpc"]
         assert!(names.contains("generate_image"));
     }
 
+    #[cfg(any(feature = "openai", feature = "gemini"))]
     #[tokio::test]
     async fn test_run_session_build_keeps_generate_image_visible_without_executor() {
         let temp = tempfile::tempdir().expect("tempdir must be created");


### PR DESCRIPTION
## Summary

- compile the two positive CLI `generate_image` wiring tests only when OpenAI or Gemini support is enabled
- apply the same feature boundary to their fake executor fixture
- leave production image-tool composition unchanged

## Root cause

The tests were introduced while slim `rkat` builds still pulled OpenAI transitively through realtime support, so an image-planning profile was always present. After provider dependencies were correctly removed from slim builds, `--no-default-features --features session-store,mcp` became genuinely provider-free: it has no image planner and correctly does not advertise `generate_image`. The old positive tests were still compiled there and asserted a capability that the binary intentionally does not expose.

## Impact

This restores the release feature-matrix gate without reintroducing provider dependencies or false capability visibility into slim binaries. OpenAI/Gemini builds continue to exercise both original image wiring contracts.

## Validation

- `make fmt-check test-feature-matrix-surface`
- `./scripts/repo-cargo nextest run -p rkat --no-default-features --features session-store,mcp --no-capture` (170/170 passed)
- focused OpenAI matrix for both image wiring tests (2/2 passed)
- full pre-push hooks, including changed-crate clippy and unit/e2e-fast gate
- independent adversarial review: GREEN
