### PR TITLE
fix(mob): revive retired sessions before executor attachment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -111,6 +111,12 @@ via cargo-semver-checks against the published baselines).
   recurrence, cycle, and persisted-MCP integrity checks intact. Long-lived
   sessions therefore stop growing quadratically with turn count while real
   transcript revisions remain listable and restorable.
+- Explicit mob-member resume now revives an archived session in authority
+  order: promote the session document, synchronize the live semantic snapshot,
+  reset the durable `Retired` runtime, then attach the executor. Ordinary
+  executor registration still cannot cross the `Retired` terminal, and any
+  later provisioning failure restores the exact `Archived` + `Retired` pair
+  without leaving a live agent, executor, or provisioner sidecar.
 - Python and TypeScript now validate canonical `comms/send` result variants and
   member-progress snapshots before returning them, rejecting missing, legacy,
   malformed, or unknown fields instead of casting them to generated types.

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -541,7 +541,7 @@
           "FILE:@@//meerkat-hooks/Cargo.toml 58cbd8239c7e2a6595558cb9e41910b336af6c75979996b402723506906e9ba9",
           "FILE:@@//meerkat-memory/Cargo.toml 900ef053d9a24a0a5483152d04f26e0103047ff6cf9ff1b2beb22e6aadc89bdc",
           "FILE:@@//meerkat-session/Cargo.toml 1a675cd7417158c1c35ef7c888d4f254d2c166f9c71ea893bd689d97b7f9e4ec",
-          "FILE:@@//meerkat-mob/Cargo.toml 5ac51ec187f960442eede4de15e526ce4f8971c7f8d538e00b92ae14295c34ed",
+          "FILE:@@//meerkat-mob/Cargo.toml 7cad76069b4934e7c4f8114047e04f08496c683d518037269f8f9a7b6af6a771",
           "FILE:@@//meerkat-mob-mcp/Cargo.toml ed49cc8162d6ad5ffee6a932bc4baa09bb7240b3402b2bffbda126076fdc18b4",
           "FILE:@@//meerkat-cli/Cargo.toml 5629d7347e55cf3232e2bfaac95bc771f04b81333b9003d27a736c4f3261e0a5",
           "FILE:@@//meerkat-mob-pack/Cargo.toml 9ac2462d05c859e5b4ab523d6bebe65fe1940f619796a2356b6cd7d00ef68965",

--- a/meerkat-mob/Cargo.toml
+++ b/meerkat-mob/Cargo.toml
@@ -60,6 +60,14 @@ meerkat-session = { workspace = true, features = ["session-store"] }
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 tokio_with_wasm = { workspace = true }
 
+[target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
+# The persistent cold-restart integration harness uses FactoryAgentBuilder,
+# whose durable live-session synchronization is gated by the facade's
+# session-store feature. jsonl-store keeps the facade feature view coherent
+# with the direct JsonlStore dev dependency below; neither feature is imposed
+# on production meerkat-mob consumers.
+meerkat = { workspace = true, features = ["jsonl-store", "session-store"] }
+
 [dev-dependencies]
 tokio = { workspace = true, features = ["test-util", "macros", "rt-multi-thread"] }
 serde_json = { workspace = true }

--- a/meerkat-mob/src/runtime/provisioner.rs
+++ b/meerkat-mob/src/runtime/provisioner.rs
@@ -397,7 +397,7 @@ fn stamp_eager_session_owned_initial_turn_metadata(req: &mut CreateSessionReques
 #[cfg(feature = "runtime-adapter")]
 impl SessionBackend {
     #[cfg(feature = "runtime-adapter")]
-    async fn restore_failed_resume_before_receipt(
+    pub(super) async fn restore_failed_resume_before_receipt(
         &self,
         session_id: &SessionId,
         restore_retired: bool,
@@ -407,20 +407,76 @@ impl SessionBackend {
                 "resume rollback for '{session_id}' requires runtime authority"
             ))
         })?;
-        if restore_retired
-            && adapter.contains_session(session_id).await
-            && !adapter
-                .meerkat_machine_archive_snapshot(session_id)
-                .await
-                .is_some_and(|snapshot| {
-                    snapshot.control.phase == meerkat_runtime::RuntimeState::Retired
-                })
-        {
-            adapter.retire_runtime(session_id).await.map_err(|error| {
-                MobError::Internal(format!(
-                    "failed to restore revived session '{session_id}' to Retired: {error}"
-                ))
-            })?;
+        if restore_retired {
+            // A retired-session revival crosses two durable authorities before
+            // executor attachment: Archived -> Active, then Retired -> Idle.
+            // First remove the stale live projection: its agent snapshot was
+            // materialized while Archived and is not the promoted document
+            // authority. The archive protocol must read the durable Active
+            // projection instead.
+            match self.session_service.discard_live_session(session_id).await {
+                Ok(()) | Err(SessionError::NotFound { .. }) => {}
+                Err(error) => return Err(error.into()),
+            }
+
+            let retired_document = self
+                .session_service
+                .load_revivable_retired_session(session_id)
+                .await?;
+            let document_already_archived = retired_document.as_ref().is_some_and(|session| {
+                session.lifecycle_terminal()
+                    == Some(meerkat_core::session::SessionLifecycleTerminal::Archived)
+            });
+
+            if retired_document.is_some() && !document_already_archived {
+                // Active+Retired is the crash-recoverable midpoint of revival.
+                // Temporarily return the runtime to Idle so the document
+                // archive authority cannot mistake Retired compatibility
+                // evidence for an already-written Archived document.
+                adapter.reset_runtime(session_id).await.map_err(|error| {
+                    MobError::Internal(format!(
+                        "failed to reopen revived session '{session_id}' for document rollback: {error}"
+                    ))
+                })?;
+            }
+
+            if !document_already_archived {
+                match self
+                    .session_service
+                    .archive_with_mob_lifecycle_authority(session_id)
+                    .await
+                {
+                    Ok(()) | Err(SessionError::NotFound { .. }) => {}
+                    Err(error) => {
+                        return Err(MobError::Internal(format!(
+                            "failed to restore revived session '{session_id}' to Archived+Retired: {error}"
+                        )));
+                    }
+                }
+            }
+
+            let restored = self
+                .session_service
+                .load_revivable_retired_session(session_id)
+                .await?
+                .ok_or_else(|| {
+                    MobError::Internal(format!(
+                        "revived session rollback did not restore retired session '{session_id}'"
+                    ))
+                })?;
+            if restored.lifecycle_terminal()
+                != Some(meerkat_core::session::SessionLifecycleTerminal::Archived)
+            {
+                return Err(MobError::Internal(format!(
+                    "revived session rollback did not restore archived document '{session_id}'"
+                )));
+            }
+
+            if adapter.contains_session(session_id).await {
+                self.unregister_runtime_session_binding(session_id).await?;
+            }
+            self.remove_runtime_session_state(session_id).await;
+            return Ok(());
         }
         if adapter.contains_session(session_id).await {
             adapter
@@ -641,6 +697,14 @@ impl SessionBackend {
         if let Some(state) = removed {
             state.clear_queued_turns().await;
         }
+    }
+
+    #[cfg(test)]
+    pub(super) async fn has_runtime_session_sidecar_for_test(
+        &self,
+        session_id: &SessionId,
+    ) -> bool {
+        self.runtime_sessions.read().await.contains_key(session_id)
     }
 
     async fn unregister_runtime_session_binding(
@@ -2220,6 +2284,34 @@ impl MobProvisioner for SessionBackend {
                     ))
                 })?;
             }
+            if reviving_retired_session {
+                // Explicit revival owns the only path across both absorbing
+                // lifecycle boundaries. Prove and promote the archived
+                // document while the runtime is still durably Retired, then
+                // reset Retired -> Idle before generic executor attachment.
+                // Retired must remain non-registrable on every ordinary
+                // ensure-session path.
+                self.session_service
+                    .promote_revivable_retired_session(
+                        &created_bridge_session_id,
+                        adapter.session_control_authority(),
+                    )
+                    .await
+                    .map_err(|error| {
+                        MobError::Internal(format!(
+                            "failed to promote revived durable session document '{created_bridge_session_id}': {error}"
+                        ))
+                    })?;
+                adapter
+                    .reset_runtime(&created_bridge_session_id)
+                    .await
+                    .map_err(|error| {
+                        MobError::Internal(format!(
+                            "failed to promote revived durable session '{created_bridge_session_id}' to idle: {error}"
+                        ))
+                    })?;
+                session_origin = ProvisionSessionOrigin::RevivedRetired;
+            }
             tracing::debug!(
                 bridge_session_id = %created_bridge_session_id,
                 "SessionBackend::provision_member checking runtime session state"
@@ -2299,72 +2391,6 @@ impl MobProvisioner for SessionBackend {
             .ops_adapter
             .mark_member_provisioned(&created_bridge_session_id, &req.peer_name)
             .await?;
-        if reviving_retired_session {
-            let adapter = self.runtime_adapter.as_ref().ok_or_else(|| {
-                MobError::Internal(
-                    "retired durable session revival lost runtime authority".into(),
-                )
-            })?;
-            // Prove and consume the archived+retired revival boundary before
-            // mutating runtime state.  The document transition is authorized
-            // only while the durable runtime still says Retired; resetting it
-            // first would erase the evidence that makes this a revival rather
-            // than an arbitrary archived-session reopen.
-            if let Err(error) = self
-                .session_service
-                .promote_revivable_retired_session(
-                    &created_bridge_session_id,
-                    adapter.session_control_authority(),
-                )
-                .await
-            {
-                let mut cleanup_failures = Vec::new();
-                if let Err(cleanup_error) =
-                    adapter.retire_runtime(&created_bridge_session_id).await
-                {
-                    cleanup_failures.push(format!("retire runtime: {cleanup_error}"));
-                }
-                if let Err(cleanup_error) =
-                    adapter.unregister_session(&created_bridge_session_id).await
-                {
-                    cleanup_failures.push(format!("unregister runtime: {cleanup_error}"));
-                }
-                if let Err(cleanup_error) = self
-                    .session_service
-                    .discard_live_session(&created_bridge_session_id)
-                    .await
-                {
-                    cleanup_failures.push(format!("discard live session: {cleanup_error}"));
-                }
-                let cleanup_suffix = if cleanup_failures.is_empty() {
-                    String::new()
-                } else {
-                    format!("; additionally cleanup failed: {}", cleanup_failures.join("; "))
-                };
-                return Err(MobError::Internal(format!(
-                    "failed to promote revived durable session document '{created_bridge_session_id}': {error}{cleanup_suffix}"
-                )));
-            }
-            if let Err(error) = adapter.reset_runtime(&created_bridge_session_id).await {
-                // The document is active now, so restore the exact
-                // archived+retired pair before returning failure.  This path
-                // is deliberately authority-backed and retryable; it never
-                // leaves an Active document pointing at a Retired runtime.
-                let restore_error = self
-                    .archive_with_authority_then_unregister(&created_bridge_session_id)
-                    .await
-                    .err();
-                return Err(MobError::Internal(format!(
-                    "failed to promote revived durable session '{created_bridge_session_id}' to idle: {error}{}",
-                    restore_error
-                        .map(|restore_error| format!(
-                            "; restoring archived+retired lifecycle also failed: {restore_error}"
-                        ))
-                        .unwrap_or_default()
-                )));
-            }
-            session_origin = ProvisionSessionOrigin::RevivedRetired;
-        }
         tracing::debug!(
             bridge_session_id = %created_bridge_session_id,
             operation_id = %operation_id,

--- a/meerkat-mob/src/runtime/tests.rs
+++ b/meerkat-mob/src/runtime/tests.rs
@@ -6856,6 +6856,22 @@ impl SessionAgent for OverlayProbeSessionAgent {
         Ok(self.session.clone())
     }
 
+    #[cfg(not(target_arch = "wasm32"))]
+    fn sync_session_from_durable_snapshot(
+        &mut self,
+        session: Session,
+    ) -> Result<(), meerkat_core::error::AgentError> {
+        if session.id() != self.session.id() {
+            return Err(meerkat_core::error::AgentError::InternalError(format!(
+                "durable overlay-probe session {} does not match live session {}",
+                session.id(),
+                self.session.id()
+            )));
+        }
+        self.session = session;
+        Ok(())
+    }
+
     fn durable_llm_identity(&self) -> Option<SessionLlmIdentity> {
         self.session
             .session_metadata()
@@ -26832,6 +26848,232 @@ async fn test_provision_member_uses_local_bindings_before_routed_runtime_bound()
         signal_surface.log.lock().await.is_empty(),
         "member provisioning must not publish RuntimeBound with the session runtime id; the routed mob binding owns that signal"
     );
+}
+
+#[cfg(feature = "runtime-adapter")]
+#[tokio::test]
+async fn test_retired_session_revival_failure_restores_archived_retired_pair() {
+    let provider_visible_tools = Arc::new(Mutex::new(Vec::new()));
+    let provider_turn_overlays = Arc::new(Mutex::new(Vec::new()));
+    let memory_store = Arc::new(MemoryStore::new());
+    let session_store: Arc<dyn SessionStore> = memory_store.clone();
+    let runtime_store = Arc::new(meerkat_runtime::InMemoryRuntimeStore::new());
+    let runtime_store_dyn: Arc<dyn meerkat_runtime::RuntimeStore> = runtime_store.clone();
+    let blob_store: Arc<dyn meerkat_core::BlobStore> =
+        Arc::new(meerkat_store::MemoryBlobStore::new());
+    let service = Arc::new(meerkat_session::PersistentSessionService::new(
+        OverlayProbeSessionAgentBuilder {
+            provider_visible_tools,
+            provider_turn_overlays,
+        },
+        16,
+        session_store,
+        runtime_store_dyn,
+        blob_store,
+    ));
+    let adapter = service
+        .runtime_adapter()
+        .expect("persistent service runtime adapter");
+    let provisioner =
+        super::provisioner::SessionBackend::new(service.clone(), Some(adapter.clone()), None);
+    let session = Session::new();
+    let session_id = session.id().clone();
+    let runtime_id = meerkat_runtime::LogicalRuntimeId::for_session(&session_id);
+
+    let receipt = provisioner
+        .provision_member(super::provisioner::ProvisionMemberRequest {
+            session_origin: super::provisioner::ProvisionSessionOrigin::Fresh,
+            create_session: CreateSessionRequest {
+                injected_context: Vec::new(),
+                model: "claude-sonnet-4-5".to_string(),
+                prompt: "retired revival rollback seed".to_string().into(),
+                system_prompt: meerkat_core::SystemPromptOverride::Inherit,
+                max_tokens: None,
+                event_tx: None,
+                build: Some(meerkat_core::service::SessionBuildOptions {
+                    resume_session: Some(session),
+                    comms_name: Some("test-mob/worker/revival-rollback".to_string()),
+                    keep_alive: true,
+                    ..Default::default()
+                }),
+                initial_turn: meerkat_core::service::InitialTurnPolicy::Defer,
+                deferred_prompt_policy: meerkat_core::service::DeferredPromptPolicy::Discard,
+                labels: None,
+            },
+            binding: test_external_binding("revival-rollback-worker"),
+            peer_name: "revival-rollback-worker".to_string(),
+            owner_bridge_session_id: None,
+            ops_registry: None,
+            generated_self_owned_operation_owner: Some(session_id.clone()),
+        })
+        .await
+        .expect("seed session provision");
+    provisioner
+        .retire_member(&receipt.member_ref)
+        .await
+        .expect("retire seed session");
+
+    let archived = memory_store
+        .load(&session_id)
+        .await
+        .expect("load archived seed projection")
+        .expect("archived seed projection remains durable");
+    assert!(
+        service
+            .load_persisted_session(&session_id)
+            .await
+            .expect("ordinary read of retired seed session")
+            .is_none(),
+        "Retired runtime authority must make the seed session archived to ordinary reads"
+    );
+    assert_eq!(
+        meerkat_runtime::store::load_runtime_state(runtime_store.as_ref(), &runtime_id)
+            .await
+            .expect("load retired seed runtime"),
+        Some(meerkat_runtime::RuntimeState::Retired)
+    );
+
+    // The generated owner mismatch is deliberately validated after the
+    // authorized promotion/reset and executor attachment. It therefore gives
+    // the pre-receipt rollback its strongest deterministic failure point.
+    let mismatched_owner = SessionId::new();
+    let error = provisioner
+        .provision_member(super::provisioner::ProvisionMemberRequest {
+            session_origin: super::provisioner::ProvisionSessionOrigin::ResumedDurable,
+            create_session: CreateSessionRequest {
+                injected_context: Vec::new(),
+                model: "claude-sonnet-4-5".to_string(),
+                prompt: "retired revival rollback resume".to_string().into(),
+                system_prompt: meerkat_core::SystemPromptOverride::Inherit,
+                max_tokens: None,
+                event_tx: None,
+                build: Some(meerkat_core::service::SessionBuildOptions {
+                    resume_session: Some(archived),
+                    comms_name: Some("test-mob/worker/revival-rollback".to_string()),
+                    keep_alive: true,
+                    ..Default::default()
+                }),
+                initial_turn: meerkat_core::service::InitialTurnPolicy::Defer,
+                deferred_prompt_policy: meerkat_core::service::DeferredPromptPolicy::Discard,
+                labels: None,
+            },
+            binding: test_external_binding("revival-rollback-worker"),
+            peer_name: "revival-rollback-worker".to_string(),
+            owner_bridge_session_id: None,
+            ops_registry: None,
+            generated_self_owned_operation_owner: Some(mismatched_owner),
+        })
+        .await
+        .expect_err("post-attachment validation must fail");
+    assert!(
+        error
+            .to_string()
+            .contains("did not match created bridge session"),
+        "unexpected post-attachment failure: {error:?}"
+    );
+
+    let restored = memory_store
+        .load(&session_id)
+        .await
+        .expect("load rolled-back session projection")
+        .expect("rolled-back session projection remains durable");
+    assert_eq!(
+        restored.lifecycle_terminal(),
+        Some(meerkat_core::session::SessionLifecycleTerminal::Archived),
+        "post-promotion failure must restore the Archived document"
+    );
+    assert_eq!(
+        meerkat_runtime::store::load_runtime_state(runtime_store.as_ref(), &runtime_id)
+            .await
+            .expect("load rolled-back runtime"),
+        Some(meerkat_runtime::RuntimeState::Retired),
+        "post-promotion failure must restore the Retired runtime"
+    );
+    assert!(
+        service
+            .load_persisted_session(&session_id)
+            .await
+            .expect("ordinary read after rollback")
+            .is_none(),
+        "rolled-back archived session must stay hidden from ordinary reads"
+    );
+    assert!(
+        !service
+            .has_live_session(&session_id)
+            .await
+            .expect("live-session lookup after rollback"),
+        "rollback must discard the revived live agent"
+    );
+    assert!(
+        !adapter.contains_session(&session_id).await,
+        "rollback must remove the runtime registration"
+    );
+    assert!(
+        !adapter
+            .session_has_executor(&session_id)
+            .await
+            .unwrap_or(false),
+        "rollback must remove the runtime executor"
+    );
+    assert!(
+        !provisioner
+            .has_runtime_session_sidecar_for_test(&session_id)
+            .await,
+        "rollback must remove the provisioner sidecar"
+    );
+
+    // Also pin the earlier crash midpoint: document promotion committed but
+    // runtime reset did not. Retired compatibility evidence must not make the
+    // rollback mistake an Active document for an already-written archive.
+    adapter
+        .prepare_local_session_bindings(session_id.clone())
+        .await
+        .expect("recover retired runtime registration for midpoint rollback");
+    service
+        .revive_archived_session_with_machine_authority(
+            &session_id,
+            adapter.session_control_authority(),
+        )
+        .await
+        .expect("promote document into Active+Retired crash midpoint");
+    assert_eq!(
+        memory_store
+            .load(&session_id)
+            .await
+            .expect("load midpoint projection")
+            .expect("midpoint projection remains durable")
+            .lifecycle_terminal(),
+        Some(meerkat_core::session::SessionLifecycleTerminal::Active)
+    );
+    assert_eq!(
+        meerkat_runtime::store::load_runtime_state(runtime_store.as_ref(), &runtime_id)
+            .await
+            .expect("load midpoint runtime"),
+        Some(meerkat_runtime::RuntimeState::Retired)
+    );
+
+    provisioner
+        .restore_failed_resume_before_receipt(&session_id, true)
+        .await
+        .expect("rollback Active+Retired crash midpoint");
+    assert_eq!(
+        memory_store
+            .load(&session_id)
+            .await
+            .expect("load midpoint rollback projection")
+            .expect("midpoint rollback projection remains durable")
+            .lifecycle_terminal(),
+        Some(meerkat_core::session::SessionLifecycleTerminal::Archived),
+        "midpoint rollback must restore the explicit Archived document"
+    );
+    assert_eq!(
+        meerkat_runtime::store::load_runtime_state(runtime_store.as_ref(), &runtime_id)
+            .await
+            .expect("load midpoint rollback runtime"),
+        Some(meerkat_runtime::RuntimeState::Retired),
+        "midpoint rollback must restore the Retired runtime"
+    );
+    assert!(!adapter.contains_session(&session_id).await);
 }
 
 #[cfg(feature = "runtime-adapter")]

--- a/meerkat-mob/tests/cold_restart_mob_resume.rs
+++ b/meerkat-mob/tests/cold_restart_mob_resume.rs
@@ -569,6 +569,232 @@ async fn mob_cold_restart_resume_autonomous_lead_durable_runtime_store() {
     run_cold_restart_scenario(true, MobRuntimeMode::AutonomousHost).await;
 }
 
+/// An explicitly resumed member may adopt its archived+Retired session after a
+/// full host restart. The revival must promote both lifecycle projections and
+/// preserve the exact bridge-session identity and transcript.
+#[tokio::test(flavor = "multi_thread")]
+async fn mob_cold_restart_explicit_resume_revives_archived_retired_session_in_place() {
+    let temp = tempfile::tempdir().expect("temp dir");
+    let paths = Paths::new(temp.path());
+    let runtime_store: Arc<dyn meerkat_runtime::RuntimeStore> =
+        Arc::new(meerkat_runtime::InMemoryRuntimeStore::new());
+
+    let mut definition = mob_definition(MobRuntimeMode::TurnDriven);
+    definition.id = MobId::from("retired-revival-mob");
+    definition.orchestrator = None;
+    definition.wiring = WiringRules {
+        auto_wire_orchestrator: false,
+        role_wiring: vec![],
+    };
+
+    // ---------------- Lifetime 1: create, use, then retire ----------------
+    let (service_1, store_1) = persistent_service(&paths, runtime_store.clone());
+    let storage_1 = MobStorage::persistent(&paths.mob_db_path).expect("persistent mob storage");
+    let handle_1 = MobBuilder::new(definition, storage_1)
+        .with_session_service(service_1.clone())
+        .with_default_llm_client(Arc::new(meerkat_client::TestClient::default()))
+        .create()
+        .await
+        .expect("create persistent mob");
+
+    let worker = AgentIdentity::from("w-1");
+    handle_1
+        .spawn_spec(SpawnMemberSpec::new("worker", worker.clone()))
+        .await
+        .expect("spawn worker before retirement");
+    let original_session_id = handle_1
+        .resolve_bridge_session_id(&worker)
+        .await
+        .expect("worker session id before retirement");
+    send_and_wait(
+        &handle_1,
+        service_1.as_ref(),
+        "w-1",
+        "PRE_RETIRE_REVIVAL_TOKEN alpha",
+        "before-retirement",
+    )
+    .await;
+
+    handle_1
+        .retire(worker.clone())
+        .await
+        .expect("retire worker before cold restart");
+
+    assert!(
+        service_1
+            .load_persisted_session(&original_session_id)
+            .await
+            .expect("ordinary persisted-session read after retirement")
+            .is_none(),
+        "ordinary reads must continue to hide archived sessions"
+    );
+    let mut archived = service_1
+        .load_revivable_retired_session(&original_session_id)
+        .await
+        .expect("load retired session through explicit revival seam")
+        .expect("archived+Retired session must remain available for explicit revival");
+    assert_eq!(archived.id(), &original_session_id);
+    let archived_history = to_string(archived.messages()).expect("serialize archived history");
+    assert!(
+        archived_history.contains("PRE_RETIRE_REVIVAL_TOKEN alpha"),
+        "retired session must retain its pre-retirement transcript: {archived_history}"
+    );
+    let runtime_id = meerkat_runtime::LogicalRuntimeId::for_session(&original_session_id);
+    assert_eq!(
+        meerkat_runtime::store::load_runtime_state(runtime_store.as_ref(), &runtime_id)
+            .await
+            .expect("load runtime state after retirement"),
+        Some(meerkat_runtime::RuntimeState::Retired),
+        "retirement must durably retire runtime authority"
+    );
+
+    // Mob retirement also accepts the older Retired-only compatibility shape,
+    // where the explicit document marker is absent. Exercise the stronger
+    // archived-document variant as well: older stores and direct machine
+    // archive authority can carry an explicit Archived marker, and revival
+    // must synchronize that promoted Active snapshot into the already-created
+    // live agent before its first checkpoint.
+    archived
+        .set_lifecycle_terminal(meerkat_core::session::SessionLifecycleTerminal::Archived)
+        .expect("stamp explicit archived document fixture");
+    runtime_store
+        .commit_session_snapshot(
+            &runtime_id,
+            meerkat_runtime::store::SessionDelta {
+                session_snapshot: serde_json::to_vec(&archived)
+                    .expect("serialize explicit archived runtime snapshot"),
+            },
+        )
+        .await
+        .expect("persist explicit archived runtime snapshot");
+    store_1
+        .save_authoritative_projection(&archived)
+        .await
+        .expect("persist explicit archived compatibility projection");
+    assert_eq!(
+        service_1
+            .load_revivable_retired_session(&original_session_id)
+            .await
+            .expect("reload explicit archived session")
+            .expect("explicit archived session remains revivable")
+            .lifecycle_terminal(),
+        Some(meerkat_core::session::SessionLifecycleTerminal::Archived)
+    );
+
+    handle_1
+        .shutdown()
+        .await
+        .expect("shutdown mob before cold restart");
+    drop(handle_1);
+    drop(service_1);
+
+    // ---------------- Lifetime 2: reopen, then explicitly revive ----------
+    let (service_2, store_2) = persistent_service(&paths, runtime_store.clone());
+    let storage_2 = MobStorage::persistent(&paths.mob_db_path).expect("reopen mob storage");
+    let handle_2 = MobBuilder::for_resume(storage_2)
+        .with_session_service(service_2.clone())
+        .with_default_llm_client(Arc::new(meerkat_client::TestClient::default()))
+        .notify_orchestrator_on_resume(false)
+        .resume()
+        .await
+        .expect("resume mob after cold restart");
+
+    handle_2
+        .spawn_spec(
+            SpawnMemberSpec::new("worker", worker.clone())
+                .with_resume_bridge_session_id(original_session_id.clone()),
+        )
+        .await
+        .expect("explicitly revive archived+Retired worker session");
+
+    assert_eq!(
+        handle_2.resolve_bridge_session_id(&worker).await,
+        Some(original_session_id.clone()),
+        "revival must preserve the exact bridge-session id"
+    );
+    assert_member_active(&member_entry(&handle_2, "w-1").await, "after revival");
+
+    let revived = service_2
+        .load_authoritative_session(&original_session_id)
+        .await
+        .expect("load revived authoritative session")
+        .expect("revived session must remain durable");
+    assert_eq!(
+        revived.lifecycle_terminal(),
+        Some(meerkat_core::session::SessionLifecycleTerminal::Active),
+        "revival must promote the durable session document to Active"
+    );
+    assert!(
+        service_2
+            .load_persisted_session(&original_session_id)
+            .await
+            .expect("ordinary persisted-session read after revival")
+            .is_some(),
+        "revival must make the session visible through the ordinary active-session seam"
+    );
+    assert_ne!(
+        meerkat_runtime::store::load_runtime_state(runtime_store.as_ref(), &runtime_id)
+            .await
+            .expect("load runtime state after revival"),
+        Some(meerkat_runtime::RuntimeState::Retired),
+        "revival must reactivate runtime authority"
+    );
+
+    wait_for_history_contains_all(
+        service_2.as_ref(),
+        &original_session_id,
+        &["PRE_RETIRE_REVIVAL_TOKEN alpha"],
+        "after-revival-history",
+    )
+    .await;
+    send_and_wait(
+        &handle_2,
+        service_2.as_ref(),
+        "w-1",
+        "POST_REVIVAL_TOKEN omega",
+        "after-revival-turn",
+    )
+    .await;
+    wait_for_history_contains_all(
+        service_2.as_ref(),
+        &original_session_id,
+        &["PRE_RETIRE_REVIVAL_TOKEN alpha", "POST_REVIVAL_TOKEN omega"],
+        "final-revival-history",
+    )
+    .await;
+
+    let after_turn = service_2
+        .load_authoritative_session(&original_session_id)
+        .await
+        .expect("load authoritative session after revived turn")
+        .expect("revived session remains authoritative after turn");
+    assert_eq!(
+        after_turn.lifecycle_terminal(),
+        Some(meerkat_core::session::SessionLifecycleTerminal::Active),
+        "the revived live agent must not checkpoint its stale Archived snapshot over durable Active"
+    );
+    let compatibility_projection = store_2
+        .load(&original_session_id)
+        .await
+        .expect("load compatibility projection after revived turn")
+        .expect("compatibility projection remains present after revived turn");
+    assert_eq!(
+        compatibility_projection.lifecycle_terminal(),
+        Some(meerkat_core::session::SessionLifecycleTerminal::Active),
+        "the first revived turn must preserve the Active compatibility projection"
+    );
+    assert!(
+        service_2
+            .load_persisted_session(&original_session_id)
+            .await
+            .expect("ordinary persisted-session read after revived turn")
+            .is_some(),
+        "the first revived turn must leave the session visible through the active read seam"
+    );
+
+    handle_2.shutdown().await.expect("final shutdown");
+}
+
 /// A broken wired member still needs its exact old-generation endpoint after
 /// a full service restart. The endpoint is required to retire reciprocal trust
 /// safely before spawning and wiring the replacement generation.

--- a/meerkat-session/src/persistent.rs
+++ b/meerkat-session/src/persistent.rs
@@ -6340,11 +6340,13 @@ impl<B: SessionAgentBuilder + 'static> PersistentSessionService<B> {
             // revival. The document promotion may have landed while the
             // runtime is still Retired. Treat that exact Active+Retired pair
             // as an idempotent in-progress revival, repair the compatibility
-            // projection, and let the caller perform the runtime reset. No
-            // other runtime state is accepted here.
-            let active = self.save_compatibility_projection_only(session).await?;
-            self.synchronize_live_session_after_archived_revival(id, &active)
-                .await?;
+            // projection, and let the caller perform the runtime reset. A
+            // live agent in this branch was materialized from this already-
+            // active snapshot, so requiring durable-snapshot synchronization
+            // would reject otherwise-valid custom SessionAgent
+            // implementations that use the default unsupported capability.
+            // No other runtime state is accepted here.
+            self.save_compatibility_projection_only(session).await?;
             return Ok(());
         }
 
@@ -20746,6 +20748,83 @@ mod tests {
             ),
             "unexpected active-session revival error: {active_error:?}"
         );
+    }
+
+    #[tokio::test]
+    async fn test_machine_authorized_active_retired_revival_does_not_require_live_snapshot_sync() {
+        let store: Arc<dyn SessionStore> = Arc::new(MemoryStore::new());
+        let runtime_store = Arc::new(InMemoryRuntimeStore::new());
+        let service = PersistentSessionService::new(
+            EventfulBuilder,
+            4,
+            Arc::clone(&store),
+            Arc::clone(&runtime_store) as Arc<dyn RuntimeStore>,
+            memory_blob_store(),
+        );
+        let session = Session::new();
+        let id = session.id().clone();
+        store.save(&session).await.expect("seed active session");
+
+        let machine = meerkat_runtime::MeerkatMachine::persistent(
+            Arc::clone(&runtime_store) as Arc<dyn RuntimeStore>,
+            memory_blob_store(),
+        );
+        machine
+            .register_session(id.clone())
+            .await
+            .expect("register active runtime");
+        meerkat_runtime::RuntimeControlPlane::retire(
+            &machine,
+            &PersistentSessionService::<EventfulBuilder>::runtime_id_for_session(&id),
+        )
+        .await
+        .expect("retire runtime while leaving the document active");
+
+        let admission = service
+            .reserve_create_session_admission()
+            .await
+            .expect("reserve live-session admission");
+        let created = service
+            .create_session_with_reserved_machine_archived_resume_admission(
+                resume_request(session),
+                admission,
+                machine.session_control_authority(),
+            )
+            .await
+            .expect("materialize the already-active compatibility snapshot");
+        assert_eq!(created.session_id, id);
+        assert!(
+            service
+                .inner
+                .has_live_session(&id)
+                .await
+                .expect("live-session status should succeed")
+        );
+
+        // EventfulDummyAgent intentionally uses SessionAgent's default
+        // DurableSnapshotSyncUnsupported capability. This idempotent crash
+        // boundary must not require a semantic sync because the live agent
+        // was just built from the same already-active snapshot.
+        service
+            .revive_archived_session_with_machine_authority(
+                &id,
+                machine.session_control_authority(),
+            )
+            .await
+            .expect("Active+Retired compatibility revival must remain supported");
+        assert!(
+            service
+                .inner
+                .has_live_session(&id)
+                .await
+                .expect("live-session status should succeed after revival")
+        );
+        let durable = service
+            .load_authoritative_session_base(&id)
+            .await
+            .expect("load active session")
+            .expect("active session remains durable");
+        assert!(!session_marks_archived(&durable));
     }
 
     /// Ask 21b regression: the partial state left by an archive whose

--- a/meerkat-session/src/persistent.rs
+++ b/meerkat-session/src/persistent.rs
@@ -6291,6 +6291,30 @@ impl<B: SessionAgentBuilder + 'static> PersistentSessionService<B> {
 }
 
 impl<B: SessionAgentBuilder + 'static> PersistentSessionService<B> {
+    async fn synchronize_live_session_after_archived_revival(
+        &self,
+        id: &SessionId,
+        active: &Session,
+    ) -> Result<(), SessionError> {
+        if !self.inner.has_live_session(id).await? {
+            return Ok(());
+        }
+        match self
+            .inner
+            .sync_session_from_durable_snapshot(id, active.clone())
+            .await
+        {
+            Ok(()) => Ok(()),
+            Err(SessionError::NotFound { .. }) if !self.inner.has_live_session(id).await? => {
+                // The live task may exit between the presence probe and the
+                // command send. No stale live projection remains to overwrite
+                // the promoted durable document in that case.
+                Ok(())
+            }
+            Err(error) => Err(error),
+        }
+    }
+
     /// Promote an archived document back to Active under explicit machine
     /// control. This is the durable half of retired-session revival; ordinary
     /// create/resume remains unable to cross the absorbing Archived terminal.
@@ -6318,7 +6342,9 @@ impl<B: SessionAgentBuilder + 'static> PersistentSessionService<B> {
             // as an idempotent in-progress revival, repair the compatibility
             // projection, and let the caller perform the runtime reset. No
             // other runtime state is accepted here.
-            self.save_compatibility_projection_only(session).await?;
+            let active = self.save_compatibility_projection_only(session).await?;
+            self.synchronize_live_session_after_archived_revival(id, &active)
+                .await?;
             return Ok(());
         }
 
@@ -6373,7 +6399,9 @@ impl<B: SessionAgentBuilder + 'static> PersistentSessionService<B> {
                     "failed to persist revived runtime snapshot for session {id}: {error}"
                 )))
             })?;
-        self.save_compatibility_projection_only(session).await?;
+        let active = self.save_compatibility_projection_only(session).await?;
+        self.synchronize_live_session_after_archived_revival(id, &active)
+            .await?;
         if let Some(gate) = self.existing_gate_for_session(id).await {
             *gate.cancelled.lock().await = false;
         }


### PR DESCRIPTION
## Summary

Fixes MobKit upstream Ask 34 by making explicit mob-member resume revive an archived, terminally retired session before generic executor attachment.

## Root cause

The cold-restart resume path materialized the requested session and immediately entered the ordinary runtime/executor attachment path while the durable runtime was still `Retired`. That path correctly refuses registration across a terminal runtime, so a valid identity-first resume failed before the later revival code could run.

## What changed

- Promote the durable session document from `Archived` to `Active` under archived-resume authority.
- Synchronize an already-materialized live semantic session from that durable snapshot so its next checkpoint cannot restore stale archived metadata.
- Reset the durable runtime from `Retired` to `Idle` only after the document/live projection is active.
- Attach the executor through the existing generic path only after those authority transitions complete.
- On any later provisioning failure, restore the exact `Archived` + `Retired` pair and remove the live agent, executor registration, runtime registration, and provisioner sidecar.
- Preserve the normal rule that generic executor registration cannot cross `Retired`; no machine DSL or terminal-state contract is weakened.

## Coverage

- Public cold-restart integration: spawn, turn, retire, reopen, explicitly resume the same session ID, then take another turn while preserving transcript history.
- Exact post-revival `Active` checks on both the authoritative session and JSONL compatibility projection, including after the first checkpoint.
- Failure injection after executor attachment verifies exact rollback and no leaked runtime state.
- Direct `Active` + `Retired` crash-midpoint rollback coverage.
- Compatibility coverage proves an already-active revival does not require custom session agents to implement durable snapshot sync; strict sync remains required for true archived promotion.
- Downstream MobKit ignored acceptance test passes against this checkout with dependency pins and lock hashes unchanged.

## Validation

- Focused rollback test: passed.
- Focused public cold-restart revival test: passed.
- `meerkat-mob` Nextest suite: 1,230 passed, 7 skipped.
- `meerkat-session` unit and integration suites: passed.
- `make check`
- `make lint`
- `make fmt-check`
- WASM `meerkat-mob` check
- schema freshness, generated BUILD checks, and `git diff --check`

Ask 35 is already merged in #878; this PR is the remaining upstream fix planned for Meerkat 0.7.30.
