### PR TITLE
Publish Homebrew before Windows release build

### DIFF
--- a/.github/actions/update-homebrew/action.yml
+++ b/.github/actions/update-homebrew/action.yml
@@ -1,0 +1,175 @@
+name: Update Homebrew tap
+description: Update the rkat formula from published release checksums
+
+inputs:
+  release_tag:
+    description: Release tag, for example v0.7.29
+    required: true
+  github_token:
+    description: GitHub token used to inspect the source repository release
+    required: true
+  tap_token:
+    description: Token with push access to lukacf/homebrew-meerkat
+    required: true
+  checksums_path:
+    description: Optional local checksum manifest; downloads the release manifest when omitted
+    required: false
+    default: ""
+
+runs:
+  using: composite
+  steps:
+    # An assets-only backfill can target an OLD tag after a newer release has
+    # shipped. The tap must never downgrade every `brew upgrade` user.
+    - name: Require target tag to be the latest release
+      id: latest_guard
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.github_token }}
+        RELEASE_TAG: ${{ inputs.release_tag }}
+      run: |
+        set -euo pipefail
+        LATEST=$(gh release view --repo "${GITHUB_REPOSITORY}" --json tagName --jq .tagName)
+        if [ "${LATEST}" != "${RELEASE_TAG}" ]; then
+          echo "skip=true" >> "$GITHUB_OUTPUT"
+          echo "target ${RELEASE_TAG} is not the latest release (${LATEST}); leaving the tap untouched"
+        else
+          echo "skip=false" >> "$GITHUB_OUTPUT"
+        fi
+
+    - name: Checkout tap
+      if: steps.latest_guard.outputs.skip != 'true'
+      uses: actions/checkout@v6
+      with:
+        repository: lukacf/homebrew-meerkat
+        token: ${{ inputs.tap_token }}
+        path: homebrew-meerkat
+
+    - name: Resolve checksums
+      id: checksums
+      if: steps.latest_guard.outputs.skip != 'true'
+      shell: bash
+      env:
+        CHECKSUMS_PATH: ${{ inputs.checksums_path }}
+        RELEASE_TAG: ${{ inputs.release_tag }}
+      run: |
+        set -euo pipefail
+        resolved="${RUNNER_TEMP}/rkat-checksums.sha256"
+        if [[ -n "${CHECKSUMS_PATH}" ]]; then
+          source="${CHECKSUMS_PATH}"
+          if [[ "${source}" != /* ]]; then
+            source="${GITHUB_WORKSPACE}/${source}"
+          fi
+          if [[ ! -f "${source}" ]]; then
+            echo "Local checksum manifest does not exist: ${source}" >&2
+            exit 1
+          fi
+          cp "${source}" "${resolved}"
+        else
+          curl -fsSL "https://github.com/lukacf/meerkat/releases/download/${RELEASE_TAG}/checksums.sha256" -o "${resolved}"
+        fi
+        echo "path=${resolved}" >> "${GITHUB_OUTPUT}"
+
+    - name: Generate updated formula
+      if: steps.latest_guard.outputs.skip != 'true'
+      shell: bash
+      env:
+        CHECKSUMS_PATH: ${{ steps.checksums.outputs.path }}
+        VERSION: ${{ inputs.release_tag }}
+      run: |
+        set -euo pipefail
+        VERSION="${VERSION#v}"
+        TAG="${{ inputs.release_tag }}"
+        BASE="https://github.com/lukacf/meerkat/releases/download/${TAG}"
+
+        get_sha() {
+          local name="$1" sha
+          sha="$(awk -v name="${name}" '$2 == name { print $1; found = 1 } END { if (!found) exit 1 }' "${CHECKSUMS_PATH}")"
+          if [[ ! "${sha}" =~ ^[0-9a-f]{64}$ ]]; then
+            echo "Missing or invalid SHA256 for ${name}" >&2
+            return 1
+          fi
+          printf '%s\n' "${sha}"
+        }
+
+        gen_resource() {
+          local name="$1" target="$2" sha
+          sha="$(get_sha "${name}-${VERSION}-${target}.tar.gz")"
+          echo "  resource \"${name}\" do"
+          echo "    url \"${BASE}/${name}-${VERSION}-${target}.tar.gz\""
+          echo "    sha256 \"${sha}\""
+          echo "  end"
+        }
+
+        gen_platform() {
+          local target="$1" sha
+          sha="$(get_sha "rkat-${VERSION}-${target}.tar.gz")"
+          echo "    url \"${BASE}/rkat-${VERSION}-${target}.tar.gz\""
+          echo "    sha256 \"${sha}\""
+          echo ""
+          for r in rkat-rpc rkat-rest rkat-mcp; do
+            gen_resource "$r" "$target"
+            echo ""
+          done
+        }
+
+        {
+          echo 'class Rkat < Formula'
+          echo '  desc "Minimal, high-performance agent harness for LLM-powered applications"'
+          echo '  homepage "https://github.com/lukacf/meerkat"'
+          echo "  version \"${VERSION}\""
+          echo '  license "MIT"'
+          echo ''
+          echo '  on_macos do'
+          echo '    on_arm do'
+          gen_platform "aarch64-apple-darwin"
+          echo '    end'
+          echo ''
+          echo '    on_intel do'
+          gen_platform "x86_64-apple-darwin"
+          echo '    end'
+          echo '  end'
+          echo ''
+          echo '  on_linux do'
+          echo '    on_arm do'
+          gen_platform "aarch64-unknown-linux-gnu"
+          echo '    end'
+          echo ''
+          echo '    on_intel do'
+          gen_platform "x86_64-unknown-linux-gnu"
+          echo '    end'
+          echo '  end'
+          echo ''
+          echo '  def install'
+          echo '    bin.install "rkat"'
+          echo ''
+          echo '    %w[rkat-rpc rkat-rest rkat-mcp].each do |name|'
+          echo '      resource(name).stage do'
+          echo '        bin.install name'
+          echo '      end'
+          echo '    end'
+          echo '  end'
+          echo ''
+          echo '  test do'
+          echo '    assert_match "rkat #{version}", shell_output("#{bin}/rkat --version")'
+          echo '  end'
+          echo 'end'
+        } > homebrew-meerkat/rkat.rb
+
+    - name: Commit and push formula
+      if: steps.latest_guard.outputs.skip != 'true'
+      shell: bash
+      working-directory: homebrew-meerkat
+      env:
+        VERSION: ${{ inputs.release_tag }}
+      run: |
+        set -euo pipefail
+        if git diff --quiet -- rkat.rb; then
+          echo "Homebrew formula already up to date"
+          exit 0
+        fi
+        git config user.name "github-actions[bot]"
+        git config user.email "github-actions[bot]@users.noreply.github.com"
+        git add rkat.rb
+        git commit -m "Update rkat to ${VERSION#v}"
+        git push

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -691,6 +691,91 @@ jobs:
           path: dist/*
           if-no-files-found: error
 
+  publish_unix_release_and_homebrew:
+    name: Publish macOS/Linux release assets and update Homebrew
+    needs: [release_validate_gate, build_binaries_buildbuddy]
+    if: >-
+      always() &&
+      startsWith(github.ref, 'refs/tags/v') &&
+      needs.release_validate_gate.result == 'success' &&
+      needs.build_binaries_buildbuddy.result == 'success' &&
+      github.actor == 'lukacf' &&
+      (vars.MEERKAT_RELEASE_BUILDBUDDY == 'true' ||
+       vars.MEERKAT_RELEASE_BUILDBUDDY == '1')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Download macOS/Linux artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: meerkat-*-buildbuddy
+          path: release-artifacts
+
+      - name: Build macOS/Linux checksum manifest
+        env:
+          RELEASE_TAG: ${{ github.ref_name }}
+        run: scripts/release-build-asset-manifest release-artifacts "${RELEASE_TAG}"
+
+      - name: Require complete Homebrew archive set
+        env:
+          RELEASE_TAG: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          python3 - "${RELEASE_TAG}" release-artifacts/index.json <<'PY'
+          import json
+          import sys
+
+          tag, index_path = sys.argv[1:]
+          version = tag.removeprefix("v")
+          binaries = ("rkat", "rkat-rpc", "rkat-rest", "rkat-mcp")
+          targets = (
+              "aarch64-apple-darwin",
+              "x86_64-apple-darwin",
+              "aarch64-unknown-linux-gnu",
+              "x86_64-unknown-linux-gnu",
+          )
+          expected = {
+              f"{binary}-{version}-{target}.tar.gz"
+              for binary in binaries
+              for target in targets
+          }
+          with open(index_path, encoding="utf-8") as source:
+              actual = set(json.load(source)["artifacts"])
+          if actual != expected:
+              missing = sorted(expected - actual)
+              extra = sorted(actual - expected)
+              raise SystemExit(
+                  f"Homebrew release asset mismatch: missing={missing}, extra={extra}"
+              )
+          print(f"Verified {len(actual)} macOS/Linux release archives")
+          PY
+
+      # Never churn already-published archives on a rerun. Missing archives
+      # are still added, while the final publisher handles Windows later.
+      - name: Publish macOS/Linux release assets
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            release-artifacts/**/*.tar.gz
+          draft: false
+          fail_on_unmatched_files: true
+          generate_release_notes: true
+          overwrite_files: false
+          tag_name: ${{ github.ref_name }}
+
+      - name: Update Homebrew tap from published macOS/Linux assets
+        continue-on-error: true
+        uses: ./.github/actions/update-homebrew
+        with:
+          release_tag: ${{ github.ref_name }}
+          github_token: ${{ github.token }}
+          tap_token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          checksums_path: release-artifacts/checksums.sha256
+
   build_web_sdk_package:
     name: Build Web SDK package
     needs: [require_ci_green, release_validate_gate]
@@ -814,13 +899,18 @@ jobs:
         github.event.inputs.publish_release_assets_only == 'true' &&
         needs.release_validate_gate.result == 'skipped')) &&
       needs.build_binaries_gate.result == 'success'
-    needs: [release_validate_gate, build_binaries_gate]
+    # Waiting for the early publisher prevents manifest upload races if a
+    # future Windows build happens to finish before the Unix release job.
+    # `always()` above keeps this authoritative path available if that early
+    # optimization is skipped or fails.
+    needs: [release_validate_gate, build_binaries_gate, publish_unix_release_and_homebrew]
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
+      # Recovery runs execute the current workflow against an older release
+      # tag, so load helpers from the workflow ref rather than that old tag.
+      - name: Checkout workflow helpers
         uses: actions/checkout@v6
         with:
-          ref: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.release_tag != '' && github.event.inputs.release_tag || github.ref }}
           fetch-depth: 0
 
       - name: Download all artifacts
@@ -829,7 +919,6 @@ jobs:
           path: release-artifacts
 
       - name: Build checksum manifest
-        working-directory: release-artifacts
         env:
           RELEASE_TAG: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.release_tag || github.ref_name }}
         run: |
@@ -838,69 +927,31 @@ jobs:
             echo "release_tag is required for release asset recovery" >&2
             exit 1
           fi
-          python3 - <<'PY'
-          import hashlib
-          import json
-          import os
-          from pathlib import Path
+          scripts/release-build-asset-manifest release-artifacts "${RELEASE_TAG}"
 
-          def sha256(path):
-              digest = hashlib.sha256()
-              with path.open("rb") as source:
-                  for chunk in iter(lambda: source.read(1024 * 1024), b""):
-                      digest.update(chunk)
-              return digest.hexdigest()
-
-          archive_paths = sorted(
-              (
-                  path
-                  for path in Path(".").rglob("*")
-                  if path.is_file()
-                  and (path.name.endswith(".tar.gz") or path.name.endswith(".zip"))
-              ),
-              key=lambda path: (path.name, path.as_posix()),
-          )
-          if not archive_paths:
-              raise SystemExit("No release artifacts found")
-
-          artifacts_by_name = {}
-          for path in archive_paths:
-              public_name = path.name
-              previous = artifacts_by_name.get(public_name)
-              if previous is not None:
-                  raise SystemExit(
-                      "duplicate release asset basename "
-                      f"{public_name!r}: {previous.as_posix()} and {path.as_posix()}"
-                  )
-              artifacts_by_name[public_name] = path
-
-          with open("checksums.sha256", "w", encoding="utf-8") as checksums:
-              for public_name, path in artifacts_by_name.items():
-                  checksums.write(f"{sha256(path)}  {public_name}\n")
-
-          tag = os.environ["RELEASE_TAG"]
-          manifest = {
-              "version": tag.lstrip("v"),
-              "tag": tag,
-              "artifacts": list(artifacts_by_name),
-              "checksums": "checksums.sha256",
-          }
-
-          with open("index.json", "w", encoding="utf-8") as f:
-              json.dump(manifest, f, indent=2)
-          PY
-
-      - name: Publish GitHub release
+      - name: Publish release archives
         uses: softprops/action-gh-release@v2
         with:
           files: |
             release-artifacts/**/*.tar.gz
             release-artifacts/**/*.zip
+          draft: false
+          fail_on_unmatched_files: true
+          generate_release_notes: true
+          overwrite_files: false
+          tag_name: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.release_tag || github.ref_name }}
+
+      # Publish checksums and index.json only after every platform archive is
+      # present, keeping the public manifest a complete release authority.
+      - name: Publish complete release manifest
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
             release-artifacts/checksums.sha256
             release-artifacts/index.json
           draft: false
           fail_on_unmatched_files: true
-          generate_release_notes: true
+          overwrite_files: true
           tag_name: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.release_tag || github.ref_name }}
 
   update_homebrew:
@@ -914,132 +965,17 @@ jobs:
     needs: [publish_github_release]
     runs-on: ubuntu-latest
     steps:
-      # An assets-only backfill can target an OLD tag after a newer release
-      # has already shipped; pointing the tap at it would DOWNGRADE every
-      # `brew upgrade` user (field: the v0.7.24 backfill re-pointed the tap
-      # from 0.7.25 to 0.7.24). The tap must only ever track the repository's
-      # latest release.
-      - name: Require target tag to be the latest release
-        id: latest_guard
-        env:
-          GH_TOKEN: ${{ github.token }}
-          RELEASE_TAG: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.release_tag || github.ref_name }}
-        run: |
-          set -euo pipefail
-          LATEST=$(gh release view --repo "${GITHUB_REPOSITORY}" --json tagName --jq .tagName)
-          if [ "${LATEST}" != "${RELEASE_TAG}" ]; then
-            echo "skip=true" >> "$GITHUB_OUTPUT"
-            echo "target ${RELEASE_TAG} is not the latest release (${LATEST}); leaving the tap untouched"
-          else
-            echo "skip=false" >> "$GITHUB_OUTPUT"
-          fi
-
-      - name: Checkout tap
-        if: steps.latest_guard.outputs.skip != 'true'
+      - name: Checkout workflow helpers
         uses: actions/checkout@v6
+
+      # This is the authoritative fallback for GitHub-hosted releases and for
+      # any transient failure in the early BuildBuddy/Homebrew path.
+      - name: Update Homebrew tap from complete release
+        uses: ./.github/actions/update-homebrew
         with:
-          repository: lukacf/homebrew-meerkat
-          token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
-          path: homebrew-meerkat
-
-      - name: Download checksums
-        if: steps.latest_guard.outputs.skip != 'true'
-        env:
-          RELEASE_TAG: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.release_tag || github.ref_name }}
-        run: |
-          set -euo pipefail
-          curl -fsSL "https://github.com/lukacf/meerkat/releases/download/${RELEASE_TAG}/checksums.sha256" -o checksums.sha256
-
-      - name: Generate updated formula
-        if: steps.latest_guard.outputs.skip != 'true'
-        env:
-          VERSION: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.release_tag || github.ref_name }}
-        run: |
-          set -euo pipefail
-          VERSION="${VERSION#v}"
-          TAG="${{ github.event_name == 'workflow_dispatch' && github.event.inputs.release_tag || github.ref_name }}"
-          BASE="https://github.com/lukacf/meerkat/releases/download/${TAG}"
-
-          get_sha() { grep "$1" checksums.sha256 | awk '{print $1}'; }
-
-          gen_resource() {
-            local name="$1" target="$2"
-            echo "  resource \"${name}\" do"
-            echo "    url \"${BASE}/${name}-${VERSION}-${target}.tar.gz\""
-            echo "    sha256 \"$(get_sha "${name}-${VERSION}-${target}.tar.gz")\""
-            echo "  end"
-          }
-
-          gen_platform() {
-            local target="$1"
-            echo "    url \"${BASE}/rkat-${VERSION}-${target}.tar.gz\""
-            echo "    sha256 \"$(get_sha "rkat-${VERSION}-${target}.tar.gz")\""
-            echo ""
-            for r in rkat-rpc rkat-rest rkat-mcp; do
-              gen_resource "$r" "$target"
-              echo ""
-            done
-          }
-
-          {
-            echo 'class Rkat < Formula'
-            echo '  desc "Minimal, high-performance agent harness for LLM-powered applications"'
-            echo '  homepage "https://github.com/lukacf/meerkat"'
-            echo "  version \"${VERSION}\""
-            echo '  license "MIT"'
-            echo ''
-            echo '  on_macos do'
-            echo '    on_arm do'
-            gen_platform "aarch64-apple-darwin"
-            echo '    end'
-            echo ''
-            echo '    on_intel do'
-            gen_platform "x86_64-apple-darwin"
-            echo '    end'
-            echo '  end'
-            echo ''
-            echo '  on_linux do'
-            echo '    on_arm do'
-            gen_platform "aarch64-unknown-linux-gnu"
-            echo '    end'
-            echo ''
-            echo '    on_intel do'
-            gen_platform "x86_64-unknown-linux-gnu"
-            echo '    end'
-            echo '  end'
-            echo ''
-            echo '  def install'
-            echo '    bin.install "rkat"'
-            echo ''
-            echo '    %w[rkat-rpc rkat-rest rkat-mcp].each do |name|'
-            echo '      resource(name).stage do'
-            echo '        bin.install name'
-            echo '      end'
-            echo '    end'
-            echo '  end'
-            echo ''
-            echo '  test do'
-            echo '    assert_match "rkat #{version}", shell_output("#{bin}/rkat --version")'
-            echo '  end'
-            echo 'end'
-          } > homebrew-meerkat/rkat.rb
-
-      - name: Commit and push formula
-        if: steps.latest_guard.outputs.skip != 'true'
-        working-directory: homebrew-meerkat
-        env:
-          VERSION: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.release_tag || github.ref_name }}
-        run: |
-          set -euo pipefail
-          if git diff --quiet -- rkat.rb; then
-            echo "Homebrew formula already up to date"
-            exit 0
-          fi
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add rkat.rb
-          git commit -m "Update rkat to ${VERSION#v}"
-          git push
+          release_tag: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.release_tag || github.ref_name }}
+          github_token: ${{ github.token }}
+          tap_token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
 
   # Registry publishing runs automatically on tag pushes alongside binary
   # builds. For recovery (e.g. npm was down during the tag-triggered run),

--- a/scripts/release-build-asset-manifest
+++ b/scripts/release-build-asset-manifest
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+"""Build checksums.sha256 and index.json for release archives."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import sys
+from pathlib import Path
+
+
+def sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as source:
+        for chunk in iter(lambda: source.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def main() -> int:
+    if len(sys.argv) != 3:
+        print(
+            f"usage: {Path(sys.argv[0]).name} ARTIFACT_ROOT RELEASE_TAG",
+            file=sys.stderr,
+        )
+        return 2
+
+    root = Path(sys.argv[1])
+    tag = sys.argv[2].strip()
+    if not root.is_dir():
+        raise SystemExit(f"Artifact root does not exist: {root}")
+    if not tag:
+        raise SystemExit("Release tag must not be empty")
+
+    archive_paths = sorted(
+        (
+            path
+            for path in root.rglob("*")
+            if path.is_file()
+            and (path.name.endswith(".tar.gz") or path.name.endswith(".zip"))
+        ),
+        key=lambda path: (path.name, path.as_posix()),
+    )
+    if not archive_paths:
+        raise SystemExit("No release artifacts found")
+
+    artifacts_by_name: dict[str, Path] = {}
+    for path in archive_paths:
+        public_name = path.name
+        previous = artifacts_by_name.get(public_name)
+        if previous is not None:
+            raise SystemExit(
+                "duplicate release asset basename "
+                f"{public_name!r}: {previous.as_posix()} and {path.as_posix()}"
+            )
+        artifacts_by_name[public_name] = path
+
+    checksums_path = root / "checksums.sha256"
+    with checksums_path.open("w", encoding="utf-8") as checksums:
+        for public_name, path in artifacts_by_name.items():
+            checksums.write(f"{sha256(path)}  {public_name}\n")
+
+    manifest = {
+        "version": tag.lstrip("v"),
+        "tag": tag,
+        "artifacts": list(artifacts_by_name),
+        "checksums": checksums_path.name,
+    }
+    with (root / "index.json").open("w", encoding="utf-8") as index:
+        json.dump(manifest, index, indent=2)
+        index.write("\n")
+
+    print(f"Built release manifest for {len(artifacts_by_name)} archives")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/release-workflow-dispatch
+++ b/scripts/release-workflow-dispatch
@@ -8,10 +8,12 @@ usage: release-workflow-dispatch [--mode full|assets|packages|web-sdk|web-sdk-pu
 Dispatches the release workflow through the same public/default vs owner-only
 BuildBuddy backend split used by CI.
 
-Backend note: release_backend=buildbuddy covers release validation and all
-surface binary assets, including Windows. @rkat/web is built once as a release
-artifact before npm publishing. Credentialed registry publish jobs still run on
-GitHub-hosted runners; use the narrow recovery modes for retries.
+Backend note: release_backend=buildbuddy covers release validation plus the
+Linux and macOS surface binaries. Windows remains on a GitHub-hosted runner;
+the Unix assets and Homebrew formula publish without waiting for it. @rkat/web
+is built once as a release artifact before npm publishing. Credentialed
+registry publish jobs still run on GitHub-hosted runners; use the narrow
+recovery modes for retries.
 
 Environment equivalents:
   VERSION or RELEASE_TAG     Release tag, for example v0.6.1.
@@ -205,7 +207,7 @@ printf 'release workflow mode: %s\n' "${mode}"
 printf 'release workflow ref: %s\n' "${workflow_ref}"
 printf 'release workflow tag: %s\n' "${version}"
 if [[ "${backend}" == "buildbuddy" ]]; then
-  printf 'release workflow acceleration: BuildBuddy validation + Linux/macOS/Windows binary builds\n'
+  printf 'release workflow acceleration: BuildBuddy validation + early Linux/macOS assets and Homebrew; Windows remains GitHub-hosted\n'
 else
   printf 'release workflow acceleration: GitHub-hosted validation + binary asset builds\n'
 fi

--- a/xtask/BUILD.bazel
+++ b/xtask/BUILD.bazel
@@ -667,6 +667,7 @@ rust_test(
     data = [
         ":package_runfiles",
         "//:github_workflows",
+        "//:repo_governance_files",
         "tests/rustfmt_host.sh",
         "@@rules_rust++rust+rustfmt_nightly-2026-04-16__aarch64-apple-darwin_tools//:rustfmt_bin",
         "@@rules_rust++rust+rustfmt_nightly-2026-04-16__aarch64-apple-darwin_tools//:rustc_lib",

--- a/xtask/tests/release_workflow_asset_manifest.rs
+++ b/xtask/tests/release_workflow_asset_manifest.rs
@@ -15,6 +15,13 @@ fn workflow_yml_path() -> PathBuf {
     path
 }
 
+fn manifest_script_path() -> PathBuf {
+    let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    path.pop();
+    path.push("scripts/release-build-asset-manifest");
+    path
+}
+
 fn read_workflow(path: &Path) -> serde_yaml::Value {
     let text = std::fs::read_to_string(path)
         .unwrap_or_else(|error| panic!("cannot read {}: {error}", path.display()));
@@ -48,36 +55,14 @@ fn step_script<'a>(
         })
 }
 
-fn embedded_python(script: &str) -> &str {
-    script
-        .split_once("python3 - <<'PY'\n")
-        .and_then(|(_, rest)| rest.rsplit_once("\nPY").map(|(python, _)| python))
-        .unwrap_or_else(|| {
-            panic!("manifest step must contain a python3 heredoc; script:\n{script}")
-        })
-}
-
-fn run_manifest(python: &str, root: &Path) -> Output {
+fn run_manifest(root: &Path) -> Output {
     let interpreter = std::env::var_os("PYTHON").unwrap_or_else(|| OsString::from("python3"));
     Command::new(interpreter)
-        .arg("-c")
-        .arg(python)
-        .current_dir(root)
-        .env("RELEASE_TAG", "v0.7.28")
+        .arg(manifest_script_path())
+        .arg(root)
+        .arg("v0.7.28")
         .output()
         .expect("run release manifest Python")
-}
-
-fn manifest_python() -> String {
-    let path = workflow_yml_path();
-    let workflow = read_workflow(&path);
-    let script = step_script(
-        &workflow,
-        &path,
-        "publish_github_release",
-        "Build checksum manifest",
-    );
-    embedded_python(script).to_owned()
 }
 
 #[test]
@@ -90,6 +75,15 @@ fn release_asset_manifest_contract_stays_flat_and_collision_checked() {
         "publish_github_release",
         "Build checksum manifest",
     );
+    assert!(
+        script
+            .contains("scripts/release-build-asset-manifest release-artifacts \"${RELEASE_TAG}\""),
+        "release workflow must delegate to the manifest authority; script:\n{script}"
+    );
+
+    let manifest_path = manifest_script_path();
+    let manifest = std::fs::read_to_string(&manifest_path)
+        .unwrap_or_else(|error| panic!("cannot read {}: {error}", manifest_path.display()));
 
     for contract in [
         "key=lambda path: (path.name, path.as_posix())",
@@ -100,17 +94,17 @@ fn release_asset_manifest_contract_stays_flat_and_collision_checked() {
         "\"artifacts\": list(artifacts_by_name)",
     ] {
         assert!(
-            script.contains(contract),
-            "release manifest step must preserve `{contract}`; script:\n{script}"
+            manifest.contains(contract),
+            "release manifest authority must preserve `{contract}`; script:\n{manifest}"
         );
     }
 
     assert!(
-        !script.contains("p.as_posix().lstrip(\"./\")"),
+        !manifest.contains("p.as_posix().lstrip(\"./\")"),
         "index.json must not expose workflow-artifact staging directories"
     );
     assert!(
-        !script.contains("xargs sha256sum"),
+        !manifest.contains("xargs sha256sum"),
         "checksums.sha256 must be rendered from public basenames, not staged paths"
     );
 }
@@ -128,7 +122,7 @@ fn nested_release_artifacts_render_flat_sorted_manifests() {
     std::fs::write(cli_dir.join(cli_name), b"alpha").expect("write cli archive");
     std::fs::write(rpc_dir.join(rpc_name), b"beta").expect("write rpc archive");
 
-    let output = run_manifest(&manifest_python(), temp.path());
+    let output = run_manifest(temp.path());
     assert!(
         output.status.success(),
         "manifest script failed: {}",
@@ -173,7 +167,7 @@ fn duplicate_release_asset_basenames_fail_before_manifest_write() {
             .expect("write duplicate archive");
     }
 
-    let output = run_manifest(&manifest_python(), temp.path());
+    let output = run_manifest(temp.path());
     assert!(
         !output.status.success(),
         "duplicate public asset names must fail"


### PR DESCRIPTION
## Summary

- publish the 16 macOS/Linux release archives as soon as the BuildBuddy matrix finishes
- update Homebrew immediately from those live archive URLs and the locally generated checksums
- keep `checksums.sha256` and `index.json` unpublished until Windows finishes, so the public manifest is always complete
- append the Windows archives without deleting or re-uploading the already-live Unix assets
- share manifest generation and Homebrew update logic between the early and final paths

## Why

The Windows release build currently takes roughly 2h45m, while the macOS/Linux artifacts finish much earlier. Homebrew only consumes macOS/Linux archives, so making the tap wait for Windows adds hours with no safety benefit.

## Safety

- the early path runs only for normal owner-triggered tag releases using the configured BuildBuddy backend
- the exact 4 binaries x 4 Homebrew targets are checked before anything is published
- reruns keep existing archives immutable (`overwrite_files: false`)
- the final publisher waits for the early job to avoid races, but its `always()` gate still provides the authoritative fallback if the optimization is skipped or fails
- the existing latest-release guard remains the authority preventing an old recovery tag from downgrading the tap
- the final Homebrew job remains as a required retry/no-op fallback after the complete release

## Validation

- `actionlint .github/workflows/release.yml`
- YAML parse of `.github/actions/update-homebrew/action.yml`
- `make verify-version-parity`
- `make fmt-check`
- release dispatcher BuildBuddy dry-run
- manifest generation, duplicate-basename, exact Unix archive-set, local-checksum, missing-checksum, and formula-generation smoke tests
- generated manifest compared against the published v0.7.29 release authority
- repository pre-push gate
