### PR TITLE
fix(dogma): close standalone and SDK authority gaps

### DIFF
--- a/.claude/skills/meerkat-platform/references/api_reference.md
+++ b/.claude/skills/meerkat-platform/references/api_reference.md
@@ -624,7 +624,7 @@ Mob methods:
 Type/parsing notes:
 
 - capability status may arrive as externally-tagged enum maps (e.g. `{"DisabledByPolicy": {...}}`) and is normalized to the tag string.
-- event parsing defaults missing fields to empty/zero values to keep partial stream payloads parseable.
+- event-envelope parsing requires canonical `event_id`, typed `source`, `seq`, `timestamp_ms`, and object `payload` facts; missing or malformed facts fail with `INVALID_RESPONSE` rather than being defaulted.
 - `RunResult.skill_diagnostics` is typed as `SkillRuntimeDiagnostics`.
 - generated image blocks preserve `image_id`, `blob_id`, `media_type`, `width`, `height`, `revised_prompt`, and provider `meta`.
 - image-generation wire contracts are exported as `WireGenerateImageRequest`, `WireGenerateImageExecutionPlan`, `WireImageGenerationToolResult`, `WireImageOperationPhase`, and `WireAssistantImageRef`.
@@ -714,7 +714,7 @@ Mob methods:
 Type/parsing notes:
 
 - capability status may arrive as externally-tagged enum maps (e.g. `{ DisabledByPolicy: {...} }`) and is normalized to the tag string.
-- event parsing defaults missing fields to empty/zero values to keep partial stream payloads parseable.
+- event-envelope parsing requires canonical `event_id`, typed `source`, `seq`, `timestamp_ms`, and object `payload` facts; missing or malformed facts fail with `INVALID_RESPONSE` rather than being defaulted.
 - `RunResult.skillDiagnostics` is typed as `SkillRuntimeDiagnostics`.
 - generated image blocks preserve `imageId`, `blobId`, `mediaType`, `width`, `height`, `revisedPrompt`, and provider `meta`.
 - image-generation wire contracts are exported as `WireGenerateImageRequest`, `WireGenerateImageExecutionPlan`, `WireImageGenerationToolResult`, `WireImageOperationPhase`, and `WireAssistantImageRef`.

--- a/meerkat-core/src/agent/state.rs
+++ b/meerkat-core/src/agent/state.rs
@@ -93,6 +93,64 @@ struct MachineAcceptedModelFallbackActivation {
     proof: crate::StickyModelFallbackActivationProof,
 }
 
+/// Rollback guard for the synchronous process-local transcript + memory pair.
+///
+/// `EphemeralImmediate` stores publish through a non-async trait method, so an
+/// agent run future cannot be dropped between installing the transcript rewrite
+/// and committing or rejecting its paired memory batch. The guard restores the
+/// pre-rewrite session on a returned store error or unwind; completed indexing
+/// errors retain the attempted cadence, matching the ordinary non-fatal
+/// compaction retry policy.
+struct EphemeralCompactionRewriteGuard<'a> {
+    session: &'a mut crate::Session,
+    cadence: &'a mut crate::compact::SessionCompactionCadence,
+    rollback_session: Option<crate::Session>,
+    rollback_cadence: Option<crate::compact::SessionCompactionCadence>,
+}
+
+impl<'a> EphemeralCompactionRewriteGuard<'a> {
+    fn install(
+        session: &'a mut crate::Session,
+        replacement: crate::Session,
+        cadence: &'a mut crate::compact::SessionCompactionCadence,
+        rollback_cadence: crate::compact::SessionCompactionCadence,
+    ) -> Self {
+        let rollback_session = std::mem::replace(session, replacement);
+        Self {
+            session,
+            cadence,
+            rollback_session: Some(rollback_session),
+            rollback_cadence: Some(rollback_cadence),
+        }
+    }
+
+    fn commit(mut self) {
+        self.rollback_session = None;
+        self.rollback_cadence = None;
+    }
+
+    fn rollback_index_error_preserving_attempt(mut self) {
+        if let Some(session) = self.rollback_session.take() {
+            *self.session = session;
+        }
+        // A completed indexing error is a real compaction attempt. Leave the
+        // live attempted cadence in place so the normal guard prevents an
+        // immediate retry; only cancellation restores the pre-attempt cadence.
+        self.rollback_cadence = None;
+    }
+}
+
+impl Drop for EphemeralCompactionRewriteGuard<'_> {
+    fn drop(&mut self) {
+        if let Some(session) = self.rollback_session.take() {
+            *self.session = session;
+        }
+        if let Some(cadence) = self.rollback_cadence.take() {
+            *self.cadence = cadence;
+        }
+    }
+}
+
 impl MachineAcceptedModelFallbackActivation {
     fn authorize(
         mut switch: AgentLlmFallbackSwitch,
@@ -1855,26 +1913,39 @@ where
                                                 (false, false)
                                             }
                                             crate::memory::CompactionProjectionPersistence::EphemeralImmediate => {
-                                                // Process-local only: publish
-                                                // the in-memory rewrite first,
-                                                // then index, and roll both
-                                                // local facts back on failure.
-                                                let original_session = std::mem::replace(
-                                                    &mut self.session,
-                                                    compacted_session,
-                                                );
-                                                let indexed = match self
-                                                    .compaction_memory_batch(&outcome.discarded)
-                                                {
+                                                // Process-local only: install
+                                                // the rewrite, synchronously
+                                                // publish its all-or-none memory
+                                                // batch, then commit/rollback the
+                                                // guard before the next await.
+                                                // Stores that advertise this
+                                                // mode but do not implement the
+                                                // synchronous contract fail
+                                                // closed via the trait default.
+                                                let batch = self
+                                                    .compaction_memory_batch(&outcome.discarded);
+                                                let rewrite_guard =
+                                                    EphemeralCompactionRewriteGuard::install(
+                                                        &mut self.session,
+                                                        compacted_session,
+                                                        &mut self.compaction_cadence,
+                                                        rollback_state
+                                                            .rollback_compaction_cadence
+                                                            .clone(),
+                                                    );
+                                                let indexed = match batch {
                                                     Ok(batch) => memory_store
-                                                        .index_scoped_batch(batch)
-                                                        .await,
+                                                        .publish_ephemeral_compaction_batch(batch),
                                                     Err(error) => Err(error),
                                                 };
                                                 match indexed {
-                                                    Ok(_) => (true, true),
+                                                    Ok(_) => {
+                                                        rewrite_guard.commit();
+                                                        (true, true)
+                                                    }
                                                     Err(error) => {
-                                                        self.session = original_session;
+                                                        rewrite_guard
+                                                            .rollback_index_error_preserving_attempt();
                                                         projection_failure = Some(error);
                                                         (false, false)
                                                     }
@@ -6039,17 +6110,8 @@ mod tests {
                 .filter_map(|(_, _, metadata)| metadata.source.source_range())
                 .collect()
         }
-    }
 
-    #[async_trait]
-    impl MemoryStore for RecordingMemoryStore {
-        fn compaction_projection_persistence(
-            &self,
-        ) -> crate::memory::CompactionProjectionPersistence {
-            crate::memory::CompactionProjectionPersistence::EphemeralImmediate
-        }
-
-        async fn index_scoped_batch(
+        fn record_batch(
             &self,
             batch: MemoryIndexBatch,
         ) -> Result<MemoryIndexReceipt, MemoryStoreError> {
@@ -6073,6 +6135,68 @@ mod tests {
                 scope: receipt_scope,
                 indexed_entries,
             })
+        }
+    }
+
+    #[async_trait]
+    impl MemoryStore for RecordingMemoryStore {
+        fn compaction_projection_persistence(
+            &self,
+        ) -> crate::memory::CompactionProjectionPersistence {
+            crate::memory::CompactionProjectionPersistence::EphemeralImmediate
+        }
+
+        async fn index_scoped_batch(
+            &self,
+            batch: MemoryIndexBatch,
+        ) -> Result<MemoryIndexReceipt, MemoryStoreError> {
+            self.record_batch(batch)
+        }
+
+        fn publish_ephemeral_compaction_batch(
+            &self,
+            batch: MemoryIndexBatch,
+        ) -> Result<MemoryIndexReceipt, MemoryStoreError> {
+            self.record_batch(batch)
+        }
+
+        async fn search(
+            &self,
+            _scope: &MemorySearchScope,
+            _query: &str,
+            _limit: usize,
+        ) -> Result<Vec<MemoryResult>, MemoryStoreError> {
+            Ok(Vec::new())
+        }
+    }
+
+    struct MisdeclaredEphemeralMemoryStore {
+        async_index_entered: std::sync::atomic::AtomicBool,
+    }
+
+    impl MisdeclaredEphemeralMemoryStore {
+        fn new() -> Self {
+            Self {
+                async_index_entered: std::sync::atomic::AtomicBool::new(false),
+            }
+        }
+    }
+
+    #[async_trait]
+    impl MemoryStore for MisdeclaredEphemeralMemoryStore {
+        fn compaction_projection_persistence(
+            &self,
+        ) -> crate::memory::CompactionProjectionPersistence {
+            crate::memory::CompactionProjectionPersistence::EphemeralImmediate
+        }
+
+        async fn index_scoped_batch(
+            &self,
+            _batch: MemoryIndexBatch,
+        ) -> Result<MemoryIndexReceipt, MemoryStoreError> {
+            self.async_index_entered
+                .store(true, std::sync::atomic::Ordering::SeqCst);
+            std::future::pending::<Result<MemoryIndexReceipt, MemoryStoreError>>().await
         }
 
         async fn search(
@@ -8451,6 +8575,48 @@ mod tests {
         assert_eq!(cadence.session_boundary_index, 2);
         assert_eq!(cadence.last_compaction_boundary_index, None);
         assert_eq!(cadence.last_compaction_attempt_boundary_index, Some(1));
+    }
+
+    #[tokio::test]
+    async fn misdeclared_ephemeral_store_never_enters_async_index_and_preserves_transcript() {
+        let client = Arc::new(CompactionAwareLlmClient::new());
+        let compactor = Arc::new(DiscardingCompactor::new(1));
+        let memory_store = Arc::new(MisdeclaredEphemeralMemoryStore::new());
+        let mut agent = with_test_turn_state_handle(AgentBuilder::new())
+            .compactor(compactor)
+            .memory_store(memory_store.clone())
+            .build_standalone(client, Arc::new(NoTools), Arc::new(NoopStore))
+            .await;
+
+        agent.run("first".into()).await.unwrap();
+        tokio::time::timeout(
+            std::time::Duration::from_secs(5),
+            agent.run("second".into()),
+        )
+        .await
+        .expect("misdeclared store must fail synchronously, never await async indexing")
+        .expect("synchronous compaction publication rejection is a non-fatal attempt");
+
+        assert!(
+            !memory_store
+                .async_index_entered
+                .load(std::sync::atomic::Ordering::SeqCst),
+            "EphemeralImmediate compaction must never fall back to the cancellable async index path"
+        );
+        assert!(
+            agent
+                .session()
+                .messages()
+                .iter()
+                .any(|message| message.as_indexable_text().contains("first")),
+            "fail-closed synchronous publication must preserve discarded source history"
+        );
+        assert!(
+            !agent.session().messages().iter().any(|message| {
+                matches!(message, Message::User(user) if user.transcript_role.is_compaction_summary())
+            }),
+            "rejected synchronous publication must roll back the compaction summary"
+        );
     }
 
     #[tokio::test]

--- a/meerkat-core/src/memory.rs
+++ b/meerkat-core/src/memory.rs
@@ -187,8 +187,12 @@ pub enum CompactionProjectionPersistence {
     /// and explicit indexing may still work, but compaction must preserve the
     /// transcript rather than publishing an unpaired memory projection.
     Unsupported,
-    /// Process-local store with no durable crash window. The agent may publish
-    /// the batch immediately after its in-memory transcript rewrite succeeds.
+    /// Process-local store with no durable crash window. The store MUST
+    /// implement [`MemoryStore::publish_ephemeral_compaction_batch`] as a
+    /// synchronous all-or-none publication: on `Ok`, every admitted request is
+    /// visible before the method returns; on `Err`, none is visible. The agent
+    /// pairs that call with its in-memory transcript rewrite without crossing
+    /// an async cancellation point.
     EphemeralImmediate,
     /// Durable store. Batches must first be persisted invisibly, then finalized
     /// only after the runtime atomically commits the paired transcript rewrite.
@@ -741,6 +745,31 @@ pub trait MemoryStore: Send + Sync {
         &self,
         batch: MemoryIndexBatch,
     ) -> Result<MemoryIndexReceipt, MemoryStoreError>;
+
+    /// Synchronously publish an ephemeral compaction batch all-or-none.
+    ///
+    /// This is a separate contract from ordinary async indexing. A store that
+    /// advertises [`CompactionProjectionPersistence::EphemeralImmediate`] MUST
+    /// override this method and complete publication before returning `Ok`.
+    /// It MUST return `Err` without making any request visible when immediate
+    /// publication cannot be completed synchronously (for example, lock
+    /// contention). The agent installs the paired transcript rewrite, invokes
+    /// this method, and commits or rolls back that rewrite before its next
+    /// `.await`; therefore cancellation cannot observe only one side of the
+    /// transcript-memory pair.
+    ///
+    /// The default fails closed so a store cannot gain compaction support by
+    /// declaring `EphemeralImmediate` while implementing only the cancellable
+    /// [`MemoryStore::index_scoped_batch`] path.
+    fn publish_ephemeral_compaction_batch(
+        &self,
+        batch: MemoryIndexBatch,
+    ) -> Result<MemoryIndexReceipt, MemoryStoreError> {
+        let _ = batch;
+        Err(MemoryStoreError::Unsupported {
+            operation: "publish_ephemeral_compaction_batch",
+        })
+    }
 
     /// Persist a compaction batch durably but invisibly.
     ///

--- a/meerkat-memory/src/simple.rs
+++ b/meerkat-memory/src/simple.rs
@@ -35,6 +35,24 @@ impl SimpleMemoryStore {
             entries: RwLock::new(Vec::new()),
         }
     }
+
+    fn prepare_batch(batch: MemoryIndexBatch) -> (MemoryIndexScope, Vec<MemoryEntry>) {
+        let (receipt_scope, requests) = batch.into_parts();
+        let entries = requests
+            .into_iter()
+            .filter_map(|request| {
+                let (scope, content, metadata) = request.into_parts();
+                // Store-side include/exclude gate (#319): skip content the
+                // producer marked non-indexable (Excluded), index the rest.
+                content.is_indexable().then(|| MemoryEntry {
+                    scope,
+                    content: content.into_indexable_text(),
+                    metadata,
+                })
+            })
+            .collect();
+        (receipt_scope, entries)
+    }
 }
 
 impl Default for SimpleMemoryStore {
@@ -48,8 +66,8 @@ impl MemoryStore for SimpleMemoryStore {
     fn compaction_projection_persistence(
         &self,
     ) -> meerkat_core::memory::CompactionProjectionPersistence {
-        // This implementation is process-local and has no durable crash
-        // window, so in-memory rewrite-then-index publication is safe.
+        // This implementation is process-local and supplies the mandatory
+        // synchronous all-or-none compaction publication method below.
         meerkat_core::memory::CompactionProjectionPersistence::EphemeralImmediate
     }
 
@@ -57,23 +75,29 @@ impl MemoryStore for SimpleMemoryStore {
         &self,
         batch: MemoryIndexBatch,
     ) -> Result<MemoryIndexReceipt, MemoryStoreError> {
-        let (receipt_scope, requests) = batch.into_parts();
+        let (receipt_scope, prepared) = Self::prepare_batch(batch);
+        let indexed_entries = prepared.len();
         let mut entries = self.entries.write().await;
-        let mut indexed_entries = 0usize;
-        for request in requests {
-            let (scope, content, metadata) = request.into_parts();
-            // Store-side include/exclude gate (#319): skip content the producer
-            // marked non-indexable (Excluded), index the rest.
-            if !content.is_indexable() {
-                continue;
-            }
-            entries.push(MemoryEntry {
-                scope,
-                content: content.into_indexable_text(),
-                metadata,
-            });
-            indexed_entries += 1;
-        }
+        entries.extend(prepared);
+        Ok(MemoryIndexReceipt {
+            scope: receipt_scope,
+            indexed_entries,
+        })
+    }
+
+    fn publish_ephemeral_compaction_batch(
+        &self,
+        batch: MemoryIndexBatch,
+    ) -> Result<MemoryIndexReceipt, MemoryStoreError> {
+        let (receipt_scope, prepared) = Self::prepare_batch(batch);
+        let indexed_entries = prepared.len();
+        let mut entries = self.entries.try_write().map_err(|_| {
+            MemoryStoreError::Storage(
+                "ephemeral compaction publication lock is busy; refusing cancellable fallback"
+                    .to_string(),
+            )
+        })?;
+        entries.extend(prepared);
         Ok(MemoryIndexReceipt {
             scope: receipt_scope,
             indexed_entries,
@@ -256,6 +280,39 @@ mod tests {
         let scope = MemorySearchScope::for_session(SessionId::new());
         let results = store.search(&scope, "anything", 10).await.unwrap();
         assert!(results.is_empty());
+    }
+
+    #[tokio::test]
+    async fn ephemeral_compaction_publication_is_synchronous_and_fails_closed_on_contention() {
+        let store = SimpleMemoryStore::new();
+        let session_id = SessionId::new();
+        let scope = MemoryIndexScope::for_session(session_id.clone());
+
+        let held_entries = store.entries.write().await;
+        let blocked = store.publish_ephemeral_compaction_batch(
+            MemoryIndexBatch::new(
+                scope.clone(),
+                vec![request("must remain unpublished", &session_id)],
+            )
+            .unwrap(),
+        );
+        assert!(matches!(blocked, Err(MemoryStoreError::Storage(_))));
+        assert!(
+            held_entries.is_empty(),
+            "lock contention must publish none of the compaction batch"
+        );
+        drop(held_entries);
+
+        let receipt = store
+            .publish_ephemeral_compaction_batch(
+                MemoryIndexBatch::new(scope, vec![request("published synchronously", &session_id)])
+                    .unwrap(),
+            )
+            .unwrap();
+        assert_eq!(receipt.indexed_entries, 1);
+        let entries = store.entries.read().await;
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].content, "published synchronously");
     }
 
     #[tokio::test]

--- a/meerkat-session/src/ephemeral.rs
+++ b/meerkat-session/src/ephemeral.rs
@@ -23,7 +23,8 @@ use meerkat_core::service::{
     TurnToolOverlay,
 };
 use meerkat_core::session_document::{
-    SessionDocumentEffect, SessionDocumentKey, SessionDocumentMachineAuthority,
+    SessionArchiveDisposition, SessionArchiveRuntimeObservation, SessionDocumentEffect,
+    SessionDocumentKey, SessionDocumentLifecycle, SessionDocumentMachineAuthority,
 };
 use meerkat_core::time_compat::SystemTime;
 use meerkat_core::types::{ContentInput, RunResult, SessionId, ToolResult, Usage};
@@ -65,6 +66,70 @@ const EVENT_CHANNEL_CAPACITY: usize = 256;
 
 /// Capacity for session command channel.
 const COMMAND_CHANNEL_CAPACITY: usize = 8;
+
+/// Drive the canonical session-document archive authority for the standalone
+/// profile and require its exact mechanical action vector before the service
+/// mutates either live or archived registries.
+fn authorize_standalone_archive(id: &SessionId) -> Result<(), SessionError> {
+    let mut authority = SessionDocumentMachineAuthority::new();
+    let document_key = SessionDocumentKey::new(id.to_string());
+    authority
+        .recover_session_lifecycle_terminal(document_key.clone(), SessionDocumentLifecycle::Active)
+        .map_err(|error| {
+            SessionError::Agent(AgentError::InternalError(format!(
+                "generated session document authority rejected standalone lifecycle recovery for \
+                 session {id}: {error}"
+            )))
+        })?;
+    let effects = authority
+        .archive_session_document(
+            document_key,
+            false,
+            false,
+            SessionArchiveRuntimeObservation::Absent,
+        )
+        .map_err(|error| {
+            SessionError::Agent(AgentError::InternalError(format!(
+                "generated session document authority rejected standalone archive for session \
+                 {id}: {error}"
+            )))
+        })?;
+    require_standalone_archive_verdict(id, effects)
+}
+
+fn require_standalone_archive_verdict(
+    id: &SessionId,
+    effects: Vec<SessionDocumentEffect>,
+) -> Result<(), SessionError> {
+    match effects.as_slice() {
+        [
+            SessionDocumentEffect::SessionArchiveResolved {
+                disposition: SessionArchiveDisposition::Archive,
+                write_document: false,
+                retire_runtime: false,
+            },
+        ] => Ok(()),
+        [
+            SessionDocumentEffect::SessionArchiveResolved {
+                disposition,
+                write_document,
+                retire_runtime,
+            },
+        ] => Err(SessionError::Agent(AgentError::InternalError(format!(
+            "generated session document authority returned invalid standalone archive verdict \
+                 for session {id}: disposition={disposition:?}, \
+                 write_document={write_document}, retire_runtime={retire_runtime}"
+        )))),
+        [] => Err(SessionError::Agent(AgentError::InternalError(format!(
+            "generated session document authority returned no standalone archive verdict for \
+             session {id}"
+        )))),
+        _ => Err(SessionError::Agent(AgentError::InternalError(format!(
+            "generated session document authority returned an ambiguous or unexpected standalone \
+             archive effect vector for session {id}"
+        )))),
+    }
+}
 
 fn lag_aware_session_event_stream(
     session_id: SessionId,
@@ -4145,22 +4210,62 @@ impl<B: SessionAgentBuilder + 'static> SessionService for EphemeralSessionServic
     }
 
     async fn archive(&self, id: &SessionId) -> Result<(), SessionError> {
-        let mut sessions = self.sessions.write().await;
+        // Reserve shutdown capacity without retaining the global live-session
+        // registry. A saturated session must not block reads, interrupts, or
+        // unrelated session work while archive waits for its own actor.
+        let (mut sessions, shutdown_permit) = loop {
+            let expected_sender = {
+                let sessions = self.sessions.read().await;
+                sessions
+                    .get(id)
+                    .ok_or_else(|| SessionError::NotFound { id: id.clone() })?
+                    .command_tx
+                    .clone()
+            };
+            let reserved = expected_sender.clone().reserve_owned().await;
+            let sessions = self.sessions.write().await;
+            let Some(current) = sessions.get(id) else {
+                return Err(SessionError::NotFound { id: id.clone() });
+            };
+            if !current.command_tx.same_channel(&expected_sender) {
+                // The logical session was rematerialized while capacity was
+                // pending. Drop any old-channel permit and retry against the
+                // exact current actor; stale capacity is never authority.
+                drop(sessions);
+                drop(reserved);
+                continue;
+            }
+            let shutdown_permit = reserved.map_err(|_| {
+                SessionError::Agent(meerkat_core::error::AgentError::InternalError(
+                    "Session task exited before archive shutdown could be reserved".to_string(),
+                ))
+            })?;
+            break (sessions, shutdown_permit);
+        };
+        // Every remaining awaitable realization resource is acquired before
+        // asking the document machine to authorize the lifecycle change.
+        // Cancellation while acquiring the archived-view guard therefore
+        // leaves both registries and every live-handle carrier untouched.
+        // Global lock order for the only operation that needs both registries:
+        // live sessions, then archived views. Readers never retain an archived
+        // view guard while acquiring the live registry.
+        let mut archived_views = self.archived_views.write().await;
+        // Standalone archive still changes the canonical session-document
+        // lifecycle fact. Obtain the generated Active -> Archived verdict
+        // only after effect realization can complete without another await.
+        authorize_standalone_archive(id)?;
         let handle = sessions
             .swap_remove(id)
             .ok_or_else(|| SessionError::NotFound { id: id.clone() })?;
+        let archived_view = Self::archived_view_from_handle(id, &handle);
+        archived_views.insert(id.clone(), archived_view);
+
         handle.actor_witness.revoke();
-        drop(sessions);
         // Clear the singular typed materialization record with the handle; a
         // staged session's registry-held permit drops with it, freeing the
         // reserved capacity.
         self.staged_registry.forget(id);
         handle.archive_snapshot_gate.close_for_snapshot();
-        let archived_view = Self::archived_view_from_handle(id, &handle);
-        self.archived_views
-            .write()
-            .await
-            .insert(id.clone(), archived_view);
 
         let projection = {
             let mut slot = lock_turn_admission(&handle.turn_admission);
@@ -4169,7 +4274,12 @@ impl<B: SessionAgentBuilder + 'static> SessionService for EphemeralSessionServic
         if let Some(projection) = projection {
             handle.state_tx.send_replace(projection);
         }
-        let _ = handle.command_tx.send(SessionCommand::Shutdown).await;
+        drop(archived_views);
+        drop(sessions);
+        // The reserved permit turns shutdown delivery into the final
+        // synchronous realization step: there is no post-verdict cancellation
+        // point that can strand the two registries in different lifecycles.
+        drop(shutdown_permit.send(SessionCommand::Shutdown));
         Ok(())
     }
 
@@ -7470,6 +7580,64 @@ mod archive_snapshot_gate_tests {
     use super::*;
 
     #[test]
+    fn standalone_archive_verdict_fails_closed_on_missing_ambiguous_or_wrong_effects() {
+        let session_id = SessionId::new();
+        assert!(require_standalone_archive_verdict(&session_id, Vec::new()).is_err());
+        assert!(
+            require_standalone_archive_verdict(
+                &session_id,
+                vec![SessionDocumentEffect::SessionArchiveResolved {
+                    disposition: SessionArchiveDisposition::AlreadyArchived,
+                    write_document: false,
+                    retire_runtime: false,
+                }],
+            )
+            .is_err()
+        );
+        assert!(
+            require_standalone_archive_verdict(
+                &session_id,
+                vec![SessionDocumentEffect::SessionArchiveResolved {
+                    disposition: SessionArchiveDisposition::Archive,
+                    write_document: true,
+                    retire_runtime: false,
+                }],
+            )
+            .is_err()
+        );
+        assert!(
+            require_standalone_archive_verdict(
+                &session_id,
+                vec![
+                    SessionDocumentEffect::SessionArchiveResolved {
+                        disposition: SessionArchiveDisposition::Archive,
+                        write_document: false,
+                        retire_runtime: false,
+                    },
+                    SessionDocumentEffect::SessionArchiveResolved {
+                        disposition: SessionArchiveDisposition::Archive,
+                        write_document: false,
+                        retire_runtime: false,
+                    },
+                ],
+            )
+            .is_err()
+        );
+        assert!(
+            require_standalone_archive_verdict(
+                &session_id,
+                vec![SessionDocumentEffect::SessionArchiveResolved {
+                    disposition: SessionArchiveDisposition::Archive,
+                    write_document: false,
+                    retire_runtime: false,
+                }],
+            )
+            .is_ok(),
+            "the exact standalone action vector is authorized"
+        );
+    }
+
+    #[test]
     fn archive_snapshot_gate_rejects_context_after_snapshot_close() {
         let gate = ArchiveSnapshotGate::open();
         let open_guard = gate.enter_apply();
@@ -8442,6 +8610,133 @@ mod archive_shutdown_drain_tests {
             matches!(result, Err(SessionError::NotFound { .. })),
             "post-archive context application must be a typed NotFound, got {result:?}"
         );
+
+        let rearchive = service.archive(&session_id).await;
+        assert!(
+            matches!(rearchive, Err(SessionError::NotFound { .. })),
+            "machine-authorized standalone archive must preserve re-archive NotFound, got \
+            {rearchive:?}"
+        );
+    }
+
+    /// Archive must not commit its machine-authorized lifecycle transition
+    /// until shutdown delivery and archived-view storage can both complete
+    /// without another await. Cancelling while the command queue is full must
+    /// therefore preserve the exact live registry state.
+    #[tokio::test]
+    async fn cancelled_archive_waiting_for_shutdown_capacity_preserves_live_session() {
+        let hooks = DrainProbeHooks::new();
+        let service = Arc::new(EphemeralSessionService::new(
+            DrainProbeBuilder {
+                hooks: hooks.clone(),
+            },
+            2,
+        ));
+        let created = service
+            .create_session(create_request())
+            .await
+            .expect("create deferred session");
+        let session_id = created.session_id.clone();
+        let other_session_id = service
+            .create_session(create_request())
+            .await
+            .expect("create unrelated deferred session")
+            .session_id;
+        let command_tx = command_tx_for(service.as_ref(), &session_id).await;
+
+        // Hold the actor inside a run so its command receiver cannot drain.
+        let turn_service = Arc::clone(&service);
+        let turn_session = session_id.clone();
+        let turn = tokio::spawn(async move {
+            turn_service
+                .start_turn(&turn_session, start_turn_request())
+                .await
+        });
+        tokio::time::timeout(WAITER_TIMEOUT, hooks.entered_run.notified())
+            .await
+            .expect("turn should enter the probe run");
+
+        // Fill every command slot. Archive may snapshot A's actor sender, but
+        // it must remain lock-free and pre-verdict while reserving capacity.
+        let mut queued_context_replies = Vec::with_capacity(COMMAND_CHANNEL_CAPACITY);
+        for _ in 0..COMMAND_CHANNEL_CAPACITY {
+            let (reply_tx, reply_rx) = oneshot::channel();
+            command_tx
+                .send(SessionCommand::ApplyRuntimeSystemContext {
+                    appends: Vec::new(),
+                    reply_tx,
+                })
+                .await
+                .expect("blocked actor keeps its command receiver alive");
+            queued_context_replies.push(reply_rx);
+        }
+
+        let mut archive = Box::pin(service.archive(&session_id));
+        assert!(
+            tokio::time::timeout(Duration::from_millis(50), archive.as_mut())
+                .await
+                .is_err(),
+            "archive must wait for reserved shutdown capacity"
+        );
+
+        // Waiting on A's saturated queue must not retain the global sessions
+        // writer. Unrelated session B stays promptly readable through both the
+        // public live-query and the read path used by interrupt dispatch.
+        let other_is_live = tokio::time::timeout(
+            Duration::from_secs(1),
+            service.has_live_session(&other_session_id),
+        )
+        .await
+        .expect("archive A must not block live-session reads for B")
+        .expect("B live-session query should succeed");
+        assert!(other_is_live);
+        let other_interrupt =
+            tokio::time::timeout(Duration::from_secs(1), service.interrupt(&other_session_id))
+                .await
+                .expect("archive A must not block interrupt-relevant registry access for B");
+        assert!(
+            matches!(other_interrupt, Err(SessionError::NotRunning { .. })),
+            "idle B should remain promptly readable and report NotRunning, got {other_interrupt:?}"
+        );
+        drop(archive);
+
+        // Dropping the pending future releases its locks and reservation wait;
+        // no machine verdict or registry/authority mutation may have happened.
+        {
+            let sessions = service.sessions.read().await;
+            let handle = sessions
+                .get(&session_id)
+                .expect("cancelled pre-verdict archive preserves live handle");
+            assert!(handle.actor_witness.is_live());
+            assert!(!handle.command_tx.is_closed());
+        }
+        assert!(
+            !service
+                .archived_views
+                .read()
+                .await
+                .contains_key(&session_id),
+            "cancelled pre-verdict archive must not publish an archived view"
+        );
+
+        // The preserved session remains fully operable and can subsequently be
+        // archived once the actor is allowed to drain the queued commands.
+        hooks.release_run.add_permits(1);
+        let run_result = tokio::time::timeout(WAITER_TIMEOUT, turn)
+            .await
+            .expect("turn task should finish")
+            .expect("turn task should not panic")
+            .expect("preserved turn must succeed");
+        assert_eq!(run_result.text, "ran");
+        service
+            .archive(&session_id)
+            .await
+            .expect("archive succeeds after capacity becomes available");
+        drop(queued_context_replies);
+        service
+            .archive(&other_session_id)
+            .await
+            .expect("cleanup unrelated session");
     }
 
     /// Regression (0.7.2): `discard_live_session` must be idempotent.

--- a/meerkat-web-runtime/src/lib.rs
+++ b/meerkat-web-runtime/src/lib.rs
@@ -12,7 +12,7 @@
 //! - `init_runtime_from_config(config_json)` — bare-bones bootstrap without mobpack
 //! - `runtime_version()` → crate version string (for JS/WASM version mismatch detection)
 //!
-//! ### Session (runtime-backed session-handle façades)
+//! ### Session (standalone ephemeral session-handle façades)
 //! - `create_session(mobpack_bytes, config_json)` → handle
 //! - `start_turn(handle, prompt)` → JSON result
 //! - `get_session_state(handle)` → JSON
@@ -166,9 +166,11 @@ struct SessionConfig {
     /// Enable comms for this session (registers in InprocRegistry).
     #[serde(default)]
     comms_name: Option<String>,
-    /// Whether this session stays alive after the initial turn (enables comms drain loop).
-    #[serde(default)]
-    keep_alive: bool,
+    /// Rejection-only capture for the retired raw Web option. Presence is
+    /// rejected even when the supplied value is `false`: direct Web sessions
+    /// use the standalone ephemeral substrate and cannot own keep-alive.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    keep_alive: Option<bool>,
     /// Application-defined labels (flow through mob spawn, not used at create_session level).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub labels: Option<BTreeMap<String, String>>,
@@ -296,14 +298,14 @@ fn build_bootstrap_config(
 // ═══════════════════════════════════════════════════════════
 
 // ═══════════════════════════════════════════════════════════
-// Runtime-backed browser session-handle façade
+// Standalone ephemeral browser session-handle façade
 // ═══════════════════════════════════════════════════════════
 
 type WasmSessionEventReceiver = crate::tokio::sync::broadcast::Receiver<
     meerkat_core::event::EventEnvelope<meerkat_core::event::AgentEvent>,
 >;
 
-struct RuntimeHandleSession {
+struct StandaloneHandleSession {
     session_id: meerkat_core::SessionId,
     mob_id: String,
     event_rx: WasmSessionEventReceiver,
@@ -313,14 +315,14 @@ struct RuntimeHandleSession {
 // RuntimeState — service-based infrastructure
 // ═══════════════════════════════════════════════════════════
 
-type WasmSessionService = meerkat::EphemeralSessionService<meerkat::FactoryAgentBuilder>;
+type WasmStandaloneSessionService = meerkat::EphemeralSessionService<meerkat::FactoryAgentBuilder>;
 
 struct RuntimeState {
     mob_state: Arc<MobMcpState>,
     /// Concrete session service — needed for subscribe_session_events_raw.
-    session_service: Arc<WasmSessionService>,
-    /// Opaque browser-local handles mapped to runtime-owned sessions.
-    sessions: BTreeMap<u32, RuntimeHandleSession>,
+    session_service: Arc<WasmStandaloneSessionService>,
+    /// Opaque browser-local handles mapped to standalone ephemeral sessions.
+    sessions: BTreeMap<u32, StandaloneHandleSession>,
     next_handle: u32,
     /// Trust-verified bootstrap mobpack (definition id + skills), consumed when
     /// `create_session_simple` builds a standalone session so the verified pack
@@ -522,7 +524,7 @@ fn build_provider_base_urls(
 fn build_service_infrastructure(
     config: Config,
     max_sessions: usize,
-) -> Result<(Arc<WasmSessionService>, Arc<MobMcpState>), JsValue> {
+) -> Result<(Arc<WasmStandaloneSessionService>, Arc<MobMcpState>), JsValue> {
     // Plan §4d.wasm.1 closure — wire the JS external-auth callback into
     // the provider runtime registry. The resolver itself handles the
     // "no callback registered" case by returning `MissingSecret`; we
@@ -1454,10 +1456,25 @@ pub fn init_runtime_from_config(config_json: &str) -> Result<JsValue, JsValue> {
 }
 
 // ═══════════════════════════════════════════════════════════
-// Exported WASM API — Session (runtime-backed session-handle façades)
+// Exported WASM API — Session (standalone ephemeral session-handle façades)
 // ═══════════════════════════════════════════════════════════
 
-fn next_runtime_handle(state: &mut RuntimeState) -> u32 {
+const UNSUPPORTED_KEEP_ALIVE_CODE: &str = "unsupported_session_option";
+const UNSUPPORTED_KEEP_ALIVE_MESSAGE: &str = "`keep_alive` is unavailable for direct Web sessions because @rkat/web uses the standalone ephemeral substrate and has no runtime-owned keep-alive ingress or comms drain; omit `keep_alive` and drive turns explicitly";
+
+fn parse_standalone_session_config(config_json: &str) -> Result<SessionConfig, serde_json::Value> {
+    let config: SessionConfig =
+        serde_json::from_str(config_json).map_err(|error| err_value("invalid_config", error))?;
+    if config.keep_alive.is_some() {
+        return Err(err_value(
+            UNSUPPORTED_KEEP_ALIVE_CODE,
+            UNSUPPORTED_KEEP_ALIVE_MESSAGE,
+        ));
+    }
+    Ok(config)
+}
+
+fn next_standalone_handle(state: &mut RuntimeState) -> u32 {
     let handle = state.next_handle.max(1);
     state.next_handle = handle.wrapping_add(1);
     while state.next_handle == 0 || state.sessions.contains_key(&state.next_handle) {
@@ -1489,7 +1506,6 @@ fn build_session_request_with_auth_binding(
     }
     if let Some(name) = config.comms_name.clone() {
         build_config.comms_name = Some(name);
-        build_config.keep_alive = config.keep_alive;
     }
     build_config.additional_instructions = config.additional_instructions.clone();
     build_config.app_context = config.app_context.clone();
@@ -1512,7 +1528,7 @@ fn build_session_request_with_auth_binding(
     })
 }
 
-fn create_runtime_backed_session(
+fn create_standalone_session(
     config: SessionConfig,
     system_prompt: Option<String>,
     mob_id: String,
@@ -1540,10 +1556,10 @@ fn create_runtime_backed_session(
     };
 
     with_runtime_state_mut(|state| {
-        let handle = next_runtime_handle(state);
+        let handle = next_standalone_handle(state);
         state.sessions.insert(
             handle,
-            RuntimeHandleSession {
+            StandaloneHandleSession {
                 session_id,
                 mob_id,
                 event_rx,
@@ -1555,7 +1571,7 @@ fn create_runtime_backed_session(
 
 /// Create a session from a mobpack + config.
 ///
-/// Allocates a real session through the initialized runtime-backed session
+/// Allocates a session through the initialized standalone ephemeral session
 /// service, then returns a browser-local session handle for convenience.
 ///
 /// The pack's skills/definition become session prompt truth here, so this
@@ -1569,15 +1585,14 @@ pub fn create_session(mobpack_bytes: &[u8], config_json: &str) -> Result<u32, Js
     let parsed =
         extract_verify_and_parse_mobpack(mobpack_bytes, trust.policy, &trust.trusted_signers)
             .map_err(js_from_value)?;
-    let config: SessionConfig =
-        serde_json::from_str(config_json).map_err(|e| err_str("invalid_config", e))?;
+    let config = parse_standalone_session_config(config_json).map_err(js_from_value)?;
     let system_prompt = compile_system_prompt(
         &parsed.definition.id,
         &parsed.manifest.mobpack.name,
         &parsed.skills,
         config.system_prompt.as_deref(),
     );
-    create_runtime_backed_session(config, Some(system_prompt), parsed.definition.id)
+    create_standalone_session(config, Some(system_prompt), parsed.definition.id)
 }
 
 /// Create a standalone session through initialized runtime state.
@@ -1588,8 +1603,7 @@ pub fn create_session(mobpack_bytes: &[u8], config_json: &str) -> Result<u32, Js
 /// than discarded.
 #[wasm_bindgen]
 pub fn create_session_simple(config_json: &str) -> Result<u32, JsValue> {
-    let config: SessionConfig =
-        serde_json::from_str(config_json).map_err(|e| err_str("invalid_config", e))?;
+    let config = parse_standalone_session_config(config_json).map_err(js_from_value)?;
     let (system_prompt, mob_id) = with_runtime_state(|state| {
         Ok(match &state.bootstrap_mobpack {
             Some(pack) => (
@@ -1599,7 +1613,7 @@ pub fn create_session_simple(config_json: &str) -> Result<u32, JsValue> {
             None => (config.system_prompt.clone(), String::new()),
         })
     })?;
-    create_runtime_backed_session(config, system_prompt, mob_id)
+    create_standalone_session(config, system_prompt, mob_id)
 }
 
 #[derive(Debug, Deserialize)]
@@ -1706,7 +1720,7 @@ pub async fn append_system_context(handle: u32, request_json: &str) -> Result<Js
     ))
 }
 
-/// Run a turn through the runtime-backed session service.
+/// Run a turn through the standalone ephemeral session service.
 ///
 /// On success, resolves (Ok) with a JSON-serialized [`meerkat_contracts::WireRunResult`]
 /// — the same canonical wire shape RPC's `turn/start` returns — exposing
@@ -1869,7 +1883,7 @@ fn err_web_destroy_session(error: WebDestroySessionError) -> JsValue {
 }
 
 async fn destroy_session_with_services(
-    session_service: Arc<WasmSessionService>,
+    session_service: Arc<WasmStandaloneSessionService>,
     mob_state: Arc<MobMcpState>,
     session_id: meerkat_core::SessionId,
 ) -> Result<(), WebDestroySessionError> {
@@ -2986,8 +3000,8 @@ mod tests {
         MobForkHelperOptions, MobSpawnHelperOptions, StreamRef, SubscriptionInner,
         close_subscription, merge_runtime_system_context_state, parse_js_tool_result,
         parse_mob_event_cursor, parse_mob_lifecycle_action_arg, parse_mobpack,
-        parse_prompt_content_input, poll_subscription, serialize_subscription_item,
-        session_error_envelope, stream_lagged_envelope,
+        parse_prompt_content_input, parse_standalone_session_config, poll_subscription,
+        serialize_subscription_item, session_error_envelope, stream_lagged_envelope,
     };
     #[cfg(target_arch = "wasm32")]
     use super::{
@@ -3016,6 +3030,48 @@ mod tests {
     use std::collections::HashMap;
     #[cfg(not(target_arch = "wasm32"))]
     use std::sync::Arc;
+
+    #[test]
+    fn raw_keep_alive_true_without_comms_is_rejected_at_parse_boundary() {
+        let error =
+            parse_standalone_session_config(r#"{"model":"claude-sonnet-4-5","keep_alive":true}"#)
+                .expect_err("raw keep_alive presence must be rejected");
+
+        assert_eq!(error["code"], "unsupported_session_option");
+        assert!(
+            error["message"]
+                .as_str()
+                .expect("typed error must include a message")
+                .contains("standalone ephemeral")
+        );
+    }
+
+    #[test]
+    fn raw_keep_alive_false_with_comms_is_rejected_at_parse_boundary() {
+        let error = parse_standalone_session_config(
+            r#"{"model":"claude-sonnet-4-5","comms_name":"browser-agent","keep_alive":false}"#,
+        )
+        .expect_err("raw keep_alive presence must be rejected regardless of value");
+
+        assert_eq!(error["code"], "unsupported_session_option");
+        assert!(
+            error["message"]
+                .as_str()
+                .expect("typed error must include a message")
+                .contains("runtime-owned keep-alive ingress or comms drain")
+        );
+    }
+
+    #[test]
+    fn raw_keep_alive_omission_preserves_standalone_comms_config() {
+        let config = parse_standalone_session_config(
+            r#"{"model":"claude-sonnet-4-5","comms_name":"browser-agent"}"#,
+        )
+        .expect("comms without keep_alive remains supported");
+
+        assert_eq!(config.comms_name.as_deref(), Some("browser-agent"));
+        assert_eq!(config.keep_alive, None);
+    }
 
     fn request_from_append(
         append: &PendingSystemContextAppend,

--- a/sdks/python/meerkat/client.py
+++ b/sdks/python/meerkat/client.py
@@ -36,7 +36,8 @@ from urllib.error import URLError
 import urllib.request
 
 from .errors import CapabilityUnavailableError, MeerkatError
-from .events import Usage, parse_event
+from .event_envelope import parse_agent_event_envelope
+from .events import Usage
 from .generated.types import CONTRACT_VERSION
 from .generated.version_compat import (
     is_compatible_with as _generated_is_compatible_with,
@@ -250,7 +251,6 @@ from .types import (
     ScheduleToolsResult,
     ScheduleToolCall,
     EventEnvelope,
-    EventSourceIdentity,
     McpLiveOpResponse,
     ResolvedModelCapabilities,
     RunResult,
@@ -2407,8 +2407,12 @@ class MeerkatClient:
                 "limit": limit,
             },
         )
+        if not isinstance(raw, dict):
+            raise MeerkatError(
+                "INVALID_RESPONSE", "Invalid mob/events response: expected object"
+            )
         return {
-            "events": MeerkatClient._require_list_field(
+            "events": MeerkatClient._require_present_list_field(
                 raw, "events", "Invalid mob/events response"
             )
         }
@@ -3500,55 +3504,7 @@ class MeerkatClient:
 
     @staticmethod
     def _parse_agent_event_envelope(raw: dict[str, Any]) -> EventEnvelope:
-        # Only parse a payload that is actually present as an object. An absent
-        # or non-object payload leaves `payload=None` (mirrors the TS envelope
-        # parser) rather than synthesizing a typeless frame that the
-        # fail-closed `parse_event` would (correctly) reject.
-        payload = raw.get("payload")
-        return EventEnvelope(
-            event_id=str(raw.get("event_id", "")),
-            source=MeerkatClient._parse_event_source_identity(raw.get("source")),
-            seq=int(raw.get("seq", 0)),
-            timestamp_ms=int(raw.get("timestamp_ms", 0)),
-            payload=parse_event(payload) if isinstance(payload, dict) else None,
-        )
-
-    @staticmethod
-    def _parse_event_source_identity(raw: Any) -> EventSourceIdentity | None:
-        if not isinstance(raw, dict):
-            return None
-        source_type = raw.get("type")
-        if source_type == "session":
-            session_id = raw.get("session_id", raw.get("sessionId"))
-            return (
-                EventSourceIdentity(type="session", session_id=session_id)
-                if isinstance(session_id, str)
-                else None
-            )
-        if source_type == "runtime":
-            runtime_id = raw.get("runtime_id", raw.get("runtimeId"))
-            return (
-                EventSourceIdentity(type="runtime", runtime_id=runtime_id)
-                if isinstance(runtime_id, str)
-                else None
-            )
-        if source_type == "interaction":
-            interaction_id = raw.get("interaction_id", raw.get("interactionId"))
-            return (
-                EventSourceIdentity(type="interaction", interaction_id=interaction_id)
-                if isinstance(interaction_id, str)
-                else None
-            )
-        if source_type == "callback":
-            return EventSourceIdentity(type="callback")
-        if source_type == "external":
-            source_id = raw.get("source_id", raw.get("sourceId"))
-            return (
-                EventSourceIdentity(type="external", source_id=source_id)
-                if isinstance(source_id, str)
-                else None
-            )
-        return None
+        return parse_agent_event_envelope(raw)
 
     @staticmethod
     def _parse_attributed_mob_event(raw: dict[str, Any]) -> AttributedEvent:

--- a/sdks/python/meerkat/event_envelope.py
+++ b/sdks/python/meerkat/event_envelope.py
@@ -1,0 +1,104 @@
+"""Strict parsing for canonical agent-event envelopes."""
+
+from __future__ import annotations
+
+from typing import Any
+from uuid import UUID
+
+from .errors import MeerkatError
+from .events import parse_event
+from .types import EventEnvelope, EventSourceIdentity
+
+MAX_U64 = (1 << 64) - 1
+
+
+def _invalid(reason: str, raw: Any) -> MeerkatError:
+    return MeerkatError(
+        "INVALID_RESPONSE",
+        f"Invalid agent event envelope: {reason}",
+        details=raw,
+    )
+
+
+def _require_record(raw: Any, field: str, envelope: Any) -> dict[str, Any]:
+    if not isinstance(raw, dict):
+        raise _invalid(f"{field} must be an object", envelope)
+    return raw
+
+
+def _require_non_empty_string(raw: dict[str, Any], field: str, envelope: Any) -> str:
+    value = raw.get(field)
+    if not isinstance(value, str) or not value:
+        raise _invalid(f"{field} must be a non-empty string", envelope)
+    return value
+
+
+def _require_uuid(raw: dict[str, Any], field: str, envelope: Any) -> str:
+    value = _require_non_empty_string(raw, field, envelope)
+    try:
+        parsed = UUID(value)
+    except ValueError as error:
+        raise _invalid(f"{field} must be a canonical UUID", envelope) from error
+    if str(parsed) != value:
+        raise _invalid(f"{field} must be a canonical UUID", envelope)
+    return value
+
+
+def _require_unsigned_integer(raw: dict[str, Any], field: str, envelope: Any) -> int:
+    value = raw.get(field)
+    if (
+        isinstance(value, bool)
+        or not isinstance(value, int)
+        or value < 0
+        or value > MAX_U64
+    ):
+        raise _invalid(f"{field} must be an unsigned 64-bit integer", envelope)
+    return value
+
+
+def parse_event_source_identity(raw: Any, envelope: Any) -> EventSourceIdentity:
+    """Parse the required discriminated event-source identity."""
+
+    record = _require_record(raw, "source", envelope)
+    source_type = _require_non_empty_string(record, "type", envelope)
+    if source_type == "session":
+        return EventSourceIdentity(
+            type=source_type,
+            session_id=_require_uuid(record, "session_id", envelope),
+        )
+    if source_type == "runtime":
+        return EventSourceIdentity(
+            type=source_type,
+            runtime_id=_require_non_empty_string(record, "runtime_id", envelope),
+        )
+    if source_type == "interaction":
+        return EventSourceIdentity(
+            type=source_type,
+            interaction_id=_require_uuid(record, "interaction_id", envelope),
+        )
+    if source_type == "callback":
+        return EventSourceIdentity(type=source_type)
+    if source_type == "external":
+        return EventSourceIdentity(
+            type=source_type,
+            source_id=_require_non_empty_string(record, "source_id", envelope),
+        )
+    raise _invalid(f"source.type has unsupported value {source_type!r}", envelope)
+
+
+def parse_agent_event_envelope(raw: Any) -> EventEnvelope:
+    """Parse a full wire envelope without fabricating identity/order facts."""
+
+    record = _require_record(raw, "envelope", raw)
+    payload = _require_record(record.get("payload"), "payload", raw)
+    mob_id: str | None = None
+    if record.get("mob_id") is not None:
+        mob_id = _require_non_empty_string(record, "mob_id", raw)
+    return EventEnvelope(
+        event_id=_require_uuid(record, "event_id", raw),
+        source=parse_event_source_identity(record.get("source"), raw),
+        seq=_require_unsigned_integer(record, "seq", raw),
+        timestamp_ms=_require_unsigned_integer(record, "timestamp_ms", raw),
+        payload=parse_event(payload),
+        mob_id=mob_id,
+    )

--- a/sdks/python/meerkat/streaming.py
+++ b/sdks/python/meerkat/streaming.py
@@ -12,8 +12,9 @@ import json
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, AsyncIterator, Callable
 
+from .event_envelope import parse_agent_event_envelope
 from .errors import MeerkatError, meerkat_error_from_jsonrpc_code
-from .events import Event, TextDelta, UnknownEvent, parse_event
+from .events import Event, TextDelta
 
 if TYPE_CHECKING:
     from .session import Session
@@ -221,6 +222,8 @@ class _StdoutDispatcher:
                     continue
                 session_id = params.get("session_id", "")
                 event = params.get("event")
+                if not isinstance(event, dict):
+                    event = {"invalid_event_envelope": event}
                 queue = self._event_queues.get(session_id)
                 if queue is not None:
                     await queue.put(event)
@@ -370,7 +373,7 @@ class EventStream:
                         raw = self._event_queue.get_nowait()
                         if raw is None:
                             break
-                        yield parse_event(raw)
+                        yield parse_agent_event_envelope(raw).payload
                     self._finalise(await response_task)
                     return
 
@@ -388,7 +391,7 @@ class EventStream:
                     if raw is None:
                         self._finalise(await response_task)
                         return
-                    yield parse_event(raw)
+                    yield parse_agent_event_envelope(raw).payload
         finally:
             if queue_get is not None and not queue_get.done():
                 queue_get.cancel()

--- a/sdks/python/meerkat/types.py
+++ b/sdks/python/meerkat/types.py
@@ -653,7 +653,7 @@ class MobEventCursorEntry(TypedDict, total=False):
 
 
 class MobEventsResult(TypedDict):
-    events: list[MobEventCursorEntry]
+    events: list[Any]
 
 
 MobControlScope = Literal[
@@ -1001,7 +1001,7 @@ class SessionTranscriptRewriteResult:
 class EventSourceIdentity:
     """Typed source identity for session or runtime event semantics."""
 
-    type: str = ""
+    type: str
     session_id: str | None = None
     runtime_id: str | None = None
     interaction_id: str | None = None
@@ -1012,20 +1012,21 @@ class EventSourceIdentity:
 class EventEnvelope:
     """Session or agent event with delivery metadata."""
 
-    event_id: str = ""
-    source: EventSourceIdentity | None = None
-    seq: int = 0
-    timestamp_ms: int = 0
-    payload: Event | None = None
+    event_id: str
+    source: EventSourceIdentity
+    seq: int
+    timestamp_ms: int
+    payload: Event
+    mob_id: str | None = None
 
 
 @dataclass(frozen=True, slots=True)
 class AttributedEvent:
     """Mob event annotated with the emitting member identity."""
 
-    source: str = ""
-    role: str = ""
-    envelope: EventEnvelope = field(default_factory=EventEnvelope)
+    source: str
+    role: str
+    envelope: EventEnvelope
     source_fence_token: int | None = None
 
 

--- a/sdks/python/tests/fixtures/fake_stream_rpc.mjs
+++ b/sdks/python/tests/fixtures/fake_stream_rpc.mjs
@@ -99,8 +99,18 @@ rl.on("line", (line) => {
   if (method === "session/stream_open") {
     const sessionId = String(params.session_id ?? "");
     if (sessionId === "buffered-session") {
-      write(streamEvent("stream-buffered", "e1", "hi", 1));
-      write(streamEvent("stream-buffered", "e2", "there", 2));
+      write(streamEvent(
+        "stream-buffered",
+        "00000000-0000-4000-8000-000000000010",
+        "hi",
+        1,
+      ));
+      write(streamEvent(
+        "stream-buffered",
+        "00000000-0000-4000-8000-000000000011",
+        "there",
+        2,
+      ));
       write(streamEnd("stream-buffered", "remote_end"));
       write({
         jsonrpc: "2.0",
@@ -164,8 +174,17 @@ rl.on("line", (line) => {
           params: {
             session_id: sessionId,
             event: {
-              type: "text_delta",
-              delta: "LATE_TAIL_PUBLIC",
+              event_id: "00000000-0000-4000-8000-000000000012",
+              source: {
+                type: "session",
+                session_id: "00000000-0000-4000-8000-000000000001",
+              },
+              seq: 3,
+              timestamp_ms: 3,
+              payload: {
+                type: "text_delta",
+                delta: "LATE_TAIL_PUBLIC",
+              },
             },
           },
         });

--- a/sdks/python/tests/test_streaming.py
+++ b/sdks/python/tests/test_streaming.py
@@ -53,11 +53,26 @@ def error_response(request_id: int, code: int, message: str) -> str:
     return jline({"jsonrpc": "2.0", "id": request_id, "error": {"code": code, "message": message}})
 
 
+def agent_event_envelope(
+    event: dict, *, event_id: str = "00000000-0000-4000-8000-000000000010"
+) -> dict:
+    return {
+        "event_id": event_id,
+        "source": {"type": "callback"},
+        "seq": 0,
+        "timestamp_ms": 1,
+        "payload": event,
+    }
+
+
 def event_notification(session_id: str, event: dict) -> str:
     return jline({
         "jsonrpc": "2.0",
         "method": "session/event",
-        "params": {"session_id": session_id, "event": event},
+        "params": {
+            "session_id": session_id,
+            "event": agent_event_envelope(event),
+        },
     })
 
 
@@ -308,7 +323,7 @@ class TestStdoutDispatcher:
         d.start()
         queue = d.subscribe_events("s1")
         event = await asyncio.wait_for(queue.get(), timeout=1.0)
-        assert event == ev
+        assert event == agent_event_envelope(ev)
         await d.stop()
 
     @pytest.mark.asyncio
@@ -353,9 +368,9 @@ class TestStdoutDispatcher:
 
         result = await future
         assert len(events) == 3
-        assert events[0]["type"] == "turn_started"
-        assert events[1]["type"] == "text_delta"
-        assert events[2]["type"] == "text_complete"
+        assert events[0]["payload"]["type"] == "turn_started"
+        assert events[1]["payload"]["type"] == "text_delta"
+        assert events[2]["payload"]["type"] == "text_complete"
         assert result["session_id"] == "s1"
         await d.stop()
 
@@ -393,9 +408,9 @@ class TestStdoutDispatcher:
         queue = d.subscribe_pending_stream(request_id=1)
         _ = d.expect_response(1)
         e1 = await asyncio.wait_for(queue.get(), timeout=1.0)
-        assert e1["type"] == "run_started"
+        assert e1["payload"]["type"] == "run_started"
         e2 = await asyncio.wait_for(queue.get(), timeout=1.0)
-        assert e2["type"] == "text_delta"
+        assert e2["payload"]["type"] == "text_delta"
         await d.stop()
 
     @pytest.mark.asyncio
@@ -412,7 +427,7 @@ class TestStdoutDispatcher:
         queue = d.subscribe_pending_stream(request_id=1)
         _ = d.expect_response(1)
         e = await asyncio.wait_for(queue.get(), timeout=1.0)
-        assert e["delta"] == "right"
+        assert e["payload"]["delta"] == "right"
         sentinel = await asyncio.wait_for(queue.get(), timeout=1.0)
         assert sentinel is None
         await d.stop()
@@ -435,9 +450,9 @@ class TestStdoutDispatcher:
         _ = d.expect_response(1)
         _ = d.expect_response(2)
         ea = await asyncio.wait_for(queue_a.get(), timeout=1.0)
-        assert ea["delta"] == "A"
+        assert ea["payload"]["delta"] == "A"
         eb = await asyncio.wait_for(queue_b.get(), timeout=1.0)
-        assert eb["delta"] == "B"
+        assert eb["payload"]["delta"] == "B"
         await d.stop()
 
     @pytest.mark.asyncio
@@ -460,7 +475,7 @@ class TestStdoutDispatcher:
         with pytest.raises(MeerkatError):
             await asyncio.wait_for(future_a, timeout=1.0)
         eb = await asyncio.wait_for(queue_b.get(), timeout=1.0)
-        assert eb["delta"] == "B"
+        assert eb["payload"]["delta"] == "B"
         await d.stop()
 
     @pytest.mark.asyncio
@@ -475,8 +490,8 @@ class TestStdoutDispatcher:
         q2 = d.subscribe_events("s2")
         e1 = await asyncio.wait_for(q1.get(), timeout=1.0)
         e2 = await asyncio.wait_for(q2.get(), timeout=1.0)
-        assert e1["delta"] == "A"
-        assert e2["delta"] == "B"
+        assert e1["payload"]["delta"] == "A"
+        assert e2["payload"]["delta"] == "B"
         await d.stop()
 
     @pytest.mark.asyncio
@@ -720,7 +735,7 @@ class TestStandaloneSubscriptions:
 
     @pytest.mark.asyncio
     async def test_stream_notification_buffered_until_stream_queue_registered(self):
-        ev = {"event_id": "e1", "payload": {"type": "text_delta", "delta": "hi"}}
+        ev = agent_event_envelope({"type": "text_delta", "delta": "hi"})
         reader = asyncio.StreamReader()
         d = _StdoutDispatcher(reader)
         d.start()
@@ -734,8 +749,14 @@ class TestStandaloneSubscriptions:
 
     @pytest.mark.asyncio
     async def test_stream_notifications_buffered_until_stream_queue_registered_preserve_order(self):
-        ev1 = {"event_id": "e1", "payload": {"type": "text_delta", "delta": "hi"}}
-        ev2 = {"event_id": "e2", "payload": {"type": "text_delta", "delta": "there"}}
+        ev1 = agent_event_envelope(
+            {"type": "text_delta", "delta": "hi"},
+            event_id="00000000-0000-4000-8000-000000000011",
+        )
+        ev2 = agent_event_envelope(
+            {"type": "text_delta", "delta": "there"},
+            event_id="00000000-0000-4000-8000-000000000012",
+        )
         reader = asyncio.StreamReader()
         d = _StdoutDispatcher(reader)
         d.start()
@@ -786,7 +807,7 @@ class TestStandaloneSubscriptions:
 
     @pytest.mark.asyncio
     async def test_stream_notification_dispatched_to_stream_queue(self):
-        ev = {"event_id": "e1", "payload": {"type": "text_delta", "delta": "hi"}}
+        ev = agent_event_envelope({"type": "text_delta", "delta": "hi"})
         reader = make_reader([stream_notification("stream-1", ev)])
         d = _StdoutDispatcher(reader)
         d.start()
@@ -798,7 +819,7 @@ class TestStandaloneSubscriptions:
     @pytest.mark.asyncio
     async def test_event_subscription_context_manager_closes_stream(self):
         queue: asyncio.Queue[dict | None] = asyncio.Queue()
-        queue.put_nowait({"event_id": "e1", "payload": {"type": "text_delta", "delta": "hi"}})
+        queue.put_nowait(agent_event_envelope({"type": "text_delta", "delta": "hi"}))
         dispatcher = type("Dispatcher", (), {"unsubscribe_stream": lambda self, _sid: None})()
         closed = []
 

--- a/sdks/python/tests/test_types.py
+++ b/sdks/python/tests/test_types.py
@@ -26,6 +26,21 @@ def _make_member_ref(mob_id: str, agent_identity: str) -> str:
     )
 
 
+def _agent_event_envelope(
+    payload: dict, *, event_id: str = "00000000-0000-4000-8000-000000000010"
+) -> dict:
+    return {
+        "event_id": event_id,
+        "source": {
+            "type": "session",
+            "session_id": "00000000-0000-4000-8000-000000000001",
+        },
+        "seq": 7,
+        "timestamp_ms": 1_700_000_000_000,
+        "payload": payload,
+    }
+
+
 def test_runtime_host_capabilities_expose_typed_multi_host_feature_flags():
     from meerkat.generated.types import (
         ContractVersion,
@@ -2656,9 +2671,9 @@ def test_parse_attributed_mob_event_preserves_source_fence_token():
             "source": {"identity": "writer", "generation": 2},
             "source_fence_token": 7,
             "role": "worker",
-            "envelope": {
-                "payload": {"type": "text_delta", "delta": "hi"},
-            },
+            "envelope": _agent_event_envelope(
+                {"type": "text_delta", "delta": "hi"}
+            ),
         }
     )
 
@@ -2672,9 +2687,9 @@ def test_parse_attributed_mob_event_omitted_source_fence_token_is_none():
         {
             "source": {"identity": "writer", "generation": 0},
             "role": "worker",
-            "envelope": {
-                "payload": {"type": "text_delta", "delta": "hi"},
-            },
+            "envelope": _agent_event_envelope(
+                {"type": "text_delta", "delta": "hi"}
+            ),
         }
     )
 
@@ -2686,7 +2701,9 @@ def test_parse_attributed_mob_event_fails_closed_on_missing_source():
         MeerkatClient._parse_attributed_mob_event(
             {
                 "role": "worker",
-                "envelope": {"payload": {"type": "text_delta", "delta": "hi"}},
+                "envelope": _agent_event_envelope(
+                    {"type": "text_delta", "delta": "hi"}
+                ),
             }
         )
 
@@ -2699,7 +2716,9 @@ def test_parse_attributed_mob_event_rejects_legacy_string_source():
             {
                 "source": "writer",
                 "role": "worker",
-                "envelope": {"payload": {"type": "text_delta", "delta": "hi"}},
+                "envelope": _agent_event_envelope(
+                    {"type": "text_delta", "delta": "hi"}
+                ),
             }
         )
 
@@ -2710,7 +2729,9 @@ def test_parse_attributed_mob_event_requires_generation():
             {
                 "source": {"identity": "writer"},
                 "role": "worker",
-                "envelope": {"payload": {"type": "text_delta", "delta": "hi"}},
+                "envelope": _agent_event_envelope(
+                    {"type": "text_delta", "delta": "hi"}
+                ),
             }
         )
 
@@ -2721,7 +2742,9 @@ def test_parse_attributed_mob_event_rejects_negative_generation():
             {
                 "source": {"identity": "writer", "generation": -1},
                 "role": "worker",
-                "envelope": {"payload": {"type": "text_delta", "delta": "hi"}},
+                "envelope": _agent_event_envelope(
+                    {"type": "text_delta", "delta": "hi"}
+                ),
             }
         )
 
@@ -2743,38 +2766,140 @@ def test_parse_attributed_mob_event_fails_closed_on_non_number_fence():
                 "source": {"identity": "writer", "generation": 0},
                 "role": "worker",
                 "source_fence_token": "7",
-                "envelope": {"payload": {"type": "text_delta", "delta": "hi"}},
+                "envelope": _agent_event_envelope(
+                    {"type": "text_delta", "delta": "hi"}
+                ),
             }
         )
 
 
 def test_parse_event_envelope_uses_typed_source_not_legacy_source_id():
     event = MeerkatClient._parse_agent_event_envelope(
-        {
-            "source": {
-                "type": "session",
-                "session_id": "00000000-0000-4000-8000-000000000001",
-            },
-            "payload": {"type": "text_delta", "delta": "hi"},
-        }
+        _agent_event_envelope({"type": "text_delta", "delta": "hi"})
     )
 
-    assert event.source is not None
     assert event.source.type == "session"
     assert event.source.session_id == "00000000-0000-4000-8000-000000000001"
+    assert event.event_id == "00000000-0000-4000-8000-000000000010"
+    assert event.seq == 7
+    assert event.timestamp_ms == 1_700_000_000_000
 
 
-def test_parse_event_envelope_does_not_classify_legacy_session_string():
-    event = MeerkatClient._parse_agent_event_envelope(
-        {
-            "source_id": "session:00000000-0000-4000-8000-000000000001",
-            "payload": {"type": "text_delta", "delta": "hi"},
-        }
-    )
+@pytest.mark.parametrize(
+    "missing",
+    ["event_id", "source", "seq", "timestamp_ms", "payload"],
+)
+def test_parse_event_envelope_rejects_every_missing_required_fact(missing: str):
+    raw = _agent_event_envelope({"type": "text_delta", "delta": "hi"})
+    del raw[missing]
 
-    # The legacy envelope-level string key no longer exists on the typed
-    # envelope and never classifies a typed source.
-    assert event.source is None
+    with pytest.raises(MeerkatError) as excinfo:
+        MeerkatClient._parse_agent_event_envelope(raw)
+    assert excinfo.value.code == "INVALID_RESPONSE"
+    assert missing in str(excinfo.value)
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [("event_id", 7), ("seq", -1), ("seq", 1.5), ("timestamp_ms", "now")],
+)
+def test_parse_event_envelope_rejects_malformed_scalars(field: str, value):
+    raw = _agent_event_envelope({"type": "text_delta", "delta": "hi"})
+    raw[field] = value
+
+    with pytest.raises(MeerkatError) as excinfo:
+        MeerkatClient._parse_agent_event_envelope(raw)
+    assert excinfo.value.code == "INVALID_RESPONSE"
+
+
+@pytest.mark.parametrize("field", ["seq", "timestamp_ms"])
+def test_parse_event_envelope_rejects_values_above_u64(field: str):
+    raw = _agent_event_envelope({"type": "text_delta", "delta": "hi"})
+    raw[field] = 1 << 64
+
+    with pytest.raises(MeerkatError) as excinfo:
+        MeerkatClient._parse_agent_event_envelope(raw)
+    assert excinfo.value.code == "INVALID_RESPONSE"
+    assert "unsigned 64-bit integer" in str(excinfo.value)
+
+
+def test_parse_event_envelope_accepts_u64_maximum():
+    raw = _agent_event_envelope({"type": "text_delta", "delta": "hi"})
+    raw["seq"] = (1 << 64) - 1
+    raw["timestamp_ms"] = (1 << 64) - 1
+
+    event = MeerkatClient._parse_agent_event_envelope(raw)
+
+    assert event.seq == (1 << 64) - 1
+    assert event.timestamp_ms == (1 << 64) - 1
+
+
+@pytest.mark.parametrize(
+    "event_id",
+    [
+        "not-a-uuid",
+        "019e63c2000070008000000000000010",
+        "019E63C2-0000-7000-8000-000000000010",
+    ],
+)
+def test_parse_event_envelope_rejects_non_canonical_event_uuid(event_id: str):
+    raw = _agent_event_envelope({"type": "text_delta", "delta": "hi"})
+    raw["event_id"] = event_id
+
+    with pytest.raises(MeerkatError) as excinfo:
+        MeerkatClient._parse_agent_event_envelope(raw)
+    assert excinfo.value.code == "INVALID_RESPONSE"
+    assert "event_id" in str(excinfo.value)
+
+
+def test_parse_event_envelope_rejects_legacy_source_id_without_typed_source():
+    raw = _agent_event_envelope({"type": "text_delta", "delta": "hi"})
+    del raw["source"]
+    raw["source_id"] = "session:00000000-0000-4000-8000-000000000001"
+
+    with pytest.raises(MeerkatError) as excinfo:
+        MeerkatClient._parse_agent_event_envelope(raw)
+    assert excinfo.value.code == "INVALID_RESPONSE"
+    assert "source" in str(excinfo.value)
+
+
+@pytest.mark.parametrize(
+    "source",
+    [None, "session", {"type": "session"}, {"type": "unknown"}],
+)
+def test_parse_event_envelope_rejects_malformed_typed_source(source):
+    raw = _agent_event_envelope({"type": "text_delta", "delta": "hi"})
+    raw["source"] = source
+
+    with pytest.raises(MeerkatError) as excinfo:
+        MeerkatClient._parse_agent_event_envelope(raw)
+    assert excinfo.value.code == "INVALID_RESPONSE"
+
+
+@pytest.mark.parametrize(
+    "source",
+    [
+        {"type": "session", "session_id": "session-1"},
+        {"type": "interaction", "interaction_id": "interaction-1"},
+    ],
+)
+def test_parse_event_envelope_rejects_non_uuid_typed_source(source):
+    raw = _agent_event_envelope({"type": "text_delta", "delta": "hi"})
+    raw["source"] = source
+
+    with pytest.raises(MeerkatError) as excinfo:
+        MeerkatClient._parse_agent_event_envelope(raw)
+    assert excinfo.value.code == "INVALID_RESPONSE"
+    assert "canonical UUID" in str(excinfo.value)
+
+
+def test_parse_event_envelope_preserves_optional_mob_id():
+    raw = _agent_event_envelope({"type": "text_delta", "delta": "hi"})
+    raw["mob_id"] = "00000000-0000-4000-8000-000000000020"
+
+    event = MeerkatClient._parse_agent_event_envelope(raw)
+
+    assert event.mob_id == "00000000-0000-4000-8000-000000000020"
 
 
 def test_parse_tool_config_changed():
@@ -6767,6 +6892,34 @@ async def test_read_mob_events_rejects_non_list_events() -> None:
 
     async def fake_request(_method, _params):
         return {"events": "not-a-list"}
+
+    client._request = fake_request  # type: ignore[method-assign]
+
+    with pytest.raises(MeerkatError) as excinfo:
+        await client.read_mob_events("mob-1")
+    assert excinfo.value.code == "INVALID_RESPONSE"
+
+
+@pytest.mark.asyncio
+async def test_read_mob_events_rejects_missing_events() -> None:
+    client = MeerkatClient()
+
+    async def fake_request(_method, _params):
+        return {}
+
+    client._request = fake_request  # type: ignore[method-assign]
+
+    with pytest.raises(MeerkatError) as excinfo:
+        await client.read_mob_events("mob-1")
+    assert excinfo.value.code == "INVALID_RESPONSE"
+
+
+@pytest.mark.asyncio
+async def test_read_mob_events_rejects_non_object_result() -> None:
+    client = MeerkatClient()
+
+    async def fake_request(_method, _params):
+        return None
 
     client._request = fake_request  # type: ignore[method-assign]
 

--- a/sdks/test-fixtures/fake_stream_rpc.mjs
+++ b/sdks/test-fixtures/fake_stream_rpc.mjs
@@ -1,8 +1,12 @@
 #!/usr/bin/env node
 
 import readline from "node:readline";
+import { readFileSync } from "node:fs";
 
-const CONTRACT_VERSION = "0.4.6";
+const versionInfo = JSON.parse(
+  readFileSync(new URL("../../artifacts/schemas/version.json", import.meta.url), "utf8"),
+);
+const CONTRACT_VERSION = versionInfo.contract_version;
 
 function write(message) {
   process.stdout.write(`${JSON.stringify(message)}\n`);
@@ -95,8 +99,18 @@ rl.on("line", (line) => {
   if (method === "session/stream_open") {
     const sessionId = String(params.session_id ?? "");
     if (sessionId === "buffered-session") {
-      write(streamEvent("stream-buffered", "e1", "hi", 1));
-      write(streamEvent("stream-buffered", "e2", "there", 2));
+      write(streamEvent(
+        "stream-buffered",
+        "00000000-0000-4000-8000-000000000010",
+        "hi",
+        1,
+      ));
+      write(streamEvent(
+        "stream-buffered",
+        "00000000-0000-4000-8000-000000000011",
+        "there",
+        2,
+      ));
       write(streamEnd("stream-buffered", "remote_end"));
       write({
         jsonrpc: "2.0",
@@ -160,8 +174,17 @@ rl.on("line", (line) => {
           params: {
             session_id: sessionId,
             event: {
-              type: "text_delta",
-              delta: "LATE_TAIL_PUBLIC",
+              event_id: "00000000-0000-4000-8000-000000000012",
+              source: {
+                type: "session",
+                session_id: "00000000-0000-4000-8000-000000000001",
+              },
+              seq: 3,
+              timestamp_ms: 3,
+              payload: {
+                type: "text_delta",
+                delta: "LATE_TAIL_PUBLIC",
+              },
             },
           },
         });

--- a/sdks/typescript/src/client.ts
+++ b/sdks/typescript/src/client.ts
@@ -218,7 +218,7 @@ import {
   type MobPeerTarget,
   type MobUnreachablePeer,
 } from "./mob.js";
-import { parseCoreEvent } from "./events.js";
+import { parseAgentEventEnvelope } from "./event-envelope.js";
 import { EventStream, AsyncQueue } from "./streaming.js";
 import { EventSubscription } from "./subscription.js";
 import type {
@@ -231,7 +231,6 @@ import type {
   ContentInput,
   ContentBlock,
   CreateScheduleRequest,
-  EventSourceIdentity,
   HelpOptions,
   ModelProfile,
   ModelsCatalog,
@@ -2997,9 +2996,20 @@ export class MeerkatClient {
       params.limit = options.limit;
     }
     const result = await this.request("mob/events", params);
-    const events = Array.isArray(result.events)
-      ? (result.events as Array<Record<string, unknown>>)
-      : [];
+    if (
+      typeof result !== "object" ||
+      result === null ||
+      Array.isArray(result) ||
+      !Object.hasOwn(result, "events") ||
+      !Array.isArray(result.events)
+    ) {
+      throw new MeerkatError(
+        "INVALID_RESPONSE",
+        "Invalid mob/events response: events must be an array",
+        result,
+      );
+    }
+    const events = result.events;
     return { events };
   }
 
@@ -3176,57 +3186,7 @@ export class MeerkatClient {
   }
 
   private static parseAgentEventEnvelope(raw: Record<string, unknown>): AgentEventEnvelope {
-    const eventId = MeerkatClient.parseOptionalString(raw.event_id ?? raw.eventId);
-    const source = MeerkatClient.parseEventSourceIdentity(raw.source);
-    const seq = MeerkatClient.parseOptionalNumber(raw.seq);
-    const timestampMs = MeerkatClient.parseOptionalNumber(raw.timestamp_ms ?? raw.timestampMs);
-    const payloadRaw = raw.payload;
-    const payload = payloadRaw && typeof payloadRaw === "object"
-      ? parseCoreEvent(payloadRaw as Record<string, unknown>)
-      : undefined;
-    return {
-      ...(eventId != null ? { eventId } : {}),
-      ...(source != null ? { source } : {}),
-      ...(seq != null ? { seq } : {}),
-      ...(timestampMs != null ? { timestampMs } : {}),
-      ...(payload ? { payload } : {}),
-    };
-  }
-
-  private static parseEventSourceIdentity(raw: unknown): EventSourceIdentity | undefined {
-    if (!raw || typeof raw !== "object") {
-      return undefined;
-    }
-    const record = raw as Record<string, unknown>;
-    const type = MeerkatClient.parseOptionalString(record.type);
-    switch (type) {
-      case "session": {
-        const sessionId = MeerkatClient.parseOptionalString(record.session_id ?? record.sessionId);
-        return sessionId != null ? { type: "session", sessionId } : undefined;
-      }
-      case "runtime": {
-        const runtimeId = MeerkatClient.parseOptionalString(record.runtime_id ?? record.runtimeId);
-        return runtimeId != null ? { type: "runtime", runtimeId } : undefined;
-      }
-      case "interaction": {
-        const interactionId = MeerkatClient.parseOptionalString(
-          record.interaction_id ?? record.interactionId,
-        );
-        return interactionId != null ? { type: "interaction", interactionId } : undefined;
-      }
-      case "callback":
-        return { type: "callback" };
-      case "external": {
-        const sourceId = MeerkatClient.parseOptionalString(record.source_id ?? record.sourceId);
-        return sourceId != null ? { type: "external", sourceId } : undefined;
-      }
-      default:
-        return undefined;
-    }
-  }
-
-  private static parseOptionalString(raw: unknown): string | undefined {
-    return typeof raw === "string" ? raw : undefined;
+    return parseAgentEventEnvelope(raw);
   }
 
   private static parseRequiredString(raw: unknown, context: string): string {
@@ -3234,10 +3194,6 @@ export class MeerkatClient {
       return raw;
     }
     throw new MeerkatError("INVALID_RESPONSE", context);
-  }
-
-  private static parseOptionalNumber(raw: unknown): number | undefined {
-    return typeof raw === "number" && Number.isFinite(raw) ? raw : undefined;
   }
 
   private static parseAttributedMobEvent(raw: Record<string, unknown>): AttributedMobEvent {
@@ -3923,19 +3879,21 @@ export class MeerkatClient {
         return;
       }
       const sessionId = String(params.session_id ?? "");
-      const event = params.event as Record<string, unknown> | undefined;
-      if (event) {
-        const queue = this.eventQueues.get(sessionId);
-        if (queue) {
-          queue.put(event);
-        } else if (this.pendingStreamQueues.size > 0) {
-          // A stream is pending but its session_id is not yet bound. Buffer by
-          // session_id; the create response that binds this session_id drains
-          // exactly this buffer into the matching request's queue.
-          const buffered = this.unmatchedStreamBuffer.get(sessionId) ?? [];
-          buffered.push(event);
-          this.unmatchedStreamBuffer.set(sessionId, buffered);
-        }
+      const rawEvent = params.event;
+      const event: Record<string, unknown> =
+        typeof rawEvent === "object" && rawEvent !== null && !Array.isArray(rawEvent)
+          ? (rawEvent as Record<string, unknown>)
+          : { invalid_event_envelope: rawEvent };
+      const queue = this.eventQueues.get(sessionId);
+      if (queue) {
+        queue.put(event);
+      } else if (this.pendingStreamQueues.size > 0) {
+        // A stream is pending but its session_id is not yet bound. Buffer by
+        // session_id; the create response that binds this session_id drains
+        // exactly this buffer into the matching request's queue.
+        const buffered = this.unmatchedStreamBuffer.get(sessionId) ?? [];
+        buffered.push(event);
+        this.unmatchedStreamBuffer.set(sessionId, buffered);
       }
     }
   }

--- a/sdks/typescript/src/event-envelope.ts
+++ b/sdks/typescript/src/event-envelope.ts
@@ -1,0 +1,112 @@
+/** Strict parsing for the canonical agent-event envelope. */
+
+import { parseCoreEvent } from "./events.js";
+import { MeerkatError } from "./generated/errors.js";
+import type { AgentEventEnvelope, EventSourceIdentity } from "./types.js";
+
+const CANONICAL_UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
+
+function invalidEnvelope(
+  reason: string,
+  raw: unknown,
+): MeerkatError {
+  return new MeerkatError(
+    "INVALID_RESPONSE",
+    `Invalid agent event envelope: ${reason}`,
+    raw,
+  );
+}
+
+function requireRecord(raw: unknown, field: string, envelope: unknown): Record<string, unknown> {
+  if (typeof raw !== "object" || raw === null || Array.isArray(raw)) {
+    throw invalidEnvelope(`${field} must be an object`, envelope);
+  }
+  return raw as Record<string, unknown>;
+}
+
+function requireNonEmptyString(
+  raw: Record<string, unknown>,
+  field: string,
+  envelope: unknown,
+): string {
+  const value = raw[field];
+  if (typeof value !== "string" || value.length === 0) {
+    throw invalidEnvelope(`${field} must be a non-empty string`, envelope);
+  }
+  return value;
+}
+
+function requireUnsignedInteger(
+  raw: Record<string, unknown>,
+  field: string,
+  envelope: unknown,
+): number {
+  const value = raw[field];
+  if (typeof value !== "number" || !Number.isSafeInteger(value) || value < 0) {
+    throw invalidEnvelope(`${field} must be a non-negative safe integer`, envelope);
+  }
+  return value;
+}
+
+function requireUuid(
+  raw: Record<string, unknown>,
+  field: string,
+  envelope: unknown,
+): string {
+  const value = requireNonEmptyString(raw, field, envelope);
+  if (!CANONICAL_UUID.test(value)) {
+    throw invalidEnvelope(`${field} must be a canonical UUID`, envelope);
+  }
+  return value;
+}
+
+export function parseEventSourceIdentity(
+  raw: unknown,
+  envelope: unknown,
+): EventSourceIdentity {
+  const record = requireRecord(raw, "source", envelope);
+  const type = requireNonEmptyString(record, "type", envelope);
+  switch (type) {
+    case "session":
+      return {
+        type,
+        sessionId: requireUuid(record, "session_id", envelope),
+      };
+    case "runtime":
+      return {
+        type,
+        runtimeId: requireNonEmptyString(record, "runtime_id", envelope),
+      };
+    case "interaction":
+      return {
+        type,
+        interactionId: requireUuid(record, "interaction_id", envelope),
+      };
+    case "callback":
+      return { type };
+    case "external":
+      return {
+        type,
+        sourceId: requireNonEmptyString(record, "source_id", envelope),
+      };
+    default:
+      throw invalidEnvelope(`source.type has unsupported value ${JSON.stringify(type)}`, envelope);
+  }
+}
+
+export function parseAgentEventEnvelope(raw: unknown): AgentEventEnvelope {
+  const record = requireRecord(raw, "envelope", raw);
+  const payload = requireRecord(record.payload, "payload", raw);
+  let mobId: string | undefined;
+  if (record.mob_id !== undefined && record.mob_id !== null) {
+    mobId = requireNonEmptyString(record, "mob_id", raw);
+  }
+  return {
+    eventId: requireUuid(record, "event_id", raw),
+    source: parseEventSourceIdentity(record.source, raw),
+    seq: requireUnsignedInteger(record, "seq", raw),
+    timestampMs: requireUnsignedInteger(record, "timestamp_ms", raw),
+    payload: parseCoreEvent(payload),
+    ...(mobId !== undefined ? { mobId } : {}),
+  };
+}

--- a/sdks/typescript/src/streaming.ts
+++ b/sdks/typescript/src/streaming.ts
@@ -17,7 +17,8 @@
  */
 
 import type { StreamEvent } from "./events.js";
-import { isTextDelta, parseEvent } from "./events.js";
+import { isTextDelta } from "./events.js";
+import { parseAgentEventEnvelope } from "./event-envelope.js";
 import type { RunResult } from "./types.js";
 import type { Session } from "./session.js";
 import { MeerkatError } from "./generated/errors.js";
@@ -192,7 +193,7 @@ export class EventStream implements AsyncIterable<StreamEvent> {
           this._finalise(responseResult!);
           return;
         }
-        yield parseEvent(raw);
+        yield parseAgentEventEnvelope(raw).payload;
       } else {
         cancel();
       }
@@ -232,7 +233,7 @@ export class EventStream implements AsyncIterable<StreamEvent> {
           return;
         }
         yieldedEvent = true;
-        yield parseEvent(raw);
+        yield parseAgentEventEnvelope(raw).payload;
       }
 
       if (yieldedEvent) {

--- a/sdks/typescript/src/types.ts
+++ b/sdks/typescript/src/types.ts
@@ -484,6 +484,7 @@ export interface EventEnvelope<T = unknown> {
   readonly seq: number;
   readonly event_id: string;
   readonly payload: T;
+  readonly mob_id?: string;
 }
 
 export interface AttributedEvent {
@@ -678,7 +679,7 @@ export interface MobEventsOptions {
 }
 
 export interface MobEventsResult {
-  readonly events: readonly Record<string, unknown>[];
+  readonly events: readonly unknown[];
 }
 
 export interface MobStoredProfile {
@@ -1246,11 +1247,12 @@ export interface SessionOptions {
 
 /** Explicit standalone session-event envelope. */
 export interface AgentEventEnvelope {
-  readonly eventId?: string;
-  readonly source?: EventSourceIdentity;
-  readonly seq?: number;
-  readonly timestampMs?: number;
-  readonly payload?: import("./events.js").AgentEvent;
+  readonly eventId: string;
+  readonly source: EventSourceIdentity;
+  readonly seq: number;
+  readonly timestampMs: number;
+  readonly payload: import("./events.js").AgentEvent;
+  readonly mobId?: string;
 }
 
 /** Mob-wide attributed event emitted by member/mob observation streams. */

--- a/sdks/typescript/tests/e2e_sdk_smoke.test.mjs
+++ b/sdks/typescript/tests/e2e_sdk_smoke.test.mjs
@@ -116,20 +116,11 @@ describe("E2E Smoke: TypeScript SDK package", { skip: !binaryPath }, () => {
 describe("E2E Smoke: TypeScript SDK package against scripted stream RPC", () => {
   let MeerkatClient;
   let client;
-  let fixtureVersionMismatch = false;
 
   before(async () => {
     ({ MeerkatClient } = await import("../dist/index.js"));
     client = new MeerkatClient(fakeStreamBinary);
-    try {
-      await client.connect();
-    } catch (error) {
-      if (String(error?.code) === "VERSION_MISMATCH") {
-        fixtureVersionMismatch = true;
-        return;
-      }
-      throw error;
-    }
+    await client.connect();
   });
 
   after(async () => {
@@ -138,10 +129,7 @@ describe("E2E Smoke: TypeScript SDK package against scripted stream RPC", () => 
     }
   });
 
-  it("replays buffered standalone stream events in order and exposes remote_end", async (t) => {
-    if (fixtureVersionMismatch) {
-      t.skip("scripted RPC fixture contract version is stale for this SDK");
-    }
+  it("replays buffered standalone stream events in order and exposes remote_end", async () => {
     const sub = await client.subscribeSessionEvents("buffered-session");
     const deltas = [];
     for await (const event of sub) {
@@ -152,10 +140,7 @@ describe("E2E Smoke: TypeScript SDK package against scripted stream RPC", () => 
     assert.equal(sub.terminalOutcome?.outcome, "remote_end");
   });
 
-  it("surfaces terminal_error on the packaged standalone subscription API", async (t) => {
-    if (fixtureVersionMismatch) {
-      t.skip("scripted RPC fixture contract version is stale for this SDK");
-    }
+  it("surfaces terminal_error on the packaged standalone subscription API", async () => {
     const sub = await client.subscribeSessionEvents("terminal-error-session");
     const iterator = sub[Symbol.asyncIterator]();
     const first = await iterator.next();
@@ -165,10 +150,7 @@ describe("E2E Smoke: TypeScript SDK package against scripted stream RPC", () => 
     assert.equal(sub.terminalOutcome?.error?.code, "stream_queue_overflow");
   });
 
-  it("drains late tail turn events through the packaged streaming API", async (t) => {
-    if (fixtureVersionMismatch) {
-      t.skip("scripted RPC fixture contract version is stale for this SDK");
-    }
+  it("drains late tail turn events through the packaged streaming API", async () => {
     const stream = client._startTurnStreaming(
       "late-tail-stream-session",
       "trigger late tail",

--- a/sdks/typescript/tests/skills.test.js
+++ b/sdks/typescript/tests/skills.test.js
@@ -8,6 +8,16 @@ import { DeferredSession, Session } from "../dist/session.js";
 import { MeerkatClient } from "../dist/client.js";
 import { MeerkatError } from "../dist/index.js";
 
+function agentEventEnvelope(payload, eventId = "00000000-0000-4000-8000-000000000010") {
+  return {
+    event_id: eventId,
+    source: { type: "callback" },
+    seq: 0,
+    timestamp_ms: 1,
+    payload,
+  };
+}
+
 describe("Skills v2.1", () => {
   it("Session.invokeSkill sends structured skillRefs to _startTurn", async () => {
     const calls = [];
@@ -279,7 +289,7 @@ describe("Skills v2.1", () => {
         method: "session/event",
         params: {
           session_id: "s-early",
-          event: { type: "text_delta", delta: "early" },
+          event: agentEventEnvelope({ type: "text_delta", delta: "early" }),
         },
       }),
     );
@@ -299,13 +309,17 @@ describe("Skills v2.1", () => {
   it("createSessionStreaming does not clear buffered standalone stream events", async () => {
     const client = new MeerkatClient();
     client.process = { stdin: { write() {} } };
-    client.unmatchedStandaloneStreamBuffer.set("stream-1", [{ event_id: "e1" }]);
+    client.unmatchedStandaloneStreamBuffer.set("stream-1", [{
+      event_id: "00000000-0000-4000-8000-000000000011",
+    }]);
     client.registerRequest = () => Promise.resolve({ session_id: "s-created" });
 
     client.createSessionStreaming("hello");
     await new Promise((resolve) => setImmediate(resolve));
 
-    assert.deepEqual(client.unmatchedStandaloneStreamBuffer.get("stream-1"), [{ event_id: "e1" }]);
+    assert.deepEqual(client.unmatchedStandaloneStreamBuffer.get("stream-1"), [{
+      event_id: "00000000-0000-4000-8000-000000000011",
+    }]);
   });
 
   it("concurrent createSessionStreaming calls are admitted and correlated by request id", async () => {
@@ -329,13 +343,25 @@ describe("Skills v2.1", () => {
     client.handleLine(
       JSON.stringify({
         method: "session/event",
-        params: { session_id: "s-A", event: { type: "text_delta", delta: "AA" } },
+        params: {
+          session_id: "s-A",
+          event: agentEventEnvelope(
+            { type: "text_delta", delta: "AA" },
+            "00000000-0000-4000-8000-000000000012",
+          ),
+        },
       }),
     );
     client.handleLine(
       JSON.stringify({
         method: "session/event",
-        params: { session_id: "s-B", event: { type: "text_delta", delta: "BB" } },
+        params: {
+          session_id: "s-B",
+          event: agentEventEnvelope(
+            { type: "text_delta", delta: "BB" },
+            "00000000-0000-4000-8000-000000000013",
+          ),
+        },
       }),
     );
 
@@ -573,7 +599,10 @@ describe("Skills v2.1", () => {
           method: "session/stream_event",
           params: {
             stream_id: "stream-1",
-            event: { event_id: "e1", payload: { type: "text_delta", delta: "hi" } },
+            event: agentEventEnvelope(
+              { type: "text_delta", delta: "hi" },
+              "00000000-0000-4000-8000-000000000014",
+            ),
           },
         }));
         return { stream_id: "stream-1" };
@@ -602,7 +631,10 @@ describe("Skills v2.1", () => {
           method: "session/stream_event",
           params: {
             stream_id: "stream-ordered",
-            event: { event_id: "e1", payload: { type: "text_delta", delta: "hi" } },
+            event: agentEventEnvelope(
+              { type: "text_delta", delta: "hi" },
+              "00000000-0000-4000-8000-000000000014",
+            ),
           },
         }));
         client.handleLine(JSON.stringify({
@@ -610,7 +642,10 @@ describe("Skills v2.1", () => {
           method: "session/stream_event",
           params: {
             stream_id: "stream-ordered",
-            event: { event_id: "e2", payload: { type: "text_delta", delta: "there" } },
+            event: agentEventEnvelope(
+              { type: "text_delta", delta: "there" },
+              "00000000-0000-4000-8000-000000000015",
+            ),
           },
         }));
         return { stream_id: "stream-ordered" };

--- a/sdks/typescript/tests/streaming.test.js
+++ b/sdks/typescript/tests/streaming.test.js
@@ -11,6 +11,16 @@ import {
   meerkatErrorFromSemanticCode,
 } from "../dist/index.js";
 
+function agentEventEnvelope(payload, eventId = "00000000-0000-4000-8000-000000000010") {
+  return {
+    event_id: eventId,
+    source: { type: "callback" },
+    seq: 0,
+    timestamp_ms: 1,
+    payload,
+  };
+}
+
 const MULTI_HOST_ERROR_CASES = [
   {
     rpcCode: -32025,
@@ -79,7 +89,7 @@ describe("EventStream late drain", () => {
       tool_calls: 0,
       usage: { input_tokens: 1, output_tokens: 1 },
     });
-    queue.put({ type: "text_delta", delta: "tail" });
+    queue.put(agentEventEnvelope({ type: "text_delta", delta: "tail" }));
 
     const result = await consume;
     assert.deepEqual(

--- a/sdks/typescript/tests/types.test.js
+++ b/sdks/typescript/tests/types.test.js
@@ -1275,26 +1275,71 @@ describe("Typed Events", () => {
     assert.deepEqual(event.raw, raw);
   });
 
-  it("should not fabricate standalone event envelope metadata or payload", () => {
-    const envelope = MeerkatClient.parseAgentEventEnvelope({
-      event_id: 3,
-      seq: "0",
-      timestamp_ms: "0",
-      payload: "not-an-object",
-    });
+  const validEnvelope = () => ({
+    event_id: "00000000-0000-4000-8000-000000000010",
+    source: { type: "callback" },
+    seq: 7,
+    timestamp_ms: 1_700_000_000_000,
+    payload: { type: "text_delta", delta: "hi" },
+  });
 
-    assert.equal(envelope.eventId, undefined);
-    assert.equal(envelope.seq, undefined);
-    assert.equal(envelope.timestampMs, undefined);
-    assert.equal(envelope.payload, undefined);
+  it("should reject every missing required standalone envelope fact", () => {
+    for (const field of ["event_id", "source", "seq", "timestamp_ms", "payload"]) {
+      const raw = validEnvelope();
+      delete raw[field];
+      assert.throws(
+        () => MeerkatClient.parseAgentEventEnvelope(raw),
+        (error) =>
+          error instanceof MeerkatError &&
+          error.code === "INVALID_RESPONSE" &&
+          String(error.message).includes(field),
+      );
+    }
+  });
+
+  it("should reject malformed standalone envelope scalars", () => {
+    for (const [field, value] of [
+      ["event_id", 3],
+      ["seq", -1],
+      ["seq", 1.5],
+      ["timestamp_ms", "now"],
+    ]) {
+      const raw = validEnvelope();
+      raw[field] = value;
+      assert.throws(
+        () => MeerkatClient.parseAgentEventEnvelope(raw),
+        (error) => error instanceof MeerkatError && error.code === "INVALID_RESPONSE",
+      );
+    }
+  });
+
+  it("should reject string-but-non-canonical event UUIDs", () => {
+    for (const eventId of [
+      "not-a-uuid",
+      "019e63c2000070008000000000000010",
+      "019E63C2-0000-7000-8000-000000000010",
+    ]) {
+      const raw = validEnvelope();
+      raw.event_id = eventId;
+      assert.throws(
+        () => MeerkatClient.parseAgentEventEnvelope(raw),
+        (error) =>
+          error instanceof MeerkatError &&
+          error.code === "INVALID_RESPONSE" &&
+          String(error.message).includes("event_id"),
+      );
+    }
   });
 
   it("should use typed event source without trusting legacy source id", () => {
     const envelope = MeerkatClient.parseAgentEventEnvelope({
+      event_id: "00000000-0000-4000-8000-000000000010",
       source: {
         type: "session",
         session_id: "00000000-0000-4000-8000-000000000001",
       },
+      seq: 7,
+      timestamp_ms: 1_700_000_000_000,
       payload: { type: "text_delta", delta: "hi" },
     });
 
@@ -1305,15 +1350,73 @@ describe("Typed Events", () => {
   });
 
   it("should not classify source from legacy session strings", () => {
-    const envelope = MeerkatClient.parseAgentEventEnvelope({
-      source_id: "session:00000000-0000-4000-8000-000000000001",
-      payload: { type: "text_delta", delta: "hi" },
-    });
+    const raw = validEnvelope();
+    delete raw.source;
+    raw.source_id = "session:00000000-0000-4000-8000-000000000001";
+    assert.throws(
+      () => MeerkatClient.parseAgentEventEnvelope(raw),
+      (error) => error instanceof MeerkatError && error.code === "INVALID_RESPONSE",
+    );
+  });
 
-    // The legacy envelope-level string never classifies a typed source and is
-    // no longer surfaced on the typed envelope.
-    assert.equal(envelope.source, undefined);
-    assert.equal(envelope.sourceId, undefined);
+  it("should reject malformed typed sources", () => {
+    for (const source of [null, "session", { type: "session" }, { type: "unknown" }]) {
+      const raw = validEnvelope();
+      raw.source = source;
+      assert.throws(
+        () => MeerkatClient.parseAgentEventEnvelope(raw),
+        (error) => error instanceof MeerkatError && error.code === "INVALID_RESPONSE",
+      );
+    }
+  });
+
+  it("should reject string-but-non-UUID session and interaction sources", () => {
+    for (const source of [
+      { type: "session", session_id: "session-1" },
+      { type: "interaction", interaction_id: "interaction-1" },
+    ]) {
+      const raw = validEnvelope();
+      raw.source = source;
+      assert.throws(
+        () => MeerkatClient.parseAgentEventEnvelope(raw),
+        (error) =>
+          error instanceof MeerkatError &&
+          error.code === "INVALID_RESPONSE" &&
+          String(error.message).includes("canonical UUID"),
+      );
+    }
+  });
+
+  it("should preserve the optional mob id", () => {
+    const raw = validEnvelope();
+    raw.mob_id = "00000000-0000-4000-8000-000000000020";
+
+    const envelope = MeerkatClient.parseAgentEventEnvelope(raw);
+
+    assert.equal(envelope.mobId, "00000000-0000-4000-8000-000000000020");
+  });
+});
+
+describe("Mob events response parsing", () => {
+  it("rejects missing and non-array events", async () => {
+    for (const response of [null, {}, { events: null }, { events: "not-an-array" }]) {
+      const client = new MeerkatClient();
+      client.request = async () => response;
+      await assert.rejects(
+        () => client.readMobEvents("mob-1"),
+        (error) => error instanceof MeerkatError && error.code === "INVALID_RESPONSE",
+      );
+    }
+  });
+
+  it("preserves every canonical JSON value in a present events array", async () => {
+    const client = new MeerkatClient();
+    const expected = [null, 1, "event", { cursor: 2 }];
+    client.request = async () => ({ events: expected });
+
+    const result = await client.readMobEvents("mob-1");
+
+    assert.deepEqual(result.events, expected);
   });
 });
 
@@ -4508,7 +4611,10 @@ describe("Mob surface fail-closed status parsing (DOGMA Rule 6)", () => {
   // role; nothing coalesced to "".
   describe("parseAttributedMobEvent", () => {
     const validEnvelope = {
+      event_id: "00000000-0000-4000-8000-000000000010",
       source: { type: "session", session_id: "00000000-0000-4000-8000-000000000001" },
+      seq: 7,
+      timestamp_ms: 1_700_000_000_000,
       payload: { type: "text_delta", delta: "hi" },
     };
 

--- a/sdks/web/src/generated/runtime.ts
+++ b/sdks/web/src/generated/runtime.ts
@@ -75,8 +75,6 @@ export interface SessionConfig {
   maxTokens?: number;
   /** Enable comms for this session. */
   commsName?: string;
-  /** Whether this session runs in keep-alive mode. */
-  keepAlive?: boolean;
   /** Application-defined labels. */
   labels?: Record<string, string>;
   /** Additional instruction sections appended to the system prompt. */

--- a/sdks/web/src/runtime.ts
+++ b/sdks/web/src/runtime.ts
@@ -52,7 +52,6 @@ function sessionToWasm(config: SessionConfig): Record<string, unknown> {
     system_prompt: config.systemPrompt,
     max_tokens: config.maxTokens,
     comms_name: config.commsName,
-    keep_alive: config.keepAlive,
     labels: config.labels,
     additional_instructions: config.additionalInstructions,
     app_context: config.appContext,
@@ -384,7 +383,7 @@ export class MeerkatRuntime {
     return parseMobListResult(parseJsonPayload(json, 'Invalid mob/list response'));
   }
 
-  /** Create a direct session façade backed by a real runtime session identity. */
+  /** Create a direct session façade backed by a standalone ephemeral session. */
   createSession(config: SessionConfig): Session {
     const handle = this.wasm.create_session_simple(
       JSON.stringify(sessionToWasm(config)),

--- a/sdks/web/src/session.ts
+++ b/sdks/web/src/session.ts
@@ -190,12 +190,12 @@ export class Session {
     } as TurnResult;
   }
 
-  /** Get the current runtime-backed session state. */
+  /** Get the current standalone session state. */
   getState(): SessionState {
     return JSON.parse(this.getStateFn(this.handle)) as SessionState;
   }
 
-  /** The authoritative runtime session ID behind this local browser handle. */
+  /** The authoritative standalone session ID behind this local browser handle. */
   get sessionId(): string {
     return this.getState().session_id;
   }

--- a/sdks/web/tests/types.test.ts
+++ b/sdks/web/tests/types.test.ts
@@ -103,6 +103,13 @@ const sessionConfig: SessionConfig = {
   additionalInstructions: ['Be concise.'],
 };
 
+const unsupportedKeepAliveSessionConfig: SessionConfig = {
+  model: 'claude-sonnet-4-5',
+  // @ts-expect-error direct Web sessions are standalone and expose no keep-alive mode.
+  keepAlive: true,
+};
+void unsupportedKeepAliveSessionConfig;
+
 // ─── Auth RPC helpers ───────────────────────────────────────────
 
 const authTransport: AuthTransport = {

--- a/tools/sdk-codegen/generate.py
+++ b/tools/sdk-codegen/generate.py
@@ -4872,8 +4872,6 @@ export interface SessionConfig {
   maxTokens?: number;
   /** Enable comms for this session. */
   commsName?: string;
-  /** Whether this session runs in keep-alive mode. */
-  keepAlive?: boolean;
   /** Application-defined labels. */
   labels?: Record<string, string>;
   /** Additional instruction sections appended to the system prompt. */


### PR DESCRIPTION
## Summary

- route standalone archive through the generated session document machine, with cancellation-safe realization and shutdown capacity reserved outside the global session lock
- remove the unsupported Web keep-alive claim and reject either raw `keep_alive` value before allocating a session
- require canonical event envelopes across Python and TypeScript subscriptions and request-coupled streams
- make ephemeral-immediate compaction projection synchronously atomic and fail closed when a store cannot provide that contract

## Root cause

Standalone shells and SDK readers were still originating or defaulting semantic facts outside their canonical generated/runtime owners. Ephemeral compaction also exposed a cancellable split-publication seam.

## Validation

- `make check`
- `make fmt-check`
- `make docs-check`
- `make wasm-check`
- `make test-sdk-web`
- `make verify-sdk-codegen-freshness`
- core library: 1292 tests passed
- session library: 84 tests passed
- Python deterministic SDK: 497 tests passed
- TypeScript SDK: 252 tests passed
- scripted Python and TypeScript stream regressions: 5 tests passed, 0 skipped
- pre-commit and pre-push repository gates passed
- two independent adversarial reviewers returned GREEN on the final rebased bytes
