### PR TITLE
fix(cli): bound mob spawn stack and bootstrap OAuth reads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -169,6 +169,10 @@ via cargo-semver-checks against the published baselines).
   authority in one transaction, and retains append-only original row bytes.
   Operators must still stop all v0.6.34 processes because one-shot legacy CLI
   runs did not consistently publish lease evidence.
+- Full-tools CLI `mob_create` followed by `mob_spawn_member` now stays within
+  the production 2 MiB Tokio worker-stack budget.
+- Direct `rkat mob run` and `rkat mob deploy` now complete the legacy OAuth
+  credential-read bootstrap before loading member runtime configuration.
 - Rejected atomic runtime commits now abort every pre-commit session
   projection—not only compaction—including the live transcript/checkpointer
   and pending context events before recovery checkpoints can reload the prior

--- a/meerkat-cli/src/main.rs
+++ b/meerkat-cli/src/main.rs
@@ -3658,7 +3658,7 @@ async fn handle_run_command(
     // forward on the credential-READ path so users who upgraded but never
     // re-logged in are still migrated (the login-time trigger alone misses
     // them). Runs at most once per process; failures are logged, not fatal.
-    ensure_legacy_login_credentials_migrated_once(scope).await;
+    prepare_credential_reads(scope).await;
     let output = resolve_cli_output_selection(
         output,
         json,
@@ -6078,6 +6078,16 @@ async fn ensure_legacy_login_credentials_migrated_once(scope: &RuntimeScope) {
             return;
         }
     };
+    prepare_credential_reads_with_persistence(scope, persistence).await;
+}
+
+/// Execute the credential-read bootstrap against an already-open persistence
+/// authority. Production obtains this from the platform default backend; tests
+/// inject an isolated authority while traversing the exact command wrapper.
+async fn prepare_credential_reads_with_persistence(
+    scope: &RuntimeScope,
+    persistence: meerkat_providers::auth_store::ProviderAuthPersistence,
+) {
     let store = persistence.token_store();
     if let Err(e) =
         migrate_legacy_login_credentials_to_global(persistence.clone(), scope.auth_lease.clone())
@@ -6098,6 +6108,24 @@ async fn ensure_legacy_login_credentials_migrated_once(scope: &RuntimeScope) {
     }
     #[cfg(not(all(feature = "anthropic", feature = "openai", feature = "gemini")))]
     let _ = scope;
+}
+
+#[cfg(test)]
+tokio::task_local! {
+    static TEST_CREDENTIAL_READ_PERSISTENCE:
+        meerkat_providers::auth_store::ProviderAuthPersistence;
+}
+
+/// Shared bootstrap for CLI paths that are about to resolve provider
+/// credentials. Config-only and inspection commands intentionally do not call
+/// this helper.
+async fn prepare_credential_reads(scope: &RuntimeScope) {
+    #[cfg(test)]
+    if let Ok(persistence) = TEST_CREDENTIAL_READ_PERSISTENCE.try_with(Clone::clone) {
+        prepare_credential_reads_with_persistence(scope, persistence).await;
+        return;
+    }
+    ensure_legacy_login_credentials_migrated_once(scope).await;
 }
 
 #[cfg(all(feature = "anthropic", feature = "openai", feature = "gemini"))]
@@ -9701,6 +9729,7 @@ fn compose_rpc_mob_external_tools(
 #[derive(Default)]
 struct CliServiceBuildDefaults {
     default_schedule_tools: Option<Arc<dyn AgentToolDispatcher>>,
+    default_workgraph_tools: Option<Arc<dyn AgentToolDispatcher>>,
     image_generation_machine: Option<Arc<meerkat_runtime::MeerkatMachine>>,
     default_blob_store: Option<Arc<dyn meerkat_core::BlobStore>>,
     default_image_generation_executor: Option<Arc<dyn meerkat_llm_core::ImageGenerationExecutor>>,
@@ -9720,6 +9749,7 @@ fn build_cli_service_with_defaults(
     builder.default_blob_store = defaults.default_blob_store;
     builder.default_image_generation_executor = defaults.default_image_generation_executor;
     meerkat::surface::set_default_schedule_tools(&builder, defaults.default_schedule_tools);
+    meerkat::surface::set_default_workgraph_tools(&builder, defaults.default_workgraph_tools);
     meerkat::surface::build_embedded_service_from_builder(builder, max_sessions)
 }
 
@@ -16047,6 +16077,11 @@ async fn load_deploy_runtime_config(
     scope: &RuntimeScope,
     cli_overrides: CliOverrides,
 ) -> anyhow::Result<Config> {
+    // A direct `rkat mob run/deploy` can be the first credential-reading
+    // command after an upgrade. Finish the dev->global compatibility bootstrap
+    // before composing the global config tail used by member builds.
+    prepare_credential_reads(scope).await;
+
     // Read the head realm's own raw config doc (head of the chain).
     let mut head = Config::default();
     let config_path =
@@ -17723,6 +17758,61 @@ mod tests {
         );
     }
 
+    // A direct mobpack invocation can be the first credential-reading command
+    // after upgrading from 0.7.5. Its deploy-config loader must await the
+    // dev->global bootstrap before composing the inherited global tail.
+    #[cfg(all(
+        feature = "mob",
+        feature = "anthropic",
+        feature = "openai",
+        feature = "gemini"
+    ))]
+    #[tokio::test]
+    async fn direct_mob_config_load_bootstraps_legacy_dev_login_first() {
+        use meerkat_providers::auth_store::{TokenKey, TokenStore};
+
+        let temp = tempfile::tempdir().expect("tempdir");
+        let scope = test_scope(temp.path().join("realms"), "mob-first");
+        let store: Arc<dyn TokenStore> = Arc::new(NonEnumerableTokenStore::new());
+        let persistence = test_provider_auth_persistence(Arc::clone(&store));
+        let dev_key = TokenKey::parse("dev", "openai_oauth").expect("legacy token key");
+        store
+            .save(&dev_key, &openai_oauth_tokens())
+            .await
+            .expect("seed legacy token");
+        assert!(
+            store.list().await.expect("list token keys").is_empty(),
+            "fixture must model a keyring backend that cannot enumerate"
+        );
+
+        let config = TEST_CREDENTIAL_READ_PERSISTENCE
+            .scope(
+                persistence,
+                load_deploy_runtime_config(&scope, CliOverrides::default()),
+            )
+            .await
+            .expect("direct mob config load through production wrapper");
+
+        let target = meerkat_core::resolve_auth_binding_or_default_for_provider(
+            &config,
+            meerkat_core::Provider::OpenAI,
+            None,
+            Some(&scope.locator.realm),
+            false,
+        )
+        .expect("mob member inherits migrated global binding");
+        assert_eq!(target.auth_binding.realm.as_str(), "global");
+        assert_eq!(target.auth_binding.binding.as_str(), "openai_oauth");
+        assert!(
+            store
+                .load(&TokenKey::parse("global", "openai_oauth").unwrap())
+                .await
+                .unwrap()
+                .is_some(),
+            "bootstrap must copy the legacy token before config composition"
+        );
+    }
+
     #[cfg(all(feature = "anthropic", feature = "openai", feature = "gemini"))]
     #[tokio::test]
     async fn test_cli_auth_status_rehydrates_marked_oauth_token_after_restart() {
@@ -18521,6 +18611,107 @@ default_model = "gemma"
     struct CapturingLlmClient {
         captured_tool_names: Arc<Mutex<Vec<String>>>,
         captured_system_prompt: Arc<Mutex<Option<String>>>,
+    }
+
+    #[cfg(feature = "mob")]
+    struct ScriptedMobSpawnClient {
+        calls: std::sync::atomic::AtomicUsize,
+    }
+
+    #[cfg(feature = "mob")]
+    impl ScriptedMobSpawnClient {
+        fn new() -> Self {
+            Self {
+                calls: std::sync::atomic::AtomicUsize::new(0),
+            }
+        }
+    }
+
+    #[cfg(feature = "mob")]
+    #[async_trait]
+    impl LlmClient for ScriptedMobSpawnClient {
+        fn project_replay_messages(
+            &self,
+            messages: &[meerkat_core::Message],
+        ) -> Result<Vec<meerkat_core::Message>, LlmError> {
+            Ok(messages.to_vec())
+        }
+
+        fn stream<'a>(
+            &'a self,
+            _request: &'a LlmRequest,
+        ) -> Pin<Box<dyn futures::Stream<Item = Result<LlmEvent, LlmError>> + Send + 'a>> {
+            let call = self.calls.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            let events = match call {
+                0 => vec![
+                    Ok(LlmEvent::ToolCallComplete {
+                        id: "create-mob".into(),
+                        name: "mob_create".into(),
+                        args: serde_json::json!({
+                            "definition": {
+                                "id": "stack-budget-mob",
+                                "profiles": {
+                                    "worker": {
+                                        "model": "gpt-5.4",
+                                        "tools": { "comms": true },
+                                        "peer_description": "worker",
+                                        "runtime_mode": "turn_driven"
+                                    }
+                                }
+                            }
+                        }),
+                        meta: None,
+                    }),
+                    Ok(LlmEvent::Done {
+                        outcome: LlmDoneOutcome::Success {
+                            stop_reason: meerkat_core::StopReason::ToolUse,
+                        },
+                    }),
+                ],
+                1 => vec![
+                    Ok(LlmEvent::ToolCallComplete {
+                        id: "spawn-worker".into(),
+                        name: "mob_spawn_member".into(),
+                        args: serde_json::json!({
+                            "mob_id": "stack-budget-mob",
+                            "profile": "worker",
+                            "member_id": "worker",
+                            "runtime_mode": "turn_driven",
+                            "auth_binding": {
+                                "realm": "global",
+                                "binding": "openai_oauth"
+                            }
+                        }),
+                        meta: None,
+                    }),
+                    Ok(LlmEvent::Done {
+                        outcome: LlmDoneOutcome::Success {
+                            stop_reason: meerkat_core::StopReason::ToolUse,
+                        },
+                    }),
+                ],
+                _ => vec![
+                    Ok(LlmEvent::TextDelta {
+                        delta: "spawn complete".into(),
+                        meta: None,
+                    }),
+                    Ok(LlmEvent::Done {
+                        outcome: LlmDoneOutcome::Success {
+                            stop_reason: meerkat_core::StopReason::EndTurn,
+                        },
+                    }),
+                ],
+            };
+            Box::pin(stream::iter(events))
+        }
+
+        fn provider(&self) -> meerkat_core::Provider {
+            meerkat_core::Provider::OpenAI
+        }
+
+        async fn health_check(&self) -> Result<(), LlmError> {
+            Ok(())
+        }
     }
 
     impl CapturingLlmClient {
@@ -23143,6 +23334,201 @@ capabilities = ["rpc"]
         assert!(system_prompt.contains("mob_list"));
         assert!(system_prompt.contains("mob_create"));
         assert!(system_prompt.contains("delegate"));
+    }
+
+    // The formal lifecycle model cannot express native Rust future size or a
+    // Tokio worker's stack budget. Exercise the real CLI full-tools surface,
+    // explicit auth binding, and mob_create -> mob_spawn_member dispatch on a
+    // literal production-scale caller stack plus one production-scale worker.
+    #[cfg(all(feature = "mob", feature = "openai"))]
+    #[test]
+    fn tools_full_with_explicit_auth_binding_can_spawn_within_production_stack_budget() {
+        let test_thread = std::thread::Builder::new()
+            .name("mob-spawn-small-stack".into())
+            .stack_size(2 * 1024 * 1024)
+            .spawn(|| {
+                let runtime = tokio::runtime::Builder::new_multi_thread()
+                    .worker_threads(1)
+                    .thread_stack_size(2 * 1024 * 1024)
+                    .enable_all()
+                    .build()
+                    .expect("small-stack test runtime");
+                runtime.block_on(tools_full_with_explicit_auth_binding_stack_budget_scenario());
+            })
+            .expect("spawn small-stack mob regression thread");
+        test_thread
+            .join()
+            .expect("small-stack mob regression thread must not overflow");
+    }
+
+    #[cfg(all(feature = "mob", feature = "openai"))]
+    async fn tools_full_with_explicit_auth_binding_stack_budget_scenario() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let mut config = Config::default();
+        config
+            .merge_toml_str(
+                r#"
+[realm.global]
+default_binding = "openai_oauth"
+
+[realm.global.backend.openai]
+provider = "openai"
+backend_kind = "openai_api"
+
+[realm.global.auth.inline]
+provider = "openai"
+auth_method = "api_key"
+source = { kind = "inline_secret", secret = "provider-free-test-secret" }
+
+[realm.global.binding.openai_oauth]
+backend_profile = "openai"
+auth_profile = "inline"
+default_model = "gpt-5.4"
+"#,
+            )
+            .expect("inline global binding config");
+
+        let tooling = resolve_tool_preset(ToolPreset::Full, false);
+        assert!(tooling.builtins && tooling.shell && tooling.workgraph && tooling.mob);
+        assert_eq!(tooling.memory, cfg!(feature = "memory-store-session"));
+        let factory = AgentFactory::new(temp.path().join("sessions"))
+            .builtins(tooling.builtins)
+            .shell(tooling.shell)
+            .memory(tooling.memory)
+            .workgraph(tooling.workgraph)
+            .mob(tooling.mob);
+        let workgraph_service =
+            meerkat::WorkGraphService::new(Arc::new(meerkat::MemoryWorkGraphStore::new()));
+        let service = Arc::new(build_cli_service_with_defaults(
+            factory,
+            config,
+            CliServiceBuildDefaults {
+                default_workgraph_tools: Some(Arc::new(meerkat::WorkGraphToolSurface::new(
+                    workgraph_service,
+                ))),
+                ..CliServiceBuildDefaults::default()
+            },
+        ));
+
+        let runtime_adapter =
+            <EphemeralSessionService<FactoryAgentBuilder> as meerkat_mob::MobSessionService>::runtime_adapter(
+                service.as_ref(),
+            )
+            .expect("embedded session service must expose its runtime adapter");
+        let parent_session = Session::new();
+        let parent_session_id = parent_session.id().clone();
+        let parent_bindings = runtime_adapter
+            .prepare_bindings(parent_session_id.clone())
+            .await
+            .expect("prepare exact parent runtime bindings");
+
+        let mob_service: Arc<dyn meerkat_mob::MobSessionService> =
+            Arc::new(RunMobSessionService::new(Arc::clone(&service)));
+        let mob_state = Arc::new(meerkat_mob_mcp::MobMcpState::new(
+            mob_service,
+            meerkat_mob::MobControlPrincipal::Owner,
+        ));
+        let mob_factory: Arc<dyn meerkat_core::service::MobToolsFactory> = Arc::new(
+            meerkat_mob_mcp::AgentMobToolSurfaceFactory::new(Arc::clone(&mob_state)),
+        );
+        let scripted_client = Arc::new(ScriptedMobSpawnClient::new());
+        let creator_tool_access_policy = meerkat_core::ops::ToolAccessPolicy::DenyList(
+            ["forbidden_child_tool"].into_iter().collect(),
+        );
+        let mut build = SessionBuildOptions {
+            resume_session: Some(parent_session),
+            runtime_build_mode: meerkat_core::RuntimeBuildMode::SessionOwned(parent_bindings),
+            initial_turn_metadata: Some(meerkat_runtime::runtime_stamped_prompt_turn_metadata(
+                None,
+            )),
+            mob_tools: Some(mob_factory),
+            tool_access_policy: Some(creator_tool_access_policy.clone()),
+            auth_binding: Some(AuthBindingRef {
+                realm: meerkat_core::RealmId::global(),
+                binding: meerkat_core::BindingId::parse("openai_oauth").expect("binding id"),
+                profile: None,
+                origin: meerkat_core::connection::BindingOrigin::Configured,
+            }),
+            llm_client_override: Some(meerkat::encode_llm_client_override_for_service(
+                scripted_client.clone(),
+            )),
+            ..SessionBuildOptions::default()
+        };
+        build.apply_generated_create_only_mob_operator_access(
+            meerkat_core::ToolCategoryOverride::Enable,
+        );
+
+        let result = tokio::time::timeout(
+            std::time::Duration::from_secs(15),
+            service.create_session(CreateSessionRequest {
+                injected_context: Vec::new(),
+                model: "gpt-5.4".into(),
+                prompt: "create the mob and spawn worker".into(),
+                system_prompt: meerkat::SystemPromptOverride::Inherit,
+                max_tokens: Some(128),
+                event_tx: None,
+                initial_turn: meerkat_core::service::InitialTurnPolicy::RunImmediately,
+                deferred_prompt_policy: DeferredPromptPolicy::Discard,
+                build: Some(build),
+                labels: None,
+            }),
+        )
+        .await
+        .expect("explicit auth + mob spawn must complete within the regression timeout")
+        .expect("explicit auth + mob spawn must return safely");
+        assert_eq!(result.text, "spawn complete");
+        assert_eq!(result.session_id, parent_session_id);
+        assert_eq!(
+            scripted_client
+                .calls
+                .load(std::sync::atomic::Ordering::SeqCst),
+            3,
+            "script must traverse create, spawn, then completion"
+        );
+
+        let handle = mob_state
+            .handle_for(&meerkat_mob::MobId::from("stack-budget-mob"))
+            .await
+            .expect("created mob");
+        let roster = handle.roster().await;
+        let worker = roster
+            .get_by_identity(&meerkat_mob::AgentIdentity::from("worker"))
+            .expect("scripted mob_spawn_member must reach the real mob runtime");
+        assert!(
+            worker.bridge_session_id().is_some(),
+            "spawned worker must carry its backing session identity"
+        );
+        let worker_session_id = worker
+            .bridge_session_id()
+            .cloned()
+            .expect("spawned worker session identity");
+        drop(roster);
+
+        let parent_policy = <EphemeralSessionService<FactoryAgentBuilder> as meerkat_mob::MobSessionService>::load_persisted_session(
+            service.as_ref(),
+            &parent_session_id,
+        )
+        .await
+        .expect("non-reentrant parent session policy read")
+        .expect("live parent session")
+        .try_session_metadata()
+        .expect("typed parent session metadata")
+        .and_then(|metadata| metadata.tooling.tool_access_policy);
+        let child_policy = <EphemeralSessionService<FactoryAgentBuilder> as meerkat_mob::MobSessionService>::load_persisted_session(
+            service.as_ref(),
+            &worker_session_id,
+        )
+        .await
+        .expect("non-reentrant child session policy read")
+        .expect("live child session")
+        .try_session_metadata()
+        .expect("typed child session metadata")
+        .and_then(|metadata| metadata.tooling.tool_access_policy);
+        assert_eq!(parent_policy, Some(creator_tool_access_policy));
+        assert_eq!(
+            child_policy, parent_policy,
+            "spawn must propagate the exact factory-resolved parent policy"
+        );
     }
 
     #[cfg(feature = "mob")]

--- a/meerkat-core/src/agent/state.rs
+++ b/meerkat-core/src/agent/state.rs
@@ -4047,56 +4047,15 @@ where
                         // expiry becomes a `ToolError::Timeout` so it flows
                         // through `terminal_tool_outcome_for_error` exactly like
                         // any other tool execution failure.
-                        let tool_dispatch_context = self.tool_dispatch_context.clone();
-                        let default_timeout = self.tools_config.default_timeout;
-                        let tool_timeouts = self.tools_config.tool_timeouts.clone();
-                        let max_concurrent = self.tools_config.max_concurrent.max(1);
-                        let dispatch_semaphore =
-                            Arc::new(tokio::sync::Semaphore::new(max_concurrent));
-                        let dispatch_futures: Vec<_> = executable_tool_calls
-                            .into_iter()
-                            .map(|(tool_index, tc)| {
-                                let tools_ref = Arc::clone(&tools_ref);
-                                let tool_dispatch_context = tool_dispatch_context.clone();
-                                let dispatch_semaphore = Arc::clone(&dispatch_semaphore);
-                                let call_timeout = tool_timeouts
-                                    .get(tc.name.as_str())
-                                    .copied()
-                                    .unwrap_or(default_timeout);
-                                async move {
-                                    let start = crate::time_compat::Instant::now();
-                                    let dispatch_result = match dispatch_semaphore.acquire().await {
-                                        Ok(_permit) => {
-                                            match tokio::time::timeout(
-                                                call_timeout,
-                                                tools_ref.dispatch_with_context(
-                                                    tc.as_view(),
-                                                    &tool_dispatch_context,
-                                                ),
-                                            )
-                                            .await
-                                            {
-                                                Ok(result) => result,
-                                                Err(_) => Err(ToolError::timeout(
-                                                    tc.name.clone(),
-                                                    u64::try_from(call_timeout.as_millis())
-                                                        .unwrap_or(u64::MAX),
-                                                )),
-                                            }
-                                        }
-                                        Err(_) => Err(ToolError::execution_failed(
-                                            "tool dispatch concurrency semaphore closed",
-                                        )),
-                                    };
-                                    let duration_ms = start.elapsed().as_millis() as u64;
-                                    (tool_index, tc, dispatch_result, duration_ms)
-                                }
-                            })
-                            .collect();
-
-                        let mut dispatch_results =
-                            futures::future::join_all(dispatch_futures).await;
-                        dispatch_results.sort_by_key(|(tool_index, _, _, _)| *tool_index);
+                        let dispatch_results = dispatch_tool_calls_boxed(
+                            Arc::clone(&tools_ref),
+                            self.tool_dispatch_context.clone(),
+                            self.tools_config.default_timeout,
+                            self.tools_config.tool_timeouts.clone(),
+                            self.tools_config.max_concurrent.max(1),
+                            executable_tool_calls,
+                        )
+                        .await;
 
                         // Process results and emit events
                         let mut all_async_ops = Vec::<crate::ops::AsyncOpRef>::new();
@@ -4889,6 +4848,77 @@ impl ToolCallOwned {
             args: &self.args,
         }
     }
+}
+
+type ToolDispatchResult = (
+    usize,
+    ToolCallOwned,
+    Result<crate::ops::ToolDispatchOutcome, ToolError>,
+    u64,
+);
+
+#[cfg(not(target_arch = "wasm32"))]
+type ToolDispatchFuture =
+    std::pin::Pin<Box<dyn std::future::Future<Output = Vec<ToolDispatchResult>> + Send + 'static>>;
+#[cfg(target_arch = "wasm32")]
+type ToolDispatchFuture =
+    std::pin::Pin<Box<dyn std::future::Future<Output = Vec<ToolDispatchResult>> + 'static>>;
+
+// Keep construction and polling of the concrete tool-dispatch batch out of
+// the already-large agent run-loop poll frame.
+#[inline(never)]
+fn dispatch_tool_calls_boxed<T: AgentToolDispatcher + ?Sized + 'static>(
+    tools_ref: Arc<T>,
+    tool_dispatch_context: super::ToolDispatchContext,
+    default_timeout: std::time::Duration,
+    tool_timeouts: std::collections::HashMap<String, std::time::Duration>,
+    max_concurrent: usize,
+    executable_tool_calls: Vec<(usize, ToolCallOwned)>,
+) -> ToolDispatchFuture {
+    Box::pin(async move {
+        let dispatch_semaphore = Arc::new(tokio::sync::Semaphore::new(max_concurrent));
+        let dispatch_futures: Vec<_> = executable_tool_calls
+            .into_iter()
+            .map(|(tool_index, tc)| {
+                let tools_ref = Arc::clone(&tools_ref);
+                let tool_dispatch_context = tool_dispatch_context.clone();
+                let dispatch_semaphore = Arc::clone(&dispatch_semaphore);
+                let call_timeout = tool_timeouts
+                    .get(tc.name.as_str())
+                    .copied()
+                    .unwrap_or(default_timeout);
+                async move {
+                    let start = crate::time_compat::Instant::now();
+                    let dispatch_result = match dispatch_semaphore.acquire().await {
+                        Ok(_permit) => {
+                            match tokio::time::timeout(
+                                call_timeout,
+                                tools_ref
+                                    .dispatch_with_context(tc.as_view(), &tool_dispatch_context),
+                            )
+                            .await
+                            {
+                                Ok(result) => result,
+                                Err(_) => Err(ToolError::timeout(
+                                    tc.name.clone(),
+                                    u64::try_from(call_timeout.as_millis()).unwrap_or(u64::MAX),
+                                )),
+                            }
+                        }
+                        Err(_) => Err(ToolError::execution_failed(
+                            "tool dispatch concurrency semaphore closed",
+                        )),
+                    };
+                    let duration_ms = start.elapsed().as_millis() as u64;
+                    (tool_index, tc, dispatch_result, duration_ms)
+                }
+            })
+            .collect();
+
+        let mut dispatch_results = futures::future::join_all(dispatch_futures).await;
+        dispatch_results.sort_by_key(|(tool_index, _, _, _)| *tool_index);
+        dispatch_results
+    })
 }
 
 #[cfg(test)]

--- a/meerkat-core/src/service/mod.rs
+++ b/meerkat-core/src/service/mod.rs
@@ -826,14 +826,18 @@ pub struct ParentToolCompositionAuthority {
 
 struct ParentToolCompositionAuthorityInner {
     tool_scope: RwLock<Option<crate::ToolScope>>,
+    resolved_tool_access_policy: Option<crate::ops::ToolAccessPolicy>,
 }
 
 impl ParentToolCompositionAuthority {
     #[cfg_attr(not(meerkat_internal_agent_factory_build), allow(dead_code))]
-    fn new_from_agent_factory_composition() -> Self {
+    fn new_from_agent_factory_composition(
+        resolved_tool_access_policy: Option<crate::ops::ToolAccessPolicy>,
+    ) -> Self {
         Self {
             inner: Arc::new(ParentToolCompositionAuthorityInner {
                 tool_scope: RwLock::new(None),
+                resolved_tool_access_policy,
             }),
         }
     }
@@ -891,6 +895,14 @@ impl ParentToolCompositionAuthority {
     /// Returns the tool definitions currently visible to the parent agent.
     pub fn snapshot_visible_tools(&self) -> Vec<Arc<ToolDef>> {
         self.visible_tool_snapshot_result().unwrap_or_default()
+    }
+
+    /// Returns the parent's factory-resolved call-level tool access policy.
+    ///
+    /// `None` is authoritative unrestricted access. AgentFactory rejects an
+    /// unresolved `Inherit` before the built agent can execute a turn.
+    pub fn resolved_tool_access_policy(&self) -> Option<crate::ops::ToolAccessPolicy> {
+        self.inner.resolved_tool_access_policy.clone()
     }
 
     /// Authorize an inherited child visibility filter from this parent-owned
@@ -979,14 +991,19 @@ fn validate_agent_factory_parent_tool_composition_bridge_token(
 #[doc(hidden)]
 #[allow(improper_ctypes_definitions, unsafe_code)]
 #[unsafe(export_name = concat!(
-    "__meerkat_agent_factory_parent_tool_composition_authority_new_v1_",
+    "__meerkat_agent_factory_parent_tool_composition_authority_new_v2_",
     env!("MEERKAT_AGENT_FACTORY_POLICY_BRIDGE_SYMBOL_SUFFIX")
 ))]
 pub(crate) extern "Rust" fn agent_factory_parent_tool_composition_authority_new(
     token: &'static (dyn std::any::Any + Send + Sync),
+    resolved_tool_access_policy: Option<crate::ops::ToolAccessPolicy>,
 ) -> Result<ParentToolCompositionAuthority, String> {
     validate_agent_factory_parent_tool_composition_bridge_token(token)?;
-    Ok(ParentToolCompositionAuthority::new_from_agent_factory_composition())
+    Ok(
+        ParentToolCompositionAuthority::new_from_agent_factory_composition(
+            resolved_tool_access_policy,
+        ),
+    )
 }
 
 #[cfg(all(meerkat_internal_agent_factory_build, not(test)))]
@@ -2603,7 +2620,12 @@ mod tests {
             provenance: None,
         })]);
         let tool_scope = crate::ToolScope::new(tools);
-        let authority = ParentToolCompositionAuthority::new_from_agent_factory_composition();
+        let policy = crate::ops::ToolAccessPolicy::DenyList(
+            ["restricted".to_string()].into_iter().collect(),
+        );
+        let authority = ParentToolCompositionAuthority::new_from_agent_factory_composition(Some(
+            policy.clone(),
+        ));
         authority.set_tool_scope_from_agent_factory_composition(&tool_scope);
         let ctx = MobToolSnapshotContext::ParentOwned(authority);
         match ctx {
@@ -2611,6 +2633,7 @@ mod tests {
                 let snapshot = p.snapshot_visible_tools();
                 assert_eq!(snapshot.len(), 1);
                 assert_eq!(snapshot[0].name, "test_tool");
+                assert_eq!(p.resolved_tool_access_policy(), Some(policy));
             }
             MobToolSnapshotContext::Standalone => panic!("expected ParentOwned"),
         }

--- a/meerkat-mob-mcp/src/agent_tools.rs
+++ b/meerkat-mob-mcp/src/agent_tools.rs
@@ -24,7 +24,7 @@ use meerkat_mob::{
 use schemars::{JsonSchema, schema_for};
 use serde::Deserialize;
 use serde_json::{Value, json};
-use std::sync::Arc;
+use std::{future::Future, pin::Pin, sync::Arc};
 
 #[cfg(not(target_arch = "wasm32"))]
 use ::tokio::{
@@ -62,6 +62,57 @@ const TOOL_MOB_PROFILE_LIST: &str = "mob_profile_list";
 const TOOL_MOB_PROFILE_UPDATE: &str = "mob_profile_update";
 const TOOL_MOB_PROFILE_DELETE: &str = "mob_profile_delete";
 const TOOL_MOB_PROFILE_LIST_SOURCES: &str = "mob_profile_list_sources";
+
+#[cfg(not(target_arch = "wasm32"))]
+type AgentDispatchFuture<'a> =
+    Pin<Box<dyn Future<Output = Result<meerkat_core::ToolDispatchOutcome, ToolError>> + Send + 'a>>;
+#[cfg(target_arch = "wasm32")]
+type AgentDispatchFuture<'a> =
+    Pin<Box<dyn Future<Output = Result<meerkat_core::ToolDispatchOutcome, ToolError>> + 'a>>;
+
+#[cfg(not(target_arch = "wasm32"))]
+type AgentOperationFuture<'a, T> = Pin<Box<dyn Future<Output = T> + Send + 'a>>;
+#[cfg(target_arch = "wasm32")]
+type AgentOperationFuture<'a, T> = Pin<Box<dyn Future<Output = T> + 'a>>;
+
+#[cfg(not(target_arch = "wasm32"))]
+type MobCreateFuture = Pin<Box<dyn Future<Output = Result<MobId, MobError>> + Send + 'static>>;
+#[cfg(target_arch = "wasm32")]
+type MobCreateFuture = Pin<Box<dyn Future<Output = Result<MobId, MobError>> + 'static>>;
+
+// Construct each large concrete async state machine behind an inline-resistant
+// heap boundary. `Box::pin(self.dispatch_...)` inside the dispatch match still
+// materializes the concrete future as a stack temporary in debug builds.
+macro_rules! boxed_agent_dispatch {
+    ($boxed:ident, $inner:ident $(, $arg:ident : $arg_ty:ty)*) => {
+        #[inline(never)]
+        fn $boxed<'a>(
+            &'a self,
+            call: ToolCallView<'a>,
+            $($arg: $arg_ty),*
+        ) -> AgentDispatchFuture<'a> {
+            Box::pin(self.$inner(call, $($arg),*))
+        }
+    };
+}
+
+#[inline(never)]
+fn mob_create_with_owner_bridge_boxed(
+    state: Arc<MobMcpState>,
+    definition: MobDefinition,
+    owner_bridge_session_id: SessionId,
+) -> MobCreateFuture {
+    Box::pin(async move {
+        state
+            .mob_create_definition_with_owner_bridge_session(
+                definition,
+                owner_bridge_session_id,
+                true,
+                false,
+            )
+            .await
+    })
+}
 
 // ─── ResolvedSpawnTooling ────────────────────────────────────────────────
 
@@ -102,6 +153,16 @@ fn lower_wire_placement(placement: Option<WireHostRef>) -> Option<HostId> {
 
 // ─── AgentMobToolSurface ─────────────────────────────────────────────────
 
+#[derive(Clone)]
+enum ParentToolAccessPolicySource {
+    /// AgentFactory supplied the already-resolved effective parent policy
+    /// through its opaque parent-composition authority.
+    Resolved(Option<meerkat_core::ops::ToolAccessPolicy>),
+    /// Compatibility path for public constructors that predate the opaque
+    /// authority handoff. Resolve from durable session metadata at dispatch.
+    LegacySessionMetadata,
+}
+
 /// Agent-internal tool surface for mob delegation and orchestration.
 ///
 /// Composed by `build_agent()` into the tool gateway. Provides 8 tools
@@ -116,6 +177,7 @@ pub struct AgentMobToolSurface {
     /// (via apply_session_effects). Falls back to a local RwLock when no shared
     /// handle is provided (non-runtime test paths).
     effective_authority: Arc<std::sync::RwLock<MobToolAuthorityContext>>,
+    parent_tool_access_policy_source: ParentToolAccessPolicySource,
     tools: Arc<[Arc<ToolDef>]>,
     owner_bridge_session_id: SessionId,
     /// Model name inherited by implicit mob helpers.
@@ -274,6 +336,33 @@ impl AgentMobToolSurface {
         comms_runtime: Option<Arc<dyn meerkat_core::agent::CommsRuntime>>,
         snapshot_context: meerkat_core::service::MobToolSnapshotContext,
     ) -> Self {
+        Self::new_with_effective_authority_and_policy_source(
+            state,
+            implicit_mob_id,
+            effective_authority,
+            ParentToolAccessPolicySource::LegacySessionMetadata,
+            model,
+            owner_bridge_session_id,
+            comms_name,
+            comms_peer_id,
+            comms_runtime,
+            snapshot_context,
+        )
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn new_with_effective_authority_and_policy_source(
+        state: Arc<MobMcpState>,
+        implicit_mob_id: Option<MobId>,
+        effective_authority: Arc<std::sync::RwLock<MobToolAuthorityContext>>,
+        parent_tool_access_policy_source: ParentToolAccessPolicySource,
+        model: String,
+        owner_bridge_session_id: SessionId,
+        comms_name: Option<String>,
+        comms_peer_id: Option<PeerId>,
+        comms_runtime: Option<Arc<dyn meerkat_core::agent::CommsRuntime>>,
+        snapshot_context: meerkat_core::service::MobToolSnapshotContext,
+    ) -> Self {
         let has_profile_store = state.realm_profile_store().is_some();
         let has_snapshot_provider = matches!(
             &snapshot_context,
@@ -297,6 +386,7 @@ impl AgentMobToolSurface {
             state,
             cached_implicit_mob_id: RwLock::new(implicit_mob_id),
             effective_authority,
+            parent_tool_access_policy_source,
             tools,
             owner_bridge_session_id,
             model,
@@ -674,50 +764,79 @@ impl AgentMobToolSurface {
 
     /// Resolve the spawned child's effective tool access policy.
     ///
-    /// `Inherit`/absent resolves to this (parent) session's effective policy
-    /// from `SessionMetadata.tooling.tool_access_policy` — the same field the
-    /// factory stamps at build. Every backend exposes the parent through the
-    /// metadata-only `load_persisted_session_metadata` seam: the persistent
-    /// service projects the durable metadata row and the ephemeral service
-    /// derives the view from the LIVE session (a restricted ephemeral parent
-    /// must never mint unrestricted children because its policy was invisible
-    /// to the read seam). A metadata READ FAULT — including corrupt durable
-    /// metadata, which the seam surfaces as `Err`, never `Ok(None)` — fails
-    /// the spawn closed rather than silently minting an ungated child; a
-    /// genuinely absent parent session (host/operator-authored spawn)
-    /// resolves to unrestricted.
-    async fn resolve_child_tool_access_policy(
-        &self,
-        tool_name: &str,
+    /// Factory-built surfaces resolve from their immutable composition
+    /// authority. Legacy public constructors retain their metadata-read
+    /// behavior, but that branch stays erased so it cannot inflate the
+    /// factory spawn future or re-enter a factory-owned live parent.
+    #[inline(never)]
+    fn resolve_child_tool_access_policy_boxed<'a>(
+        &'a self,
+        tool_name: &'a str,
         requested: Option<meerkat_core::ops::ToolAccessPolicy>,
-    ) -> Result<Option<meerkat_core::ops::ToolAccessPolicy>, ToolError> {
+    ) -> AgentOperationFuture<'a, Result<Option<meerkat_core::ops::ToolAccessPolicy>, ToolError>>
+    {
+        // Preserve the historical explicit-policy fast path: an admitted
+        // AllowList/DenyList never needs parent metadata.
         if matches!(
-            requested,
+            requested.as_ref(),
             Some(
                 meerkat_core::ops::ToolAccessPolicy::AllowList(_)
                     | meerkat_core::ops::ToolAccessPolicy::DenyList(_)
             )
         ) {
-            return Ok(effective_child_tool_access_policy(requested, None));
+            return Box::pin(std::future::ready(Ok(requested)));
         }
-        let parent_view = self
-            .state
-            .session_service()
-            .load_persisted_session_metadata(&self.owner_bridge_session_id)
-            .await
-            .map_err(|error| {
-                ToolError::execution_failed(format!(
-                    "tool '{tool_name}' parent tool access policy read failed; \
-                     refusing to resolve the child tool access policy: {error}"
-                ))
-            })?;
-        let parent_effective = parent_view
-            .and_then(|view| view.session_metadata)
-            .and_then(|metadata| metadata.tooling.tool_access_policy);
-        Ok(effective_child_tool_access_policy(
-            requested,
-            parent_effective,
-        ))
+
+        match &self.parent_tool_access_policy_source {
+            ParentToolAccessPolicySource::Resolved(parent_effective) => {
+                let result = if matches!(
+                    parent_effective,
+                    Some(meerkat_core::ops::ToolAccessPolicy::Inherit)
+                ) {
+                    Err(ToolError::execution_failed(format!(
+                        "tool '{tool_name}' parent tool access policy was not resolved at build"
+                    )))
+                } else {
+                    Ok(effective_child_tool_access_policy(
+                        requested,
+                        parent_effective.clone(),
+                    ))
+                };
+                Box::pin(std::future::ready(result))
+            }
+            ParentToolAccessPolicySource::LegacySessionMetadata => {
+                self.resolve_child_tool_access_policy_from_metadata_boxed(tool_name, requested)
+            }
+        }
+    }
+
+    #[inline(never)]
+    fn resolve_child_tool_access_policy_from_metadata_boxed<'a>(
+        &'a self,
+        tool_name: &'a str,
+        requested: Option<meerkat_core::ops::ToolAccessPolicy>,
+    ) -> AgentOperationFuture<'a, Result<Option<meerkat_core::ops::ToolAccessPolicy>, ToolError>>
+    {
+        Box::pin(async move {
+            let parent_view = self
+                .state
+                .session_service()
+                .load_persisted_session_metadata(&self.owner_bridge_session_id)
+                .await
+                .map_err(|error| {
+                    ToolError::execution_failed(format!(
+                        "tool '{tool_name}' parent tool access policy read failed; \
+                         refusing to resolve the child tool access policy: {error}"
+                    ))
+                })?;
+            let parent_effective = parent_view
+                .and_then(|view| view.session_metadata)
+                .and_then(|metadata| metadata.tooling.tool_access_policy);
+            Ok(effective_child_tool_access_policy(
+                requested,
+                parent_effective,
+            ))
+        })
     }
 
     async fn record_successful_operator_action(
@@ -991,10 +1110,10 @@ impl AgentMobToolSurface {
         spec.override_profile = resolved.override_profile;
 
         // Transitive containment: the delegate surface carries no explicit
-        // policy, so the helper inherits this (parent) session's persisted
-        // effective tool access policy.
+        // policy, so the helper inherits the parent's resolved policy from
+        // the factory authority or the legacy metadata seam.
         spec.tool_access_policy = self
-            .resolve_child_tool_access_policy(call.name, spec.tool_access_policy.take())
+            .resolve_child_tool_access_policy_boxed(call.name, spec.tool_access_policy.take())
             .await?;
 
         // Spawn via MobMcpState
@@ -1063,25 +1182,29 @@ impl AgentMobToolSurface {
         let session_effects =
             vec![meerkat_core::SessionEffect::ReplaceMobToolAuthorityContext { authority_context }];
 
-        let mob_id = self
-            .state
-            .mob_create_definition_with_owner_bridge_session(
-                args.definition,
-                self.owner_bridge_session_id.clone(),
-                true,
-                false,
-            )
-            .await
-            .map_err(|e| Self::map_mob_error(call, e))?;
-
+        let mob_id = mob_create_with_owner_bridge_boxed(
+            Arc::clone(&self.state),
+            args.definition,
+            self.owner_bridge_session_id.clone(),
+        )
+        .await
+        .map_err(|e| Self::map_mob_error(call, e))?;
         if let Ok(handle) = self.bound_handle(&mob_id).await {
-            self.record_successful_operator_action(&handle, call.name)
+            self.record_successful_operator_action_boxed(&handle, call.name)
                 .await;
         }
-
         // The outcome and the grant computed from the same intended mob id are
         // returned as a single atomic effect bundle for the turn owner to commit.
         Self::encode_result_with_effects(call, json!({"mob_id": mob_id}), session_effects)
+    }
+
+    #[inline(never)]
+    fn record_successful_operator_action_boxed<'a>(
+        &'a self,
+        handle: &'a MobHandle,
+        tool_name: &'a str,
+    ) -> AgentOperationFuture<'a, ()> {
+        Box::pin(self.record_successful_operator_action(handle, tool_name))
     }
 
     async fn dispatch_mob_destroy(
@@ -1133,21 +1256,14 @@ impl AgentMobToolSurface {
             .map_err(|e| ToolError::invalid_arguments(call.name, e.to_string()))?;
         let mob_id = MobId::from(args.mob_id.clone());
 
-        self.ensure_spawn_member_scope(call.name, &mob_id, &args)
+        self.ensure_spawn_member_scope_boxed(call.name, &mob_id, &args)
             .await?;
         let audit_handle = self
             .bound_handle(&mob_id)
             .await
             .map_err(|e| Self::map_mob_error(call, e))?;
-
         if let Some(objective_id) = objective_id {
-            let owner_identity = self
-                .state
-                .objective_principal_for_mob_owner_session(&mob_id, &self.owner_bridge_session_id)
-                .await
-                .map_err(|error| Self::map_mob_error(call, error))?;
-            self.state
-                .mob_bind_objective_owner(&mob_id, owner_identity, objective_id)
+            self.bind_spawn_objective_owner_boxed(&mob_id, objective_id)
                 .await
                 .map_err(|error| Self::map_mob_error(call, error))?;
         }
@@ -1165,30 +1281,77 @@ impl AgentMobToolSurface {
             spec.auto_wire_parent = auto_wire;
         }
         if let Some(tooling) = args.tooling {
-            let resolved = self.resolve_spawn_tooling(&tooling).await?;
+            let resolved = self.resolve_spawn_tooling_boxed(&tooling).await?;
             spec.inherited_tool_filter = resolved.inherited_tool_filter;
             spec.override_profile = resolved.override_profile;
         }
         // Transitive containment: this spawn surface accepts no explicit
-        // policy argument, so `Inherit`/absent resolves to this (parent)
-        // session's persisted effective tool access policy.
+        // policy argument, so `Inherit`/absent resolves to the parent's
+        // effective policy through the selected compatibility source.
         spec.tool_access_policy = self
-            .resolve_child_tool_access_policy(call.name, spec.tool_access_policy.take())
+            .resolve_child_tool_access_policy_boxed(call.name, spec.tool_access_policy.take())
             .await?;
         if let Some(cref) = args.auth_binding {
             // Reconstruct origin: Configured server-side (client cannot forge it).
             spec.auth_binding = Some(cref.into());
         }
 
-        let spawn_result = audit_handle
-            .spawn_spec_with_generated_owner_context(spec, self.owner_bridge_session_id.clone())
+        let spawn_result = self
+            .spawn_spec_with_generated_owner_context_boxed(&audit_handle, spec)
             .await
             .map_err(|e| Self::map_mob_error(call, e))?;
-
-        self.record_successful_operator_action(&audit_handle, call.name)
+        self.record_successful_operator_action_boxed(&audit_handle, call.name)
             .await;
-
         Self::encode_result(call, Self::spawn_result_payload(&mob_id, &spawn_result))
+    }
+
+    #[inline(never)]
+    fn ensure_spawn_member_scope_boxed<'a>(
+        &'a self,
+        tool_name: &'a str,
+        mob_id: &'a MobId,
+        args: &'a SpawnMemberArgs,
+    ) -> AgentOperationFuture<'a, Result<(), ToolError>> {
+        Box::pin(self.ensure_spawn_member_scope(tool_name, mob_id, args))
+    }
+
+    #[inline(never)]
+    fn bind_spawn_objective_owner_boxed<'a>(
+        &'a self,
+        mob_id: &'a MobId,
+        objective_id: meerkat_core::interaction::ObjectiveId,
+    ) -> AgentOperationFuture<'a, Result<(), MobError>> {
+        Box::pin(async move {
+            let owner_identity = self
+                .state
+                .objective_principal_for_mob_owner_session(mob_id, &self.owner_bridge_session_id)
+                .await?;
+            self.state
+                .mob_bind_objective_owner(mob_id, owner_identity, objective_id)
+                .await
+        })
+    }
+
+    #[inline(never)]
+    fn resolve_spawn_tooling_boxed<'a>(
+        &'a self,
+        tooling: &'a meerkat_mob::SpawnTooling,
+    ) -> AgentOperationFuture<'a, Result<ResolvedSpawnTooling, ToolError>> {
+        Box::pin(self.resolve_spawn_tooling(tooling))
+    }
+
+    #[inline(never)]
+    fn spawn_spec_with_generated_owner_context_boxed<'a>(
+        &'a self,
+        handle: &'a MobHandle,
+        spec: SpawnMemberSpec,
+    ) -> AgentOperationFuture<'a, Result<meerkat_mob::SpawnResult, MobError>> {
+        Box::pin(
+            handle.spawn_spec_with_generated_owner_context(
+                spec,
+                self.owner_bridge_session_id.clone(),
+            ),
+        )
     }
 
     async fn dispatch_conclude_objective(
@@ -1541,6 +1704,95 @@ impl AgentMobToolSurface {
             .collect();
         Self::encode_result(call, json!({"sources": sources}))
     }
+
+    boxed_agent_dispatch!(
+        dispatch_delegate_boxed,
+        dispatch_delegate,
+        objective_id: Option<meerkat_core::interaction::ObjectiveId>
+    );
+    boxed_agent_dispatch!(
+        dispatch_conclude_objective_boxed,
+        dispatch_conclude_objective,
+        objective_id: Option<meerkat_core::interaction::ObjectiveId>
+    );
+    boxed_agent_dispatch!(dispatch_mob_create_boxed, dispatch_mob_create);
+    boxed_agent_dispatch!(dispatch_mob_destroy_boxed, dispatch_mob_destroy);
+    boxed_agent_dispatch!(
+        dispatch_mob_spawn_member_boxed,
+        dispatch_mob_spawn_member,
+        objective_id: Option<meerkat_core::interaction::ObjectiveId>
+    );
+    boxed_agent_dispatch!(dispatch_mob_retire_member_boxed, dispatch_mob_retire_member);
+    boxed_agent_dispatch!(dispatch_mob_check_member_boxed, dispatch_mob_check_member);
+    boxed_agent_dispatch!(dispatch_mob_list_members_boxed, dispatch_mob_list_members);
+    boxed_agent_dispatch!(dispatch_mob_list_boxed, dispatch_mob_list);
+    boxed_agent_dispatch!(dispatch_mob_wire_boxed, dispatch_mob_wire);
+    boxed_agent_dispatch!(dispatch_mob_unwire_boxed, dispatch_mob_unwire);
+    boxed_agent_dispatch!(
+        dispatch_mob_profile_create_boxed,
+        dispatch_mob_profile_create
+    );
+    boxed_agent_dispatch!(dispatch_mob_profile_get_boxed, dispatch_mob_profile_get);
+    boxed_agent_dispatch!(dispatch_mob_profile_list_boxed, dispatch_mob_profile_list);
+    boxed_agent_dispatch!(
+        dispatch_mob_profile_update_boxed,
+        dispatch_mob_profile_update
+    );
+    boxed_agent_dispatch!(
+        dispatch_mob_profile_delete_boxed,
+        dispatch_mob_profile_delete
+    );
+    boxed_agent_dispatch!(
+        dispatch_mob_profile_list_sources_boxed,
+        dispatch_mob_profile_list_sources
+    );
+
+    async fn dispatch_with_context_stack_bounded(
+        &self,
+        call: ToolCallView<'_>,
+        context: &meerkat_core::ToolDispatchContext,
+    ) -> Result<meerkat_core::ToolDispatchOutcome, ToolError> {
+        let objective_id = context
+            .turn_metadata(meerkat_core::agent::TOOL_DISPATCH_OBJECTIVE_ID_KEY)
+            .and_then(serde_json::Value::as_str)
+            .map(uuid::Uuid::parse_str)
+            .transpose()
+            .map_err(|error| {
+                ToolError::execution_failed(format!(
+                    "{}: invalid objective correlation in dispatch context: {error}",
+                    call.name
+                ))
+            })?
+            .map(meerkat_core::interaction::ObjectiveId);
+        match call.name {
+            TOOL_DELEGATE => self.dispatch_delegate_boxed(call, objective_id).await,
+            TOOL_CONCLUDE_OBJECTIVE => {
+                self.dispatch_conclude_objective_boxed(call, objective_id)
+                    .await
+            }
+            TOOL_MOB_CREATE => self.dispatch_mob_create_boxed(call).await,
+            TOOL_MOB_DESTROY => self.dispatch_mob_destroy_boxed(call).await,
+            TOOL_MOB_SPAWN_MEMBER => {
+                self.dispatch_mob_spawn_member_boxed(call, objective_id)
+                    .await
+            }
+            TOOL_MOB_RETIRE_MEMBER => self.dispatch_mob_retire_member_boxed(call).await,
+            TOOL_MOB_CHECK_MEMBER => self.dispatch_mob_check_member_boxed(call).await,
+            TOOL_MOB_LIST_MEMBERS => self.dispatch_mob_list_members_boxed(call).await,
+            TOOL_MOB_LIST => self.dispatch_mob_list_boxed(call).await,
+            TOOL_MOB_WIRE => self.dispatch_mob_wire_boxed(call).await,
+            TOOL_MOB_UNWIRE => self.dispatch_mob_unwire_boxed(call).await,
+            TOOL_MOB_PROFILE_CREATE => self.dispatch_mob_profile_create_boxed(call).await,
+            TOOL_MOB_PROFILE_GET => self.dispatch_mob_profile_get_boxed(call).await,
+            TOOL_MOB_PROFILE_LIST => self.dispatch_mob_profile_list_boxed(call).await,
+            TOOL_MOB_PROFILE_UPDATE => self.dispatch_mob_profile_update_boxed(call).await,
+            TOOL_MOB_PROFILE_DELETE => self.dispatch_mob_profile_delete_boxed(call).await,
+            TOOL_MOB_PROFILE_LIST_SOURCES => {
+                self.dispatch_mob_profile_list_sources_boxed(call).await
+            }
+            _ => Err(ToolError::not_found(call.name)),
+        }
+    }
 }
 
 // ─── MobToolsFactory implementation ─────────────────────────────────────
@@ -1590,10 +1842,30 @@ impl meerkat_core::service::MobToolsFactory for AgentMobToolSurfaceFactory {
         let effective_authority_handle = args
             .effective_authority
             .unwrap_or_else(|| Arc::new(std::sync::RwLock::new(authority_context)));
-        let surface = AgentMobToolSurface::new_with_effective_authority(
+        let parent_tool_access_policy_source = match &args.snapshot_context {
+            meerkat_core::service::MobToolSnapshotContext::ParentOwned(authority) => {
+                ParentToolAccessPolicySource::Resolved(authority.resolved_tool_access_policy())
+            }
+            meerkat_core::service::MobToolSnapshotContext::Standalone => {
+                ParentToolAccessPolicySource::LegacySessionMetadata
+            }
+        };
+        if matches!(
+            &parent_tool_access_policy_source,
+            ParentToolAccessPolicySource::Resolved(Some(
+                meerkat_core::ops::ToolAccessPolicy::Inherit
+            ))
+        ) {
+            return Err(std::io::Error::other(
+                "mob tool creator policy must be resolved before surface construction",
+            )
+            .into());
+        }
+        let surface = AgentMobToolSurface::new_with_effective_authority_and_policy_source(
             Arc::clone(&self.state),
             implicit_mob_id,
             effective_authority_handle,
+            parent_tool_access_policy_source,
             args.model,
             args.session_id,
             args.comms_name,
@@ -1642,40 +1914,8 @@ impl AgentToolDispatcher for AgentMobToolSurface {
         call: ToolCallView<'_>,
         context: &meerkat_core::ToolDispatchContext,
     ) -> Result<meerkat_core::ToolDispatchOutcome, ToolError> {
-        let objective_id = context
-            .turn_metadata(meerkat_core::agent::TOOL_DISPATCH_OBJECTIVE_ID_KEY)
-            .and_then(serde_json::Value::as_str)
-            .map(uuid::Uuid::parse_str)
-            .transpose()
-            .map_err(|error| {
-                ToolError::execution_failed(format!(
-                    "{}: invalid objective correlation in dispatch context: {error}",
-                    call.name
-                ))
-            })?
-            .map(meerkat_core::interaction::ObjectiveId);
-        match call.name {
-            TOOL_DELEGATE => Box::pin(self.dispatch_delegate(call, objective_id)).await,
-            TOOL_CONCLUDE_OBJECTIVE => self.dispatch_conclude_objective(call, objective_id).await,
-            TOOL_MOB_CREATE => self.dispatch_mob_create(call).await,
-            TOOL_MOB_DESTROY => self.dispatch_mob_destroy(call).await,
-            TOOL_MOB_SPAWN_MEMBER => {
-                Box::pin(self.dispatch_mob_spawn_member(call, objective_id)).await
-            }
-            TOOL_MOB_RETIRE_MEMBER => self.dispatch_mob_retire_member(call).await,
-            TOOL_MOB_CHECK_MEMBER => self.dispatch_mob_check_member(call).await,
-            TOOL_MOB_LIST_MEMBERS => self.dispatch_mob_list_members(call).await,
-            TOOL_MOB_LIST => self.dispatch_mob_list(call).await,
-            TOOL_MOB_WIRE => self.dispatch_mob_wire(call).await,
-            TOOL_MOB_UNWIRE => self.dispatch_mob_unwire(call).await,
-            TOOL_MOB_PROFILE_CREATE => self.dispatch_mob_profile_create(call).await,
-            TOOL_MOB_PROFILE_GET => self.dispatch_mob_profile_get(call).await,
-            TOOL_MOB_PROFILE_LIST => self.dispatch_mob_profile_list(call).await,
-            TOOL_MOB_PROFILE_UPDATE => self.dispatch_mob_profile_update(call).await,
-            TOOL_MOB_PROFILE_DELETE => self.dispatch_mob_profile_delete(call).await,
-            TOOL_MOB_PROFILE_LIST_SOURCES => self.dispatch_mob_profile_list_sources(call).await,
-            _ => Err(ToolError::not_found(call.name)),
-        }
+        self.dispatch_with_context_stack_bounded(call, context)
+            .await
     }
 
     fn capabilities(&self) -> meerkat_core::agent::DispatcherCapabilities {
@@ -1698,6 +1938,7 @@ impl AgentToolDispatcher for AgentMobToolSurface {
             state: this.state,
             cached_implicit_mob_id: this.cached_implicit_mob_id,
             effective_authority: this.effective_authority,
+            parent_tool_access_policy_source: this.parent_tool_access_policy_source,
             control_principal: this.control_principal,
             tools: this.tools,
             owner_bridge_session_id,
@@ -3012,6 +3253,8 @@ mod tests {
 
     struct RealCommsSessionSvc {
         sessions: tokio::sync::RwLock<HashMap<SessionId, RealCommsSessionActor>>,
+        persisted_sessions: tokio::sync::RwLock<HashMap<SessionId, meerkat_core::Session>>,
+        persisted_metadata_loads: AtomicU64,
         actor_registry: meerkat_session::LiveSessionActorRegistry,
         counter: AtomicU64,
         runtime_adapter: Arc<meerkat_runtime::MeerkatMachine>,
@@ -3023,6 +3266,8 @@ mod tests {
         fn new() -> Self {
             Self {
                 sessions: tokio::sync::RwLock::new(HashMap::new()),
+                persisted_sessions: tokio::sync::RwLock::new(HashMap::new()),
+                persisted_metadata_loads: AtomicU64::new(0),
                 actor_registry: meerkat_session::LiveSessionActorRegistry::default(),
                 counter: AtomicU64::new(0),
                 runtime_adapter: Arc::new(meerkat_runtime::MeerkatMachine::ephemeral()),
@@ -3041,6 +3286,13 @@ mod tests {
 
         async fn register_external_comms(&self, name: &str) -> Arc<TestCommsRuntime> {
             TestCommsRuntime::new(name, Arc::clone(&self.registry)).await
+        }
+
+        async fn seed_persisted_session(&self, session: meerkat_core::Session) {
+            self.persisted_sessions
+                .write()
+                .await
+                .insert(session.id().clone(), session);
         }
 
         async fn create_session_with_actor_slot(
@@ -3362,9 +3614,38 @@ mod tests {
 
         async fn load_persisted_session(
             &self,
-            _session_id: &SessionId,
+            session_id: &SessionId,
         ) -> Result<Option<meerkat_core::Session>, SessionError> {
-            Ok(None)
+            Ok(self
+                .persisted_sessions
+                .read()
+                .await
+                .get(session_id)
+                .cloned())
+        }
+
+        async fn load_persisted_session_metadata(
+            &self,
+            session_id: &SessionId,
+        ) -> Result<Option<meerkat_core::PersistedSessionMetadataView>, SessionError> {
+            self.persisted_metadata_loads
+                .fetch_add(1, Ordering::Relaxed);
+            let Some(session) = self
+                .persisted_sessions
+                .read()
+                .await
+                .get(session_id)
+                .cloned()
+            else {
+                return Ok(None);
+            };
+            meerkat_core::PersistedSessionMetadataView::try_from_session(&session)
+                .map(Some)
+                .map_err(|error| {
+                    SessionError::Agent(meerkat_core::error::AgentError::InternalError(format!(
+                        "session {session_id} metadata projection failed in test service: {error}"
+                    )))
+                })
         }
 
         async fn apply_runtime_turn(
@@ -3755,6 +4036,18 @@ mod tests {
             name: "unknown_tool",
             args: &args_raw,
         };
+
+        // Guard the concrete dispatcher future itself. Large-stack CI lanes
+        // can otherwise mask a compiler-generated aggregate branch frame.
+        let context = meerkat_core::ToolDispatchContext::default();
+        let dispatch_future = surface.dispatch_with_context_stack_bounded(call, &context);
+        let dispatch_future_size = std::mem::size_of_val(&dispatch_future);
+        assert!(
+            dispatch_future_size <= 1024,
+            "agent mob dispatcher future grew beyond its stack budget: {dispatch_future_size} bytes"
+        );
+        drop(dispatch_future);
+
         let result = surface.dispatch(call).await;
         assert!(matches!(result, Err(ToolError::NotFound { .. })));
     }
@@ -5194,6 +5487,81 @@ mod tests {
 
     fn deny_policy(names: &[&str]) -> meerkat_core::ops::ToolAccessPolicy {
         meerkat_core::ops::ToolAccessPolicy::DenyList(names.iter().copied().collect())
+    }
+
+    /// Public constructors predate the opaque AgentFactory composition
+    /// authority. They must continue to inherit a restricted parent's durable
+    /// policy, while explicit child policy remains a metadata-free fast path.
+    #[tokio::test]
+    async fn public_constructor_preserves_restricted_parent_policy_containment() {
+        let service = Arc::new(RealCommsSessionSvc::new());
+        let parent_session_id = SessionId::new();
+        let parent_policy = allow_policy(&["read_file"]);
+        let mut parent_session = meerkat_core::Session::with_id(parent_session_id.clone());
+        parent_session
+            .set_session_metadata(meerkat_core::SessionMetadata {
+                schema_version: meerkat_core::SESSION_METADATA_SCHEMA_VERSION,
+                model: "claude-sonnet-4-5".to_string(),
+                max_tokens: 4096,
+                structured_output_retries: meerkat_core::config::default_structured_output_retries(
+                ),
+                provider: Provider::Anthropic,
+                self_hosted_server_id: None,
+                provider_params: None,
+                tooling: meerkat_core::SessionTooling {
+                    tool_access_policy: Some(parent_policy.clone()),
+                    ..meerkat_core::SessionTooling::default()
+                },
+                keep_alive: false,
+                comms_name: None,
+                peer_meta: None,
+                realm_id: None,
+                instance_id: None,
+                backend: None,
+                config_generation: None,
+                auth_binding: None,
+                mob_member_binding: None,
+            })
+            .expect("restricted parent metadata must serialize");
+        service.seed_persisted_session(parent_session).await;
+        let session_service: Arc<dyn meerkat_mob::MobSessionService> = service.clone();
+        let state = Arc::new(MobMcpState::new(
+            session_service,
+            meerkat_mob::MobControlPrincipal::Owner,
+        ));
+        let surface = AgentMobToolSurface::new(
+            state,
+            None,
+            create_only_authority(),
+            "claude-sonnet-4-5".to_string(),
+            parent_session_id,
+            None,
+            None,
+            None,
+        );
+
+        let inherited = surface
+            .resolve_child_tool_access_policy_boxed(TOOL_MOB_SPAWN_MEMBER, None)
+            .await
+            .expect("legacy constructor must resolve persisted parent policy");
+        assert_eq!(inherited, Some(parent_policy));
+        assert_eq!(
+            service.persisted_metadata_loads.load(Ordering::Relaxed),
+            1,
+            "inherited policy must use the legacy metadata seam exactly once"
+        );
+
+        let explicit = deny_policy(&["bash"]);
+        let explicit_result = surface
+            .resolve_child_tool_access_policy_boxed(TOOL_MOB_SPAWN_MEMBER, Some(explicit.clone()))
+            .await
+            .expect("explicit child policy remains admitted");
+        assert_eq!(explicit_result, Some(explicit));
+        assert_eq!(
+            service.persisted_metadata_loads.load(Ordering::Relaxed),
+            1,
+            "explicit child policy must bypass the parent metadata read"
+        );
     }
 
     /// Escape regression: a restricted parent + `Inherit` (or absent) child

--- a/meerkat-mob/src/runtime/actor.rs
+++ b/meerkat-mob/src/runtime/actor.rs
@@ -13,6 +13,51 @@ use super::scope_gate::{RoutedMobCommand, ScopeAdmission};
 use super::terminalization::{FlowFailureCause, TerminalizationOutcome, TerminalizationTarget};
 use super::transaction::LifecycleRollback;
 use super::*;
+
+#[cfg(not(target_arch = "wasm32"))]
+type ActorCommandFuture<'a, T> =
+    std::pin::Pin<Box<dyn std::future::Future<Output = T> + Send + 'a>>;
+#[cfg(target_arch = "wasm32")]
+type ActorCommandFuture<'a, T> = std::pin::Pin<Box<dyn std::future::Future<Output = T> + 'a>>;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ActorLoopControl {
+    ProceedBoundary,
+    SkipBoundary,
+    BreakActor,
+}
+
+// Expand the command match synchronously so each arm constructs and erases
+// its own async future. A single async block around the whole match recreates
+// the aggregate command-loop poll frame this boundary exists to avoid.
+macro_rules! boxed_actor_dispatch {
+    ($cmd:expr, {
+        $($(#[$meta:meta])* $pattern:pat => $body:block)*
+        @control
+        $($(#[$control_meta:meta])* $control_pattern:pat => $control_body:block)*
+    }) => {{
+        match $cmd {
+            $(
+                $(#[$meta])*
+                $pattern => {
+                    let future: ActorCommandFuture<'_, ActorLoopControl> = Box::pin(async move {
+                        $body
+                        ActorLoopControl::ProceedBoundary
+                    });
+                    future
+                }
+            )*
+            $(
+                $(#[$control_meta])*
+                $control_pattern => {
+                    let future: ActorCommandFuture<'_, ActorLoopControl> =
+                        Box::pin(async move $control_body);
+                    future
+                }
+            )*
+        }
+    }};
+}
 use crate::control_policy::{
     CommandAuthority, CommandAuthorityKind, MemberOperatorExecutionFence, MobControlPrincipal,
     ResolvedControlPolicy, ScopeDenial,
@@ -15466,118 +15511,38 @@ impl MobActor {
         self.shutdown_actor_owned_background_work().await;
     }
 
-    /// Main actor loop: process commands sequentially until Shutdown.
-    pub(super) async fn run(mut self, mut command_rx: mpsc::Receiver<RoutedMobCommand>) {
-        if matches!(self.dsl_state(), MobState::Running) {
-            if let Err(error) = self.restore_generated_member_operation_bindings().await {
-                tracing::error!(
-                    mob_id = %self.definition.id,
-                    error = %error,
-                    "failed to restore generated mob member operation bindings during actor startup; entering Stopped"
-                );
-                self.fail_startup_to_stopped("mob member operation binding restore failure")
-                    .await;
-            }
-        }
-        if let Err(error) = self.recover_durable_member_live_open_cleanups().await {
-            tracing::error!(
-                mob_id = %self.definition.id,
-                error = %error,
-                "durable member-live Open cleanup recovery failed; fail-stopping before command admission"
-            );
-            self.quiesce_volatile_producers_after_fail_stop().await;
-            return;
-        }
-        // Prune only after generated member bindings have recovered: before
-        // that point the machine snapshot may not yet contain every current
-        // session/residency atom, and treating absence as stale would evict a
-        // valid replay row. A failed binding restore transitions to Stopped
-        // and deliberately skips pruning this incomplete snapshot.
-        if matches!(self.state(), MobState::Running)
-            && let Err(error) = self.prune_stale_member_operator_requests().await
-        {
-            tracing::error!(
-                mob_id = %self.definition.id,
-                error = %error,
-                "failed to prune stale member-operator ledger rows during actor recovery"
-            );
-            self.fail_startup_to_stopped("member-operator ledger recovery pruning failure")
-                .await;
-        }
-        if matches!(self.state(), MobState::Running) {
-            if let Err(error) = self.ensure_autonomous_runtimes_from_roster(false).await {
-                tracing::error!(
-                    mob_id = %self.definition.id,
-                    error = %error,
-                    "failed to start autonomous host loops during actor startup; entering Stopped"
-                );
-                // Per-session recovery failures are actor-owned lifecycle
-                // facts. Persist Stop and retain the handle so an explicit
-                // MobHandle::resume retry can return the original typed
-                // capability failure; startup must not make an Ok builder
-                // result look Running or ready.
-                self.fail_startup_to_stopped("autonomous runtime startup failure")
-                    .await;
-            }
-        }
-        let mut deferred_commands: VecDeque<RoutedMobCommand> = VecDeque::new();
-        let mut host_status_polls_in_flight = BTreeSet::new();
-        let mut host_status_poll = tokio::time::interval(super::handle::HOST_STATUS_POLL_INTERVAL);
-        #[cfg(not(target_arch = "wasm32"))]
-        host_status_poll.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
-        // Consume interval's immediate first tick. Bind/rebind already perform
-        // an eager observation; the periodic driver starts one cadence later.
-        host_status_poll.tick().await;
-        'actor: loop {
-            self.drain_completed_actor_io_tasks();
-            self.drain_completed_peer_delivery_tasks();
-            let member_live_mutation_pending = !self.member_live_mutation_tasks.is_empty();
-            let routed = if let Some(routed) = deferred_commands.pop_front() {
-                routed
-            } else {
-                tokio::select! {
-                    routed = command_rx.recv() => {
-                        let Some(routed) = routed else {
-                            break;
-                        };
-                        routed
-                    }
-                    _tick = host_status_poll.tick() => {
-                        self.spawn_periodic_host_status_polls(&mut host_status_polls_in_flight).await;
-                        continue;
-                    }
-                    joined = self.member_live_mutation_tasks.join_next(),
-                        if member_live_mutation_pending =>
-                    {
-                        if let Some(joined) = joined
-                            && let Err(error) =
-                                self.reconcile_joined_member_live_mutation(
-                                    joined,
-                                    MemberLiveReconcileMode::Background,
-                                ).await
-                        {
-                            tracing::warn!(
-                                mob_id = %self.definition.id,
-                                error = %error,
-                                "mutating member-live completion reconciliation failed"
-                            );
-                        }
-                        continue;
-                    }
+    #[inline(never)]
+    fn dispatch_command_boxed<'a>(
+        &'a mut self,
+        authority: &'a CommandAuthority,
+        cmd: MobCommand,
+        command_rx: &'a mut mpsc::Receiver<RoutedMobCommand>,
+        deferred_commands: &'a mut VecDeque<RoutedMobCommand>,
+        host_status_polls_in_flight: &'a mut BTreeSet<mob_dsl::HostId>,
+    ) -> ActorCommandFuture<'a, ActorLoopControl> {
+        match cmd {
+            // Keep this catalog-classified fail-closed gate as ordinary AST so
+            // the machine-authority drift audit can verify the exact
+            // MobCommand -> MobMachineInput relationship.
+            MobCommand::SetSpawnPolicy { policy, reply_tx } => Box::pin(async move {
+                let enabled = policy.is_some();
+                let result = self
+                    .apply_dsl_input(
+                        mob_dsl::MobMachineInput::SetSpawnPolicy { enabled },
+                        "set_spawn_policy",
+                    )
+                    .map_err(|error| {
+                        MobError::Internal(format!(
+                            "SetSpawnPolicy rejected by MobMachine guards before shell policy write: {error}"
+                        ))
+                    });
+                if result.is_ok() {
+                    self.spawn_policy.set(policy).await;
                 }
-            };
-            // Chokepoint (a): resolve+require BEFORE any handler logic, on
-            // the actor's own serialized machine state (DEC-P5E-4). Deferred
-            // commands keep their authority and re-enter the gate here.
-            let RoutedMobCommand { authority, cmd } = routed;
-            tracing::debug!(command_kind = cmd.kind(), "MobActor received command");
-            let cmd = match self.admit_command_scope(&authority, cmd) {
-                ScopeAdmission::Admitted(cmd) => cmd,
-                // The typed denial was already sent down the command's own
-                // reply channel by `reject_scope_denied`.
-                ScopeAdmission::Denied => continue,
-            };
-            match cmd {
+                let _ = reply_tx.send(result);
+                ActorLoopControl::ProceedBoundary
+            }),
+            cmd => boxed_actor_dispatch!(cmd, {
                 MobCommand::Spawn {
                     spec,
                     spawn_source,
@@ -15694,7 +15659,7 @@ impl MobActor {
                             binding_incarnation,
                             "discarding stale periodic host-status response"
                         );
-                        continue;
+                        return ActorLoopControl::SkipBoundary;
                     }
                     match result {
                         Ok(status) => {
@@ -15808,7 +15773,7 @@ impl MobActor {
                             fence_token = key.fence_token.0,
                             "discarding orphan release completion from a superseded host binding"
                         );
-                        continue;
+                        return ActorLoopControl::SkipBoundary;
                     }
                     let succeeded = result.is_ok();
                     let completion_was_owned = Self::absorb_host_orphan_release_completion(
@@ -16174,7 +16139,7 @@ impl MobActor {
                                                 )
                                                 .await;
                                             });
-                                            continue;
+                                            return ActorLoopControl::SkipBoundary;
                                         }
                                     }
                                 }
@@ -16211,7 +16176,7 @@ impl MobActor {
                                             .await;
                                         });
                                     }
-                                    continue;
+                                    return ActorLoopControl::SkipBoundary;
                                 }
                             };
                             self.spawn_turn_completed_reply(
@@ -16339,7 +16304,7 @@ impl MobActor {
                 MobCommand::ProjectMachineInput { input, reply_tx } => {
                     if let Err(error) = Self::reject_raw_grant_machine_input(&input) {
                         let _ = reply_tx.send(Err(error));
-                        continue;
+                        return ActorLoopControl::SkipBoundary;
                     }
                     let result = self
                         .apply_dsl_input(*input, "project_machine_input")
@@ -16349,7 +16314,7 @@ impl MobActor {
                 MobCommand::ApplyMachineInputEffects { input, reply_tx } => {
                     if let Err(error) = Self::reject_raw_grant_machine_input(&input) {
                         let _ = reply_tx.send(Err(error));
-                        continue;
+                        return ActorLoopControl::SkipBoundary;
                     }
                     let result =
                         self.apply_dsl_input_collect_effects(*input, "apply_machine_input_effects");
@@ -17605,7 +17570,7 @@ impl MobActor {
                         // further commands are accepted.
                         self.lifecycle_tasks.abort_all();
                         while self.lifecycle_tasks.join_next().await.is_some() {}
-                        break 'actor;
+                        return ActorLoopControl::BreakActor;
                     }
                 }
                 MobCommand::Reset { reply_tx } => {
@@ -17822,24 +17787,18 @@ impl MobActor {
                     let result = self.handle_cancel_all_work(runtime_id, fence_token).await;
                     let _ = reply_tx.send(result);
                 }
-                MobCommand::SetSpawnPolicy { policy, reply_tx } => {
-                    let enabled = policy.is_some();
-                    let result = self.apply_dsl_input(
-                        mob_dsl::MobMachineInput::SetSpawnPolicy { enabled },
-                        "set_spawn_policy",
-                    )
-                    .map_err(|error| {
-                        MobError::Internal(format!(
-                            "SetSpawnPolicy rejected by MobMachine guards before shell policy write: {error}"
-                        ))
-                    });
-                    if result.is_ok() {
-                        self.spawn_policy.set(policy).await;
-                    }
-                    let _ = reply_tx.send(result);
-                }
                 MobCommand::QueryPhase { reply_tx } => {
                     let _ = reply_tx.send(Ok(self.state()));
+                }
+                @control
+                MobCommand::SetSpawnPolicy { reply_tx, .. } => {
+                    // The outer AST-visible catalog gate owns this variant.
+                    // Keep the erased inner match safely exhaustive if that
+                    // ownership boundary is ever changed.
+                    let _ = reply_tx.send(Err(MobError::Internal(
+                        "SetSpawnPolicy escaped its catalog-gated dispatch arm".into(),
+                    )));
+                    ActorLoopControl::SkipBoundary
                 }
                 #[cfg(any(test, feature = "test-support"))]
                 MobCommand::CrashStopPreservingDurableWorkForTest { reply_tx } => {
@@ -17849,7 +17808,7 @@ impl MobActor {
                     // The exact stores remain the only restart authority.
                     self.quiesce_volatile_producers_after_fail_stop().await;
                     let _ = reply_tx.send(Ok(()));
-                    break;
+                    ActorLoopControl::BreakActor
                 }
                 MobCommand::Shutdown { reply_tx } => {
                     if let Err(error) = self.probe_command_admission(
@@ -17858,11 +17817,11 @@ impl MobActor {
                         "shutdown_command_admission",
                     ) {
                         let _ = reply_tx.send(Err(error));
-                        continue;
+                        return ActorLoopControl::SkipBoundary;
                     }
                     if let Err(error) = self.drain_member_live_mutations_for_lifecycle().await {
                         let _ = reply_tx.send(Err(error));
-                        continue;
+                        return ActorLoopControl::SkipBoundary;
                     }
                     if let Err(error) = self
                         .close_controller_local_member_live_channels_for_shutdown(
@@ -17871,7 +17830,7 @@ impl MobActor {
                         .await
                     {
                         let _ = reply_tx.send(Err(error));
-                        continue;
+                        return ActorLoopControl::SkipBoundary;
                     }
                     let mut result = self
                         .fail_all_pending_spawns("mob runtime is shutting down")
@@ -17881,7 +17840,7 @@ impl MobActor {
                             let _ = reply_tx.send(result);
                         }
                         if !self.durable_uncertainty_fail_stop {
-                            continue;
+                            return ActorLoopControl::SkipBoundary;
                         }
                     } else {
                         self.cancel_pending_peer_deliveries("mob runtime is shutting down")
@@ -17939,17 +17898,145 @@ impl MobActor {
                         }
                         if !self.durable_uncertainty_fail_stop {
                             if succeeded {
-                                break;
+                                return ActorLoopControl::BreakActor;
                             }
                             // Required teardown retains this actor as the
                             // retry owner. Never publish Stopped or exit while
                             // a runtime binding is unresolved.
-                            continue;
+                            return ActorLoopControl::SkipBoundary;
                         }
                     }
+                    ActorLoopControl::ProceedBoundary
                 }
-            }
+            }),
+        }
+    }
 
+    /// Main actor loop: process commands sequentially until Shutdown.
+    pub(super) async fn run(mut self, mut command_rx: mpsc::Receiver<RoutedMobCommand>) {
+        if matches!(self.dsl_state(), MobState::Running) {
+            if let Err(error) = self.restore_generated_member_operation_bindings().await {
+                tracing::error!(
+                    mob_id = %self.definition.id,
+                    error = %error,
+                    "failed to restore generated mob member operation bindings during actor startup; entering Stopped"
+                );
+                self.fail_startup_to_stopped("mob member operation binding restore failure")
+                    .await;
+            }
+        }
+        if let Err(error) = self.recover_durable_member_live_open_cleanups().await {
+            tracing::error!(
+                mob_id = %self.definition.id,
+                error = %error,
+                "durable member-live Open cleanup recovery failed; fail-stopping before command admission"
+            );
+            self.quiesce_volatile_producers_after_fail_stop().await;
+            return;
+        }
+        // Prune only after generated member bindings have recovered: before
+        // that point the machine snapshot may not yet contain every current
+        // session/residency atom, and treating absence as stale would evict a
+        // valid replay row. A failed binding restore transitions to Stopped
+        // and deliberately skips pruning this incomplete snapshot.
+        if matches!(self.state(), MobState::Running)
+            && let Err(error) = self.prune_stale_member_operator_requests().await
+        {
+            tracing::error!(
+                mob_id = %self.definition.id,
+                error = %error,
+                "failed to prune stale member-operator ledger rows during actor recovery"
+            );
+            self.fail_startup_to_stopped("member-operator ledger recovery pruning failure")
+                .await;
+        }
+        if matches!(self.state(), MobState::Running) {
+            if let Err(error) = self.ensure_autonomous_runtimes_from_roster(false).await {
+                tracing::error!(
+                    mob_id = %self.definition.id,
+                    error = %error,
+                    "failed to start autonomous host loops during actor startup; entering Stopped"
+                );
+                // Per-session recovery failures are actor-owned lifecycle
+                // facts. Persist Stop and retain the handle so an explicit
+                // MobHandle::resume retry can return the original typed
+                // capability failure; startup must not make an Ok builder
+                // result look Running or ready.
+                self.fail_startup_to_stopped("autonomous runtime startup failure")
+                    .await;
+            }
+        }
+        let mut deferred_commands: VecDeque<RoutedMobCommand> = VecDeque::new();
+        let mut host_status_polls_in_flight = BTreeSet::new();
+        let mut host_status_poll = tokio::time::interval(super::handle::HOST_STATUS_POLL_INTERVAL);
+        #[cfg(not(target_arch = "wasm32"))]
+        host_status_poll.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+        // Consume interval's immediate first tick. Bind/rebind already perform
+        // an eager observation; the periodic driver starts one cadence later.
+        host_status_poll.tick().await;
+        'actor: loop {
+            self.drain_completed_actor_io_tasks();
+            self.drain_completed_peer_delivery_tasks();
+            let member_live_mutation_pending = !self.member_live_mutation_tasks.is_empty();
+            let routed = if let Some(routed) = deferred_commands.pop_front() {
+                routed
+            } else {
+                tokio::select! {
+                    routed = command_rx.recv() => {
+                        let Some(routed) = routed else {
+                            break;
+                        };
+                        routed
+                    }
+                    _tick = host_status_poll.tick() => {
+                        self.spawn_periodic_host_status_polls(&mut host_status_polls_in_flight).await;
+                        continue;
+                    }
+                    joined = self.member_live_mutation_tasks.join_next(),
+                        if member_live_mutation_pending =>
+                    {
+                        if let Some(joined) = joined
+                            && let Err(error) =
+                                self.reconcile_joined_member_live_mutation(
+                                    joined,
+                                    MemberLiveReconcileMode::Background,
+                                ).await
+                        {
+                            tracing::warn!(
+                                mob_id = %self.definition.id,
+                                error = %error,
+                                "mutating member-live completion reconciliation failed"
+                            );
+                        }
+                        continue;
+                    }
+                }
+            };
+            // Chokepoint (a): resolve+require BEFORE any handler logic, on
+            // the actor's own serialized machine state (DEC-P5E-4). Deferred
+            // commands keep their authority and re-enter the gate here.
+            let RoutedMobCommand { authority, cmd } = routed;
+            tracing::debug!(command_kind = cmd.kind(), "MobActor received command");
+            let cmd = match self.admit_command_scope(&authority, cmd) {
+                ScopeAdmission::Admitted(cmd) => cmd,
+                // The typed denial was already sent down the command's own
+                // reply channel by `reject_scope_denied`.
+                ScopeAdmission::Denied => continue,
+            };
+            match self
+                .dispatch_command_boxed(
+                    &authority,
+                    cmd,
+                    &mut command_rx,
+                    &mut deferred_commands,
+                    &mut host_status_polls_in_flight,
+                )
+                .await
+            {
+                ActorLoopControl::ProceedBoundary => {}
+                ActorLoopControl::SkipBoundary => continue,
+                ActorLoopControl::BreakActor => break,
+            }
             if self.durable_uncertainty_fail_stop {
                 tracing::error!(
                     mob_id = %self.definition.id,

--- a/meerkat-mob/src/runtime/builder.rs
+++ b/meerkat-mob/src/runtime/builder.rs
@@ -13,6 +13,31 @@ use std::collections::{BTreeMap, BTreeSet, HashMap};
 
 const MOB_COMMAND_CHANNEL_CAPACITY: usize = 4096;
 
+#[cfg(all(feature = "runtime-adapter", not(target_arch = "wasm32")))]
+type RuntimeStartFuture = std::pin::Pin<
+    Box<dyn std::future::Future<Output = Result<MobHandle, MobError>> + Send + 'static>,
+>;
+#[cfg(all(feature = "runtime-adapter", target_arch = "wasm32"))]
+type RuntimeStartFuture =
+    std::pin::Pin<Box<dyn std::future::Future<Output = Result<MobHandle, MobError>> + 'static>>;
+
+#[cfg(all(feature = "runtime-adapter", not(target_arch = "wasm32")))]
+type RuntimeActorFuture = std::pin::Pin<Box<dyn std::future::Future<Output = ()> + Send + 'static>>;
+#[cfg(all(feature = "runtime-adapter", target_arch = "wasm32"))]
+type RuntimeActorFuture = std::pin::Pin<Box<dyn std::future::Future<Output = ()> + 'static>>;
+
+// Erase the actor loop before passing it to the executor. Constructing the
+// concrete actor future in an already-large runtime-bootstrap poll frame can
+// otherwise exhaust a production-size worker stack before Tokio owns it.
+#[cfg(feature = "runtime-adapter")]
+#[inline(never)]
+fn runtime_actor_future(
+    actor: MobActor,
+    command_rx: mpsc::Receiver<super::scope_gate::RoutedMobCommand>,
+) -> RuntimeActorFuture {
+    Box::pin(actor.run(command_rx))
+}
+
 fn placed_orchestrator_resume_notification_is_non_gating(error: &MobError) -> bool {
     // This turn is informational and runs before the restored controller has
     // re-probed placed hosts. Any well-formed terminal response from the
@@ -7099,206 +7124,218 @@ impl MobBuilder {
     /// Create the mob: emit MobCreated event, start the actor, return handle.
     #[cfg(feature = "runtime-adapter")]
     pub async fn create(self) -> Result<MobHandle, MobError> {
-        let MobBuilder {
-            mode,
-            storage,
-            session_service,
-            #[cfg(feature = "runtime-adapter")]
-            runtime_adapter,
-            workgraph_service,
-            allow_ephemeral_sessions,
-            notify_orchestrator_on_resume,
-            tool_bundles,
-            default_llm_client,
-            default_external_tools_provider,
-            spawn_base_prompt_source,
-            spawn_member_customizer,
-            owner_bridge_session_create_authority,
-            realtime_session_factory,
-            controlling_acceptor,
-            member_live_host,
-        } = self;
-        #[cfg(not(feature = "runtime-adapter"))]
-        let runtime_adapter: RuntimeAdapterOption = None;
+        Self::create_boxed(self).await
+    }
 
-        let definition = match mode {
-            BuilderMode::Create(definition) => definition,
-            BuilderMode::Resume => {
+    // Keep the concrete create future out of callers such as agent-tool
+    // dispatch. The generated machine authority and runtime bootstrap make the
+    // un-erased debug future large enough to exhaust a production-size worker
+    // stack before its first suspension point.
+    #[cfg(feature = "runtime-adapter")]
+    #[inline(never)]
+    fn create_boxed(builder: Self) -> RuntimeStartFuture {
+        Box::pin(async move {
+            let MobBuilder {
+                mode,
+                storage,
+                session_service,
+                #[cfg(feature = "runtime-adapter")]
+                runtime_adapter,
+                workgraph_service,
+                allow_ephemeral_sessions,
+                notify_orchestrator_on_resume,
+                tool_bundles,
+                default_llm_client,
+                default_external_tools_provider,
+                spawn_base_prompt_source,
+                spawn_member_customizer,
+                owner_bridge_session_create_authority,
+                realtime_session_factory,
+                controlling_acceptor,
+                member_live_host,
+            } = builder;
+            #[cfg(not(feature = "runtime-adapter"))]
+            let runtime_adapter: RuntimeAdapterOption = None;
+
+            let definition = match mode {
+                BuilderMode::Create(definition) => definition,
+                BuilderMode::Resume => {
+                    return Err(MobError::Internal(
+                        "MobBuilder::create() cannot be used with for_resume(); call resume()"
+                            .to_string(),
+                    ));
+                }
+            };
+            MobSupervisorBridge::preflight_ingress_ownership(
+                definition
+                    .backend
+                    .external
+                    .as_ref()
+                    .and_then(|external| external.supervisor_bridge.as_ref()),
+                controlling_acceptor.as_ref(),
+            )?;
+            let mut diagnostics = crate::validate::validate_definition(&definition);
+            diagnostics.extend(crate::spec::SpecValidator::validate(&definition));
+            let (errors, warnings) = crate::validate::partition_diagnostics(diagnostics);
+            if !errors.is_empty() {
+                return Err(MobError::DefinitionError(errors));
+            }
+            for warning in warnings {
+                tracing::warn!(
+                    code = %warning.code,
+                    location = ?warning.location,
+                    "{}",
+                    warning.message
+                );
+            }
+            let session_service = session_service
+                .ok_or_else(|| MobError::Internal("session_service is required".into()))?;
+            if !allow_ephemeral_sessions && !session_service.supports_persistent_sessions() {
                 return Err(MobError::Internal(
-                    "MobBuilder::create() cannot be used with for_resume(); call resume()"
+                    "session_service must satisfy persistent-session contract (REQ-MOB-030)"
                         .to_string(),
                 ));
             }
-        };
-        MobSupervisorBridge::preflight_ingress_ownership(
-            definition
-                .backend
-                .external
-                .as_ref()
-                .and_then(|external| external.supervisor_bridge.as_ref()),
-            controlling_acceptor.as_ref(),
-        )?;
-        let mut diagnostics = crate::validate::validate_definition(&definition);
-        diagnostics.extend(crate::spec::SpecValidator::validate(&definition));
-        let (errors, warnings) = crate::validate::partition_diagnostics(diagnostics);
-        if !errors.is_empty() {
-            return Err(MobError::DefinitionError(errors));
-        }
-        for warning in warnings {
-            tracing::warn!(
-                code = %warning.code,
-                location = ?warning.location,
-                "{}",
-                warning.message
-            );
-        }
-        let session_service = session_service
-            .ok_or_else(|| MobError::Internal("session_service is required".into()))?;
-        if !allow_ephemeral_sessions && !session_service.supports_persistent_sessions() {
-            return Err(MobError::Internal(
-                "session_service must satisfy persistent-session contract (REQ-MOB-030)"
-                    .to_string(),
-            ));
-        }
-        let runtime_adapter =
-            canonical_runtime_adapter_for_session_service(&session_service, runtime_adapter)?;
+            let runtime_adapter =
+                canonical_runtime_adapter_for_session_service(&session_service, runtime_adapter)?;
 
-        // §8: AutonomousHost profiles require a runtime adapter. Validate at
-        // build time so Option<adapter> on the trait doesn't hide an ownership
-        // requirement that only surfaces at spawn time.
-        #[cfg(feature = "runtime-adapter")]
-        {
-            let has_autonomous = definition
-                .profiles
-                .values()
-                .filter_map(|b| b.as_inline())
-                .any(|p| p.runtime_mode == crate::MobRuntimeMode::AutonomousHost);
-            if has_autonomous && runtime_adapter.is_none() {
-                return Err(MobError::Internal(
+            // §8: AutonomousHost profiles require a runtime adapter. Validate at
+            // build time so Option<adapter> on the trait doesn't hide an ownership
+            // requirement that only surfaces at spawn time.
+            #[cfg(feature = "runtime-adapter")]
+            {
+                let has_autonomous = definition
+                    .profiles
+                    .values()
+                    .filter_map(|b| b.as_inline())
+                    .any(|p| p.runtime_mode == crate::MobRuntimeMode::AutonomousHost);
+                if has_autonomous && runtime_adapter.is_none() {
+                    return Err(MobError::Internal(
                     "definition contains AutonomousHost profiles but no runtime adapter is available; \
                      provide one via with_runtime_adapter() or use a session service that implements \
                      runtime_adapter()"
                         .to_string(),
                 ));
+                }
             }
-        }
 
-        let mut dsl_authority = Box::new(seed_mob_authority());
-        let owner_bridge_event = match owner_bridge_session_create_authority.as_ref() {
-            Some(binding) => bind_owner_bridge_session_authority_for_create(
+            let mut dsl_authority = Box::new(seed_mob_authority());
+            let owner_bridge_event = match owner_bridge_session_create_authority.as_ref() {
+                Some(binding) => bind_owner_bridge_session_authority_for_create(
+                    &mut dsl_authority,
+                    binding,
+                    "create_owner_bridge_session",
+                )?,
+                None => None,
+            };
+            seed_mob_definition_spawn_policy(
                 &mut dsl_authority,
-                binding,
-                "create_owner_bridge_session",
-            )?,
-            None => None,
-        };
-        seed_mob_definition_spawn_policy(
-            &mut dsl_authority,
-            &definition,
-            "create_definition_spawn_policy",
-        )?;
-        finish_seeded_mob_authority_phase(&mut dsl_authority, MobState::Running)?;
+                &definition,
+                "create_definition_spawn_policy",
+            )?;
+            finish_seeded_mob_authority_phase(&mut dsl_authority, MobState::Running)?;
 
-        // Emit MobCreated event first
-        let definition_for_event = (*definition).clone();
-        storage
-            .events
-            .append(NewMobEvent {
-                mob_id: definition.id.clone(),
-                timestamp: None,
-                kind: MobEventKind::MobCreated {
-                    definition: Box::new(definition_for_event),
-                },
-            })
-            .await?;
-        if let Some(owner_bridge_event) = owner_bridge_event {
+            // Emit MobCreated event first
+            let definition_for_event = (*definition).clone();
             storage
                 .events
                 .append(NewMobEvent {
                     mob_id: definition.id.clone(),
                     timestamp: None,
-                    kind: owner_bridge_event,
+                    kind: MobEventKind::MobCreated {
+                        definition: Box::new(definition_for_event),
+                    },
                 })
                 .await?;
-        }
-        Self::sync_definition_with_spec_store(
-            storage.specs.clone(),
-            definition.id.clone(),
-            definition.as_ref(),
-        )
-        .await?;
-        Self::ensure_supervisor_authority(
-            storage.runtime_metadata.clone(),
-            definition.id.clone(),
-            &mut dsl_authority,
-        )
-        .await?;
-        Self::recover_host_bindings(
-            storage.runtime_metadata.clone(),
-            &definition.id,
-            &mut dsl_authority,
-            "create_after_insert_race",
-        )
-        .await?;
-        let supervisor_authority = storage
-            .runtime_metadata
-            .load_supervisor_authority(&definition.id)
-            .await?
-            .ok_or_else(|| {
-                MobError::Internal(format!(
-                    "missing supervisor runtime metadata for newly created mob '{}'",
-                    definition.id
-                ))
-            })?;
-        let supervisor_bridge = Arc::new(
-            MobSupervisorBridge::new_with_controlling_acceptor(
-                &definition.id,
-                supervisor_authority.clone(),
-                definition
-                    .backend
-                    .external
-                    .as_ref()
-                    .and_then(|external| external.supervisor_bridge.clone()),
-                controlling_acceptor.clone(),
+            if let Some(owner_bridge_event) = owner_bridge_event {
+                storage
+                    .events
+                    .append(NewMobEvent {
+                        mob_id: definition.id.clone(),
+                        timestamp: None,
+                        kind: owner_bridge_event,
+                    })
+                    .await?;
+            }
+            Self::sync_definition_with_spec_store(
+                storage.specs.clone(),
+                definition.id.clone(),
+                definition.as_ref(),
             )
-            .await?,
-        );
+            .await?;
+            Self::ensure_supervisor_authority(
+                storage.runtime_metadata.clone(),
+                definition.id.clone(),
+                &mut dsl_authority,
+            )
+            .await?;
+            Self::recover_host_bindings(
+                storage.runtime_metadata.clone(),
+                &definition.id,
+                &mut dsl_authority,
+                "create_after_insert_race",
+            )
+            .await?;
+            let supervisor_authority = storage
+                .runtime_metadata
+                .load_supervisor_authority(&definition.id)
+                .await?
+                .ok_or_else(|| {
+                    MobError::Internal(format!(
+                        "missing supervisor runtime metadata for newly created mob '{}'",
+                        definition.id
+                    ))
+                })?;
+            let supervisor_bridge = Arc::new(
+                MobSupervisorBridge::new_with_controlling_acceptor(
+                    &definition.id,
+                    supervisor_authority.clone(),
+                    definition
+                        .backend
+                        .external
+                        .as_ref()
+                        .and_then(|external| external.supervisor_bridge.clone()),
+                    controlling_acceptor.clone(),
+                )
+                .await?,
+            );
 
-        #[cfg(not(target_arch = "wasm32"))]
-        let supervisor_startup_guard =
-            SupervisorBridgeStartupGuard::new(Arc::clone(&supervisor_bridge));
+            #[cfg(not(target_arch = "wasm32"))]
+            let supervisor_startup_guard =
+                SupervisorBridgeStartupGuard::new(Arc::clone(&supervisor_bridge));
 
-        let start_result = Self::start_runtime(
-            definition,
-            Roster::new(),
-            dsl_authority,
-            storage.events.clone(),
-            storage.runs.clone(),
-            storage.runtime_metadata.clone(),
-            supervisor_bridge,
-            session_service,
-            runtime_adapter,
-            workgraph_service,
-            tool_bundles,
-            default_llm_client,
-            default_external_tools_provider,
-            spawn_base_prompt_source,
-            spawn_member_customizer,
-            storage.realm_profiles.clone(),
-            notify_orchestrator_on_resume,
-            realtime_session_factory,
-            controlling_acceptor,
-            member_live_host,
-        )
-        .await;
-        #[cfg(not(target_arch = "wasm32"))]
-        {
-            supervisor_startup_guard.settle(start_result).await
-        }
-        #[cfg(target_arch = "wasm32")]
-        {
-            start_result
-        }
+            let start_result = Self::start_runtime(
+                definition,
+                Roster::new(),
+                dsl_authority,
+                storage.events.clone(),
+                storage.runs.clone(),
+                storage.runtime_metadata.clone(),
+                supervisor_bridge,
+                session_service,
+                runtime_adapter,
+                workgraph_service,
+                tool_bundles,
+                default_llm_client,
+                default_external_tools_provider,
+                spawn_base_prompt_source,
+                spawn_member_customizer,
+                storage.realm_profiles.clone(),
+                notify_orchestrator_on_resume,
+                realtime_session_factory,
+                controlling_acceptor,
+                member_live_host,
+            )
+            .await;
+            #[cfg(not(target_arch = "wasm32"))]
+            {
+                supervisor_startup_guard.settle(start_result).await
+            }
+            #[cfg(target_arch = "wasm32")]
+            {
+                start_result
+            }
+        })
     }
 
     /// Resume a mob from persisted events.
@@ -9266,7 +9303,8 @@ impl MobBuilder {
 
     #[cfg(feature = "runtime-adapter")]
     #[allow(clippy::too_many_arguments)]
-    async fn start_runtime(
+    #[inline(never)]
+    fn start_runtime(
         definition: Arc<MobDefinition>,
         initial_roster: Roster,
         mut dsl_authority: Box<crate::machines::mob_machine::MobMachineAuthority>,
@@ -9287,83 +9325,88 @@ impl MobBuilder {
         realtime_session_factory: Option<Arc<dyn meerkat_client::RealtimeSessionFactory>>,
         controlling_acceptor: Option<ControllingAcceptorConfig>,
         member_live_host: Option<Arc<dyn meerkat_runtime::member_live::MemberLiveHost>>,
-    ) -> Result<MobHandle, MobError> {
-        // Row #320 seed: the orphan budget is machine state, seeded once from the
-        // definition's `max_orphaned_turns` limit. Covers both the create and
-        // resume runtime-start paths (both route through `start_runtime`).
-        let max_orphaned_turns = definition
-            .limits
-            .as_ref()
-            .and_then(|limits| limits.max_orphaned_turns)
-            .unwrap_or(8) as u64;
-        apply_seeded_mob_input(
-            dsl_authority.as_mut(),
-            crate::machines::mob_machine::MobMachineInput::SeedOrphanBudget {
-                budget: max_orphaned_turns,
-            },
-            "seed_orphan_budget",
-        )?;
-        let (machine_state_watch_tx, _machine_state_watch_rx) =
-            tokio::sync::watch::channel(dsl_authority.state().clone());
-        let provisioner: Arc<dyn MobProvisioner> = Arc::new(
-            MultiBackendProvisioner::new(
-                session_service.clone(),
-                runtime_adapter.clone(),
-                workgraph_service,
-                definition.backend.external.clone(),
-                Arc::clone(&supervisor_bridge),
-            )
-            .with_binding_persistence(definition.id.clone(), runtime_metadata.clone()),
-        );
-        let roster = Arc::new(RwLock::new(RosterAuthority::from_roster(initial_roster)));
-        let (command_tx, command_rx) = mpsc::channel(MOB_COMMAND_CHANNEL_CAPACITY);
-        let restore_diagnostics = Arc::new(RwLock::new(HashMap::new()));
-        let wiring = RuntimeWiring {
-            roster,
-            dsl_authority,
-            machine_state_watch_tx,
-            reachability_observations: Arc::new(super::handle::ReachabilityObservations::default()),
-            restore_diagnostics,
-            runtime_metadata,
-            supervisor_bridge,
-            command_tx,
-            command_rx,
-        };
+    ) -> RuntimeStartFuture {
+        Box::pin(async move {
+            // Row #320 seed: the orphan budget is machine state, seeded once from the
+            // definition's `max_orphaned_turns` limit. Covers both the create and
+            // resume runtime-start paths (both route through `start_runtime`).
+            let max_orphaned_turns = definition
+                .limits
+                .as_ref()
+                .and_then(|limits| limits.max_orphaned_turns)
+                .unwrap_or(8) as u64;
+            apply_seeded_mob_input(
+                dsl_authority.as_mut(),
+                crate::machines::mob_machine::MobMachineInput::SeedOrphanBudget {
+                    budget: max_orphaned_turns,
+                },
+                "seed_orphan_budget",
+            )?;
+            let (machine_state_watch_tx, _machine_state_watch_rx) =
+                tokio::sync::watch::channel(dsl_authority.state().clone());
+            let provisioner: Arc<dyn MobProvisioner> = Arc::new(
+                MultiBackendProvisioner::new(
+                    session_service.clone(),
+                    runtime_adapter.clone(),
+                    workgraph_service,
+                    definition.backend.external.clone(),
+                    Arc::clone(&supervisor_bridge),
+                )
+                .with_binding_persistence(definition.id.clone(), runtime_metadata.clone()),
+            );
+            let roster = Arc::new(RwLock::new(RosterAuthority::from_roster(initial_roster)));
+            let (command_tx, command_rx) = mpsc::channel(MOB_COMMAND_CHANNEL_CAPACITY);
+            let restore_diagnostics = Arc::new(RwLock::new(HashMap::new()));
+            let wiring = RuntimeWiring {
+                roster,
+                dsl_authority,
+                machine_state_watch_tx,
+                reachability_observations: Arc::new(
+                    super::handle::ReachabilityObservations::default(),
+                ),
+                restore_diagnostics,
+                runtime_metadata,
+                supervisor_bridge,
+                command_tx,
+                command_rx,
+            };
 
-        Self::start_runtime_with_components(
-            definition,
-            wiring,
-            events,
-            run_store,
-            session_service,
-            runtime_adapter,
-            provisioner,
-            tool_bundles,
-            default_llm_client,
-            default_external_tools_provider,
-            spawn_base_prompt_source,
-            spawn_member_customizer,
-            realm_profile_store,
-            notify_orchestrator_on_resume,
-            BTreeMap::new(),
-            HashSet::new(),
-            HashSet::new(),
-            HashSet::new(),
-            BTreeSet::new(),
-            Vec::new(),
-            Vec::new(),
-            1,
-            true,
-            realtime_session_factory,
-            controlling_acceptor,
-            member_live_host,
-        )
-        .await
+            Self::start_runtime_with_components(
+                definition,
+                wiring,
+                events,
+                run_store,
+                session_service,
+                runtime_adapter,
+                provisioner,
+                tool_bundles,
+                default_llm_client,
+                default_external_tools_provider,
+                spawn_base_prompt_source,
+                spawn_member_customizer,
+                realm_profile_store,
+                notify_orchestrator_on_resume,
+                BTreeMap::new(),
+                HashSet::new(),
+                HashSet::new(),
+                HashSet::new(),
+                BTreeSet::new(),
+                Vec::new(),
+                Vec::new(),
+                1,
+                true,
+                realtime_session_factory,
+                controlling_acceptor,
+                member_live_host,
+            )
+            .await
+        })
     }
 
     #[cfg(feature = "runtime-adapter")]
     #[allow(clippy::too_many_arguments)]
-    async fn start_runtime_with_components(
+    #[inline(never)]
+    fn start_runtime_with_components(
         definition: Arc<MobDefinition>,
         wiring: RuntimeWiring,
         events: Arc<dyn MobEventStore>,
@@ -9390,386 +9433,396 @@ impl MobBuilder {
         realtime_session_factory: Option<Arc<dyn meerkat_client::RealtimeSessionFactory>>,
         controlling_acceptor: Option<ControllingAcceptorConfig>,
         member_live_host: Option<Arc<dyn meerkat_runtime::member_live::MemberLiveHost>>,
-    ) -> Result<MobHandle, MobError> {
-        // Recover the actor-local idempotency index from durable public events
-        // before spawning any runtime-owned tasks. Private remote-turn custody
-        // is then overlaid below from the validated recovery material.
-        let durable_events = events.replay_all().await?;
-        #[cfg(test)]
-        let actor_runtime_id = register_actor_runtime_for_test(&definition.id);
-        let next_fence_token = combine_recovered_fence_token_seeds(
-            next_fence_token_seed(wiring.dsl_authority.state()),
-            recovered_fence_token_floor,
-        );
-        // Reverse-lane ingress is an explicit host-process composition fact.
-        // Never invent a loopback listener here: publishing it to a different
-        // machine would make route installation look converged while the peer
-        // dials itself. An absent capability fails the mixed-host route closed.
-        let run_store = authority_validating_mob_run_store(run_store);
-        let RuntimeWiring {
-            roster,
-            dsl_authority,
-            machine_state_watch_tx,
-            reachability_observations,
-            restore_diagnostics,
-            runtime_metadata,
-            supervisor_bridge,
-            command_tx,
-            command_rx,
-        } = wiring;
-        let handle_session_service = session_service.clone();
-        let wiring_public_phase = seeded_mob_public_phase(dsl_authority.state());
-        // Terminal-phase watch: seed with the initial phase so a status()
-        // call before any DSL transition returns the right answer.
-        let (phase_watch_tx_actor, phase_watch_rx) =
-            tokio::sync::watch::channel(wiring_public_phase);
-        let handle = MobHandle {
-            // Explicit launch-site mint (A16): the launching process IS the
-            // owning operator — not ambient inference (gotcha #19).
-            command_authority: crate::control_policy::CommandAuthority::principal(
-                crate::control_policy::MobControlPrincipal::Owner,
-            ),
-            command_tx: command_tx.clone(),
-            roster: roster.clone(),
-            definition: definition.clone(),
-            events: events.clone(),
-            run_store: run_store.clone(),
-            flow_streams: Arc::new(tokio::sync::Mutex::new(BTreeMap::new())),
-            session_service: handle_session_service.clone(),
-            runtime_adapter: runtime_adapter.clone(),
-            restore_diagnostics: restore_diagnostics.clone(),
-            supervisor_bridge: supervisor_bridge.clone(),
-            machine_state_watch_rx: machine_state_watch_tx.subscribe(),
-            reachability_observations: Arc::clone(&reachability_observations),
-            phase_watch_rx,
-            realtime_session_factory,
-        };
-        // Row #320: the orphan budget is MobMachine state (seeded once in
-        // `start_runtime` from `definition.limits.max_orphaned_turns`); the
-        // executor no longer holds a shell-side budget.
-        let actor_flow_executor = ActorFlowTurnExecutor::new(handle.clone(), provisioner.clone());
-        // Phase 6 (§7.4): the member event pump manager — one detached
-        // `PollMemberEvents` loop per placed member, durable cursors in the
-        // runtime metadata store (DEC-P6E-9/10/11).
-        let member_event_pumps = Arc::new(super::event_pump::MemberEventPumpManager::new(
-            definition.id.clone(),
-            supervisor_bridge.clone(),
-            runtime_metadata.clone(),
-            Arc::new(super::event_pump::HandleHostRuntimeIncarnationObserver {
-                handle: handle.clone(),
-            }),
-        ));
-        member_event_pumps
-            .install_reachability_observations(Arc::clone(&reachability_observations));
-        // Cross-lane hook wiring (ADJ-P6-10, FLAG-P6F-5): ONE
-        // RemoteFlowTicketRegistry per mob, shared by the executor
-        // (arm/disarm) and the pump (rows-then-sidecar feed); the A17
-        // pump-liveness hook routes through the actor's machine-fact
-        // material derivation.
-        member_event_pumps.install_outcome_sink(actor_flow_executor.remote_flow_ticket_registry());
-        member_event_pumps.install_obligation_probe(Arc::new(
-            super::event_pump::HandleObligationProbe {
-                handle: handle.clone(),
-            },
-        ));
-        actor_flow_executor.install_remote_turn_obligation_pump(Arc::new(
-            super::event_pump::HandleObligationPump {
-                handle: handle.clone(),
-            },
-        ));
-        // The actor holds the SAME registry Arc for member-lifetime
-        // boundaries (disposal lane drop, placed-respawn rematerializing
-        // mark).
-        let remote_flow_tickets = actor_flow_executor.remote_flow_ticket_registry();
-        let intent_reconciler_provisioner = provisioner.clone();
-        let intent_reconciler_tickets = remote_flow_tickets.clone();
-        let kickoff_reconciler_provisioner = provisioner.clone();
-        let kickoff_reconciler_metadata = runtime_metadata.clone();
-        let completion_reconciler_provisioner = provisioner.clone();
-        let flow_executor: Arc<dyn FlowTurnExecutor> = Arc::new(actor_flow_executor);
-        let topology_service = Arc::new(super::topology::MobTopologyService::new(
-            definition.topology.clone(),
-        ));
-        // Normalize public phase: fresh creation + stale Creating restores both
-        // become Running. Persisted Stopped/Completed/Destroyed are preserved.
-        let public_phase = match wiring_public_phase {
-            MobState::Creating => MobState::Running,
-            phase => phase,
-        };
-        // Plain mobs (orchestrator: None in the definition) skip orchestrator
-        // guards entirely. The coordinator-bound fact is MobMachine state
-        // (see `coordinator_bound` in the mob DSL), initialized to `true`
-        // by the machine's init block; no shell-side bind is needed.
-        let has_orchestrator = definition.orchestrator.is_some();
-        let flow_engine = FlowEngine::new(
-            flow_executor,
-            handle.clone(),
-            run_store.clone(),
-            events.clone(),
-            topology_service,
-        );
-        let spawn_policy = Arc::new(super::spawn_policy::SpawnPolicyService::with_policy(
-            super::spawn_policy::policy_from_definition_config(definition.spawn_policy.as_ref()),
-        ));
+    ) -> RuntimeStartFuture {
+        Box::pin(async move {
+            // Recover the actor-local idempotency index from durable public events
+            // before spawning any runtime-owned tasks. Private remote-turn custody
+            // is then overlaid below from the validated recovery material.
+            let durable_events = events.replay_all().await?;
+            #[cfg(test)]
+            let actor_runtime_id = register_actor_runtime_for_test(&definition.id);
+            let next_fence_token = combine_recovered_fence_token_seeds(
+                next_fence_token_seed(wiring.dsl_authority.state()),
+                recovered_fence_token_floor,
+            );
+            // Reverse-lane ingress is an explicit host-process composition fact.
+            // Never invent a loopback listener here: publishing it to a different
+            // machine would make route installation look converged while the peer
+            // dials itself. An absent capability fails the mixed-host route closed.
+            let run_store = authority_validating_mob_run_store(run_store);
+            let RuntimeWiring {
+                roster,
+                dsl_authority,
+                machine_state_watch_tx,
+                reachability_observations,
+                restore_diagnostics,
+                runtime_metadata,
+                supervisor_bridge,
+                command_tx,
+                command_rx,
+            } = wiring;
+            let handle_session_service = session_service.clone();
+            let wiring_public_phase = seeded_mob_public_phase(dsl_authority.state());
+            // Terminal-phase watch: seed with the initial phase so a status()
+            // call before any DSL transition returns the right answer.
+            let (phase_watch_tx_actor, phase_watch_rx) =
+                tokio::sync::watch::channel(wiring_public_phase);
+            let handle = MobHandle {
+                // Explicit launch-site mint (A16): the launching process IS the
+                // owning operator — not ambient inference (gotcha #19).
+                command_authority: crate::control_policy::CommandAuthority::principal(
+                    crate::control_policy::MobControlPrincipal::Owner,
+                ),
+                command_tx: command_tx.clone(),
+                roster: roster.clone(),
+                definition: definition.clone(),
+                events: events.clone(),
+                run_store: run_store.clone(),
+                flow_streams: Arc::new(tokio::sync::Mutex::new(BTreeMap::new())),
+                session_service: handle_session_service.clone(),
+                runtime_adapter: runtime_adapter.clone(),
+                restore_diagnostics: restore_diagnostics.clone(),
+                supervisor_bridge: supervisor_bridge.clone(),
+                machine_state_watch_rx: machine_state_watch_tx.subscribe(),
+                reachability_observations: Arc::clone(&reachability_observations),
+                phase_watch_rx,
+                realtime_session_factory,
+            };
+            // Row #320: the orphan budget is MobMachine state (seeded once in
+            // `start_runtime` from `definition.limits.max_orphaned_turns`); the
+            // executor no longer holds a shell-side budget.
+            let actor_flow_executor =
+                ActorFlowTurnExecutor::new(handle.clone(), provisioner.clone());
+            // Phase 6 (§7.4): the member event pump manager — one detached
+            // `PollMemberEvents` loop per placed member, durable cursors in the
+            // runtime metadata store (DEC-P6E-9/10/11).
+            let member_event_pumps = Arc::new(super::event_pump::MemberEventPumpManager::new(
+                definition.id.clone(),
+                supervisor_bridge.clone(),
+                runtime_metadata.clone(),
+                Arc::new(super::event_pump::HandleHostRuntimeIncarnationObserver {
+                    handle: handle.clone(),
+                }),
+            ));
+            member_event_pumps
+                .install_reachability_observations(Arc::clone(&reachability_observations));
+            // Cross-lane hook wiring (ADJ-P6-10, FLAG-P6F-5): ONE
+            // RemoteFlowTicketRegistry per mob, shared by the executor
+            // (arm/disarm) and the pump (rows-then-sidecar feed); the A17
+            // pump-liveness hook routes through the actor's machine-fact
+            // material derivation.
+            member_event_pumps
+                .install_outcome_sink(actor_flow_executor.remote_flow_ticket_registry());
+            member_event_pumps.install_obligation_probe(Arc::new(
+                super::event_pump::HandleObligationProbe {
+                    handle: handle.clone(),
+                },
+            ));
+            actor_flow_executor.install_remote_turn_obligation_pump(Arc::new(
+                super::event_pump::HandleObligationPump {
+                    handle: handle.clone(),
+                },
+            ));
+            // The actor holds the SAME registry Arc for member-lifetime
+            // boundaries (disposal lane drop, placed-respawn rematerializing
+            // mark).
+            let remote_flow_tickets = actor_flow_executor.remote_flow_ticket_registry();
+            let intent_reconciler_provisioner = provisioner.clone();
+            let intent_reconciler_tickets = remote_flow_tickets.clone();
+            let kickoff_reconciler_provisioner = provisioner.clone();
+            let kickoff_reconciler_metadata = runtime_metadata.clone();
+            let completion_reconciler_provisioner = provisioner.clone();
+            let flow_executor: Arc<dyn FlowTurnExecutor> = Arc::new(actor_flow_executor);
+            let topology_service = Arc::new(super::topology::MobTopologyService::new(
+                definition.topology.clone(),
+            ));
+            // Normalize public phase: fresh creation + stale Creating restores both
+            // become Running. Persisted Stopped/Completed/Destroyed are preserved.
+            let public_phase = match wiring_public_phase {
+                MobState::Creating => MobState::Running,
+                phase => phase,
+            };
+            // Plain mobs (orchestrator: None in the definition) skip orchestrator
+            // guards entirely. The coordinator-bound fact is MobMachine state
+            // (see `coordinator_bound` in the mob DSL), initialized to `true`
+            // by the machine's init block; no shell-side bind is needed.
+            let has_orchestrator = definition.orchestrator.is_some();
+            let flow_engine = FlowEngine::new(
+                flow_executor,
+                handle.clone(),
+                run_store.clone(),
+                events.clone(),
+                topology_service,
+            );
+            let spawn_policy = Arc::new(super::spawn_policy::SpawnPolicyService::with_policy(
+                super::spawn_policy::policy_from_definition_config(
+                    definition.spawn_policy.as_ref(),
+                ),
+            ));
 
-        // Wave-c C-6c — flip the composition binding from `Standalone`
-        // to `Wired(_)` whenever a runtime adapter is present, wiring
-        // the mob producer into the `MeerkatConsumerSurface` on
-        // `MeerkatMachine`. Builds without `runtime-adapter` keep the
-        // standalone path (no consumer exists by construction).
-        #[cfg(feature = "runtime-adapter")]
-        let composition_binding = match &runtime_adapter {
-            Some(adapter) => {
-                let binding = super::composition::wired_binding_from_runtime_adapter(adapter);
-                super::composition::attach_signal_dispatcher_to_runtime_adapter(
-                    adapter,
-                    command_tx.clone(),
-                );
-                binding
-            }
-            None => meerkat_runtime::composition::CompositionBinding::Standalone,
-        };
-        #[cfg(not(feature = "runtime-adapter"))]
-        let composition_binding = meerkat_runtime::composition::CompositionBinding::Standalone;
-
-        let dsl_topology_epoch = Arc::new(std::sync::atomic::AtomicU64::new(
-            dsl_authority.state().topology_epoch,
-        ));
-        let dsl_authority_owner_token = dsl_authority.generated_authority_owner_token();
-
-        // DEC-U3: the member-operator upcall responder is spawned next to
-        // the actor and owned BY the actor (shut down when its run loop
-        // exits, Drop-abort backstop). It serves member upcalls arriving on
-        // the supervisor bridge runtime's inbox.
-        #[cfg(all(feature = "runtime-adapter", not(target_arch = "wasm32")))]
-        let upcall_responder = Some(super::upcall_responder::spawn_upcall_responder(
-            handle.clone(),
-            runtime_metadata.clone(),
-        ));
-
-        // Detached host I/O is actor-local, so recovered bound hosts start a
-        // fresh volatile binding incarnation. Every later successful
-        // bind/rebind/revoke boundary advances this fence and purges release
-        // reservations minted by its predecessor.
-        let host_binding_incarnations = dsl_authority
-            .state()
-            .host_bind_phase
-            .iter()
-            .filter(|(_, phase)| **phase == mob_dsl::HostBindPhase::Bound)
-            .map(|(host_id, _)| (host_id.clone(), 1_u64))
-            .collect();
-        let placed_completion_durable_index = Arc::new(std::sync::Mutex::new(
-            super::actor::PlacedCompletionDurableIndex::recover_with_private_remote_turns(
-                &durable_events,
-                &definition.id,
-                &recovered_private_remote_turns,
-            )?,
-        ));
-
-        let mut actor = MobActor {
-            definition,
-            roster,
-            events,
-            placed_completion_durable_index,
-            run_store,
-            provisioner,
-            flow_engine,
-            has_orchestrator,
-            notify_orchestrator_on_resume,
-            run_tasks: BTreeMap::new(),
-            run_cancel_tokens: BTreeMap::new(),
-            flow_streams: handle.flow_streams.clone(),
-            command_tx,
-            tool_bundles,
-            default_llm_client,
-            retired_event_index: Arc::new(RwLock::new(retired_event_index)),
-            retirement_started_event_index: Arc::new(RwLock::new(retirement_started_event_index)),
-            preserved_respawn_topology_event_index: Arc::new(RwLock::new(
-                preserved_respawn_topology_event_index,
-            )),
-            autonomous_initial_turns: Arc::new(tokio::sync::Mutex::new(BTreeMap::new())),
-            autonomous_stop_interrupts: BTreeMap::new(),
-            autonomous_stop_interrupted: BTreeMap::new(),
-            autonomous_stop_interrupt_cursor: 0,
-            next_spawn_ticket: 0,
-            // ADJ-8 (multi-host fence reseed): the shell fence counter must
-            // sort ABOVE every replayed fence after a controlling restart —
-            // the member-host dedup ladder is ORDER-comparing (StaleFence on
-            // a tuple below the recorded row), so a reset-to-1 counter would
-            // draw spurious permanent rejects for legitimate re-issues. The
-            // machine still owns every fence guard; this is a mechanical
-            // monotonicity seed over both recovered machine maxima and every
-            // canonical placed carrier loaded at startup. Pending/terminal
-            // carriers may already have been exactly cleaned, so the explicit
-            // floor preserves their fence high-water after their machine maps
-            // are intentionally resolved.
-            next_fence_token: std::sync::atomic::AtomicU64::new(next_fence_token),
-            pending_spawns: PendingSpawnLineage::new(),
-            pending_spawn_cleanup_anchors: BTreeMap::new(),
-            edge_locks: Arc::new(super::edge_locks::EdgeLockRegistry::new()),
-            lifecycle_tasks: tokio::task::JoinSet::new(),
-            actor_io_tasks: tokio::task::JoinSet::new(),
-            member_live_mutation_tasks: tokio::task::JoinSet::new(),
-            member_live_open_cleanup_obligations: BTreeMap::new(),
-            member_live_open_cleanup_inflight: BTreeSet::new(),
-            next_member_live_open_cleanup_ticket: 0,
-            orphan_release_reservations: BTreeMap::new(),
-            host_binding_incarnations,
-            host_runtime_incarnations: BTreeMap::new(),
-            next_peer_delivery_ticket: 0,
-            peer_delivery_tasks: tokio::task::JoinSet::new(),
-            peer_delivery_inflight: BTreeMap::new(),
-            peer_delivery_permits: Arc::new(tokio::sync::Semaphore::new(
-                super::actor::MAX_PENDING_PEER_DELIVERIES,
-            )),
-            session_service: handle_session_service,
+            // Wave-c C-6c — flip the composition binding from `Standalone`
+            // to `Wired(_)` whenever a runtime adapter is present, wiring
+            // the mob producer into the `MeerkatConsumerSurface` on
+            // `MeerkatMachine`. Builds without `runtime-adapter` keep the
+            // standalone path (no consumer exists by construction).
             #[cfg(feature = "runtime-adapter")]
-            runtime_adapter,
-            restore_diagnostics,
-            member_revival_locks: Arc::new(tokio::sync::Mutex::new(HashMap::new())),
-            runtime_metadata,
-            supervisor_bridge,
-            member_live_host,
-            member_event_pumps,
-            remote_flow_tickets,
-            reachability_observations,
-            #[cfg(all(feature = "runtime-adapter", not(target_arch = "wasm32")))]
-            upcall_responder,
-            spawn_policy,
-            dsl_authority: *dsl_authority,
-            dsl_topology_epoch,
-            dsl_authority_owner_token,
-            machine_state_watch_tx,
-            phase_watch_tx: phase_watch_tx_actor,
-            default_external_tools_provider,
-            per_spawn_external_tools: tokio::sync::RwLock::new(per_spawn_external_tools),
-            spawn_base_prompt_source,
-            spawn_member_customizer,
-            realm_profile_store,
-            composition_binding,
-            pending_routed_effects: Vec::new(),
-            destroy_cleanup_active: false,
-            durable_uncertainty_fail_stop: false,
-            respawn_topology_reply_withheld: false,
-            #[cfg(not(target_arch = "wasm32"))]
-            controlling_acceptor: controlling_acceptor
-                .map(super::actor::ControllingAcceptorState::new),
-        };
-        #[cfg(target_arch = "wasm32")]
-        let _ = controlling_acceptor;
-        // A17 recovery trigger (DEC-P6E-11): obligations survive via event
-        // replay, subscriptions do not — re-derive pending remote-turn
-        // obligations from recovered machine state and keep their members'
-        // pumps alive so recovered flow terminals still drain.
-        let recovered_obligations: Vec<crate::ids::AgentIdentity> = actor
-            .dsl_authority
-            .state()
-            .pending_remote_turn_outcomes
-            .iter()
-            .chain(
-                actor
-                    .dsl_authority
-                    .state()
-                    .committed_remote_turn_outcomes
-                    .iter(),
-            )
-            .chain(
-                actor
-                    .dsl_authority
-                    .state()
-                    .resolved_remote_turn_outcomes
-                    .iter(),
-            )
-            .map(|obligation| crate::ids::AgentIdentity::from(obligation.agent_identity.0.as_str()))
-            .chain(
-                actor
-                    .dsl_authority
-                    .state()
-                    .pending_placed_kickoff_outcomes
-                    .iter()
-                    .chain(
-                        actor
-                            .dsl_authority
-                            .state()
-                            .resolved_placed_kickoff_outcomes
-                            .iter(),
-                    )
-                    .map(|obligation| {
-                        crate::ids::AgentIdentity::from(obligation.agent_identity.0.as_str())
-                    }),
-            )
-            .collect::<BTreeSet<_>>()
-            .into_iter()
-            .collect();
-        // A durable MobDestroying marker is a retry anchor, not a completed
-        // destroy. Public authority is already closed by destroy_admitted,
-        // but the recovered actor must automatically resume the exact member,
-        // host, and storage cleanup rather than waiting for an operator verb.
-        let resume_destroy_cleanup = actor.dsl_authority.state().destroy_admitted
-            && actor.dsl_authority.state().lifecycle_phase
-                != crate::machines::mob_machine::MobPhase::Destroyed;
-        let recovered_lifecycle_retry_intent = match (
-            actor.dsl_authority.state().lifecycle_phase,
-            actor
-                .dsl_authority
-                .state()
-                .placed_completion_lifecycle_intent,
-        ) {
-            (
-                crate::machines::mob_machine::MobPhase::Stopped,
-                Some(mob_dsl::PlacedCompletionLifecycleIntentKind::Stop),
-            )
-            | (
-                crate::machines::mob_machine::MobPhase::Completed,
-                Some(mob_dsl::PlacedCompletionLifecycleIntentKind::Complete),
-            )
-            | (crate::machines::mob_machine::MobPhase::Destroyed, _) => None,
-            (_, intent) => intent,
-        };
-        let recovered_retirements = if resume_destroy_cleanup {
-            Vec::new()
-        } else {
-            actor
-                .dsl_authority
-                .state()
-                .identity_to_runtime
-                .iter()
-                .filter(|(_, runtime_id)| {
-                    matches!(
-                        actor
-                            .dsl_authority
-                            .state()
-                            .member_state_markers
-                            .get(*runtime_id),
-                        Some(crate::machines::mob_machine::MobMemberState::Retiring)
-                    )
-                })
-                .map(|(identity, _)| crate::ids::AgentIdentity::from(identity.0.as_str()))
-                .collect::<Vec<_>>()
-        };
-        // Cold-recovery convergence workers are owned by this actor instance.
-        // Register them before moving the actor into its run loop so every
-        // terminal path can abort and join them before command-channel closure.
-        if !recovered_obligations.is_empty() {
-            let pump_handle = handle.clone();
-            actor.actor_io_tasks.spawn(async move {
-                #[cfg(test)]
-                let _startup_worker_guard = ActorOwnedStartupWorkerGuard::new(actor_runtime_id);
-                for identity in recovered_obligations {
-                    if let Err(error) = pump_handle.ensure_pump_for_obligation(&identity).await {
-                        tracing::warn!(
-                            agent_identity = %identity,
-                            error = %error,
-                            "recovered remote-turn obligation could not keep its pump alive"
-                        );
-                    }
+            let composition_binding = match &runtime_adapter {
+                Some(adapter) => {
+                    let binding = super::composition::wired_binding_from_runtime_adapter(adapter);
+                    super::composition::attach_signal_dispatcher_to_runtime_adapter(
+                        adapter,
+                        command_tx.clone(),
+                    );
+                    binding
                 }
-            });
-        }
-        if !resume_destroy_cleanup {
-            for host_id in recovered_host_revocations {
-                let revoke_handle = handle.clone();
+                None => meerkat_runtime::composition::CompositionBinding::Standalone,
+            };
+            #[cfg(not(feature = "runtime-adapter"))]
+            let composition_binding = meerkat_runtime::composition::CompositionBinding::Standalone;
+
+            let dsl_topology_epoch = Arc::new(std::sync::atomic::AtomicU64::new(
+                dsl_authority.state().topology_epoch,
+            ));
+            let dsl_authority_owner_token = dsl_authority.generated_authority_owner_token();
+
+            // DEC-U3: the member-operator upcall responder is spawned next to
+            // the actor and owned BY the actor (shut down when its run loop
+            // exits, Drop-abort backstop). It serves member upcalls arriving on
+            // the supervisor bridge runtime's inbox.
+            #[cfg(all(feature = "runtime-adapter", not(target_arch = "wasm32")))]
+            let upcall_responder = Some(super::upcall_responder::spawn_upcall_responder(
+                handle.clone(),
+                runtime_metadata.clone(),
+            ));
+
+            // Detached host I/O is actor-local, so recovered bound hosts start a
+            // fresh volatile binding incarnation. Every later successful
+            // bind/rebind/revoke boundary advances this fence and purges release
+            // reservations minted by its predecessor.
+            let host_binding_incarnations = dsl_authority
+                .state()
+                .host_bind_phase
+                .iter()
+                .filter(|(_, phase)| **phase == mob_dsl::HostBindPhase::Bound)
+                .map(|(host_id, _)| (host_id.clone(), 1_u64))
+                .collect();
+            let placed_completion_durable_index = Arc::new(std::sync::Mutex::new(
+                super::actor::PlacedCompletionDurableIndex::recover_with_private_remote_turns(
+                    &durable_events,
+                    &definition.id,
+                    &recovered_private_remote_turns,
+                )?,
+            ));
+
+            let mut actor = MobActor {
+                definition,
+                roster,
+                events,
+                placed_completion_durable_index,
+                run_store,
+                provisioner,
+                flow_engine,
+                has_orchestrator,
+                notify_orchestrator_on_resume,
+                run_tasks: BTreeMap::new(),
+                run_cancel_tokens: BTreeMap::new(),
+                flow_streams: handle.flow_streams.clone(),
+                command_tx,
+                tool_bundles,
+                default_llm_client,
+                retired_event_index: Arc::new(RwLock::new(retired_event_index)),
+                retirement_started_event_index: Arc::new(RwLock::new(
+                    retirement_started_event_index,
+                )),
+                preserved_respawn_topology_event_index: Arc::new(RwLock::new(
+                    preserved_respawn_topology_event_index,
+                )),
+                autonomous_initial_turns: Arc::new(tokio::sync::Mutex::new(BTreeMap::new())),
+                autonomous_stop_interrupts: BTreeMap::new(),
+                autonomous_stop_interrupted: BTreeMap::new(),
+                autonomous_stop_interrupt_cursor: 0,
+                next_spawn_ticket: 0,
+                // ADJ-8 (multi-host fence reseed): the shell fence counter must
+                // sort ABOVE every replayed fence after a controlling restart —
+                // the member-host dedup ladder is ORDER-comparing (StaleFence on
+                // a tuple below the recorded row), so a reset-to-1 counter would
+                // draw spurious permanent rejects for legitimate re-issues. The
+                // machine still owns every fence guard; this is a mechanical
+                // monotonicity seed over both recovered machine maxima and every
+                // canonical placed carrier loaded at startup. Pending/terminal
+                // carriers may already have been exactly cleaned, so the explicit
+                // floor preserves their fence high-water after their machine maps
+                // are intentionally resolved.
+                next_fence_token: std::sync::atomic::AtomicU64::new(next_fence_token),
+                pending_spawns: PendingSpawnLineage::new(),
+                pending_spawn_cleanup_anchors: BTreeMap::new(),
+                edge_locks: Arc::new(super::edge_locks::EdgeLockRegistry::new()),
+                lifecycle_tasks: tokio::task::JoinSet::new(),
+                actor_io_tasks: tokio::task::JoinSet::new(),
+                member_live_mutation_tasks: tokio::task::JoinSet::new(),
+                member_live_open_cleanup_obligations: BTreeMap::new(),
+                member_live_open_cleanup_inflight: BTreeSet::new(),
+                next_member_live_open_cleanup_ticket: 0,
+                orphan_release_reservations: BTreeMap::new(),
+                host_binding_incarnations,
+                host_runtime_incarnations: BTreeMap::new(),
+                next_peer_delivery_ticket: 0,
+                peer_delivery_tasks: tokio::task::JoinSet::new(),
+                peer_delivery_inflight: BTreeMap::new(),
+                peer_delivery_permits: Arc::new(tokio::sync::Semaphore::new(
+                    super::actor::MAX_PENDING_PEER_DELIVERIES,
+                )),
+                session_service: handle_session_service,
+                #[cfg(feature = "runtime-adapter")]
+                runtime_adapter,
+                restore_diagnostics,
+                member_revival_locks: Arc::new(tokio::sync::Mutex::new(HashMap::new())),
+                runtime_metadata,
+                supervisor_bridge,
+                member_live_host,
+                member_event_pumps,
+                remote_flow_tickets,
+                reachability_observations,
+                #[cfg(all(feature = "runtime-adapter", not(target_arch = "wasm32")))]
+                upcall_responder,
+                spawn_policy,
+                dsl_authority: *dsl_authority,
+                dsl_topology_epoch,
+                dsl_authority_owner_token,
+                machine_state_watch_tx,
+                phase_watch_tx: phase_watch_tx_actor,
+                default_external_tools_provider,
+                per_spawn_external_tools: tokio::sync::RwLock::new(per_spawn_external_tools),
+                spawn_base_prompt_source,
+                spawn_member_customizer,
+                realm_profile_store,
+                composition_binding,
+                pending_routed_effects: Vec::new(),
+                destroy_cleanup_active: false,
+                durable_uncertainty_fail_stop: false,
+                respawn_topology_reply_withheld: false,
+                #[cfg(not(target_arch = "wasm32"))]
+                controlling_acceptor: controlling_acceptor
+                    .map(super::actor::ControllingAcceptorState::new),
+            };
+            #[cfg(target_arch = "wasm32")]
+            let _ = controlling_acceptor;
+            // A17 recovery trigger (DEC-P6E-11): obligations survive via event
+            // replay, subscriptions do not — re-derive pending remote-turn
+            // obligations from recovered machine state and keep their members'
+            // pumps alive so recovered flow terminals still drain.
+            let recovered_obligations: Vec<crate::ids::AgentIdentity> = actor
+                .dsl_authority
+                .state()
+                .pending_remote_turn_outcomes
+                .iter()
+                .chain(
+                    actor
+                        .dsl_authority
+                        .state()
+                        .committed_remote_turn_outcomes
+                        .iter(),
+                )
+                .chain(
+                    actor
+                        .dsl_authority
+                        .state()
+                        .resolved_remote_turn_outcomes
+                        .iter(),
+                )
+                .map(|obligation| {
+                    crate::ids::AgentIdentity::from(obligation.agent_identity.0.as_str())
+                })
+                .chain(
+                    actor
+                        .dsl_authority
+                        .state()
+                        .pending_placed_kickoff_outcomes
+                        .iter()
+                        .chain(
+                            actor
+                                .dsl_authority
+                                .state()
+                                .resolved_placed_kickoff_outcomes
+                                .iter(),
+                        )
+                        .map(|obligation| {
+                            crate::ids::AgentIdentity::from(obligation.agent_identity.0.as_str())
+                        }),
+                )
+                .collect::<BTreeSet<_>>()
+                .into_iter()
+                .collect();
+            // A durable MobDestroying marker is a retry anchor, not a completed
+            // destroy. Public authority is already closed by destroy_admitted,
+            // but the recovered actor must automatically resume the exact member,
+            // host, and storage cleanup rather than waiting for an operator verb.
+            let resume_destroy_cleanup = actor.dsl_authority.state().destroy_admitted
+                && actor.dsl_authority.state().lifecycle_phase
+                    != crate::machines::mob_machine::MobPhase::Destroyed;
+            let recovered_lifecycle_retry_intent = match (
+                actor.dsl_authority.state().lifecycle_phase,
+                actor
+                    .dsl_authority
+                    .state()
+                    .placed_completion_lifecycle_intent,
+            ) {
+                (
+                    crate::machines::mob_machine::MobPhase::Stopped,
+                    Some(mob_dsl::PlacedCompletionLifecycleIntentKind::Stop),
+                )
+                | (
+                    crate::machines::mob_machine::MobPhase::Completed,
+                    Some(mob_dsl::PlacedCompletionLifecycleIntentKind::Complete),
+                )
+                | (crate::machines::mob_machine::MobPhase::Destroyed, _) => None,
+                (_, intent) => intent,
+            };
+            let recovered_retirements = if resume_destroy_cleanup {
+                Vec::new()
+            } else {
+                actor
+                    .dsl_authority
+                    .state()
+                    .identity_to_runtime
+                    .iter()
+                    .filter(|(_, runtime_id)| {
+                        matches!(
+                            actor
+                                .dsl_authority
+                                .state()
+                                .member_state_markers
+                                .get(*runtime_id),
+                            Some(crate::machines::mob_machine::MobMemberState::Retiring)
+                        )
+                    })
+                    .map(|(identity, _)| crate::ids::AgentIdentity::from(identity.0.as_str()))
+                    .collect::<Vec<_>>()
+            };
+            // Cold-recovery convergence workers are owned by this actor instance.
+            // Register them before moving the actor into its run loop so every
+            // terminal path can abort and join them before command-channel closure.
+            if !recovered_obligations.is_empty() {
+                let pump_handle = handle.clone();
                 actor.actor_io_tasks.spawn(async move {
+                    #[cfg(test)]
+                    let _startup_worker_guard = ActorOwnedStartupWorkerGuard::new(actor_runtime_id);
+                    for identity in recovered_obligations {
+                        if let Err(error) = pump_handle.ensure_pump_for_obligation(&identity).await
+                        {
+                            tracing::warn!(
+                                agent_identity = %identity,
+                                error = %error,
+                                "recovered remote-turn obligation could not keep its pump alive"
+                            );
+                        }
+                    }
+                });
+            }
+            if !resume_destroy_cleanup {
+                for host_id in recovered_host_revocations {
+                    let revoke_handle = handle.clone();
+                    actor.actor_io_tasks.spawn(async move {
                     #[cfg(test)]
                     let _startup_worker_guard = ActorOwnedStartupWorkerGuard::new(actor_runtime_id);
                     let mut retry_delay = std::time::Duration::from_millis(25);
@@ -9793,11 +9846,11 @@ impl MobBuilder {
                         }
                     }
                 });
+                }
             }
-        }
-        for identity in recovered_retirements {
-            let retire_handle = handle.clone();
-            actor.actor_io_tasks.spawn(async move {
+            for identity in recovered_retirements {
+                let retire_handle = handle.clone();
+                actor.actor_io_tasks.spawn(async move {
                 #[cfg(test)]
                 let _startup_worker_guard = ActorOwnedStartupWorkerGuard::new(actor_runtime_id);
                 let mut retry_delay = std::time::Duration::from_millis(25);
@@ -9821,10 +9874,10 @@ impl MobBuilder {
                     }
                 }
             });
-        }
-        if resume_destroy_cleanup {
-            let destroy_handle = handle.clone();
-            actor.actor_io_tasks.spawn(async move {
+            }
+            if resume_destroy_cleanup {
+                let destroy_handle = handle.clone();
+                actor.actor_io_tasks.spawn(async move {
                 #[cfg(test)]
                 let _startup_worker_guard = ActorOwnedStartupWorkerGuard::new(actor_runtime_id);
                 let mut retry_delay = std::time::Duration::from_millis(25);
@@ -9849,55 +9902,56 @@ impl MobBuilder {
                     }
                 }
             });
-        } else if let Some(intent) = recovered_lifecycle_retry_intent {
-            let lifecycle_handle = handle.clone();
-            actor.actor_io_tasks.spawn(async move {
-                #[cfg(test)]
-                let _startup_worker_guard = ActorOwnedStartupWorkerGuard::new(actor_runtime_id);
-                drive_recovered_placed_lifecycle_intent(lifecycle_handle, intent).await;
-            });
-        }
-        if remote_intent_reconciler_enabled {
-            let completion_reconciler_task =
-                super::placed_completion_reconciler::PlacedCompletionReconciler::run_owned(
-                    handle.mob_id().clone(),
-                    handle.clone(),
-                    completion_reconciler_provisioner,
-                );
-            actor.actor_io_tasks.spawn(async move {
-                #[cfg(test)]
-                let _startup_worker_guard = ActorOwnedStartupWorkerGuard::new(actor_runtime_id);
-                completion_reconciler_task.await;
-            });
-            let kickoff_reconciler_task =
-                super::placed_kickoff_reconciler::PlacedKickoffReconciler::run_owned(
-                    handle.mob_id().clone(),
-                    handle.clone(),
-                    kickoff_reconciler_provisioner,
-                    kickoff_reconciler_metadata,
-                );
-            actor.actor_io_tasks.spawn(async move {
-                #[cfg(test)]
-                let _startup_worker_guard = ActorOwnedStartupWorkerGuard::new(actor_runtime_id);
-                kickoff_reconciler_task.await;
-            });
-            let reconciler_task =
-                super::remote_turn_reconciler::RemoteTurnIntentReconciler::run_owned(
-                    handle.mob_id().clone(),
-                    handle.clone(),
-                    intent_reconciler_provisioner,
-                    intent_reconciler_tickets,
-                    recovered_remote_intent_runs,
-                );
-            actor.actor_io_tasks.spawn(async move {
-                #[cfg(test)]
-                let _startup_worker_guard = ActorOwnedStartupWorkerGuard::new(actor_runtime_id);
-                reconciler_task.await;
-            });
-        }
-        tokio::spawn(actor.run(command_rx));
+            } else if let Some(intent) = recovered_lifecycle_retry_intent {
+                let lifecycle_handle = handle.clone();
+                actor.actor_io_tasks.spawn(async move {
+                    #[cfg(test)]
+                    let _startup_worker_guard = ActorOwnedStartupWorkerGuard::new(actor_runtime_id);
+                    drive_recovered_placed_lifecycle_intent(lifecycle_handle, intent).await;
+                });
+            }
+            if remote_intent_reconciler_enabled {
+                let completion_reconciler_task =
+                    super::placed_completion_reconciler::PlacedCompletionReconciler::run_owned(
+                        handle.mob_id().clone(),
+                        handle.clone(),
+                        completion_reconciler_provisioner,
+                    );
+                actor.actor_io_tasks.spawn(async move {
+                    #[cfg(test)]
+                    let _startup_worker_guard = ActorOwnedStartupWorkerGuard::new(actor_runtime_id);
+                    completion_reconciler_task.await;
+                });
+                let kickoff_reconciler_task =
+                    super::placed_kickoff_reconciler::PlacedKickoffReconciler::run_owned(
+                        handle.mob_id().clone(),
+                        handle.clone(),
+                        kickoff_reconciler_provisioner,
+                        kickoff_reconciler_metadata,
+                    );
+                actor.actor_io_tasks.spawn(async move {
+                    #[cfg(test)]
+                    let _startup_worker_guard = ActorOwnedStartupWorkerGuard::new(actor_runtime_id);
+                    kickoff_reconciler_task.await;
+                });
+                let reconciler_task =
+                    super::remote_turn_reconciler::RemoteTurnIntentReconciler::run_owned(
+                        handle.mob_id().clone(),
+                        handle.clone(),
+                        intent_reconciler_provisioner,
+                        intent_reconciler_tickets,
+                        recovered_remote_intent_runs,
+                    );
+                actor.actor_io_tasks.spawn(async move {
+                    #[cfg(test)]
+                    let _startup_worker_guard = ActorOwnedStartupWorkerGuard::new(actor_runtime_id);
+                    reconciler_task.await;
+                });
+            }
+            tokio::spawn(runtime_actor_future(actor, command_rx));
 
-        Ok(handle)
+            Ok(handle)
+        })
     }
 }
 

--- a/meerkat/src/factory.rs
+++ b/meerkat/src/factory.rs
@@ -225,11 +225,12 @@ unsafe extern "Rust" {
     ) -> CoreAgentFactoryBuildFuture;
 
     #[link_name = concat!(
-        "__meerkat_agent_factory_parent_tool_composition_authority_new_v1_",
+        "__meerkat_agent_factory_parent_tool_composition_authority_new_v2_",
         env!("MEERKAT_AGENT_FACTORY_POLICY_BRIDGE_SYMBOL_SUFFIX")
     )]
     fn core_agent_factory_parent_tool_composition_authority_new(
         factory_bridge_token: &'static (dyn Any + Send + Sync),
+        resolved_tool_access_policy: Option<meerkat_core::ops::ToolAccessPolicy>,
     ) -> Result<meerkat_core::service::ParentToolCompositionAuthority, String>;
 
     #[link_name = concat!(
@@ -5558,6 +5559,7 @@ impl AgentFactory {
             let parent_tool_authority = unsafe {
                 core_agent_factory_parent_tool_composition_authority_new(
                     agent_factory_policy_bridge_token(),
+                    build_config.tool_access_policy.clone(),
                 )
             }
             .map_err(|err| {
@@ -6653,6 +6655,7 @@ mod tests {
         let authority = unsafe {
             core_agent_factory_parent_tool_composition_authority_new(
                 agent_factory_policy_bridge_token(),
+                None,
             )
         }
         .expect("test parent tool composition authority should mint through AgentFactory bridge");


### PR DESCRIPTION
## Summary

- bound the full-tools CLI `mob_create` -> `mob_spawn_member` path to the production 2 MiB Tokio worker stack by erasing the oversized async dispatch boundaries
- bootstrap credential reads before direct `rkat mob run` / `rkat mob deploy` configuration composition, so legacy OAuth bindings are available on first load
- carry the already-resolved parent tool policy through the existing opaque composition authority, while preserving fail-closed metadata resolution for the public legacy constructors
- retain complete member-turn dispatch context, including exact `self_hosted_server_id`, and reject ephemeral model overrides when no reconfiguration host is installed

## Validation

- literal 2 MiB full-tools create -> spawn regression
- mob dispatcher future-size guard
- direct legacy OAuth bootstrap regression
- public-constructor restricted-parent containment/read-count regression
- member-turn dispatch-context and queued self-hosted identity regressions
- ephemeral model-override admission regression
- `meerkat-core` semver: 223/223 checks passed against 0.8.0
- `meerkat-mob-mcp` semver: 223/223 checks passed against 0.8.0
- touched-crate clippy with all targets/features and `-D warnings`
- independent architecture and adversarial test reviews: green
