### PR TITLE
fix(mob): join in-progress unregister during shutdown

### DIFF
--- a/meerkat-mob/src/runtime/actor.rs
+++ b/meerkat-mob/src/runtime/actor.rs
@@ -12512,7 +12512,19 @@ impl MobActor {
                 // (0.7.2 D1): it aborts the comms drain task *and* awaits its
                 // quiescence before committing teardown, so a separate
                 // pre-unregister `abort_comms_drain` here is redundant.
-                if let Err(error) = adapter.unregister_session(&session_id).await {
+                let unregister_result = match adapter.unregister_session(&session_id).await {
+                    // Unregister is an independently-owned saga. Its caller
+                    // grace can race the final teardown acknowledgement, so
+                    // join (or deliberately retry) that exact registration
+                    // once more before classifying the binding as unresolved.
+                    // A second in-progress result remains a bounded,
+                    // retryable shutdown failure.
+                    Err(meerkat_runtime::RuntimeDriverError::UnregisterInProgress { .. }) => {
+                        adapter.unregister_session(&session_id).await
+                    }
+                    result => result,
+                };
+                if let Err(error) = unregister_result {
                     failures.push(format!(
                         "failed to unregister runtime session {session_id} during mob teardown: {error}"
                     ));


### PR DESCRIPTION
## Summary

- treat `RuntimeDriverError::UnregisterInProgress` as the runtime contract defines it: retry once to join the independently owned teardown saga
- keep Mob shutdown bounded; a second in-progress result remains a retryable shutdown failure
- preserve all concrete unregister errors

## Why this blocks 0.8.1

Exact-`main` CI run 29634482896 failed Unit shard 2 in `test_shutdown_does_not_stall_on_stuck_lifecycle_notification`: Mob teardown classified the first 2-second caller-grace expiry as terminal even though the unregister coordinator was still valid and joinable.

## Validation

- exact failing Unit partition: 1,089/1,089 passed
- focused regression: passed
- focused stress: 100/100 passed at concurrency 24
- shutdown lifecycle matrix: passed
- `meerkat-mob` all-target/all-feature Clippy: passed
- mandatory pre-push gate: passed
- independent adversarial review: approved; relevant unregister concurrency and bounded-drain tests passed