### PR TITLE
Build release manifests from published assets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -767,6 +767,23 @@ jobs:
           overwrite_files: false
           tag_name: ${{ github.ref_name }}
 
+      # `overwrite_files: false` can preserve an archive from an earlier run.
+      # Re-read the live assets so Homebrew always receives hashes for the
+      # bytes users will actually download, not for a fresh local rebuild.
+      - name: Download published macOS/Linux release assets
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          rm -rf published-release-artifacts
+          mkdir -p published-release-artifacts
+          gh release download "${RELEASE_TAG}" \
+            --repo "${GITHUB_REPOSITORY}" \
+            --pattern '*.tar.gz' \
+            --dir published-release-artifacts
+          scripts/release-build-asset-manifest published-release-artifacts "${RELEASE_TAG}"
+
       - name: Update Homebrew tap from published macOS/Linux assets
         continue-on-error: true
         uses: ./.github/actions/update-homebrew
@@ -774,7 +791,7 @@ jobs:
           release_tag: ${{ github.ref_name }}
           github_token: ${{ github.token }}
           tap_token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
-          checksums_path: release-artifacts/checksums.sha256
+          checksums_path: published-release-artifacts/checksums.sha256
 
   build_web_sdk_package:
     name: Build Web SDK package
@@ -941,14 +958,32 @@ jobs:
           overwrite_files: false
           tag_name: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.release_tag || github.ref_name }}
 
+      # A recovery run can reuse existing archives whose compressed bytes do
+      # not match a fresh rebuild. Build the public manifest from the release
+      # assets themselves after all missing archives have been uploaded.
+      - name: Download published release archives
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.release_tag || github.ref_name }}
+        run: |
+          set -euo pipefail
+          rm -rf published-release-artifacts
+          mkdir -p published-release-artifacts
+          gh release download "${RELEASE_TAG}" \
+            --repo "${GITHUB_REPOSITORY}" \
+            --pattern '*.tar.gz' \
+            --pattern '*.zip' \
+            --dir published-release-artifacts
+          scripts/release-build-asset-manifest published-release-artifacts "${RELEASE_TAG}"
+
       # Publish checksums and index.json only after every platform archive is
       # present, keeping the public manifest a complete release authority.
       - name: Publish complete release manifest
         uses: softprops/action-gh-release@v2
         with:
           files: |
-            release-artifacts/checksums.sha256
-            release-artifacts/index.json
+            published-release-artifacts/checksums.sha256
+            published-release-artifacts/index.json
           draft: false
           fail_on_unmatched_files: true
           overwrite_files: true

--- a/xtask/tests/release_workflow_asset_manifest.rs
+++ b/xtask/tests/release_workflow_asset_manifest.rs
@@ -29,12 +29,12 @@ fn read_workflow(path: &Path) -> serde_yaml::Value {
         .unwrap_or_else(|error| panic!("cannot parse {} as YAML: {error}", path.display()))
 }
 
-fn step_script<'a>(
+fn workflow_step<'a>(
     workflow: &'a serde_yaml::Value,
     path: &Path,
     job_name: &str,
     step_name: &str,
-) -> &'a str {
+) -> &'a serde_yaml::Value {
     workflow
         .get("jobs")
         .and_then(|jobs| jobs.get(job_name))
@@ -45,7 +45,22 @@ fn step_script<'a>(
                 step.get("name").and_then(serde_yaml::Value::as_str) == Some(step_name)
             })
         })
-        .and_then(|step| step.get("run"))
+        .unwrap_or_else(|| {
+            panic!(
+                "{} must define {job_name:?} step {step_name:?}",
+                path.display()
+            )
+        })
+}
+
+fn step_script<'a>(
+    workflow: &'a serde_yaml::Value,
+    path: &Path,
+    job_name: &str,
+    step_name: &str,
+) -> &'a str {
+    workflow_step(workflow, path, job_name, step_name)
+        .get("run")
         .and_then(serde_yaml::Value::as_str)
         .unwrap_or_else(|| {
             panic!(
@@ -53,6 +68,81 @@ fn step_script<'a>(
                 path.display()
             )
         })
+}
+
+#[test]
+fn published_assets_are_manifest_authority_on_reruns() {
+    let path = workflow_yml_path();
+    let workflow = read_workflow(&path);
+
+    let early_download = step_script(
+        &workflow,
+        &path,
+        "publish_unix_release_and_homebrew",
+        "Download published macOS/Linux release assets",
+    );
+    for contract in [
+        "gh release download",
+        "--pattern '*.tar.gz'",
+        "scripts/release-build-asset-manifest published-release-artifacts",
+    ] {
+        assert!(
+            early_download.contains(contract),
+            "early release path must preserve `{contract}`; script:\n{early_download}"
+        );
+    }
+
+    let early_homebrew = workflow_step(
+        &workflow,
+        &path,
+        "publish_unix_release_and_homebrew",
+        "Update Homebrew tap from published macOS/Linux assets",
+    );
+    assert_eq!(
+        early_homebrew
+            .get("with")
+            .and_then(|inputs| inputs.get("checksums_path"))
+            .and_then(serde_yaml::Value::as_str),
+        Some("published-release-artifacts/checksums.sha256"),
+        "Homebrew must use checksums derived from live release assets"
+    );
+
+    let final_download = step_script(
+        &workflow,
+        &path,
+        "publish_github_release",
+        "Download published release archives",
+    );
+    for contract in [
+        "gh release download",
+        "--pattern '*.tar.gz'",
+        "--pattern '*.zip'",
+        "scripts/release-build-asset-manifest published-release-artifacts",
+    ] {
+        assert!(
+            final_download.contains(contract),
+            "final release path must preserve `{contract}`; script:\n{final_download}"
+        );
+    }
+
+    let manifest_files = workflow_step(
+        &workflow,
+        &path,
+        "publish_github_release",
+        "Publish complete release manifest",
+    )
+    .get("with")
+    .and_then(|inputs| inputs.get("files"))
+    .and_then(serde_yaml::Value::as_str)
+    .expect("manifest publisher must declare files");
+    assert_eq!(
+        manifest_files.lines().collect::<Vec<_>>(),
+        [
+            "published-release-artifacts/checksums.sha256",
+            "published-release-artifacts/index.json",
+        ],
+        "the complete manifest must come from downloaded live assets"
+    );
 }
 
 fn run_manifest(root: &Path) -> Output {


### PR DESCRIPTION
## Summary

- rebuild the early Homebrew checksum set from the macOS/Linux archives downloaded back from the live GitHub release
- rebuild the final `checksums.sha256` and `index.json` from all live release archives after missing Windows assets are uploaded
- pin both authorities in the release workflow contract test

## Why

Follow-up to #876. Its immutable rerun behavior correctly keeps existing archives when `overwrite_files: false`, but a fresh local rebuild can have different compressed bytes. Publishing manifests from those fresh local artifacts could therefore make checksums disagree with the preserved live assets.

The release itself is now the read authority: upload missing archives, download the resulting live archive set, then derive Homebrew and public manifests from exactly those bytes.

## Validation

- targeted release workflow contract suite: 4 passed
- real v0.7.29 live assets downloaded with the new command; rebuilt manifest matched the published checksums and index exactly
- `actionlint .github/workflows/release.yml`
- `make fmt-check`
- `make buildbuddy-generate-check`
- full repository pre-push gate
