### PR TITLE
fix: validate release hook Python runtime

### DIFF
--- a/scripts/release-doctor
+++ b/scripts/release-doctor
@@ -56,6 +56,18 @@ else
   bad "npm is not installed; SDK publish checks need npm"
 fi
 
+release_python="${PYTHON:-$(command -v python3.11 2>/dev/null || command -v python3 2>/dev/null || true)}"
+if [[ -z "${release_python}" ]]; then
+  bad "release hook Python is missing; install Python >= 3.10"
+elif "${release_python}" -c \
+  'import sys; raise SystemExit(0 if sys.version_info >= (3, 10) else 1)'; then
+  release_python_version="$("${release_python}" -c 'import platform; print(platform.python_version())')"
+  pass "release hook Python ${release_python_version} satisfies >= 3.10"
+else
+  release_python_version="$("${release_python}" --version 2>&1 || true)"
+  bad "release hook Python '${release_python}' is too old (${release_python_version:-unknown}); require >= 3.10"
+fi
+
 if command -v gh >/dev/null 2>&1 && gh auth status >/dev/null 2>&1; then
   gh_user="$(gh api user --jq '.login' 2>/dev/null || true)"
   owner_release_account=false

--- a/scripts/release-hook.sh
+++ b/scripts/release-hook.sh
@@ -23,14 +23,30 @@ case "${DRY_RUN:-}" in
         ;;
 esac
 
+# cargo-release invokes this hook from individual crate directories. Resolve
+# caller-provided relative interpreter paths and all later outputs from the
+# workspace root.
+cd "$ROOT"
+
+# Keep the release path on the same Python floor as the SDK/codegen targets.
+# macOS can place an older system `python3` ahead of Homebrew in PATH, so prefer
+# the supported python3.11 interpreter unless the caller selected one explicitly.
+PYTHON="${PYTHON:-$(command -v python3.11 2>/dev/null || command -v python3 2>/dev/null || true)}"
+if [[ -z "$PYTHON" ]] || ! "$PYTHON" -c \
+    'import sys; raise SystemExit(0 if sys.version_info >= (3, 10) else 1)'; then
+    selected_version="unavailable"
+    if [[ -n "$PYTHON" ]]; then
+        selected_version="$("$PYTHON" --version 2>&1 || true)"
+    fi
+    echo "error: release hook requires Python >= 3.10; selected '${PYTHON:-missing}' (${selected_version:-unavailable})" >&2
+    exit 1
+fi
+
 # cargo-release runs this hook per-crate. Only execute once.
 SENTINEL="$ROOT/.release-hook-done"
 if [[ -f "$SENTINEL" ]] && [[ "$(cat "$SENTINEL")" == "$VERSION" ]]; then
     exit 0
 fi
-
-# All commands must run from workspace root (emit-schemas writes to ./artifacts/)
-cd "$ROOT"
 
 echo "==> Release hook: syncing SDK versions to $VERSION"
 
@@ -55,7 +71,7 @@ sed "/pub const CURRENT/,/};/{
     s/minor: [0-9]*/minor: $V_MINOR/
     s/patch: [0-9]*/patch: $V_PATCH/
 }" "$VERSION_RS" > "${VERSION_RS}.tmp" && mv "${VERSION_RS}.tmp" "$VERSION_RS"
-VERSION_PRERELEASE="$V_PRE" python3 - "$VERSION_RS" <<'PY'
+VERSION_PRERELEASE="$V_PRE" "$PYTHON" - "$VERSION_RS" <<'PY'
 from pathlib import Path
 import os
 import re
@@ -84,7 +100,7 @@ echo "==> Emitting schemas..."
 "$CARGO" run -p meerkat-contracts --features schema --bin emit-schemas
 
 echo "==> Running SDK codegen..."
-python3 "$ROOT/tools/sdk-codegen/generate.py"
+"$PYTHON" "$ROOT/tools/sdk-codegen/generate.py"
 
 echo "==> Regenerating BuildBuddy BUILD files..."
 make buildbuddy-generate


### PR DESCRIPTION
## Summary

- make the cargo-release hook honor `PYTHON` and otherwise use the repository's Python 3.11-first selection policy
- fail before release-hook mutations when the selected interpreter is older than Python 3.10
- teach `release-doctor` to validate the same runtime before a release begins

## Root cause

The macOS release shell resolves bare `python3` to `/usr/bin/python3` 3.9.6. The hook bypassed the Make/codegen interpreter policy and invoked that binary directly, while `tools/sdk-codegen/generate.py` uses Python 3.10 `match` syntax. A live 0.7.28 release therefore aborted during codegen, before commit/tag/push.

## Validation

- `bash -n scripts/release-hook.sh scripts/release-doctor`
- old-Python hook guard fails before changing release outputs
- old-Python doctor reports the runtime failure
- default `make release-doctor` selects Python 3.11.15 and passes 21/21
- `make verify-sdk-codegen-freshness`
- `make check-rust-release-config`
- `make fmt-check`
- pre-push repository gates
- independent adversarial review: GREEN