### PR TITLE
docs(cli): fix auth and mobpack help contracts

### DIFF
--- a/.claude/skills/meerkat-cli-reference/SKILL.md
+++ b/.claude/skills/meerkat-cli-reference/SKILL.md
@@ -291,7 +291,18 @@ rkat mob pack <dir> -o <pack> [--sign <key> --signer-id <id>]
 rkat mob inspect <pack>
 rkat mob validate <pack> [--trust-policy permissive|strict]
 rkat mob deploy <pack> <prompt> [--model <model>] [--max-total-tokens N] [--max-duration D] [--max-tool-calls N] [--trust-policy permissive|strict] [--surface cli|rpc]
-rkat mob web build <pack> -o <dir> [--trust-policy permissive|strict]
+rkat mob web build <pack> -o <dir> --wasm <PKG_DIR|name_bg.wasm> [--trust-policy permissive|strict]
+```
+
+Packing with `--sign` embeds the signer identity and public key but does not
+install that signer in a trust store. For a locally signed pack whose signer is
+not installed, use the explicit permissive posture (signature verification
+still runs and reports an unknown-signer warning):
+
+```bash
+rkat mob validate ./dist/release-triage.mobpack --trust-policy permissive
+rkat mob run ./dist/release-triage.mobpack --flow main --trust-policy permissive
+rkat mob web build ./dist/release-triage.mobpack -o ./dist/release-triage-web --wasm <PKG_DIR|name_bg.wasm> --trust-policy permissive
 ```
 
 For `rkat run` prompts that need `mob_*` tools, use `--tools full` or config

--- a/.claude/skills/meerkat-platform/SKILL.md
+++ b/.claude/skills/meerkat-platform/SKILL.md
@@ -304,25 +304,79 @@ rkat mob wait-kickoff <mob_id> [--member <agent_identity>...] [--timeout-ms N] [
 
 ### Mobpack + web build quick paths
 
+A mobpack source directory must contain these two files:
+
+```toml
+# manifest.toml
+[mobpack]
+name = "review-team"
+version = "1.0.0"
+```
+
+```json
+{
+  "id": "review-team",
+  "profiles": {
+    "lead": {
+      "model": "claude-sonnet-4-6",
+      "tools": { "builtins": true, "comms": true }
+    },
+    "reviewer": {
+      "model": "claude-sonnet-4-6",
+      "tools": { "builtins": true, "comms": true }
+    }
+  },
+  "wiring": {
+    "auto_wire_orchestrator": false,
+    "role_wiring": [{ "a": "lead", "b": "reviewer" }]
+  },
+  "flows": {
+    "main": {
+      "steps": {
+        "review": { "role": "lead", "message": "Review the change" }
+      }
+    }
+  }
+}
+```
+
+`manifest.toml` is TOML and requires the `[mobpack]` table with non-empty
+`name` and `version`. `definition.json` is JSON and requires a string `id`;
+`profiles`, `wiring`, and `flows` may be omitted. Portable mobpacks may use only
+inline profiles. A profile that will spawn a member must set `tools.comms` to
+`true`, because member construction rejects `comms=false`. When present,
+`wiring` is an object, never an array or boolean: `auto_wire_orchestrator` is a
+boolean and `role_wiring` is an array of
+`{ "a": "<profile>", "b": "<profile>" }` edges. Flow `steps` are objects keyed
+by step id; each flat step requires `role` and `message`. A flow dispatches to
+an existing runnable member of that role; declaring a profile does not spawn
+one at create or pack time. `rkat mob run` and `MobHandle::run_flow`
+automatically provision one turn-driven target for each missing flat-step role
+before dispatch. Pre-spawn through a host or SDK only when you need to choose
+the member identity or supply non-default spawn options.
+
 ```bash
 # Build portable artifact
 rkat mob pack ./mobs/release-triage -o ./dist/release-triage.mobpack \
   --sign ./keys/release.key --signer-id team@example.com   # --sign requires --signer-id
 rkat mob inspect ./dist/release-triage.mobpack
-rkat mob validate ./dist/release-triage.mobpack
+rkat mob validate ./dist/release-triage.mobpack --trust-policy permissive
+rkat mob run ./dist/release-triage.mobpack --flow main --trust-policy permissive
 
-# Invoke as a typed callable run
-rkat mob run ./dist/release-triage.mobpack --prompt "triage latest regressions" --trust-policy strict
-
-# Browser bundle
-cargo install wasm-pack
-rkat mob web build ./dist/release-triage.mobpack -o ./dist/release-triage-web
+# Browser bundle from prebuilt wasm-pack output
+rkat mob web build ./dist/release-triage.mobpack -o ./dist/release-triage-web \
+  --wasm <PKG_DIR|name_bg.wasm> --trust-policy permissive
 ```
 
-Web build env overrides:
+Signing records the signer ID and public key in the artifact; it does not add
+that signer to the user or project trusted-signers store. The explicit
+`permissive` policy above is the local-development posture: the signature is
+still verified and the unknown signer produces a warning. Use `strict` only
+after installing the signer in a trusted-signers store.
 
-- `RKAT_WASM_PACK_BIN`: explicit wasm-pack binary path
-- `RKAT_WEB_RUNTIME_CRATE_DIR`: explicit web runtime crate directory for build
+`mob web build` requires `--wasm` pointing to a wasm-pack `--target web` output
+directory or its `*_bg.wasm` file with the sibling JavaScript glue. The CLI
+does not compile wasm32 itself.
 
 ### WASM runtime + Web SDK (browser embedded)
 

--- a/.claude/skills/meerkat-platform/references/api_reference.md
+++ b/.claude/skills/meerkat-platform/references/api_reference.md
@@ -187,7 +187,7 @@ Primary CLI mob usage is tool-driven from `run`/`run --resume` prompts using `mo
 | `grant <mob_id> <principal> --scope ...` / `revoke-grant ...` / `grants <mob_id>` | Manage remote-console control scopes |
 | `member-history <mob_id> <agent_identity>` / `route-installs <mob_id>` | Read placed-member history and route-install obligations |
 | `live open\|close\|status\|control ...` | Operate a member live channel; there is intentionally no `live send` verb |
-| `run <pack_or_mob_id> [--flow] [--param] [--prompt] [--detach] [--json]` | Invoke a mobpack or installed mob as a typed callable run; `--prompt` binds `params.prompt` |
+| `run <pack_or_mob_id> [--flow] [--param] [--prompt] [--detach] [--json] [--trust-policy]` | Invoke a mobpack or installed mob as a typed callable run; `--prompt` binds `params.prompt` |
 | `runs <mob_id> [--flow] [--json]` | List persisted run resources for a mob |
 | `status <mob_id> <run_id> [--json]` | Read one run resource status |
 | `logs <mob_id> [--after-cursor] [--limit] [--json]` | Read mob event history for run diagnostics |
@@ -198,9 +198,18 @@ Primary CLI mob usage is tool-driven from `run`/`run --resume` prompts using `mo
 | `inspect <pack>` | Inspect a `.mobpack` archive |
 | `validate <pack> [--trust-policy permissive\|strict]` | Validate a `.mobpack` archive |
 | `deploy <pack> <prompt> [--model] [--max-total-tokens] [--max-duration] [--max-tool-calls] [--trust-policy] [--surface cli\|rpc]` | Validate/register/deploy a `.mobpack`; orchestrator-less packs warn that prompts are not delivered and flows are not started |
-| `web build <pack> -o <dir> [--trust-policy]` | Build a browser-deployable WASM bundle |
+| `web build <pack> -o <dir> --wasm <PKG_DIR\|name_bg.wasm> [--trust-policy]` | Build a browser-deployable WASM bundle from required prebuilt wasm-pack output |
 
 Lifecycle verbs that used to live on the CLI (`create`, `spawn`, `retire`, `wire`, `unwire`, `turn`, `stop`, `resume`, `complete`, `events`, `destroy`) are reached through the agent tools (`mob_create`, `mob_spawn_member`, `mob_wire`, ...) or through the RPC `mob/*` methods listed below.
+
+Signing a pack does not install its signer in a trust store. The executable
+local path for an uninstalled signer is explicit permissive mode:
+
+```bash
+rkat mob validate ./dist/release-triage.mobpack --trust-policy permissive
+rkat mob run ./dist/release-triage.mobpack --flow main --trust-policy permissive
+rkat mob web build ./dist/release-triage.mobpack -o ./dist/release-triage-web --wasm <PKG_DIR|name_bg.wasm> --trust-policy permissive
+```
 
 ---
 

--- a/.claude/skills/meerkat-platform/references/mobs.md
+++ b/.claude/skills/meerkat-platform/references/mobs.md
@@ -325,7 +325,7 @@ rkat mob fork-helper team-mob lead-1 "Investigate the failing test cluster." --a
 rkat mob member-status team-mob lead-1 --json
 rkat mob force-cancel team-mob worker-1
 rkat mob respawn team-mob worker-1 --initial-message "restart"
-rkat mob run ./dist/release-triage.mobpack --prompt "triage latest regressions" --json
+rkat mob run ./dist/release-triage.mobpack --prompt "triage latest regressions" --trust-policy permissive --json
 rkat mob runs team-mob --json
 rkat mob status team-mob <run_id> --json
 rkat mob attach team-mob <run_id> --json
@@ -338,17 +338,16 @@ rkat mob run-flow team-mob --flow triage --stream
 rkat mob pack ./mobs/release-triage -o ./dist/release-triage.mobpack \
   --sign ./keys/release.key --signer-id team@example.com   # --sign requires --signer-id
 rkat mob inspect ./dist/release-triage.mobpack
-rkat mob validate ./dist/release-triage.mobpack
-rkat mob run ./dist/release-triage.mobpack --prompt "triage latest regressions" --trust-policy strict
-rkat mob web build ./dist/release-triage.mobpack -o ./dist/release-triage-web
+rkat mob validate ./dist/release-triage.mobpack --trust-policy permissive
+rkat mob run ./dist/release-triage.mobpack --flow main --trust-policy permissive
+rkat mob web build ./dist/release-triage.mobpack -o ./dist/release-triage-web \
+  --wasm <PKG_DIR|name_bg.wasm> --trust-policy permissive
 ```
 
-Web build prerequisites:
-
-```bash
-cargo install wasm-pack
-export PATH="$HOME/.cargo/bin:$PATH"
-```
+Packing signs the artifact but does not install its signer. The explicit
+permissive policy is therefore the local posture until the signer is installed;
+signature verification still runs and warns that the signer is unknown.
+`--wasm` is required and names prebuilt wasm-pack `--target web` output.
 
 ### WASM browser surface
 

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -387,6 +387,7 @@ test_suite(
         "//meerkat-capabilities:meerkat_capabilities_unit_test",
         "//meerkat-cli:auth_binding_single_parser_test",
         "//meerkat-cli:cli_auth_flow_test",
+        "//meerkat-cli:help_mobpack_contract_test",
         "//meerkat-cli:mcp_convention_roots_test",
         "//meerkat-cli:runtime_backed_ingress_test",
         "//meerkat-cli:slim_feature_graph_test",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -159,6 +159,10 @@ via cargo-semver-checks against the published baselines).
   retained cleanup sidecar while cancellation-safe retirement is still
   uncertain. Stale registration or attachment witnesses continue to fail
   closed instead of blocking the valid retry path.
+- CLI OAuth guidance now uses the inherited global binding, and embedded
+  `rkat help` includes the exact mobpack manifest, definition, wiring, flow,
+  required member-comms shapes, automatic flat-step role provisioning, and
+  executable local signed-pack trust and web-runtime arguments.
 - Rejected atomic runtime commits now abort every pre-commit session
   projection—not only compaction—including the live transcript/checkpointer
   and pending context events before recovery checkpoints can reload the prior

--- a/README.md
+++ b/README.md
@@ -102,11 +102,20 @@ Same realm means shared sessions, config, backend, credentials, schedules, blobs
 
 ```bash
 rkat auth login openai
-rkat auth profiles --realm dev
-rkat run --model gpt-5.6-sol --auth-binding dev:openai_oauth "Summarize this pull request"
+rkat auth profiles  # defaults to the reserved global realm
+rkat run --model gpt-5.6-sol "Summarize this pull request"
+
+# Optional: pin the login-created OAuth binding explicitly.
+rkat run --model gpt-5.6-sol --auth-binding global:openai_oauth "Summarize this pull request"
 ```
 
-Realm bindings also work through REST, JSON-RPC, SDKs, and mob member launches, so applications can scope credentials per tenant, session, or team member without hardcoding provider keys. Bindings are provider-checked against the selected model, so an OpenAI binding should be paired with an OpenAI model, an Anthropic binding with an Anthropic model, and so on.
+`rkat auth login` writes the reserved `global` realm, which workspace realms
+inherit automatically. Realm bindings also work through REST, JSON-RPC, SDKs,
+and mob member launches, so applications can scope credentials per tenant,
+session, or team member without hardcoding provider keys. Bindings are
+provider-checked against the selected model, so an OpenAI binding should be
+paired with an OpenAI model, an Anthropic binding with an Anthropic model, and
+so on.
 
 **Give it tools and let it work.** Enable shell access, MCP tools, schedules, comms, and mob orchestration with the `full` tool preset:
 
@@ -422,18 +431,21 @@ Build once, run in multiple environments with a portable `.mobpack`:
 rkat mob pack ./mobs/release-triage -o ./dist/release-triage.mobpack \
   --sign ./keys/release.key --signer-id release-team
 rkat mob inspect ./dist/release-triage.mobpack
-rkat mob validate ./dist/release-triage.mobpack
-rkat mob deploy ./dist/release-triage.mobpack "triage latest regressions" --trust-policy strict
+rkat mob validate ./dist/release-triage.mobpack --trust-policy permissive
+rkat mob run ./dist/release-triage.mobpack --flow main --trust-policy permissive
 ```
 
-Strict trust requires the signer ID and public key to be present in the user or project trusted-signers store before deploy.
+Packing embeds the signer identity and public key but does not install that
+signer in a trust store. The local commands above therefore opt into permissive
+trust explicitly; the signature is still verified and an unknown-signer warning
+is reported. Use strict trust after installing the signer ID and public key in
+the user or project trusted-signers store.
 
 Browser target from the same artifact:
 
 ```bash
-cargo install wasm-pack
-export PATH="$HOME/.cargo/bin:$PATH"
-rkat mob web build ./dist/release-triage.mobpack -o ./dist/release-triage-web
+rkat mob web build ./dist/release-triage.mobpack -o ./dist/release-triage-web \
+  --wasm <PKG_DIR|name_bg.wasm> --trust-policy permissive
 ```
 
 See full guide: [Mobpack and Web Deployment](https://docs.rkat.ai/guides/mobpack).

--- a/docs/cli/commands.mdx
+++ b/docs/cli/commands.mdx
@@ -357,10 +357,10 @@ binds to it.
 ```bash
 rkat mob pack <DIR> -o <OUT.mobpack> [--sign <KEY_FILE> --signer-id <ID>]
 rkat mob inspect <PACK.mobpack>
-rkat mob validate <PACK.mobpack>
-rkat mob run <PACK.mobpack|MOB_ID> [--flow <FLOW_ID>] [--param <KEY=VALUE>...] [--prompt <TEXT>] [--detach] [--json]
+rkat mob validate <PACK.mobpack> [--trust-policy <permissive|strict>]
+rkat mob run <PACK.mobpack|MOB_ID> [--flow <FLOW_ID>] [--param <KEY=VALUE>...] [--prompt <TEXT>] [--detach] [--json] [--trust-policy <permissive|strict>]
 rkat mob deploy <PACK.mobpack> <PROMPT> [--trust-policy <permissive|strict>] [--surface <cli|rpc>]
-rkat mob web build <PACK.mobpack> -o <OUT_DIR> --wasm <PKG_DIR|name_bg.wasm>
+rkat mob web build <PACK.mobpack> -o <OUT_DIR> --wasm <PKG_DIR|name_bg.wasm> [--trust-policy <permissive|strict>]
 rkat mob run-flow <MOB_ID> --flow <FLOW_ID> [--params <JSON>] [--stream|--no-stream]
 rkat mob flow-status <MOB_ID> <RUN_ID>
 rkat mob runs <MOB_ID> [--flow <FLOW_ID>] [--json]
@@ -422,11 +422,11 @@ Examples:
 ```bash
 rkat mob pack ./mobs/release-triage -o dist/release-triage.mobpack
 rkat mob inspect dist/release-triage.mobpack
-rkat mob validate dist/release-triage.mobpack
-rkat mob run dist/release-triage.mobpack --prompt "triage the latest release regressions"
+rkat mob validate dist/release-triage.mobpack --trust-policy permissive
+rkat mob run dist/release-triage.mobpack --prompt "triage the latest release regressions" --trust-policy permissive
 rkat mob run release-triage --flow main --param severity='"high"' --detach
 rkat mob attach release-triage <RUN_ID>
-rkat mob web build dist/release-triage.mobpack -o dist/release-triage-web --wasm sdks/web/wasm
+rkat mob web build dist/release-triage.mobpack -o dist/release-triage-web --wasm ./meerkat-web-runtime/pkg --trust-policy permissive
 ```
 
 ### Trust policy
@@ -438,13 +438,14 @@ rkat mob web build dist/release-triage.mobpack -o dist/release-triage-web --wasm
 
 The CLI does not compile wasm32 itself. `--wasm` is required and must point at
 the prebuilt meerkat-web-runtime artifacts — either the wasm-pack `--target web`
-output **directory** (which holds `meerkat_web_runtime.js` + `meerkat_web_runtime_bg.wasm`)
-or that `*_bg.wasm` file (the sibling `.js` glue is copied alongside). Use the
-committed `sdks/web/wasm`, or build it:
+output **directory** (which holds `meerkat_web_runtime.js` +
+`meerkat_web_runtime_bg.wasm`) or that `*_bg.wasm` file (the sibling `.js` glue
+is copied alongside). `mob web build` copies those artifacts into its output.
+wasm-pack is one way to generate the required input:
 
 ```bash
 cargo install wasm-pack
-wasm-pack build meerkat-web-runtime --target web --out-dir sdks/web/wasm
+wasm-pack build meerkat-web-runtime --target web --out-dir pkg
 ```
 
 The emitted bundle is self-contained and runnable: serve the output directory and
@@ -511,7 +512,8 @@ Checks:
 - config readability
 - common provider API keys
 - MCP config loading
-- `wasm-pack` availability for `mob web build`
+- `wasm-pack` availability as one way to generate the required `--wasm`
+  artifacts; `mob web build` copies them and does not invoke wasm-pack
 
 ## init
 

--- a/docs/examples/mobpack.mdx
+++ b/docs/examples/mobpack.mdx
@@ -29,6 +29,10 @@ rkat mob pack ./mobs/release-triage \
   --signer-id team@example.com
 ```
 
+Signing embeds the public key but does not install the signer as trusted. The
+local commands below therefore use permissive mode; use strict only after
+installing that signer in the verifier's trust configuration.
+
 ## Inspect a pack
 
 View the contents, metadata, and signature status of a `.mobpack` without deploying.
@@ -42,7 +46,7 @@ rkat mob inspect ./dist/release-triage.mobpack
 Check structural integrity, schema conformance, and signature validity.
 
 ```bash
-rkat mob validate ./dist/release-triage.mobpack
+rkat mob validate ./dist/release-triage.mobpack --trust-policy permissive
 ```
 
 ## Run a pack
@@ -53,7 +57,7 @@ before the flow starts; `--prompt` is sugar for `--param prompt=<text>`.
 ```bash
 rkat mob run ./dist/release-triage.mobpack \
   --prompt "triage latest regressions" \
-  --trust-policy strict \
+  --trust-policy permissive \
   --json
 ```
 

--- a/docs/examples/wasm.mdx
+++ b/docs/examples/wasm.mdx
@@ -4,7 +4,7 @@ description: "Browser deployment with the meerkat-web-runtime embedded surface."
 icon: "globe"
 ---
 
-The WASM runtime compiles the full Meerkat agent stack to wasm32 for browser deployment. It routes through the same `AgentFactory::build_agent()` pipeline as all other surfaces.
+The WASM runtime is the full Meerkat agent stack compiled to wasm32 for browser deployment. It routes through the same `AgentFactory::build_agent()` pipeline as all other surfaces.
 
 <Note>
 This page is intentionally browser/WASM-specific rather than a cross-surface tabbed page. Use [Examples: Mobpack](/examples/mobpack) first if you want the packaging/deployment path that usually leads into browser delivery.
@@ -14,12 +14,13 @@ This page is intentionally browser/WASM-specific rather than a cross-surface tab
 
 <Tabs>
   <Tab title="CLI">
-    Build a self-contained, runnable web bundle from a `.mobpack` artifact.
-    `--wasm` points at the prebuilt meerkat-web-runtime (the wasm-pack
-    `--target web` output dir, or the committed `sdks/web/wasm`):
+    Assemble a self-contained, runnable web bundle from a `.mobpack` artifact.
+    The command does not compile wasm32; it copies the required prebuilt
+    meerkat-web-runtime from the generated wasm-pack `--target web` output
+    directory named by `--wasm`:
 
     ```bash
-    rkat mob web build ./dist/my-mob.mobpack -o ./dist/web-bundle --wasm ./sdks/web/wasm
+    rkat mob web build ./dist/my-mob.mobpack -o ./dist/web-bundle --wasm ./meerkat-web-runtime/pkg --trust-policy permissive
     ```
 
     Then serve and open it: `python3 -m http.server -d ./dist/web-bundle`.

--- a/docs/guides/mobpack.mdx
+++ b/docs/guides/mobpack.mdx
@@ -27,7 +27,7 @@ Use this guide when you want to:
 ```bash
 rkat mob pack ./mobs/release-triage -o ./dist/release-triage.mobpack
 rkat mob inspect ./dist/release-triage.mobpack
-rkat mob validate ./dist/release-triage.mobpack
+rkat mob validate ./dist/release-triage.mobpack --trust-policy permissive
 ```
 
 Expected source files:
@@ -44,10 +44,12 @@ Sign at pack time:
 rkat mob pack ./mobs/release-triage -o ./dist/release-triage.mobpack --sign ./keys/release.key --signer-id release@example.com
 ```
 
-Run with strict trust:
+Signing embeds the public key but does not install the signer in the verifier's
+trust configuration. Use permissive mode for this immediate local path, then
+switch to strict after installing the signer as trusted:
 
 ```bash
-rkat mob run ./dist/release-triage.mobpack --prompt "triage release regressions" --trust-policy strict
+rkat mob run ./dist/release-triage.mobpack --prompt "triage release regressions" --trust-policy permissive
 ```
 
 Trust policy resolution:
@@ -69,7 +71,7 @@ Strict mode rejects:
 One-shot CLI run:
 
 ```bash
-rkat mob run ./dist/release-triage.mobpack --prompt "triage latest incidents"
+rkat mob run ./dist/release-triage.mobpack --prompt "triage latest incidents" --trust-policy permissive
 ```
 
 Detached reusable run:
@@ -81,18 +83,20 @@ rkat mob attach release-triage <RUN_ID>
 
 ## Browser target: `mob web build`
 
-The web build compiles the **real meerkat agent stack** to wasm32 — same agent loop, same LLM providers (Anthropic, OpenAI, Gemini), same streaming as CLI/RPC/REST. Not a simulation.
+The browser runtime is the **real meerkat agent stack** compiled to wasm32 —
+same agent loop, same LLM providers (Anthropic, OpenAI, Gemini), and same
+streaming as CLI/RPC/REST. `mob web build` does not compile it; the command
+copies the required prebuilt runtime artifacts into the browser bundle.
 
 Prerequisites: the prebuilt meerkat-web-runtime artifacts — the wasm-bindgen
 glue (`meerkat_web_runtime.js`) and its paired `meerkat_web_runtime_bg.wasm` —
-produced by `wasm-pack build meerkat-web-runtime --target web` (or the committed
-`sdks/web/wasm` directory). The CLI does not compile wasm32 itself and fails
-closed without them — it never emits a placeholder bundle. Pass either the
-wasm-pack output **directory** or the `*_bg.wasm` file (the sibling `.js` glue is
-copied alongside it):
+produced by `wasm-pack build meerkat-web-runtime --target web` or an equivalent
+wasm-bindgen pipeline. The CLI fails closed without them and never emits a
+placeholder bundle. Pass either the generated output **directory** or the
+`*_bg.wasm` file (the sibling `.js` glue is copied alongside it):
 
 ```bash
-rkat mob web build ./dist/release-triage.mobpack -o ./dist/release-triage-web --wasm ./sdks/web/wasm
+rkat mob web build ./dist/release-triage.mobpack -o ./dist/release-triage-web --wasm ./meerkat-web-runtime/pkg --trust-policy permissive
 ```
 
 Output is a self-contained, runnable bundle — serve the directory (e.g.

--- a/docs/guides/mobs.mdx
+++ b/docs/guides/mobs.mdx
@@ -682,12 +682,13 @@ artifact:
 ```bash
 rkat mob pack ./mobs/release-triage -o ./dist/release-triage.mobpack
 rkat mob inspect ./dist/release-triage.mobpack
-rkat mob validate ./dist/release-triage.mobpack
-rkat mob run ./dist/release-triage.mobpack --prompt "triage latest release regressions"
+rkat mob validate ./dist/release-triage.mobpack --trust-policy permissive
+rkat mob run ./dist/release-triage.mobpack --prompt "triage latest release regressions" --trust-policy permissive
 ```
 
 Use mobpacks when the mob should be versioned, signed, reviewed, deployed, or
-compiled for the browser.
+bundled for browser deployment. `mob web build` copies required prebuilt
+wasm-pack output into that bundle; it does not compile wasm32.
 
 ## Troubleshooting
 

--- a/docs/reference/mob-architecture.mdx
+++ b/docs/reference/mob-architecture.mdx
@@ -84,10 +84,13 @@ material for deployment through:
 ```bash
 rkat mob pack ./mob -o ./dist/mob.mobpack
 rkat mob inspect ./dist/mob.mobpack
-rkat mob validate ./dist/mob.mobpack
-rkat mob run ./dist/mob.mobpack --prompt "run this mob"
-rkat mob web build ./dist/mob.mobpack -o ./dist/web --wasm ./path/to/runtime_bg.wasm
+rkat mob validate ./dist/mob.mobpack --trust-policy permissive
+rkat mob run ./dist/mob.mobpack --prompt "run this mob" --trust-policy permissive
+rkat mob web build ./dist/mob.mobpack -o ./dist/web --wasm ./meerkat-web-runtime/pkg --trust-policy permissive
 ```
+
+`mob web build` copies the required prebuilt wasm-pack output into the browser
+bundle; it does not compile wasm32.
 
 ## Live Channels
 

--- a/meerkat-cli/BUILD.bazel
+++ b/meerkat-cli/BUILD.bazel
@@ -710,6 +710,100 @@ rust_test(
 )
 
 rust_test(
+    name = "help_mobpack_contract_test",
+    aliases = aliases(
+        package_name = "meerkat-cli",
+        normal = True,
+        normal_dev = True,
+        proc_macro = True,
+        proc_macro_dev = True,
+    ),
+    crate_name = "help_mobpack_contract",
+    crate_root = "tests/help_mobpack_contract.rs",
+    crate_features = [
+        "anthropic",
+        "comms",
+        "gemini",
+        "integration-real-tests",
+        "jsonl-store",
+        "mcp",
+        "meerkat-rpc?/comms",
+        "meerkat-rpc?/mcp",
+        "meerkat-rpc?/openai-realtime",
+        "meerkat-rpc?/schedule",
+        "meerkat-rpc?/workgraph",
+        "memory-store",
+        "mob",
+        "openai",
+        "openai-realtime",
+        "rpc-surface",
+        "schedule",
+        "session-store",
+        "skills",
+        "workgraph",
+    ],
+    edition = "2024",
+    compile_data = [
+        "Cargo.toml",
+        "src/main.rs",
+    ],
+    srcs = [
+        "tests/help_mobpack_contract.rs",
+    ],
+    visibility = ["//visibility:public"],
+    rustc_env = {
+        "CARGO_PKG_VERSION": "0.8.0",
+        "CARGO_BIN_NAME": "help_mobpack_contract",
+        "CARGO_MANIFEST_DIR": "./meerkat-cli",
+    },
+    tags = [
+        "fast",
+    ],
+    size = "small",
+    data = [
+        ":package_runfiles",
+        "//meerkat-cli:rkat",
+    ],
+    env = {
+        "RUST_MIN_STACK": "16777216",
+        "CARGO_BIN_EXE_rkat": "$(rootpath //meerkat-cli:rkat)",
+    },
+    proc_macro_deps = all_crate_deps(
+        package_name = "meerkat-cli",
+        proc_macro = True,
+        proc_macro_dev = True,
+    ),
+    deps = [
+        "//meerkat-mob-mcp:meerkat_mob_mcp_with_runtime_test_support",
+        "//meerkat-mob-pack:meerkat_mob_pack_with_runtime_test_support",
+        "//meerkat-mob:meerkat_mob_with_runtime_test_support",
+        "//meerkat-rpc:meerkat_rpc_with_runtime_test_support",
+        "//meerkat:meerkat_anthropic_agent_factory_build",
+        "//meerkat:meerkat_auth_core_agent_factory_build",
+        "//meerkat:meerkat_client_agent_factory_build",
+        "//meerkat:meerkat_comms_agent_factory_build",
+        "//meerkat:meerkat_contracts_agent_factory_build",
+        "//meerkat:meerkat_core_agent_factory_build",
+        "//meerkat:meerkat_gemini_agent_factory_build",
+        "//meerkat:meerkat_live_agent_factory_build",
+        "//meerkat:meerkat_llm_core_agent_factory_build",
+        "//meerkat:meerkat_mcp_agent_factory_build_test_support",
+        "//meerkat:meerkat_models_agent_factory_build",
+        "//meerkat:meerkat_openai_agent_factory_build",
+        "//meerkat:meerkat_providers_agent_factory_build",
+        "//meerkat:meerkat_runtime_agent_factory_build_test_support",
+        "//meerkat:meerkat_session_agent_factory_build_with_runtime_test_support",
+        "//meerkat:meerkat_store_agent_factory_build",
+        "//meerkat:meerkat_tools_agent_factory_build_with_runtime_test_support",
+        "//meerkat:meerkat_with_runtime_test_support",
+    ] + all_crate_deps(
+        package_name = "meerkat-cli",
+        normal = True,
+        normal_dev = True,
+    ),
+)
+
+rust_test(
     name = "live_smoke_cli_test",
     aliases = aliases(
         package_name = "meerkat-cli",
@@ -2289,6 +2383,7 @@ test_suite(
     tests = [
         ":auth_binding_single_parser_test",
         ":cli_auth_flow_test",
+        ":help_mobpack_contract_test",
         ":mcp_convention_roots_test",
         ":runtime_backed_ingress_test",
         ":slim_feature_graph_test",

--- a/meerkat-cli/src/main.rs
+++ b/meerkat-cli/src/main.rs
@@ -1970,7 +1970,7 @@ enum Commands {
 
     #[cfg(feature = "mob")]
     #[command(
-        after_help = "Examples:\n  rkat mob pack ./mobs/release-triage -o dist/release-triage.mobpack\n  rkat mob inspect dist/release-triage.mobpack\n  rkat mob validate dist/release-triage.mobpack\n  rkat mob deploy dist/release-triage.mobpack \"triage the latest release regressions\"\n  rkat mob web build dist/release-triage.mobpack -o dist/release-triage-web"
+        after_help = "Examples:\n  rkat mob pack ./mobs/release-triage -o dist/release-triage.mobpack\n  rkat mob inspect dist/release-triage.mobpack\n  rkat mob validate dist/release-triage.mobpack --trust-policy permissive\n  rkat mob run dist/release-triage.mobpack --flow main --trust-policy permissive\n  rkat mob web build dist/release-triage.mobpack -o dist/release-triage-web --wasm <PKG_DIR|name_bg.wasm> --trust-policy permissive"
     )]
     /// Mob orchestration commands
     Mob {
@@ -3158,10 +3158,10 @@ enum MobWebCommands {
         #[arg(short = 'o', long)]
         output: PathBuf,
         /// Prebuilt meerkat-web-runtime artifacts: either the wasm-pack `--target web` output
-        /// directory (e.g. `sdks/web/wasm`) or its `<name>_bg.wasm` file (the sibling
+        /// directory (e.g. generated `sdks/web/wasm`) or its `<name>_bg.wasm` file (the sibling
         /// `<name>.js` glue is copied alongside). Required: the CLI does not compile wasm32 itself.
         #[arg(long)]
-        wasm: Option<PathBuf>,
+        wasm: PathBuf,
         #[arg(long, value_enum)]
         trust_policy: Option<TrustPolicyArg>,
     },
@@ -7348,9 +7348,15 @@ async fn handle_doctor(scope: &RuntimeScope) -> anyhow::Result<()> {
         .await;
     match wasm_pack {
         Ok(output) if output.status.success() => {
-            println!("ok\twasm-pack\tavailable");
+            println!(
+                "ok\twasm-pack\tavailable (one way to generate the prebuilt artifacts required \
+                 by `rkat mob web build --wasm`; the build command does not invoke wasm-pack)"
+            );
         }
-        _ => println!("warn\twasm-pack\tnot found (needed for `rkat mob web build`)"),
+        _ => println!(
+            "warn\twasm-pack\tnot found (one way to generate the prebuilt artifacts required by \
+             `rkat mob web build --wasm`; the build command does not invoke wasm-pack)"
+        ),
     }
 
     if ok {
@@ -14469,7 +14475,8 @@ async fn handle_mob_command(command: MobCommands, scope: &RuntimeScope) -> anyho
     {
         println!(
             "{}",
-            execute_mob_web_build(scope, pack, output, wasm.as_deref(), *trust_policy).await?
+            execute_mob_web_build(scope, pack, output, Some(wasm.as_path()), *trust_policy,)
+                .await?
         );
         return Ok(());
     }
@@ -15356,7 +15363,7 @@ async fn execute_mob_web_build(
         anyhow::anyhow!(
             "mob web build failed: missing --wasm <pkg-dir|name_bg.wasm>; pass the prebuilt \
              meerkat-web-runtime artifacts (e.g. `wasm-pack build meerkat-web-runtime --target \
-             web`, or the committed sdks/web/wasm dir). The CLI does not compile wasm32 itself."
+             web`, or the generated sdks/web/wasm dir). The CLI does not compile wasm32 itself."
         )
     })?;
     let (glue_path, wasm_path) = resolve_web_runtime_assets(wasm_arg)?;
@@ -21384,6 +21391,19 @@ url = "https://user.example/mcp"
     #[cfg(feature = "mob")]
     #[test]
     fn test_cli_mob_web_build_command_parses() {
+        assert!(
+            Cli::try_parse_from([
+                "rkat",
+                "mob",
+                "web",
+                "build",
+                "./fixture.mobpack",
+                "-o",
+                "./web-out",
+            ])
+            .is_err(),
+            "mob web build must require --wasm at parse time"
+        );
         let cli = Cli::try_parse_from([
             "rkat",
             "mob",
@@ -21392,6 +21412,8 @@ url = "https://user.example/mcp"
             "./fixture.mobpack",
             "-o",
             "./web-out",
+            "--wasm",
+            "./wasm-pkg",
         ])
         .expect("mob web build command should parse");
 
@@ -21410,7 +21432,7 @@ url = "https://user.example/mcp"
             } => {
                 assert_eq!(pack, PathBuf::from("./fixture.mobpack"));
                 assert_eq!(output, PathBuf::from("./web-out"));
-                assert_eq!(wasm, None);
+                assert_eq!(wasm, PathBuf::from("./wasm-pkg"));
                 assert_eq!(trust_policy, None);
             }
             _ => unreachable!("expected mob web build command"),

--- a/meerkat-cli/tests/help_mobpack_contract.rs
+++ b/meerkat-cli/tests/help_mobpack_contract.rs
@@ -1,0 +1,322 @@
+#![cfg(feature = "mob")]
+
+use std::process::{Command, Output};
+
+const ACTIVE_DOCS_NAV: &str = include_str!("../../docs/docs.json");
+const ACTIVE_MOBPACK_DOCS: &[(&str, &str)] = &[
+    (
+        "guides/mobpack",
+        include_str!("../../docs/guides/mobpack.mdx"),
+    ),
+    ("guides/mobs", include_str!("../../docs/guides/mobs.mdx")),
+    (
+        "examples/mobpack",
+        include_str!("../../docs/examples/mobpack.mdx"),
+    ),
+    (
+        "examples/wasm",
+        include_str!("../../docs/examples/wasm.mdx"),
+    ),
+    ("cli/commands", include_str!("../../docs/cli/commands.mdx")),
+    (
+        "reference/mob-architecture",
+        include_str!("../../docs/reference/mob-architecture.mdx"),
+    ),
+];
+
+fn output_text(output: &Output) -> String {
+    format!(
+        "stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    )
+}
+
+fn fenced_block<'a>(section: &'a str, language: &str) -> Result<&'a str, String> {
+    let opening = format!("```{language}\n");
+    section
+        .split_once(&opening)
+        .and_then(|(_, rest)| rest.split_once("\n```").map(|(body, _)| body))
+        .ok_or_else(|| format!("missing {language} block in embedded mobpack help"))
+}
+
+fn assert_local_pack_commands_use_permissive(source: &str, body: &str) {
+    let joined_commands = body.replace("\\\n", " ");
+    for line in joined_commands.lines().map(str::trim) {
+        let concrete_pack_path = line.contains(".mobpack") && !line.contains('<');
+        let verifies_pack = line.starts_with("rkat mob validate");
+        let runs_pack = line.starts_with("rkat mob run");
+        let builds_pack = line.starts_with("rkat mob web build");
+        if concrete_pack_path && (verifies_pack || runs_pack || builds_pack) {
+            assert!(
+                line.contains("--trust-policy permissive"),
+                "{source} has a default-strict local pack command: {line}"
+            );
+        }
+    }
+}
+
+fn assert_active_mobpack_doc_contract(route: &str, body: &str) {
+    assert!(
+        ACTIVE_DOCS_NAV.contains(&format!("\"{route}\"")),
+        "contract test must cover only an active docs route: {route}"
+    );
+
+    let collapsed = body
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ")
+        .to_ascii_lowercase();
+    for stale in [
+        "the web build compiles",
+        "committed `sdks/web/wasm`",
+        "--wasm ./sdks/web/wasm",
+        "--wasm sdks/web/wasm",
+        "`wasm-pack` availability for `mob web build`",
+    ] {
+        assert!(
+            !collapsed.contains(stale),
+            "active doc {route} restored stale contract: {stale}"
+        );
+    }
+
+    assert_local_pack_commands_use_permissive(&format!("active doc {route}"), body);
+
+    if collapsed.contains("rkat mob web build") {
+        assert!(
+            collapsed.contains("copies")
+                && collapsed.contains("prebuilt")
+                && collapsed.contains("does not compile"),
+            "active doc {route} must say web build copies prebuilt artifacts without compiling wasm"
+        );
+    }
+}
+
+#[test]
+fn embedded_help_mobpack_examples_match_typed_authoring_contracts()
+-> Result<(), Box<dyn std::error::Error>> {
+    for (route, body) in ACTIVE_MOBPACK_DOCS {
+        assert_active_mobpack_doc_contract(route, body);
+    }
+    assert_local_pack_commands_use_permissive(
+        "embedded references/mobs.md",
+        meerkat::help::MEERKAT_PLATFORM_MOBS_REFERENCE,
+    );
+
+    let section = meerkat::help::MEERKAT_PLATFORM_SKILL_BODY
+        .split_once("### Mobpack + web build quick paths")
+        .map(|(_, section)| section)
+        .ok_or("embedded help must contain the mobpack quick-path section")?;
+
+    let manifest: meerkat_mob_pack::manifest::MobpackManifest =
+        toml::from_str(fenced_block(section, "toml")?)?;
+    assert_eq!(manifest.mobpack.name, "review-team");
+    assert_eq!(manifest.mobpack.version, "1.0.0");
+
+    let definition: meerkat_mob::MobDefinition =
+        serde_json::from_str(fenced_block(section, "json")?)?;
+    assert_eq!(definition.id.as_str(), "review-team");
+    assert_eq!(definition.profiles.len(), 2);
+    assert!(definition.profiles.values().all(|binding| {
+        binding
+            .as_inline()
+            .is_some_and(|profile| profile.tools.comms)
+    }));
+    assert_eq!(definition.wiring.role_wiring.len(), 1);
+    assert_eq!(definition.flows.len(), 1);
+    let main_flow = definition
+        .flows
+        .values()
+        .next()
+        .ok_or("definition must contain the main flow")?;
+    assert_eq!(main_flow.steps.len(), 1);
+
+    let command_block = fenced_block(section, "bash")?;
+    assert!(
+        command_block
+            .contains("mob validate ./dist/release-triage.mobpack --trust-policy permissive"),
+        "a locally signed pack is not trusted merely because pack embedded its key"
+    );
+    assert!(
+        command_block.contains(
+            "rkat mob run ./dist/release-triage.mobpack --flow main --trust-policy permissive"
+        ),
+        "mob run must exercise automatic flat-step role provisioning"
+    );
+    assert!(
+        command_block.contains("--wasm <PKG_DIR|name_bg.wasm> --trust-policy permissive"),
+        "web build must receive both its prebuilt runtime and the honest local trust posture"
+    );
+    assert!(
+        meerkat::help::MEERKAT_CLI_REFERENCE_SKILL_BODY
+            .contains("rkat mob web build <pack> -o <dir> --wasm <PKG_DIR|name_bg.wasm>"),
+        "the exact CLI authority must make --wasm required"
+    );
+    let normalized_section = section.split_whitespace().collect::<Vec<_>>().join(" ");
+    assert!(
+        normalized_section.contains("automatically provision one turn-driven target")
+            && normalized_section.contains("Pre-spawn through a host or SDK only when you need"),
+        "help must explain automatic flow provisioning and the explicit pre-spawn boundary"
+    );
+
+    // Exercise the documented artifact path through the shipped CLI, rather
+    // than accepting examples merely because their TOML and JSON deserialize.
+    let temp = tempfile::tempdir()?;
+    let source = temp.path().join("mobs").join("release-triage");
+    let dist = temp.path().join("dist");
+    std::fs::create_dir_all(&source)?;
+    std::fs::create_dir_all(&dist)?;
+    std::fs::write(source.join("manifest.toml"), fenced_block(section, "toml")?)?;
+    std::fs::write(
+        source.join("definition.json"),
+        fenced_block(section, "json")?,
+    )?;
+    let signing_key = temp.path().join("release.key");
+    std::fs::write(
+        &signing_key,
+        "0707070707070707070707070707070707070707070707070707070707070707\n",
+    )?;
+    let pack = dist.join("release-triage.mobpack");
+    let rkat = env!("CARGO_BIN_EXE_rkat");
+
+    let empty_path = temp.path().join("empty-path");
+    std::fs::create_dir_all(&empty_path)?;
+    let doctor = Command::new(rkat)
+        .current_dir(temp.path())
+        .env("HOME", temp.path())
+        .env("XDG_CONFIG_HOME", temp.path().join("config"))
+        .env("PATH", &empty_path)
+        .arg("doctor")
+        .output()?;
+    let doctor_output = output_text(&doctor);
+    assert!(
+        doctor_output.contains(
+            "one way to generate the prebuilt artifacts required by `rkat mob web build --wasm`"
+        ) && doctor_output.contains("the build command does not invoke wasm-pack"),
+        "doctor must describe wasm-pack as an optional artifact generator: {doctor_output}"
+    );
+    assert!(
+        !doctor_output.contains("needed for `rkat mob web build`"),
+        "doctor restored the false direct dependency claim: {doctor_output}"
+    );
+
+    let packed = Command::new(rkat)
+        .current_dir(temp.path())
+        .env("HOME", temp.path())
+        .env("XDG_CONFIG_HOME", temp.path().join("config"))
+        .env_remove("RKAT_TRUST_POLICY")
+        .args(["mob", "pack"])
+        .arg(&source)
+        .args(["-o"])
+        .arg(&pack)
+        .args(["--sign"])
+        .arg(&signing_key)
+        .args(["--signer-id", "team@example.com"])
+        .output()?;
+    assert!(
+        packed.status.success(),
+        "mob pack failed: {}",
+        output_text(&packed)
+    );
+
+    let inspected = Command::new(rkat)
+        .current_dir(temp.path())
+        .env("HOME", temp.path())
+        .env("XDG_CONFIG_HOME", temp.path().join("config"))
+        .arg("mob")
+        .arg("inspect")
+        .arg(&pack)
+        .output()?;
+    assert!(
+        inspected.status.success(),
+        "mob inspect failed: {}",
+        output_text(&inspected)
+    );
+
+    let permissive = Command::new(rkat)
+        .current_dir(temp.path())
+        .env("HOME", temp.path())
+        .env("XDG_CONFIG_HOME", temp.path().join("config"))
+        .env_remove("RKAT_TRUST_POLICY")
+        .arg("mob")
+        .arg("validate")
+        .arg(&pack)
+        .args(["--trust-policy", "permissive"])
+        .output()?;
+    assert!(
+        permissive.status.success(),
+        "permissive mob validate failed: {}",
+        output_text(&permissive)
+    );
+    assert!(
+        String::from_utf8_lossy(&permissive.stdout)
+            .contains("signature valid but signer is unknown in permissive mode"),
+        "permissive validation must surface unknown-signer warning: {}",
+        output_text(&permissive)
+    );
+
+    let strict = Command::new(rkat)
+        .current_dir(temp.path())
+        .env("HOME", temp.path())
+        .env("XDG_CONFIG_HOME", temp.path().join("config"))
+        .env_remove("RKAT_TRUST_POLICY")
+        .arg("mob")
+        .arg("validate")
+        .arg(&pack)
+        .args(["--trust-policy", "strict"])
+        .output()?;
+    assert!(
+        !strict.status.success()
+            && String::from_utf8_lossy(&strict.stderr).contains("unknown signer"),
+        "strict validation must reject the uninstalled signer: {}",
+        output_text(&strict)
+    );
+
+    let wasm_pkg = temp.path().join("wasm-pkg");
+    std::fs::create_dir_all(&wasm_pkg)?;
+    let wasm_bytes = b"\0asm\x01\0\0\0";
+    std::fs::write(wasm_pkg.join("real_bg.wasm"), wasm_bytes)?;
+    std::fs::write(
+        wasm_pkg.join("real.js"),
+        "export default function init() {}\n",
+    )?;
+    let web_out = dist.join("release-triage-web");
+    let web_build = Command::new(rkat)
+        .current_dir(temp.path())
+        .env("HOME", temp.path())
+        .env("XDG_CONFIG_HOME", temp.path().join("config"))
+        .env_remove("RKAT_TRUST_POLICY")
+        .arg("mob")
+        .arg("web")
+        .arg("build")
+        .arg(&pack)
+        .args(["-o"])
+        .arg(&web_out)
+        .arg("--wasm")
+        .arg(&wasm_pkg)
+        .args(["--trust-policy", "permissive"])
+        .output()?;
+    assert!(
+        web_build.status.success(),
+        "permissive mob web build failed: {}",
+        output_text(&web_build)
+    );
+    assert_eq!(std::fs::read(web_out.join("real_bg.wasm"))?, wasm_bytes);
+    assert_eq!(
+        std::fs::read_to_string(web_out.join("real.js"))?,
+        "export default function init() {}\n"
+    );
+    for required in [
+        "mobpack.bin",
+        "manifest.web.toml",
+        "meerkat-bootstrap.js",
+        "index.html",
+    ] {
+        assert!(
+            web_out.join(required).is_file(),
+            "web build must emit {required}"
+        );
+    }
+
+    Ok(())
+}

--- a/meerkat/src/help.rs
+++ b/meerkat/src/help.rs
@@ -160,6 +160,88 @@ mod tests {
     }
 
     #[test]
+    fn platform_skill_embeds_mobpack_authoring_contract() {
+        fn fenced_block<'a>(section: &'a str, language: &str) -> &'a str {
+            let opening = format!("```{language}\n");
+            section
+                .split_once(&opening)
+                .and_then(|(_, rest)| rest.split_once("\n```").map(|(body, _)| body))
+                .unwrap_or_else(|| panic!("missing {language} block in embedded mobpack help"))
+        }
+
+        let section = MEERKAT_PLATFORM_SKILL_BODY
+            .split_once("### Mobpack + web build quick paths")
+            .map(|(_, section)| section)
+            .expect("embedded help must contain the mobpack quick-path section");
+        let manifest: toml::Value = toml::from_str(fenced_block(section, "toml"))
+            .expect("embedded manifest.toml example must be valid TOML");
+        assert_eq!(manifest["mobpack"]["name"].as_str(), Some("review-team"));
+        assert_eq!(manifest["mobpack"]["version"].as_str(), Some("1.0.0"));
+
+        let definition: serde_json::Value = serde_json::from_str(fenced_block(section, "json"))
+            .expect("embedded definition.json example must be valid JSON");
+        assert_eq!(definition["id"].as_str(), Some("review-team"));
+        assert_eq!(
+            definition["profiles"]["lead"]["tools"]["comms"].as_bool(),
+            Some(true)
+        );
+        assert_eq!(
+            definition["profiles"]["reviewer"]["tools"]["comms"].as_bool(),
+            Some(true)
+        );
+        assert_eq!(
+            definition["wiring"]["auto_wire_orchestrator"].as_bool(),
+            Some(false)
+        );
+        assert_eq!(
+            definition["wiring"]["role_wiring"][0]["a"].as_str(),
+            Some("lead")
+        );
+        assert_eq!(
+            definition["wiring"]["role_wiring"][0]["b"].as_str(),
+            Some("reviewer")
+        );
+
+        assert!(MEERKAT_PLATFORM_SKILL_BODY.contains("# manifest.toml"));
+        assert!(MEERKAT_PLATFORM_SKILL_BODY.contains("`definition.json` is JSON"));
+        assert!(
+            MEERKAT_PLATFORM_SKILL_BODY.contains(r#""tools": { "builtins": true, "comms": true }"#),
+            "embedded help must state the required mob member comms capability"
+        );
+        assert!(MEERKAT_PLATFORM_SKILL_BODY.contains(r#""wiring": {"#));
+        assert!(
+            MEERKAT_PLATFORM_SKILL_BODY
+                .contains(r#""role_wiring": [{ "a": "lead", "b": "reviewer" }]"#),
+            "embedded help must show the exact role wiring edge shape"
+        );
+        assert!(
+            MEERKAT_PLATFORM_SKILL_BODY.contains("`wiring` is an object, never an")
+                && MEERKAT_PLATFORM_SKILL_BODY.contains("array or boolean"),
+            "embedded help must reject the common wiring array/boolean misconception"
+        );
+        let quick_path = section
+            .split_once("### WASM runtime + Web SDK")
+            .map_or(section, |(quick_path, _)| quick_path);
+        let quick_path_commands = fenced_block(quick_path, "bash");
+        assert!(
+            quick_path.contains("automatically provision one turn-driven target")
+                && quick_path_commands
+                    .lines()
+                    .any(|line| line.trim_start().starts_with("rkat mob run ")),
+            "mobpack help must describe and invoke automatic flat-step role provisioning"
+        );
+        assert!(
+            quick_path.contains("--trust-policy permissive")
+                && quick_path.contains("--wasm <PKG_DIR|name_bg.wasm>"),
+            "the local signed-pack path must use honest trust and a real prebuilt web runtime"
+        );
+        assert!(
+            MEERKAT_CLI_REFERENCE_SKILL_BODY.contains("--wasm <PKG_DIR|name_bg.wasm>"),
+            "the embedded exact CLI authority must make the web runtime artifact required"
+        );
+    }
+
+    #[test]
     fn platform_skill_pins_current_cli_help_facts() {
         for legacy_help_file in [
             "api_reference.md",


### PR DESCRIPTION
## Summary

- align mobpack authoring/help with shipped flow auto-provisioning semantics
- make `mob web build --wasm` required at the CLI boundary and update every active exact-command authority
- document the honest permissive posture for a newly signed local pack whose signer is not installed yet
- turn the embedded help examples into fenced, parsed contracts and exercise the artifact path through the shipped binary

## Contract corrections

- `MobBuilder::create`/packing do not spawn members, but `rkat mob run` and `MobHandle::run_flow` provision one turn-driven target for each missing flat-step role; explicit pre-spawn is only needed to choose identity/options
- a signature embedded in a pack proves integrity but does not install signer trust, so local examples use `--trust-policy permissive`; strict remains the installed-signer posture
- browser bundle construction requires an existing wasm-pack output directory or `*_bg.wasm` plus sibling glue; the CLI does not compile wasm32 itself

## Validation

- `rkat` mob-web parse regression
- shipped-binary `help_mobpack_contract`, including pack/inspect/permissive validate, strict rejection, and tiny valid WASM web build
- embedded platform and CLI-reference skill contract tests
- focused Clippy with warnings denied
- independent review after correction

