### PR TITLE
fix(runtime): reclaim cold same-epoch bindings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -182,6 +182,11 @@ via cargo-semver-checks against the published baselines).
   publication is also cancellation-safe: the exact runtime-loop attachment,
   its initial backlog wake, and startup projection/persistence belong to the
   loop owner, preventing a false `Attached`/ready state without an executor.
+- Cold local-resource registration now treats every recovered runtime binding
+  as a prior-process fact, including bindings whose ops epoch is intentionally
+  retained. The existing generated executor-exit/readmission ladder clears the
+  dead tuple before a reset or reprofile binds its distinct runtime identity,
+  preventing a guard rejection followed by unbounded teardown.
 - Transcript revision history no longer retains a complete mechanical head
   snapshot after every ordinary append once any audited rewrite exists.
   Snapshots preserve genuine rewrite endpoints plus the live head, typed

--- a/meerkat-runtime/src/meerkat_machine/dispatch_session.rs
+++ b/meerkat-runtime/src/meerkat_machine/dispatch_session.rs
@@ -1054,35 +1054,33 @@ impl MeerkatMachine {
                 .unwrap_or_else(std::sync::PoisonError::into_inner) =
                 Some(Arc::clone(&materialization_claim_state));
         }
-        // A newly recovered entry has no in-process executor. When its
-        // durable binding names an older runtime epoch than the recovered
-        // ops entry, that binding is a dead-process fact: preserving it makes
-        // the caller's authoritative PrepareBindings guard-reject the fresh
-        // epoch. Drive the existing generated recovery ladder instead of
-        // clearing shell fields: RuntimeExecutorExited moves the supported
-        // live phases to Stopped, then RegisterSessionResumesStopped below
-        // clears the epoch-scoped binding and re-admits the same session.
-        // Warm/idempotent registration never enters this arm.
+        // A newly recovered entry has no in-process executor. Any machine-valid
+        // durable runtime binding on that cold entry belongs to the previous
+        // process, even when the recovered ops entry intentionally retains
+        // the same epoch. Preserving it makes a replacement runtime id/fence/
+        // generation guard-reject PrepareBindings. Drive the existing
+        // generated recovery ladder instead of clearing shell fields:
+        // RuntimeExecutorExited moves the supported live phases to Stopped,
+        // then RegisterSessionResumesStopped below clears the epoch-scoped
+        // binding and re-admits the same session. Warm/idempotent registration
+        // never enters this arm.
         let current_epoch = crate::meerkat_machine::dsl::RuntimeEpochId::from_domain(&epoch_id);
-        let recovered_stale_bound_epoch = inserted_by_call && !live_attachment && {
+        let recovered_dead_process_binding = inserted_by_call && !live_attachment && {
             let authority = dsl_authority_shared
                 .lock()
                 .unwrap_or_else(std::sync::PoisonError::into_inner);
             let phase = super::dsl_authority::runtime_phase_from_authority(&authority);
+            let state = authority.state();
             matches!(
                 phase,
                 RuntimeState::Idle | RuntimeState::Attached | RuntimeState::Running
-            ) && authority
-                .state()
-                .active_runtime_epoch_id
-                .as_ref()
-                .is_some_and(|bound_epoch| bound_epoch != &current_epoch)
+            ) && state.active_runtime_id.is_some()
         };
-        if recovered_stale_bound_epoch {
+        if recovered_dead_process_binding {
             tracing::debug!(
                 %session_id,
                 ?current_epoch,
-                "cold recovery observed a stale bound runtime epoch; staging generated executor exit before re-registration"
+                "cold recovery observed a dead-process runtime binding; staging generated executor exit before re-registration"
             );
             let executor_exited = crate::meerkat_machine_types::
                 MeerkatMachineFieldlessRuntimeInternalInput::RuntimeExecutorExited;

--- a/meerkat-runtime/src/meerkat_machine_tests.rs
+++ b/meerkat-runtime/src/meerkat_machine_tests.rs
@@ -7435,6 +7435,90 @@ async fn cold_recovery_rebinds_idle_placement_when_ops_epoch_was_not_persisted()
         .expect("the exact controller placement tuple rebinds under the fresh epoch");
 }
 
+/// A cold process has no live executor when a machine-valid prior-process
+/// binding survives in either durable `Idle` or `Attached`. When the ops snapshot
+/// carries the same epoch as that binding, registration must clear the dead
+/// owner before a distinct replacement tuple is prepared.
+#[cfg(not(target_arch = "wasm32"))]
+#[tokio::test]
+async fn cold_registration_reclaims_same_epoch_binding_from_idle_and_attached() {
+    for persisted_state in [RuntimeState::Idle, RuntimeState::Attached] {
+        for (fence_token, runtime_generation) in [(Some(19), Some(3)), (Some(19), None)] {
+            let store = Arc::new(crate::store::InMemoryRuntimeStore::new())
+                as Arc<dyn crate::store::RuntimeStore>;
+            let session_id = SessionId::new();
+            let runtime_id = runtime_id_for_session(&session_id);
+            let placement_runtime_id = LogicalRuntimeId::new("worker:same-epoch");
+
+            let first = MeerkatMachine::persistent(Arc::clone(&store), memory_blob_store());
+            let first_bindings = first
+                .prepare_local_session_bindings(session_id.clone())
+                .await
+                .expect("first process prepares local session resources");
+            let first_epoch = first_bindings.epoch_id().clone();
+            let first_epoch_string = first_epoch.to_string();
+            crate::store::RuntimeStore::commit_machine_lifecycle(
+                store.as_ref(),
+                &runtime_id,
+                crate::store::MachineLifecycleCommit::new_with_binding(
+                    persisted_state,
+                    crate::store::MachineLifecycleBindingFacts::new(
+                        Some(placement_runtime_id.to_string()),
+                        fence_token,
+                        runtime_generation,
+                        Some(first_epoch_string.clone()),
+                    ),
+                    crate::store::SupervisorAuthoritySnapshot::UnboundNoReceipt,
+                ),
+                &[],
+            )
+            .await
+            .expect("seed the prior process's durable placement binding");
+
+            let durable = crate::store::load_machine_lifecycle(store.as_ref(), &runtime_id)
+                .await
+                .expect("load bound lifecycle")
+                .expect("bound lifecycle exists");
+            assert_eq!(durable.runtime_state(), persisted_state);
+            assert_eq!(
+                durable.binding().runtime_epoch_id(),
+                Some(first_epoch_string.as_str())
+            );
+            let durable_ops = store
+                .load_ops_lifecycle(&runtime_id)
+                .await
+                .expect("load matching ops lifecycle")
+                .expect("ops lifecycle exists");
+            assert_eq!(durable_ops.epoch_id, first_epoch);
+            drop(first_bindings);
+            drop(first);
+
+            let restarted = MeerkatMachine::persistent(Arc::clone(&store), memory_blob_store());
+            let restarted_bindings = tokio::time::timeout(
+                std::time::Duration::from_secs(2),
+                restarted.prepare_local_session_bindings(session_id.clone()),
+            )
+            .await
+            .expect("cold registration must not hang on a persisted bound row")
+            .expect("cold registration must recover the dead process binding");
+            assert_eq!(
+                restarted_bindings.epoch_id(),
+                &durable_ops.epoch_id,
+                "same-epoch durable ops authority remains canonical"
+            );
+            restarted
+                .prepare_runtime_placement_binding(
+                    session_id,
+                    LogicalRuntimeId::new("worker:replacement"),
+                    20,
+                    4,
+                )
+                .await
+                .expect("a distinct replacement placement tuple binds in the retained ops epoch");
+        }
+    }
+}
+
 /// Cold-revival class (the 0.7.25 identity-first field wedge): a process
 /// dies with a session durably Stopped AND still carrying its runtime
 /// binding (no unregister ran — the torn case). A fresh machine over the


### PR DESCRIPTION
## Summary

- reclaim a persisted cold runtime binding even when its epoch matches the recovered ops epoch
- use the existing machine-authoritative exit/stop/resume transition ladder before preparing replacement bindings
- cover both Idle and Attached durable shapes, including the legacy missing-generation witness

## Why this is separate from #890

#890 re-admits retries from `RetirementUncertain` after a transient disposal failure. This fixes a different cold-start defect: a prior-process binding can remain persisted at the same epoch, while the replacement process has a distinct runtime/fence/generation tuple. Registration then asks the machine to `PrepareBindings` from `Attached` (or from a bound `Idle`) and is guard-rejected; cleanup waits indefinitely for quiescence.

Epoch equality is not proof that a binding belongs to the current process. When this call inserted the in-memory attachment and no live attachment existed, a canonical persisted `active_runtime_id` is a cold retry anchor and must be retired through generated transitions before replacement binding preparation.

## Validation

- `cold_registration_reclaims_same_epoch_binding_from_idle_and_attached`
- adjacent missing-ops stale-epoch regression
- all 11 `cold_` runtime tests (independent review lane)
- focused clippy with warnings denied
- independent code review: no findings
- real MobKit registry-bound reset/reprofile acceptance over the same state directory: `1 passed in 16.42s`; the cold-recovery branch fired and both identities restored
