### PR TITLE
feat(tools): supervise streaming execution

### DIFF
--- a/meerkat-contracts/src/wire/result.rs
+++ b/meerkat-contracts/src/wire/result.rs
@@ -44,7 +44,7 @@ impl From<&meerkat_core::error::ToolError> for WireToolErrorClass {
             ToolError::NotFound { .. } => Self::NotFound,
             ToolError::AccessDenied { .. } => Self::AccessDenied,
             ToolError::InvalidArguments { .. } => Self::InvalidArguments,
-            ToolError::Timeout { .. } => Self::Timeout,
+            ToolError::Timeout { .. } | ToolError::InactivityTimeout { .. } => Self::Timeout,
             _ => Self::Internal,
         }
     }

--- a/meerkat-core/src/agent.rs
+++ b/meerkat-core/src/agent.rs
@@ -427,6 +427,7 @@ pub struct ToolDispatchContext {
     turn_metadata: BTreeMap<String, serde_json::Value>,
     origin_session_id: Option<crate::types::SessionId>,
     interaction_lineage_id: Option<crate::interaction::InteractionId>,
+    streaming: Option<crate::ToolStreamingDispatchContext>,
 }
 
 /// Dispatch-context key carrying the current durable objective id.
@@ -443,6 +444,7 @@ impl ToolDispatchContext {
             turn_metadata: BTreeMap::new(),
             origin_session_id: None,
             interaction_lineage_id: None,
+            streaming: None,
         }
     }
 
@@ -491,6 +493,20 @@ impl ToolDispatchContext {
 
     pub const fn interaction_lineage_id(&self) -> Option<crate::interaction::InteractionId> {
         self.interaction_lineage_id
+    }
+
+    /// Streaming-only liveness surface minted by the canonical supervisor.
+    ///
+    /// Fast and detached dispatch contexts carry no streaming surface. A tool
+    /// that declared `Streaming` must fail closed if this is absent rather than
+    /// fabricating a progress sink or cancellation authority.
+    pub const fn streaming(&self) -> Option<&crate::ToolStreamingDispatchContext> {
+        self.streaming.as_ref()
+    }
+
+    pub(crate) fn with_streaming(mut self, streaming: crate::ToolStreamingDispatchContext) -> Self {
+        self.streaming = Some(streaming);
+        self
     }
 
     pub fn current_turn_image(
@@ -917,9 +933,33 @@ pub async fn dispatch_tool_execution_plan_fenced<T: AgentToolDispatcher + ?Sized
             crate::ToolUnavailableReason::ExecutionOwnerChanged,
         ));
     }
-    dispatcher
-        .dispatch_resolved_with_context(call, context, plan)
-        .await
+    match plan.kind() {
+        crate::ResolvedExecutionKind::Streaming(policy) => {
+            let absolute_timeout = plan
+                .deadlines()
+                .effective_timeout()
+                .unwrap_or_else(|| policy.absolute_timeout());
+            crate::streaming_tool::supervise_streaming_tool(
+                call.name,
+                policy.inactivity_timeout(),
+                absolute_timeout,
+                |streaming| {
+                    let streaming_context = context.clone().with_streaming(streaming);
+                    async move {
+                        dispatcher
+                            .dispatch_resolved_with_context(call, &streaming_context, plan)
+                            .await
+                    }
+                },
+            )
+            .await
+        }
+        crate::ResolvedExecutionKind::Fast | crate::ResolvedExecutionKind::Detached(_) => {
+            dispatcher
+                .dispatch_resolved_with_context(call, context, plan)
+                .await
+        }
+    }
 }
 
 /// Compute whether the current exact catalog should stay inline or switch to deferred mode.
@@ -2048,6 +2088,11 @@ mod tests {
         catalog: Arc<[crate::ToolCatalogEntry]>,
     }
 
+    struct StreamingExecutionDispatcher {
+        catalog: Arc<[crate::ToolCatalogEntry]>,
+        saw_streaming_context: Arc<std::sync::atomic::AtomicBool>,
+    }
+
     struct IdenticalMutationDispatcher {
         tool: ToolDef,
         epoch: std::sync::atomic::AtomicU64,
@@ -2206,6 +2251,68 @@ mod tests {
                 ));
             }
             self.dispatch(call).await
+        }
+    }
+
+    #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+    #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+    impl AgentToolDispatcher for StreamingExecutionDispatcher {
+        fn tools(&self) -> Arc<[Arc<ToolDef>]> {
+            self.catalog
+                .iter()
+                .map(|entry| Arc::clone(&entry.tool))
+                .collect::<Vec<_>>()
+                .into()
+        }
+
+        fn tool_catalog_capabilities(&self) -> crate::ToolCatalogCapabilities {
+            crate::ToolCatalogCapabilities {
+                exact_catalog: true,
+                may_require_catalog_control_plane: false,
+            }
+        }
+
+        fn tool_catalog(&self) -> Arc<[crate::ToolCatalogEntry]> {
+            Arc::clone(&self.catalog)
+        }
+
+        async fn dispatch(
+            &self,
+            call: ToolCallView<'_>,
+        ) -> Result<crate::ops::ToolDispatchOutcome, crate::error::ToolError> {
+            Err(crate::ToolError::unavailable(
+                call.name,
+                crate::ToolUnavailableReason::ExecutionModeOwnerUnavailable,
+            ))
+        }
+
+        async fn dispatch_resolved_with_context(
+            &self,
+            call: ToolCallView<'_>,
+            context: &ToolDispatchContext,
+            plan: &crate::ResolvedToolExecutionPlan,
+        ) -> Result<crate::ops::ToolDispatchOutcome, crate::error::ToolError> {
+            if plan.mode() != crate::ToolExecutionMode::Streaming {
+                return Err(crate::ToolError::execution_failed(
+                    "streaming owner received a non-streaming plan",
+                ));
+            }
+            let streaming = context.streaming().ok_or_else(|| {
+                crate::ToolError::unavailable(
+                    call.name,
+                    crate::ToolUnavailableReason::ExecutionModeOwnerUnavailable,
+                )
+            })?;
+            streaming
+                .progress()
+                .try_report(
+                    crate::ToolProgressFrame::message("accepted through wrapper")
+                        .map_err(|error| crate::ToolError::other(error.to_string()))?,
+                )
+                .map_err(|error| crate::ToolError::other(error.to_string()))?;
+            self.saw_streaming_context
+                .store(true, std::sync::atomic::Ordering::SeqCst);
+            Ok(ToolResult::new(call.id.to_string(), "stream complete".to_string(), false).into())
         }
     }
 
@@ -2465,6 +2572,149 @@ mod tests {
             .await
             .expect_err("the default dispatcher must not lower detached work to dispatch()");
 
+        assert!(matches!(
+            error,
+            crate::ToolError::Unavailable {
+                reason: crate::ToolUnavailableReason::ExecutionModeOwnerUnavailable,
+                ..
+            }
+        ));
+    }
+
+    #[tokio::test]
+    async fn fenced_streaming_dispatch_mints_context_and_filtered_wrapper_preserves_it() {
+        use crate::{
+            StreamingToolExecutionPolicy, ToolDeadlineChain, ToolDeadlineContributor,
+            ToolDeadlineOwner, ToolExecutionContract, ToolExecutionMode,
+            ToolExecutionResolutionContext,
+        };
+        use std::collections::BTreeSet;
+        use std::time::Duration;
+
+        let contract = ToolExecutionContract::new(
+            BTreeSet::from([ToolExecutionMode::Streaming]),
+            ToolExecutionMode::Streaming,
+            Some(
+                StreamingToolExecutionPolicy::new(Duration::from_secs(5), Duration::from_secs(30))
+                    .unwrap(),
+            ),
+            None,
+        )
+        .unwrap();
+        let saw_streaming_context = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let owner = StreamingExecutionDispatcher {
+            catalog: Arc::from([crate::ToolCatalogEntry::session_inline(
+                Arc::new(ToolDef::new(
+                    "stream_scan",
+                    "stream scan",
+                    json!({"type": "object"}),
+                )),
+                true,
+            )
+            .with_execution_contract(contract)]),
+            saw_streaming_context: Arc::clone(&saw_streaming_context),
+        };
+        let dispatcher = Arc::new(FilteredToolDispatcher::new(
+            Arc::new(owner),
+            ["stream_scan"],
+        ));
+        let filtered_catalog = dispatcher.tool_catalog();
+        assert_eq!(
+            filtered_catalog[0].execution.default_mode(),
+            ToolExecutionMode::Streaming
+        );
+        let filtered_policy = filtered_catalog[0]
+            .execution
+            .streaming_policy()
+            .expect("wrapper preserves the streaming registration");
+        assert_eq!(filtered_policy.inactivity_timeout(), Duration::from_secs(5));
+        assert_eq!(filtered_policy.absolute_timeout(), Duration::from_secs(30));
+        let args = serde_json::value::RawValue::from_string("{}".to_string()).unwrap();
+        let call = ToolCallView {
+            id: "stream-call",
+            name: "stream_scan",
+            args: &args,
+        };
+        let context = ToolDispatchContext::default();
+        assert!(
+            context.streaming().is_none(),
+            "callers cannot pre-mint the supervised streaming context"
+        );
+        let resolution = ToolExecutionResolutionContext::new(
+            ToolDeadlineChain::new(vec![ToolDeadlineContributor::finite(
+                ToolDeadlineOwner::CoreToolDispatch,
+                Duration::from_secs(60),
+            )])
+            .unwrap(),
+        );
+        let plan =
+            crate::resolve_tool_execution_plan_fenced(&dispatcher, call, &context, &resolution)
+                .expect("streaming plan resolves through wrapper");
+
+        let outcome =
+            crate::dispatch_tool_execution_plan_fenced(&dispatcher, call, &context, &plan)
+                .await
+                .expect("streaming dispatch completes");
+
+        assert_eq!(outcome.result.text_content(), "stream complete");
+        assert!(
+            saw_streaming_context.load(std::sync::atomic::Ordering::SeqCst),
+            "the wrapper must preserve the exact supervised context"
+        );
+    }
+
+    #[tokio::test]
+    async fn declared_streaming_without_a_mode_owner_fails_closed_before_plain_dispatch() {
+        use crate::{
+            StreamingToolExecutionPolicy, ToolDeadlineChain, ToolDeadlineContributor,
+            ToolDeadlineOwner, ToolExecutionContract, ToolExecutionMode,
+            ToolExecutionResolutionContext,
+        };
+        use std::collections::BTreeSet;
+        use std::time::Duration;
+
+        let contract = ToolExecutionContract::new(
+            BTreeSet::from([ToolExecutionMode::Streaming]),
+            ToolExecutionMode::Streaming,
+            Some(
+                StreamingToolExecutionPolicy::new(Duration::from_secs(5), Duration::from_secs(30))
+                    .unwrap(),
+            ),
+            None,
+        )
+        .unwrap();
+        let dispatcher = Arc::new(ExactExecutionDispatcher {
+            catalog: Arc::from([crate::ToolCatalogEntry::session_inline(
+                Arc::new(ToolDef::new(
+                    "ownerless_stream",
+                    "ownerless",
+                    json!({"type": "object"}),
+                )),
+                true,
+            )
+            .with_execution_contract(contract)]),
+        });
+        let args = serde_json::value::RawValue::from_string("{}".to_string()).unwrap();
+        let call = ToolCallView {
+            id: "ownerless-call",
+            name: "ownerless_stream",
+            args: &args,
+        };
+        let context = ToolDispatchContext::default();
+        let resolution = ToolExecutionResolutionContext::new(
+            ToolDeadlineChain::new(vec![ToolDeadlineContributor::finite(
+                ToolDeadlineOwner::CoreToolDispatch,
+                Duration::from_secs(60),
+            )])
+            .unwrap(),
+        );
+        let plan =
+            crate::resolve_tool_execution_plan_fenced(&dispatcher, call, &context, &resolution)
+                .expect("declaration resolves");
+
+        let error = crate::dispatch_tool_execution_plan_fenced(&dispatcher, call, &context, &plan)
+            .await
+            .expect_err("missing streaming owner must fail closed");
         assert!(matches!(
             error,
             crate::ToolError::Unavailable {

--- a/meerkat-core/src/error.rs
+++ b/meerkat-core/src/error.rs
@@ -164,6 +164,10 @@ pub enum ToolError {
     #[error("Tool '{name}' timed out after {timeout_ms}ms")]
     Timeout { name: String, timeout_ms: u64 },
 
+    /// A declared streaming tool stopped producing accepted progress.
+    #[error("Streaming tool '{name}' stalled after {inactivity_ms}ms of inactivity")]
+    InactivityTimeout { name: String, inactivity_ms: u64 },
+
     /// Tool access was denied by policy
     #[error("Tool '{name}' is not allowed by policy")]
     AccessDenied { name: String },
@@ -194,6 +198,7 @@ impl ToolError {
                 "execution_failed"
             }
             Self::Timeout { .. } => "timeout",
+            Self::InactivityTimeout { .. } => "inactivity_timeout",
             Self::AccessDenied { .. } => "access_denied",
             Self::Other(_) => "tool_error",
             Self::CallbackPending { .. } => "callback_pending",
@@ -259,6 +264,12 @@ impl ToolError {
         Self::Timeout {
             name: name.into(),
             timeout_ms,
+        }
+    }
+    pub fn inactivity_timeout(name: impl Into<String>, inactivity_ms: u64) -> Self {
+        Self::InactivityTimeout {
+            name: name.into(),
+            inactivity_ms,
         }
     }
     pub fn access_denied(name: impl Into<String>) -> Self {

--- a/meerkat-core/src/lib.rs
+++ b/meerkat-core/src/lib.rs
@@ -77,6 +77,7 @@ pub mod state;
 pub mod storage_diagnostics;
 pub mod storage_durability;
 pub mod storage_layout;
+pub mod streaming_tool;
 pub mod surface_metadata;
 pub mod time_compat;
 pub mod tool_catalog;
@@ -169,6 +170,10 @@ pub use peer_correlation::{
 };
 pub use peer_meta::PeerMeta;
 pub use placement::{ExecutionPlacement, ExecutionPlacementIdentity, PlacementError};
+pub use streaming_tool::{
+    ToolCancellationToken, ToolProgressFrame, ToolProgressFrameError, ToolProgressReportError,
+    ToolProgressSink, ToolStreamingDispatchContext,
+};
 pub use surface_metadata::{
     MEERKAT_METADATA_PREFIX, RESERVED_MOB_LABEL_KEYS, ReservedMetadataKey, RuntimeMetadata,
     SurfaceMetadata, SurfaceMetadataError, is_reserved_meerkat_label_key,

--- a/meerkat-core/src/ops.rs
+++ b/meerkat-core/src/ops.rs
@@ -124,7 +124,7 @@ impl From<&ToolError> for ToolDispatchTerminalErrorKind {
             ToolError::ExecutionFailed { .. } | ToolError::ExecutionFailedWithData { .. } => {
                 Self::ExecutionFailed
             }
-            ToolError::Timeout { .. } => Self::Timeout,
+            ToolError::Timeout { .. } | ToolError::InactivityTimeout { .. } => Self::Timeout,
             ToolError::AccessDenied { .. } => Self::AccessDenied,
             ToolError::Other(_) => Self::Other,
             ToolError::CallbackPending { .. } => Self::CallbackPending,

--- a/meerkat-core/src/streaming_tool.rs
+++ b/meerkat-core/src/streaming_tool.rs
@@ -1,0 +1,662 @@
+//! Typed liveness primitives for synchronous streaming tool execution.
+
+use crate::ToolError;
+#[cfg(target_arch = "wasm32")]
+use crate::tokio;
+use serde::{Deserialize, Deserializer, Serialize};
+use std::future::Future;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::Duration;
+
+/// One accepted, non-terminal liveness update from a streaming tool.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct ToolProgressFrame {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    message: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    completed_units: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    total_units: Option<u64>,
+}
+
+impl ToolProgressFrame {
+    pub fn new(
+        message: Option<String>,
+        completed_units: Option<u64>,
+        total_units: Option<u64>,
+    ) -> Result<Self, ToolProgressFrameError> {
+        let message = message.and_then(|message| {
+            let trimmed = message.trim();
+            (!trimmed.is_empty()).then(|| trimmed.to_string())
+        });
+        if completed_units.is_some() != total_units.is_some() {
+            return Err(ToolProgressFrameError::IncompleteUnits);
+        }
+        if matches!(total_units, Some(0)) {
+            return Err(ToolProgressFrameError::ZeroTotalUnits);
+        }
+        if let (Some(completed), Some(total)) = (completed_units, total_units)
+            && completed > total
+        {
+            return Err(ToolProgressFrameError::CompletedExceedsTotal);
+        }
+        if message.is_none() && completed_units.is_none() {
+            return Err(ToolProgressFrameError::Empty);
+        }
+        Ok(Self {
+            message,
+            completed_units,
+            total_units,
+        })
+    }
+
+    pub fn message(message: impl Into<String>) -> Result<Self, ToolProgressFrameError> {
+        Self::new(Some(message.into()), None, None)
+    }
+
+    pub fn units(
+        completed_units: u64,
+        total_units: u64,
+        message: Option<String>,
+    ) -> Result<Self, ToolProgressFrameError> {
+        Self::new(message, Some(completed_units), Some(total_units))
+    }
+
+    pub fn message_text(&self) -> Option<&str> {
+        self.message.as_deref()
+    }
+
+    pub const fn completed_units(&self) -> Option<u64> {
+        self.completed_units
+    }
+
+    pub const fn total_units(&self) -> Option<u64> {
+        self.total_units
+    }
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct ToolProgressFrameWire {
+    #[serde(default)]
+    message: Option<String>,
+    #[serde(default)]
+    completed_units: Option<u64>,
+    #[serde(default)]
+    total_units: Option<u64>,
+}
+
+impl<'de> Deserialize<'de> for ToolProgressFrame {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let wire = ToolProgressFrameWire::deserialize(deserializer)?;
+        Self::new(wire.message, wire.completed_units, wire.total_units)
+            .map_err(serde::de::Error::custom)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
+pub enum ToolProgressFrameError {
+    #[error("progress frame must contain a message or a complete units update")]
+    Empty,
+    #[error("completed_units and total_units must be supplied together")]
+    IncompleteUnits,
+    #[error("progress total_units must be greater than zero")]
+    ZeroTotalUnits,
+    #[error("progress completed_units must not exceed total_units")]
+    CompletedExceedsTotal,
+}
+
+struct ToolProgressSinkInner {
+    sender: tokio::sync::mpsc::Sender<ToolProgressFrame>,
+}
+
+/// Bounded producer used by a streaming implementation to report liveness.
+#[derive(Clone)]
+pub struct ToolProgressSink {
+    inner: Arc<ToolProgressSinkInner>,
+}
+
+impl std::fmt::Debug for ToolProgressSink {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("ToolProgressSink")
+            .field("capacity", &self.inner.sender.capacity())
+            .finish_non_exhaustive()
+    }
+}
+
+impl PartialEq for ToolProgressSink {
+    fn eq(&self, other: &Self) -> bool {
+        Arc::ptr_eq(&self.inner, &other.inner)
+    }
+}
+
+impl Eq for ToolProgressSink {}
+
+impl ToolProgressSink {
+    /// Report a frame without allowing diagnostics to block execution.
+    ///
+    /// Only `Ok(())` means the canonical supervisor accepted the frame. A
+    /// malformed, closed, or backpressured report never refreshes liveness.
+    pub fn try_report(&self, frame: ToolProgressFrame) -> Result<(), ToolProgressReportError> {
+        self.inner
+            .sender
+            .try_send(frame)
+            .map_err(|error| match error {
+                tokio::sync::mpsc::error::TrySendError::Full(_) => {
+                    ToolProgressReportError::Backpressured
+                }
+                tokio::sync::mpsc::error::TrySendError::Closed(_) => {
+                    ToolProgressReportError::Closed
+                }
+            })
+    }
+
+    /// Parse a transport frame at ingress, then report only a valid typed frame.
+    pub fn try_report_json(&self, value: serde_json::Value) -> Result<(), ToolProgressReportError> {
+        let frame = serde_json::from_value(value)
+            .map_err(|error| ToolProgressReportError::Malformed(error.to_string()))?;
+        self.try_report(frame)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum ToolProgressReportError {
+    #[error("malformed streaming progress frame: {0}")]
+    Malformed(String),
+    #[error("streaming progress sink is backpressured")]
+    Backpressured,
+    #[error("streaming progress sink is closed")]
+    Closed,
+}
+
+struct ToolCancellationInner {
+    cancelled: AtomicBool,
+    changed: tokio::sync::watch::Sender<bool>,
+}
+
+/// Cooperative cancellation signal for one streaming tool dispatch.
+#[derive(Clone)]
+pub struct ToolCancellationToken {
+    inner: Arc<ToolCancellationInner>,
+}
+
+impl ToolCancellationToken {
+    fn new() -> Self {
+        let (changed, _receiver) = tokio::sync::watch::channel(false);
+        Self {
+            inner: Arc::new(ToolCancellationInner {
+                cancelled: AtomicBool::new(false),
+                changed,
+            }),
+        }
+    }
+
+    pub fn is_cancelled(&self) -> bool {
+        self.inner.cancelled.load(Ordering::Acquire)
+    }
+
+    pub async fn cancelled(&self) {
+        if self.is_cancelled() {
+            return;
+        }
+        let mut receiver = self.inner.changed.subscribe();
+        while !*receiver.borrow_and_update() {
+            if receiver.changed().await.is_err() {
+                break;
+            }
+        }
+    }
+
+    fn cancel(&self) {
+        if !self.inner.cancelled.swap(true, Ordering::AcqRel) {
+            self.inner.changed.send_replace(true);
+        }
+    }
+}
+
+impl std::fmt::Debug for ToolCancellationToken {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("ToolCancellationToken")
+            .field("cancelled", &self.is_cancelled())
+            .finish_non_exhaustive()
+    }
+}
+
+impl PartialEq for ToolCancellationToken {
+    fn eq(&self, other: &Self) -> bool {
+        Arc::ptr_eq(&self.inner, &other.inner)
+    }
+}
+
+impl Eq for ToolCancellationToken {}
+
+/// Typed streaming-only portion of [`crate::ToolDispatchContext`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ToolStreamingDispatchContext {
+    progress: ToolProgressSink,
+    cancellation: ToolCancellationToken,
+}
+
+impl ToolStreamingDispatchContext {
+    pub const fn progress(&self) -> &ToolProgressSink {
+        &self.progress
+    }
+
+    pub const fn cancellation(&self) -> &ToolCancellationToken {
+        &self.cancellation
+    }
+}
+
+struct CancelOnDrop {
+    token: ToolCancellationToken,
+    armed: bool,
+}
+
+impl CancelOnDrop {
+    fn new(token: ToolCancellationToken) -> Self {
+        Self { token, armed: true }
+    }
+
+    fn disarm(&mut self) {
+        self.armed = false;
+    }
+}
+
+impl Drop for CancelOnDrop {
+    fn drop(&mut self) {
+        if self.armed {
+            self.token.cancel();
+        }
+    }
+}
+
+pub(crate) async fn supervise_streaming_tool<T, F, MakeFuture>(
+    tool_name: &str,
+    inactivity_timeout: Duration,
+    absolute_timeout: Duration,
+    make_future: MakeFuture,
+) -> Result<T, ToolError>
+where
+    F: Future<Output = Result<T, ToolError>>,
+    MakeFuture: FnOnce(ToolStreamingDispatchContext) -> F,
+{
+    supervise_streaming_tool_with_capacity(
+        tool_name,
+        inactivity_timeout,
+        absolute_timeout,
+        32,
+        make_future,
+    )
+    .await
+}
+
+async fn supervise_streaming_tool_with_capacity<T, F, MakeFuture>(
+    tool_name: &str,
+    inactivity_timeout: Duration,
+    absolute_timeout: Duration,
+    capacity: usize,
+    make_future: MakeFuture,
+) -> Result<T, ToolError>
+where
+    F: Future<Output = Result<T, ToolError>>,
+    MakeFuture: FnOnce(ToolStreamingDispatchContext) -> F,
+{
+    let (sender, mut receiver) = tokio::sync::mpsc::channel(capacity.max(1));
+    let cancellation = ToolCancellationToken::new();
+    let context = ToolStreamingDispatchContext {
+        progress: ToolProgressSink {
+            inner: Arc::new(ToolProgressSinkInner { sender }),
+        },
+        cancellation: cancellation.clone(),
+    };
+    let mut cancel_on_drop = CancelOnDrop::new(cancellation);
+    let execution = make_future(context);
+    tokio::pin!(execution);
+    let inactivity = tokio::time::sleep(inactivity_timeout);
+    tokio::pin!(inactivity);
+    let absolute = tokio::time::sleep(absolute_timeout);
+    tokio::pin!(absolute);
+    let mut progress_open = true;
+
+    loop {
+        tokio::select! {
+            biased;
+            result = &mut execution => {
+                cancel_on_drop.disarm();
+                return result;
+            }
+            () = &mut absolute => {
+                return Err(ToolError::timeout(
+                    tool_name,
+                    duration_millis(absolute_timeout),
+                ));
+            }
+            frame = receiver.recv(), if progress_open => {
+                match frame {
+                    Some(_accepted) => {
+                        inactivity
+                            .as_mut()
+                            .set(tokio::time::sleep(inactivity_timeout));
+                    }
+                    None => progress_open = false,
+                }
+            }
+            () = &mut inactivity => {
+                return Err(ToolError::inactivity_timeout(
+                    tool_name,
+                    duration_millis(inactivity_timeout),
+                ));
+            }
+        }
+    }
+}
+
+fn duration_millis(duration: Duration) -> u64 {
+    u64::try_from(duration.as_millis()).unwrap_or(u64::MAX)
+}
+
+#[cfg(test)]
+#[allow(
+    clippy::expect_used,
+    clippy::panic,
+    clippy::redundant_clone,
+    clippy::unwrap_used
+)]
+mod tests {
+    use super::{
+        ToolProgressFrame, ToolProgressReportError, supervise_streaming_tool_with_capacity,
+    };
+    use crate::ToolError;
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::{Arc, Mutex};
+    use std::time::Duration;
+
+    fn message(text: &str) -> ToolProgressFrame {
+        ToolProgressFrame::message(text).expect("valid progress frame")
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn silent_stream_times_out_and_cancels_exact_context() {
+        let captured = Arc::new(Mutex::new(None));
+        let captured_for_dispatch = Arc::clone(&captured);
+        let task = tokio::spawn(supervise_streaming_tool_with_capacity(
+            "scan",
+            Duration::from_secs(5),
+            Duration::from_secs(30),
+            4,
+            move |context| {
+                *captured_for_dispatch.lock().unwrap() = Some(context.cancellation().clone());
+                std::future::pending::<Result<(), ToolError>>()
+            },
+        ));
+
+        tokio::task::yield_now().await;
+        tokio::time::advance(Duration::from_secs(5)).await;
+        let error = task
+            .await
+            .expect("supervisor task joins")
+            .expect_err("silent stream must time out");
+
+        assert!(matches!(
+            error,
+            ToolError::InactivityTimeout {
+                inactivity_ms: 5_000,
+                ..
+            }
+        ));
+        assert!(
+            captured
+                .lock()
+                .unwrap()
+                .as_ref()
+                .expect("cancellation captured")
+                .is_cancelled()
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn accepted_progress_resets_inactivity_but_not_absolute_ceiling() {
+        let (context_tx, context_rx) = tokio::sync::oneshot::channel();
+        let task = tokio::spawn(supervise_streaming_tool_with_capacity(
+            "scan",
+            Duration::from_secs(5),
+            Duration::from_secs(12),
+            4,
+            move |context| {
+                context_tx.send(context.clone()).unwrap();
+                std::future::pending::<Result<(), ToolError>>()
+            },
+        ));
+        let context = context_rx.await.expect("streaming context");
+
+        tokio::time::advance(Duration::from_secs(4)).await;
+        context
+            .progress()
+            .try_report(message("first accepted frame"))
+            .expect("progress accepted");
+        tokio::task::yield_now().await;
+        tokio::time::advance(Duration::from_secs(4)).await;
+        assert!(!task.is_finished(), "accepted progress resets inactivity");
+
+        context
+            .progress()
+            .try_report(message("second accepted frame"))
+            .expect("progress accepted");
+        tokio::task::yield_now().await;
+        tokio::time::advance(Duration::from_secs(3)).await;
+        assert!(!task.is_finished(), "absolute deadline has not elapsed");
+
+        tokio::time::advance(Duration::from_secs(1)).await;
+        let error = task
+            .await
+            .expect("supervisor task joins")
+            .expect_err("absolute ceiling must win despite progress");
+        assert!(matches!(
+            error,
+            ToolError::Timeout {
+                timeout_ms: 12_000,
+                ..
+            }
+        ));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn malformed_progress_never_reaches_or_resets_the_watchdog() {
+        let (context_tx, context_rx) = tokio::sync::oneshot::channel();
+        let task = tokio::spawn(supervise_streaming_tool_with_capacity(
+            "scan",
+            Duration::from_secs(5),
+            Duration::from_secs(30),
+            1,
+            move |context| {
+                context_tx.send(context.clone()).unwrap();
+                std::future::pending::<Result<(), ToolError>>()
+            },
+        ));
+        let context = context_rx.await.expect("streaming context");
+
+        tokio::time::advance(Duration::from_secs(4)).await;
+        assert!(matches!(
+            context
+                .progress()
+                .try_report_json(serde_json::json!({"message": "  "})),
+            Err(ToolProgressReportError::Malformed(_))
+        ));
+        tokio::time::advance(Duration::from_secs(1)).await;
+
+        assert!(matches!(
+            task.await
+                .expect("supervisor task joins")
+                .expect_err("malformed progress must not reset inactivity"),
+            ToolError::InactivityTimeout { .. }
+        ));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn backpressured_progress_is_rejected_and_cannot_extend_liveness() {
+        let observed_rejection = Arc::new(AtomicBool::new(false));
+        let observed_rejection_for_dispatch = Arc::clone(&observed_rejection);
+        let task = tokio::spawn(supervise_streaming_tool_with_capacity(
+            "scan",
+            Duration::from_secs(5),
+            Duration::from_secs(30),
+            1,
+            move |context| {
+                context
+                    .progress()
+                    .try_report(message("accepted"))
+                    .expect("first frame fits");
+                observed_rejection_for_dispatch.store(
+                    matches!(
+                        context.progress().try_report(message("rejected")),
+                        Err(ToolProgressReportError::Backpressured)
+                    ),
+                    Ordering::SeqCst,
+                );
+                std::future::pending::<Result<(), ToolError>>()
+            },
+        ));
+
+        tokio::task::yield_now().await;
+        assert!(observed_rejection.load(Ordering::SeqCst));
+        tokio::time::advance(Duration::from_secs(5)).await;
+        assert!(matches!(
+            task.await
+                .expect("supervisor task joins")
+                .expect_err("rejected frame must not add another liveness reset"),
+            ToolError::InactivityTimeout { .. }
+        ));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn terminal_completion_wins_an_exact_inactivity_deadline_race() {
+        let result = supervise_streaming_tool_with_capacity(
+            "scan",
+            Duration::from_secs(5),
+            Duration::from_secs(30),
+            1,
+            |_context| async {
+                tokio::time::sleep(Duration::from_secs(5)).await;
+                Ok::<_, ToolError>("complete")
+            },
+        );
+        tokio::pin!(result);
+
+        tokio::time::advance(Duration::from_secs(5)).await;
+        assert_eq!(result.await.expect("completion wins tie"), "complete");
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn continuous_progress_cannot_starve_the_absolute_ceiling() {
+        let (context_tx, context_rx) = tokio::sync::oneshot::channel();
+        let task = tokio::spawn(supervise_streaming_tool_with_capacity(
+            "scan",
+            Duration::from_secs(2),
+            Duration::from_secs(5),
+            1,
+            move |context| {
+                context_tx.send(context.clone()).unwrap();
+                std::future::pending::<Result<(), ToolError>>()
+            },
+        ));
+        let context = context_rx.await.expect("streaming context");
+        let producer = tokio::spawn(async move {
+            loop {
+                match context.progress().try_report(message("flood")) {
+                    Ok(()) | Err(ToolProgressReportError::Backpressured) => {
+                        tokio::task::yield_now().await;
+                    }
+                    Err(ToolProgressReportError::Closed) => break,
+                    Err(ToolProgressReportError::Malformed(error)) => {
+                        panic!("typed frame became malformed: {error}")
+                    }
+                }
+            }
+        });
+
+        tokio::time::advance(Duration::from_secs(5)).await;
+        assert!(matches!(
+            task.await
+                .expect("supervisor task joins")
+                .expect_err("absolute ceiling must win under continuous progress"),
+            ToolError::Timeout {
+                timeout_ms: 5_000,
+                ..
+            }
+        ));
+        producer.await.expect("producer observes closed sink");
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn outer_timeout_drop_still_cancels_the_streaming_context() {
+        let captured = Arc::new(Mutex::new(None));
+        let captured_for_dispatch = Arc::clone(&captured);
+        let supervised = supervise_streaming_tool_with_capacity(
+            "scan",
+            Duration::from_secs(20),
+            Duration::from_secs(30),
+            1,
+            move |context| {
+                *captured_for_dispatch.lock().unwrap() = Some(context.cancellation().clone());
+                std::future::pending::<Result<(), ToolError>>()
+            },
+        );
+        let outer = tokio::spawn(tokio::time::timeout(Duration::from_secs(3), supervised));
+
+        tokio::task::yield_now().await;
+        tokio::time::advance(Duration::from_secs(3)).await;
+        outer
+            .await
+            .expect("outer task joins")
+            .expect_err("outer deadline expires");
+        assert!(
+            captured
+                .lock()
+                .unwrap()
+                .as_ref()
+                .expect("cancellation captured")
+                .is_cancelled(),
+            "dropping the supervised future must signal cancellation"
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn timeout_drops_an_implementation_that_ignores_cancellation() {
+        struct DropProbe(Arc<AtomicBool>);
+        impl Drop for DropProbe {
+            fn drop(&mut self) {
+                self.0.store(true, Ordering::SeqCst);
+            }
+        }
+
+        let dropped = Arc::new(AtomicBool::new(false));
+        let dropped_for_dispatch = Arc::clone(&dropped);
+        let task = tokio::spawn(supervise_streaming_tool_with_capacity(
+            "scan",
+            Duration::from_secs(5),
+            Duration::from_secs(30),
+            1,
+            move |_context| {
+                let probe = DropProbe(dropped_for_dispatch);
+                async move {
+                    let _probe = probe;
+                    std::future::pending::<Result<(), ToolError>>().await
+                }
+            },
+        ));
+
+        tokio::task::yield_now().await;
+        tokio::time::advance(Duration::from_secs(5)).await;
+        assert!(task.await.expect("supervisor task joins").is_err());
+        assert!(
+            dropped.load(Ordering::SeqCst),
+            "dropping the supervised future is the final cleanup boundary"
+        );
+    }
+}

--- a/meerkat-mob/src/runtime/member_upcall.rs
+++ b/meerkat-mob/src/runtime/member_upcall.rs
@@ -169,6 +169,7 @@ pub(crate) enum UpcallToolErrorClass {
     InvalidArguments,
     ExecutionFailed,
     Timeout,
+    InactivityTimeout,
     AccessDenied,
     Other,
 }
@@ -247,6 +248,17 @@ impl UpcallToolOutcome {
                 message: error.to_string(),
                 name: Some(name.clone()),
                 timeout_ms: Some(*timeout_ms),
+                unavailable_reason: None,
+                data: None,
+            },
+            ToolError::InactivityTimeout {
+                name,
+                inactivity_ms,
+            } => UpcallToolError {
+                class: UpcallToolErrorClass::InactivityTimeout,
+                message: error.to_string(),
+                name: Some(name.clone()),
+                timeout_ms: Some(*inactivity_ms),
                 unavailable_reason: None,
                 data: None,
             },
@@ -358,6 +370,9 @@ impl UpcallToolError {
             },
             UpcallToolErrorClass::Timeout => {
                 ToolError::timeout(name, self.timeout_ms.unwrap_or_default())
+            }
+            UpcallToolErrorClass::InactivityTimeout => {
+                ToolError::inactivity_timeout(name, self.timeout_ms.unwrap_or_default())
             }
             UpcallToolErrorClass::AccessDenied => ToolError::access_denied(name),
             UpcallToolErrorClass::Other => ToolError::other(self.message),
@@ -1240,6 +1255,7 @@ mod tests {
             ToolError::execution_failed("boom"),
             ToolError::execution_failed_with_data("boom", json!({"cause": "unavailable"})),
             ToolError::timeout("mob_run_flow", 90_000),
+            ToolError::inactivity_timeout("stream_scan", 30_000),
             ToolError::access_denied("retire_member"),
             ToolError::other("misc"),
         ];
@@ -1265,6 +1281,19 @@ mod tests {
                 ) => {
                     assert_eq!(name, rname);
                     assert_eq!(timeout_ms, rms);
+                }
+                (
+                    ToolError::InactivityTimeout {
+                        name,
+                        inactivity_ms,
+                    },
+                    ToolError::InactivityTimeout {
+                        name: rname,
+                        inactivity_ms: rms,
+                    },
+                ) => {
+                    assert_eq!(name, rname);
+                    assert_eq!(inactivity_ms, rms);
                 }
                 (ToolError::AccessDenied { name }, ToolError::AccessDenied { name: rname }) => {
                     assert_eq!(name, rname);

--- a/scripts/agent-gate
+++ b/scripts/agent-gate
@@ -52,9 +52,15 @@ cd "${workspace_root}"
 
 case "${backend}" in
   cargo)
+    if [[ ${#args[@]} -eq 0 ]]; then
+      exec ./scripts/cargo-agent-gate
+    fi
     exec ./scripts/cargo-agent-gate "${args[@]}"
     ;;
   buildbuddy)
+    if [[ ${#args[@]} -eq 0 ]]; then
+      exec ./scripts/buildbuddy-agent-gate
+    fi
     exec ./scripts/buildbuddy-agent-gate "${args[@]}"
     ;;
   *)


### PR DESCRIPTION
## Summary

- add typed, validated streaming progress frames with a bounded canonical sink
- add cooperative cancellation and supervise streaming dispatch with independent inactivity and absolute deadlines
- preserve the streaming execution contract through filtered dispatch wrappers and fail closed without a mode owner
- project inactivity timeout consistently through public and Mob upcall result classes
- make the agent-gate wrapper safe when invoked without passthrough arguments on Bash 3

## Contract coverage

- silent streams time out and cancel
- only accepted progress resets inactivity; malformed and backpressured frames do not
- accepted progress never extends the absolute deadline
- continuous progress cannot starve the hard deadline
- completion/timeout races and ignored-cancellation cleanup are covered
- wrapper registration and context forwarding are covered
- native and wasm32 builds are covered

## Validation

- make fmt
- CARGO_INCREMENTAL=0 make check
- CARGO_INCREMENTAL=0 make lint
- CARGO_INCREMENTAL=0 make test (11,699 passed, 78 skipped; plus session follow-up tests)
- make agent-gate
- focused meerkat-core streaming suite (10 passed)
- focused wasm32-unknown-unknown meerkat-core check
- full pre-push hooks

## Stack and merge hold

This Phase 5 PR is intentionally based on Meerkat PR #913 at 5f7ff147c and must land after #913. Phase 6 will be a separate follow-on branch/PR stacked on this checkpoint if necessary.

Do not merge this PR, merge #913, tag, or publish a release until the parallel Cloud Code fixes have been released and Luka explicitly authorizes merging.