### PR TITLE
fix: harden legacy checkpoint migration against races and partial adoption

### DIFF
--- a/meerkat-core/src/generated/session_document.rs
+++ b/meerkat-core/src/generated/session_document.rs
@@ -241,6 +241,7 @@ pub enum LegacyCheckpointMigrationDisposition {
     MigrateCanonicalSnapshot,
     AdoptProjectionExtension,
     MigrateStoreProjection,
+    RebuildProjectionFromTypedSnapshot,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
@@ -785,6 +786,7 @@ enum SessionDocumentTransition {
     ResolveLegacyCheckpointMigrationDivergentCopies,
     ResolveLegacyCheckpointMigrationSnapshotOnly,
     ResolveLegacyCheckpointMigrationStoreRowOnly,
+    ResolveLegacyCheckpointMigrationTypedSnapshotLegacyProjection,
     ResolveLegacyCheckpointMigrationSnapshotLegacyProjectionTyped,
     ApplyPendingToolResults,
     TranscriptEditFork,
@@ -3374,6 +3376,14 @@ impl SessionDocumentMachineAuthority {
                 }
                 if (self.state.lifecycle_phase == SessionDocumentPhase::Ready)
                     && ((runtime_snapshot_present == true)
+                        && (runtime_snapshot_legacy == false)
+                        && (store_row_present == true)
+                        && (store_row_legacy == true))
+                {
+                    matches.push(SessionDocumentTransition::ResolveLegacyCheckpointMigrationTypedSnapshotLegacyProjection);
+                }
+                if (self.state.lifecycle_phase == SessionDocumentPhase::Ready)
+                    && ((runtime_snapshot_present == true)
                         && (runtime_snapshot_legacy == true)
                         && (store_row_present == true)
                         && (store_row_legacy == false))
@@ -3417,6 +3427,12 @@ impl SessionDocumentMachineAuthority {
                         self.state.lifecycle_phase = SessionDocumentPhase::Ready;
                         Ok(vec![
                             SessionDocumentEffect::LegacyCheckpointMigrationResolved { disposition: LegacyCheckpointMigrationDisposition::MigrateStoreProjection, },
+                        ])
+                    }
+                    SessionDocumentTransition::ResolveLegacyCheckpointMigrationTypedSnapshotLegacyProjection => {
+                        self.state.lifecycle_phase = SessionDocumentPhase::Ready;
+                        Ok(vec![
+                            SessionDocumentEffect::LegacyCheckpointMigrationResolved { disposition: LegacyCheckpointMigrationDisposition::RebuildProjectionFromTypedSnapshot, },
                         ])
                     }
                     SessionDocumentTransition::ResolveLegacyCheckpointMigrationSnapshotLegacyProjectionTyped => {

--- a/meerkat-machine-kernels/src/generated/session_document.rs
+++ b/meerkat-machine-kernels/src/generated/session_document.rs
@@ -37,6 +37,8 @@ pub enum LegacyCheckpointMigrationDisposition {
     AdoptProjectionExtension,
     #[serde(rename = "MigrateStoreProjection")]
     MigrateStoreProjection,
+    #[serde(rename = "RebuildProjectionFromTypedSnapshot")]
+    RebuildProjectionFromTypedSnapshot,
 }
 impl LegacyCheckpointMigrationDisposition {
     pub fn as_str(&self) -> &'static str {
@@ -45,6 +47,7 @@ impl LegacyCheckpointMigrationDisposition {
             Self::MigrateCanonicalSnapshot => "MigrateCanonicalSnapshot",
             Self::AdoptProjectionExtension => "AdoptProjectionExtension",
             Self::MigrateStoreProjection => "MigrateStoreProjection",
+            Self::RebuildProjectionFromTypedSnapshot => "RebuildProjectionFromTypedSnapshot",
         }
     }
 }
@@ -56,6 +59,7 @@ impl std::convert::TryFrom<&str> for LegacyCheckpointMigrationDisposition {
             "MigrateCanonicalSnapshot" => Ok(Self::MigrateCanonicalSnapshot),
             "AdoptProjectionExtension" => Ok(Self::AdoptProjectionExtension),
             "MigrateStoreProjection" => Ok(Self::MigrateStoreProjection),
+            "RebuildProjectionFromTypedSnapshot" => Ok(Self::RebuildProjectionFromTypedSnapshot),
             other => Err(format!(
                 "invalid LegacyCheckpointMigrationDisposition value `{other}`"
             )),
@@ -2555,6 +2559,7 @@ pub enum TransitionId {
     ResolveLegacyCheckpointMigrationDivergentCopies,
     ResolveLegacyCheckpointMigrationSnapshotOnly,
     ResolveLegacyCheckpointMigrationStoreRowOnly,
+    ResolveLegacyCheckpointMigrationTypedSnapshotLegacyProjection,
     ResolveLegacyCheckpointMigrationSnapshotLegacyProjectionTyped,
     ApplyPendingToolResults,
     TranscriptEditFork,

--- a/meerkat-machine-schema/src/catalog/coverage.rs
+++ b/meerkat-machine-schema/src/catalog/coverage.rs
@@ -1269,6 +1269,7 @@ pub fn canonical_machine_coverage_manifests() -> Vec<MachineCoverageManifest> {
                         "ResolveLegacyCheckpointMigrationDivergentCopies",
                         "ResolveLegacyCheckpointMigrationSnapshotOnly",
                         "ResolveLegacyCheckpointMigrationStoreRowOnly",
+                        "ResolveLegacyCheckpointMigrationTypedSnapshotLegacyProjection",
                         "ResolveLegacyCheckpointMigrationSnapshotLegacyProjectionTyped",
                     ])
                     .effects(&[

--- a/meerkat-machine-schema/src/catalog/dsl/mod.rs
+++ b/meerkat-machine-schema/src/catalog/dsl/mod.rs
@@ -773,6 +773,7 @@ pub fn session_document_schema_metadata() -> MachineSchemaMetadata {
                     "MigrateCanonicalSnapshot",
                     "AdoptProjectionExtension",
                     "MigrateStoreProjection",
+                    "RebuildProjectionFromTypedSnapshot",
                 ],
             ),
             NamedTypeBinding::string_enum(

--- a/meerkat-machine-schema/src/catalog/dsl/session_document.rs
+++ b/meerkat-machine-schema/src/catalog/dsl/session_document.rs
@@ -485,6 +485,11 @@ pub enum LegacyCheckpointMigrationDisposition {
     MigrateCanonicalSnapshot,
     AdoptProjectionExtension,
     MigrateStoreProjection,
+    /// The runtime snapshot is already typed but the session-store row is
+    /// still legacy (a crash between the migration's two durable writes, or
+    /// a pre-existing partial adoption). The shell rebuilds the projection
+    /// from the verified runtime authority; nothing is re-stamped.
+    RebuildProjectionFromTypedSnapshot,
 }
 
 // ---------------------------------------------------------------------------
@@ -4076,6 +4081,29 @@ machine! {
             to Ready
             emit LegacyCheckpointMigrationResolved {
                 disposition: LegacyCheckpointMigrationDisposition::MigrateStoreProjection
+            }
+        }
+
+        transition ResolveLegacyCheckpointMigrationTypedSnapshotLegacyProjection {
+            on input ResolveLegacyCheckpointMigration {
+                session_id,
+                runtime_snapshot_present,
+                runtime_snapshot_legacy,
+                store_row_present,
+                store_row_legacy,
+                transcript_relation
+            }
+            guard {
+                self.lifecycle_phase == Phase::Ready
+                && runtime_snapshot_present == true
+                && runtime_snapshot_legacy == false
+                && store_row_present == true
+                && store_row_legacy == true
+            }
+            update {}
+            to Ready
+            emit LegacyCheckpointMigrationResolved {
+                disposition: LegacyCheckpointMigrationDisposition::RebuildProjectionFromTypedSnapshot
             }
         }
 

--- a/meerkat-session/src/persistent.rs
+++ b/meerkat-session/src/persistent.rs
@@ -976,10 +976,17 @@ async fn load_verified_runtime_checkpoint_authority(
 /// The committed runtime snapshot classified for authority resolution: absent,
 /// fully verified, or a pre-typed legacy document eligible for the one-time
 /// recovery migration. Malformed evidence and intra-turn rows still error.
+///
+/// The legacy variant retains the exact loaded bytes: the migration stamp's
+/// authority base takes byte custody of the observed source BLOB, so custody
+/// must bind to what the store actually held, never a re-serialization.
 enum CommittedCheckpointCopy {
     Absent,
     Verified(VerifiedCheckpointAuthority),
-    Legacy(Session),
+    Legacy {
+        session: Session,
+        serialized: Vec<u8>,
+    },
 }
 
 async fn load_runtime_checkpoint_copy(
@@ -1017,7 +1024,10 @@ async fn load_runtime_checkpoint_copy(
             .map_err(session_checkpoint_read_error)?,
         meerkat_core::SessionCheckpointState::LegacyUnverified { .. }
     ) {
-        return Ok(CommittedCheckpointCopy::Legacy(session));
+        return Ok(CommittedCheckpointCopy::Legacy {
+            session,
+            serialized,
+        });
     }
     VerifiedCheckpointAuthority::from_session_with_serialized(session, serialized, session_id, role)
         .map(CommittedCheckpointCopy::Verified)
@@ -3300,6 +3310,31 @@ impl<B: SessionAgentBuilder + 'static> PersistentSessionService<B> {
                         .load(id)
                         .await
                         .map_err(|e| SessionError::Store(Box::new(e)))?;
+                    // A legacy store head under a verified snapshot is the
+                    // partial-adoption shape (a crash between the migration's
+                    // two durable writes). Read-source arbitration fails
+                    // closed on a legacy head, so converge the row onto the
+                    // verified authority first and re-read it.
+                    let store_head = match store_head {
+                        Some(head)
+                            if matches!(
+                                head.try_checkpoint_state()
+                                    .map_err(session_checkpoint_read_error)?,
+                                meerkat_core::SessionCheckpointState::LegacyUnverified { .. }
+                            ) =>
+                        {
+                            self.load_committed_checkpoint_authority(
+                                id,
+                                "authoritative session read",
+                            )
+                            .await?;
+                            self.store
+                                .load(id)
+                                .await
+                                .map_err(|e| SessionError::Store(Box::new(e)))?
+                        }
+                        other => other,
+                    };
                     let session_is_live = self.inner.has_live_session(id).await?;
                     Some(self.resolve_runtime_snapshot_read_source(
                         id,
@@ -6865,17 +6900,18 @@ impl<B: SessionAgentBuilder + 'static> PersistentSessionService<B> {
     ///
     /// Write order is runtime snapshot first, projection second: a crash
     /// between the two leaves a verified runtime authority over a legacy
-    /// row, which every reader already tolerates and the next projection
-    /// write converges.
+    /// row, which the machine's `RebuildProjectionFromTypedSnapshot`
+    /// disposition converges on the next read.
     async fn migrate_legacy_checkpoint_authority(
         &self,
         id: &SessionId,
-        runtime_snapshot: Option<Session>,
+        runtime_copy: CommittedCheckpointCopy,
         store_row: Option<Session>,
         role: &str,
     ) -> Result<VerifiedCheckpointAuthority, SessionError> {
-        let runtime_snapshot_present = runtime_snapshot.is_some();
-        let runtime_snapshot_legacy = runtime_snapshot.is_some();
+        let runtime_snapshot_present = !matches!(runtime_copy, CommittedCheckpointCopy::Absent);
+        let runtime_snapshot_legacy =
+            matches!(runtime_copy, CommittedCheckpointCopy::Legacy { .. });
         let store_row_present = store_row.is_some();
         let store_row_legacy = match store_row.as_ref() {
             Some(row) => matches!(
@@ -6885,7 +6921,11 @@ impl<B: SessionAgentBuilder + 'static> PersistentSessionService<B> {
             ),
             None => false,
         };
-        let transcript_relation = match (runtime_snapshot.as_ref(), store_row.as_ref()) {
+        let legacy_snapshot = match &runtime_copy {
+            CommittedCheckpointCopy::Legacy { session, .. } => Some(session),
+            _ => None,
+        };
+        let transcript_relation = match (legacy_snapshot, store_row.as_ref()) {
             (Some(snapshot), Some(row)) if store_row_legacy => {
                 match meerkat_core::legacy_session_transcript_relation(snapshot, row)
                     .map_err(session_checkpoint_read_error)?
@@ -6936,43 +6976,95 @@ impl<B: SessionAgentBuilder + 'static> PersistentSessionService<B> {
                 )))
             })?;
 
-        let (source, write_runtime_snapshot, disposition_label) = match disposition {
-            LegacyCheckpointMigrationDisposition::MigrateCanonicalSnapshot => {
-                (runtime_snapshot, true, "migrate_canonical_snapshot")
-            }
-            LegacyCheckpointMigrationDisposition::AdoptProjectionExtension => {
-                (store_row, true, "adopt_projection_extension")
-            }
-            LegacyCheckpointMigrationDisposition::MigrateStoreProjection => {
-                (store_row, false, "migrate_store_projection")
-            }
-            LegacyCheckpointMigrationDisposition::RefuseDivergent => {
-                tracing::warn!(
-                    session_id = %id,
-                    role,
-                    "legacy checkpoint copies are divergent; one-time recovery migration \
-                     refused fail-closed and requires the explicit operator migration tool"
-                );
+        if disposition == LegacyCheckpointMigrationDisposition::RefuseDivergent {
+            tracing::warn!(
+                session_id = %id,
+                role,
+                "legacy checkpoint copies are divergent; one-time recovery migration \
+                 refused fail-closed and requires the explicit operator migration tool"
+            );
+            return Err(SessionError::Agent(AgentError::InternalError(format!(
+                "cannot prepare {role} for session {id}: legacy checkpoint copies are \
+                 divergent (the committed runtime snapshot and the session-store \
+                 projection are not related by transcript prefix extension); one-time \
+                 recovery migration is refused fail-closed and requires the explicit \
+                 operator migration tool"
+            ))));
+        }
+        if disposition == LegacyCheckpointMigrationDisposition::RebuildProjectionFromTypedSnapshot {
+            // Partial adoption (a crash between the migration's two durable
+            // writes): the runtime snapshot is already typed authority and
+            // only the projection row is still legacy. Nothing is
+            // re-stamped; the projection converges onto the verified
+            // authority through the same CAS-guarded write.
+            let CommittedCheckpointCopy::Verified(authority) = runtime_copy else {
                 return Err(SessionError::Agent(AgentError::InternalError(format!(
-                    "cannot prepare {role} for session {id}: legacy checkpoint copies are \
-                     divergent (the committed runtime snapshot and the session-store \
-                     projection are not related by transcript prefix extension); one-time \
-                     recovery migration is refused fail-closed and requires the explicit \
-                     operator migration tool"
+                    "generated session document authority resolved a projection rebuild \
+                     without a verified runtime snapshot for session {id}"
+                ))));
+            };
+            self.persist_migrated_projection(&authority.session).await?;
+            tracing::info!(
+                session_id = %id,
+                role,
+                disposition = "rebuild_projection_from_typed_snapshot",
+                source_bytes = authority.serialized.len(),
+                wrote_runtime_snapshot = false,
+                "one-time legacy checkpoint recovery migration converged a legacy \
+                 projection row onto the verified runtime authority"
+            );
+            return Ok(authority);
+        }
+
+        let observed_runtime_bytes = match &runtime_copy {
+            CommittedCheckpointCopy::Legacy { serialized, .. } => Some(serialized.clone()),
+            _ => None,
+        };
+        let (source_blob, write_runtime_snapshot, disposition_label) = match disposition {
+            LegacyCheckpointMigrationDisposition::MigrateCanonicalSnapshot => {
+                // Custody binds to the exact bytes the runtime store held.
+                let blob = observed_runtime_bytes.clone().ok_or_else(|| {
+                    SessionError::Agent(AgentError::InternalError(format!(
+                        "generated session document authority named an absent legacy \
+                         snapshot while migrating session {id}"
+                    )))
+                })?;
+                (blob, true, "migrate_canonical_snapshot")
+            }
+            LegacyCheckpointMigrationDisposition::AdoptProjectionExtension
+            | LegacyCheckpointMigrationDisposition::MigrateStoreProjection => {
+                let row = store_row.as_ref().ok_or_else(|| {
+                    SessionError::Agent(AgentError::InternalError(format!(
+                        "generated session document authority named an absent legacy \
+                         store row while migrating session {id}"
+                    )))
+                })?;
+                // `SessionStore::load` yields the decoded document, not raw
+                // row bytes, so custody binds to this exact serialization —
+                // which the migration then writes to both stores, making it
+                // the stored bytes everywhere.
+                let blob = serde_json::to_vec(row).map_err(|error| {
+                    SessionError::Agent(AgentError::InternalError(format!(
+                        "failed to serialize legacy migration source for session {id}: {error}"
+                    )))
+                })?;
+                let write_runtime =
+                    disposition == LegacyCheckpointMigrationDisposition::AdoptProjectionExtension;
+                let label = if write_runtime {
+                    "adopt_projection_extension"
+                } else {
+                    "migrate_store_projection"
+                };
+                (blob, write_runtime, label)
+            }
+            LegacyCheckpointMigrationDisposition::RefuseDivergent
+            | LegacyCheckpointMigrationDisposition::RebuildProjectionFromTypedSnapshot => {
+                return Err(SessionError::Agent(AgentError::InternalError(format!(
+                    "unreachable legacy checkpoint migration disposition for session {id}"
                 ))));
             }
         };
-        let source = source.ok_or_else(|| {
-            SessionError::Agent(AgentError::InternalError(format!(
-                "generated session document authority named an absent legacy copy while migrating session {id}"
-            )))
-        })?;
 
-        let source_blob = serde_json::to_vec(&source).map_err(|error| {
-            SessionError::Agent(AgentError::InternalError(format!(
-                "failed to serialize legacy migration source for session {id}: {error}"
-            )))
-        })?;
         // INITIAL cursors match the shipped v0.6.34 migrator and are correct
         // for lineages that never minted authority. Fleets whose continuity
         // rows record a nonzero generation floor adopt through the exported
@@ -6983,46 +7075,16 @@ impl<B: SessionAgentBuilder + 'static> PersistentSessionService<B> {
             meerkat_core::SessionCheckpointRevision::INITIAL,
         )
         .map_err(|error| checkpoint_prepare_error(id, role, error))?;
-        let prepared = PreparedCheckpointDocument {
-            session: adopted.session,
-            stamp: adopted.stamp,
-            serialized: adopted.serialized,
-        };
 
         if write_runtime_snapshot {
-            self.runtime_store
-                .commit_session_snapshot(
-                    &Self::runtime_id_for_session(id),
-                    SessionDelta {
-                        session_snapshot: prepared.serialized.clone(),
-                    },
-                )
-                .await
-                .map_err(|error| {
-                    SessionError::Agent(AgentError::InternalError(format!(
-                        "legacy migration runtime snapshot persistence failed for session {id}: {error}"
-                    )))
-                })?;
-        }
-        if let Some(incremental) = self.incremental.clone() {
-            save_session_projection_incremental(
-                incremental.as_ref(),
-                self.blob_store.as_ref(),
-                self.event_store.as_ref(),
-                self.projector.as_ref(),
-                &prepared.session,
-                &[],
+            self.commit_migrated_runtime_snapshot(
+                id,
+                observed_runtime_bytes.as_deref(),
+                &adopted.serialized,
             )
             .await?;
-        } else {
-            // The pre-typed row may legitimately shrink (a stale-prefix
-            // projection rebuilt from the canonical snapshot), so this is the
-            // authoritative-projection save, not the append-guarded `save`.
-            self.store
-                .save_authoritative_projection(&prepared.session)
-                .await
-                .map_err(|error| SessionError::Store(Box::new(error)))?;
         }
+        self.persist_migrated_projection(&adopted.session).await?;
         // Migration cost lands inside ordinary resume/certification windows;
         // operators expect it to be observable, not inferred from latency.
         tracing::info!(
@@ -7034,11 +7096,100 @@ impl<B: SessionAgentBuilder + 'static> PersistentSessionService<B> {
             "one-time legacy checkpoint recovery migration stamped a pre-typed session document"
         );
         VerifiedCheckpointAuthority::from_session_with_serialized(
-            prepared.session,
-            prepared.serialized,
+            adopted.session,
+            adopted.serialized,
             id,
             role,
         )
+    }
+
+    /// Guarded runtime-snapshot write for the one-time migration: the commit
+    /// lands only if the snapshot still holds the exact observed legacy
+    /// bytes, so a concurrent writer that already committed typed authority
+    /// (another process finishing its own migration and running turns) is
+    /// never overwritten by a stale migration root. The probe-then-commit
+    /// window is not atomic across processes; the residual race cannot lose
+    /// committed content because the projection write is CAS-guarded and the
+    /// read-source arbitration recovers a clobbered snapshot from the
+    /// extending store head, after which the next boundary commit rewrites
+    /// the snapshot.
+    async fn commit_migrated_runtime_snapshot(
+        &self,
+        id: &SessionId,
+        observed: Option<&[u8]>,
+        migrated: &[u8],
+    ) -> Result<(), SessionError> {
+        let current = self
+            .runtime_store
+            .load_session_snapshot(&Self::runtime_id_for_session(id))
+            .await
+            .map_err(|error| {
+                SessionError::Agent(AgentError::InternalError(format!(
+                    "legacy migration runtime snapshot probe failed for session {id}: {error}"
+                )))
+            })?;
+        let unchanged = match (observed, current.as_deref()) {
+            (Some(observed), Some(current)) => observed == current,
+            (None, None) => true,
+            _ => false,
+        };
+        if !unchanged {
+            return Err(SessionError::Agent(AgentError::InternalError(format!(
+                "runtime session snapshot for session {id} changed concurrently during \
+                 legacy checkpoint migration; retrying re-observes the current state"
+            ))));
+        }
+        self.runtime_store
+            .commit_session_snapshot(
+                &Self::runtime_id_for_session(id),
+                SessionDelta {
+                    session_snapshot: migrated.to_vec(),
+                },
+            )
+            .await
+            .map_err(|error| {
+                SessionError::Agent(AgentError::InternalError(format!(
+                    "legacy migration runtime snapshot persistence failed for session {id}: {error}"
+                )))
+            })
+    }
+
+    /// CAS-guarded projection write for the one-time migration. The pre-typed
+    /// row may legitimately shrink (a stale-prefix projection rebuilt from
+    /// the canonical snapshot), so this is the authoritative-projection save
+    /// keyed on the persisted row's continuity token, never the append-guarded
+    /// `save`; a row that changed concurrently fails the preflight closed and
+    /// retry re-observes.
+    async fn persist_migrated_projection(&self, session: &Session) -> Result<(), SessionError> {
+        if let Some(incremental) = self.incremental.clone() {
+            verify_incremental_projection_continuity(incremental.as_ref(), session)
+                .await
+                .map_err(|error| SessionError::Store(Box::new(error)))?;
+            save_session_projection_incremental(
+                incremental.as_ref(),
+                self.blob_store.as_ref(),
+                self.event_store.as_ref(),
+                self.projector.as_ref(),
+                session,
+                &[],
+            )
+            .await
+        } else {
+            let expected_current_revision = verify_authoritative_projection_persisted_continuity(
+                self.store.as_ref(),
+                self.blob_store.as_ref(),
+                session,
+            )
+            .await
+            .map_err(|error| SessionError::Store(Box::new(error)))?;
+            self.store
+                .save_authoritative_projection_if_current_revision(
+                    session,
+                    expected_current_revision,
+                )
+                .await
+                .map_err(|error| SessionError::Store(Box::new(error)))
+        }
     }
 
     /// Resolve the latest verified committed document authority without ever
@@ -7077,21 +7228,24 @@ impl<B: SessionAgentBuilder + 'static> PersistentSessionService<B> {
             ),
             None => false,
         };
+        // Any legacy copy on either side routes through the machine-owned
+        // one-time migration: a legacy runtime snapshot (with or without a
+        // row), a store-only legacy row, and the partial-adoption shape
+        // (verified snapshot over a still-legacy row) all converge there.
+        if matches!(runtime_copy, CommittedCheckpointCopy::Legacy { .. }) || store_row_is_legacy {
+            return self
+                .migrate_legacy_checkpoint_authority(id, runtime_copy, store_session, role)
+                .await
+                .map(Some);
+        }
         let runtime = match runtime_copy {
-            CommittedCheckpointCopy::Legacy(snapshot) => {
-                return self
-                    .migrate_legacy_checkpoint_authority(id, Some(snapshot), store_session, role)
-                    .await
-                    .map(Some);
-            }
-            CommittedCheckpointCopy::Absent if store_row_is_legacy => {
-                return self
-                    .migrate_legacy_checkpoint_authority(id, None, store_session, role)
-                    .await
-                    .map(Some);
-            }
             CommittedCheckpointCopy::Absent => None,
             CommittedCheckpointCopy::Verified(authority) => Some(authority),
+            CommittedCheckpointCopy::Legacy { .. } => {
+                return Err(SessionError::Agent(AgentError::InternalError(format!(
+                    "unreachable legacy runtime snapshot classification for session {id}"
+                ))));
+            }
         };
         let Some(store_session) = store_session else {
             return Ok(runtime);
@@ -30711,6 +30865,96 @@ mod tests {
         );
         let row_stamp = verified_store_row(&store, &id).await;
         assert_eq!(row_stamp, authority.stamp);
+    }
+
+    #[tokio::test]
+    async fn partial_adoption_heals_legacy_projection_from_typed_snapshot() {
+        // A crash between the migration's two durable writes leaves a typed
+        // runtime snapshot over a still-legacy store row. The ordinary read
+        // must converge the row instead of failing closed forever.
+        let store: Arc<dyn SessionStore> = Arc::new(MemoryStore::new());
+        let runtime_store = Arc::new(InMemoryRuntimeStore::new());
+        let service = legacy_migration_service(&store, &runtime_store);
+
+        let legacy = legacy_session_with_texts(&["turn one", "turn two"]);
+        let id = legacy.id().clone();
+        let legacy_bytes = serde_json::to_vec(&legacy).expect("legacy session should serialize");
+        let adopted = meerkat_core::adopt_legacy_session(
+            &legacy_bytes,
+            meerkat_core::SessionGeneration::INITIAL,
+            meerkat_core::SessionCheckpointRevision::INITIAL,
+        )
+        .expect("legacy session should adopt");
+        runtime_store
+            .commit_session_snapshot(
+                &PersistentSessionService::<DummyBuilder>::runtime_id_for_session(&id),
+                SessionDelta {
+                    session_snapshot: adopted.serialized.clone(),
+                },
+            )
+            .await
+            .expect("typed runtime snapshot should commit");
+        store.save(&legacy).await.expect("legacy row should save");
+
+        let session = service
+            .load_authoritative_session(&id)
+            .await
+            .expect("partial adoption must heal on the ordinary read")
+            .expect("session should exist");
+        assert_eq!(session.messages().len(), 2);
+        let row_stamp = verified_store_row(&store, &id).await;
+        assert_eq!(
+            row_stamp, adopted.stamp,
+            "projection row must converge onto the verified runtime authority"
+        );
+    }
+
+    #[tokio::test]
+    async fn migration_stamp_binds_to_observed_snapshot_bytes() {
+        // Custody evidence must name the bytes the runtime store actually
+        // held, not a fresh re-serialization of the decoded document.
+        let store: Arc<dyn SessionStore> = Arc::new(MemoryStore::new());
+        let runtime_store = Arc::new(InMemoryRuntimeStore::new());
+        let service = legacy_migration_service(&store, &runtime_store);
+
+        let legacy = legacy_session_with_texts(&["observed bytes"]);
+        let id = legacy.id().clone();
+        let pretty_bytes =
+            serde_json::to_vec_pretty(&legacy).expect("legacy session should serialize");
+        let compact_bytes = serde_json::to_vec(&legacy).expect("legacy session should serialize");
+        assert_ne!(pretty_bytes, compact_bytes);
+        runtime_store
+            .commit_session_snapshot(
+                &PersistentSessionService::<DummyBuilder>::runtime_id_for_session(&id),
+                SessionDelta {
+                    session_snapshot: pretty_bytes.clone(),
+                },
+            )
+            .await
+            .expect("legacy runtime snapshot should commit");
+
+        let authority = service
+            .load_committed_checkpoint_authority(&id, "legacy migration test")
+            .await
+            .expect("snapshot-only migration should succeed")
+            .expect("migrated authority should exist");
+        match authority.stamp.authority_base() {
+            meerkat_core::SessionCheckpointAuthorityBase::Legacy {
+                source_blob_digest, ..
+            } => {
+                assert_eq!(
+                    source_blob_digest,
+                    &meerkat_core::legacy_session_source_blob_digest(&pretty_bytes),
+                    "custody must bind to the exact observed snapshot bytes"
+                );
+                assert_ne!(
+                    source_blob_digest,
+                    &meerkat_core::legacy_session_source_blob_digest(&compact_bytes),
+                    "custody must not bind to a re-serialization"
+                );
+            }
+            other => panic!("expected legacy authority base, got {other:?}"),
+        }
     }
 
     #[tokio::test]

--- a/specs/machines/session_document/ci.cfg
+++ b/specs/machines/session_document/ci.cfg
@@ -1,7 +1,7 @@
 SPECIFICATION Spec
 CONSTANTS
   BooleanValues = {TRUE, FALSE}
-  LegacyCheckpointMigrationDispositionValues = {"RefuseDivergent", "MigrateCanonicalSnapshot", "AdoptProjectionExtension", "MigrateStoreProjection"}
+  LegacyCheckpointMigrationDispositionValues = {"RefuseDivergent", "MigrateCanonicalSnapshot", "AdoptProjectionExtension", "MigrateStoreProjection", "RebuildProjectionFromTypedSnapshot"}
   LegacyCheckpointTranscriptRelationValues = {"Divergent", "Identical", "ProjectionExtendsSnapshot", "SnapshotExtendsProjection", "NotComparable"}
   LiveSessionAuthorityKindValues = {"LiveAuthoritative", "DurableAuthoritative"}
   LiveSessionAuthorityReasonValues = {"StoredArchived", "LiveUncommittedTranscript", "RuntimeSystemContextDiverged", "StoredTranscriptRevisionDiverged"}

--- a/specs/machines/session_document/contract.md
+++ b/specs/machines/session_document/contract.md
@@ -977,6 +977,14 @@ _Generated from the Rust machine catalog. Do not edit by hand._
 - Emits: `LegacyCheckpointMigrationResolved`
 - To: `Ready`
 
+### `ResolveLegacyCheckpointMigrationTypedSnapshotLegacyProjection`
+- From: `Ready`
+- On: `ResolveLegacyCheckpointMigration`(session_id, runtime_snapshot_present, runtime_snapshot_legacy, store_row_present, store_row_legacy, transcript_relation)
+- Guards:
+  - ``
+- Emits: `LegacyCheckpointMigrationResolved`
+- To: `Ready`
+
 ### `ResolveLegacyCheckpointMigrationSnapshotLegacyProjectionTyped`
 - From: `Ready`
 - On: `ResolveLegacyCheckpointMigration`(session_id, runtime_snapshot_present, runtime_snapshot_legacy, store_row_present, store_row_legacy, transcript_relation)

--- a/specs/machines/session_document/deep.cfg
+++ b/specs/machines/session_document/deep.cfg
@@ -1,7 +1,7 @@
 SPECIFICATION Spec
 CONSTANTS
   BooleanValues = {TRUE, FALSE}
-  LegacyCheckpointMigrationDispositionValues = {"RefuseDivergent", "MigrateCanonicalSnapshot", "AdoptProjectionExtension", "MigrateStoreProjection"}
+  LegacyCheckpointMigrationDispositionValues = {"RefuseDivergent", "MigrateCanonicalSnapshot", "AdoptProjectionExtension", "MigrateStoreProjection", "RebuildProjectionFromTypedSnapshot"}
   LegacyCheckpointTranscriptRelationValues = {"Divergent", "Identical", "ProjectionExtendsSnapshot", "SnapshotExtendsProjection", "NotComparable"}
   LiveSessionAuthorityKindValues = {"LiveAuthoritative", "DurableAuthoritative"}
   LiveSessionAuthorityReasonValues = {"StoredArchived", "LiveUncommittedTranscript", "RuntimeSystemContextDiverged", "StoredTranscriptRevisionDiverged"}

--- a/specs/machines/session_document/mapping.md
+++ b/specs/machines/session_document/mapping.md
@@ -343,6 +343,9 @@ This section is generated from the Rust machine catalog. Do not edit it by hand.
 - `ResolveLegacyCheckpointMigrationStoreRowOnly`
   - anchors: `session_document_authority`
   - scenarios: (unclaimed)
+- `ResolveLegacyCheckpointMigrationTypedSnapshotLegacyProjection`
+  - anchors: `session_document_authority`
+  - scenarios: (unclaimed)
 - `ResolveLegacyCheckpointMigrationSnapshotLegacyProjectionTyped`
   - anchors: `session_document_authority`
   - scenarios: (unclaimed)

--- a/specs/machines/session_document/model.tla
+++ b/specs/machines/session_document/model.tla
@@ -934,6 +934,14 @@ ResolveLegacyCheckpointMigrationStoreRowOnly(session_id, runtime_snapshot_presen
     /\ UNCHANGED << session_first_turn_phase, session_pending_initial_prompt_present, session_pending_tool_results_count, session_lifecycle_terminal >>
 
 
+ResolveLegacyCheckpointMigrationTypedSnapshotLegacyProjection(session_id, runtime_snapshot_present, runtime_snapshot_legacy, store_row_present, store_row_legacy, transcript_relation) ==
+    /\ phase = "Ready"
+    /\ ((runtime_snapshot_present = TRUE) /\ (runtime_snapshot_legacy = FALSE) /\ (store_row_present = TRUE) /\ (store_row_legacy = TRUE))
+    /\ phase' = "Ready"
+    /\ model_step_count' = model_step_count + 1
+    /\ UNCHANGED << session_first_turn_phase, session_pending_initial_prompt_present, session_pending_tool_results_count, session_lifecycle_terminal >>
+
+
 ResolveLegacyCheckpointMigrationSnapshotLegacyProjectionTyped(session_id, runtime_snapshot_present, runtime_snapshot_legacy, store_row_present, store_row_legacy, transcript_relation) ==
     /\ phase = "Ready"
     /\ ((runtime_snapshot_present = TRUE) /\ (runtime_snapshot_legacy = TRUE) /\ (store_row_present = TRUE) /\ (store_row_legacy = FALSE))
@@ -1118,6 +1126,7 @@ Next ==
     \/ \E session_id \in SessionIdValues : \E transcript_relation \in LegacyCheckpointTranscriptRelationValues : ResolveLegacyCheckpointMigrationDivergentCopies(session_id, TRUE, TRUE, TRUE, TRUE, transcript_relation)
     \/ \E session_id \in SessionIdValues : \E store_row_legacy \in BOOLEAN : \E transcript_relation \in LegacyCheckpointTranscriptRelationValues : ResolveLegacyCheckpointMigrationSnapshotOnly(session_id, TRUE, TRUE, FALSE, store_row_legacy, transcript_relation)
     \/ \E session_id \in SessionIdValues : \E runtime_snapshot_legacy \in BOOLEAN : \E transcript_relation \in LegacyCheckpointTranscriptRelationValues : ResolveLegacyCheckpointMigrationStoreRowOnly(session_id, FALSE, runtime_snapshot_legacy, TRUE, TRUE, transcript_relation)
+    \/ \E session_id \in SessionIdValues : \E transcript_relation \in LegacyCheckpointTranscriptRelationValues : ResolveLegacyCheckpointMigrationTypedSnapshotLegacyProjection(session_id, TRUE, FALSE, TRUE, TRUE, transcript_relation)
     \/ \E session_id \in SessionIdValues : \E transcript_relation \in LegacyCheckpointTranscriptRelationValues : ResolveLegacyCheckpointMigrationSnapshotLegacyProjectionTyped(session_id, TRUE, TRUE, TRUE, FALSE, transcript_relation)
     \/ \E session_id \in SessionIdValues : \E result_count \in 0..2 : ApplyPendingToolResults(session_id, result_count)
     \/ \E session_id \in SessionIdValues : \E fork_or_rewrite_directive \in TranscriptEditKindValues : TranscriptEditFork(session_id, fork_or_rewrite_directive)


### PR DESCRIPTION
## Summary

Fixes the three findings from the Codex review of #909 (all verified real against the code) so the storage rearchitecture can start on a clean base.

### 1. Migration writes race concurrent typed successors (P1) — fixed

The unconditional `commit_session_snapshot` + `save_authoritative_projection` could overwrite a typed successor committed by another process between the legacy observation and the migration write (zero-quiescence upgrade), losing committed turns. Now:

- The projection write is the **CAS-guarded** authoritative-projection save keyed on the persisted row's continuity token, reusing the same `verify_authoritative_projection_persisted_continuity` preflight as the runtime-checkpoint path (incremental stores get `verify_incremental_projection_continuity`). A concurrently-changed row fails the preflight closed; retry re-observes.
- The runtime snapshot commit **probes** that the snapshot still holds the exact observed legacy bytes before writing. The probe-to-commit window is not atomic cross-process, but the residual race provably cannot lose committed content: the CAS keeps the store row authoritative, and read-source arbitration recovers a clobbered snapshot from the extending store head, after which the next boundary commit rewrites it. This reasoning is documented on `commit_migrated_runtime_snapshot`.

### 2. Partial adoption wedged sessions permanently (P1) — fixed

A crash between the migration's two writes leaves a verified runtime snapshot over a still-legacy store row. `resolve_runtime_snapshot_read_source` fails closed on a legacy **store head** too, so the transient failure made the session permanently unreadable — worse than #909's commit message claimed. Now:

- New machine disposition `RebuildProjectionFromTypedSnapshot` (SessionDocumentMachine, transition `ResolveLegacyCheckpointMigrationTypedSnapshotLegacyProjection`): verified snapshot + legacy row → the shell rebuilds the projection from the verified authority via the same CAS-guarded write; **nothing is re-stamped**.
- Triggered from both seams: `load_committed_checkpoint_authority` (any legacy copy on either side now routes through the machine) and the ordinary read's store-head check.

### 3. Stamp custody bound to re-serialized bytes (P2) — fixed

`CommittedCheckpointCopy::Legacy` now carries the exact loaded snapshot bytes, and `MigrateCanonicalSnapshot` stamps custody of those observed bytes. Store-row sources keep a documented re-serialization (the `SessionStore` trait yields decoded documents, not raw rows) — which the migration then writes to both stores, making it the stored bytes everywhere.

## Test plan

- 2 new tests: `partial_adoption_heals_legacy_projection_from_typed_snapshot` (typed snapshot + legacy row → ordinary read heals, row converges onto the verified stamp) and `migration_stamp_binds_to_observed_snapshot_bytes` (pretty-printed snapshot bytes → custody digest matches observed bytes, not the compact re-serialization).
- Full `meerkat-core` + `meerkat-session` suites (session-store + session-compaction): 1,841 passed, 0 failed — including all 9 tests from #909 unchanged (the divergence-refusal no-writes property holds under the new guarded writes).
- `make machine-check-drift`: 10 machines, 7 compositions up to date; machine + protocol codegen regenerated.
- Scoped clippy `--all-targets --all-features -D warnings`: clean. Full pre-push gate: passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)