### PR TITLE
feat: machine-owned auto-migration of pre-typed session checkpoints

### DIFF
--- a/meerkat-core/src/checkpoint.rs
+++ b/meerkat-core/src/checkpoint.rs
@@ -1138,6 +1138,63 @@ pub fn legacy_session_transcript_relation(
     )
 }
 
+/// One adopted legacy session: the typed migration stamp bound to the exact
+/// source bytes, the stamped document, and its serialized durable form.
+pub struct AdoptedLegacySession {
+    pub session: Session,
+    pub stamp: SessionCheckpointStamp,
+    pub serialized: Vec<u8>,
+}
+
+/// Adopt one pre-typed (legacy-unverified) session BLOB into typed checkpoint
+/// authority via a one-time recovery migration.
+///
+/// This is the shared stamping seam for every backend that holds pre-typed
+/// documents — the disk resolver, remote store implementations, and
+/// continuity-snapshot adoption — so the ordering subtleties live in exactly
+/// one place. Contract for callers:
+///
+/// - `source_blob` must be the FINAL bytes: perform any metadata repair
+///   (for example comms-name rewrites at restore) before calling, because
+///   the stamp's `Legacy` authority base takes byte custody of exactly these
+///   bytes.
+/// - `observed_generation` / `observed_checkpoint_revision` must come from
+///   the externally observed continuity cursor when one exists. `INITIAL`
+///   cursors are correct only for lineages that never minted authority
+///   (pre-typed fleets with no continuity generation floor); stamping a
+///   lower generation than the continuity row records makes the mismatch
+///   sticky, because the document then verifies and no longer re-migrates.
+/// - The blob must decode as a legacy-unverified document; typed documents
+///   are refused with a typed error, never re-stamped.
+pub fn adopt_legacy_session(
+    source_blob: &[u8],
+    observed_generation: SessionGeneration,
+    observed_checkpoint_revision: SessionCheckpointRevision,
+) -> Result<AdoptedLegacySession, SessionCheckpointError> {
+    let mut session: Session = serde_json::from_slice(source_blob)?;
+    let stamp = SessionCheckpointStamp::recovery_migration(
+        &session,
+        source_blob,
+        observed_generation,
+        observed_checkpoint_revision,
+    )?;
+    session.install_checkpoint_stamp(stamp.clone())?;
+    let serialized = serde_json::to_vec(&session)?;
+    match session.try_checkpoint_state()? {
+        SessionCheckpointState::Verified(verified) if verified == stamp => {}
+        _ => {
+            return Err(SessionCheckpointError::AuthorityBaseConflict(
+                "adopted legacy session failed post-install verification".to_string(),
+            ));
+        }
+    }
+    Ok(AdoptedLegacySession {
+        session,
+        stamp,
+        serialized,
+    })
+}
+
 /// Periodic session persistence hook.
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
@@ -1742,6 +1799,42 @@ mod tests {
             legacy_session_transcript_relation(&snapshot, &divergent).expect("divergent relation"),
             LegacySessionTranscriptRelation::Divergent
         );
+    }
+
+    #[test]
+    fn adopt_legacy_session_stamps_blob_and_refuses_typed_documents() {
+        let legacy = session_with_text("legacy blob");
+        let blob = serde_json::to_vec(&legacy).expect("legacy session should serialize");
+        let adopted = adopt_legacy_session(
+            &blob,
+            SessionGeneration::INITIAL,
+            SessionCheckpointRevision::INITIAL,
+        )
+        .expect("legacy blob should adopt");
+        assert_eq!(
+            adopted.stamp.provenance(),
+            SessionCheckpointProvenance::RecoveryMigration
+        );
+        assert_eq!(adopted.stamp.generation(), SessionGeneration::INITIAL);
+        let reloaded: Session =
+            serde_json::from_slice(&adopted.serialized).expect("adopted bytes should decode");
+        assert!(matches!(
+            reloaded
+                .try_checkpoint_state()
+                .expect("adopted checkpoint state should decode"),
+            SessionCheckpointState::Verified(stamp) if stamp == adopted.stamp
+        ));
+
+        let typed_blob =
+            serde_json::to_vec(&stamped_root(&legacy)).expect("typed session should serialize");
+        assert!(matches!(
+            adopt_legacy_session(
+                &typed_blob,
+                SessionGeneration::INITIAL,
+                SessionCheckpointRevision::INITIAL,
+            ),
+            Err(SessionCheckpointError::AuthorityBaseConflict(_))
+        ));
     }
 
     #[test]

--- a/meerkat-core/src/checkpoint.rs
+++ b/meerkat-core/src/checkpoint.rs
@@ -1067,6 +1067,77 @@ pub fn session_checkpoints_are_exact(
     Ok(session_checkpoint_relation(left, right)? == SessionCheckpointRelation::Exact)
 }
 
+/// Mechanical transcript relation between two legacy (unstamped) copies of the
+/// same session document, observed during one-time recovery migration.
+///
+/// Legacy documents carry no stamps, so ancestry cannot be proven typed. The
+/// only mechanical proof available is per-message canonical-JSON prefix
+/// equality over the transcripts. Non-transcript fields are deliberately not
+/// compared: whichever copy migration adopts carries its own non-transcript
+/// fields wholesale, and pre-typed writers routinely differ on save-time
+/// bookkeeping without diverging conversation content.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LegacySessionTranscriptRelation {
+    /// Same message count and per-message canonical equality.
+    Identical,
+    /// The snapshot's transcript is a strict prefix of the projection's.
+    ProjectionExtendsSnapshot,
+    /// The projection's transcript is a strict prefix of the snapshot's.
+    SnapshotExtendsProjection,
+    /// Neither transcript is a prefix of the other.
+    Divergent,
+}
+
+/// Classify the transcript relation between the committed runtime snapshot
+/// copy and the session-store projection copy of one legacy session document.
+///
+/// Both documents must decode as `LegacyUnverified` and carry the same
+/// session id; typed documents must use `session_checkpoint_relation`.
+pub fn legacy_session_transcript_relation(
+    snapshot: &Session,
+    projection: &Session,
+) -> Result<LegacySessionTranscriptRelation, SessionCheckpointError> {
+    for (side, session) in [("snapshot", snapshot), ("projection", projection)] {
+        if !matches!(
+            session.try_checkpoint_state()?,
+            SessionCheckpointState::LegacyUnverified { .. }
+        ) {
+            return Err(SessionCheckpointError::AuthorityBaseConflict(format!(
+                "legacy transcript relation requires an untyped legacy {side} document"
+            )));
+        }
+    }
+    if snapshot.id() != projection.id() {
+        return Err(SessionCheckpointError::SessionIdMismatch {
+            expected: snapshot.id().clone(),
+            actual: projection.id().clone(),
+        });
+    }
+    let snapshot_messages = snapshot.messages();
+    let projection_messages = projection.messages();
+    let shared = snapshot_messages.len().min(projection_messages.len());
+    for (snapshot_message, projection_message) in snapshot_messages
+        .iter()
+        .take(shared)
+        .zip(projection_messages.iter().take(shared))
+    {
+        let snapshot_value = serde_json::to_value(snapshot_message)?;
+        let projection_value = serde_json::to_value(projection_message)?;
+        if snapshot_value != projection_value {
+            return Ok(LegacySessionTranscriptRelation::Divergent);
+        }
+    }
+    Ok(
+        match snapshot_messages.len().cmp(&projection_messages.len()) {
+            std::cmp::Ordering::Equal => LegacySessionTranscriptRelation::Identical,
+            std::cmp::Ordering::Less => LegacySessionTranscriptRelation::ProjectionExtendsSnapshot,
+            std::cmp::Ordering::Greater => {
+                LegacySessionTranscriptRelation::SnapshotExtendsProjection
+            }
+        },
+    )
+}
+
 /// Periodic session persistence hook.
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
@@ -1638,5 +1709,58 @@ mod tests {
             session_checkpoint_digest(&session).expect("original digest"),
             session_checkpoint_digest(&reconstructed).expect("reconstructed digest")
         );
+    }
+
+    #[test]
+    fn legacy_transcript_relation_classifies_prefix_extension_and_divergence() {
+        let snapshot = session_with_text("turn one");
+
+        let identical = snapshot.clone();
+        assert_eq!(
+            legacy_session_transcript_relation(&snapshot, &identical).expect("identical relation"),
+            LegacySessionTranscriptRelation::Identical
+        );
+
+        let mut extended = snapshot.clone();
+        extended.push(Message::User(UserMessage::text("turn two".to_string())));
+        assert_eq!(
+            legacy_session_transcript_relation(&snapshot, &extended).expect("extension relation"),
+            LegacySessionTranscriptRelation::ProjectionExtendsSnapshot
+        );
+        assert_eq!(
+            legacy_session_transcript_relation(&extended, &snapshot)
+                .expect("stale projection relation"),
+            LegacySessionTranscriptRelation::SnapshotExtendsProjection
+        );
+
+        let mut divergent = snapshot.clone();
+        std::sync::Arc::make_mut(&mut divergent.messages).clear();
+        divergent.push(Message::User(UserMessage::text(
+            "a different turn one".to_string(),
+        )));
+        assert_eq!(
+            legacy_session_transcript_relation(&snapshot, &divergent).expect("divergent relation"),
+            LegacySessionTranscriptRelation::Divergent
+        );
+    }
+
+    #[test]
+    fn legacy_transcript_relation_refuses_typed_documents_and_foreign_sessions() {
+        let legacy = session_with_text("legacy copy");
+        let typed = stamped_root(&session_with_text("typed copy"));
+        assert!(matches!(
+            legacy_session_transcript_relation(&typed, &legacy),
+            Err(SessionCheckpointError::AuthorityBaseConflict(_))
+        ));
+        assert!(matches!(
+            legacy_session_transcript_relation(&legacy, &typed),
+            Err(SessionCheckpointError::AuthorityBaseConflict(_))
+        ));
+
+        let foreign = session_with_text("legacy copy");
+        assert!(matches!(
+            legacy_session_transcript_relation(&legacy, &foreign),
+            Err(SessionCheckpointError::SessionIdMismatch { .. })
+        ));
     }
 }

--- a/meerkat-core/src/generated/session_document.rs
+++ b/meerkat-core/src/generated/session_document.rs
@@ -225,6 +225,25 @@ pub enum RuntimeCheckpointProjectionDisposition {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+pub enum LegacyCheckpointTranscriptRelation {
+    #[default]
+    Divergent,
+    Identical,
+    ProjectionExtendsSnapshot,
+    SnapshotExtendsProjection,
+    NotComparable,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+pub enum LegacyCheckpointMigrationDisposition {
+    #[default]
+    RefuseDivergent,
+    MigrateCanonicalSnapshot,
+    AdoptProjectionExtension,
+    MigrateStoreProjection,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 pub enum SessionDocumentLifecycle {
     #[default]
     Active,
@@ -457,6 +476,14 @@ pub enum SessionDocumentInput {
     ResolveRuntimeCheckpointProjection {
         session_id: SessionDocumentKey,
     },
+    ResolveLegacyCheckpointMigration {
+        session_id: SessionDocumentKey,
+        runtime_snapshot_present: bool,
+        runtime_snapshot_legacy: bool,
+        store_row_present: bool,
+        store_row_legacy: bool,
+        transcript_relation: LegacyCheckpointTranscriptRelation,
+    },
     ResolveRuntimeSnapshotReadSource {
         session_id: SessionDocumentKey,
         store_head_extends_snapshot: bool,
@@ -586,6 +613,9 @@ pub enum SessionDocumentEffect {
     },
     RuntimeCheckpointProjectionResolved {
         disposition: RuntimeCheckpointProjectionDisposition,
+    },
+    LegacyCheckpointMigrationResolved {
+        disposition: LegacyCheckpointMigrationDisposition,
     },
     RuntimeSnapshotReadSourceResolved {
         read_from_store_head: bool,
@@ -749,6 +779,13 @@ enum SessionDocumentTransition {
     ResolveRuntimeProjectionRollbackReject,
     ResolveRuntimeCheckpointProjectionActive,
     ResolveRuntimeCheckpointProjectionArchived,
+    ResolveLegacyCheckpointMigrationSnapshotIdenticalProjection,
+    ResolveLegacyCheckpointMigrationSnapshotAheadOfProjection,
+    ResolveLegacyCheckpointMigrationProjectionExtension,
+    ResolveLegacyCheckpointMigrationDivergentCopies,
+    ResolveLegacyCheckpointMigrationSnapshotOnly,
+    ResolveLegacyCheckpointMigrationStoreRowOnly,
+    ResolveLegacyCheckpointMigrationSnapshotLegacyProjectionTyped,
     ApplyPendingToolResults,
     TranscriptEditFork,
     TranscriptEditRewrite,
@@ -3268,6 +3305,129 @@ impl SessionDocumentMachineAuthority {
                     }),
                 }
             }
+            SessionDocumentInput::ResolveLegacyCheckpointMigration {
+                session_id,
+                runtime_snapshot_present,
+                runtime_snapshot_legacy,
+                store_row_present,
+                store_row_legacy,
+                transcript_relation,
+            } => {
+                let mut matches = Vec::new();
+                if (self.state.lifecycle_phase == SessionDocumentPhase::Ready)
+                    && ((runtime_snapshot_present == true)
+                        && (runtime_snapshot_legacy == true)
+                        && (store_row_present == true)
+                        && (store_row_legacy == true)
+                        && (transcript_relation == LegacyCheckpointTranscriptRelation::Identical))
+                {
+                    matches.push(SessionDocumentTransition::ResolveLegacyCheckpointMigrationSnapshotIdenticalProjection);
+                }
+                if (self.state.lifecycle_phase == SessionDocumentPhase::Ready)
+                    && ((runtime_snapshot_present == true)
+                        && (runtime_snapshot_legacy == true)
+                        && (store_row_present == true)
+                        && (store_row_legacy == true)
+                        && (transcript_relation
+                            == LegacyCheckpointTranscriptRelation::SnapshotExtendsProjection))
+                {
+                    matches.push(SessionDocumentTransition::ResolveLegacyCheckpointMigrationSnapshotAheadOfProjection);
+                }
+                if (self.state.lifecycle_phase == SessionDocumentPhase::Ready)
+                    && ((runtime_snapshot_present == true)
+                        && (runtime_snapshot_legacy == true)
+                        && (store_row_present == true)
+                        && (store_row_legacy == true)
+                        && (transcript_relation
+                            == LegacyCheckpointTranscriptRelation::ProjectionExtendsSnapshot))
+                {
+                    matches.push(SessionDocumentTransition::ResolveLegacyCheckpointMigrationProjectionExtension);
+                }
+                if (self.state.lifecycle_phase == SessionDocumentPhase::Ready)
+                    && ((runtime_snapshot_present == true)
+                        && (runtime_snapshot_legacy == true)
+                        && (store_row_present == true)
+                        && (store_row_legacy == true)
+                        && (transcript_relation == LegacyCheckpointTranscriptRelation::Divergent))
+                {
+                    matches.push(
+                        SessionDocumentTransition::ResolveLegacyCheckpointMigrationDivergentCopies,
+                    );
+                }
+                if (self.state.lifecycle_phase == SessionDocumentPhase::Ready)
+                    && ((runtime_snapshot_present == true)
+                        && (runtime_snapshot_legacy == true)
+                        && (store_row_present == false))
+                {
+                    matches.push(
+                        SessionDocumentTransition::ResolveLegacyCheckpointMigrationSnapshotOnly,
+                    );
+                }
+                if (self.state.lifecycle_phase == SessionDocumentPhase::Ready)
+                    && ((runtime_snapshot_present == false)
+                        && (store_row_present == true)
+                        && (store_row_legacy == true))
+                {
+                    matches.push(
+                        SessionDocumentTransition::ResolveLegacyCheckpointMigrationStoreRowOnly,
+                    );
+                }
+                if (self.state.lifecycle_phase == SessionDocumentPhase::Ready)
+                    && ((runtime_snapshot_present == true)
+                        && (runtime_snapshot_legacy == true)
+                        && (store_row_present == true)
+                        && (store_row_legacy == false))
+                {
+                    matches.push(SessionDocumentTransition::ResolveLegacyCheckpointMigrationSnapshotLegacyProjectionTyped);
+                }
+                let transition =
+                    Self::single_transition(matches, "ResolveLegacyCheckpointMigration")?;
+                match transition {
+                    SessionDocumentTransition::ResolveLegacyCheckpointMigrationSnapshotIdenticalProjection => {
+                        self.state.lifecycle_phase = SessionDocumentPhase::Ready;
+                        Ok(vec![
+                            SessionDocumentEffect::LegacyCheckpointMigrationResolved { disposition: LegacyCheckpointMigrationDisposition::MigrateCanonicalSnapshot, },
+                        ])
+                    }
+                    SessionDocumentTransition::ResolveLegacyCheckpointMigrationSnapshotAheadOfProjection => {
+                        self.state.lifecycle_phase = SessionDocumentPhase::Ready;
+                        Ok(vec![
+                            SessionDocumentEffect::LegacyCheckpointMigrationResolved { disposition: LegacyCheckpointMigrationDisposition::MigrateCanonicalSnapshot, },
+                        ])
+                    }
+                    SessionDocumentTransition::ResolveLegacyCheckpointMigrationProjectionExtension => {
+                        self.state.lifecycle_phase = SessionDocumentPhase::Ready;
+                        Ok(vec![
+                            SessionDocumentEffect::LegacyCheckpointMigrationResolved { disposition: LegacyCheckpointMigrationDisposition::AdoptProjectionExtension, },
+                        ])
+                    }
+                    SessionDocumentTransition::ResolveLegacyCheckpointMigrationDivergentCopies => {
+                        self.state.lifecycle_phase = SessionDocumentPhase::Ready;
+                        Ok(vec![
+                            SessionDocumentEffect::LegacyCheckpointMigrationResolved { disposition: LegacyCheckpointMigrationDisposition::RefuseDivergent, },
+                        ])
+                    }
+                    SessionDocumentTransition::ResolveLegacyCheckpointMigrationSnapshotOnly => {
+                        self.state.lifecycle_phase = SessionDocumentPhase::Ready;
+                        Ok(vec![
+                            SessionDocumentEffect::LegacyCheckpointMigrationResolved { disposition: LegacyCheckpointMigrationDisposition::MigrateCanonicalSnapshot, },
+                        ])
+                    }
+                    SessionDocumentTransition::ResolveLegacyCheckpointMigrationStoreRowOnly => {
+                        self.state.lifecycle_phase = SessionDocumentPhase::Ready;
+                        Ok(vec![
+                            SessionDocumentEffect::LegacyCheckpointMigrationResolved { disposition: LegacyCheckpointMigrationDisposition::MigrateStoreProjection, },
+                        ])
+                    }
+                    SessionDocumentTransition::ResolveLegacyCheckpointMigrationSnapshotLegacyProjectionTyped => {
+                        self.state.lifecycle_phase = SessionDocumentPhase::Ready;
+                        Ok(vec![
+                            SessionDocumentEffect::LegacyCheckpointMigrationResolved { disposition: LegacyCheckpointMigrationDisposition::RefuseDivergent, },
+                        ])
+                    }
+                    #[allow(unreachable_patterns)] _ => Err(SessionDocumentError { op: "ResolveLegacyCheckpointMigration_transition" }),
+                }
+            }
             SessionDocumentInput::ResolveRuntimeSnapshotReadSource {
                 session_id,
                 store_head_extends_snapshot,
@@ -4023,6 +4183,25 @@ impl SessionDocumentMachineAuthority {
         session_id: SessionDocumentKey,
     ) -> Result<Vec<SessionDocumentEffect>, SessionDocumentError> {
         self.apply_input(SessionDocumentInput::ResolveRuntimeCheckpointProjection { session_id })
+    }
+
+    pub fn resolve_legacy_checkpoint_migration(
+        &mut self,
+        session_id: SessionDocumentKey,
+        runtime_snapshot_present: bool,
+        runtime_snapshot_legacy: bool,
+        store_row_present: bool,
+        store_row_legacy: bool,
+        transcript_relation: LegacyCheckpointTranscriptRelation,
+    ) -> Result<Vec<SessionDocumentEffect>, SessionDocumentError> {
+        self.apply_input(SessionDocumentInput::ResolveLegacyCheckpointMigration {
+            session_id,
+            runtime_snapshot_present,
+            runtime_snapshot_legacy,
+            store_row_present,
+            store_row_legacy,
+            transcript_relation,
+        })
     }
 
     pub fn resolve_runtime_snapshot_read_source(

--- a/meerkat-core/src/lib.rs
+++ b/meerkat-core/src/lib.rs
@@ -121,14 +121,15 @@ pub use budget::{
     Budget, BudgetDimension, BudgetExceeded, BudgetLimits, BudgetObservation, BudgetPool,
 };
 pub use checkpoint::{
-    SESSION_CHECKPOINT_STAMP_SCHEMA_VERSION, SessionCheckpointAncestryProof,
-    SessionCheckpointAnchor, SessionCheckpointAuthorityBase, SessionCheckpointDigest,
-    SessionCheckpointError, SessionCheckpointMetadataState, SessionCheckpointProvenance,
-    SessionCheckpointRelation, SessionCheckpointRevision, SessionCheckpointStamp,
-    SessionCheckpointState, SessionCheckpointer, SessionGeneration, SessionLineageId,
-    legacy_session_source_blob_digest, session_checkpoint_digest,
-    session_checkpoint_metadata_state, session_checkpoint_relation, session_checkpoints_are_exact,
-    session_transcript_history_checkpoint_digest, transcript_history_checkpoint_digest,
+    LegacySessionTranscriptRelation, SESSION_CHECKPOINT_STAMP_SCHEMA_VERSION,
+    SessionCheckpointAncestryProof, SessionCheckpointAnchor, SessionCheckpointAuthorityBase,
+    SessionCheckpointDigest, SessionCheckpointError, SessionCheckpointMetadataState,
+    SessionCheckpointProvenance, SessionCheckpointRelation, SessionCheckpointRevision,
+    SessionCheckpointStamp, SessionCheckpointState, SessionCheckpointer, SessionGeneration,
+    SessionLineageId, legacy_session_source_blob_digest, legacy_session_transcript_relation,
+    session_checkpoint_digest, session_checkpoint_metadata_state, session_checkpoint_relation,
+    session_checkpoints_are_exact, session_transcript_history_checkpoint_digest,
+    transcript_history_checkpoint_digest,
 };
 pub use comms::{
     CommsCommand, EventStream, InputSource, InputStreamMode, PeerDirectoryEntry,

--- a/meerkat-core/src/lib.rs
+++ b/meerkat-core/src/lib.rs
@@ -121,15 +121,15 @@ pub use budget::{
     Budget, BudgetDimension, BudgetExceeded, BudgetLimits, BudgetObservation, BudgetPool,
 };
 pub use checkpoint::{
-    LegacySessionTranscriptRelation, SESSION_CHECKPOINT_STAMP_SCHEMA_VERSION,
+    AdoptedLegacySession, LegacySessionTranscriptRelation, SESSION_CHECKPOINT_STAMP_SCHEMA_VERSION,
     SessionCheckpointAncestryProof, SessionCheckpointAnchor, SessionCheckpointAuthorityBase,
     SessionCheckpointDigest, SessionCheckpointError, SessionCheckpointMetadataState,
     SessionCheckpointProvenance, SessionCheckpointRelation, SessionCheckpointRevision,
     SessionCheckpointStamp, SessionCheckpointState, SessionCheckpointer, SessionGeneration,
-    SessionLineageId, legacy_session_source_blob_digest, legacy_session_transcript_relation,
-    session_checkpoint_digest, session_checkpoint_metadata_state, session_checkpoint_relation,
-    session_checkpoints_are_exact, session_transcript_history_checkpoint_digest,
-    transcript_history_checkpoint_digest,
+    SessionLineageId, adopt_legacy_session, legacy_session_source_blob_digest,
+    legacy_session_transcript_relation, session_checkpoint_digest,
+    session_checkpoint_metadata_state, session_checkpoint_relation, session_checkpoints_are_exact,
+    session_transcript_history_checkpoint_digest, transcript_history_checkpoint_digest,
 };
 pub use comms::{
     CommsCommand, EventStream, InputSource, InputStreamMode, PeerDirectoryEntry,

--- a/meerkat-machine-kernels/src/generated/session_document.rs
+++ b/meerkat-machine-kernels/src/generated/session_document.rs
@@ -27,6 +27,130 @@ pub fn schema() -> meerkat_machine_schema::MachineSchema {
     serde::Serialize,
     serde::Deserialize,
 )]
+pub enum LegacyCheckpointMigrationDisposition {
+    #[default]
+    #[serde(rename = "RefuseDivergent")]
+    RefuseDivergent,
+    #[serde(rename = "MigrateCanonicalSnapshot")]
+    MigrateCanonicalSnapshot,
+    #[serde(rename = "AdoptProjectionExtension")]
+    AdoptProjectionExtension,
+    #[serde(rename = "MigrateStoreProjection")]
+    MigrateStoreProjection,
+}
+impl LegacyCheckpointMigrationDisposition {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::RefuseDivergent => "RefuseDivergent",
+            Self::MigrateCanonicalSnapshot => "MigrateCanonicalSnapshot",
+            Self::AdoptProjectionExtension => "AdoptProjectionExtension",
+            Self::MigrateStoreProjection => "MigrateStoreProjection",
+        }
+    }
+}
+impl std::convert::TryFrom<&str> for LegacyCheckpointMigrationDisposition {
+    type Error = String;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        match value {
+            "RefuseDivergent" => Ok(Self::RefuseDivergent),
+            "MigrateCanonicalSnapshot" => Ok(Self::MigrateCanonicalSnapshot),
+            "AdoptProjectionExtension" => Ok(Self::AdoptProjectionExtension),
+            "MigrateStoreProjection" => Ok(Self::MigrateStoreProjection),
+            other => Err(format!(
+                "invalid LegacyCheckpointMigrationDisposition value `{other}`"
+            )),
+        }
+    }
+}
+impl std::convert::TryFrom<String> for LegacyCheckpointMigrationDisposition {
+    type Error = String;
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        Self::try_from(value.as_str())
+    }
+}
+impl std::fmt::Display for LegacyCheckpointMigrationDisposition {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+#[allow(non_camel_case_types)]
+#[derive(
+    Debug,
+    Clone,
+    Copy,
+    Default,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash,
+    serde::Serialize,
+    serde::Deserialize,
+)]
+pub enum LegacyCheckpointTranscriptRelation {
+    #[default]
+    #[serde(rename = "Divergent")]
+    Divergent,
+    #[serde(rename = "Identical")]
+    Identical,
+    #[serde(rename = "ProjectionExtendsSnapshot")]
+    ProjectionExtendsSnapshot,
+    #[serde(rename = "SnapshotExtendsProjection")]
+    SnapshotExtendsProjection,
+    #[serde(rename = "NotComparable")]
+    NotComparable,
+}
+impl LegacyCheckpointTranscriptRelation {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Divergent => "Divergent",
+            Self::Identical => "Identical",
+            Self::ProjectionExtendsSnapshot => "ProjectionExtendsSnapshot",
+            Self::SnapshotExtendsProjection => "SnapshotExtendsProjection",
+            Self::NotComparable => "NotComparable",
+        }
+    }
+}
+impl std::convert::TryFrom<&str> for LegacyCheckpointTranscriptRelation {
+    type Error = String;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        match value {
+            "Divergent" => Ok(Self::Divergent),
+            "Identical" => Ok(Self::Identical),
+            "ProjectionExtendsSnapshot" => Ok(Self::ProjectionExtendsSnapshot),
+            "SnapshotExtendsProjection" => Ok(Self::SnapshotExtendsProjection),
+            "NotComparable" => Ok(Self::NotComparable),
+            other => Err(format!(
+                "invalid LegacyCheckpointTranscriptRelation value `{other}`"
+            )),
+        }
+    }
+}
+impl std::convert::TryFrom<String> for LegacyCheckpointTranscriptRelation {
+    type Error = String;
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        Self::try_from(value.as_str())
+    }
+}
+impl std::fmt::Display for LegacyCheckpointTranscriptRelation {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+#[allow(non_camel_case_types)]
+#[derive(
+    Debug,
+    Clone,
+    Copy,
+    Default,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash,
+    serde::Serialize,
+    serde::Deserialize,
+)]
 pub enum LiveSessionAuthorityKind {
     #[default]
     #[serde(rename = "LiveAuthoritative")]
@@ -1850,6 +1974,15 @@ pub mod inputs {
         pub session_id: SessionId,
     }
     #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+    pub struct ResolveLegacyCheckpointMigration {
+        pub session_id: SessionId,
+        pub runtime_snapshot_present: bool,
+        pub runtime_snapshot_legacy: bool,
+        pub store_row_present: bool,
+        pub store_row_legacy: bool,
+        pub transcript_relation: LegacyCheckpointTranscriptRelation,
+    }
+    #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
     pub struct ResolveRuntimeSnapshotReadSource {
         pub session_id: SessionId,
         pub store_head_extends_snapshot: bool,
@@ -1923,6 +2056,7 @@ pub enum Input {
     RecoverSessionFromStore(inputs::RecoverSessionFromStore),
     ResolveRuntimeProjectionRollback(inputs::ResolveRuntimeProjectionRollback),
     ResolveRuntimeCheckpointProjection(inputs::ResolveRuntimeCheckpointProjection),
+    ResolveLegacyCheckpointMigration(inputs::ResolveLegacyCheckpointMigration),
     ResolveRuntimeSnapshotReadSource(inputs::ResolveRuntimeSnapshotReadSource),
     ApplyPendingToolResults(inputs::ApplyPendingToolResults),
     TranscriptEdit(inputs::TranscriptEdit),
@@ -2002,6 +2136,9 @@ impl Input {
             Self::ResolveRuntimeCheckpointProjection(_) => {
                 InputKind::ResolveRuntimeCheckpointProjection
             }
+            Self::ResolveLegacyCheckpointMigration(_) => {
+                InputKind::ResolveLegacyCheckpointMigration
+            }
             Self::ResolveRuntimeSnapshotReadSource(_) => {
                 InputKind::ResolveRuntimeSnapshotReadSource
             }
@@ -2052,6 +2189,7 @@ pub enum InputKind {
     RecoverSessionFromStore,
     ResolveRuntimeProjectionRollback,
     ResolveRuntimeCheckpointProjection,
+    ResolveLegacyCheckpointMigration,
     ResolveRuntimeSnapshotReadSource,
     ApplyPendingToolResults,
     TranscriptEdit,
@@ -2193,6 +2331,10 @@ pub mod effects {
         pub disposition: RuntimeCheckpointProjectionDisposition,
     }
     #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+    pub struct LegacyCheckpointMigrationResolved {
+        pub disposition: LegacyCheckpointMigrationDisposition,
+    }
+    #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
     pub struct RuntimeSnapshotReadSourceResolved {
         pub read_from_store_head: bool,
     }
@@ -2254,6 +2396,7 @@ pub enum Effect {
     SessionStoreRecoverySourceResolved(effects::SessionStoreRecoverySourceResolved),
     RuntimeProjectionRollbackResolved(effects::RuntimeProjectionRollbackResolved),
     RuntimeCheckpointProjectionResolved(effects::RuntimeCheckpointProjectionResolved),
+    LegacyCheckpointMigrationResolved(effects::LegacyCheckpointMigrationResolved),
     RuntimeSnapshotReadSourceResolved(effects::RuntimeSnapshotReadSourceResolved),
     SessionToolResultsApplied(effects::SessionToolResultsApplied),
     TranscriptRewriteCommitted(effects::TranscriptRewriteCommitted),
@@ -2293,6 +2436,7 @@ pub enum EffectKind {
     SessionStoreRecoverySourceResolved,
     RuntimeProjectionRollbackResolved,
     RuntimeCheckpointProjectionResolved,
+    LegacyCheckpointMigrationResolved,
     RuntimeSnapshotReadSourceResolved,
     SessionToolResultsApplied,
     TranscriptRewriteCommitted,
@@ -2405,6 +2549,13 @@ pub enum TransitionId {
     ResolveRuntimeProjectionRollbackReject,
     ResolveRuntimeCheckpointProjectionActive,
     ResolveRuntimeCheckpointProjectionArchived,
+    ResolveLegacyCheckpointMigrationSnapshotIdenticalProjection,
+    ResolveLegacyCheckpointMigrationSnapshotAheadOfProjection,
+    ResolveLegacyCheckpointMigrationProjectionExtension,
+    ResolveLegacyCheckpointMigrationDivergentCopies,
+    ResolveLegacyCheckpointMigrationSnapshotOnly,
+    ResolveLegacyCheckpointMigrationStoreRowOnly,
+    ResolveLegacyCheckpointMigrationSnapshotLegacyProjectionTyped,
     ApplyPendingToolResults,
     TranscriptEditFork,
     TranscriptEditRewrite,

--- a/meerkat-machine-schema/src/catalog/coverage.rs
+++ b/meerkat-machine-schema/src/catalog/coverage.rs
@@ -1257,6 +1257,13 @@ pub fn canonical_machine_coverage_manifests() -> Vec<MachineCoverageManifest> {
                         "ApplyPendingToolResults",
                         "ResolveRuntimeCheckpointProjectionActive",
                         "ResolveRuntimeCheckpointProjectionArchived",
+                        "ResolveLegacyCheckpointMigrationSnapshotIdenticalProjection",
+                        "ResolveLegacyCheckpointMigrationSnapshotAheadOfProjection",
+                        "ResolveLegacyCheckpointMigrationProjectionExtension",
+                        "ResolveLegacyCheckpointMigrationDivergentCopies",
+                        "ResolveLegacyCheckpointMigrationSnapshotOnly",
+                        "ResolveLegacyCheckpointMigrationStoreRowOnly",
+                        "ResolveLegacyCheckpointMigrationSnapshotLegacyProjectionTyped",
                     ])
                     .effects(&[
                         "SessionFirstTurnPhaseResolved",
@@ -1277,6 +1284,7 @@ pub fn canonical_machine_coverage_manifests() -> Vec<MachineCoverageManifest> {
                         "SessionBuildStateRestoreAuthorized",
                         "SystemPromptMutationAuthorized",
                         "RuntimeCheckpointProjectionResolved",
+                        "LegacyCheckpointMigrationResolved",
                     ]),
             )],
             &[

--- a/meerkat-machine-schema/src/catalog/dsl/mod.rs
+++ b/meerkat-machine-schema/src/catalog/dsl/mod.rs
@@ -752,6 +752,29 @@ pub fn session_document_schema_metadata() -> MachineSchemaMetadata {
                 "RuntimeCheckpointProjectionDisposition",
                 &["IgnoreArchived", "Project"],
             ),
+            // Legacy-checkpoint recovery-migration region typed vocabulary
+            // (one-time migration of pre-typed documents into typed
+            // checkpoint authority; RefuseDivergent/Divergent are the
+            // fail-closed defaults).
+            NamedTypeBinding::string_enum(
+                "LegacyCheckpointTranscriptRelation",
+                &[
+                    "Divergent",
+                    "Identical",
+                    "ProjectionExtendsSnapshot",
+                    "SnapshotExtendsProjection",
+                    "NotComparable",
+                ],
+            ),
+            NamedTypeBinding::string_enum(
+                "LegacyCheckpointMigrationDisposition",
+                &[
+                    "RefuseDivergent",
+                    "MigrateCanonicalSnapshot",
+                    "AdoptProjectionExtension",
+                    "MigrateStoreProjection",
+                ],
+            ),
             NamedTypeBinding::string_enum(
                 "LiveSessionAuthorityReason",
                 &[

--- a/meerkat-machine-schema/src/catalog/dsl/session_document.rs
+++ b/meerkat-machine-schema/src/catalog/dsl/session_document.rs
@@ -454,6 +454,39 @@ pub enum RuntimeCheckpointProjectionDisposition {
     Project,
 }
 
+/// Mechanical transcript relation between the two legacy copies of one
+/// pre-typed session document, observed by the shell during one-time
+/// recovery migration (committed runtime snapshot vs session-store
+/// projection). The default is the fail-closed conflict shape.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+pub enum LegacyCheckpointTranscriptRelation {
+    #[default]
+    Divergent,
+    Identical,
+    ProjectionExtendsSnapshot,
+    SnapshotExtendsProjection,
+    /// Fewer than two legacy copies exist, so no transcript relation is
+    /// defined; single-copy transitions never read this field.
+    NotComparable,
+}
+
+/// Machine-owned disposition for the one-time recovery migration of a
+/// pre-typed (legacy-unverified) session document into typed checkpoint
+/// authority.
+///
+/// `RefuseDivergent` is the fail-closed default: two legacy copies whose
+/// transcripts are not related by prefix extension carry no mechanical
+/// proof of which conversation is authoritative, so migration is refused
+/// and the divergence surfaces as typed evidence for the operator tool.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+pub enum LegacyCheckpointMigrationDisposition {
+    #[default]
+    RefuseDivergent,
+    MigrateCanonicalSnapshot,
+    AdoptProjectionExtension,
+    MigrateStoreProjection,
+}
+
 // ---------------------------------------------------------------------------
 // Transcript-edit region (folded from the meerkat-session persistent.rs
 // `persist_transcript_fork` / `persist_transcript_rewrite` commit paths under
@@ -836,6 +869,26 @@ machine! {
             ResolveRuntimeCheckpointProjection { session_id: SessionId },
 
             // -----------------------------------------------------------
+            // Legacy-checkpoint recovery-migration region. Every document
+            // written before typed checkpoint stamps decodes as
+            // legacy-unverified and fails closed at each authority seam,
+            // with no released on-ramp into typed authority. The shell
+            // observes the mechanical carriers only — which copies exist,
+            // whether each is legacy, and the transcript prefix relation
+            // between them — and THIS machine owns whether the one-time
+            // recovery migration runs, which copy it adopts, or whether
+            // the divergence is refused as typed operator evidence.
+            // -----------------------------------------------------------
+            ResolveLegacyCheckpointMigration {
+                session_id: SessionId,
+                runtime_snapshot_present: bool,
+                runtime_snapshot_legacy: bool,
+                store_row_present: bool,
+                store_row_legacy: bool,
+                transcript_relation: Enum<LegacyCheckpointTranscriptRelation>,
+            },
+
+            // -----------------------------------------------------------
             // Runtime-snapshot read-source region. On load, the committed
             // runtime session snapshot normally leads the durable store head
             // (it commits at the run boundary). A torn shutdown can freeze it
@@ -1066,6 +1119,14 @@ machine! {
             // projection writer may be invoked for retained runtime bytes.
             RuntimeCheckpointProjectionResolved {
                 disposition: Enum<RuntimeCheckpointProjectionDisposition>,
+            },
+
+            // Legacy-checkpoint recovery-migration disposition. The shell
+            // mirrors this verdict exactly: it stamps the named copy via
+            // recovery migration and re-projects the other, or surfaces the
+            // fail-closed refusal; it never chooses a copy itself.
+            LegacyCheckpointMigrationResolved {
+                disposition: Enum<LegacyCheckpointMigrationDisposition>,
             },
 
             // Runtime-snapshot read-source verdict. The shell mirrors
@@ -1339,6 +1400,7 @@ machine! {
         disposition SessionStoreRecoverySourceResolved => local seam NoOwnerRealization,
         disposition RuntimeProjectionRollbackResolved => local seam NoOwnerRealization,
         disposition RuntimeCheckpointProjectionResolved => local seam NoOwnerRealization,
+        disposition LegacyCheckpointMigrationResolved => local seam NoOwnerRealization,
         disposition RuntimeSnapshotReadSourceResolved => local seam NoOwnerRealization,
         disposition SessionToolResultsApplied => local seam NoOwnerRealization,
         disposition TranscriptRewriteCommitted => local seam NoOwnerRealization,
@@ -3864,6 +3926,179 @@ machine! {
             to Ready
             emit RuntimeCheckpointProjectionResolved {
                 disposition: RuntimeCheckpointProjectionDisposition::IgnoreArchived
+            }
+        }
+
+        // ===============================================================
+        // Legacy-checkpoint recovery-migration region. Total over the legal
+        // observation shapes the shell can emit: the runtime snapshot copy
+        // is legacy (with the projection absent, legacy-related by prefix,
+        // or already typed), or the runtime snapshot is absent and the
+        // session-store row is the sole legacy copy. Content custody is
+        // lifecycle-independent: migration stamps the exact observed
+        // conversation and never alters the document's lifecycle terminal.
+        // ===============================================================
+
+        transition ResolveLegacyCheckpointMigrationSnapshotIdenticalProjection {
+            on input ResolveLegacyCheckpointMigration {
+                session_id,
+                runtime_snapshot_present,
+                runtime_snapshot_legacy,
+                store_row_present,
+                store_row_legacy,
+                transcript_relation
+            }
+            guard {
+                self.lifecycle_phase == Phase::Ready
+                && runtime_snapshot_present == true
+                && runtime_snapshot_legacy == true
+                && store_row_present == true
+                && store_row_legacy == true
+                && transcript_relation == LegacyCheckpointTranscriptRelation::Identical
+            }
+            update {}
+            to Ready
+            emit LegacyCheckpointMigrationResolved {
+                disposition: LegacyCheckpointMigrationDisposition::MigrateCanonicalSnapshot
+            }
+        }
+
+        transition ResolveLegacyCheckpointMigrationSnapshotAheadOfProjection {
+            on input ResolveLegacyCheckpointMigration {
+                session_id,
+                runtime_snapshot_present,
+                runtime_snapshot_legacy,
+                store_row_present,
+                store_row_legacy,
+                transcript_relation
+            }
+            guard {
+                self.lifecycle_phase == Phase::Ready
+                && runtime_snapshot_present == true
+                && runtime_snapshot_legacy == true
+                && store_row_present == true
+                && store_row_legacy == true
+                && transcript_relation == LegacyCheckpointTranscriptRelation::SnapshotExtendsProjection
+            }
+            update {}
+            to Ready
+            emit LegacyCheckpointMigrationResolved {
+                disposition: LegacyCheckpointMigrationDisposition::MigrateCanonicalSnapshot
+            }
+        }
+
+        transition ResolveLegacyCheckpointMigrationProjectionExtension {
+            on input ResolveLegacyCheckpointMigration {
+                session_id,
+                runtime_snapshot_present,
+                runtime_snapshot_legacy,
+                store_row_present,
+                store_row_legacy,
+                transcript_relation
+            }
+            guard {
+                self.lifecycle_phase == Phase::Ready
+                && runtime_snapshot_present == true
+                && runtime_snapshot_legacy == true
+                && store_row_present == true
+                && store_row_legacy == true
+                && transcript_relation == LegacyCheckpointTranscriptRelation::ProjectionExtendsSnapshot
+            }
+            update {}
+            to Ready
+            emit LegacyCheckpointMigrationResolved {
+                disposition: LegacyCheckpointMigrationDisposition::AdoptProjectionExtension
+            }
+        }
+
+        transition ResolveLegacyCheckpointMigrationDivergentCopies {
+            on input ResolveLegacyCheckpointMigration {
+                session_id,
+                runtime_snapshot_present,
+                runtime_snapshot_legacy,
+                store_row_present,
+                store_row_legacy,
+                transcript_relation
+            }
+            guard {
+                self.lifecycle_phase == Phase::Ready
+                && runtime_snapshot_present == true
+                && runtime_snapshot_legacy == true
+                && store_row_present == true
+                && store_row_legacy == true
+                && transcript_relation == LegacyCheckpointTranscriptRelation::Divergent
+            }
+            update {}
+            to Ready
+            emit LegacyCheckpointMigrationResolved {
+                disposition: LegacyCheckpointMigrationDisposition::RefuseDivergent
+            }
+        }
+
+        transition ResolveLegacyCheckpointMigrationSnapshotOnly {
+            on input ResolveLegacyCheckpointMigration {
+                session_id,
+                runtime_snapshot_present,
+                runtime_snapshot_legacy,
+                store_row_present,
+                store_row_legacy,
+                transcript_relation
+            }
+            guard {
+                self.lifecycle_phase == Phase::Ready
+                && runtime_snapshot_present == true
+                && runtime_snapshot_legacy == true
+                && store_row_present == false
+            }
+            update {}
+            to Ready
+            emit LegacyCheckpointMigrationResolved {
+                disposition: LegacyCheckpointMigrationDisposition::MigrateCanonicalSnapshot
+            }
+        }
+
+        transition ResolveLegacyCheckpointMigrationStoreRowOnly {
+            on input ResolveLegacyCheckpointMigration {
+                session_id,
+                runtime_snapshot_present,
+                runtime_snapshot_legacy,
+                store_row_present,
+                store_row_legacy,
+                transcript_relation
+            }
+            guard {
+                self.lifecycle_phase == Phase::Ready
+                && runtime_snapshot_present == false
+                && store_row_present == true
+                && store_row_legacy == true
+            }
+            update {}
+            to Ready
+            emit LegacyCheckpointMigrationResolved {
+                disposition: LegacyCheckpointMigrationDisposition::MigrateStoreProjection
+            }
+        }
+
+        transition ResolveLegacyCheckpointMigrationSnapshotLegacyProjectionTyped {
+            on input ResolveLegacyCheckpointMigration {
+                session_id,
+                runtime_snapshot_present,
+                runtime_snapshot_legacy,
+                store_row_present,
+                store_row_legacy,
+                transcript_relation
+            }
+            guard {
+                self.lifecycle_phase == Phase::Ready
+                && runtime_snapshot_present == true
+                && runtime_snapshot_legacy == true
+                && store_row_present == true
+                && store_row_legacy == false
+            }
+            update {}
+            to Ready
+            emit LegacyCheckpointMigrationResolved {
+                disposition: LegacyCheckpointMigrationDisposition::RefuseDivergent
             }
         }
 

--- a/meerkat-session/src/persistent.rs
+++ b/meerkat-session/src/persistent.rs
@@ -6936,13 +6936,23 @@ impl<B: SessionAgentBuilder + 'static> PersistentSessionService<B> {
                 )))
             })?;
 
-        let (source, write_runtime_snapshot) = match disposition {
+        let (source, write_runtime_snapshot, disposition_label) = match disposition {
             LegacyCheckpointMigrationDisposition::MigrateCanonicalSnapshot => {
-                (runtime_snapshot, true)
+                (runtime_snapshot, true, "migrate_canonical_snapshot")
             }
-            LegacyCheckpointMigrationDisposition::AdoptProjectionExtension => (store_row, true),
-            LegacyCheckpointMigrationDisposition::MigrateStoreProjection => (store_row, false),
+            LegacyCheckpointMigrationDisposition::AdoptProjectionExtension => {
+                (store_row, true, "adopt_projection_extension")
+            }
+            LegacyCheckpointMigrationDisposition::MigrateStoreProjection => {
+                (store_row, false, "migrate_store_projection")
+            }
             LegacyCheckpointMigrationDisposition::RefuseDivergent => {
+                tracing::warn!(
+                    session_id = %id,
+                    role,
+                    "legacy checkpoint copies are divergent; one-time recovery migration \
+                     refused fail-closed and requires the explicit operator migration tool"
+                );
                 return Err(SessionError::Agent(AgentError::InternalError(format!(
                     "cannot prepare {role} for session {id}: legacy checkpoint copies are \
                      divergent (the committed runtime snapshot and the session-store \
@@ -6963,14 +6973,21 @@ impl<B: SessionAgentBuilder + 'static> PersistentSessionService<B> {
                 "failed to serialize legacy migration source for session {id}: {error}"
             )))
         })?;
-        let stamp = meerkat_core::SessionCheckpointStamp::recovery_migration(
-            &source,
+        // INITIAL cursors match the shipped v0.6.34 migrator and are correct
+        // for lineages that never minted authority. Fleets whose continuity
+        // rows record a nonzero generation floor adopt through the exported
+        // `adopt_legacy_session` helper with the observed cursor instead.
+        let adopted = meerkat_core::adopt_legacy_session(
             &source_blob,
             meerkat_core::SessionGeneration::INITIAL,
             meerkat_core::SessionCheckpointRevision::INITIAL,
         )
         .map_err(|error| checkpoint_prepare_error(id, role, error))?;
-        let prepared = PreparedCheckpointDocument::install(source, stamp, role)?;
+        let prepared = PreparedCheckpointDocument {
+            session: adopted.session,
+            stamp: adopted.stamp,
+            serialized: adopted.serialized,
+        };
 
         if write_runtime_snapshot {
             self.runtime_store
@@ -7006,6 +7023,16 @@ impl<B: SessionAgentBuilder + 'static> PersistentSessionService<B> {
                 .await
                 .map_err(|error| SessionError::Store(Box::new(error)))?;
         }
+        // Migration cost lands inside ordinary resume/certification windows;
+        // operators expect it to be observable, not inferred from latency.
+        tracing::info!(
+            session_id = %id,
+            role,
+            disposition = disposition_label,
+            source_bytes = source_blob.len(),
+            wrote_runtime_snapshot = write_runtime_snapshot,
+            "one-time legacy checkpoint recovery migration stamped a pre-typed session document"
+        );
         VerifiedCheckpointAuthority::from_session_with_serialized(
             prepared.session,
             prepared.serialized,

--- a/meerkat-session/src/persistent.rs
+++ b/meerkat-session/src/persistent.rs
@@ -59,6 +59,7 @@ use meerkat_core::service::{
     StageToolResultsResult, StartTurnRequest,
 };
 use meerkat_core::session_document::{
+    LegacyCheckpointMigrationDisposition, LegacyCheckpointTranscriptRelation,
     LiveSessionAuthorityKind, LiveSessionAuthorityReason, RuntimeCheckpointProjectionDisposition,
     SessionArchiveDisposition, SessionArchiveRuntimeObservation, SessionDocumentEffect,
     SessionDocumentKey, SessionDocumentMachineAuthority, TranscriptEditKind,
@@ -970,6 +971,56 @@ async fn load_verified_runtime_checkpoint_authority(
         return Ok(None);
     };
     VerifiedCheckpointAuthority::from_serialized(serialized, session_id, role).map(Some)
+}
+
+/// The committed runtime snapshot classified for authority resolution: absent,
+/// fully verified, or a pre-typed legacy document eligible for the one-time
+/// recovery migration. Malformed evidence and intra-turn rows still error.
+enum CommittedCheckpointCopy {
+    Absent,
+    Verified(VerifiedCheckpointAuthority),
+    Legacy(Session),
+}
+
+async fn load_runtime_checkpoint_copy(
+    runtime_store: &dyn RuntimeStore,
+    session_id: &SessionId,
+    role: &str,
+) -> Result<CommittedCheckpointCopy, SessionError> {
+    let Some(serialized) = runtime_store
+        .load_session_snapshot(&LogicalRuntimeId::for_session(session_id))
+        .await
+        .map_err(|error| {
+            SessionError::Agent(AgentError::InternalError(format!(
+                "failed to load {role} for session {session_id}: {error}"
+            )))
+        })?
+    else {
+        return Ok(CommittedCheckpointCopy::Absent);
+    };
+    let session: Session = serde_json::from_slice(&serialized).map_err(|error| {
+        SessionError::Store(Box::new(SessionStoreError::Serialization(format!(
+            "failed to decode {role} for session {session_id}: {error}"
+        ))))
+    })?;
+    if session.id() != session_id {
+        return Err(session_checkpoint_read_error(
+            meerkat_core::SessionCheckpointError::SessionIdMismatch {
+                expected: session_id.clone(),
+                actual: session.id().clone(),
+            },
+        ));
+    }
+    if matches!(
+        session
+            .try_checkpoint_state()
+            .map_err(session_checkpoint_read_error)?,
+        meerkat_core::SessionCheckpointState::LegacyUnverified { .. }
+    ) {
+        return Ok(CommittedCheckpointCopy::Legacy(session));
+    }
+    VerifiedCheckpointAuthority::from_session_with_serialized(session, serialized, session_id, role)
+        .map(CommittedCheckpointCopy::Verified)
 }
 
 fn session_materialized_at_transcript_revision(
@@ -3209,6 +3260,32 @@ impl<B: SessionAgentBuilder + 'static> PersistentSessionService<B> {
         } else {
             match Self::load_runtime_session_snapshot_for_session(&self.runtime_store, id).await? {
                 Some(snapshot) => {
+                    // A pre-typed legacy snapshot cannot enter read-source
+                    // arbitration (every verified-stamp read below fails
+                    // closed on it). Run the machine-owned one-time recovery
+                    // migration first; the migrated document is the
+                    // committed authority for this read and both durable
+                    // copies now carry the typed stamp.
+                    let snapshot = if matches!(
+                        snapshot
+                            .try_checkpoint_state()
+                            .map_err(session_checkpoint_read_error)?,
+                        meerkat_core::SessionCheckpointState::LegacyUnverified { .. }
+                    ) {
+                        self.load_committed_checkpoint_authority(
+                            id,
+                            "authoritative session read",
+                        )
+                        .await?
+                        .ok_or_else(|| {
+                            SessionError::Agent(AgentError::InternalError(format!(
+                                "legacy checkpoint migration returned no authority for session {id}"
+                            )))
+                        })?
+                        .session
+                    } else {
+                        snapshot
+                    };
                     // The committed runtime snapshot normally leads the
                     // durable store head (it commits at the run boundary).
                     // A torn shutdown can freeze it as a stale strict
@@ -3237,6 +3314,33 @@ impl<B: SessionAgentBuilder + 'static> PersistentSessionService<B> {
                         .load(id)
                         .await
                         .map_err(|e| SessionError::Store(Box::new(e)))?;
+                    // A store-only pre-typed row (fleets that predate runtime
+                    // checkpointing entirely) migrates through the same
+                    // machine-owned seam before recovery-source eligibility.
+                    let store_projection = match store_projection {
+                        Some(row)
+                            if matches!(
+                                row.try_checkpoint_state()
+                                    .map_err(session_checkpoint_read_error)?,
+                                meerkat_core::SessionCheckpointState::LegacyUnverified { .. }
+                            ) =>
+                        {
+                            Some(
+                                self.load_committed_checkpoint_authority(
+                                    id,
+                                    "authoritative session read",
+                                )
+                                .await?
+                                .ok_or_else(|| {
+                                    SessionError::Agent(AgentError::InternalError(format!(
+                                        "legacy checkpoint migration returned no authority for session {id}"
+                                    )))
+                                })?
+                                .session,
+                            )
+                        }
+                        other => other,
+                    };
                     // Recovery-source eligibility (whether a store-only
                     // projection may stand in as authoritative when the
                     // runtime snapshot is absent) is owned by the canonical
@@ -6742,27 +6846,227 @@ impl<B: SessionAgentBuilder + 'static> PersistentSessionService<B> {
         Ok(())
     }
 
+    /// One-time, level-triggered recovery migration of a pre-typed session
+    /// document into typed checkpoint authority.
+    ///
+    /// Every document written before typed checkpoint stamps decodes as
+    /// legacy-unverified and fails closed at each authority seam; nothing in
+    /// the released upgrade path stamps existing fleets. The shell here
+    /// observes only mechanical carriers — which durable copies exist,
+    /// whether each is legacy, and the transcript prefix relation between
+    /// them — and mirrors the canonical `SessionDocumentMachine` migration
+    /// disposition exactly. It never chooses a copy itself.
+    ///
+    /// Cursor seeding matches the shipped v0.6.34 migrator: the migration
+    /// root retains `SessionGeneration::INITIAL` and
+    /// `SessionCheckpointRevision::INITIAL`. Identity matching compares
+    /// session/lineage/generation only, and lease/fence cursors are
+    /// ownership, never checkpoint content.
+    ///
+    /// Write order is runtime snapshot first, projection second: a crash
+    /// between the two leaves a verified runtime authority over a legacy
+    /// row, which every reader already tolerates and the next projection
+    /// write converges.
+    async fn migrate_legacy_checkpoint_authority(
+        &self,
+        id: &SessionId,
+        runtime_snapshot: Option<Session>,
+        store_row: Option<Session>,
+        role: &str,
+    ) -> Result<VerifiedCheckpointAuthority, SessionError> {
+        let runtime_snapshot_present = runtime_snapshot.is_some();
+        let runtime_snapshot_legacy = runtime_snapshot.is_some();
+        let store_row_present = store_row.is_some();
+        let store_row_legacy = match store_row.as_ref() {
+            Some(row) => matches!(
+                row.try_checkpoint_state()
+                    .map_err(session_checkpoint_read_error)?,
+                meerkat_core::SessionCheckpointState::LegacyUnverified { .. }
+            ),
+            None => false,
+        };
+        let transcript_relation = match (runtime_snapshot.as_ref(), store_row.as_ref()) {
+            (Some(snapshot), Some(row)) if store_row_legacy => {
+                match meerkat_core::legacy_session_transcript_relation(snapshot, row)
+                    .map_err(session_checkpoint_read_error)?
+                {
+                    meerkat_core::LegacySessionTranscriptRelation::Identical => {
+                        LegacyCheckpointTranscriptRelation::Identical
+                    }
+                    meerkat_core::LegacySessionTranscriptRelation::ProjectionExtendsSnapshot => {
+                        LegacyCheckpointTranscriptRelation::ProjectionExtendsSnapshot
+                    }
+                    meerkat_core::LegacySessionTranscriptRelation::SnapshotExtendsProjection => {
+                        LegacyCheckpointTranscriptRelation::SnapshotExtendsProjection
+                    }
+                    meerkat_core::LegacySessionTranscriptRelation::Divergent => {
+                        LegacyCheckpointTranscriptRelation::Divergent
+                    }
+                }
+            }
+            _ => LegacyCheckpointTranscriptRelation::NotComparable,
+        };
+
+        let mut authority = SessionDocumentMachineAuthority::new();
+        let effects = authority
+            .resolve_legacy_checkpoint_migration(
+                SessionDocumentKey::new(id.to_string()),
+                runtime_snapshot_present,
+                runtime_snapshot_legacy,
+                store_row_present,
+                store_row_legacy,
+                transcript_relation,
+            )
+            .map_err(|error| {
+                SessionError::Agent(AgentError::InternalError(format!(
+                    "generated session document authority rejected legacy checkpoint migration resolution for session {id}: {error}"
+                )))
+            })?;
+        let disposition = effects
+            .iter()
+            .find_map(|effect| match effect {
+                SessionDocumentEffect::LegacyCheckpointMigrationResolved { disposition } => {
+                    Some(*disposition)
+                }
+                _ => None,
+            })
+            .ok_or_else(|| {
+                SessionError::Agent(AgentError::InternalError(format!(
+                    "generated session document authority returned no legacy checkpoint migration disposition for session {id}"
+                )))
+            })?;
+
+        let (source, write_runtime_snapshot) = match disposition {
+            LegacyCheckpointMigrationDisposition::MigrateCanonicalSnapshot => {
+                (runtime_snapshot, true)
+            }
+            LegacyCheckpointMigrationDisposition::AdoptProjectionExtension => (store_row, true),
+            LegacyCheckpointMigrationDisposition::MigrateStoreProjection => (store_row, false),
+            LegacyCheckpointMigrationDisposition::RefuseDivergent => {
+                return Err(SessionError::Agent(AgentError::InternalError(format!(
+                    "cannot prepare {role} for session {id}: legacy checkpoint copies are \
+                     divergent (the committed runtime snapshot and the session-store \
+                     projection are not related by transcript prefix extension); one-time \
+                     recovery migration is refused fail-closed and requires the explicit \
+                     operator migration tool"
+                ))));
+            }
+        };
+        let source = source.ok_or_else(|| {
+            SessionError::Agent(AgentError::InternalError(format!(
+                "generated session document authority named an absent legacy copy while migrating session {id}"
+            )))
+        })?;
+
+        let source_blob = serde_json::to_vec(&source).map_err(|error| {
+            SessionError::Agent(AgentError::InternalError(format!(
+                "failed to serialize legacy migration source for session {id}: {error}"
+            )))
+        })?;
+        let stamp = meerkat_core::SessionCheckpointStamp::recovery_migration(
+            &source,
+            &source_blob,
+            meerkat_core::SessionGeneration::INITIAL,
+            meerkat_core::SessionCheckpointRevision::INITIAL,
+        )
+        .map_err(|error| checkpoint_prepare_error(id, role, error))?;
+        let prepared = PreparedCheckpointDocument::install(source, stamp, role)?;
+
+        if write_runtime_snapshot {
+            self.runtime_store
+                .commit_session_snapshot(
+                    &Self::runtime_id_for_session(id),
+                    SessionDelta {
+                        session_snapshot: prepared.serialized.clone(),
+                    },
+                )
+                .await
+                .map_err(|error| {
+                    SessionError::Agent(AgentError::InternalError(format!(
+                        "legacy migration runtime snapshot persistence failed for session {id}: {error}"
+                    )))
+                })?;
+        }
+        if let Some(incremental) = self.incremental.clone() {
+            save_session_projection_incremental(
+                incremental.as_ref(),
+                self.blob_store.as_ref(),
+                self.event_store.as_ref(),
+                self.projector.as_ref(),
+                &prepared.session,
+                &[],
+            )
+            .await?;
+        } else {
+            // The pre-typed row may legitimately shrink (a stale-prefix
+            // projection rebuilt from the canonical snapshot), so this is the
+            // authoritative-projection save, not the append-guarded `save`.
+            self.store
+                .save_authoritative_projection(&prepared.session)
+                .await
+                .map_err(|error| SessionError::Store(Box::new(error)))?;
+        }
+        VerifiedCheckpointAuthority::from_session_with_serialized(
+            prepared.session,
+            prepared.serialized,
+            id,
+            role,
+        )
+    }
+
     /// Resolve the latest verified committed document authority without ever
     /// treating the legacy Boolean or an intra-turn projection as authority.
     /// RuntimeStore wins unless SessionStore carries a verified committed
     /// direct successor (the projection-only lifecycle commit case).
+    ///
+    /// A legacy-unverified copy on either side no longer fails closed here:
+    /// the machine-owned one-time recovery migration
+    /// (`migrate_legacy_checkpoint_authority`) stamps the observed
+    /// conversation and this resolver returns the migrated authority.
     async fn load_committed_checkpoint_authority(
         &self,
         id: &SessionId,
         role: &str,
     ) -> Result<Option<VerifiedCheckpointAuthority>, SessionError> {
-        let runtime = load_verified_runtime_checkpoint_authority(
+        let runtime_copy = load_runtime_checkpoint_copy(
             self.runtime_store.as_ref(),
             id,
             "committed runtime session snapshot",
         )
         .await?;
-        let Some(store_session) = self
+        let store_session = self
             .store
             .load(id)
             .await
-            .map_err(|error| SessionError::Store(Box::new(error)))?
-        else {
+            .map_err(|error| SessionError::Store(Box::new(error)))?;
+        let store_row_is_legacy = match store_session.as_ref() {
+            Some(row) => matches!(
+                row.try_checkpoint_state().map_err(|error| {
+                    SessionError::Agent(AgentError::InternalError(format!(
+                        "session-store checkpoint evidence while preparing {role} for session {id} is invalid: {error}"
+                    )))
+                })?,
+                meerkat_core::SessionCheckpointState::LegacyUnverified { .. }
+            ),
+            None => false,
+        };
+        let runtime = match runtime_copy {
+            CommittedCheckpointCopy::Legacy(snapshot) => {
+                return self
+                    .migrate_legacy_checkpoint_authority(id, Some(snapshot), store_session, role)
+                    .await
+                    .map(Some);
+            }
+            CommittedCheckpointCopy::Absent if store_row_is_legacy => {
+                return self
+                    .migrate_legacy_checkpoint_authority(id, None, store_session, role)
+                    .await
+                    .map(Some);
+            }
+            CommittedCheckpointCopy::Absent => None,
+            CommittedCheckpointCopy::Verified(authority) => Some(authority),
+        };
+        let Some(store_session) = store_session else {
             return Ok(runtime);
         };
         let store_stamp = match store_session.try_checkpoint_state().map_err(|error| {
@@ -30141,5 +30445,328 @@ mod tests {
             .await
             .expect("revision-body read must be served from load_messages");
         assert_eq!(page.messages.len(), 2, "parent body served out-of-line");
+    }
+
+    // ------------------------------------------------------------------
+    // Legacy-checkpoint recovery migration (the released fleets written
+    // before typed checkpoint stamps). Every shape here reproduces a real
+    // pre-0.8.2 store layout and must heal level-triggered on first touch.
+    // ------------------------------------------------------------------
+
+    fn legacy_migration_service(
+        store: &Arc<dyn SessionStore>,
+        runtime_store: &Arc<InMemoryRuntimeStore>,
+    ) -> PersistentSessionService<DummyBuilder> {
+        PersistentSessionService::new(
+            DummyBuilder,
+            4,
+            Arc::clone(store),
+            Arc::clone(runtime_store) as Arc<dyn RuntimeStore>,
+            memory_blob_store(),
+        )
+    }
+
+    fn legacy_session_with_texts(texts: &[&str]) -> Session {
+        let mut session = Session::new();
+        for text in texts {
+            session.push(Message::User(UserMessage::text((*text).to_string())));
+        }
+        session
+    }
+
+    fn with_transcript_truncated(session: &Session, keep: usize) -> Session {
+        let mut document = serde_json::to_value(session).expect("session should serialize");
+        document
+            .get_mut("messages")
+            .and_then(serde_json::Value::as_array_mut)
+            .expect("session messages should be an array")
+            .truncate(keep);
+        serde_json::from_value(document).expect("truncated session should deserialize")
+    }
+
+    async fn seed_legacy_runtime_snapshot(runtime_store: &InMemoryRuntimeStore, session: &Session) {
+        runtime_store
+            .commit_session_snapshot(
+                &PersistentSessionService::<DummyBuilder>::runtime_id_for_session(session.id()),
+                SessionDelta {
+                    session_snapshot: serde_json::to_vec(session)
+                        .expect("legacy session should serialize"),
+                },
+            )
+            .await
+            .expect("legacy runtime snapshot should commit");
+    }
+
+    async fn verified_runtime_snapshot(
+        runtime_store: &InMemoryRuntimeStore,
+        id: &SessionId,
+    ) -> meerkat_core::SessionCheckpointStamp {
+        let bytes = runtime_store
+            .load_session_snapshot(
+                &PersistentSessionService::<DummyBuilder>::runtime_id_for_session(id),
+            )
+            .await
+            .expect("runtime snapshot load should succeed")
+            .expect("runtime snapshot should exist");
+        let snapshot: Session =
+            serde_json::from_slice(&bytes).expect("runtime snapshot should decode");
+        match snapshot
+            .try_checkpoint_state()
+            .expect("runtime snapshot checkpoint state should decode")
+        {
+            meerkat_core::SessionCheckpointState::Verified(stamp) => stamp,
+            meerkat_core::SessionCheckpointState::LegacyUnverified { .. } => {
+                panic!("runtime snapshot should be stamped after migration")
+            }
+        }
+    }
+
+    async fn verified_store_row(
+        store: &Arc<dyn SessionStore>,
+        id: &SessionId,
+    ) -> meerkat_core::SessionCheckpointStamp {
+        let row = store
+            .load(id)
+            .await
+            .expect("store row load should succeed")
+            .expect("store row should exist");
+        match row
+            .try_checkpoint_state()
+            .expect("store row checkpoint state should decode")
+        {
+            meerkat_core::SessionCheckpointState::Verified(stamp) => stamp,
+            meerkat_core::SessionCheckpointState::LegacyUnverified { .. } => {
+                panic!("store row should be stamped after migration")
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn legacy_runtime_snapshot_with_identical_projection_auto_migrates() {
+        let store: Arc<dyn SessionStore> = Arc::new(MemoryStore::new());
+        let runtime_store = Arc::new(InMemoryRuntimeStore::new());
+        let service = legacy_migration_service(&store, &runtime_store);
+
+        let legacy = with_legacy_checkpoint_marker(
+            &legacy_session_with_texts(&["turn one", "turn two"]),
+            true,
+        );
+        let id = legacy.id().clone();
+        seed_legacy_runtime_snapshot(&runtime_store, &legacy).await;
+        store.save(&legacy).await.expect("legacy row should save");
+
+        let authority = service
+            .load_committed_checkpoint_authority(&id, "legacy migration test")
+            .await
+            .expect("legacy authority load should migrate, not refuse")
+            .expect("migrated authority should exist");
+        assert_eq!(
+            authority.stamp.provenance(),
+            meerkat_core::SessionCheckpointProvenance::RecoveryMigration
+        );
+        assert_eq!(
+            authority.stamp.generation(),
+            meerkat_core::SessionGeneration::INITIAL
+        );
+        assert_eq!(authority.session.messages().len(), 2);
+
+        let snapshot_stamp = verified_runtime_snapshot(&runtime_store, &id).await;
+        assert_eq!(snapshot_stamp, authority.stamp);
+        let row_stamp = verified_store_row(&store, &id).await;
+        assert_eq!(row_stamp, authority.stamp);
+
+        // Level-triggered idempotency: the second load sees Verified copies
+        // and returns the exact same stamp without re-migrating.
+        let again = service
+            .load_committed_checkpoint_authority(&id, "legacy migration test")
+            .await
+            .expect("verified authority load should succeed")
+            .expect("verified authority should exist");
+        assert_eq!(again.stamp, authority.stamp);
+    }
+
+    #[tokio::test]
+    async fn legacy_projection_extension_is_adopted_without_losing_the_tail() {
+        let store: Arc<dyn SessionStore> = Arc::new(MemoryStore::new());
+        let runtime_store = Arc::new(InMemoryRuntimeStore::new());
+        let service = legacy_migration_service(&store, &runtime_store);
+
+        let snapshot = legacy_session_with_texts(&["turn one", "turn two"]);
+        let id = snapshot.id().clone();
+        let mut projection = snapshot.clone();
+        projection.push(Message::User(UserMessage::text(
+            "projection-only trailing turn".to_string(),
+        )));
+        seed_legacy_runtime_snapshot(&runtime_store, &snapshot).await;
+        store
+            .save(&projection)
+            .await
+            .expect("extended projection should save");
+
+        let authority = service
+            .load_committed_checkpoint_authority(&id, "legacy migration test")
+            .await
+            .expect("extension migration should succeed")
+            .expect("migrated authority should exist");
+        assert_eq!(
+            authority.session.messages().len(),
+            3,
+            "the projection-only trailing turn must survive migration"
+        );
+        assert_eq!(
+            authority.stamp.provenance(),
+            meerkat_core::SessionCheckpointProvenance::RecoveryMigration
+        );
+
+        // Both durable copies converge on the adopted extension.
+        let snapshot_stamp = verified_runtime_snapshot(&runtime_store, &id).await;
+        assert_eq!(snapshot_stamp, authority.stamp);
+        let row_stamp = verified_store_row(&store, &id).await;
+        assert_eq!(row_stamp, authority.stamp);
+    }
+
+    #[tokio::test]
+    async fn legacy_stale_projection_is_rebuilt_from_canonical_snapshot() {
+        let store: Arc<dyn SessionStore> = Arc::new(MemoryStore::new());
+        let runtime_store = Arc::new(InMemoryRuntimeStore::new());
+        let service = legacy_migration_service(&store, &runtime_store);
+
+        let snapshot = legacy_session_with_texts(&["turn one", "turn two"]);
+        let id = snapshot.id().clone();
+        let stale_projection = with_transcript_truncated(&snapshot, 1);
+        seed_legacy_runtime_snapshot(&runtime_store, &snapshot).await;
+        store
+            .save(&stale_projection)
+            .await
+            .expect("stale projection should save");
+
+        let authority = service
+            .load_committed_checkpoint_authority(&id, "legacy migration test")
+            .await
+            .expect("stale-projection migration should succeed")
+            .expect("migrated authority should exist");
+        assert_eq!(
+            authority.session.messages().len(),
+            2,
+            "canonical snapshot must win over its own stale prefix"
+        );
+        let row_stamp = verified_store_row(&store, &id).await;
+        assert_eq!(row_stamp, authority.stamp);
+        let row = store
+            .load(&id)
+            .await
+            .expect("store row load should succeed")
+            .expect("store row should exist");
+        assert_eq!(row.messages().len(), 2, "projection rebuilt from canonical");
+    }
+
+    #[tokio::test]
+    async fn store_only_legacy_row_auto_migrates_without_runtime_snapshot() {
+        // The 0.7.9 fleet shape: no runtime-store snapshot exists at all and
+        // the session-store row is the sole durable copy.
+        let store: Arc<dyn SessionStore> = Arc::new(MemoryStore::new());
+        let runtime_store = Arc::new(InMemoryRuntimeStore::new());
+        let service = legacy_migration_service(&store, &runtime_store);
+
+        let legacy =
+            with_legacy_checkpoint_marker(&legacy_session_with_texts(&["only durable copy"]), true);
+        let id = legacy.id().clone();
+        store.save(&legacy).await.expect("legacy row should save");
+
+        let authority = service
+            .load_committed_checkpoint_authority(&id, "legacy migration test")
+            .await
+            .expect("store-only migration should succeed")
+            .expect("migrated authority should exist");
+        assert_eq!(
+            authority.stamp.provenance(),
+            meerkat_core::SessionCheckpointProvenance::RecoveryMigration
+        );
+        let row_stamp = verified_store_row(&store, &id).await;
+        assert_eq!(row_stamp, authority.stamp);
+    }
+
+    #[tokio::test]
+    async fn divergent_legacy_copies_refuse_migration_and_mutate_nothing() {
+        let store: Arc<dyn SessionStore> = Arc::new(MemoryStore::new());
+        let runtime_store = Arc::new(InMemoryRuntimeStore::new());
+        let service = legacy_migration_service(&store, &runtime_store);
+
+        let snapshot = legacy_session_with_texts(&["turn one", "snapshot tail"]);
+        let id = snapshot.id().clone();
+        let mut divergent = with_transcript_truncated(&snapshot, 1);
+        divergent.push(Message::User(UserMessage::text(
+            "conflicting projection tail".to_string(),
+        )));
+        seed_legacy_runtime_snapshot(&runtime_store, &snapshot).await;
+        store
+            .save(&divergent)
+            .await
+            .expect("divergent projection should save");
+
+        let error = match service
+            .load_committed_checkpoint_authority(&id, "legacy migration test")
+            .await
+        {
+            Err(error) => error,
+            Ok(_) => panic!("divergent legacy copies must refuse migration"),
+        };
+        assert!(
+            error.to_string().contains("divergent"),
+            "refusal must name the divergence: {error}"
+        );
+
+        // Fail-closed: neither durable copy was mutated.
+        let bytes = runtime_store
+            .load_session_snapshot(
+                &PersistentSessionService::<DummyBuilder>::runtime_id_for_session(&id),
+            )
+            .await
+            .expect("runtime snapshot load should succeed")
+            .expect("runtime snapshot should exist");
+        let untouched: Session =
+            serde_json::from_slice(&bytes).expect("runtime snapshot should decode");
+        assert!(matches!(
+            untouched
+                .try_checkpoint_state()
+                .expect("checkpoint state should decode"),
+            meerkat_core::SessionCheckpointState::LegacyUnverified { .. }
+        ));
+        let row = store
+            .load(&id)
+            .await
+            .expect("store row load should succeed")
+            .expect("store row should exist");
+        assert!(matches!(
+            row.try_checkpoint_state()
+                .expect("checkpoint state should decode"),
+            meerkat_core::SessionCheckpointState::LegacyUnverified { .. }
+        ));
+    }
+
+    #[tokio::test]
+    async fn legacy_runtime_snapshot_heals_ordinary_authoritative_resume_read() {
+        // The production brick: an upgraded binary resuming a pre-typed
+        // session through the ordinary read path must migrate, not refuse.
+        let store: Arc<dyn SessionStore> = Arc::new(MemoryStore::new());
+        let runtime_store = Arc::new(InMemoryRuntimeStore::new());
+        let service = legacy_migration_service(&store, &runtime_store);
+
+        let legacy = legacy_session_with_texts(&["turn one", "turn two"]);
+        let id = legacy.id().clone();
+        seed_legacy_runtime_snapshot(&runtime_store, &legacy).await;
+        store.save(&legacy).await.expect("legacy row should save");
+
+        let session = service
+            .load_authoritative_session(&id)
+            .await
+            .expect("authoritative resume read should migrate legacy copies")
+            .expect("session should exist");
+        assert_eq!(session.messages().len(), 2);
+        let snapshot_stamp = verified_runtime_snapshot(&runtime_store, &id).await;
+        assert_eq!(
+            snapshot_stamp.provenance(),
+            meerkat_core::SessionCheckpointProvenance::RecoveryMigration
+        );
     }
 }

--- a/specs/machines/session_document/ci.cfg
+++ b/specs/machines/session_document/ci.cfg
@@ -1,6 +1,8 @@
 SPECIFICATION Spec
 CONSTANTS
   BooleanValues = {TRUE, FALSE}
+  LegacyCheckpointMigrationDispositionValues = {"RefuseDivergent", "MigrateCanonicalSnapshot", "AdoptProjectionExtension", "MigrateStoreProjection"}
+  LegacyCheckpointTranscriptRelationValues = {"Divergent", "Identical", "ProjectionExtendsSnapshot", "SnapshotExtendsProjection", "NotComparable"}
   LiveSessionAuthorityKindValues = {"LiveAuthoritative", "DurableAuthoritative"}
   LiveSessionAuthorityReasonValues = {"StoredArchived", "LiveUncommittedTranscript", "RuntimeSystemContextDiverged", "StoredTranscriptRevisionDiverged"}
   NatValues = {1}

--- a/specs/machines/session_document/contract.md
+++ b/specs/machines/session_document/contract.md
@@ -50,6 +50,7 @@ _Generated from the Rust machine catalog. Do not edit by hand._
 - `RecoverSessionFromStore`(session_id: SessionId, has_metadata: Bool, has_build_state: Bool, runtime_projection_quarantined: Bool)
 - `ResolveRuntimeProjectionRollback`(session_id: SessionId, row_continues_authority: Bool, row_is_runtime_checkpoint: Bool)
 - `ResolveRuntimeCheckpointProjection`(session_id: SessionId)
+- `ResolveLegacyCheckpointMigration`(session_id: SessionId, runtime_snapshot_present: Bool, runtime_snapshot_legacy: Bool, store_row_present: Bool, store_row_legacy: Bool, transcript_relation: LegacyCheckpointTranscriptRelation)
 - `ResolveRuntimeSnapshotReadSource`(session_id: SessionId, store_head_extends_snapshot: Bool, store_head_is_runtime_checkpoint: Bool, session_is_live: Bool)
 - `ApplyPendingToolResults`(session_id: SessionId, result_count: u64)
 - `TranscriptEdit`(session_id: SessionId, fork_or_rewrite_directive: TranscriptEditKind)
@@ -90,6 +91,7 @@ _Generated from the Rust machine catalog. Do not edit by hand._
 - `SessionStoreRecoverySourceResolved`(recoverable: Bool)
 - `RuntimeProjectionRollbackResolved`(disposition: RuntimeProjectionRollbackDisposition)
 - `RuntimeCheckpointProjectionResolved`(disposition: RuntimeCheckpointProjectionDisposition)
+- `LegacyCheckpointMigrationResolved`(disposition: LegacyCheckpointMigrationDisposition)
 - `RuntimeSnapshotReadSourceResolved`(read_from_store_head: Bool)
 - `SessionToolResultsApplied`(session_id: SessionId, applied_count: u64)
 - `TranscriptRewriteCommitted`(kind: TranscriptEditKind, success: Bool)
@@ -925,6 +927,62 @@ _Generated from the Rust machine catalog. Do not edit by hand._
 - Guards:
   - ``
 - Emits: `RuntimeCheckpointProjectionResolved`
+- To: `Ready`
+
+### `ResolveLegacyCheckpointMigrationSnapshotIdenticalProjection`
+- From: `Ready`
+- On: `ResolveLegacyCheckpointMigration`(session_id, runtime_snapshot_present, runtime_snapshot_legacy, store_row_present, store_row_legacy, transcript_relation)
+- Guards:
+  - ``
+- Emits: `LegacyCheckpointMigrationResolved`
+- To: `Ready`
+
+### `ResolveLegacyCheckpointMigrationSnapshotAheadOfProjection`
+- From: `Ready`
+- On: `ResolveLegacyCheckpointMigration`(session_id, runtime_snapshot_present, runtime_snapshot_legacy, store_row_present, store_row_legacy, transcript_relation)
+- Guards:
+  - ``
+- Emits: `LegacyCheckpointMigrationResolved`
+- To: `Ready`
+
+### `ResolveLegacyCheckpointMigrationProjectionExtension`
+- From: `Ready`
+- On: `ResolveLegacyCheckpointMigration`(session_id, runtime_snapshot_present, runtime_snapshot_legacy, store_row_present, store_row_legacy, transcript_relation)
+- Guards:
+  - ``
+- Emits: `LegacyCheckpointMigrationResolved`
+- To: `Ready`
+
+### `ResolveLegacyCheckpointMigrationDivergentCopies`
+- From: `Ready`
+- On: `ResolveLegacyCheckpointMigration`(session_id, runtime_snapshot_present, runtime_snapshot_legacy, store_row_present, store_row_legacy, transcript_relation)
+- Guards:
+  - ``
+- Emits: `LegacyCheckpointMigrationResolved`
+- To: `Ready`
+
+### `ResolveLegacyCheckpointMigrationSnapshotOnly`
+- From: `Ready`
+- On: `ResolveLegacyCheckpointMigration`(session_id, runtime_snapshot_present, runtime_snapshot_legacy, store_row_present, store_row_legacy, transcript_relation)
+- Guards:
+  - ``
+- Emits: `LegacyCheckpointMigrationResolved`
+- To: `Ready`
+
+### `ResolveLegacyCheckpointMigrationStoreRowOnly`
+- From: `Ready`
+- On: `ResolveLegacyCheckpointMigration`(session_id, runtime_snapshot_present, runtime_snapshot_legacy, store_row_present, store_row_legacy, transcript_relation)
+- Guards:
+  - ``
+- Emits: `LegacyCheckpointMigrationResolved`
+- To: `Ready`
+
+### `ResolveLegacyCheckpointMigrationSnapshotLegacyProjectionTyped`
+- From: `Ready`
+- On: `ResolveLegacyCheckpointMigration`(session_id, runtime_snapshot_present, runtime_snapshot_legacy, store_row_present, store_row_legacy, transcript_relation)
+- Guards:
+  - ``
+- Emits: `LegacyCheckpointMigrationResolved`
 - To: `Ready`
 
 ### `ApplyPendingToolResults`

--- a/specs/machines/session_document/deep.cfg
+++ b/specs/machines/session_document/deep.cfg
@@ -1,6 +1,8 @@
 SPECIFICATION Spec
 CONSTANTS
   BooleanValues = {TRUE, FALSE}
+  LegacyCheckpointMigrationDispositionValues = {"RefuseDivergent", "MigrateCanonicalSnapshot", "AdoptProjectionExtension", "MigrateStoreProjection"}
+  LegacyCheckpointTranscriptRelationValues = {"Divergent", "Identical", "ProjectionExtendsSnapshot", "SnapshotExtendsProjection", "NotComparable"}
   LiveSessionAuthorityKindValues = {"LiveAuthoritative", "DurableAuthoritative"}
   LiveSessionAuthorityReasonValues = {"StoredArchived", "LiveUncommittedTranscript", "RuntimeSystemContextDiverged", "StoredTranscriptRevisionDiverged"}
   NatValues = {0, 1, 2}

--- a/specs/machines/session_document/mapping.md
+++ b/specs/machines/session_document/mapping.md
@@ -325,6 +325,27 @@ This section is generated from the Rust machine catalog. Do not edit it by hand.
 - `ResolveRuntimeCheckpointProjectionArchived`
   - anchors: `session_document_authority`
   - scenarios: (unclaimed)
+- `ResolveLegacyCheckpointMigrationSnapshotIdenticalProjection`
+  - anchors: `session_document_authority`
+  - scenarios: (unclaimed)
+- `ResolveLegacyCheckpointMigrationSnapshotAheadOfProjection`
+  - anchors: `session_document_authority`
+  - scenarios: (unclaimed)
+- `ResolveLegacyCheckpointMigrationProjectionExtension`
+  - anchors: `session_document_authority`
+  - scenarios: (unclaimed)
+- `ResolveLegacyCheckpointMigrationDivergentCopies`
+  - anchors: `session_document_authority`
+  - scenarios: (unclaimed)
+- `ResolveLegacyCheckpointMigrationSnapshotOnly`
+  - anchors: `session_document_authority`
+  - scenarios: (unclaimed)
+- `ResolveLegacyCheckpointMigrationStoreRowOnly`
+  - anchors: `session_document_authority`
+  - scenarios: (unclaimed)
+- `ResolveLegacyCheckpointMigrationSnapshotLegacyProjectionTyped`
+  - anchors: `session_document_authority`
+  - scenarios: (unclaimed)
 - `ApplyPendingToolResults`
   - anchors: `session_document_authority`
   - scenarios: (unclaimed)
@@ -439,6 +460,9 @@ This section is generated from the Rust machine catalog. Do not edit it by hand.
   - anchors: (unclaimed)
   - scenarios: (unclaimed)
 - `RuntimeCheckpointProjectionResolved`
+  - anchors: `session_document_authority`
+  - scenarios: (unclaimed)
+- `LegacyCheckpointMigrationResolved`
   - anchors: `session_document_authority`
   - scenarios: (unclaimed)
 - `RuntimeSnapshotReadSourceResolved`

--- a/specs/machines/session_document/model.tla
+++ b/specs/machines/session_document/model.tla
@@ -3,7 +3,7 @@ EXTENDS TLC, Naturals, Sequences, FiniteSets
 
 \* Generated semantic machine model for SessionDocumentMachine.
 
-CONSTANTS BooleanValues, LiveSessionAuthorityKindValues, LiveSessionAuthorityReasonValues, NatValues, ObservedSessionTailKindValues, PendingContinuationDispositionValues, PendingContinuationPublicTerminalValues, RealtimeTranscriptLaneKindValues, RealtimeTranscriptMaterializeDecisionValues, RealtimeTranscriptRoleKindValues, RealtimeTranscriptStopReasonKindValues, RealtimeUserContentBlobFinalizeDispositionValues, RealtimeUserContentBlobRecoveryDispositionValues, RealtimeUserContentBlobStageDispositionValues, RealtimeUserContentIdentityDispositionValues, ResumeOverrideRejectionValues, ResumeProviderSelectionValues, ResumeSelfHostedSelectionValues, RuntimeCheckpointProjectionDispositionValues, RuntimeProjectionRollbackDispositionValues, SessionArchiveDispositionValues, SessionArchiveRuntimeObservationValues, SessionDocumentLifecycleValues, SessionFirstTurnPhaseValues, SessionIdValues, SessionInitialPromptStageDecisionValues, SessionSystemPromptSourceValues, SystemContextAppendDecisionValues, SystemContextPersistAppendAdmissionValues, SystemContextSourceValues, TranscriptEditKindValues
+CONSTANTS BooleanValues, LegacyCheckpointMigrationDispositionValues, LegacyCheckpointTranscriptRelationValues, LiveSessionAuthorityKindValues, LiveSessionAuthorityReasonValues, NatValues, ObservedSessionTailKindValues, PendingContinuationDispositionValues, PendingContinuationPublicTerminalValues, RealtimeTranscriptLaneKindValues, RealtimeTranscriptMaterializeDecisionValues, RealtimeTranscriptRoleKindValues, RealtimeTranscriptStopReasonKindValues, RealtimeUserContentBlobFinalizeDispositionValues, RealtimeUserContentBlobRecoveryDispositionValues, RealtimeUserContentBlobStageDispositionValues, RealtimeUserContentIdentityDispositionValues, ResumeOverrideRejectionValues, ResumeProviderSelectionValues, ResumeSelfHostedSelectionValues, RuntimeCheckpointProjectionDispositionValues, RuntimeProjectionRollbackDispositionValues, SessionArchiveDispositionValues, SessionArchiveRuntimeObservationValues, SessionDocumentLifecycleValues, SessionFirstTurnPhaseValues, SessionIdValues, SessionInitialPromptStageDecisionValues, SessionSystemPromptSourceValues, SystemContextAppendDecisionValues, SystemContextPersistAppendAdmissionValues, SystemContextSourceValues, TranscriptEditKindValues
 
 None == [tag |-> "none", value |-> "none"]
 Some(v) == [tag |-> "some", value |-> v]
@@ -886,6 +886,62 @@ ResolveRuntimeCheckpointProjectionArchived(session_id) ==
     /\ UNCHANGED << session_first_turn_phase, session_pending_initial_prompt_present, session_pending_tool_results_count, session_lifecycle_terminal >>
 
 
+ResolveLegacyCheckpointMigrationSnapshotIdenticalProjection(session_id, runtime_snapshot_present, runtime_snapshot_legacy, store_row_present, store_row_legacy, transcript_relation) ==
+    /\ phase = "Ready"
+    /\ ((runtime_snapshot_present = TRUE) /\ (runtime_snapshot_legacy = TRUE) /\ (store_row_present = TRUE) /\ (store_row_legacy = TRUE) /\ (transcript_relation = "Identical"))
+    /\ phase' = "Ready"
+    /\ model_step_count' = model_step_count + 1
+    /\ UNCHANGED << session_first_turn_phase, session_pending_initial_prompt_present, session_pending_tool_results_count, session_lifecycle_terminal >>
+
+
+ResolveLegacyCheckpointMigrationSnapshotAheadOfProjection(session_id, runtime_snapshot_present, runtime_snapshot_legacy, store_row_present, store_row_legacy, transcript_relation) ==
+    /\ phase = "Ready"
+    /\ ((runtime_snapshot_present = TRUE) /\ (runtime_snapshot_legacy = TRUE) /\ (store_row_present = TRUE) /\ (store_row_legacy = TRUE) /\ (transcript_relation = "SnapshotExtendsProjection"))
+    /\ phase' = "Ready"
+    /\ model_step_count' = model_step_count + 1
+    /\ UNCHANGED << session_first_turn_phase, session_pending_initial_prompt_present, session_pending_tool_results_count, session_lifecycle_terminal >>
+
+
+ResolveLegacyCheckpointMigrationProjectionExtension(session_id, runtime_snapshot_present, runtime_snapshot_legacy, store_row_present, store_row_legacy, transcript_relation) ==
+    /\ phase = "Ready"
+    /\ ((runtime_snapshot_present = TRUE) /\ (runtime_snapshot_legacy = TRUE) /\ (store_row_present = TRUE) /\ (store_row_legacy = TRUE) /\ (transcript_relation = "ProjectionExtendsSnapshot"))
+    /\ phase' = "Ready"
+    /\ model_step_count' = model_step_count + 1
+    /\ UNCHANGED << session_first_turn_phase, session_pending_initial_prompt_present, session_pending_tool_results_count, session_lifecycle_terminal >>
+
+
+ResolveLegacyCheckpointMigrationDivergentCopies(session_id, runtime_snapshot_present, runtime_snapshot_legacy, store_row_present, store_row_legacy, transcript_relation) ==
+    /\ phase = "Ready"
+    /\ ((runtime_snapshot_present = TRUE) /\ (runtime_snapshot_legacy = TRUE) /\ (store_row_present = TRUE) /\ (store_row_legacy = TRUE) /\ (transcript_relation = "Divergent"))
+    /\ phase' = "Ready"
+    /\ model_step_count' = model_step_count + 1
+    /\ UNCHANGED << session_first_turn_phase, session_pending_initial_prompt_present, session_pending_tool_results_count, session_lifecycle_terminal >>
+
+
+ResolveLegacyCheckpointMigrationSnapshotOnly(session_id, runtime_snapshot_present, runtime_snapshot_legacy, store_row_present, store_row_legacy, transcript_relation) ==
+    /\ phase = "Ready"
+    /\ ((runtime_snapshot_present = TRUE) /\ (runtime_snapshot_legacy = TRUE) /\ (store_row_present = FALSE))
+    /\ phase' = "Ready"
+    /\ model_step_count' = model_step_count + 1
+    /\ UNCHANGED << session_first_turn_phase, session_pending_initial_prompt_present, session_pending_tool_results_count, session_lifecycle_terminal >>
+
+
+ResolveLegacyCheckpointMigrationStoreRowOnly(session_id, runtime_snapshot_present, runtime_snapshot_legacy, store_row_present, store_row_legacy, transcript_relation) ==
+    /\ phase = "Ready"
+    /\ ((runtime_snapshot_present = FALSE) /\ (store_row_present = TRUE) /\ (store_row_legacy = TRUE))
+    /\ phase' = "Ready"
+    /\ model_step_count' = model_step_count + 1
+    /\ UNCHANGED << session_first_turn_phase, session_pending_initial_prompt_present, session_pending_tool_results_count, session_lifecycle_terminal >>
+
+
+ResolveLegacyCheckpointMigrationSnapshotLegacyProjectionTyped(session_id, runtime_snapshot_present, runtime_snapshot_legacy, store_row_present, store_row_legacy, transcript_relation) ==
+    /\ phase = "Ready"
+    /\ ((runtime_snapshot_present = TRUE) /\ (runtime_snapshot_legacy = TRUE) /\ (store_row_present = TRUE) /\ (store_row_legacy = FALSE))
+    /\ phase' = "Ready"
+    /\ model_step_count' = model_step_count + 1
+    /\ UNCHANGED << session_first_turn_phase, session_pending_initial_prompt_present, session_pending_tool_results_count, session_lifecycle_terminal >>
+
+
 ApplyPendingToolResults(session_id, result_count) ==
     /\ phase = "Ready"
     /\ phase' = "Ready"
@@ -1056,6 +1112,13 @@ Next ==
     \/ \E session_id \in SessionIdValues : \E row_continues_authority \in BOOLEAN : \E row_is_runtime_checkpoint \in BOOLEAN : ResolveRuntimeProjectionRollbackReject(session_id, row_continues_authority, row_is_runtime_checkpoint)
     \/ \E session_id \in SessionIdValues : ResolveRuntimeCheckpointProjectionActive(session_id)
     \/ \E session_id \in SessionIdValues : ResolveRuntimeCheckpointProjectionArchived(session_id)
+    \/ \E session_id \in SessionIdValues : \E transcript_relation \in LegacyCheckpointTranscriptRelationValues : ResolveLegacyCheckpointMigrationSnapshotIdenticalProjection(session_id, TRUE, TRUE, TRUE, TRUE, transcript_relation)
+    \/ \E session_id \in SessionIdValues : \E transcript_relation \in LegacyCheckpointTranscriptRelationValues : ResolveLegacyCheckpointMigrationSnapshotAheadOfProjection(session_id, TRUE, TRUE, TRUE, TRUE, transcript_relation)
+    \/ \E session_id \in SessionIdValues : \E transcript_relation \in LegacyCheckpointTranscriptRelationValues : ResolveLegacyCheckpointMigrationProjectionExtension(session_id, TRUE, TRUE, TRUE, TRUE, transcript_relation)
+    \/ \E session_id \in SessionIdValues : \E transcript_relation \in LegacyCheckpointTranscriptRelationValues : ResolveLegacyCheckpointMigrationDivergentCopies(session_id, TRUE, TRUE, TRUE, TRUE, transcript_relation)
+    \/ \E session_id \in SessionIdValues : \E store_row_legacy \in BOOLEAN : \E transcript_relation \in LegacyCheckpointTranscriptRelationValues : ResolveLegacyCheckpointMigrationSnapshotOnly(session_id, TRUE, TRUE, FALSE, store_row_legacy, transcript_relation)
+    \/ \E session_id \in SessionIdValues : \E runtime_snapshot_legacy \in BOOLEAN : \E transcript_relation \in LegacyCheckpointTranscriptRelationValues : ResolveLegacyCheckpointMigrationStoreRowOnly(session_id, FALSE, runtime_snapshot_legacy, TRUE, TRUE, transcript_relation)
+    \/ \E session_id \in SessionIdValues : \E transcript_relation \in LegacyCheckpointTranscriptRelationValues : ResolveLegacyCheckpointMigrationSnapshotLegacyProjectionTyped(session_id, TRUE, TRUE, TRUE, FALSE, transcript_relation)
     \/ \E session_id \in SessionIdValues : \E result_count \in 0..2 : ApplyPendingToolResults(session_id, result_count)
     \/ \E session_id \in SessionIdValues : \E fork_or_rewrite_directive \in TranscriptEditKindValues : TranscriptEditFork(session_id, fork_or_rewrite_directive)
     \/ \E session_id \in SessionIdValues : \E fork_or_rewrite_directive \in TranscriptEditKindValues : TranscriptEditRewrite(session_id, fork_or_rewrite_directive)

--- a/xtask/src/protocol_codegen.rs
+++ b/xtask/src/protocol_codegen.rs
@@ -4619,6 +4619,8 @@ fn generate_session_document_authority(machine: &MachineSchema) -> Result<String
         "LiveSessionAuthorityReason",
         "RuntimeProjectionRollbackDisposition",
         "RuntimeCheckpointProjectionDisposition",
+        "LegacyCheckpointTranscriptRelation",
+        "LegacyCheckpointMigrationDisposition",
         "SessionDocumentLifecycle",
         "SessionArchiveDisposition",
         "SessionArchiveRuntimeObservation",
@@ -4718,6 +4720,8 @@ fn session_document_default_variant(name: &str) -> Result<&'static str> {
         "LiveSessionAuthorityReason" => Ok("StoredArchived"),
         "RuntimeProjectionRollbackDisposition" => Ok("RejectDivergent"),
         "RuntimeCheckpointProjectionDisposition" => Ok("IgnoreArchived"),
+        "LegacyCheckpointTranscriptRelation" => Ok("Divergent"),
+        "LegacyCheckpointMigrationDisposition" => Ok("RefuseDivergent"),
         "SessionDocumentLifecycle" => Ok("Active"),
         "SessionArchiveDisposition" => Ok("Archive"),
         "SessionArchiveRuntimeObservation" => Ok("Absent"),
@@ -5537,6 +5541,8 @@ fn session_document_type_is_copy(type_name: &str) -> bool {
             | "PendingContinuationPublicTerminal"
             | "SessionDocumentLifecycle"
             | "RuntimeCheckpointProjectionDisposition"
+            | "LegacyCheckpointTranscriptRelation"
+            | "LegacyCheckpointMigrationDisposition"
             | "SessionArchiveDisposition"
             | "SessionArchiveRuntimeObservation"
     )
@@ -5597,6 +5603,7 @@ fn validate_session_document_authority_schema(machine: &MachineSchema) -> Result
         "RecoverSessionLifecycleTerminal",
         "ArchiveSessionDocument",
         "ResolveRuntimeCheckpointProjection",
+        "ResolveLegacyCheckpointMigration",
     ] {
         machine
             .inputs
@@ -5633,6 +5640,7 @@ fn validate_session_document_authority_schema(machine: &MachineSchema) -> Result
         "SessionLifecycleTerminalRecovered",
         "SessionArchiveResolved",
         "RuntimeCheckpointProjectionResolved",
+        "LegacyCheckpointMigrationResolved",
     ] {
         machine
             .effects
@@ -5664,6 +5672,8 @@ fn validate_session_document_authority_schema(machine: &MachineSchema) -> Result
         "LiveSessionAuthorityReason",
         "RuntimeProjectionRollbackDisposition",
         "RuntimeCheckpointProjectionDisposition",
+        "LegacyCheckpointTranscriptRelation",
+        "LegacyCheckpointMigrationDisposition",
         "SessionDocumentLifecycle",
         "SessionArchiveDisposition",
         "SessionArchiveRuntimeObservation",


### PR DESCRIPTION
## Summary

0.8.2 shipped the read side of typed checkpoint stamps — every authority seam fails closed on legacy-unverified documents with "explicit migration is required" — and the `recovery_migration` primitive, but **no released on-ramp** that applies it to an existing fleet. The only shipped migrator (`rkat session migrate`) is gated to v0.6.34 bare-`"idle"` co-located sqlite shapes. Upgrading any real pre-0.8.2 deployment bricks every resumed identity: 32/32 on a real 0.7.9 dataset at `load_committed_checkpoint_authority` (store-only shape), and the runtime-snapshot shape bricks even earlier, on the ordinary resume read in `resolve_runtime_snapshot_read_source`. Downstream context: HomeCore dump-driven restore testing (mobkit), where a fully-broken candidate would previously have certified and flipped.

This PR adds the missing on-ramp as a **machine-owned, level-triggered one-time migration** at the committed-authority resolver, so upgrades are zero-ceremony.

### Machine authority (SessionDocumentMachine)

New `ResolveLegacyCheckpointMigration` input + 7 transitions. The shell observes only mechanical carriers — which durable copies exist, whether each is legacy, and the transcript prefix relation between them — and mirrors the machine disposition:

- `MigrateCanonicalSnapshot` — identical copies, snapshot-only, or a stale-prefix projection (rebuilt from canonical)
- `AdoptProjectionExtension` — a projection that provably extends the snapshot is adopted, so no trailing turn is lost
- `MigrateStoreProjection` — store-only fleets that predate runtime checkpointing (the 0.7.9 shape)
- `RefuseDivergent` (fail-closed default) — unrelated transcripts, and the mixed legacy-snapshot/typed-row shape; typed refusal names the divergence for the operator tool

### Core: exported stamping seam + relation predicate

- `meerkat_core::adopt_legacy_session(source_blob, generation, revision)` — the shared adoption helper the storage-unification plan calls for, so remote backends (ob3/BigQuery) and mobkit continuity snapshots reuse one implementation of the ordering subtleties (stamp binds to final bytes after metadata repair; observed cursor comes from the continuity row; typed documents refused). The resolver's auto-migration is one caller of it.
- `meerkat_core::legacy_session_transcript_relation` — per-message canonical-JSON prefix comparison between two unstamped copies.

### Shell (PersistentSessionService)

`migrate_legacy_checkpoint_authority` mirrors the machine verdict, adopts via the exported helper (INITIAL cursors), writes the runtime snapshot first and the CAS-tolerant authoritative projection second so a crash between the two converges on retry. Wired into both brick points: `load_committed_checkpoint_authority` and the authoritative resume read. Verified copies short-circuit — idempotent, exactly once per document. Every migration emits `tracing::info` (session, disposition, source bytes); refusals emit `tracing::warn` — migration cost lands inside resume/certification windows and is observable, not inferred from latency.

## Relationship to the storage-unification plan (Revision 2)

- **Conscious override**: the plan's hotfix ledger favored an explicit quiescent migration step over eager adoption at open. This PR implements lazy per-session adoption at first authority touch instead, per operator decision — zero-ceremony upgrades outweigh the maintenance-window framing. The Phase 6 `rkat storage migrate` verb becomes the bulk/fenced form of this same machinery (the machine disposition + `adopt_legacy_session` are exactly the "0.8.x hotfix machinery" Phase 6 case 4 plans to invoke under the fence).
- **Documented residual**: the auto path seeds INITIAL cursors, correct for lineages that never minted authority (both known datasets are generation 0). Fleets whose continuity rows record a nonzero generation floor must adopt through `adopt_legacy_session` with the observed cursor (mobkit-side, per the plan's companion arc) — stamping a lower generation would be sticky, since a verified document no longer re-migrates. The helper's doc comment carries this warning.
- Fail-closed `RefuseDivergent` with no synthesis matches the plan's migration principle 5 and split-brain posture.

## Design decisions (operator-confirmed)

- Auto-migration in meerkat rather than a downstream (mobkit) bridge or a manual quiesce-the-fleet tool — the resolver seam heals every consumer.
- Divergence policy: adopt a provable extension, else canonical wins; true conflicts refuse fail-closed.
- Existing `recoverable_divergence` (mob identity) starts working for free once the canonical is stamped here.

## Test plan

- 9 new tests: identical-copy migration + idempotency, extension adoption (tail survives), stale-projection rebuild, store-only 0.7.9 shape, divergent refusal with zero durable writes, ordinary-resume-read heal, adoption-helper round-trip + typed-blob refusal, relation classification, typed/foreign-session refusal.
- Full `meerkat-core` + `meerkat-session` suites (session-store + session-compaction features): 1,839 passed, 0 failed.
- `make machine-check-drift`: 10 machines, 7 compositions up to date; machine + protocol codegen regenerated; posters unchanged.
- Scoped clippy `--all-targets --all-features -D warnings`: clean. Full pre-push gate: passed.
- External acceptance pending: the HomeCore dump-driven local restore harness (one command, no production risk) against this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)