### PR TITLE
fix(runtime): re-drive missing-live member revival

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,6 +103,15 @@ via cargo-semver-checks against the published baselines).
 
 ### Fixed
 
+- Delivery-time Mob member revival now carries an explicit machine-authorized
+  missing-live-materialization intent. Exact ownerless `Idle` or `Attached`
+  records with `Queuing` or orphaned `Active` registration are re-driven
+  in-process through the generated
+  executor-exit observation and same-session resume intent, clearing the full
+  V3 runtime-binding tuple without touching queued inputs. Executor
+  publication is also cancellation-safe: the exact runtime-loop attachment,
+  its initial backlog wake, and startup projection/persistence belong to the
+  loop owner, preventing a false `Attached`/ready state without an executor.
 - Transcript revision history no longer retains a complete mechanical head
   snapshot after every ordinary append once any audited rewrite exists.
   Snapshots preserve genuine rewrite endpoints plus the live head, typed

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -123,8 +123,8 @@
     "https://bcr.bazel.build/modules/rules_cc/0.2.0/MODULE.bazel": "b5c17f90458caae90d2ccd114c81970062946f49f355610ed89bebf954f5783c",
     "https://bcr.bazel.build/modules/rules_cc/0.2.13/MODULE.bazel": "eecdd666eda6be16a8d9dc15e44b5c75133405e820f620a234acc4b1fdc5aa37",
     "https://bcr.bazel.build/modules/rules_cc/0.2.17/MODULE.bazel": "1849602c86cb60da8613d2de887f9566a6d354a6df6d7009f9d04a14402f9a84",
-    "https://bcr.bazel.build/modules/rules_cc/0.2.21/MODULE.bazel": "ab8f5a18726b5127e884ee1a3ce7979786c3d09b10945bee96ead70c4e071f17",
-    "https://bcr.bazel.build/modules/rules_cc/0.2.21/source.json": "13c4c48da6209345b312c8b772a2b4e7bd1631e068c7f120804a75d96acae503",
+    "https://bcr.bazel.build/modules/rules_cc/0.2.22/MODULE.bazel": "94df4328edef9e44d38de5e73b037cd348e75e7ae55f4e21bf07878c41a31ebb",
+    "https://bcr.bazel.build/modules/rules_cc/0.2.22/source.json": "b2d6d6f9c332ce269ad75b89c6f3168d809a66173c9040210fb9bcc733ab42fa",
     "https://bcr.bazel.build/modules/rules_cc/0.2.4/MODULE.bazel": "1ff1223dfd24f3ecf8f028446d4a27608aa43c3f41e346d22838a4223980b8cc",
     "https://bcr.bazel.build/modules/rules_cc/0.2.8/MODULE.bazel": "f1df20f0bf22c28192a794f29b501ee2018fa37a3862a1a2132ae2940a23a642",
     "https://bcr.bazel.build/modules/rules_foreign_cc/0.9.0/MODULE.bazel": "c9e8c682bf75b0e7c704166d79b599f93b72cfca5ad7477df596947891feeef6",
@@ -484,7 +484,7 @@
     },
     "@@rules_rust+//crate_universe:extensions.bzl%crate": {
       "general": {
-        "bzlTransitiveDigest": "ocFBQ+1iVRlU0Fc7MalKdQWuYGblpISpAG8AnGXw8ks=",
+        "bzlTransitiveDigest": "IH+7oRVifE7zcpf0kLdlFajbVDXfXePxhBRABcYBMRs=",
         "usagesDigest": "owDryE1ufKZrG8oMhCyCMnwCxDLWUqGvhwgTzJpL7tQ=",
         "recordedInputs": [
           "ENV:CARGO_BAZEL_DEBUG \\0",
@@ -497,6 +497,7 @@
           "ENV:REPIN \\0",
           "REPO_MAPPING:bazel_features+,bazel_features_globals bazel_features++version_extension+bazel_features_globals",
           "REPO_MAPPING:bazel_features+,bazel_features_version bazel_features++version_extension+bazel_features_version",
+          "REPO_MAPPING:rules_cc+,bazel_features bazel_features+",
           "REPO_MAPPING:rules_cc+,bazel_skylib bazel_skylib+",
           "REPO_MAPPING:rules_cc+,bazel_tools bazel_tools",
           "REPO_MAPPING:rules_cc+,cc_compatibility_proxy rules_cc++compatibility_proxy+cc_compatibility_proxy",
@@ -7033,11 +7034,12 @@
     },
     "@@rules_rust+//crate_universe/private:internal_extensions.bzl%cu_nr": {
       "general": {
-        "bzlTransitiveDigest": "Sx1N1L+6UYX3Q+vEjkRWMf+xmjdZEJAuda3NyaDkEVA=",
+        "bzlTransitiveDigest": "nG28ECBQNHJjRZ3TvkXf/TsjgPtH5V1xE/REo/EHebY=",
         "usagesDigest": "ZmL90WEq2B6/NJ8rtHAqdnDPn+/9xG/GWR5K4UU4tyo=",
         "recordedInputs": [
           "REPO_MAPPING:bazel_features+,bazel_features_globals bazel_features++version_extension+bazel_features_globals",
           "REPO_MAPPING:bazel_features+,bazel_features_version bazel_features++version_extension+bazel_features_version",
+          "REPO_MAPPING:rules_cc+,bazel_features bazel_features+",
           "REPO_MAPPING:rules_cc+,bazel_skylib bazel_skylib+",
           "REPO_MAPPING:rules_cc+,bazel_tools bazel_tools",
           "REPO_MAPPING:rules_cc+,cc_compatibility_proxy rules_cc++compatibility_proxy+cc_compatibility_proxy",

--- a/meerkat-mob/src/runtime/actor.rs
+++ b/meerkat-mob/src/runtime/actor.rs
@@ -5792,6 +5792,8 @@ impl MobActor {
                 owner_bridge_session_id: None,
                 ops_registry: None,
                 generated_self_owned_operation_owner: Some(bridge_session_id.clone()),
+                runtime_revival_intent:
+                    super::provisioner::RuntimeRevivalIntent::MissingLiveMaterialization,
             })
             .await?;
         let revived_session_id =
@@ -10271,6 +10273,8 @@ impl MobActor {
                         owner_bridge_session_id: owner_bridge_session_id.clone(),
                         ops_registry: ops_registry.clone(),
                         generated_self_owned_operation_owner: None,
+                        runtime_revival_intent:
+                            super::provisioner::RuntimeRevivalIntent::None,
                     };
                     let resolved_labels = labels.unwrap_or_default();
                     return Ok((
@@ -10440,6 +10444,7 @@ impl MobActor {
                 owner_bridge_session_id: owner_bridge_session_id.clone(),
                 ops_registry: ops_registry.clone(),
                 generated_self_owned_operation_owner: None,
+                runtime_revival_intent: super::provisioner::RuntimeRevivalIntent::None,
             };
             let resolved_labels = labels.unwrap_or_default();
             Ok((
@@ -11086,6 +11091,7 @@ impl MobActor {
             owner_bridge_session_id: None,
             ops_registry: None,
             generated_self_owned_operation_owner: None,
+            runtime_revival_intent: super::provisioner::RuntimeRevivalIntent::None,
         };
         let admitted_bridge_session_id =
             admit_bridge_session_for_spawn(&mut provision_request.create_session);
@@ -16346,6 +16352,7 @@ impl MobActor {
             owner_bridge_session_id: None,
             ops_registry: None,
             generated_self_owned_operation_owner: None,
+            runtime_revival_intent: super::provisioner::RuntimeRevivalIntent::None,
         };
         if let Some((owner_bridge_session_id, ops_registry)) = respawn_peer_only_owner_context {
             provision_request.owner_bridge_session_id = Some(owner_bridge_session_id);

--- a/meerkat-mob/src/runtime/builder.rs
+++ b/meerkat-mob/src/runtime/builder.rs
@@ -3409,6 +3409,7 @@ impl MobBuilder {
                         generated_self_owned_operation_owner: Some(
                             generated_self_owned_operation_owner,
                         ),
+                        runtime_revival_intent: super::provisioner::RuntimeRevivalIntent::None,
                     })
                     .await
                 {
@@ -3552,6 +3553,7 @@ impl MobBuilder {
                 owner_bridge_session_id: None,
                 ops_registry: None,
                 generated_self_owned_operation_owner: None,
+                runtime_revival_intent: super::provisioner::RuntimeRevivalIntent::None,
             };
             let admitted_bridge_session_id =
                 super::actor::admit_bridge_session_for_spawn(&mut provision_request.create_session);

--- a/meerkat-mob/src/runtime/provisioner.rs
+++ b/meerkat-mob/src/runtime/provisioner.rs
@@ -237,6 +237,18 @@ pub struct ProvisionMemberRequest {
     pub(crate) owner_bridge_session_id: Option<SessionId>,
     pub ops_registry: Option<Arc<dyn OpsLifecycleRegistry>>,
     pub(crate) generated_self_owned_operation_owner: Option<SessionId>,
+    /// Internal proof that MobMachine authorized rebuilding a durable member
+    /// whose live session materialization is missing in this process. Only
+    /// that delivery-time revival may publish the missing-owner observation
+    /// and re-run same-session readmission before attaching its replacement.
+    pub(crate) runtime_revival_intent: RuntimeRevivalIntent,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub(crate) enum RuntimeRevivalIntent {
+    #[default]
+    None,
+    MissingLiveMaterialization,
 }
 
 #[doc(hidden)]
@@ -396,6 +408,20 @@ fn stamp_eager_session_owned_initial_turn_metadata(req: &mut CreateSessionReques
 
 #[cfg(feature = "runtime-adapter")]
 impl SessionBackend {
+    async fn replacement_runtime_session_state(
+        existing: Arc<RuntimeSessionState>,
+        preserve_missing_live_context: bool,
+    ) -> Arc<RuntimeSessionState> {
+        if preserve_missing_live_context {
+            existing
+        } else {
+            existing.clear_queued_turns().await;
+            Arc::new(RuntimeSessionState {
+                queued_turns: Mutex::new(RuntimeSessionQueue::default()),
+            })
+        }
+    }
+
     #[cfg(feature = "runtime-adapter")]
     pub(super) async fn restore_failed_resume_before_receipt(
         &self,
@@ -581,6 +607,7 @@ impl SessionBackend {
     async fn runtime_session_state(
         &self,
         session_id: &SessionId,
+        preserve_missing_live_context: bool,
     ) -> Result<Option<Arc<RuntimeSessionState>>, MobError> {
         let Some(adapter) = self.runtime_adapter.as_ref() else {
             return Ok(None);
@@ -603,10 +630,13 @@ impl SessionBackend {
             {
                 return Ok(Some(existing));
             }
-            existing.clear_queued_turns().await;
-            let state = Arc::new(RuntimeSessionState {
-                queued_turns: Mutex::new(RuntimeSessionQueue::default()),
-            });
+            // Missing executor materialization does not invalidate session-
+            // side turn ownership. Preserve that exact sidecar only for the
+            // machine-authorized intent; ordinary replacement keeps the prior
+            // clear-and-recreate behavior.
+            let state =
+                Self::replacement_runtime_session_state(existing, preserve_missing_live_context)
+                    .await;
             let executor = Box::new(MobSessionRuntimeExecutor::new(
                 self.session_service.clone(),
                 Arc::clone(adapter),
@@ -615,9 +645,9 @@ impl SessionBackend {
                 state.clone(),
                 Arc::clone(&self.runtime_sessions),
             ));
-            // Runtime session registrations are capability bindings. If the
-            // adapter lost this session, drop any queued bridge context from
-            // the stale binding before reattaching with a fresh sidecar.
+            // Runtime session registrations are capability bindings. Missing-
+            // live revival reuses the exact context selected above; ordinary
+            // replacement retains the prior fresh-sidecar behavior.
             #[cfg(target_arch = "wasm32")]
             {
                 let adapter = Arc::clone(adapter);
@@ -1136,7 +1166,7 @@ impl SessionBackend {
                 "runtime-backed turn requested without runtime adapter: {session_id}"
             ))
         })?;
-        let state = self.runtime_session_state(session_id).await?;
+        let state = self.runtime_session_state(session_id, false).await?;
         let adapter_session_id = session_id.clone();
         let requested_input_id = input.id().clone();
         let mut context_input_id = requested_input_id.clone();
@@ -1278,7 +1308,7 @@ impl SessionBackend {
                 "runtime-backed turn requested without runtime adapter: {session_id}"
             ))
         })?;
-        let state = self.runtime_session_state(session_id).await?;
+        let state = self.runtime_session_state(session_id, false).await?;
         let adapter_session_id = session_id.clone();
         let requested_input_id = input.id().clone();
         let (queued_event_tx, deferred_delivery) =
@@ -1675,6 +1705,37 @@ mod tests {
         assert!(
             result.is_none(),
             "deferred buffer must not fabricate events; channel should close empty"
+        );
+    }
+
+    #[cfg(feature = "runtime-adapter")]
+    #[tokio::test]
+    async fn missing_live_replacement_preserves_exact_queued_turn_sidecar() {
+        let state = std::sync::Arc::new(super::RuntimeSessionState::empty_for_test());
+        let input_id = meerkat_core::lifecycle::InputId::new();
+        let (event_tx, _event_rx) = tokio::sync::mpsc::channel(1);
+        assert!(
+            state
+                .enqueue_turn_context(input_id.clone(), Some(event_tx))
+                .await
+        );
+
+        let replacement = super::SessionBackend::replacement_runtime_session_state(
+            std::sync::Arc::clone(&state),
+            true,
+        )
+        .await;
+
+        assert!(
+            std::sync::Arc::ptr_eq(&replacement, &state),
+            "MissingLive replacement must retain the exact sidecar owner"
+        );
+        assert!(
+            replacement
+                .take_turn_context_for_inputs(&[input_id])
+                .await
+                .is_some(),
+            "queued TurnEventTx context must survive executor replacement"
         );
     }
 
@@ -2103,6 +2164,8 @@ impl MobProvisioner for SessionBackend {
         mut req: ProvisionMemberRequest,
     ) -> Result<MemberSpawnReceipt, MobError> {
         let mut session_origin = req.session_origin;
+        let missing_live_materialization =
+            req.runtime_revival_intent == RuntimeRevivalIntent::MissingLiveMaterialization;
         tracing::debug!(
             binding = ?req.binding,
             peer_name = %req.peer_name,
@@ -2187,6 +2250,86 @@ impl MobProvisioner for SessionBackend {
                     })
             {
                 reviving_retired_session = true;
+            }
+            if missing_live_materialization && !reviving_retired_session {
+                let observed_runtime_state = adapter
+                    .runtime_state(&member_bridge_session_id)
+                    .await
+                    .map_err(|error| {
+                        MobError::Internal(format!(
+                            "failed to inspect missing-live member runtime '{member_bridge_session_id}': {error}"
+                        ))
+                    })?;
+                let has_live_executor = adapter
+                    .session_has_executor(&member_bridge_session_id)
+                    .await
+                    .map_err(|error| {
+                        MobError::Internal(format!(
+                            "failed to inspect missing-live member executor '{member_bridge_session_id}': {error}"
+                        ))
+                    })?;
+                // Only exact Idle/Attached absence is a missing-owner proof.
+                // Stopped continues through ordinary stopped-session revival,
+                // while a genuinely live executor remains the exact owner and
+                // is reused by the rebuilt session.
+                if matches!(
+                    observed_runtime_state,
+                    meerkat_runtime::RuntimeState::Idle | meerkat_runtime::RuntimeState::Attached
+                ) && !has_live_executor
+                {
+                    #[cfg(target_arch = "wasm32")]
+                    let redrive_result = {
+                        let adapter = Arc::clone(adapter);
+                        let bridge_session_id = member_bridge_session_id.clone();
+                        let authority = adapter.session_control_authority();
+                        let (reply_tx, reply_rx) = oneshot::channel();
+                        tokio::spawn(async move {
+                            let result = adapter
+                                .redrive_missing_executor_for_revival(&bridge_session_id, authority)
+                                .await;
+                            let _ = reply_tx.send(result);
+                        });
+                        reply_rx.await.map_err(|_| {
+                            MobError::Internal(
+                                "missing-live runtime re-drive task was canceled".to_string(),
+                            )
+                        })?
+                    };
+                    #[cfg(not(target_arch = "wasm32"))]
+                    let redrive_result = adapter
+                        .redrive_missing_executor_for_revival(
+                            &member_bridge_session_id,
+                            adapter.session_control_authority(),
+                        )
+                        .await;
+                    match redrive_result {
+                        Ok(()) => {}
+                        Err(meerkat_runtime::RuntimeDriverError::NotReady {
+                            state: meerkat_runtime::RuntimeState::Stopped,
+                        }) => {
+                            tracing::debug!(
+                                bridge_session_id = %member_bridge_session_id,
+                                "missing-live revival raced canonical runtime stop; ordinary stopped-session revival now owns readmission"
+                            );
+                        }
+                        Err(error) => {
+                            if adapter
+                                .session_has_executor(&member_bridge_session_id)
+                                .await
+                                .is_ok_and(|present| present)
+                            {
+                                tracing::debug!(
+                                    bridge_session_id = %member_bridge_session_id,
+                                    "missing-live revival observed a concurrent executor materialization"
+                                );
+                            } else {
+                                return Err(MobError::Internal(format!(
+                                    "failed to re-drive missing-live member runtime '{member_bridge_session_id}': {error}"
+                                )));
+                            }
+                        }
+                    }
+                }
             }
             if let Some(ref mut build) = req.create_session.build {
                 build.runtime_build_mode =
@@ -2316,7 +2459,10 @@ impl MobProvisioner for SessionBackend {
                 bridge_session_id = %created_bridge_session_id,
                 "SessionBackend::provision_member checking runtime session state"
             );
-            self.runtime_session_state(&created_bridge_session_id)
+            self.runtime_session_state(
+                &created_bridge_session_id,
+                missing_live_materialization,
+            )
                 .await?;
             tracing::debug!(
                 bridge_session_id = %created_bridge_session_id,
@@ -2798,7 +2944,7 @@ impl MobProvisioner for SessionBackend {
 
     async fn ensure_runtime_session_state(&self, member_ref: &MemberRef) -> Result<(), MobError> {
         let bridge_session_id = Self::require_session(member_ref, "ensure runtime session for")?;
-        self.runtime_session_state(&bridge_session_id)
+        self.runtime_session_state(&bridge_session_id, false)
             .await?
             .ok_or_else(|| {
                 MobError::Internal(format!(
@@ -3547,6 +3693,7 @@ impl MobProvisioner for MultiBackendProvisioner {
                         ops_registry: req.ops_registry,
                         generated_self_owned_operation_owner: req
                             .generated_self_owned_operation_owner,
+                        runtime_revival_intent: req.runtime_revival_intent,
                     })
                     .await
             }

--- a/meerkat-mob/src/runtime/tests.rs
+++ b/meerkat-mob/src/runtime/tests.rs
@@ -26836,6 +26836,7 @@ async fn test_provision_member_uses_local_bindings_before_routed_runtime_bound()
             owner_bridge_session_id: None,
             ops_registry: None,
             generated_self_owned_operation_owner: Some(bridge_session_id.clone()),
+            runtime_revival_intent: super::provisioner::RuntimeRevivalIntent::None,
         })
         .await
         .expect("member provision should install local runtime resources");
@@ -26905,6 +26906,7 @@ async fn test_retired_session_revival_failure_restores_archived_retired_pair() {
             owner_bridge_session_id: None,
             ops_registry: None,
             generated_self_owned_operation_owner: Some(session_id.clone()),
+            runtime_revival_intent: super::provisioner::RuntimeRevivalIntent::None,
         })
         .await
         .expect("seed session provision");
@@ -26962,6 +26964,7 @@ async fn test_retired_session_revival_failure_restores_archived_retired_pair() {
             owner_bridge_session_id: None,
             ops_registry: None,
             generated_self_owned_operation_owner: Some(mismatched_owner),
+            runtime_revival_intent: super::provisioner::RuntimeRevivalIntent::None,
         })
         .await
         .expect_err("post-attachment validation must fail");
@@ -38014,6 +38017,234 @@ async fn test_discarded_live_session_revived_by_machine_authorized_dispatch() {
         .await
         .expect("member status");
     assert_eq!(snapshot.status, crate::runtime::MobMemberStatus::Active);
+}
+
+/// Delivery-time MissingLive regression: the member and its durable session
+/// snapshot remain Active, but a completed runtime stop left the registered
+/// session with no executor. Delivery-time binding preparation readmits that
+/// ownerless runtime and a stale binding tuple advances it to Attached. The
+/// next turn must authorize the narrow MissingLiveMaterialization redrive,
+/// retire the completed stop receipt, rebuild the exact bridge session, and
+/// execute without classifying the member Broken.
+#[cfg(feature = "runtime-adapter")]
+#[tokio::test]
+async fn test_ownerless_stale_runtime_binding_is_redriven_by_missing_live_dispatch() {
+    use meerkat_runtime::SessionServiceRuntimeExt as _;
+    use meerkat_runtime::composition::{ConsumerSurface as _, OwnedFieldValue};
+    use meerkat_runtime::generated::meerkat_mob_seam as seam_facts;
+
+    let mut definition = sample_definition();
+    definition
+        .profiles
+        .get_mut(&ProfileName::from("worker"))
+        .expect("worker profile")
+        .as_inline_mut()
+        .expect("inline worker profile")
+        .runtime_mode = crate::MobRuntimeMode::TurnDriven;
+    let (handle, service) = create_test_mob(definition).await;
+    let adapter = service.enable_runtime_adapter();
+    let receipt = handle
+        .spawn(
+            ProfileName::from("worker"),
+            AgentIdentity::from("w-missing-live-redrive"),
+            None,
+        )
+        .await
+        .expect("spawn turn-driven worker");
+    let bridge_session_id = receipt
+        .bridge_session_id()
+        .cloned()
+        .expect("session-backed member");
+    let initial_status = handle
+        .member_status(&AgentIdentity::from("w-missing-live-redrive"))
+        .await
+        .expect("initial member status");
+    let (agent_runtime_id, fence_token) = initial_status
+        .runtime_identity_fields()
+        .expect("active member has runtime identity");
+    let agent_runtime_id = agent_runtime_id.clone();
+    let baseline_create_requests = service.recorded_create_requests().await.len();
+    let baseline_turn_calls = service.start_turn_call_count();
+
+    assert!(
+        adapter
+            .session_has_executor(&bridge_session_id)
+            .await
+            .expect("inspect initial executor"),
+        "spawn must publish the original runtime executor"
+    );
+    adapter
+        .stop_runtime_executor(&bridge_session_id, "completed limbo shutdown")
+        .await
+        .expect("canonically stop the original runtime executor");
+    assert!(
+        adapter.contains_session(&bridge_session_id).await,
+        "completed stop must retain the registered runtime entry"
+    );
+    assert!(
+        !service
+            .has_live_session(&bridge_session_id)
+            .await
+            .expect("inspect live materialization after stop"),
+        "executor-owned cleanup must remove only the live materialization"
+    );
+    assert!(
+        service
+            .persisted_session_clone(&bridge_session_id)
+            .await
+            .is_some(),
+        "canonical stop must leave the durable mock session snapshot revivable"
+    );
+    let machine_after_stop = handle
+        .query_machine_state()
+        .await
+        .expect("query MobMachine after runtime stop");
+    let machine_identity_after_stop = crate::machines::mob_machine::AgentIdentity::from_domain(
+        &AgentIdentity::from("w-missing-live-redrive"),
+    );
+    let lifecycle_after_stop =
+        machine_after_stop.member_lifecycle_for_identity(&machine_identity_after_stop);
+    assert_eq!(
+        lifecycle_after_stop.status,
+        crate::machines::mob_machine::MobMemberLifecycleStatus::Active,
+        "runtime loss must not terminalize the actor-owned member: {lifecycle_after_stop:?}"
+    );
+    assert!(lifecycle_after_stop.error.is_none());
+
+    adapter
+        .prepare_local_session_bindings(bridge_session_id.clone())
+        .await
+        .expect("delivery-time preparation must readmit the stopped runtime");
+    assert!(
+        !adapter
+            .session_has_executor(&bridge_session_id)
+            .await
+            .expect("inspect readmitted ownerless runtime"),
+        "delivery-time binding preparation must not fabricate an executor"
+    );
+
+    meerkat_runtime::meerkat_machine::composition::MeerkatConsumerSurface::pinned(
+        Arc::clone(&adapter),
+        bridge_session_id.clone(),
+    )
+    .apply_routed_input(
+        seam_facts::inputs::prepare_bindings(),
+        vec![
+            (
+                seam_facts::fields::agent_runtime_id(),
+                OwnedFieldValue::Str(agent_runtime_id.to_string()),
+            ),
+            (
+                seam_facts::fields::fence_token(),
+                OwnedFieldValue::U64(fence_token.get()),
+            ),
+            (
+                seam_facts::fields::generation(),
+                OwnedFieldValue::U64(agent_runtime_id.generation.get()),
+            ),
+            (
+                seam_facts::fields::session_id(),
+                OwnedFieldValue::Str(bridge_session_id.to_string()),
+            ),
+        ],
+    )
+    .await
+    .expect("public composition route must manufacture the stale binding tuple");
+    assert_eq!(
+        adapter
+            .runtime_state(&bridge_session_id)
+            .await
+            .expect("inspect stale ownerless runtime"),
+        meerkat_runtime::RuntimeState::Attached,
+        "PrepareBindings on the ownerless registration exposes the supported Attached shape"
+    );
+    assert!(
+        !adapter
+            .session_has_executor(&bridge_session_id)
+            .await
+            .expect("inspect stale ownerless executor"),
+        "binding projection must not fabricate a live executor"
+    );
+
+    tokio::time::timeout(
+        Duration::from_secs(3),
+        handle
+            .member(&AgentIdentity::from("w-missing-live-redrive"))
+            .await
+            .expect("member handle")
+            .internal_turn(ContentInput::from(
+                "execute after missing-live redrive".to_string(),
+            )),
+    )
+    .await
+    .expect("missing-live materialization must not wedge")
+    .expect("machine-authorized MissingLive revival and turn must succeed");
+
+    assert!(
+        service
+            .has_live_session(&bridge_session_id)
+            .await
+            .expect("inspect revived materialization"),
+        "MissingLive revival must rebuild the same bridge session"
+    );
+    assert_eq!(
+        service.recorded_create_requests().await.len(),
+        baseline_create_requests + 1,
+        "the missing live materialization must be rebuilt exactly once"
+    );
+    assert_eq!(
+        service.start_turn_call_count(),
+        baseline_turn_calls + 1,
+        "the admitted turn must execute exactly once on the replacement runtime"
+    );
+    let turn_prompts = service.start_turn_prompts.read().await.clone();
+    assert!(
+        turn_prompts.iter().any(|(session_id, prompt)| {
+            session_id == &bridge_session_id
+                && prompt.contains("execute after missing-live redrive")
+        }),
+        "replacement executor must run the dispatched turn: {turn_prompts:?}"
+    );
+    assert!(
+        adapter
+            .session_has_executor(&bridge_session_id)
+            .await
+            .expect("inspect replacement executor"),
+        "successful materialization must publish a replacement executor"
+    );
+
+    let final_status = handle
+        .member_status(&AgentIdentity::from("w-missing-live-redrive"))
+        .await
+        .expect("final member status");
+    assert_eq!(final_status.status, crate::runtime::MobMemberStatus::Active);
+    assert!(!final_status.is_final);
+    let (final_runtime_id, final_fence_token) = final_status
+        .runtime_identity_fields()
+        .expect("revived member retains runtime identity");
+    assert_eq!(final_runtime_id, &agent_runtime_id);
+    assert_eq!(final_fence_token, fence_token);
+
+    let machine_state = handle
+        .query_machine_state()
+        .await
+        .expect("query MobMachine after missing-live revival");
+    let machine_identity = crate::machines::mob_machine::AgentIdentity::from_domain(
+        &AgentIdentity::from("w-missing-live-redrive"),
+    );
+    let lifecycle = machine_state.member_lifecycle_for_identity(&machine_identity);
+    assert_eq!(
+        lifecycle.status,
+        crate::machines::mob_machine::MobMemberLifecycleStatus::Active,
+        "successful missing-live redrive must never classify the member Broken: {lifecycle:?}"
+    );
+    assert!(lifecycle.error.is_none());
+    assert!(
+        !machine_state
+            .member_revival_pending
+            .contains(&machine_identity),
+        "successful materialization must resolve the machine-owned revival obligation"
+    );
 }
 
 #[tokio::test]

--- a/meerkat-runtime/src/meerkat_machine/composition.rs
+++ b/meerkat-runtime/src/meerkat_machine/composition.rs
@@ -416,6 +416,12 @@ mod tests {
     use crate::composition::{
         CatalogCompositionSignalDispatcher, OwnedFieldValue, RouteTable, SignalConsumerSurface,
     };
+    use meerkat_core::lifecycle::RunId;
+    use meerkat_core::lifecycle::core_executor::{
+        CoreApplyOutput, CoreExecutor, CoreExecutorError,
+    };
+    use meerkat_core::lifecycle::run_primitive::{RunApplyBoundary, RunPrimitive};
+    use meerkat_core::lifecycle::run_receipt::RunBoundaryReceiptDraft;
     use meerkat_machine_schema::identity::SignalVariantId;
 
     fn fld(slug: &str) -> FieldId {
@@ -428,6 +434,308 @@ mod tests {
 
     fn sid(slug: &str) -> SessionId {
         SessionId::parse(slug).expect("session id")
+    }
+
+    struct NoopExecutor;
+
+    #[async_trait]
+    impl CoreExecutor for NoopExecutor {
+        async fn apply(
+            &mut self,
+            run_id: RunId,
+            primitive: RunPrimitive,
+        ) -> Result<CoreApplyOutput, CoreExecutorError> {
+            Ok(CoreApplyOutput {
+                receipt: RunBoundaryReceiptDraft {
+                    run_id,
+                    boundary: RunApplyBoundary::RunStart,
+                    contributing_input_ids: primitive.contributing_input_ids().to_vec(),
+                    conversation_digest: None,
+                    message_count: 0,
+                },
+                session_snapshot: None,
+                terminal: None,
+            })
+        }
+
+        async fn cancel_after_boundary(
+            &mut self,
+            _reason: String,
+        ) -> Result<(), CoreExecutorError> {
+            Ok(())
+        }
+
+        async fn stop_runtime_executor(
+            &mut self,
+            _reason: String,
+        ) -> Result<(), CoreExecutorError> {
+            Ok(())
+        }
+    }
+
+    struct StartupGatedNoopExecutor {
+        reconciliation_started: Arc<tokio::sync::Notify>,
+        allow_reconciliation: Arc<tokio::sync::Notify>,
+        gate_first_reconciliation: std::sync::atomic::AtomicBool,
+    }
+
+    #[async_trait]
+    impl CoreExecutor for StartupGatedNoopExecutor {
+        async fn apply(
+            &mut self,
+            run_id: RunId,
+            primitive: RunPrimitive,
+        ) -> Result<CoreApplyOutput, CoreExecutorError> {
+            Ok(CoreApplyOutput {
+                receipt: RunBoundaryReceiptDraft {
+                    run_id,
+                    boundary: RunApplyBoundary::RunStart,
+                    contributing_input_ids: primitive.contributing_input_ids().to_vec(),
+                    conversation_digest: None,
+                    message_count: 0,
+                },
+                session_snapshot: None,
+                terminal: None,
+            })
+        }
+
+        async fn reconcile_committed_compaction_projections(
+            &mut self,
+            _intents: &[meerkat_core::CompactionProjectionIntent],
+        ) -> Result<(), CoreExecutorError> {
+            if self
+                .gate_first_reconciliation
+                .swap(false, std::sync::atomic::Ordering::AcqRel)
+            {
+                self.reconciliation_started.notify_one();
+                self.allow_reconciliation.notified().await;
+            }
+            Ok(())
+        }
+
+        async fn cancel_after_boundary(
+            &mut self,
+            _reason: String,
+        ) -> Result<(), CoreExecutorError> {
+            Ok(())
+        }
+
+        async fn stop_runtime_executor(
+            &mut self,
+            _reason: String,
+        ) -> Result<(), CoreExecutorError> {
+            Ok(())
+        }
+    }
+
+    async fn begin_startup_gated_attachment(
+        machine: &Arc<MeerkatMachine>,
+        session_id: &SessionId,
+    ) -> (tokio::task::JoinHandle<()>, Arc<tokio::sync::Notify>) {
+        let reconciliation_started = Arc::new(tokio::sync::Notify::new());
+        let allow_reconciliation = Arc::new(tokio::sync::Notify::new());
+        let registration = tokio::spawn({
+            let machine = Arc::clone(machine);
+            let session_id = session_id.clone();
+            let reconciliation_started = Arc::clone(&reconciliation_started);
+            let allow_reconciliation = Arc::clone(&allow_reconciliation);
+            async move {
+                machine
+                    .ensure_session_with_executor(
+                        session_id,
+                        Box::new(StartupGatedNoopExecutor {
+                            reconciliation_started,
+                            allow_reconciliation,
+                            gate_first_reconciliation: std::sync::atomic::AtomicBool::new(true),
+                        }),
+                    )
+                    .await
+                    .expect("replacement executor must finish attaching after startup release");
+            }
+        });
+
+        tokio::time::timeout(
+            std::time::Duration::from_secs(2),
+            reconciliation_started.notified(),
+        )
+        .await
+        .expect("replacement executor must reach startup reconciliation");
+
+        let attached = machine
+            .session_dsl_state(session_id)
+            .await
+            .expect("attached replacement authority exists");
+        assert_eq!(attached.lifecycle_phase, mm_dsl::MeerkatPhase::Attached);
+        assert_eq!(
+            attached.registration_phase,
+            mm_dsl::RegistrationPhase::Active
+        );
+        {
+            let sessions = machine.sessions.read().await;
+            let entry = sessions
+                .get(session_id)
+                .expect("replacement attachment remains registered");
+            assert!(
+                entry.has_live_attachment(),
+                "startup reconciliation begins only after the replacement attachment is published"
+            );
+        }
+
+        (registration, allow_reconciliation)
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    async fn route_replacement_and_finish_gated_attachment(
+        machine: &Arc<MeerkatMachine>,
+        session_id: &SessionId,
+        registration: tokio::task::JoinHandle<()>,
+        allow_reconciliation: Arc<tokio::sync::Notify>,
+        completion: crate::completion::CompletionHandle,
+        replacement_runtime_id: &'static str,
+        replacement_fence_token: u64,
+        replacement_generation: u64,
+    ) {
+        // Queue the routed input while executor startup still owns the session
+        // mutation gate. Tokio's FIFO mutex then gives this already-waiting
+        // route the exact Attached seam before the runtime loop can dequeue
+        // the preserved backlog.
+        let route_started = Arc::new(tokio::sync::Notify::new());
+        let routed = tokio::spawn({
+            let machine = Arc::clone(machine);
+            let session_id = session_id.clone();
+            let route_started = Arc::clone(&route_started);
+            async move {
+                route_started.notify_one();
+                MeerkatConsumerSurface::pinned(Arc::clone(&machine), session_id.clone())
+                    .apply_routed_input(
+                        iv("PrepareBindings"),
+                        vec![
+                            (
+                                fld("agent_runtime_id"),
+                                OwnedFieldValue::Str(replacement_runtime_id.into()),
+                            ),
+                            (
+                                fld("fence_token"),
+                                OwnedFieldValue::U64(replacement_fence_token),
+                            ),
+                            (
+                                fld("generation"),
+                                OwnedFieldValue::U64(replacement_generation),
+                            ),
+                            (
+                                fld("session_id"),
+                                OwnedFieldValue::Str(session_id.to_string()),
+                            ),
+                        ],
+                    )
+                    .await
+                    .expect("routed replacement binding is admitted at Attached");
+            }
+        });
+        tokio::time::timeout(std::time::Duration::from_secs(2), route_started.notified())
+            .await
+            .expect("replacement binding route must start");
+        tokio::task::yield_now().await;
+        assert!(
+            !routed.is_finished(),
+            "the routed input must wait behind executor startup's mutation-gate ownership"
+        );
+
+        allow_reconciliation.notify_one();
+        tokio::time::timeout(std::time::Duration::from_secs(2), registration)
+            .await
+            .expect("replacement executor registration must finish")
+            .expect("replacement executor registration task must not panic");
+        tokio::time::timeout(std::time::Duration::from_secs(2), routed)
+            .await
+            .expect("replacement binding route must finish")
+            .expect("replacement binding route task must not panic");
+
+        let completion_outcome = tokio::time::timeout(
+            std::time::Duration::from_secs(2),
+            completion.wait_authorized(),
+        )
+        .await;
+        let completion_outcome = match completion_outcome {
+            Ok(outcome) => outcome,
+            Err(error) => {
+                let snapshot = machine
+                    .meerkat_machine_spine_snapshot(session_id)
+                    .await
+                    .expect("runtime spine exists after completion timeout");
+                panic!(
+                    "preserved queued input must complete on the replacement executor: {error}; snapshot={snapshot:#?}"
+                );
+            }
+        };
+        match completion_outcome {
+            crate::completion::CompletionOutcome::CompletedWithoutResult => {}
+            other => panic!("expected preserved input completion, got {other:?}"),
+        }
+
+        let rebound = machine
+            .session_dsl_state(session_id)
+            .await
+            .expect("rebound session authority exists");
+        assert_eq!(rebound.lifecycle_phase, mm_dsl::MeerkatPhase::Attached);
+        assert_eq!(
+            rebound.registration_phase,
+            mm_dsl::RegistrationPhase::Active
+        );
+        assert!(
+            matches!(&rebound.active_runtime_id, Some(value) if value.0 == replacement_runtime_id)
+        );
+        assert_eq!(
+            rebound.active_fence_token,
+            Some(mm_dsl::FenceToken(replacement_fence_token))
+        );
+        assert_eq!(
+            rebound.active_runtime_generation,
+            Some(mm_dsl::Generation(replacement_generation))
+        );
+        assert_eq!(
+            rebound.active_runtime_epoch_id, None,
+            "the composition route does not project a runtime epoch id"
+        );
+    }
+
+    fn assert_input_spine_preserved(
+        before: &crate::meerkat_machine_types::MeerkatInputsSnapshot,
+        after: &crate::meerkat_machine_types::MeerkatInputsSnapshot,
+    ) {
+        assert_eq!(after.queue, before.queue);
+        assert_eq!(after.steer_queue, before.steer_queue);
+        assert_eq!(after.current_run_id, before.current_run_id);
+        assert_eq!(
+            after.current_run_contributors,
+            before.current_run_contributors
+        );
+        assert_eq!(after.post_admission_signal, before.post_admission_signal);
+        assert_eq!(
+            after.silent_intent_overrides,
+            before.silent_intent_overrides
+        );
+        assert_eq!(after.admission_order.len(), before.admission_order.len());
+        for (after_input, before_input) in after.admission_order.iter().zip(&before.admission_order)
+        {
+            assert_eq!(after_input.input_id, before_input.input_id);
+            assert_eq!(after_input.content_shape, before_input.content_shape);
+            assert_eq!(after_input.request_id, before_input.request_id);
+            assert_eq!(after_input.reservation_key, before_input.reservation_key);
+            assert_eq!(after_input.handling_mode, before_input.handling_mode);
+            assert_eq!(
+                after_input.live_interrupt_required,
+                before_input.live_interrupt_required
+            );
+            assert_eq!(after_input.lifecycle, before_input.lifecycle);
+            assert_eq!(after_input.terminal_outcome, before_input.terminal_outcome);
+            assert_eq!(after_input.last_run_id, before_input.last_run_id);
+            assert_eq!(
+                after_input.last_boundary_sequence,
+                before_input.last_boundary_sequence
+            );
+            assert_eq!(after_input.is_prompt, before_input.is_prompt);
+        }
     }
 
     async fn bind_runtime(
@@ -906,6 +1214,553 @@ mod tests {
                 Some(mm_dsl::FenceToken(13))
             ));
         }
+    }
+
+    #[tokio::test]
+    async fn v3_idle_stale_binding_is_redriven_before_routed_revival_rebinds() {
+        let store = Arc::new(crate::store::InMemoryRuntimeStore::new());
+        let runtime_store: Arc<dyn crate::store::RuntimeStore> = store.clone();
+        let session_id = sid("00000000-0000-0000-0000-000000000034");
+        let runtime_id = MeerkatMachine::logical_runtime_id(&session_id);
+
+        crate::store::RuntimeStore::commit_machine_lifecycle(
+            store.as_ref(),
+            &runtime_id,
+            crate::store::MachineLifecycleCommit::new_with_binding(
+                crate::RuntimeState::Idle,
+                crate::store::MachineLifecycleBindingFacts::new(
+                    Some("stale-mob-runtime:7".into()),
+                    Some(41),
+                    Some(7),
+                    Some("stale-runtime-epoch".into()),
+                ),
+                crate::store::SupervisorAuthoritySnapshot::UnboundNoReceipt,
+            ),
+            &[],
+        )
+        .await
+        .expect("seed idle lifecycle with the interrupted epoch's binding tuple");
+
+        let encoded =
+            crate::store::RuntimeStore::load_machine_lifecycle_record(store.as_ref(), &runtime_id)
+                .await
+                .expect("load seeded lifecycle record")
+                .expect("seeded lifecycle record exists");
+        let encoded: serde_json::Value =
+            serde_json::from_slice(&encoded).expect("lifecycle record is JSON");
+        assert_eq!(
+            encoded["record_version"], 3,
+            "the regression fixture must exercise the field's V3 durable shape"
+        );
+
+        let machine = Arc::new(MeerkatMachine::persistent(
+            runtime_store,
+            Arc::new(meerkat_store::MemoryBlobStore::new()),
+        ));
+        let signal_surface = Arc::new(RecordingSignalSurface::default());
+        let schema = meerkat_machine_schema::catalog::meerkat_mob_seam_composition();
+        let table = RouteTable::from_schema(&schema).expect("catalog routes");
+        let dispatcher: CatalogCompositionSignalDispatcher<MeerkatSeamSignal> =
+            CatalogCompositionSignalDispatcher::new(schema.name.clone(), table)
+                .with_consumer(signal_surface.clone());
+        machine.set_composition_signal_dispatcher(Arc::new(dispatcher));
+
+        machine
+            .prepare_local_session_bindings(session_id.clone())
+            .await
+            .expect("delivery-time local preparation recovers the idle runtime");
+
+        let recovered = machine
+            .session_dsl_state(&session_id)
+            .await
+            .expect("recovered session authority exists");
+        assert_eq!(recovered.lifecycle_phase, mm_dsl::MeerkatPhase::Idle);
+        assert_eq!(
+            recovered.registration_phase,
+            mm_dsl::RegistrationPhase::Queuing,
+            "V3 does not persist an executor claim, so cold recovery must queue a replacement"
+        );
+        assert!(
+            matches!(&recovered.active_runtime_id, Some(value) if value.0 == "stale-mob-runtime:7")
+        );
+        assert_eq!(recovered.active_fence_token, Some(mm_dsl::FenceToken(41)));
+        assert_eq!(
+            recovered.active_runtime_generation,
+            Some(mm_dsl::Generation(7))
+        );
+        assert!(
+            matches!(&recovered.active_runtime_epoch_id, Some(value) if value.0 == "stale-runtime-epoch")
+        );
+        assert!(
+            signal_surface.log.lock().await.is_empty(),
+            "local resource recovery must not publish stale runtime readiness"
+        );
+
+        let queued_input = crate::input::Input::Prompt(crate::input::PromptInput::new(
+            "durable work queued before missing-executor revival redrive",
+            None,
+        ));
+        let queued_input_id = queued_input.id().clone();
+        let (outcome, completion) = machine
+            .accept_input_with_completion(&session_id, queued_input)
+            .await
+            .expect("queue durable work before delivery-time redrive");
+        assert!(outcome.is_accepted());
+        let completion = completion.expect("queued durable work installs a completion waiter");
+        let durable_before =
+            crate::store::RuntimeStore::load_input_states(store.as_ref(), &runtime_id)
+                .await
+                .expect("load queued durable work before redrive");
+        assert_eq!(durable_before.len(), 1);
+        assert_eq!(durable_before[0].state.input_id, queued_input_id);
+        assert_eq!(
+            durable_before[0].seed.phase,
+            crate::input_state::InputLifecycleState::Queued
+        );
+        let spine_before_redrive = machine
+            .meerkat_machine_spine_snapshot(&session_id)
+            .await
+            .expect("runtime spine exists before redrive");
+        assert_eq!(
+            spine_before_redrive.inputs.queue,
+            vec![queued_input_id.clone()]
+        );
+
+        machine
+            .redrive_missing_executor_for_revival(&session_id, machine.session_control_authority())
+            .await
+            .expect("capability-gated redrive repairs the missing executor epoch");
+
+        let redriven = machine
+            .session_dsl_state(&session_id)
+            .await
+            .expect("redriven revival authority exists");
+        assert_eq!(redriven.lifecycle_phase, mm_dsl::MeerkatPhase::Idle);
+        assert_eq!(
+            redriven.registration_phase,
+            mm_dsl::RegistrationPhase::Queuing
+        );
+        assert_eq!(
+            redriven.active_runtime_id, None,
+            "redrive releases the stale runtime owner"
+        );
+        assert_eq!(
+            redriven.active_fence_token, None,
+            "redrive releases the stale fence"
+        );
+        assert_eq!(
+            redriven.active_runtime_generation, None,
+            "redrive releases the stale generation"
+        );
+        assert_eq!(
+            redriven.active_runtime_epoch_id, None,
+            "redrive releases the stale runtime epoch"
+        );
+        let after_redrive = machine
+            .meerkat_machine_spine_snapshot(&session_id)
+            .await
+            .expect("runtime spine remains available after redrive");
+        assert_input_spine_preserved(&spine_before_redrive.inputs, &after_redrive.inputs);
+        assert_eq!(
+            after_redrive.completion_waiters, spine_before_redrive.completion_waiters,
+            "typed exit/readmit must leave completion waiters verbatim"
+        );
+        let durable_after_redrive =
+            crate::store::RuntimeStore::load_input_states(store.as_ref(), &runtime_id)
+                .await
+                .expect("load queued durable work after redrive");
+        assert_eq!(durable_after_redrive.len(), 1);
+        assert_eq!(durable_after_redrive[0].state.input_id, queued_input_id);
+        assert_eq!(
+            durable_after_redrive[0].seed.phase,
+            crate::input_state::InputLifecycleState::Queued,
+            "the in-memory redrive must not terminalize or consume queued durable work"
+        );
+        assert!(
+            signal_surface.log.lock().await.is_empty(),
+            "redrive must not publish runtime readiness for the discarded stale tuple"
+        );
+
+        let (registration, allow_reconciliation) =
+            begin_startup_gated_attachment(&machine, &session_id).await;
+        let attached = machine
+            .session_dsl_state(&session_id)
+            .await
+            .expect("replacement startup authority exists");
+        assert_eq!(attached.active_runtime_id, None, "stale owner released");
+        assert_eq!(attached.active_fence_token, None, "stale fence released");
+        assert_eq!(
+            attached.active_runtime_generation, None,
+            "stale generation released"
+        );
+        assert_eq!(
+            attached.active_runtime_epoch_id, None,
+            "stale epoch released"
+        );
+        assert!(
+            signal_surface.log.lock().await.is_empty(),
+            "executor attachment alone must not publish runtime readiness"
+        );
+
+        let startup_persisted = crate::store::load_machine_lifecycle(store.as_ref(), &runtime_id)
+            .await
+            .expect("load startup-persisted healed lifecycle")
+            .expect("startup-persisted lifecycle exists");
+        assert_eq!(
+            startup_persisted.runtime_state(),
+            crate::RuntimeState::Idle,
+            "replacement startup may retain the repaired Idle lifecycle projection; the V3 binding tuple below is the required healed fact"
+        );
+        assert_eq!(startup_persisted.binding().agent_runtime_id(), None);
+        assert_eq!(startup_persisted.binding().fence_token(), None);
+        assert_eq!(startup_persisted.binding().runtime_generation(), None);
+        assert_eq!(startup_persisted.binding().runtime_epoch_id(), None);
+
+        route_replacement_and_finish_gated_attachment(
+            &machine,
+            &session_id,
+            registration,
+            allow_reconciliation,
+            completion,
+            "replacement-mob-runtime:8",
+            42,
+            8,
+        )
+        .await;
+
+        let healed_durable = crate::store::load_machine_lifecycle(store.as_ref(), &runtime_id)
+            .await
+            .expect("load healed lifecycle after replacement completion")
+            .expect("healed lifecycle exists");
+        assert_eq!(healed_durable.binding().agent_runtime_id(), None);
+        assert_eq!(healed_durable.binding().fence_token(), None);
+        assert_eq!(healed_durable.binding().runtime_generation(), None);
+        assert_eq!(healed_durable.binding().runtime_epoch_id(), None);
+
+        let log = signal_surface.log.lock().await;
+        assert_eq!(log.len(), 1, "replacement binding publishes readiness once");
+        assert_eq!(log[0].0.as_str(), "ObserveRuntimeReady");
+        assert_eq!(log[0].1[0].0.as_str(), "agent_runtime_id");
+        assert!(
+            matches!(&log[0].1[0].1, OwnedFieldValue::Str(value) if value == "replacement-mob-runtime:8")
+        );
+        assert_eq!(log[0].1[1].0.as_str(), "fence_token");
+        assert!(matches!(log[0].1[1].1, OwnedFieldValue::U64(42)));
+    }
+
+    #[tokio::test]
+    async fn ownerless_attached_claim_is_redriven_in_place_after_local_preparation() {
+        let machine = Arc::new(MeerkatMachine::ephemeral());
+        let session_id = sid("00000000-0000-0000-0000-000000000035");
+        let signal_surface = Arc::new(RecordingSignalSurface::default());
+        let schema = meerkat_machine_schema::catalog::meerkat_mob_seam_composition();
+        let table = RouteTable::from_schema(&schema).expect("catalog routes");
+        let dispatcher: CatalogCompositionSignalDispatcher<MeerkatSeamSignal> =
+            CatalogCompositionSignalDispatcher::new(schema.name.clone(), table)
+                .with_consumer(signal_surface.clone());
+        machine.set_composition_signal_dispatcher(Arc::new(dispatcher));
+
+        machine
+            .prepare_local_session_bindings(session_id.clone())
+            .await
+            .expect("prepare the original in-process session entry");
+        let queued_input = crate::input::Input::Prompt(crate::input::PromptInput::new(
+            "queued work survives an ownerless in-process executor claim",
+            None,
+        ));
+        let queued_input_id = queued_input.id().clone();
+        let (outcome, completion) = machine
+            .accept_input_with_completion(&session_id, queued_input)
+            .await
+            .expect("queue work before manufacturing the ownerless claim");
+        assert!(outcome.is_accepted());
+        let completion = completion.expect("queued work installs a completion waiter");
+
+        let (driver_before, authority_before, epoch_before) = {
+            let sessions = machine.sessions.read().await;
+            let entry = sessions.get(&session_id).expect("session entry exists");
+            (
+                entry.driver.clone(),
+                Arc::clone(&entry.dsl_authority),
+                entry.epoch_id.clone(),
+            )
+        };
+
+        // Manufacture the exact limbo shape on this live entry: generated
+        // Attached/Active authority with all stale binding facts, but no
+        // runtime-loop attachment or teardown owner. No recovery or entry
+        // reconstruction participates in this fixture.
+        machine
+            .stage_session_dsl_input(
+                &session_id,
+                mm_dsl::MeerkatMachineInput::PrepareBindings {
+                    agent_runtime_id: mm_dsl::AgentRuntimeId(
+                        "ownerless-stale-mob-runtime:9".into(),
+                    ),
+                    fence_token: mm_dsl::FenceToken(51),
+                    generation: Some(mm_dsl::Generation(9)),
+                    runtime_epoch_id: Some(mm_dsl::RuntimeEpochId(
+                        "ownerless-stale-runtime-epoch".into(),
+                    )),
+                    session_id: mm_dsl::SessionId(session_id.to_string()),
+                },
+                "OwnerlessAttachedRegressionBinding",
+            )
+            .await
+            .expect("stage the stale binding tuple on the same session entry");
+        machine
+            .stage_session_dsl_input(
+                &session_id,
+                mm_dsl::MeerkatMachineInput::EnsureSessionWithExecutor {
+                    session_id: mm_dsl::SessionId(session_id.to_string()),
+                },
+                "OwnerlessAttachedRegressionClaim",
+            )
+            .await
+            .expect("stage the ownerless active executor claim");
+        {
+            let mut driver = driver_before.lock().await;
+            driver.sync_control_projection_from_dsl_authority();
+        }
+
+        let ownerless = machine
+            .session_dsl_state(&session_id)
+            .await
+            .expect("ownerless authority exists");
+        assert_eq!(ownerless.lifecycle_phase, mm_dsl::MeerkatPhase::Attached);
+        assert_eq!(
+            ownerless.registration_phase,
+            mm_dsl::RegistrationPhase::Active
+        );
+        assert!(
+            matches!(&ownerless.active_runtime_id, Some(value) if value.0 == "ownerless-stale-mob-runtime:9")
+        );
+        assert_eq!(ownerless.active_fence_token, Some(mm_dsl::FenceToken(51)));
+        assert_eq!(
+            ownerless.active_runtime_generation,
+            Some(mm_dsl::Generation(9))
+        );
+        assert!(
+            matches!(&ownerless.active_runtime_epoch_id, Some(value) if value.0 == "ownerless-stale-runtime-epoch")
+        );
+        {
+            let sessions = machine.sessions.read().await;
+            let entry = sessions.get(&session_id).expect("ownerless entry exists");
+            assert!(
+                !entry.has_live_attachment(),
+                "completed exact stop cleanup must leave no live executor"
+            );
+            assert!(entry.runtime_loop_teardown.is_none());
+        }
+
+        machine
+            .prepare_local_session_bindings(session_id.clone())
+            .await
+            .expect("real delivery-time preparation revisits the same ownerless entry");
+        let prepared_ownerless = machine
+            .session_dsl_state(&session_id)
+            .await
+            .expect("locally prepared ownerless authority exists");
+        assert!(
+            matches!(
+                prepared_ownerless.lifecycle_phase,
+                mm_dsl::MeerkatPhase::Idle | mm_dsl::MeerkatPhase::Attached
+            ),
+            "same-instance local preparation may preserve Attached or normalize to Idle; redrive owns both orphaned Active shapes"
+        );
+        assert_eq!(
+            prepared_ownerless.registration_phase,
+            mm_dsl::RegistrationPhase::Active,
+            "the limbo'd executor claim remains active until the explicit redrive"
+        );
+        assert!(
+            matches!(&prepared_ownerless.active_runtime_id, Some(value) if value.0 == "ownerless-stale-mob-runtime:9")
+        );
+        assert_eq!(
+            prepared_ownerless.active_fence_token,
+            Some(mm_dsl::FenceToken(51))
+        );
+        assert_eq!(
+            prepared_ownerless.active_runtime_generation,
+            Some(mm_dsl::Generation(9))
+        );
+        assert!(
+            matches!(&prepared_ownerless.active_runtime_epoch_id, Some(value) if value.0 == "ownerless-stale-runtime-epoch")
+        );
+
+        let before_redrive = machine
+            .meerkat_machine_spine_snapshot(&session_id)
+            .await
+            .expect("ownerless runtime spine exists before redrive");
+        assert_eq!(before_redrive.inputs.queue, vec![queued_input_id.clone()]);
+        machine
+            .redrive_missing_executor_for_revival(&session_id, machine.session_control_authority())
+            .await
+            .expect("redrive repairs the locally prepared ownerless active claim");
+
+        let redriven = machine
+            .session_dsl_state(&session_id)
+            .await
+            .expect("redriven ownerless authority exists");
+        assert_eq!(redriven.lifecycle_phase, mm_dsl::MeerkatPhase::Idle);
+        assert_eq!(
+            redriven.registration_phase,
+            mm_dsl::RegistrationPhase::Queuing
+        );
+        assert_eq!(redriven.active_runtime_id, None);
+        assert_eq!(redriven.active_fence_token, None);
+        assert_eq!(redriven.active_runtime_generation, None);
+        assert_eq!(redriven.active_runtime_epoch_id, None);
+        let after_redrive = machine
+            .meerkat_machine_spine_snapshot(&session_id)
+            .await
+            .expect("ownerless runtime spine survives redrive");
+        assert_input_spine_preserved(&before_redrive.inputs, &after_redrive.inputs);
+        assert_eq!(
+            after_redrive.completion_waiters, before_redrive.completion_waiters,
+            "same-instance exit/readmit must leave completion waiters verbatim"
+        );
+        {
+            let sessions = machine.sessions.read().await;
+            let entry = sessions
+                .get(&session_id)
+                .expect("same entry survives redrive");
+            assert!(Arc::ptr_eq(&driver_before, &entry.driver));
+            assert!(Arc::ptr_eq(&authority_before, &entry.dsl_authority));
+            assert_eq!(entry.epoch_id, epoch_before);
+            assert!(
+                !entry.has_live_attachment(),
+                "completed exact stop cleanup must leave no live executor"
+            );
+            assert!(entry.runtime_loop_teardown.is_none());
+        }
+        assert!(
+            signal_surface.log.lock().await.is_empty(),
+            "fixture staging and redrive must not publish stale runtime readiness"
+        );
+
+        let (registration, allow_reconciliation) =
+            begin_startup_gated_attachment(&machine, &session_id).await;
+        route_replacement_and_finish_gated_attachment(
+            &machine,
+            &session_id,
+            registration,
+            allow_reconciliation,
+            completion,
+            "ownerless-replacement-mob-runtime:10",
+            52,
+            10,
+        )
+        .await;
+
+        let log = signal_surface.log.lock().await;
+        assert_eq!(log.len(), 1, "replacement binding publishes readiness once");
+        assert_eq!(log[0].0.as_str(), "ObserveRuntimeReady");
+        assert!(
+            matches!(&log[0].1[0].1, OwnedFieldValue::Str(value) if value == "ownerless-replacement-mob-runtime:10")
+        );
+        assert!(matches!(log[0].1[1].1, OwnedFieldValue::U64(52)));
+    }
+
+    #[tokio::test]
+    async fn completed_stop_cleanup_after_idle_preparation_does_not_block_redrive() {
+        let machine = Arc::new(MeerkatMachine::ephemeral());
+        let session_id = sid("00000000-0000-0000-0000-000000000036");
+        machine
+            .prepare_local_session_bindings(session_id.clone())
+            .await
+            .expect("prepare the original session entry");
+        machine
+            .ensure_session_with_executor(session_id.clone(), Box::new(NoopExecutor))
+            .await
+            .expect("attach the exact executor that will own stop cleanup");
+        machine
+            .stop_runtime_executor(&session_id, "completed cleanup regression")
+            .await
+            .expect("exact executor stop cleanup completes");
+
+        let stopped = machine
+            .session_dsl_state(&session_id)
+            .await
+            .expect("stopped authority remains registered");
+        assert_eq!(stopped.lifecycle_phase, mm_dsl::MeerkatPhase::Stopped);
+        {
+            let sessions = machine.sessions.read().await;
+            let entry = sessions.get(&session_id).expect("stopped entry remains");
+            let coordinator = entry
+                .runtime_stop_cleanup_coordinator
+                .as_ref()
+                .expect("completed exact cleanup receipt remains attached to the epoch");
+            assert!(matches!(
+                coordinator.result_rx.borrow().clone(),
+                Some(Ok(()))
+            ));
+            assert!(
+                !entry.has_live_attachment(),
+                "completed exact stop cleanup must leave no live executor"
+            );
+        }
+
+        // Re-admit first, as the delivery path can do before its later local
+        // bindings preparation. The subsequent idempotent preparation must
+        // not turn the completed cleanup receipt into an in-progress owner.
+        machine
+            .stage_session_dsl_input(
+                &session_id,
+                mm_dsl::MeerkatMachineInput::RegisterSession {
+                    session_id: mm_dsl::SessionId(session_id.to_string()),
+                },
+                "CompletedStopRegressionReadmit",
+            )
+            .await
+            .expect("re-admit the stopped session without recreating its entry");
+        machine
+            .prepare_local_session_bindings(session_id.clone())
+            .await
+            .expect("local preparation preserves the re-admitted session");
+
+        let prepared = machine
+            .session_dsl_state(&session_id)
+            .await
+            .expect("prepared re-admitted authority exists");
+        assert_eq!(prepared.lifecycle_phase, mm_dsl::MeerkatPhase::Idle);
+        assert_eq!(
+            prepared.registration_phase,
+            mm_dsl::RegistrationPhase::Queuing
+        );
+        {
+            let sessions = machine.sessions.read().await;
+            let entry = sessions
+                .get(&session_id)
+                .expect("prepared entry remains registered");
+            assert!(
+                entry.runtime_stop_cleanup_coordinator.is_none(),
+                "local preparation must retire the completed exact cleanup receipt"
+            );
+        }
+
+        machine
+            .redrive_missing_executor_for_revival(&session_id, machine.session_control_authority())
+            .await
+            .expect(
+                "redrive retires completed cleanup ownership instead of reporting stop in progress",
+            );
+
+        let redriven = machine
+            .session_dsl_state(&session_id)
+            .await
+            .expect("redriven authority exists");
+        assert_eq!(redriven.lifecycle_phase, mm_dsl::MeerkatPhase::Idle);
+        assert_eq!(
+            redriven.registration_phase,
+            mm_dsl::RegistrationPhase::Queuing
+        );
+        let sessions = machine.sessions.read().await;
+        let entry = sessions
+            .get(&session_id)
+            .expect("redriven session remains registered");
+        assert!(entry.runtime_stop_cleanup_coordinator.is_none());
+        assert!(entry.runtime_loop_teardown.is_none());
     }
 
     #[tokio::test]

--- a/meerkat-runtime/src/meerkat_machine/dsl_effects.rs
+++ b/meerkat-runtime/src/meerkat_machine/dsl_effects.rs
@@ -94,6 +94,16 @@ impl MeerkatMachine {
         authority: &crate::driver::ephemeral::SharedIngressDslAuthority,
         input: MeerkatMachineFieldlessRuntimeInternalInput,
     ) -> Result<StagedSessionDslInput, String> {
+        let mut authority = authority
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        Self::stage_runtime_owner_dsl_transition_on_locked_authority(&mut authority, input)
+    }
+
+    pub(super) fn stage_runtime_owner_dsl_transition_on_locked_authority(
+        authority: &mut dsl::MeerkatMachineAuthority,
+        input: MeerkatMachineFieldlessRuntimeInternalInput,
+    ) -> Result<StagedSessionDslInput, String> {
         let variant = input.input_variant();
         if !canonical_meerkat_machine_runtime_internal_input_variant_manifest().contains(&variant) {
             return Err(format!(
@@ -115,7 +125,7 @@ impl MeerkatMachine {
                 input.authority()
             ));
         }
-        Self::stage_dsl_transition_on_authority_after_typed_gate(
+        Self::stage_dsl_transition_on_locked_authority_after_typed_gate(
             authority,
             input.dsl_input(),
             variant.as_str(),
@@ -161,6 +171,19 @@ impl MeerkatMachine {
         Self::stage_dsl_transition_on_authority_after_typed_gate(authority, input, context)
     }
 
+    /// Stage a transition while the caller retains the shared authority's
+    /// synchronous mutex. This is reserved for no-await publication handoffs
+    /// that must prevent session-owned handles from interleaving between a
+    /// generated claim and its exact shell attachment.
+    pub(super) fn stage_dsl_transition_on_locked_authority(
+        authority: &mut dsl::MeerkatMachineAuthority,
+        input: dsl::MeerkatMachineInput,
+        context: &str,
+    ) -> Result<StagedSessionDslInput, String> {
+        Self::reject_raw_fieldless_runtime_internal_dsl_input(&input)?;
+        Self::stage_dsl_transition_on_locked_authority_after_typed_gate(authority, input, context)
+    }
+
     fn stage_dsl_transition_on_authority_after_typed_gate(
         authority: &crate::driver::ephemeral::SharedIngressDslAuthority,
         input: dsl::MeerkatMachineInput,
@@ -169,8 +192,20 @@ impl MeerkatMachine {
         let mut authority = authority
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner);
+        Self::stage_dsl_transition_on_locked_authority_after_typed_gate(
+            &mut authority,
+            input,
+            context,
+        )
+    }
+
+    fn stage_dsl_transition_on_locked_authority_after_typed_gate(
+        authority: &mut dsl::MeerkatMachineAuthority,
+        input: dsl::MeerkatMachineInput,
+        context: &str,
+    ) -> Result<StagedSessionDslInput, String> {
         let previous_snapshot = authority.snapshot();
-        let effects = dsl::MeerkatMachineMutator::apply(&mut *authority, input)
+        let effects = dsl::MeerkatMachineMutator::apply(authority, input)
             .map(|transition| DslTransitionEffects::new(transition.into_effects()))
             .map_err(|err| dsl_authority::map_error(err, context))?;
         let committed_snapshot = authority.snapshot();

--- a/meerkat-runtime/src/meerkat_machine/mod.rs
+++ b/meerkat-runtime/src/meerkat_machine/mod.rs
@@ -1070,6 +1070,52 @@ impl StagedSessionDslInput {
     }
 }
 
+/// Panic-safe owner for an executor-registration claim staged while the
+/// caller holds the shared authority mutex. There are no await points between
+/// construction and exact attachment publication, and session-owned handles
+/// cannot interleave because the mutex remains held. Drop restores directly
+/// through that locked authority until publication disarms the claim.
+#[must_use = "an unpublished executor claim must be rolled back or transferred to an attachment"]
+struct PendingExecutorRegistrationClaim<'a> {
+    authority: &'a mut dsl::MeerkatMachineAuthority,
+    previous_snapshot: Option<dsl::MeerkatMachineAuthoritySnapshot>,
+}
+
+impl<'a> PendingExecutorRegistrationClaim<'a> {
+    fn new(
+        authority: &'a mut dsl::MeerkatMachineAuthority,
+        staged: StagedSessionDslInput,
+    ) -> Result<(Self, bool), RuntimeDriverError> {
+        if staged.has_routed_signal_effect() {
+            authority.restore_snapshot(staged.previous_snapshot);
+            return Err(RuntimeDriverError::Internal(
+                "executor-registration claim unexpectedly carried a routed signal effect".into(),
+            ));
+        }
+        let revived_stopped_session = staged.revived_stopped_session();
+        Ok((
+            Self {
+                authority,
+                previous_snapshot: Some(staged.previous_snapshot),
+            },
+            revived_stopped_session,
+        ))
+    }
+
+    fn transfer_to_attachment(mut self, _published: RuntimeLoopAttachmentPublished) {
+        self.previous_snapshot = None;
+    }
+}
+
+impl Drop for PendingExecutorRegistrationClaim<'_> {
+    fn drop(&mut self) {
+        let Some(previous_snapshot) = self.previous_snapshot.take() else {
+            return;
+        };
+        self.authority.restore_snapshot(previous_snapshot);
+    }
+}
+
 #[derive(Clone, Copy)]
 enum CommittedEffectDispatchFailure {
     PreserveCommittedDslState,
@@ -1218,6 +1264,11 @@ struct RuntimeSessionEntry {
     /// Current epoch's single ordinary-stop cleanup owner. Unlike unregister,
     /// its successful terminal leaves this registration in generated Stopped.
     runtime_stop_cleanup_coordinator: Option<RuntimeStopCleanupCoordinator>,
+    /// A missing-executor re-drive repaired live authority while durable
+    /// publication belongs to the next exact loop owner.
+    /// Retaining this for the epoch makes every replacement retry persist the
+    /// repaired lifecycle before it reports startup ready.
+    pending_revival_lifecycle_persist: Arc<std::sync::atomic::AtomicBool>,
     /// Retry witness installed before the final generated UnregisterSession
     /// transition. If an owned saga panics after that transition changes the
     /// live projection to Queuing/session_id=None, the next saga resumes the
@@ -1263,6 +1314,11 @@ struct RuntimeLoopAttachment {
     interrupt_handle: Option<Arc<dyn meerkat_core::lifecycle::CoreExecutorInterruptHandle>>,
     loop_handle: tokio::task::JoinHandle<()>,
 }
+
+/// Proof that the exact runtime loop and its teardown handoff were installed
+/// into the authoritative session entry. Only this token can disarm an
+/// unpublished executor-registration claim.
+struct RuntimeLoopAttachmentPublished;
 
 /// Mechanical runtime-loop channel slot.
 enum RuntimeLoopAttachmentSlot {
@@ -1332,6 +1388,11 @@ impl RuntimeSessionEntry {
         }
     }
 
+    fn attachment_is_dead(&self) -> bool {
+        matches!(self.attachment_slot, RuntimeLoopAttachmentSlot::Attached(_))
+            && !self.attachment_is_live()
+    }
+
     fn generated_executor_registration_active(&self) -> bool {
         let authority = self
             .dsl_authority
@@ -1344,11 +1405,7 @@ impl RuntimeSessionEntry {
     }
 
     fn generated_executor_registration_has_viable_attachment(&self) -> bool {
-        self.generated_executor_registration_active()
-            && match &self.attachment_slot {
-                RuntimeLoopAttachmentSlot::Empty => true,
-                RuntimeLoopAttachmentSlot::Attached(_) => self.attachment_is_live(),
-            }
+        self.generated_executor_registration_active() && self.attachment_is_live()
     }
 
     fn close_handle_teardown_gate(&self) {
@@ -1377,32 +1434,23 @@ impl RuntimeSessionEntry {
         )
     }
 
-    fn generated_stop_deferred(&self) -> bool {
-        self.dsl_authority
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner)
-            .state()
-            .runtime_stop_deferred
-    }
-
-    fn stage_generated_executor_registration_claim(
-        &self,
+    fn stage_generated_executor_registration_claim_locked(
+        authority: &mut dsl::MeerkatMachineAuthority,
         session_id: &SessionId,
     ) -> Result<StagedSessionDslInput, String> {
-        let staged = MeerkatMachine::stage_dsl_transition_on_authority(
-            &self.dsl_authority,
+        let staged = MeerkatMachine::stage_dsl_transition_on_locked_authority(
+            authority,
             dsl::MeerkatMachineInput::EnsureSessionWithExecutor {
                 session_id: dsl::SessionId::from_domain(session_id),
             },
             "EnsureSessionWithExecutor",
         )?;
-        if self.generated_executor_registration_active() {
+        if matches!(
+            authority.state().registration_phase,
+            dsl::RegistrationPhase::Active
+        ) {
             Ok(staged)
         } else {
-            let mut authority = self
-                .dsl_authority
-                .lock()
-                .unwrap_or_else(std::sync::PoisonError::into_inner);
             authority.restore_snapshot(staged.previous_snapshot);
             Err("generated MeerkatMachine did not grant active executor registration".into())
         }
@@ -1428,7 +1476,7 @@ impl RuntimeSessionEntry {
         boundary_handle: Option<Arc<dyn meerkat_core::lifecycle::CoreExecutorBoundaryHandle>>,
         interrupt_handle: Option<Arc<dyn meerkat_core::lifecycle::CoreExecutorInterruptHandle>>,
         spawned_loop: crate::runtime_loop::SpawnedRuntimeLoop,
-    ) {
+    ) -> RuntimeLoopAttachmentPublished {
         let crate::runtime_loop::SpawnedRuntimeLoop {
             loop_handle,
             teardown_slot,
@@ -1447,6 +1495,7 @@ impl RuntimeSessionEntry {
             interrupt_handle,
             loop_handle,
         });
+        RuntimeLoopAttachmentPublished
     }
 
     /// Detach the runtime-loop channels, returning the loop's `JoinHandle` so a
@@ -1477,28 +1526,50 @@ impl RuntimeSessionEntry {
         &mut self,
         session_id: &SessionId,
     ) -> Result<(), RuntimeDriverError> {
-        if !matches!(self.attachment_slot, RuntimeLoopAttachmentSlot::Empty) {
-            return Err(RuntimeDriverError::Internal(format!(
-                "revived session {session_id} still carries a runtime-loop attachment"
-            )));
-        }
         match self.runtime_stop_cleanup_coordinator.as_ref() {
-            None if self.runtime_loop_teardown.is_none() => return Ok(()),
+            None if self.runtime_loop_teardown.is_none()
+                && matches!(self.attachment_slot, RuntimeLoopAttachmentSlot::Empty) =>
+            {
+                return Ok(());
+            }
             None => {
                 return Err(RuntimeDriverError::Internal(format!(
-                    "revived session {session_id} carries a teardown slot without its stop coordinator"
+                    "revived session {session_id} carries an attachment or teardown slot without its stop coordinator"
                 )));
             }
-            Some(coordinator) => match coordinator.result_rx.borrow().clone() {
-                Some(Ok(())) => {}
-                None => {
-                    return Err(RuntimeDriverError::RuntimeStopInProgress {
-                        runtime_id: self.runtime_id.clone(),
-                    });
+            Some(coordinator) => {
+                let coordinator_slot_is_current = match (
+                    coordinator.teardown_slot.as_ref(),
+                    self.runtime_loop_teardown.as_ref(),
+                ) {
+                    (Some(coordinator_slot), Some(current_slot)) => {
+                        Arc::ptr_eq(coordinator_slot, current_slot)
+                    }
+                    (None, None) => true,
+                    _ => false,
+                };
+                if !coordinator_slot_is_current {
+                    return Err(RuntimeDriverError::Internal(format!(
+                        "revived session {session_id} carries a stale runtime-stop teardown owner"
+                    )));
                 }
-                Some(Err(error)) => return Err(error),
-            },
+                match coordinator.result_rx.borrow().clone() {
+                    Some(Ok(())) => {}
+                    None => {
+                        return Err(RuntimeDriverError::RuntimeStopInProgress {
+                            runtime_id: self.runtime_id.clone(),
+                        });
+                    }
+                    Some(Err(error)) => return Err(error),
+                }
+            }
         }
+        if self.attachment_is_live() {
+            return Err(RuntimeDriverError::Internal(format!(
+                "revived session {session_id} still carries a live runtime-loop attachment"
+            )));
+        }
+        self.attachment_slot = RuntimeLoopAttachmentSlot::Empty;
         self.runtime_stop_cleanup_coordinator = None;
         self.runtime_loop_teardown = None;
         Ok(())

--- a/meerkat-runtime/src/meerkat_machine/session_management.rs
+++ b/meerkat-runtime/src/meerkat_machine/session_management.rs
@@ -690,6 +690,7 @@ impl MeerkatMachine {
             runtime_loop_teardown: None,
             unregister_coordinator: None,
             runtime_stop_cleanup_coordinator: None,
+            pending_revival_lifecycle_persist: Arc::new(std::sync::atomic::AtomicBool::new(false)),
             pending_unregister_finalization: None,
             unregister_teardown_observations: Arc::new(
                 UnregisterTeardownMechanicalObservations::new(),
@@ -834,6 +835,7 @@ impl MeerkatMachine {
             runtime_loop_teardown: None,
             unregister_coordinator: None,
             runtime_stop_cleanup_coordinator: None,
+            pending_revival_lifecycle_persist: Arc::new(std::sync::atomic::AtomicBool::new(false)),
             pending_unregister_finalization: None,
             unregister_teardown_observations: Arc::new(
                 UnregisterTeardownMechanicalObservations::new(),
@@ -1042,6 +1044,7 @@ impl MeerkatMachine {
             runtime_loop_teardown: None,
             unregister_coordinator: None,
             runtime_stop_cleanup_coordinator: None,
+            pending_revival_lifecycle_persist: Arc::new(std::sync::atomic::AtomicBool::new(false)),
             pending_unregister_finalization: None,
             unregister_teardown_observations: recovered_teardown_observations,
             provisional_interrupt_handle: None,
@@ -1267,10 +1270,14 @@ impl MeerkatMachine {
                 completions: SharedCompletionRegistry,
                 ops_lifecycle: Arc<crate::ops_lifecycle::RuntimeOpsLifecycleRegistry>,
                 dsl_authority: Arc<std::sync::Mutex<dsl::MeerkatMachineAuthority>>,
-                staged: Box<StagedSessionDslInput>,
-                repaired_dead_attachment: bool,
+                inserted_cold_entry: bool,
                 _gate_guard: crate::tokio::sync::OwnedMutexGuard<()>,
             },
+        }
+
+        enum ExecutorPublicationError {
+            DslRejected(String),
+            Internal(RuntimeDriverError),
         }
 
         let existing = loop {
@@ -1286,39 +1293,31 @@ impl MeerkatMachine {
                 if let Some(error) = entry.registration_blocked_by_unregister(&session_id) {
                     break ExistingExecutorClaim::Blocked(error);
                 }
-                let repaired_dead_attachment = entry.clear_dead_attachment();
-                let repaired_deferred_stop =
-                    repaired_dead_attachment && entry.generated_stop_deferred();
-                if repaired_dead_attachment
-                    && !repaired_deferred_stop
-                    && let Err(reason) = entry.stage_generated_executor_exit_observation()
-                {
-                    break ExistingExecutorClaim::Rejected(reason);
-                }
-                if entry.generated_executor_registration_active() && !repaired_deferred_stop {
+                if entry.has_live_attachment() && entry.generated_executor_registration_active() {
                     break ExistingExecutorClaim::AlreadyClaimed;
                 }
                 if entry.has_live_attachment() {
-                    match entry.stage_generated_executor_registration_claim(&session_id) {
+                    let mut authority = entry
+                        .dsl_authority
+                        .lock()
+                        .unwrap_or_else(std::sync::PoisonError::into_inner);
+                    match RuntimeSessionEntry::stage_generated_executor_registration_claim_locked(
+                        &mut authority,
+                        &session_id,
+                    ) {
                         Ok(_) => break ExistingExecutorClaim::AlreadyClaimed,
                         Err(reason) => break ExistingExecutorClaim::Rejected(reason),
                     }
                 }
-                match entry.stage_generated_executor_registration_claim(&session_id) {
-                    Ok(staged) => {
-                        break ExistingExecutorClaim::Claimed {
-                            gate,
-                            driver: entry.driver.clone(),
-                            completions: entry.completions.clone(),
-                            ops_lifecycle: entry.ops_lifecycle.clone(),
-                            dsl_authority: Arc::clone(&entry.dsl_authority),
-                            staged: Box::new(staged),
-                            repaired_dead_attachment,
-                            _gate_guard: gate_guard,
-                        };
-                    }
-                    Err(reason) => break ExistingExecutorClaim::Rejected(reason),
-                }
+                break ExistingExecutorClaim::Claimed {
+                    gate,
+                    driver: entry.driver.clone(),
+                    completions: entry.completions.clone(),
+                    ops_lifecycle: entry.ops_lifecycle.clone(),
+                    dsl_authority: Arc::clone(&entry.dsl_authority),
+                    inserted_cold_entry: false,
+                    _gate_guard: gate_guard,
+                };
             }
 
             let runtime_id = Self::logical_runtime_id(&session_id);
@@ -1448,6 +1447,9 @@ impl MeerkatMachine {
                     runtime_loop_teardown: None,
                     unregister_coordinator: None,
                     runtime_stop_cleanup_coordinator: None,
+                    pending_revival_lifecycle_persist: Arc::new(
+                        std::sync::atomic::AtomicBool::new(false),
+                    ),
                     pending_unregister_finalization: None,
                     unregister_teardown_observations: recovered_teardown_observations,
                     provisional_interrupt_handle: None,
@@ -1455,29 +1457,15 @@ impl MeerkatMachine {
                     drain_slot: CommsDrainSlot::new(),
                 },
             );
-            let Some(entry) = sessions.get_mut(&session_id) else {
-                return Err(RuntimeDriverError::Internal(format!(
-                    "session {session_id} missing after executor recovery insert"
-                )));
+            break ExistingExecutorClaim::Claimed {
+                gate: mutation_gate,
+                driver,
+                completions,
+                ops_lifecycle: recovered_ops,
+                dsl_authority,
+                inserted_cold_entry: true,
+                _gate_guard: gate_guard,
             };
-            match entry.stage_generated_executor_registration_claim(&session_id) {
-                Ok(staged) => {
-                    break ExistingExecutorClaim::Claimed {
-                        gate: mutation_gate,
-                        driver,
-                        completions,
-                        ops_lifecycle: recovered_ops,
-                        dsl_authority,
-                        staged: Box::new(staged),
-                        repaired_dead_attachment: false,
-                        _gate_guard: gate_guard,
-                    };
-                }
-                Err(reason) => {
-                    sessions.remove(&session_id);
-                    break ExistingExecutorClaim::Rejected(reason);
-                }
-            }
         };
 
         let (
@@ -1485,9 +1473,8 @@ impl MeerkatMachine {
             completions,
             ops_lifecycle,
             dsl_authority,
-            staged_registration,
-            repaired_dead_attachment,
             registration_gate,
+            inserted_cold_entry,
             _gate_guard,
         ) = match existing {
             ExistingExecutorClaim::AlreadyClaimed => {
@@ -1512,39 +1499,21 @@ impl MeerkatMachine {
                 completions,
                 ops_lifecycle,
                 dsl_authority,
-                staged,
-                repaired_dead_attachment,
+                inserted_cold_entry,
                 _gate_guard,
             } => (
                 driver,
                 completions,
                 ops_lifecycle,
                 dsl_authority,
-                staged,
-                repaired_dead_attachment,
                 gate,
+                inserted_cold_entry,
                 _gate_guard,
             ),
         };
 
         let should_wake = {
-            let mut driver_guard = driver.lock().await;
-            driver_guard.sync_control_projection_from_dsl_authority();
-            if repaired_dead_attachment {
-                tracing::warn!(
-                    %session_id,
-                    "runtime driver registration was repaired by generated executor authority; publishing attachment"
-                );
-            }
-            if staged_registration.revived_stopped_session() {
-                // Machine-emitted revival (`EnsureSessionWithExecutorStopped`
-                // re-admitted a stopped session to Attached): refresh the
-                // durable lifecycle record so cross-process readers never
-                // observe a stale `Stopped` snapshot for a revived session.
-                driver_guard
-                    .persist_current_machine_lifecycle("resume")
-                    .await?;
-            }
+            let driver_guard = driver.lock().await;
             !driver_guard.as_driver().active_input_ids().is_empty()
         };
 
@@ -1598,84 +1567,197 @@ impl MeerkatMachine {
                 .get(&session_id)
                 .map(|e| Arc::clone(&e.cursor_state))
         };
-        let mut pending_loop = Some(crate::runtime_loop::spawn_runtime_loop_with_completions(
-            driver.clone(),
-            executor,
-            wake_rx,
-            effect_rx,
-            Some(completions.clone()),
-            Some(completion_feed),
-            Some(Arc::clone(&ops_lifecycle) as Arc<dyn meerkat_core::OpsLifecycleRegistry>),
-            entry_cursor_state,
-            Arc::downgrade(self),
-            session_id.clone(),
-        ));
-        let startup = pending_loop
-            .as_ref()
-            .map(crate::runtime_loop::SpawnedRuntimeLoop::startup_slot)
-            .ok_or_else(|| {
-                RuntimeDriverError::Internal("runtime loop startup handle missing".into())
-            })?;
-
-        let (published, detach_after_abort) = {
+        // Spawn, publish the exact teardown/attachment handoff, and transfer
+        // the generated claim inside one session-map critical section. There
+        // is deliberately no await between spawning the task and installing
+        // its watcher-visible teardown slot.
+        let publication = 'publication: {
             let mut sessions = self.sessions.write().await;
-            match sessions.get_mut(&session_id) {
-                None => (false, true),
-                Some(entry) => {
-                    entry.clear_dead_attachment();
-                    if entry.has_live_attachment() {
-                        (false, false)
-                    } else if !Arc::ptr_eq(&entry.mutation_gate, &registration_gate)
-                        || !Arc::ptr_eq(&entry.dsl_authority, &dsl_authority)
-                        || !Arc::ptr_eq(&entry.driver, &driver)
-                        || !Arc::ptr_eq(&entry.completions, &completions)
-                    {
-                        tracing::warn!(
-                            %session_id,
-                            "runtime session entry changed while wiring executor; aborting stale loop attachment"
-                        );
-                        (false, true)
-                    } else {
-                        match pending_loop.take() {
-                            Some(spawned_loop) => {
-                                entry.attach_runtime_loop(
-                                    wake_tx.clone(),
-                                    effect_tx,
-                                    boundary_handle,
-                                    interrupt_handle,
-                                    spawned_loop,
-                                );
-                                (true, false)
-                            }
-                            None => {
-                                tracing::error!(
-                                    %session_id,
-                                    "runtime loop handle missing during attachment publish"
-                                );
-                                (false, true)
-                            }
-                        }
-                    }
-                }
+            let entry = sessions.get_mut(&session_id).ok_or_else(|| {
+                RuntimeDriverError::Internal(format!(
+                    "session {session_id} disappeared while wiring executor"
+                ))
+            })?;
+            if let Some(error) = entry.registration_blocked_by_unregister(&session_id) {
+                return Err(error);
             }
-        };
-
-        if !published {
-            if let Some(spawned_loop) = pending_loop.take() {
-                spawned_loop.loop_handle.abort();
+            if entry.runtime_stop_cleanup_coordinator.is_some() {
+                entry.retire_completed_runtime_stop_after_revival(&session_id)?;
             }
-            if detach_after_abort {
-                Self::restore_dsl_authority_snapshot(
-                    &dsl_authority,
-                    staged_registration.previous_snapshot,
+            if entry.attachment_is_dead() {
+                return Err(RuntimeDriverError::RuntimeStopInProgress {
+                    runtime_id: entry.runtime_id.clone(),
+                });
+            }
+            if !matches!(entry.attachment_slot, RuntimeLoopAttachmentSlot::Empty)
+                || entry.runtime_loop_teardown.is_some()
+                || !Arc::ptr_eq(&entry.mutation_gate, &registration_gate)
+                || !Arc::ptr_eq(&entry.dsl_authority, &dsl_authority)
+                || !Arc::ptr_eq(&entry.driver, &driver)
+                || !Arc::ptr_eq(&entry.completions, &completions)
+            {
+                tracing::warn!(
+                    %session_id,
+                    "runtime session entry changed while wiring executor; refusing stale loop attachment"
                 );
-                let mut driver_guard = driver.lock().await;
-                driver_guard.sync_control_projection_from_dsl_authority();
                 return Err(RuntimeDriverError::Internal(
                     "runtime session entry changed while wiring executor".into(),
                 ));
             }
-            return Ok(());
+            let mut authority = dsl_authority
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            let repaired_ownerless_claim = matches!(
+                (
+                    authority.state().lifecycle_phase,
+                    authority.state().registration_phase,
+                    authority.state().current_run_id.as_ref(),
+                ),
+                (
+                    dsl::MeerkatPhase::Idle | dsl::MeerkatPhase::Attached,
+                    dsl::RegistrationPhase::Active,
+                    None,
+                )
+            );
+            if repaired_ownerless_claim {
+                let exited = Self::stage_runtime_owner_dsl_transition_on_locked_authority(
+                    &mut authority,
+                    crate::meerkat_machine_types::MeerkatMachineFieldlessRuntimeInternalInput::RuntimeExecutorExited,
+                )
+                .map_err(RuntimeDriverError::Internal)?;
+                if exited.has_routed_signal_effect() {
+                    authority.restore_snapshot(exited.previous_snapshot);
+                    return Err(RuntimeDriverError::Internal(
+                        "ownerless executor-exit repair unexpectedly emitted a routed signal"
+                            .into(),
+                    ));
+                }
+                let readmitted = Self::stage_dsl_transition_on_locked_authority(
+                    &mut authority,
+                    dsl::MeerkatMachineInput::RegisterSession {
+                        session_id: dsl::SessionId::from_domain(&session_id),
+                    },
+                    "OwnerlessExecutorClaimReadmit",
+                )
+                .map_err(RuntimeDriverError::Internal)?;
+                if readmitted.has_routed_signal_effect() {
+                    authority.restore_snapshot(readmitted.previous_snapshot);
+                    authority.restore_snapshot(exited.previous_snapshot);
+                    return Err(RuntimeDriverError::Internal(
+                        "ownerless executor readmission unexpectedly emitted a routed signal"
+                            .into(),
+                    ));
+                }
+                entry
+                    .pending_revival_lifecycle_persist
+                    .store(true, std::sync::atomic::Ordering::Release);
+            }
+            let staged_registration =
+                match RuntimeSessionEntry::stage_generated_executor_registration_claim_locked(
+                    &mut authority,
+                    &session_id,
+                ) {
+                    Ok(staged) => staged,
+                    Err(reason) => {
+                        break 'publication Err(ExecutorPublicationError::DslRejected(reason));
+                    }
+                };
+            let (pending_registration, revived_stopped_session) =
+                match PendingExecutorRegistrationClaim::new(&mut authority, staged_registration) {
+                    Ok(claim) => claim,
+                    Err(error) => {
+                        break 'publication Err(ExecutorPublicationError::Internal(error));
+                    }
+                };
+            let persist_revival_lifecycle = revived_stopped_session
+                || repaired_ownerless_claim
+                || entry
+                    .pending_revival_lifecycle_persist
+                    .load(std::sync::atomic::Ordering::Acquire);
+            let pending_revival_lifecycle_persist =
+                Arc::clone(&entry.pending_revival_lifecycle_persist);
+            let spawned_loop = crate::runtime_loop::spawn_runtime_loop_with_completions(
+                driver.clone(),
+                executor,
+                wake_rx,
+                effect_rx,
+                Some(completions.clone()),
+                Some(completion_feed),
+                Some(Arc::clone(&ops_lifecycle) as Arc<dyn meerkat_core::OpsLifecycleRegistry>),
+                entry_cursor_state,
+                Arc::downgrade(self),
+                session_id.clone(),
+                persist_revival_lifecycle,
+                Some(pending_revival_lifecycle_persist),
+            );
+            let startup = spawned_loop.startup_slot();
+            let published = entry.attach_runtime_loop(
+                wake_tx.clone(),
+                effect_tx,
+                boundary_handle,
+                interrupt_handle,
+                spawned_loop,
+            );
+            pending_registration.transfer_to_attachment(published);
+            drop(authority);
+            Ok::<_, ExecutorPublicationError>(startup)
+        };
+        let startup = match publication {
+            Ok(startup) => startup,
+            Err(ExecutorPublicationError::DslRejected(reason)) => {
+                let classified = self
+                    .classify_session_dsl_rejection(&session_id, reason)
+                    .await;
+                if inserted_cold_entry {
+                    let mut removed_entry = {
+                        let mut sessions = self.sessions.write().await;
+                        let exact_unpublished_entry =
+                            sessions.get(&session_id).is_some_and(|entry| {
+                                Arc::ptr_eq(&entry.mutation_gate, &registration_gate)
+                                    && Arc::ptr_eq(&entry.driver, &driver)
+                                    && Arc::ptr_eq(&entry.dsl_authority, &dsl_authority)
+                                    && Arc::ptr_eq(&entry.completions, &completions)
+                                    && matches!(
+                                        entry.attachment_slot,
+                                        RuntimeLoopAttachmentSlot::Empty
+                                    )
+                                    && entry.runtime_loop_teardown.is_none()
+                            });
+                        exact_unpublished_entry
+                            .then(|| sessions.remove(&session_id))
+                            .flatten()
+                    };
+                    if let Some(entry) = removed_entry.as_ref() {
+                        entry.close_handle_teardown_gate();
+                    }
+                    if let Some(entry) = removed_entry.as_mut()
+                        && let Some(worker) = entry.ops_lifecycle_persistence_worker.take()
+                    {
+                        match entry.ops_lifecycle.retire_owner_for_unregister(
+                            "cold executor attachment was rejected before publication".into(),
+                        ) {
+                            Ok(()) => join_ops_lifecycle_persistence_worker(worker).await?,
+                            Err(error) => {
+                                tracing::warn!(
+                                    %session_id,
+                                    %error,
+                                    "failed to retire ops owner after cold executor attachment rejection"
+                                );
+                            }
+                        }
+                    }
+                }
+                drop(_gate_guard);
+                return Err(classified);
+            }
+            Err(ExecutorPublicationError::Internal(error)) => return Err(error),
+        };
+
+        // Buffer the initial backlog wake immediately after publication. The
+        // runtime loop owns startup from this point; cancellation of the
+        // caller waiting below must not leave recovered inputs dormant.
+        if should_wake {
+            let _ = wake_tx.try_send(());
         }
 
         // Publishing the attachment is not readiness. The exact executor must
@@ -1694,9 +1776,6 @@ impl MeerkatMachine {
             };
         }
 
-        if should_wake {
-            let _ = wake_tx.try_send(());
-        }
         Ok(())
     }
 
@@ -1711,6 +1790,142 @@ impl MeerkatMachine {
     ) -> Result<(), RuntimeDriverError> {
         self.join_or_start_unregister_teardown(session_id, None, UnregisterTeardownCaller::Explicit)
             .await
+    }
+
+    /// Re-drive the exact missing-executor shapes used by delivery-time Mob
+    /// revival: recovered Idle/Queuing authority, an ownerless binding at
+    /// Attached/Queuing, or an orphaned Active claim left without an
+    /// attachment or teardown owner. Same-session local preparation can
+    /// normalize Attached/Active to Idle/Active, so both shapes are admitted.
+    /// The generated executor-exit observation followed by same-session
+    /// readmission clears the full binding tuple. The already-recovered driver
+    /// ledger and queues are deliberately left verbatim.
+    ///
+    /// This is deliberately narrower than general executor replacement. A
+    /// live, dead, or teardown-owned attachment is refused because only its
+    /// exact owner may discharge it.
+    #[doc(hidden)]
+    pub async fn redrive_missing_executor_for_revival(
+        &self,
+        session_id: &SessionId,
+        _authority: MachineSessionControlAuthority,
+    ) -> Result<(), RuntimeDriverError> {
+        let _gate_guard = self
+            .lock_current_session_mutation_gate(session_id)
+            .await
+            .ok_or(RuntimeDriverError::NotReady {
+                state: RuntimeState::Destroyed,
+            })?;
+
+        let (driver, dsl_authority, pending_lifecycle_persist) = {
+            let mut sessions = self.sessions.write().await;
+            let entry = sessions
+                .get_mut(session_id)
+                .ok_or(RuntimeDriverError::NotReady {
+                    state: RuntimeState::Destroyed,
+                })?;
+            if entry.runtime_stop_cleanup_coordinator.is_some() {
+                // A completed exact stop receipt is compatible with revival;
+                // retire it exactly as executor publication does. Pending,
+                // failed, stale, or live-owned teardown remains fail-closed.
+                entry.retire_completed_runtime_stop_after_revival(session_id)?;
+            }
+            if let Some(error) = entry.dsl_mutation_blocked_by_unregister(session_id) {
+                return Err(error);
+            }
+            if !matches!(entry.attachment_slot, RuntimeLoopAttachmentSlot::Empty)
+                || entry.runtime_loop_teardown.is_some()
+                || entry.runtime_stop_cleanup_coordinator.is_some()
+                || entry.unregister_coordinator.is_some()
+            {
+                return Err(RuntimeDriverError::RuntimeStopInProgress {
+                    runtime_id: entry.runtime_id.clone(),
+                });
+            }
+            (
+                Arc::clone(&entry.driver),
+                Arc::clone(&entry.dsl_authority),
+                Arc::clone(&entry.pending_revival_lifecycle_persist),
+            )
+        };
+
+        let mut driver_guard = driver.lock().await;
+        // Every await is deliberately above this point. Once generated
+        // authority changes, projection realization and the publication
+        // marker complete synchronously under the same authority mutex.
+        // Caller cancellation therefore cannot expose a half-redriven session.
+        let mut authority = dsl_authority
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let original_snapshot = authority.snapshot();
+        let stage_result = (|| -> Result<(), RuntimeDriverError> {
+            let lifecycle_phase = authority.state().lifecycle_phase;
+            let registration_phase = authority.state().registration_phase;
+            let has_current_run = authority.state().current_run_id.is_some();
+            match (lifecycle_phase, registration_phase, has_current_run) {
+                (
+                    dsl::MeerkatPhase::Idle | dsl::MeerkatPhase::Attached,
+                    dsl::RegistrationPhase::Queuing | dsl::RegistrationPhase::Active,
+                    false,
+                ) => {
+                    let exited = Self::stage_runtime_owner_dsl_transition_on_locked_authority(
+                        &mut authority,
+                        crate::meerkat_machine_types::MeerkatMachineFieldlessRuntimeInternalInput::RuntimeExecutorExited,
+                    )
+                    .map_err(RuntimeDriverError::Internal)?;
+                    if exited.has_routed_signal_effect() {
+                        return Err(RuntimeDriverError::Internal(
+                            "missing-executor exit observation unexpectedly emitted a routed signal"
+                                .into(),
+                        ));
+                    }
+                    let readmitted = Self::stage_dsl_transition_on_locked_authority(
+                        &mut authority,
+                        dsl::MeerkatMachineInput::RegisterSession {
+                            session_id: dsl::SessionId::from_domain(session_id),
+                        },
+                        "MissingExecutorRevivalReadmit",
+                    )
+                    .map_err(RuntimeDriverError::Internal)?;
+                    if readmitted.has_routed_signal_effect() {
+                        return Err(RuntimeDriverError::Internal(
+                            "missing-executor readmission unexpectedly emitted a routed signal"
+                                .into(),
+                        ));
+                    }
+                }
+                _ => {
+                    return Err(RuntimeDriverError::NotReady {
+                        state: dsl_authority::runtime_phase_from_authority(&authority),
+                    });
+                }
+            }
+            let repaired = authority.state();
+            if repaired.lifecycle_phase != dsl::MeerkatPhase::Idle
+                || repaired.registration_phase != dsl::RegistrationPhase::Queuing
+                || repaired.current_run_id.is_some()
+                || repaired.active_runtime_id.is_some()
+                || repaired.active_fence_token.is_some()
+                || repaired.active_runtime_generation.is_some()
+                || repaired.active_runtime_epoch_id.is_some()
+            {
+                return Err(RuntimeDriverError::Internal(
+                    "missing-executor revival did not produce cleared Idle/Queuing authority"
+                        .into(),
+                ));
+            }
+            Ok(())
+        })();
+        if let Err(error) = stage_result {
+            authority.restore_snapshot(original_snapshot);
+            return Err(error);
+        }
+        // Keep the mechanical projection coherent without re-locking the DSL
+        // authority we still hold. No queue or ledger mechanic is required:
+        // executor exit/readmission changes only runtime ownership.
+        driver_guard.set_control_projection(RuntimeState::Idle, None, None);
+        pending_lifecycle_persist.store(true, std::sync::atomic::Ordering::Release);
+        Ok(())
     }
 
     /// Start or join the one owned ordinary-stop operation for this epoch.
@@ -3562,9 +3777,10 @@ impl MeerkatMachine {
     /// Check whether a session has an active RuntimeLoop or attachment in
     /// progress.
     ///
-    /// `Ok(false)` means only `Queuing` (registered via `prepare_bindings()`
-    /// with no executor) or unknown. Driver faults are returned explicitly so
-    /// callers cannot accidentally treat a control-plane fault as absence.
+    /// `Ok(false)` means no viable live attachment: ordinary `Queuing`, an
+    /// orphaned generated `Active` claim whose attachment is Empty/dead, or an
+    /// unknown session. Driver faults are returned explicitly so callers
+    /// cannot accidentally treat a control-plane fault as absence.
     pub async fn session_has_executor(
         &self,
         session_id: &SessionId,

--- a/meerkat-runtime/src/meerkat_machine_tests.rs
+++ b/meerkat-runtime/src/meerkat_machine_tests.rs
@@ -5178,6 +5178,61 @@ fn revival_arms_preserve_identity_clear_epoch_binding_and_refuse_while_draining(
     .expect_err("executor revival must refuse while the unregister drain window is open");
 }
 
+/// `Queuing` is only the recovered registration default; it is not evidence
+/// that an exact authoritative binding is stale. Standard (non-Mob) recovery
+/// may reassert that tuple before attaching its executor, and generic ensure
+/// must preserve it.
+#[test]
+fn recovered_idle_exact_binding_survives_authoritative_prepare_then_executor_attach() {
+    use crate::meerkat_machine::dsl as mm_dsl;
+
+    let session_id = mm_dsl::SessionId("session-idle-current-binding".to_string());
+    let runtime_id = mm_dsl::AgentRuntimeId("runtime-current".to_string());
+    let fence = mm_dsl::FenceToken(51);
+    let generation = mm_dsl::Generation(9);
+    let epoch = mm_dsl::RuntimeEpochId("epoch-current".to_string());
+    let mut authority =
+        mm_dsl::MeerkatMachineAuthority::recover_from_state(mm_dsl::MeerkatMachineState {
+            lifecycle_phase: mm_dsl::MeerkatPhase::Idle,
+            session_id: Some(session_id.clone()),
+            registration_phase: mm_dsl::RegistrationPhase::Queuing,
+            active_runtime_id: Some(runtime_id.clone()),
+            active_fence_token: Some(fence),
+            active_runtime_generation: Some(generation),
+            active_runtime_epoch_id: Some(epoch.clone()),
+            ..Default::default()
+        })
+        .expect("an idle recovered runtime with an exact binding must be valid");
+
+    mm_dsl::MeerkatMachineMutator::apply(
+        &mut authority,
+        mm_dsl::MeerkatMachineInput::PrepareBindings {
+            agent_runtime_id: runtime_id.clone(),
+            fence_token: fence,
+            generation: Some(generation),
+            runtime_epoch_id: Some(epoch.clone()),
+            session_id: session_id.clone(),
+        },
+    )
+    .expect("exact authoritative binding reassertion must be idempotent");
+    mm_dsl::MeerkatMachineMutator::apply(
+        &mut authority,
+        mm_dsl::MeerkatMachineInput::EnsureSessionWithExecutor { session_id },
+    )
+    .expect("standard recovered runtime must attach its executor");
+
+    let attached = authority.state();
+    assert_eq!(attached.lifecycle_phase, mm_dsl::MeerkatPhase::Attached);
+    assert_eq!(
+        attached.registration_phase,
+        mm_dsl::RegistrationPhase::Active
+    );
+    assert_eq!(attached.active_runtime_id, Some(runtime_id));
+    assert_eq!(attached.active_fence_token, Some(fence));
+    assert_eq!(attached.active_runtime_generation, Some(generation));
+    assert_eq!(attached.active_runtime_epoch_id, Some(epoch));
+}
+
 #[tokio::test]
 async fn model_routing_status_proves_finite_turn_and_operation_precedence() {
     let adapter = Arc::new(MeerkatMachine::ephemeral());
@@ -8860,6 +8915,76 @@ mod stop_teardown_coordinator_class {
             .unregister_session(&session_id)
             .await
             .expect("test cleanup should remove the stopped session");
+    }
+
+    #[tokio::test]
+    async fn missing_executor_redrive_retires_completed_stop_receipt_after_readmission() {
+        let machine = Arc::new(MeerkatMachine::ephemeral());
+        let session_id = SessionId::new();
+
+        machine
+            .prepare_local_session_bindings(session_id.clone())
+            .await
+            .expect("initial local bindings should register the runtime");
+        machine
+            .stop_runtime_executor(&session_id, "completed stop receipt before revival")
+            .await
+            .expect("ownerless runtime stop should complete");
+        {
+            let sessions = machine.sessions.read().await;
+            let coordinator = sessions
+                .get(&session_id)
+                .and_then(|entry| entry.runtime_stop_cleanup_coordinator.as_ref())
+                .expect("completed stop receipt remains installed until revival");
+            assert!(matches!(
+                coordinator.result_rx.borrow().clone(),
+                Some(Ok(()))
+            ));
+        }
+
+        machine
+            .prepare_local_session_bindings(session_id.clone())
+            .await
+            .expect("delivery-time preparation should readmit the stopped session");
+        assert_eq!(
+            machine
+                .session_dsl_state(&session_id)
+                .await
+                .expect("readmitted session authority")
+                .lifecycle_phase,
+            mm_dsl::MeerkatPhase::Idle
+        );
+
+        machine
+            .redrive_missing_executor_for_revival(&session_id, machine.session_control_authority())
+            .await
+            .expect("missing-executor redrive should retire the completed exact stop receipt");
+        {
+            let sessions = machine.sessions.read().await;
+            let entry = sessions
+                .get(&session_id)
+                .expect("redriven session remains registered");
+            assert!(entry.runtime_stop_cleanup_coordinator.is_none());
+            assert!(entry.runtime_loop_teardown.is_none());
+            assert!(matches!(
+                entry.attachment_slot,
+                RuntimeLoopAttachmentSlot::Empty
+            ));
+        }
+        let redriven = machine
+            .session_dsl_state(&session_id)
+            .await
+            .expect("redriven session authority");
+        assert_eq!(redriven.lifecycle_phase, mm_dsl::MeerkatPhase::Idle);
+        assert_eq!(
+            redriven.registration_phase,
+            mm_dsl::RegistrationPhase::Queuing
+        );
+
+        machine
+            .unregister_session(&session_id)
+            .await
+            .expect("test cleanup should unregister the redriven session");
     }
 
     #[tokio::test]
@@ -24448,6 +24573,148 @@ async fn session_has_executor_follows_generated_registration_phase() {
 }
 
 #[tokio::test]
+async fn cancelled_executor_setup_before_atomic_claim_preserves_authority_and_retries() {
+    struct NoopExecutor;
+
+    #[async_trait::async_trait]
+    impl CoreExecutor for NoopExecutor {
+        async fn apply(
+            &mut self,
+            run_id: RunId,
+            primitive: RunPrimitive,
+        ) -> Result<CoreApplyOutput, CoreExecutorError> {
+            Ok(CoreApplyOutput {
+                receipt: RunBoundaryReceiptDraft {
+                    run_id,
+                    boundary: RunApplyBoundary::RunStart,
+                    contributing_input_ids: primitive.contributing_input_ids().to_vec(),
+                    conversation_digest: None,
+                    message_count: 0,
+                },
+                session_snapshot: None,
+                terminal: None,
+            })
+        }
+
+        async fn cancel_after_boundary(
+            &mut self,
+            _reason: String,
+        ) -> Result<(), CoreExecutorError> {
+            Ok(())
+        }
+
+        async fn stop_runtime_executor(
+            &mut self,
+            _reason: String,
+        ) -> Result<(), CoreExecutorError> {
+            Ok(())
+        }
+    }
+
+    let adapter = Arc::new(MeerkatMachine::ephemeral());
+    let session_id = SessionId::new();
+    adapter
+        .register_session(session_id.clone())
+        .await
+        .expect("register session");
+    let bindings = adapter
+        .prepare_local_session_bindings(session_id.clone())
+        .await
+        .expect("prepare session-owned handles");
+    let (driver, mutation_gate) = {
+        let sessions = adapter.sessions.read().await;
+        let entry = sessions.get(&session_id).expect("registered session entry");
+        (entry.driver.clone(), Arc::clone(&entry.mutation_gate))
+    };
+
+    // All awaitable setup happens before the generated claim. Hold the driver
+    // lock to park setup while the session mutation gate is owned, then prove
+    // a synchronous session handle can still advance unrelated authority and
+    // caller cancellation leaves both facts intact.
+    let driver_guard = driver.lock().await;
+    let registration = {
+        let adapter = Arc::clone(&adapter);
+        let session_id = session_id.clone();
+        tokio::spawn(async move {
+            adapter
+                .ensure_session_with_executor(session_id, Box::new(NoopExecutor))
+                .await
+        })
+    };
+    tokio::time::timeout(Duration::from_secs(1), async {
+        loop {
+            if Arc::clone(&mutation_gate).try_lock_owned().is_err() {
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("executor setup should own the mutation gate while blocked");
+
+    use meerkat_core::handles::SessionContextHandle as _;
+    assert!(
+        bindings
+            .session_context()
+            .context_advanced(77)
+            .expect("session-owned handle transition during executor setup")
+    );
+    let pending = adapter
+        .session_dsl_state(&session_id)
+        .await
+        .expect("pending session authority");
+    assert_eq!(pending.lifecycle_phase, mm_dsl::MeerkatPhase::Idle);
+    assert_eq!(
+        pending.registration_phase,
+        mm_dsl::RegistrationPhase::Queuing
+    );
+    assert_eq!(pending.last_session_context_updated_at_ms, 77);
+
+    registration.abort();
+    assert!(
+        registration
+            .await
+            .expect_err("aborted registration task must not complete")
+            .is_cancelled()
+    );
+    drop(driver_guard);
+
+    let preserved = adapter
+        .session_dsl_state(&session_id)
+        .await
+        .expect("preserved session authority");
+    assert_eq!(preserved.lifecycle_phase, mm_dsl::MeerkatPhase::Idle);
+    assert_eq!(
+        preserved.registration_phase,
+        mm_dsl::RegistrationPhase::Queuing
+    );
+    assert_eq!(preserved.last_session_context_updated_at_ms, 77);
+    {
+        let sessions = adapter.sessions.read().await;
+        let entry = sessions
+            .get(&session_id)
+            .expect("session remains registered");
+        assert_eq!(entry.control_snapshot().phase, RuntimeState::Idle);
+        assert!(!entry.has_live_attachment());
+    }
+    assert!(
+        !adapter
+            .session_has_executor(&session_id)
+            .await
+            .expect("rolled-back executor query")
+    );
+
+    adapter
+        .ensure_session_with_executor(session_id.clone(), Box::new(NoopExecutor))
+        .await
+        .expect("a fresh executor claim must succeed after cancellation rollback");
+    adapter
+        .unregister_session(&session_id)
+        .await
+        .expect("retried session should unregister cleanly");
+}
+
+#[tokio::test]
 async fn ensure_session_with_executor_waits_for_startup_reconciliation() {
     struct GatedStartupExecutor {
         reconciliation_started: Arc<Notify>,
@@ -24539,6 +24806,150 @@ async fn ensure_session_with_executor_waits_for_startup_reconciliation() {
         .unregister_session(&session_id)
         .await
         .expect("ready test session should unregister cleanly");
+}
+
+#[tokio::test]
+async fn cancelled_registration_after_attachment_publication_keeps_runtime_owner() {
+    struct GatedStartupExecutor {
+        reconciliation_started: Arc<Notify>,
+        allow_reconciliation: Arc<Notify>,
+        apply_started: Arc<Notify>,
+        startup_reconciled: bool,
+    }
+
+    #[async_trait::async_trait]
+    impl CoreExecutor for GatedStartupExecutor {
+        async fn apply(
+            &mut self,
+            run_id: RunId,
+            primitive: RunPrimitive,
+        ) -> Result<CoreApplyOutput, CoreExecutorError> {
+            self.apply_started.notify_one();
+            Ok(CoreApplyOutput {
+                receipt: RunBoundaryReceiptDraft {
+                    run_id,
+                    boundary: RunApplyBoundary::RunStart,
+                    contributing_input_ids: primitive.contributing_input_ids().to_vec(),
+                    conversation_digest: None,
+                    message_count: 0,
+                },
+                session_snapshot: None,
+                terminal: None,
+            })
+        }
+
+        async fn reconcile_committed_compaction_projections(
+            &mut self,
+            _intents: &[meerkat_core::CompactionProjectionIntent],
+        ) -> Result<(), CoreExecutorError> {
+            if !self.startup_reconciled {
+                self.startup_reconciled = true;
+                self.reconciliation_started.notify_one();
+                self.allow_reconciliation.notified().await;
+            }
+            Ok(())
+        }
+
+        async fn cancel_after_boundary(
+            &mut self,
+            _reason: String,
+        ) -> Result<(), CoreExecutorError> {
+            Ok(())
+        }
+
+        async fn stop_runtime_executor(
+            &mut self,
+            _reason: String,
+        ) -> Result<(), CoreExecutorError> {
+            Ok(())
+        }
+    }
+
+    let adapter = Arc::new(MeerkatMachine::ephemeral());
+    let session_id = SessionId::new();
+    let reconciliation_started = Arc::new(Notify::new());
+    let allow_reconciliation = Arc::new(Notify::new());
+    let apply_started = Arc::new(Notify::new());
+    adapter
+        .register_session(session_id.clone())
+        .await
+        .expect("register queued-work session");
+    let queued_input = Input::Prompt(crate::input::PromptInput::new(
+        "queued before executor publication",
+        None,
+    ));
+    let (outcome, completion) = adapter
+        .accept_input_with_completion(&session_id, queued_input)
+        .await
+        .expect("queue input before executor publication");
+    assert!(outcome.is_accepted());
+    let completion = completion.expect("queued input should install a completion waiter");
+    let registration = {
+        let adapter = Arc::clone(&adapter);
+        let session_id = session_id.clone();
+        let reconciliation_started = Arc::clone(&reconciliation_started);
+        let allow_reconciliation = Arc::clone(&allow_reconciliation);
+        let apply_started = Arc::clone(&apply_started);
+        tokio::spawn(async move {
+            adapter
+                .ensure_session_with_executor(
+                    session_id,
+                    Box::new(GatedStartupExecutor {
+                        reconciliation_started,
+                        allow_reconciliation,
+                        apply_started,
+                        startup_reconciled: false,
+                    }),
+                )
+                .await
+        })
+    };
+
+    tokio::time::timeout(Duration::from_secs(1), reconciliation_started.notified())
+        .await
+        .expect("published runtime loop must enter startup reconciliation");
+    registration.abort();
+    assert!(
+        registration
+            .await
+            .expect_err("aborted registration task must not complete")
+            .is_cancelled()
+    );
+    allow_reconciliation.notify_one();
+
+    tokio::time::timeout(Duration::from_secs(1), apply_started.notified())
+        .await
+        .expect("the publication-owned initial wake must run queued work after caller abort");
+    tokio::time::timeout(Duration::from_secs(1), completion.wait())
+        .await
+        .expect("queued completion must resolve after publication-owned wake")
+        .expect("queued completion waiter should remain valid");
+
+    tokio::time::timeout(Duration::from_secs(1), async {
+        loop {
+            if adapter
+                .session_has_executor(&session_id)
+                .await
+                .is_ok_and(|present| present)
+            {
+                let sessions = adapter.sessions.read().await;
+                if sessions
+                    .get(&session_id)
+                    .is_some_and(RuntimeSessionEntry::has_live_attachment)
+                {
+                    break;
+                }
+            }
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("caller cancellation after publication must not roll back the runtime owner");
+
+    adapter
+        .unregister_session(&session_id)
+        .await
+        .expect("published runtime owner should unregister canonically");
 }
 
 #[tokio::test]

--- a/meerkat-runtime/src/runtime_loop.rs
+++ b/meerkat-runtime/src/runtime_loop.rs
@@ -1531,6 +1531,8 @@ pub(crate) fn spawn_runtime_loop_with_completions(
     epoch_cursor_state: Option<std::sync::Arc<meerkat_core::EpochCursorState>>,
     machine_weak: std::sync::Weak<crate::meerkat_machine::MeerkatMachine>,
     session_id: meerkat_core::types::SessionId,
+    persist_revival_lifecycle: bool,
+    pending_revival_lifecycle_persist: Option<std::sync::Arc<std::sync::atomic::AtomicBool>>,
 ) -> SpawnedRuntimeLoop {
     let teardown_slot = RuntimeLoopTeardownSlot::pending();
     let startup = RuntimeLoopStartupSlot::pending();
@@ -1589,6 +1591,40 @@ pub(crate) fn spawn_runtime_loop_with_completions(
             };
         }
         let mut terminal_handoff = RuntimeLoopTerminalHandoff::default();
+
+        // The executor attachment now owns this claim. Projection sync and a
+        // stopped-session revival persist therefore run in this independently
+        // owned task, before startup readiness, so cancellation of the caller
+        // awaiting registration cannot strand Attached authority without an
+        // exact executor cleanup owner.
+        let projection_result = {
+            let mut driver_guard = driver.lock().await;
+            driver_guard.sync_control_projection_from_dsl_authority();
+            let persist_revival_lifecycle = persist_revival_lifecycle
+                || pending_revival_lifecycle_persist
+                    .as_ref()
+                    .is_some_and(|pending| pending.load(std::sync::atomic::Ordering::Acquire));
+            if persist_revival_lifecycle {
+                driver_guard
+                    .persist_current_machine_lifecycle("resume")
+                    .await
+            } else {
+                Ok(())
+            }
+        };
+        if let Err(error) = projection_result {
+            startup_guard.publish(Err(error.to_string()));
+            tracing::error!(
+                session_id = %authority_binding.session_id,
+                %error,
+                "runtime loop failed to publish revived lifecycle before accepting work"
+            );
+            return;
+        }
+        if let Some(pending) = pending_revival_lifecycle_persist {
+            pending.store(false, std::sync::atomic::Ordering::Release);
+        }
+
         // Feed-based idle wake state (local to this loop).
         // Seed from generated cursor authority when available. Even an
         // all-zero runtime-owned cursor must win over the feed watermark so a
@@ -3330,6 +3366,8 @@ mod tests {
             None,
             std::sync::Weak::<crate::meerkat_machine::MeerkatMachine>::new(),
             SessionId::new(),
+            false,
+            None,
         );
 
         effect_tx
@@ -3374,6 +3412,8 @@ mod tests {
             None,
             std::sync::Weak::<crate::meerkat_machine::MeerkatMachine>::new(),
             SessionId::new(),
+            false,
+            None,
         );
 
         drop(effect_tx);
@@ -3415,6 +3455,8 @@ mod tests {
             None,
             std::sync::Weak::<crate::meerkat_machine::MeerkatMachine>::new(),
             SessionId::new(),
+            false,
+            None,
         );
 
         drop(wake_tx);


### PR DESCRIPTION
## Summary

- add a machine-authorized `MissingLiveMaterialization` revival intent for delivery-time Mob rebuilds
- detect ownerless `Idle` or `Attached` runtime records with no viable executor and atomically re-drive them through executor-exit observation plus same-session readmission
- preserve queued inputs, completion waiters, driver identity, runtime identity/fence, and the exact queued-turn sidecar while clearing the stale V3 runtime-binding tuple before readiness
- make executor publication and cold-entry rejection cancellation-safe so an `Attached` projection cannot outlive its exact runtime-loop owner

This closes the in-process wedge whose signature is `guard rejected transition from Attached for input::PrepareBindings [dsl_guard_rejected]`: delivery-time revival no longer requires a host restart to recover an idle record with a stale binding claim.

## Validation

- `make fmt`
- `make check`
- `make lint`
- `make machine-check-drift machine-verify` (TLC clean)
- `./scripts/agent-gate --cargo --working-tree` (2,514 passed, 7 skipped)
- `./scripts/repo-cargo test -p meerkat-runtime --lib` (961 passed)
- `./scripts/repo-cargo test -p meerkat-mob --lib` (1,188 passed, 6 ignored)
- focused stale-V3, same-instance Attached, completed-stop, cancellation-before-claim, cancellation-after-publication, cold-rejection, sidecar, actor/provisioner/runtime, discarded-session, and tool-overlay revival regressions
- independent state-machine and concurrency/crash-safety reviews: GREEN
- full pre-push deterministic workspace gate: GREEN

## Complexity Delta

- Docs/scripts/tests: changelog plus state-machine, cancellation, recovery, sidecar, and end-to-end Mob regressions
- Non-test implementation: explicit revival intent, narrowly gated runtime redrive transaction, cancellation-safe executor claim/publication, and exact sidecar preservation
- Generated/schema churn: no machine schema/generated source changes; refreshed deterministic `MODULE.bazel.lock` for the repositories existing `rules_cc 0.2.22` resolution as required by the pre-push freshness gate