### PR TITLE
Enable provider caching and stabilize terminal context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,63 @@ via cargo-semver-checks against the published baselines).
 
 ## [Unreleased]
 
+### Breaking
+
+- `AnthropicCacheControlPolicy` and
+  `WireAnthropicCacheControlPolicy` add the `Automatic` variant.
+- `OpenAiProviderTag` adds the `prompt_cache_enabled` field.
+- `WireProviderTag::OpenAi` adds the `prompt_cache_enabled` field.
+
+### Billing-affecting default change
+
+- Anthropic API, Vertex, and Foundry text requests now default to Anthropic's
+  five-minute automatic prompt cache, which advances a breakpoint across the
+  growing conversation. Explicit `cache_control` request policy still wins:
+  `disabled` opts out and `system_prefix` preserves the narrower legacy
+  behavior. Amazon Bedrock remains disabled by default because its Anthropic
+  Messages backend does not support automatic caching, and explicitly
+  requesting `automatic` there now fails locally. A qualifying five-minute
+  cold cache write bills input tokens at 1.25x the base rate; cache hits bill
+  cached input tokens at 0.1x. Automatic lookup scans backward at most 20
+  cacheable blocks, so adding more than 20 blocks between requests can still
+  miss. Write/read accounting remains visible through
+  `Usage.cache_creation_tokens` / `cache_read_tokens`.
+- Factory-built public OpenAI API GPT-5.6 sessions now send
+  `prompt_cache_options: {"mode":"implicit","ttl":"30m"}` and a stable
+  per-session `prompt_cache_key` derived from the durable `SessionId`. A
+  caller-supplied key still wins, allowing hosts such as MobKit to use a
+  longer-lived identity bucket. These defaults are re-derived below persisted
+  provider parameters, so existing resumed sessions inherit them without a
+  metadata rewrite. GPT-5.6 cache writes bill at 1.25x the uncached input-token
+  rate; hits bill at the model's cached-input rate. `mode: "explicit"` authors
+  append-monotone breakpoints at deterministic message boundaries for both
+  Responses and Chat Completions. Set `prompt_cache_enabled: false` for a
+  durable opt-out: Meerkat emits explicit-only mode without a breakpoint, so
+  the request performs no cache reads or writes and incurs no cache-write
+  charges. Enabling explicit mode on a large cold transcript may create up to
+  four writes; normal growth adds one new boundary per model invocation.
+  Automatic defaults are capability-gated off for the private ChatGPT backend
+  and Azure OpenAI until those backend contracts explicitly admit them.
+  OpenAI recommends keeping traffic near 15 requests per minute per cache key;
+  higher-volume hosts should partition keys with a stable mapping. Agentic
+  tool loops can issue several model requests inside one user turn, so a
+  single tool-heavy turn can reach that guidance even without concurrent
+  users; neither a per-session nor per-identity key removes that risk. Cache
+  reads consider only the latest 50 breakpoints.
+- These defaults make Meerkat's policy and routing affinity deterministic;
+  they do not make a changing prefix cacheable. This patch does not prove
+  every system-prompt writer stable. A timestamp, changing tool membership,
+  or any other mutation before the breakpoint can still produce repeated
+  billable writes with no reads.
+
+### Changed
+
+- Typed peer terminal-response facts now persist as deduplicated
+  `SystemNotice` messages at the conversation tail instead of mutating the
+  leading system prompt. Active-turn delivery commits the notice to the
+  canonical transcript, and cold resume migrates legacy terminal blocks out
+  of the system prompt without losing their applied/idempotency records.
+
 ## [0.8.10] - 2026-07-28
 
 ### Breaking

--- a/artifacts/schemas/params.json
+++ b/artifacts/schemas/params.json
@@ -9598,6 +9598,7 @@
       "WireAnthropicCacheControlPolicy": {
         "enum": [
           "disabled",
+          "automatic",
           "system_prefix"
         ],
         "type": "string"
@@ -11354,6 +11355,12 @@
                   "null"
                 ]
               },
+              "prompt_cache_enabled": {
+                "type": [
+                  "boolean",
+                  "null"
+                ]
+              },
               "prompt_cache_key": {
                 "type": [
                   "string",
@@ -12473,6 +12480,11 @@
             "type": "string"
           },
           {
+            "const": "automatic",
+            "description": "Ask Anthropic to keep a moving breakpoint on the last cacheable block.\n\nThis is the normal multi-turn policy: the provider advances the\nbreakpoint as conversation history grows. Anthropic searches backward\nup to 20 cacheable blocks from that breakpoint, so a hit is not\nguaranteed when more than 20 new blocks are added between requests.",
+            "type": "string"
+          },
+          {
             "const": "system_prefix",
             "description": "Mark the stable top-level system prompt as an ephemeral cache prefix.",
             "type": "string"
@@ -13295,7 +13307,7 @@
                 "type": "null"
               }
             ],
-            "description": "Automatic (`implicit`) or explicit-only cache breakpoint placement."
+            "description": "Automatic (`implicit`) placement or Meerkat-authored explicit placement."
           },
           "ttl": {
             "anyOf": [
@@ -13647,6 +13659,13 @@
                 "format": "float",
                 "type": [
                   "number",
+                  "null"
+                ]
+              },
+              "prompt_cache_enabled": {
+                "description": "Meerkat-owned prompt-cache enable intent.\n\n`false` is a durable opt-out. On GPT-5.6 it lowers to explicit-only\nmode with no authored breakpoints, which performs no cache reads or\nwrites and incurs no cache-write charges.",
+                "type": [
+                  "boolean",
                   "null"
                 ]
               },
@@ -19747,6 +19766,7 @@
       "WireAnthropicCacheControlPolicy": {
         "enum": [
           "disabled",
+          "automatic",
           "system_prefix"
         ],
         "type": "string"
@@ -20352,6 +20372,12 @@
                 "format": "float",
                 "type": [
                   "number",
+                  "null"
+                ]
+              },
+              "prompt_cache_enabled": {
+                "type": [
+                  "boolean",
                   "null"
                 ]
               },
@@ -22625,6 +22651,7 @@
       "WireAnthropicCacheControlPolicy": {
         "enum": [
           "disabled",
+          "automatic",
           "system_prefix"
         ],
         "type": "string"
@@ -23061,6 +23088,12 @@
                 "format": "float",
                 "type": [
                   "number",
+                  "null"
+                ]
+              },
+              "prompt_cache_enabled": {
+                "type": [
+                  "boolean",
                   "null"
                 ]
               },
@@ -23614,6 +23647,7 @@
       "WireAnthropicCacheControlPolicy": {
         "enum": [
           "disabled",
+          "automatic",
           "system_prefix"
         ],
         "type": "string"
@@ -24050,6 +24084,12 @@
                 "format": "float",
                 "type": [
                   "number",
+                  "null"
+                ]
+              },
+              "prompt_cache_enabled": {
+                "type": [
+                  "boolean",
                   "null"
                 ]
               },
@@ -25584,6 +25624,7 @@
       "WireAnthropicCacheControlPolicy": {
         "enum": [
           "disabled",
+          "automatic",
           "system_prefix"
         ],
         "type": "string"
@@ -26470,6 +26511,12 @@
                 "format": "float",
                 "type": [
                   "number",
+                  "null"
+                ]
+              },
+              "prompt_cache_enabled": {
+                "type": [
+                  "boolean",
                   "null"
                 ]
               },
@@ -27470,6 +27517,7 @@
       "WireAnthropicCacheControlPolicy": {
         "enum": [
           "disabled",
+          "automatic",
           "system_prefix"
         ],
         "type": "string"
@@ -28078,6 +28126,12 @@
                 "format": "float",
                 "type": [
                   "number",
+                  "null"
+                ]
+              },
+              "prompt_cache_enabled": {
+                "type": [
+                  "boolean",
                   "null"
                 ]
               },
@@ -31733,6 +31787,11 @@
             "type": "string"
           },
           {
+            "const": "automatic",
+            "description": "Ask Anthropic to keep a moving breakpoint on the last cacheable block.\n\nThis is the normal multi-turn policy: the provider advances the\nbreakpoint as conversation history grows. Anthropic searches backward\nup to 20 cacheable blocks from that breakpoint, so a hit is not\nguaranteed when more than 20 new blocks are added between requests.",
+            "type": "string"
+          },
+          {
             "const": "system_prefix",
             "description": "Mark the stable top-level system prompt as an ephemeral cache prefix.",
             "type": "string"
@@ -32555,7 +32614,7 @@
                 "type": "null"
               }
             ],
-            "description": "Automatic (`implicit`) or explicit-only cache breakpoint placement."
+            "description": "Automatic (`implicit`) placement or Meerkat-authored explicit placement."
           },
           "ttl": {
             "anyOf": [
@@ -32907,6 +32966,13 @@
                 "format": "float",
                 "type": [
                   "number",
+                  "null"
+                ]
+              },
+              "prompt_cache_enabled": {
+                "description": "Meerkat-owned prompt-cache enable intent.\n\n`false` is a durable opt-out. On GPT-5.6 it lowers to explicit-only\nmode with no authored breakpoints, which performs no cache reads or\nwrites and incurs no cache-write charges.",
+                "type": [
+                  "boolean",
                   "null"
                 ]
               },
@@ -33951,6 +34017,11 @@
             "type": "string"
           },
           {
+            "const": "automatic",
+            "description": "Ask Anthropic to keep a moving breakpoint on the last cacheable block.\n\nThis is the normal multi-turn policy: the provider advances the\nbreakpoint as conversation history grows. Anthropic searches backward\nup to 20 cacheable blocks from that breakpoint, so a hit is not\nguaranteed when more than 20 new blocks are added between requests.",
+            "type": "string"
+          },
+          {
             "const": "system_prefix",
             "description": "Mark the stable top-level system prompt as an ephemeral cache prefix.",
             "type": "string"
@@ -34773,7 +34844,7 @@
                 "type": "null"
               }
             ],
-            "description": "Automatic (`implicit`) or explicit-only cache breakpoint placement."
+            "description": "Automatic (`implicit`) placement or Meerkat-authored explicit placement."
           },
           "ttl": {
             "anyOf": [
@@ -35125,6 +35196,13 @@
                 "format": "float",
                 "type": [
                   "number",
+                  "null"
+                ]
+              },
+              "prompt_cache_enabled": {
+                "description": "Meerkat-owned prompt-cache enable intent.\n\n`false` is a durable opt-out. On GPT-5.6 it lowers to explicit-only\nmode with no authored breakpoints, which performs no cache reads or\nwrites and incurs no cache-write charges.",
+                "type": [
+                  "boolean",
                   "null"
                 ]
               },

--- a/artifacts/schemas/rest-openapi.json
+++ b/artifacts/schemas/rest-openapi.json
@@ -1345,6 +1345,11 @@
             "type": "string"
           },
           {
+            "const": "automatic",
+            "description": "Ask Anthropic to keep a moving breakpoint on the last cacheable block.\n\nThis is the normal multi-turn policy: the provider advances the\nbreakpoint as conversation history grows. Anthropic searches backward\nup to 20 cacheable blocks from that breakpoint, so a hit is not\nguaranteed when more than 20 new blocks are added between requests.",
+            "type": "string"
+          },
+          {
             "const": "system_prefix",
             "description": "Mark the stable top-level system prompt as an ephemeral cache prefix.",
             "type": "string"
@@ -9848,7 +9853,7 @@
                 "type": "null"
               }
             ],
-            "description": "Automatic (`implicit`) or explicit-only cache breakpoint placement."
+            "description": "Automatic (`implicit`) placement or Meerkat-authored explicit placement."
           },
           "ttl": {
             "anyOf": [
@@ -10956,6 +10961,13 @@
                 "format": "float",
                 "type": [
                   "number",
+                  "null"
+                ]
+              },
+              "prompt_cache_enabled": {
+                "description": "Meerkat-owned prompt-cache enable intent.\n\n`false` is a durable opt-out. On GPT-5.6 it lowers to explicit-only\nmode with no authored breakpoints, which performs no cache reads or\nwrites and incurs no cache-write charges.",
+                "type": [
+                  "boolean",
                   "null"
                 ]
               },
@@ -15087,6 +15099,7 @@
       "WireAnthropicCacheControlPolicy": {
         "enum": [
           "disabled",
+          "automatic",
           "system_prefix"
         ],
         "type": "string"
@@ -17575,6 +17588,12 @@
                 "format": "float",
                 "type": [
                   "number",
+                  "null"
+                ]
+              },
+              "prompt_cache_enabled": {
+                "type": [
+                  "boolean",
                   "null"
                 ]
               },

--- a/artifacts/schemas/wire-types.json
+++ b/artifacts/schemas/wire-types.json
@@ -9339,6 +9339,7 @@
       "WireAnthropicCacheControlPolicy": {
         "enum": [
           "disabled",
+          "automatic",
           "system_prefix"
         ],
         "type": "string"
@@ -9984,6 +9985,12 @@
                 "format": "float",
                 "type": [
                   "number",
+                  "null"
+                ]
+              },
+              "prompt_cache_enabled": {
+                "type": [
+                  "boolean",
                   "null"
                 ]
               },
@@ -16214,6 +16221,7 @@
       "WireAnthropicCacheControlPolicy": {
         "enum": [
           "disabled",
+          "automatic",
           "system_prefix"
         ],
         "type": "string"
@@ -16769,6 +16777,12 @@
                 "format": "float",
                 "type": [
                   "number",
+                  "null"
+                ]
+              },
+              "prompt_cache_enabled": {
+                "type": [
+                  "boolean",
                   "null"
                 ]
               },
@@ -44155,6 +44169,7 @@
       "WireAnthropicCacheControlPolicy": {
         "enum": [
           "disabled",
+          "automatic",
           "system_prefix"
         ],
         "type": "string"
@@ -45908,6 +45923,12 @@
                 "format": "float",
                 "type": [
                   "number",
+                  "null"
+                ]
+              },
+              "prompt_cache_enabled": {
+                "type": [
+                  "boolean",
                   "null"
                 ]
               },
@@ -50031,6 +50052,7 @@
       "WireAnthropicCacheControlPolicy": {
         "enum": [
           "disabled",
+          "automatic",
           "system_prefix"
         ],
         "type": "string"
@@ -50676,6 +50698,12 @@
                 "format": "float",
                 "type": [
                   "number",
+                  "null"
+                ]
+              },
+              "prompt_cache_enabled": {
+                "type": [
+                  "boolean",
                   "null"
                 ]
               },
@@ -76069,6 +76097,7 @@
       "WireAnthropicCacheControlPolicy": {
         "enum": [
           "disabled",
+          "automatic",
           "system_prefix"
         ],
         "type": "string"
@@ -76674,6 +76703,12 @@
                 "format": "float",
                 "type": [
                   "number",
+                  "null"
+                ]
+              },
+              "prompt_cache_enabled": {
+                "type": [
+                  "boolean",
                   "null"
                 ]
               },
@@ -81660,6 +81695,7 @@
       "WireAnthropicCacheControlPolicy": {
         "enum": [
           "disabled",
+          "automatic",
           "system_prefix"
         ],
         "type": "string"
@@ -82261,6 +82297,12 @@
                 "format": "float",
                 "type": [
                   "number",
+                  "null"
+                ]
+              },
+              "prompt_cache_enabled": {
+                "type": [
+                  "boolean",
                   "null"
                 ]
               },
@@ -82607,6 +82649,7 @@
       "WireAnthropicCacheControlPolicy": {
         "enum": [
           "disabled",
+          "automatic",
           "system_prefix"
         ],
         "type": "string"
@@ -83208,6 +83251,12 @@
                 "format": "float",
                 "type": [
                   "number",
+                  "null"
+                ]
+              },
+              "prompt_cache_enabled": {
+                "type": [
+                  "boolean",
                   "null"
                 ]
               },
@@ -87083,6 +87132,7 @@
       "WireAnthropicCacheControlPolicy": {
         "enum": [
           "disabled",
+          "automatic",
           "system_prefix"
         ],
         "type": "string"
@@ -87638,6 +87688,12 @@
                 "format": "float",
                 "type": [
                   "number",
+                  "null"
+                ]
+              },
+              "prompt_cache_enabled": {
+                "type": [
+                  "boolean",
                   "null"
                 ]
               },
@@ -88231,6 +88287,7 @@
       "WireAnthropicCacheControlPolicy": {
         "enum": [
           "disabled",
+          "automatic",
           "system_prefix"
         ],
         "type": "string"
@@ -88676,6 +88733,12 @@
                 "format": "float",
                 "type": [
                   "number",
+                  "null"
+                ]
+              },
+              "prompt_cache_enabled": {
+                "type": [
+                  "boolean",
                   "null"
                 ]
               },
@@ -91096,6 +91159,11 @@
             "type": "string"
           },
           {
+            "const": "automatic",
+            "description": "Ask Anthropic to keep a moving breakpoint on the last cacheable block.\n\nThis is the normal multi-turn policy: the provider advances the\nbreakpoint as conversation history grows. Anthropic searches backward\nup to 20 cacheable blocks from that breakpoint, so a hit is not\nguaranteed when more than 20 new blocks are added between requests.",
+            "type": "string"
+          },
+          {
             "const": "system_prefix",
             "description": "Mark the stable top-level system prompt as an ephemeral cache prefix.",
             "type": "string"
@@ -91922,7 +91990,7 @@
                 "type": "null"
               }
             ],
-            "description": "Automatic (`implicit`) or explicit-only cache breakpoint placement."
+            "description": "Automatic (`implicit`) placement or Meerkat-authored explicit placement."
           },
           "ttl": {
             "anyOf": [
@@ -92274,6 +92342,13 @@
                 "format": "float",
                 "type": [
                   "number",
+                  "null"
+                ]
+              },
+              "prompt_cache_enabled": {
+                "description": "Meerkat-owned prompt-cache enable intent.\n\n`false` is a durable opt-out. On GPT-5.6 it lowers to explicit-only\nmode with no authored breakpoints, which performs no cache reads or\nwrites and incurs no cache-write charges.",
+                "type": [
+                  "boolean",
                   "null"
                 ]
               },
@@ -93333,6 +93408,11 @@
             "type": "string"
           },
           {
+            "const": "automatic",
+            "description": "Ask Anthropic to keep a moving breakpoint on the last cacheable block.\n\nThis is the normal multi-turn policy: the provider advances the\nbreakpoint as conversation history grows. Anthropic searches backward\nup to 20 cacheable blocks from that breakpoint, so a hit is not\nguaranteed when more than 20 new blocks are added between requests.",
+            "type": "string"
+          },
+          {
             "const": "system_prefix",
             "description": "Mark the stable top-level system prompt as an ephemeral cache prefix.",
             "type": "string"
@@ -94159,7 +94239,7 @@
                 "type": "null"
               }
             ],
-            "description": "Automatic (`implicit`) or explicit-only cache breakpoint placement."
+            "description": "Automatic (`implicit`) placement or Meerkat-authored explicit placement."
           },
           "ttl": {
             "anyOf": [
@@ -94511,6 +94591,13 @@
                 "format": "float",
                 "type": [
                   "number",
+                  "null"
+                ]
+              },
+              "prompt_cache_enabled": {
+                "description": "Meerkat-owned prompt-cache enable intent.\n\n`false` is a durable opt-out. On GPT-5.6 it lowers to explicit-only\nmode with no authored breakpoints, which performs no cache reads or\nwrites and incurs no cache-write charges.",
+                "type": [
+                  "boolean",
                   "null"
                 ]
               },
@@ -95581,6 +95668,11 @@
           {
             "const": "disabled",
             "description": "Do not request Anthropic prompt-cache breakpoints.",
+            "type": "string"
+          },
+          {
+            "const": "automatic",
+            "description": "Ask Anthropic to keep a moving breakpoint on the last cacheable block.\n\nThis is the normal multi-turn policy: the provider advances the\nbreakpoint as conversation history grows. Anthropic searches backward\nup to 20 cacheable blocks from that breakpoint, so a hit is not\nguaranteed when more than 20 new blocks are added between requests.",
             "type": "string"
           },
           {
@@ -96676,7 +96768,7 @@
                 "type": "null"
               }
             ],
-            "description": "Automatic (`implicit`) or explicit-only cache breakpoint placement."
+            "description": "Automatic (`implicit`) placement or Meerkat-authored explicit placement."
           },
           "ttl": {
             "anyOf": [
@@ -97028,6 +97120,13 @@
                 "format": "float",
                 "type": [
                   "number",
+                  "null"
+                ]
+              },
+              "prompt_cache_enabled": {
+                "description": "Meerkat-owned prompt-cache enable intent.\n\n`false` is a durable opt-out. On GPT-5.6 it lowers to explicit-only\nmode with no authored breakpoints, which performs no cache reads or\nwrites and incurs no cache-write charges.",
+                "type": [
+                  "boolean",
                   "null"
                 ]
               },
@@ -117103,6 +117202,7 @@
       "WireAnthropicCacheControlPolicy": {
         "enum": [
           "disabled",
+          "automatic",
           "system_prefix"
         ],
         "type": "string"
@@ -117585,6 +117685,12 @@
                 "format": "float",
                 "type": [
                   "number",
+                  "null"
+                ]
+              },
+              "prompt_cache_enabled": {
+                "type": [
+                  "boolean",
                   "null"
                 ]
               },

--- a/docs/concepts/providers.mdx
+++ b/docs/concepts/providers.mdx
@@ -180,16 +180,28 @@ or for a single CLI run with `rkat run --no-web-search "..."`.
 
 <Tabs>
   <Tab title="Anthropic">
-    | Parameter | Description |
-    |-----------|-------------|
-    | `thinking_budget_tokens` | Token budget for extended thinking (integer) |
-    | `top_k` | Top-k sampling parameter (integer) |
+    | Parameter | Values | Description |
+    |-----------|--------|-------------|
+    | `thinking_budget_tokens` | integer | Token budget for extended thinking |
+    | `top_k` | integer | Top-k sampling parameter |
+    | `cache_control` | `automatic`, `system_prefix`, `disabled` | Prompt-cache policy; native Anthropic, Vertex, and Foundry clients default to a moving automatic conversation breakpoint. Amazon Bedrock defaults to disabled because that backend does not support Anthropic automatic caching. |
 
     ```bash
     rkat run --model claude-sonnet-4-6 --params-json \
       '{"provider_tag":{"provider":"anthropic","thinking_budget_tokens":10000}}' \
       "Solve this problem"
     ```
+
+    <Note>
+    Automatic caching uses Anthropic's five-minute ephemeral cache and advances
+    the breakpoint as the conversation grows. A qualifying cold write bills
+    input tokens at 1.25x the base rate; a cache hit bills cached input tokens
+    at 0.1x. Automatic lookup scans backward at most 20 cacheable blocks, so
+    adding more than 20 blocks between requests can still miss. Set
+    `cache_control: "disabled"` to opt out, or `system_prefix` when only the
+    stable system prompt should be cached. Amazon Bedrock rejects `automatic`
+    locally but continues to support `system_prefix`.
+    </Note>
   </Tab>
   <Tab title="OpenAI">
     | Parameter | Values | Description |
@@ -198,7 +210,9 @@ or for a single CLI run with `rkat run --no-web-search "..."`.
     | `reasoning_mode` | `standard`, `pro` | GPT-5.6 Responses execution mode; default is `standard` |
     | `reasoning_context` | `auto`, `current_turn`, `all_turns` | GPT-5.6 persisted-reasoning context |
     | `text_verbosity` | `low`, `medium`, `high` | GPT-5.6 default output detail |
-    | `prompt_cache_options` | `mode`: `implicit` or `explicit`; `ttl`: `30m` | GPT-5.6 request-wide cache policy; an empty object uses API defaults |
+    | `prompt_cache_enabled` | boolean | Durable prompt-cache intent; `false` disables reads, writes, and cache-write charges |
+    | `prompt_cache_key` | string | Stable cache-routing affinity key; explicit host values override Meerkat's per-session default |
+    | `prompt_cache_options` | `mode`: `implicit` or `explicit`; `ttl`: `30m` | GPT-5.6 request-wide cache policy; explicit mode makes Meerkat mark deterministic message boundaries |
 
     ```bash
     rkat run --model gpt-5.6-terra --params-json \
@@ -212,9 +226,30 @@ or for a single CLI run with `rkat run --no-web-search "..."`.
     GPT-5.6 uses `prompt_cache_options`; the older `prompt_cache_retention`
     field is deprecated for these models. The two fields remain independent at
     the API boundary, and the only legacy retention value accepted by GPT-5.6
-    is `24h`. Meerkat does not yet author per-content cache breakpoints,
-    so `mode: "explicit"` currently disables automatic placement without adding
-    a write breakpoint.
+    is `24h`. Factory-built public OpenAI API GPT-5.6 sessions default to
+    implicit caching and a stable
+    `meerkat:session:<durable-session-id>` routing key. A key supplied by the
+    caller wins, so a long-lived host can choose a coarser stable identity
+    bucket. The default is re-derived on resume rather than persisted into
+    provider parameters and is not automatically applied to the private
+    ChatGPT or Azure OpenAI backend wires. In `mode: "explicit"`, Meerkat re-authors stable
+    breakpoints at deterministic historical message boundaries and adds new
+    ones only as the conversation grows, for both Responses and Chat
+    Completions. Set `prompt_cache_enabled: false` for a durable opt-out;
+    Meerkat then emits explicit-only mode without authoring a breakpoint, so
+    the request performs no caching and incurs no cache-write charges.
+    Enabling explicit mode on a large cold transcript can create up to four
+    writes; normal growth adds one new boundary per model invocation.
+    OpenAI recommends keeping traffic near 15 requests per minute per cache
+    key; partition higher-volume traffic with a stable mapping rather than
+    assuming a coarser identity key always improves hits. Tool-calling agents
+    can make several model requests during one user turn, so one tool-heavy
+    turn can reach that guidance without any concurrent users. Per-session and
+    per-identity keys can both hit the ceiling; choose and monitor the
+    partition from actual request rate. Cache reads consider only the latest
+    50 breakpoints.
+    GPT-5.6 cache writes bill at 1.25x the uncached input token rate; hits use
+    the model's cached-input rate.
     </Note>
   </Tab>
   <Tab title="Gemini">

--- a/docs/reference/capability-matrix.mdx
+++ b/docs/reference/capability-matrix.mdx
@@ -181,7 +181,7 @@ Gemini video URI support follows the active Google backend. Vertex Gemini accept
 
 ## Provider-native web search
 
-Web search is enabled by default for all catalog models with `supports_web_search: true`. The factory resolves provider-specific tool defaults at build time as a typed, never-persisted `ProviderTag` (the `tool_defaults` half of `ProviderParamsCarrier`). Effective per-turn params are a typed field-wise merge: explicit `provider_params` win and tool defaults fill only the unset provider-native slots -- the old RFC 7396 raw-JSON merge-patch is retired.
+Web search is enabled by default for all catalog models with `supports_web_search: true`. The factory resolves provider-specific request defaults at build time as a typed, never-persisted `ProviderTag` (the legacy-named `tool_defaults` half of `ProviderParamsCarrier`). These defaults include provider-native tool bodies and model-capability-derived cache policy. Effective per-turn params are a typed field-wise merge: explicit `provider_params` win and build defaults fill only the unset provider-native slots -- the old RFC 7396 raw-JSON merge-patch is retired.
 
 | Provider | Tool type | Config key | Default |
 |----------|-----------|------------|---------|
@@ -201,7 +201,7 @@ Web search is enabled by default for all catalog models with `supports_web_searc
 
 **Extraction turns:** Web search tools are stripped during structured output extraction to maintain the deterministic, tool-free invariant.
 
-**Hook interaction:** Pre-LLM hooks see the merged tool defaults in `HookLlmRequest.provider_params` as an observational projection. Hooks cannot rewrite effective provider params.
+**Hook interaction:** Pre-LLM hooks see the merged request defaults in `HookLlmRequest.provider_params` as an observational projection. Hooks cannot rewrite effective provider params.
 
 ## MCP server loading
 

--- a/docs/rust/advanced.mdx
+++ b/docs/rust/advanced.mdx
@@ -117,14 +117,36 @@ Pass provider parameter overrides via `AgentBuildConfig`. The JSON bag is retire
 `provider_params` is the typed `ProviderParamsOverride` (temperature, `top_p`,
 `max_output_tokens`, reasoning mode, `thinking_budget_tokens`, and an optional
 provider-specific `provider_tag`), parsed fail-closed at each surface ingress.
-Provider tags also carry opt-in provider cache hints: OpenAI can override
-Responses `store` (default remains `false`) and set `prompt_cache_key` /
-`prompt_cache_retention`; Anthropic can mark the stable system prefix with
-`cache_control`; Gemini can pass an explicit `cached_content_name`. When
-OpenAI `store` is explicitly enabled, stored response IDs may be reused as
-`previous_response_id` hints; Meerkat still keeps the local transcript as the
-canonical replay source and falls back to full replay if the provider rejects
-the hint.
+Provider tags also carry provider cache policy: OpenAI can override Responses
+`store` (default remains `false`) and set `prompt_cache_key` /
+`prompt_cache_retention`. Factory-built public OpenAI API GPT-5.6 sessions default to
+`prompt_cache_options: {"mode":"implicit","ttl":"30m"}` plus a stable
+per-session routing key derived from the durable `SessionId`; a caller-supplied
+key wins. These defaults are not applied automatically to the private ChatGPT
+or Azure OpenAI backend wires. `prompt_cache_options.mode: "explicit"` makes Meerkat author
+append-monotone breakpoints at deterministic message boundaries for Responses
+and Chat Completions. Set `prompt_cache_enabled: false` for a durable opt-out; it emits
+explicit-only mode without a breakpoint and incurs no cache-write charges.
+Keep traffic near OpenAI's recommended 15 requests per minute per cache key;
+partition higher-volume traffic with a stable mapping. Tool-calling agents can
+make several model requests during one user turn, so a single tool-heavy turn
+can reach that guidance without concurrent users; per-session and per-identity
+keys are both subject to the ceiling. Choose and monitor the partition using
+the observed model-request rate. Cache reads consider only the latest 50
+breakpoints.
+Anthropic API, Vertex, and Foundry clients default to
+`cache_control: automatic`, which keeps a moving five-minute breakpoint on the
+growing conversation (`disabled` opts out and `system_prefix` narrows the
+breakpoint). Amazon Bedrock defaults to disabled because it does not support
+Anthropic automatic caching and rejects an explicit `automatic` override
+locally; manual `system_prefix` caching remains available. Automatic lookup
+scans backward at most 20 cacheable blocks. Direct `AnthropicClientBuilder`
+users targeting a custom backend must declare whether it supports automatic
+caching; the provider runtime handles this for configured backends. Gemini can
+pass an explicit `cached_content_name`. When OpenAI `store` is explicitly
+enabled, stored response IDs may be reused as `previous_response_id` hints;
+Meerkat still keeps the local transcript as the canonical replay source and
+falls back to full replay if the provider rejects the hint.
 
 ```rust
 use meerkat_core::lifecycle::run_primitive::ProviderParamsOverride;

--- a/meerkat-anthropic/src/client.rs
+++ b/meerkat-anthropic/src/client.rs
@@ -44,6 +44,13 @@ pub struct AnthropicClient {
     connect_timeout: Duration,
     request_timeout: Duration,
     pool_idle_timeout: Duration,
+    /// Backend-owned cache default. Native Anthropic, Vertex, and Foundry use
+    /// automatic moving breakpoints; Amazon Bedrock disables this because its
+    /// Messages surface does not support Anthropic automatic caching.
+    default_cache_control: AnthropicCacheControlPolicy,
+    /// Whether this backend accepts Anthropic's request-wide automatic cache
+    /// policy. Amazon Bedrock supports manual breakpoints but not this mode.
+    automatic_cache_control_supported: bool,
     /// Dynamic authorizer — when set, replaces the `x-api-key` header
     /// path with `HttpAuthorizer::authorize` invocation (used for
     /// OAuth and cloud backends where the Bearer token is acquired at
@@ -58,6 +65,8 @@ pub struct AnthropicClientBuilder {
     connect_timeout: Duration,
     request_timeout: Duration,
     pool_idle_timeout: Duration,
+    default_cache_control: AnthropicCacheControlPolicy,
+    automatic_cache_control_supported: bool,
     authorizer: Option<std::sync::Arc<dyn meerkat_core::HttpAuthorizer>>,
 }
 
@@ -69,6 +78,8 @@ impl AnthropicClientBuilder {
             connect_timeout: DEFAULT_CONNECT_TIMEOUT,
             request_timeout: DEFAULT_REQUEST_TIMEOUT,
             pool_idle_timeout: DEFAULT_POOL_IDLE_TIMEOUT,
+            default_cache_control: AnthropicCacheControlPolicy::Automatic,
+            automatic_cache_control_supported: true,
             authorizer: None,
         }
     }
@@ -87,6 +98,27 @@ impl AnthropicClientBuilder {
         authorizer: std::sync::Arc<dyn meerkat_core::HttpAuthorizer>,
     ) -> Self {
         self.authorizer = Some(authorizer);
+        self
+    }
+
+    /// Set the backend-owned default prompt-cache policy.
+    ///
+    /// Per-request typed provider params still take precedence. Provider
+    /// runtimes use this to disable automatic caching for Amazon Bedrock while
+    /// keeping it enabled for Anthropic API, Vertex, and Foundry.
+    pub fn default_cache_control(mut self, policy: AnthropicCacheControlPolicy) -> Self {
+        self.default_cache_control = policy;
+        self
+    }
+
+    /// Declare whether the selected backend supports request-wide automatic
+    /// prompt caching.
+    ///
+    /// This is a capability guard, separate from the default policy: an
+    /// explicit per-request `Automatic` override is rejected locally when the
+    /// backend does not support it.
+    pub fn automatic_cache_control_supported(mut self, supported: bool) -> Self {
+        self.automatic_cache_control_supported = supported;
         self
     }
 
@@ -132,6 +164,8 @@ impl AnthropicClientBuilder {
             connect_timeout,
             request_timeout,
             pool_idle_timeout,
+            default_cache_control: self.default_cache_control,
+            automatic_cache_control_supported: self.automatic_cache_control_supported,
             authorizer: self.authorizer,
         })
     }
@@ -666,8 +700,26 @@ impl AnthropicClient {
             "stream": true
         });
 
+        let cache_control = anthropic_tag(request)
+            .and_then(|tag| tag.cache_control)
+            .unwrap_or(self.default_cache_control);
+
+        if matches!(cache_control, AnthropicCacheControlPolicy::Automatic)
+            && !self.automatic_cache_control_supported
+        {
+            return Err(LlmError::InvalidRequest {
+                message: "automatic Anthropic prompt caching is not supported by the configured \
+                          backend; use cache_control \"disabled\" or \"system_prefix\""
+                    .to_string(),
+            });
+        }
+
         if let Some(system) = system_prompt {
-            body["system"] = Self::anthropic_system_prompt_value(&system, anthropic_tag(request));
+            body["system"] = Self::anthropic_system_prompt_value(&system, cache_control);
+        }
+
+        if matches!(cache_control, AnthropicCacheControlPolicy::Automatic) {
+            body["cache_control"] = serde_json::json!({"type": "ephemeral"});
         }
 
         if Self::request_supports_temperature(request)
@@ -789,9 +841,12 @@ impl AnthropicClient {
         Ok(body)
     }
 
-    fn anthropic_system_prompt_value(system: &str, tag: Option<&AnthropicProviderTag>) -> Value {
-        match tag.and_then(|t| t.cache_control) {
-            Some(AnthropicCacheControlPolicy::SystemPrefix) => serde_json::json!([{
+    fn anthropic_system_prompt_value(
+        system: &str,
+        cache_control: AnthropicCacheControlPolicy,
+    ) -> Value {
+        match cache_control {
+            AnthropicCacheControlPolicy::SystemPrefix => serde_json::json!([{
                 "type": "text",
                 "text": system,
                 "cache_control": {"type": "ephemeral"}
@@ -2278,6 +2333,11 @@ mod tests {
         assert!(body.get("thinking").is_none());
         assert!(body.get("top_k").is_none());
         assert_eq!(body["model"], "claude-sonnet-4-20250514");
+        assert_eq!(
+            body["cache_control"],
+            serde_json::json!({"type": "ephemeral"}),
+            "native Anthropic requests should automatically cache the growing conversation prefix"
+        );
         Ok(())
     }
 
@@ -2310,6 +2370,10 @@ mod tests {
             body["messages"].to_string().find("cache_control").is_none(),
             "dynamic conversation messages must not receive cache_control"
         );
+        assert!(
+            body.get("cache_control").is_none(),
+            "explicit system-prefix mode must not also consume an automatic breakpoint slot"
+        );
         Ok(())
     }
 
@@ -2331,6 +2395,105 @@ mod tests {
         let body = client.build_request_body(&request)?;
 
         assert_eq!(body["system"], "stable system prefix");
+        assert!(
+            body.get("cache_control").is_none(),
+            "explicit disabled policy must suppress the backend default"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn test_request_automatic_cache_control_overrides_disabled_supported_backend_default()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let client = AnthropicClient::builder("test-key".to_string())
+            .default_cache_control(AnthropicCacheControlPolicy::Disabled)
+            .build()?;
+        let request = LlmRequest::new(
+            "claude-sonnet-4-20250514",
+            vec![Message::User(UserMessage::text("test".to_string()))],
+        )
+        .with_anthropic_tag_merge(|tag| {
+            tag.cache_control = Some(AnthropicCacheControlPolicy::Automatic);
+        });
+
+        let body = client.build_request_body(&request)?;
+
+        assert_eq!(
+            body["cache_control"],
+            serde_json::json!({"type": "ephemeral"})
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn test_request_automatic_cache_control_rejects_unsupported_backend()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let client = AnthropicClient::builder("test-key".to_string())
+            .default_cache_control(AnthropicCacheControlPolicy::Disabled)
+            .automatic_cache_control_supported(false)
+            .build()?;
+        let request = LlmRequest::new(
+            "claude-sonnet-4-20250514",
+            vec![Message::User(UserMessage::text("test".to_string()))],
+        )
+        .with_anthropic_tag_merge(|tag| {
+            tag.cache_control = Some(AnthropicCacheControlPolicy::Automatic);
+        });
+
+        let error = client
+            .build_request_body(&request)
+            .expect_err("unsupported automatic cache policy must fail locally");
+
+        assert!(matches!(
+            error,
+            LlmError::InvalidRequest { message }
+                if message.contains("automatic Anthropic prompt caching is not supported")
+        ));
+        Ok(())
+    }
+
+    #[test]
+    fn test_request_system_prefix_cache_control_remains_available_on_unsupported_automatic_backend()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let client = AnthropicClient::builder("test-key".to_string())
+            .default_cache_control(AnthropicCacheControlPolicy::Disabled)
+            .automatic_cache_control_supported(false)
+            .build()?;
+        let request = LlmRequest::new(
+            "claude-sonnet-4-20250514",
+            vec![
+                Message::System(SystemMessage::new("stable system prefix".to_string())),
+                Message::User(UserMessage::text("test".to_string())),
+            ],
+        )
+        .with_anthropic_tag_merge(|tag| {
+            tag.cache_control = Some(AnthropicCacheControlPolicy::SystemPrefix);
+        });
+
+        let body = client.build_request_body(&request)?;
+
+        assert_eq!(
+            body["system"][0]["cache_control"],
+            serde_json::json!({"type": "ephemeral"})
+        );
+        assert!(body.get("cache_control").is_none());
+        Ok(())
+    }
+
+    #[test]
+    fn test_builder_can_disable_automatic_cache_control() -> Result<(), Box<dyn std::error::Error>>
+    {
+        let client = AnthropicClient::builder("test-key".to_string())
+            .default_cache_control(AnthropicCacheControlPolicy::Disabled)
+            .build()?;
+        let request = LlmRequest::new(
+            "claude-sonnet-4-20250514",
+            vec![Message::User(UserMessage::text("test".to_string()))],
+        );
+
+        let body = client.build_request_body(&request)?;
+
+        assert!(body.get("cache_control").is_none());
         Ok(())
     }
 

--- a/meerkat-anthropic/src/runtime/mod.rs
+++ b/meerkat-anthropic/src/runtime/mod.rs
@@ -49,7 +49,25 @@ use meerkat_llm_core::provider_runtime::errors::{
 use meerkat_llm_core::provider_runtime::registry::ResolverEnvironment;
 use meerkat_llm_core::provider_runtime::runtime::ProviderRuntime;
 
+#[cfg(not(target_arch = "wasm32"))]
+use meerkat_core::lifecycle::run_primitive::AnthropicCacheControlPolicy;
+
 pub use meerkat_core::provider_matrix::anthropic::{AnthropicAuthMethod, AnthropicBackendKind};
+
+#[cfg(not(target_arch = "wasm32"))]
+fn default_cache_control_for_backend(backend: AnthropicBackendKind) -> AnthropicCacheControlPolicy {
+    match backend {
+        AnthropicBackendKind::Bedrock => AnthropicCacheControlPolicy::Disabled,
+        AnthropicBackendKind::AnthropicApi
+        | AnthropicBackendKind::Vertex
+        | AnthropicBackendKind::Foundry => AnthropicCacheControlPolicy::Automatic,
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn backend_supports_automatic_cache_control(backend: AnthropicBackendKind) -> bool {
+    !matches!(backend, AnthropicBackendKind::Bedrock)
+}
 
 #[cfg(all(not(target_arch = "wasm32"), feature = "oauth"))]
 struct ClaudeAiOAuthAuthorizer {
@@ -527,6 +545,10 @@ impl ProviderRuntime for AnthropicProviderRuntime {
             let client = crate::AnthropicClient::builder(String::new())
                 .authorizer(authorizer)
                 .base_url(base_url)
+                .default_cache_control(default_cache_control_for_backend(backend_kind))
+                .automatic_cache_control_supported(backend_supports_automatic_cache_control(
+                    backend_kind,
+                ))
                 .build()
                 .map_err(ProviderClientError::from)?;
             return Ok(Arc::new(client));
@@ -576,6 +598,10 @@ impl ProviderRuntime for AnthropicProviderRuntime {
                 let client = crate::AnthropicClient::builder(String::new())
                     .authorizer(authorizer)
                     .base_url(base_url)
+                    .default_cache_control(default_cache_control_for_backend(backend_kind))
+                    .automatic_cache_control_supported(backend_supports_automatic_cache_control(
+                        backend_kind,
+                    ))
                     .build()
                     .map_err(ProviderClientError::from)?;
                 Ok(Arc::new(client))
@@ -610,6 +636,10 @@ impl ProviderRuntime for AnthropicProviderRuntime {
                 let client = crate::AnthropicClient::builder(String::new())
                     .authorizer(authorizer)
                     .base_url(base_url)
+                    .default_cache_control(default_cache_control_for_backend(backend_kind))
+                    .automatic_cache_control_supported(backend_supports_automatic_cache_control(
+                        backend_kind,
+                    ))
                     .build()
                     .map_err(ProviderClientError::from)?;
                 Ok(Arc::new(client))
@@ -694,6 +724,38 @@ mod tests {
     #[test]
     fn provider_id_is_anthropic() {
         assert_eq!(AnthropicProviderRuntime.provider_id(), Provider::Anthropic);
+    }
+
+    #[test]
+    fn cache_control_defaults_follow_backend_capabilities() {
+        assert_eq!(
+            default_cache_control_for_backend(AnthropicBackendKind::AnthropicApi),
+            AnthropicCacheControlPolicy::Automatic
+        );
+        assert_eq!(
+            default_cache_control_for_backend(AnthropicBackendKind::Vertex),
+            AnthropicCacheControlPolicy::Automatic
+        );
+        assert_eq!(
+            default_cache_control_for_backend(AnthropicBackendKind::Foundry),
+            AnthropicCacheControlPolicy::Automatic
+        );
+        assert_eq!(
+            default_cache_control_for_backend(AnthropicBackendKind::Bedrock),
+            AnthropicCacheControlPolicy::Disabled
+        );
+        assert!(backend_supports_automatic_cache_control(
+            AnthropicBackendKind::AnthropicApi
+        ));
+        assert!(backend_supports_automatic_cache_control(
+            AnthropicBackendKind::Vertex
+        ));
+        assert!(backend_supports_automatic_cache_control(
+            AnthropicBackendKind::Foundry
+        ));
+        assert!(!backend_supports_automatic_cache_control(
+            AnthropicBackendKind::Bedrock
+        ));
     }
 
     #[cfg(all(not(target_arch = "wasm32"), feature = "oauth"))]

--- a/meerkat-contracts/src/wire/runtime.rs
+++ b/meerkat-contracts/src/wire/runtime.rs
@@ -763,6 +763,7 @@ impl From<WireAnthropicContextWindow>
 #[serde(rename_all = "snake_case")]
 pub enum WireAnthropicCacheControlPolicy {
     Disabled,
+    Automatic,
     SystemPrefix,
 }
 
@@ -773,6 +774,7 @@ impl From<meerkat_core::lifecycle::run_primitive::AnthropicCacheControlPolicy>
         use meerkat_core::lifecycle::run_primitive::AnthropicCacheControlPolicy as Core;
         match value {
             Core::Disabled => Self::Disabled,
+            Core::Automatic => Self::Automatic,
             Core::SystemPrefix => Self::SystemPrefix,
         }
     }
@@ -784,6 +786,7 @@ impl From<WireAnthropicCacheControlPolicy>
     fn from(value: WireAnthropicCacheControlPolicy) -> Self {
         match value {
             WireAnthropicCacheControlPolicy::Disabled => Self::Disabled,
+            WireAnthropicCacheControlPolicy::Automatic => Self::Automatic,
             WireAnthropicCacheControlPolicy::SystemPrefix => Self::SystemPrefix,
         }
     }
@@ -1166,6 +1169,8 @@ pub enum WireProviderTag {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         store: Option<bool>,
         #[serde(default, skip_serializing_if = "Option::is_none")]
+        prompt_cache_enabled: Option<bool>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         prompt_cache_key: Option<String>,
         #[serde(default, skip_serializing_if = "Option::is_none")]
         prompt_cache_retention: Option<WireOpenAiPromptCacheRetention>,
@@ -1237,6 +1242,7 @@ impl From<meerkat_core::lifecycle::run_primitive::ProviderTag> for WireProviderT
                 chat_template_kwargs: t.chat_template_kwargs.map(|v| v.as_value()),
                 thinking: t.thinking.map(|v| v.as_value()),
                 store: t.store,
+                prompt_cache_enabled: t.prompt_cache_enabled,
                 prompt_cache_key: t.prompt_cache_key,
                 prompt_cache_retention: t.prompt_cache_retention.map(Into::into),
                 prompt_cache_options: t.prompt_cache_options.map(Into::into),
@@ -1304,6 +1310,7 @@ impl From<WireProviderTag> for meerkat_core::lifecycle::run_primitive::ProviderT
                 chat_template_kwargs,
                 thinking,
                 store,
+                prompt_cache_enabled,
                 prompt_cache_key,
                 prompt_cache_retention,
                 prompt_cache_options,
@@ -1324,6 +1331,7 @@ impl From<WireProviderTag> for meerkat_core::lifecycle::run_primitive::ProviderT
                     .map(|v| OpaqueProviderBody::from_value(&v)),
                 thinking: thinking.map(|v| OpaqueProviderBody::from_value(&v)),
                 store,
+                prompt_cache_enabled,
                 prompt_cache_key,
                 prompt_cache_retention: prompt_cache_retention.map(Into::into),
                 prompt_cache_options: prompt_cache_options.map(Into::into),

--- a/meerkat-contracts/tests/runtime_turn_metadata_wire_override.rs
+++ b/meerkat-contracts/tests/runtime_turn_metadata_wire_override.rs
@@ -285,6 +285,7 @@ fn wire_metadata_openai_gpt_56_advanced_params_round_trip() {
             reasoning_mode: Some(OpenAiReasoningMode::Pro),
             reasoning_context: Some(OpenAiReasoningContext::AllTurns),
             text_verbosity: Some(OpenAiTextVerbosity::High),
+            prompt_cache_enabled: Some(false),
             prompt_cache_options: Some(OpenAiPromptCacheOptions {
                 mode: Some(OpenAiPromptCacheMode::Explicit),
                 ttl: Some(OpenAiPromptCacheTtl::ThirtyMinutes),
@@ -305,6 +306,7 @@ fn wire_metadata_openai_gpt_56_advanced_params_round_trip() {
     assert_eq!(tag["reasoning_mode"], serde_json::json!("pro"));
     assert_eq!(tag["reasoning_context"], serde_json::json!("all_turns"));
     assert_eq!(tag["text_verbosity"], serde_json::json!("high"));
+    assert_eq!(tag["prompt_cache_enabled"], serde_json::json!(false));
     assert_eq!(
         tag["prompt_cache_options"],
         serde_json::json!({"mode": "explicit", "ttl": "30m"})
@@ -326,6 +328,7 @@ fn wire_metadata_openai_gpt_56_advanced_params_round_trip() {
         Some(OpenAiReasoningContext::AllTurns)
     );
     assert_eq!(tag.text_verbosity, Some(OpenAiTextVerbosity::High));
+    assert_eq!(tag.prompt_cache_enabled, Some(false));
     assert_eq!(
         tag.prompt_cache_options,
         Some(OpenAiPromptCacheOptions {
@@ -389,7 +392,7 @@ fn wire_metadata_prompt_cache_fields_round_trip() {
 
     let anthropic_params = ProviderParamsOverride {
         provider_tag: Some(ProviderTag::Anthropic(AnthropicProviderTag {
-            cache_control: Some(AnthropicCacheControlPolicy::SystemPrefix),
+            cache_control: Some(AnthropicCacheControlPolicy::Automatic),
             ..Default::default()
         })),
         ..Default::default()
@@ -402,7 +405,7 @@ fn wire_metadata_prompt_cache_fields_round_trip() {
     let json = serde_json::to_value(&wire).expect("serialize anthropic wire metadata");
     assert_eq!(
         json["provider_params"]["value"]["provider_tag"]["cache_control"],
-        serde_json::json!("system_prefix")
+        serde_json::json!("automatic")
     );
 
     let gemini_params = ProviderParamsOverride {

--- a/meerkat-core/src/agent/builder.rs
+++ b/meerkat-core/src/agent/builder.rs
@@ -332,7 +332,7 @@ impl AgentBuilder {
         self
     }
 
-    /// Set typed provider-native tool defaults (resolved at build time, not persisted).
+    /// Set typed provider-native request defaults (resolved at build time, not persisted).
     pub fn provider_tool_defaults(
         mut self,
         defaults: crate::lifecycle::run_primitive::ProviderTag,

--- a/meerkat-core/src/agent/runner.rs
+++ b/meerkat-core/src/agent/runner.rs
@@ -1295,6 +1295,7 @@ where
     ) -> Result<(), SystemContextStateError> {
         let pending_count = boundary.appends().len();
         let mut next_session = self.session.clone();
+        next_session.append_peer_response_terminal_notices(boundary.appends());
         next_session
             .set_system_context_state(boundary.projected_state_after_consume())
             .map_err(SystemContextStateError::SystemContext)?;
@@ -1676,53 +1677,7 @@ where
                 self.session.push(Message::User(message));
             }
             ConversationAppendRole::SystemNotice => {
-                let notice = match append.content {
-                    CoreRenderable::SystemNotice { kind, body, blocks } => {
-                        crate::types::SystemNoticeMessage::with_blocks(kind, body, blocks)
-                    }
-                    CoreRenderable::Text { text } => crate::types::SystemNoticeMessage::with_block(
-                        crate::types::SystemNoticeKind::Generic,
-                        Some(text.clone()),
-                        crate::types::SystemNoticeBlock::RuntimeNotice {
-                            category: "runtime_notice".to_string(),
-                            detail: Some(text),
-                            payload: None,
-                        },
-                    ),
-                    CoreRenderable::Blocks { blocks } => {
-                        crate::types::SystemNoticeMessage::with_block(
-                            crate::types::SystemNoticeKind::Generic,
-                            None,
-                            crate::types::SystemNoticeBlock::RuntimeNotice {
-                                category: "runtime_notice".to_string(),
-                                detail: Some(crate::types::text_content(&blocks)),
-                                payload: None,
-                            },
-                        )
-                    }
-                    CoreRenderable::Json { value } => {
-                        crate::types::SystemNoticeMessage::with_block(
-                            crate::types::SystemNoticeKind::Generic,
-                            None,
-                            crate::types::SystemNoticeBlock::RuntimeNotice {
-                                category: "runtime_notice".to_string(),
-                                detail: None,
-                                payload: Some(value),
-                            },
-                        )
-                    }
-                    CoreRenderable::Reference { uri, label } => {
-                        crate::types::SystemNoticeMessage::with_block(
-                            crate::types::SystemNoticeKind::Generic,
-                            label,
-                            crate::types::SystemNoticeBlock::RuntimeNotice {
-                                category: "runtime_notice".to_string(),
-                                detail: Some(uri),
-                                payload: None,
-                            },
-                        )
-                    }
-                };
+                let notice = append.content.into_system_notice_message();
                 self.session.push(Message::SystemNotice(notice));
             }
             ConversationAppendRole::InjectedContext => {

--- a/meerkat-core/src/agent/state.rs
+++ b/meerkat-core/src/agent/state.rs
@@ -8004,6 +8004,7 @@ mod tests {
     struct BoundaryContextRecordingClient {
         call_count: Mutex<u32>,
         seen_system_messages: Mutex<Vec<String>>,
+        seen_terminal_notice_counts: Mutex<Vec<usize>>,
     }
 
     impl BoundaryContextRecordingClient {
@@ -8011,11 +8012,16 @@ mod tests {
             Self {
                 call_count: Mutex::new(0),
                 seen_system_messages: Mutex::new(Vec::new()),
+                seen_terminal_notice_counts: Mutex::new(Vec::new()),
             }
         }
 
         fn seen_system_messages(&self) -> Vec<String> {
             self.seen_system_messages.lock().unwrap().clone()
+        }
+
+        fn seen_terminal_notice_counts(&self) -> Vec<usize> {
+            self.seen_terminal_notice_counts.lock().unwrap().clone()
         }
     }
 
@@ -8038,6 +8044,24 @@ mod tests {
                     })
                     .collect::<Vec<_>>()
                     .join("\n"),
+            );
+            self.seen_terminal_notice_counts.lock().unwrap().push(
+                messages
+                    .iter()
+                    .filter(|message| {
+                        matches!(
+                            message,
+                            Message::SystemNotice(notice)
+                                if notice.blocks.iter().any(|block| matches!(
+                                    block,
+                                    crate::types::SystemNoticeBlock::Comms {
+                                        kind: crate::types::CommsNoticeKind::ResponseTerminal,
+                                        ..
+                                    }
+                                ))
+                        )
+                    })
+                    .count(),
             );
 
             let mut calls = self.call_count.lock().unwrap();
@@ -8786,6 +8810,133 @@ mod tests {
                 .skip(1)
                 .any(|system| system.contains("STEER_MARKER_visible_after_tool")),
             "active-turn staged context must be present on the model request after the tool boundary; seen={seen:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn active_turn_terminal_fact_is_visible_and_persisted_as_notice() {
+        let client = Arc::new(BoundaryContextRecordingClient::new());
+        let tool_started = Arc::new(Notify::new());
+        let release_tool = Arc::new(Notify::new());
+        let tools = Arc::new(BlockingToolDispatcher {
+            tools: Arc::from([Arc::new(ToolDef::new(
+                "slow_tool",
+                "blocks until the test releases it",
+                serde_json::json!({ "type": "object" }),
+            ))]),
+            started: Arc::clone(&tool_started),
+            release: Arc::clone(&release_tool),
+        });
+        let mut agent = with_test_turn_state_handle(AgentBuilder::new())
+            .system_prompt("base system prompt")
+            .build_standalone(client.clone(), tools, Arc::new(NoopStore))
+            .await;
+        let state = agent.system_context_state();
+
+        let (tx, _rx) = mpsc::channel(32);
+        let run = tokio::spawn(async move {
+            let result = agent
+                .run_with_events("start with a tool".to_string().into(), tx)
+                .await;
+            (result, agent)
+        });
+
+        tokio::time::timeout(std::time::Duration::from_secs(1), tool_started.notified())
+            .await
+            .expect("tool should start");
+
+        let route_identity = crate::handles::PeerResponseTerminalRouteIdentity::parse(
+            "550e8400-e29b-41d4-a716-446655440000",
+        )
+        .expect("route identity");
+        let correlation_id = crate::handles::PeerResponseTerminalCorrelationId::parse(
+            "018f6f79-7a82-7c4e-a552-a3b86f9630f1",
+        )
+        .expect("correlation id");
+        let fact = crate::handles::PeerResponseTerminalFact::new(
+            crate::handles::PeerResponseTerminalSource::new(
+                None,
+                route_identity,
+                crate::handles::PeerResponseTerminalDisplayIdentity::parse("Analyst")
+                    .expect("display identity"),
+            ),
+            correlation_id,
+            crate::handles::PeerResponseTerminalProjectionStatus::Completed,
+            crate::handles::PeerResponseTerminalRenderPayload::new(Some(
+                serde_json::json!({"token": "birch seventeen"}),
+            )),
+        );
+        state
+            .stage_active_turn_append(
+                &crate::service::AppendSystemContextRequest {
+                    content: crate::lifecycle::run_primitive::CoreRenderable::SystemNotice {
+                        kind: crate::types::SystemNoticeKind::Comms,
+                        body: Some("Peer terminal response context".to_string()),
+                        blocks: vec![crate::types::SystemNoticeBlock::Comms {
+                            kind: crate::types::CommsNoticeKind::ResponseTerminal,
+                            direction: crate::types::SystemNoticeDirection::Incoming,
+                            peer: Some(crate::types::SystemNoticePeer {
+                                id: fact.source.route_identity.peer_id(),
+                                display_name: Some(fact.source.display_identity.to_string()),
+                            }),
+                            sender_taint: None,
+                            request_id: Some(fact.correlation_id.to_string()),
+                            intent: None,
+                            status: Some(fact.status.label().to_string()),
+                            summary: Some("Peer terminal response".to_string()),
+                            payload: fact.render_payload_value().cloned(),
+                            content: Vec::new(),
+                        }],
+                    },
+                    source: Some(fact.context_key()),
+                    idempotency_key: Some(fact.context_key()),
+                    source_kind: crate::session::SystemContextSource::Normal,
+                    peer_response_terminal: Some(fact),
+                },
+                crate::time_compat::SystemTime::now(),
+            )
+            .expect("active terminal fact should stage");
+
+        release_tool.notify_waiters();
+        let (result, agent) = tokio::time::timeout(std::time::Duration::from_secs(2), run)
+            .await
+            .expect("run should complete")
+            .expect("run task should join");
+        assert_eq!(result.expect("agent run should succeed").turns, 2);
+
+        let seen_counts = client.seen_terminal_notice_counts();
+        assert!(
+            seen_counts.iter().skip(1).any(|count| *count == 1),
+            "the post-tool provider request must see the terminal notice: {seen_counts:?}"
+        );
+        assert_eq!(
+            agent
+                .session()
+                .messages()
+                .iter()
+                .filter(|message| {
+                    matches!(
+                        message,
+                        Message::SystemNotice(notice)
+                            if notice.blocks.iter().any(|block| matches!(
+                                block,
+                                crate::types::SystemNoticeBlock::Comms {
+                                    kind: crate::types::CommsNoticeKind::ResponseTerminal,
+                                    ..
+                                }
+                            ))
+                    )
+                })
+                .count(),
+            1,
+            "consuming the active boundary must persist the terminal notice canonically"
+        );
+        assert!(
+            client
+                .seen_system_messages()
+                .iter()
+                .all(|system| !system.contains("Peer terminal response")),
+            "terminal facts must never enter the leading system prompt"
         );
     }
 

--- a/meerkat-core/src/lifecycle/run_primitive.rs
+++ b/meerkat-core/src/lifecycle/run_primitive.rs
@@ -98,6 +98,59 @@ impl CoreRenderable {
             }
         }
     }
+
+    /// Lower runtime-authored content into the canonical system-notice
+    /// transcript representation.
+    ///
+    /// This is shared by ordinary conversation appends and typed terminal
+    /// response facts so the two paths cannot drift in their wire/model
+    /// projection.
+    #[must_use]
+    pub fn into_system_notice_message(self) -> crate::types::SystemNoticeMessage {
+        use crate::types::{SystemNoticeBlock, SystemNoticeKind, SystemNoticeMessage};
+
+        match self {
+            Self::SystemNotice { kind, body, blocks } => {
+                SystemNoticeMessage::with_blocks(kind, body, blocks)
+            }
+            Self::Text { text } => SystemNoticeMessage::with_block(
+                SystemNoticeKind::Generic,
+                Some(text.clone()),
+                SystemNoticeBlock::RuntimeNotice {
+                    category: "runtime_notice".to_string(),
+                    detail: Some(text),
+                    payload: None,
+                },
+            ),
+            Self::Blocks { blocks } => SystemNoticeMessage::with_block(
+                SystemNoticeKind::Generic,
+                None,
+                SystemNoticeBlock::RuntimeNotice {
+                    category: "runtime_notice".to_string(),
+                    detail: Some(crate::types::text_content(&blocks)),
+                    payload: None,
+                },
+            ),
+            Self::Json { value } => SystemNoticeMessage::with_block(
+                SystemNoticeKind::Generic,
+                None,
+                SystemNoticeBlock::RuntimeNotice {
+                    category: "runtime_notice".to_string(),
+                    detail: None,
+                    payload: Some(value),
+                },
+            ),
+            Self::Reference { uri, label } => SystemNoticeMessage::with_block(
+                SystemNoticeKind::Generic,
+                label,
+                SystemNoticeBlock::RuntimeNotice {
+                    category: "runtime_notice".to_string(),
+                    detail: Some(uri),
+                    payload: None,
+                },
+            ),
+        }
+    }
 }
 
 /// Which role to append to in the conversation.
@@ -405,6 +458,13 @@ pub enum AnthropicCompactionConfig {
 pub enum AnthropicCacheControlPolicy {
     /// Do not request Anthropic prompt-cache breakpoints.
     Disabled,
+    /// Ask Anthropic to keep a moving breakpoint on the last cacheable block.
+    ///
+    /// This is the normal multi-turn policy: the provider advances the
+    /// breakpoint as conversation history grows. Anthropic searches backward
+    /// up to 20 cacheable blocks from that breakpoint, so a hit is not
+    /// guaranteed when more than 20 new blocks are added between requests.
+    Automatic,
     /// Mark the stable top-level system prompt as an ephemeral cache prefix.
     SystemPrefix,
 }
@@ -471,7 +531,7 @@ pub enum OpenAiPromptCacheRetention {
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[serde(deny_unknown_fields)]
 pub struct OpenAiPromptCacheOptions {
-    /// Automatic (`implicit`) or explicit-only cache breakpoint placement.
+    /// Automatic (`implicit`) placement or Meerkat-authored explicit placement.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub mode: Option<OpenAiPromptCacheMode>,
     /// Minimum cache lifetime. GPT-5.6 currently accepts only `30m`.
@@ -528,6 +588,13 @@ pub struct OpenAiProviderTag {
     /// `Some(true)`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub store: Option<bool>,
+    /// Meerkat-owned prompt-cache enable intent.
+    ///
+    /// `false` is a durable opt-out. On GPT-5.6 it lowers to explicit-only
+    /// mode with no authored breakpoints, which performs no cache reads or
+    /// writes and incurs no cache-write charges.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub prompt_cache_enabled: Option<bool>,
     /// OpenAI prompt-cache affinity routing key.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub prompt_cache_key: Option<String>,
@@ -856,6 +923,10 @@ impl ProviderTag {
                 );
                 fill(&mut target.thinking, &default.thinking);
                 fill(&mut target.store, &default.store);
+                fill(
+                    &mut target.prompt_cache_enabled,
+                    &default.prompt_cache_enabled,
+                );
                 fill(&mut target.prompt_cache_key, &default.prompt_cache_key);
                 fill(
                     &mut target.prompt_cache_retention,
@@ -911,8 +982,9 @@ impl ProviderTag {
 /// Config-resident typed owner of provider parameter facts.
 ///
 /// The carrier pairs the explicit, persisted [`ProviderParamsOverride`] (the
-/// LLM-edge value domain) with the build-derived provider-native tool
-/// defaults. It is parsed fail-closed at config ingress — malformed provider
+/// LLM-edge value domain) with build-derived provider-native request defaults,
+/// including tool bodies and cache policy. It is parsed fail-closed at config
+/// ingress — malformed provider
 /// params are rejected when the config is read, never deferred to the first
 /// LLM call — and the per-turn effective params are produced by a typed
 /// field-wise merge ([`ProviderParamsCarrier::effective_params`]), replacing
@@ -926,8 +998,9 @@ impl ProviderTag {
 pub struct ProviderParamsCarrier {
     /// Explicit provider parameter overrides (persisted).
     pub params: ProviderParamsOverride,
-    /// Build-derived provider-native tool defaults for the session's
-    /// provider (e.g. web-search / grounding tool bodies). Never persisted.
+    /// Build-derived provider-native request defaults for the session's
+    /// provider (e.g. web-search / grounding tool bodies and cache policy).
+    /// Never persisted.
     #[serde(skip)]
     pub tool_defaults: Option<ProviderTag>,
 }
@@ -953,7 +1026,7 @@ impl ProviderParamsCarrier {
         self.params.is_empty()
     }
 
-    /// Produce the effective per-turn params: explicit overrides win, tool
+    /// Produce the effective per-turn params: explicit overrides win, request
     /// defaults fill the unset provider-native slots. A provider-family
     /// conflict propagates typed.
     pub fn effective_params(&self) -> Result<ProviderParamsOverride, ProviderParamsMergeError> {

--- a/meerkat-core/src/model_profile/schema_builder.rs
+++ b/meerkat-core/src/model_profile/schema_builder.rs
@@ -131,6 +131,8 @@ fn anthropic_thinking_schema(mode: ThinkingSupport) -> Option<Value> {
 // - reasoning_mode: string enum    (GPT-5.6 Responses)
 // - reasoning_context: string enum (GPT-5.6 Responses)
 // - text_verbosity: string enum    (GPT-5.6 Responses)
+// - prompt_cache_enabled: boolean  (GPT-5.6 Responses)
+// - prompt_cache_key: string       (GPT-5.6 Responses)
 // - prompt_cache_options: object   (GPT-5.6 Responses)
 // - seed: integer
 // - frequency_penalty: number
@@ -186,6 +188,20 @@ fn build_openai_schema(caps: &ModelCapabilities) -> Value {
 
         let mut cache_props = serde_json::Map::new();
         if !advanced.prompt_cache_modes.is_empty() {
+            props.insert(
+                "prompt_cache_enabled".into(),
+                json!({
+                    "description": "Enable prompt caching; false is a durable no-read/no-write opt-out.",
+                    "type": "boolean"
+                }),
+            );
+            props.insert(
+                "prompt_cache_key".into(),
+                json!({
+                    "description": "Stable cache-routing affinity key shared by requests with reusable prefixes.",
+                    "type": "string"
+                }),
+            );
             cache_props.insert(
                 "mode".into(),
                 string_enum_schema(

--- a/meerkat-core/src/session.rs
+++ b/meerkat-core/src/session.rs
@@ -27,7 +27,8 @@ use crate::tokio;
 use crate::tool_scope::ToolFilter;
 use crate::types::{
     AssistantBlock, BlockAssistantMessage, ContentBlock, ContentInput, Message, SessionId,
-    StopReason, ToolDef, ToolName, ToolProvenance, ToolResult, Usage, UserMessage,
+    StopReason, SystemNoticeMessage, ToolDef, ToolName, ToolProvenance, ToolResult, Usage,
+    UserMessage,
 };
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use sha2::{Digest, Sha256};
@@ -3747,17 +3748,132 @@ fn render_system_context_block(append: &PendingSystemContextAppend) -> String {
 /// classification key. Nothing reads this back to make a semantic decision.
 const SYSTEM_CONTEXT_RENDER_LABEL: &str = "[Runtime System Context]";
 
-/// Render a sequence of system-context appends into the
-/// [`SYSTEM_CONTEXT_SEPARATOR`]-joined block text that
-/// [`Session::append_system_context_blocks`] concatenates onto the system
-/// prompt. The single composition rule — shared by the append path and the
-/// resume-time tail verification so the two can never drift apart.
-fn render_system_context_blocks_joined(appends: &[PendingSystemContextAppend]) -> String {
+/// Render only appends that belong in the durable leading system prompt.
+///
+/// A typed peer terminal response is a conversation event, not agent
+/// instruction. It is persisted as a [`Message::SystemNotice`] at the
+/// transcript tail instead, keeping the stable instruction prefix immutable.
+fn render_system_prompt_context_blocks_joined(appends: &[PendingSystemContextAppend]) -> String {
     appends
         .iter()
+        .filter(|append| append.peer_response_terminal.is_none())
         .map(render_system_context_block)
         .collect::<Vec<_>>()
         .join(SYSTEM_CONTEXT_SEPARATOR)
+}
+
+fn peer_response_terminal_notice(
+    append: &PendingSystemContextAppend,
+) -> Option<SystemNoticeMessage> {
+    append.peer_response_terminal.as_ref()?;
+    Some(append.content.clone().into_system_notice_message())
+}
+
+fn system_notice_semantically_matches(
+    existing: &SystemNoticeMessage,
+    candidate: &SystemNoticeMessage,
+) -> bool {
+    existing.kind == candidate.kind
+        && existing.body == candidate.body
+        && existing.blocks == candidate.blocks
+}
+
+/// Remove legacy terminal blocks only from a suffix proven to be
+/// runtime-context-owned.
+///
+/// A recorded assembled base is the strongest split boundary. Without one,
+/// the entire ordered applied-record rendering must match the complete prompt
+/// or an exact prompt suffix; otherwise migration fails closed and leaves the
+/// transcript byte-identical.
+fn remove_legacy_peer_terminal_system_tail(
+    system_prompt: &str,
+    prior_base: Option<&str>,
+    applied: &[PendingSystemContextAppend],
+    terminal_appends: &[PendingSystemContextAppend],
+) -> (String, usize) {
+    if terminal_appends.is_empty() {
+        return (system_prompt.to_string(), 0);
+    }
+
+    let applied_tail = applied
+        .iter()
+        .map(render_system_context_block)
+        .collect::<Vec<_>>()
+        .join(SYSTEM_CONTEXT_SEPARATOR);
+    if applied_tail.is_empty() {
+        return (system_prompt.to_string(), 0);
+    }
+
+    if let Some(base) = prior_base {
+        if system_prompt == base {
+            return (system_prompt.to_string(), 0);
+        }
+        let Some(context_tail) = system_prompt
+            .strip_prefix(base)
+            .and_then(|suffix| suffix.strip_prefix(SYSTEM_CONTEXT_SEPARATOR))
+        else {
+            return (system_prompt.to_string(), 0);
+        };
+        let mut terminal_budget = BTreeMap::<String, usize>::new();
+        let mut non_terminal_renderings = BTreeSet::new();
+        for append in applied {
+            let rendered = render_system_context_block(append);
+            if append.peer_response_terminal.is_some() {
+                *terminal_budget.entry(rendered).or_default() += 1;
+            } else {
+                non_terminal_renderings.insert(rendered);
+            }
+        }
+        let mut retained = Vec::new();
+        let mut removed = 0;
+        for segment in context_tail.split(SYSTEM_CONTEXT_SEPARATOR) {
+            let terminal_remaining = terminal_budget.get_mut(segment);
+            if terminal_remaining.is_some() && non_terminal_renderings.contains(segment) {
+                return (system_prompt.to_string(), 0);
+            }
+            if let Some(remaining) = terminal_remaining.filter(|remaining| **remaining > 0) {
+                *remaining -= 1;
+                removed += 1;
+            } else {
+                retained.push(segment);
+            }
+        }
+        if removed == 0 {
+            return (system_prompt.to_string(), 0);
+        }
+        let retained_tail = retained.join(SYSTEM_CONTEXT_SEPARATOR);
+        let cleaned = if retained_tail.is_empty() {
+            base.to_string()
+        } else {
+            format!("{base}{SYSTEM_CONTEXT_SEPARATOR}{retained_tail}")
+        };
+        return (cleaned, removed);
+    }
+
+    let retained_tail = applied
+        .iter()
+        .filter(|append| append.peer_response_terminal.is_none())
+        .map(render_system_context_block)
+        .collect::<Vec<_>>()
+        .join(SYSTEM_CONTEXT_SEPARATOR);
+    let removed = terminal_appends.len();
+    let (base, tail_is_whole_prompt) = if system_prompt == applied_tail {
+        ("", true)
+    } else {
+        let suffix = format!("{SYSTEM_CONTEXT_SEPARATOR}{applied_tail}");
+        let Some(base) = system_prompt.strip_suffix(&suffix) else {
+            return (system_prompt.to_string(), 0);
+        };
+        (base, false)
+    };
+    let cleaned = if tail_is_whole_prompt {
+        retained_tail
+    } else if retained_tail.is_empty() {
+        base.to_string()
+    } else {
+        format!("{base}{SYSTEM_CONTEXT_SEPARATOR}{retained_tail}")
+    };
+    (cleaned, removed)
 }
 
 /// Compose a system prompt from a base and a verified runtime-context tail
@@ -4317,11 +4433,16 @@ mod system_context_authority {
                     }
                     continue;
                 }
-                if current_system_prompt.contains(&rendered) {
+                if append.peer_response_terminal.is_none()
+                    && current_system_prompt.contains(&rendered)
+                {
                     record_applied_append(state, append);
                     continue;
                 }
-            } else if new_appends.contains(append) || current_system_prompt.contains(&rendered) {
+            } else if new_appends.contains(append)
+                || (append.peer_response_terminal.is_none()
+                    && current_system_prompt.contains(&rendered))
+            {
                 continue;
             }
             record_applied_append(state, append);
@@ -5219,7 +5340,45 @@ impl Session {
         removed
     }
 
-    /// Append one or more runtime system-context blocks to the canonical system prompt.
+    /// Persist typed peer terminal facts as conversation-tail notices.
+    ///
+    /// The semantic comparison intentionally ignores `created_at`: a replayed
+    /// delivery of the same terminal fact must not mint another notice merely
+    /// because construction happened at a different wall-clock instant.
+    pub(crate) fn append_peer_response_terminal_notices(
+        &mut self,
+        appends: &[PendingSystemContextAppend],
+    ) -> usize {
+        let mut notices = Vec::new();
+        for candidate in appends.iter().filter_map(peer_response_terminal_notice) {
+            let already_persisted = self.messages.iter().any(|message| {
+                matches!(
+                    message,
+                    Message::SystemNotice(existing)
+                        if system_notice_semantically_matches(existing, &candidate)
+                )
+            });
+            let already_staged = notices.iter().any(|message| {
+                matches!(
+                    message,
+                    Message::SystemNotice(existing)
+                        if system_notice_semantically_matches(existing, &candidate)
+                )
+            });
+            if !already_persisted && !already_staged {
+                notices.push(Message::SystemNotice(candidate));
+            }
+        }
+        let appended = notices.len();
+        self.push_batch(notices);
+        appended
+    }
+
+    /// Apply runtime context at the canonical model boundary.
+    ///
+    /// Instruction-like context extends the leading system prompt. Typed peer
+    /// terminal responses are durable conversation events and are appended as
+    /// [`Message::SystemNotice`] records at the transcript tail instead.
     pub fn append_system_context_blocks(&mut self, appends: &[PendingSystemContextAppend]) {
         if appends.is_empty() {
             return;
@@ -5255,27 +5414,74 @@ impl Session {
             return;
         }
 
-        let rendered = render_system_context_blocks_joined(&new_appends);
-
-        let next = match self.messages.first() {
-            Some(Message::System(sys)) if !sys.content.is_empty() => {
-                format!("{}{}{}", sys.content, SYSTEM_CONTEXT_SEPARATOR, rendered)
+        let rendered = render_system_prompt_context_blocks_joined(&new_appends);
+        if !rendered.is_empty() {
+            let next = match self.messages.first() {
+                Some(Message::System(sys)) if !sys.content.is_empty() => {
+                    format!("{}{}{}", sys.content, SYSTEM_CONTEXT_SEPARATOR, rendered)
+                }
+                _ => rendered,
+            };
+            if let Err(err) = self.set_system_prompt_with_source(
+                next,
+                session_durable_config_authority::SessionSystemPromptSource::RuntimeContextAppend,
+            ) {
+                tracing::warn!(
+                    error = %err,
+                    "generated session durable-config authority rejected system-context prompt append"
+                );
+                return;
             }
-            _ => rendered,
-        };
-        if let Err(err) = self.set_system_prompt_with_source(
-            next,
-            session_durable_config_authority::SessionSystemPromptSource::RuntimeContextAppend,
-        ) {
-            tracing::warn!(
-                error = %err,
-                "generated session durable-config authority rejected system-context prompt append"
-            );
-            return;
         }
+        self.append_peer_response_terminal_notices(&new_appends);
         if let Err(err) = self.set_system_context_state(state) {
             tracing::warn!(error = %err, "failed to persist applied system-context state");
         }
+    }
+
+    /// Upgrade legacy rows that rendered typed terminal facts into the
+    /// leading system prompt before terminal facts became transcript notices.
+    ///
+    /// Exact typed records are the only authority for selecting blocks. The
+    /// old rendered blocks are removed through an audited transcript rewrite,
+    /// then missing notices are appended through the normal append path. This
+    /// produces valid persistence edges and preserves the applied/seen dedupe
+    /// records that now belong to the durable notice.
+    fn migrate_legacy_peer_terminal_context(
+        &mut self,
+        actor: Option<String>,
+    ) -> Result<bool, TranscriptEditError> {
+        let applied = self
+            .system_context_state()
+            .map(|state| state.applied)
+            .unwrap_or_default();
+        let terminal_appends = applied
+            .iter()
+            .filter(|append| append.peer_response_terminal.is_some())
+            .cloned()
+            .collect::<Vec<_>>();
+        if terminal_appends.is_empty() {
+            return Ok(false);
+        }
+
+        let mut migrated = false;
+        if let Some(Message::System(system)) = self.messages.first() {
+            let prior_base = self
+                .build_state()
+                .and_then(|state| state.assembled_system_prompt);
+            let (cleaned, removed) = remove_legacy_peer_terminal_system_tail(
+                &system.content,
+                prior_base.as_deref(),
+                &applied,
+                &terminal_appends,
+            );
+            if removed > 0 {
+                self.commit_resume_system_prompt_rewrite(cleaned, true, actor)?;
+                migrated = true;
+            }
+        }
+        migrated |= self.append_peer_response_terminal_notices(&terminal_appends) > 0;
+        Ok(migrated)
     }
 
     /// Reconcile a resumed session's persisted system prompt with a freshly
@@ -5308,6 +5514,7 @@ impl Session {
         assembled_base: String,
         actor: Option<String>,
     ) -> Result<ResumedSystemPromptReconciliation, TranscriptEditError> {
+        let migrated_terminal_context = self.migrate_legacy_peer_terminal_context(actor.clone())?;
         let persisted = match self.messages.first() {
             Some(Message::System(system)) => Some((system.content.clone(), system.mutation_kind)),
             _ => None,
@@ -5315,7 +5522,11 @@ impl Session {
 
         let Some((persisted_content, persisted_mutation_kind)) = persisted else {
             if assembled_base.is_empty() {
-                return Ok(ResumedSystemPromptReconciliation::NoChange);
+                return Ok(if migrated_terminal_context {
+                    ResumedSystemPromptReconciliation::RewrittenBase
+                } else {
+                    ResumedSystemPromptReconciliation::NoChange
+                });
             }
             // The persisted transcript never had a system prompt; introducing
             // one changes the transcript, so it flows through the same typed
@@ -5325,7 +5536,11 @@ impl Session {
         };
 
         if persisted_content == assembled_base {
-            return Ok(ResumedSystemPromptReconciliation::PreservedContinuation);
+            return Ok(if migrated_terminal_context {
+                ResumedSystemPromptReconciliation::RewrittenBase
+            } else {
+                ResumedSystemPromptReconciliation::PreservedContinuation
+            });
         }
 
         // Byte-exact reconciliation first: when the persisted content splits
@@ -5339,7 +5554,11 @@ impl Session {
         if let Some(tail) = self.verified_runtime_context_tail(&persisted_content) {
             let expected = compose_system_prompt_with_context_tail(&assembled_base, &tail);
             if expected == persisted_content {
-                return Ok(ResumedSystemPromptReconciliation::PreservedContinuation);
+                return Ok(if migrated_terminal_context {
+                    ResumedSystemPromptReconciliation::RewrittenBase
+                } else {
+                    ResumedSystemPromptReconciliation::PreservedContinuation
+                });
             }
             self.commit_resume_system_prompt_rewrite(expected, true, actor)?;
             return Ok(ResumedSystemPromptReconciliation::RewrittenBase);
@@ -5357,7 +5576,11 @@ impl Session {
             &persisted_content,
             persisted_mutation_kind,
         ) {
-            return Ok(ResumedSystemPromptReconciliation::PreservedContinuation);
+            return Ok(if migrated_terminal_context {
+                ResumedSystemPromptReconciliation::RewrittenBase
+            } else {
+                ResumedSystemPromptReconciliation::PreservedContinuation
+            });
         }
 
         // The base diverged and the runtime-context tail is not
@@ -5367,9 +5590,12 @@ impl Session {
         // be deduplicated forever — so clear the orphaned records to keep the
         // context restorable by the host.
         let dropping_applied_context = persisted_mutation_kind.is_runtime_context_append()
-            || self
-                .system_context_state()
-                .is_some_and(|state| !state.applied.is_empty());
+            || self.system_context_state().is_some_and(|state| {
+                state
+                    .applied
+                    .iter()
+                    .any(|append| append.peer_response_terminal.is_none())
+            });
         self.commit_resume_system_prompt_rewrite(assembled_base, true, actor)?;
         if dropping_applied_context {
             tracing::warn!(
@@ -5377,7 +5603,7 @@ impl Session {
                 "resume base-prompt refresh dropped an unverifiable runtime system-context tail; \
                  clearing applied-append records so keyed re-sends can restore the context"
             );
-            self.clear_applied_system_context_records();
+            self.clear_applied_system_prompt_context_records();
         }
         Ok(ResumedSystemPromptReconciliation::RewrittenBase)
     }
@@ -5409,7 +5635,7 @@ impl Session {
         }
         let rendered_tail = self
             .system_context_state()
-            .map(|state| render_system_context_blocks_joined(&state.applied))
+            .map(|state| render_system_prompt_context_blocks_joined(&state.applied))
             .unwrap_or_default();
         if rendered_tail.is_empty() {
             return None;
@@ -5464,7 +5690,7 @@ impl Session {
     /// Clear applied-append records (and their idempotency keys) after a
     /// resume rewrite dropped their rendered blocks from the System prompt,
     /// so the same keyed appends re-apply instead of deduplicating forever.
-    fn clear_applied_system_context_records(&mut self) {
+    fn clear_applied_system_prompt_context_records(&mut self) {
         let mut state = match self.try_system_context_state() {
             Ok(Some(state)) => state,
             Ok(None) => return,
@@ -5477,17 +5703,31 @@ impl Session {
                 return;
             }
         };
-        if state.applied.is_empty() {
+        if !state
+            .applied
+            .iter()
+            .any(|append| append.peer_response_terminal.is_none())
+        {
             return;
         }
         let dropped_keys: Vec<String> = state
             .applied
             .iter()
+            .filter(|append| append.peer_response_terminal.is_none())
             .filter_map(|append| append.idempotency_key.clone())
             .collect();
-        state.applied.clear();
+        state
+            .applied
+            .retain(|append| append.peer_response_terminal.is_some());
+        let retained_keys: BTreeSet<&str> = state
+            .applied
+            .iter()
+            .filter_map(|append| append.idempotency_key.as_deref())
+            .collect();
         for key in &dropped_keys {
-            state.seen.remove(key);
+            if !retained_keys.contains(key.as_str()) {
+                state.seen.remove(key);
+            }
         }
         if let Err(error) = self.set_system_context_state(state) {
             tracing::warn!(
@@ -7782,7 +8022,7 @@ pub fn resolve_session_llm_identity_override(
 ///
 /// `SessionLlmIdentity` is the durable semantic identity. This projection is
 /// the per-turn request policy the live agent must use for the next LLM call,
-/// including provider params and provider-native tool defaults resolved for
+/// including provider params and provider-native request defaults resolved for
 /// the same target model/provider.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "snake_case")]
@@ -7791,7 +8031,7 @@ pub struct SessionLlmRequestPolicy {
     /// Typed explicit provider parameter overrides for the next LLM call.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub provider_params: Option<crate::lifecycle::run_primitive::ProviderParamsOverride>,
-    /// Typed provider-native tool defaults resolved for the swapped target.
+    /// Typed provider-native request defaults resolved for the swapped target.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub provider_tool_defaults: Option<crate::lifecycle::run_primitive::ProviderTag>,
 }
@@ -8131,10 +8371,17 @@ mod tests {
     }
     use super::transcript_history::heal::legacy_transcript_messages_digest;
     use super::*;
+    use crate::handles::{
+        PeerResponseTerminalCorrelationId, PeerResponseTerminalDisplayIdentity,
+        PeerResponseTerminalFact, PeerResponseTerminalProjectionStatus,
+        PeerResponseTerminalRenderPayload, PeerResponseTerminalRouteIdentity,
+        PeerResponseTerminalSource,
+    };
     use crate::realtime_transcript::RealtimeTranscriptRole;
     use crate::types::{
-        AssistantBlock, BlockAssistantMessage, ContentBlock, StopReason, SystemMessage, Usage,
-        UserMessage,
+        AssistantBlock, BlockAssistantMessage, CommsNoticeKind, ContentBlock, StopReason,
+        SystemMessage, SystemNoticeBlock, SystemNoticeDirection, SystemNoticeKind,
+        SystemNoticePeer, Usage, UserMessage,
     };
     use std::sync::Arc;
 
@@ -13815,6 +14062,434 @@ mod tests {
         }
     }
 
+    fn peer_terminal_append(
+        key: &str,
+        request_id: &str,
+        status: PeerResponseTerminalProjectionStatus,
+    ) -> PendingSystemContextAppend {
+        let route_identity =
+            PeerResponseTerminalRouteIdentity::parse("550e8400-e29b-41d4-a716-446655440000")
+                .expect("route identity");
+        let display_identity =
+            PeerResponseTerminalDisplayIdentity::parse("Analyst").expect("display identity");
+        let correlation_id =
+            PeerResponseTerminalCorrelationId::parse(request_id).expect("correlation id");
+        let payload = serde_json::json!({"token": "birch seventeen"});
+        let fact = PeerResponseTerminalFact::new(
+            PeerResponseTerminalSource::new(None, route_identity, display_identity),
+            correlation_id,
+            status,
+            PeerResponseTerminalRenderPayload::new(Some(payload.clone())),
+        );
+        PendingSystemContextAppend {
+            content: crate::lifecycle::run_primitive::CoreRenderable::SystemNotice {
+                kind: SystemNoticeKind::Comms,
+                body: Some("Peer terminal response context".to_string()),
+                blocks: vec![SystemNoticeBlock::Comms {
+                    kind: CommsNoticeKind::ResponseTerminal,
+                    direction: SystemNoticeDirection::Incoming,
+                    peer: Some(SystemNoticePeer {
+                        id: fact.source.route_identity.peer_id(),
+                        display_name: Some(fact.source.display_identity.to_string()),
+                    }),
+                    sender_taint: None,
+                    request_id: Some(fact.correlation_id.to_string()),
+                    intent: None,
+                    status: Some(fact.status.label().to_string()),
+                    summary: Some("Peer terminal response".to_string()),
+                    payload: Some(payload),
+                    content: Vec::new(),
+                }],
+            },
+            source: Some(format!(
+                "peer_response_terminal:{}:{}",
+                fact.source.route_identity, fact.correlation_id
+            )),
+            idempotency_key: Some(key.to_string()),
+            source_kind: SystemContextSource::Normal,
+            peer_response_terminal: Some(fact),
+            accepted_at: SystemTime::UNIX_EPOCH,
+        }
+    }
+
+    fn terminal_notice_count(session: &Session) -> usize {
+        session
+            .messages()
+            .iter()
+            .filter(|message| {
+                matches!(
+                    message,
+                    Message::SystemNotice(SystemNoticeMessage {
+                        kind: SystemNoticeKind::Comms,
+                        blocks,
+                        ..
+                    }) if blocks.iter().any(|block| matches!(
+                        block,
+                        SystemNoticeBlock::Comms {
+                            kind: CommsNoticeKind::ResponseTerminal,
+                            ..
+                        }
+                    ))
+                )
+            })
+            .count()
+    }
+
+    #[test]
+    fn peer_terminal_context_preserves_system_prefix_and_appends_typed_notice() {
+        let append = peer_terminal_append(
+            "terminal-1",
+            "018f6f79-7a82-7c4e-a552-a3b86f9630f1",
+            PeerResponseTerminalProjectionStatus::Completed,
+        );
+        let mut session = Session::new();
+        session.set_system_prompt("byte-stable system prompt".to_string());
+        let leading_before = session.messages().first().cloned();
+
+        session.append_system_context_blocks(std::slice::from_ref(&append));
+
+        assert_eq!(
+            session.messages().first(),
+            leading_before.as_ref(),
+            "terminal conversation facts must not mutate the leading system message"
+        );
+        assert_eq!(terminal_notice_count(&session), 1);
+        assert!(matches!(
+            session.messages().last(),
+            Some(Message::SystemNotice(_))
+        ));
+        let state = session.system_context_state().expect("typed state");
+        assert_eq!(state.applied, vec![append]);
+        assert_eq!(
+            state.seen["terminal-1"].state,
+            SeenSystemContextState::Applied
+        );
+    }
+
+    #[test]
+    fn peer_terminal_context_dedupes_same_and_conflicting_key() {
+        let first = peer_terminal_append(
+            "terminal-1",
+            "018f6f79-7a82-7c4e-a552-a3b86f9630f1",
+            PeerResponseTerminalProjectionStatus::Completed,
+        );
+        let duplicate = PendingSystemContextAppend {
+            accepted_at: SystemTime::UNIX_EPOCH + std::time::Duration::from_secs(1),
+            ..first.clone()
+        };
+        let conflicting = peer_terminal_append(
+            "terminal-1",
+            "018f6f79-7a82-7c4e-a552-a3b86f9630f2",
+            PeerResponseTerminalProjectionStatus::Failed,
+        );
+        let mut session = Session::new();
+        session.set_system_prompt("stable".to_string());
+
+        session.append_system_context_blocks(std::slice::from_ref(&first));
+        session.append_system_context_blocks(std::slice::from_ref(&duplicate));
+        session.append_system_context_blocks(std::slice::from_ref(&conflicting));
+
+        assert_eq!(terminal_notice_count(&session), 1);
+        assert_eq!(leading_system_content(&session), "stable");
+        assert_eq!(
+            session.system_context_state().expect("typed state").applied,
+            vec![first]
+        );
+    }
+
+    #[test]
+    fn mixed_terminal_and_instruction_context_route_to_distinct_transcript_roles() {
+        let terminal = peer_terminal_append(
+            "terminal-1",
+            "018f6f79-7a82-7c4e-a552-a3b86f9630f1",
+            PeerResponseTerminalProjectionStatus::Completed,
+        );
+        let roster = roster_append();
+        let mut session = Session::new();
+        session.set_system_prompt("base".to_string());
+
+        session.append_system_context_blocks(&[terminal, roster]);
+
+        let system = leading_system_content(&session);
+        assert!(system.starts_with("base"));
+        assert!(system.contains("peer roster: lead-1, w-1"));
+        assert!(!system.contains("Peer terminal response"));
+        assert_eq!(terminal_notice_count(&session), 1);
+    }
+
+    #[test]
+    fn resume_base_change_preserves_terminal_notice_and_dedupe_authority() {
+        let terminal = peer_terminal_append(
+            "terminal-1",
+            "018f6f79-7a82-7c4e-a552-a3b86f9630f1",
+            PeerResponseTerminalProjectionStatus::Completed,
+        );
+        let mut session = Session::new();
+        session.set_system_prompt("old base".to_string());
+        session.append_system_context_blocks(std::slice::from_ref(&terminal));
+
+        let outcome = session
+            .reconcile_resumed_system_prompt("new base".to_string(), None)
+            .expect("reconcile changed base");
+
+        assert_eq!(outcome, ResumedSystemPromptReconciliation::RewrittenBase);
+        assert_eq!(leading_system_content(&session), "new base");
+        assert_eq!(terminal_notice_count(&session), 1);
+        let state = session.system_context_state().expect("typed state");
+        assert_eq!(state.applied, vec![terminal.clone()]);
+        assert!(state.seen.contains_key("terminal-1"));
+
+        session.append_system_context_blocks(std::slice::from_ref(&terminal));
+        assert_eq!(
+            terminal_notice_count(&session),
+            1,
+            "retry after cold-resume reconciliation must remain idempotent"
+        );
+        assert_eq!(leading_system_content(&session), "new base");
+    }
+
+    fn legacy_session_with_system_context(
+        base: &str,
+        appends: &[PendingSystemContextAppend],
+    ) -> Session {
+        let mut session = Session::new();
+        let rendered = appends
+            .iter()
+            .map(render_system_context_block)
+            .collect::<Vec<_>>()
+            .join(SYSTEM_CONTEXT_SEPARATOR);
+        session
+            .set_system_prompt_with_source(
+                format!("{base}{SYSTEM_CONTEXT_SEPARATOR}{rendered}"),
+                session_durable_config_authority::SessionSystemPromptSource::RuntimeContextAppend,
+            )
+            .expect("legacy runtime-context prompt");
+        let mut state = SessionSystemContextState::default();
+        let accepted =
+            system_context_authority::record_applied_system_context_blocks(&mut state, appends, "");
+        assert_eq!(accepted, appends);
+        session
+            .set_system_context_state(state)
+            .expect("legacy applied state");
+        session
+            .set_build_state(SessionBuildState {
+                assembled_system_prompt: Some(base.to_string()),
+                ..Default::default()
+            })
+            .expect("legacy build state");
+        session
+    }
+
+    #[test]
+    fn cold_resume_migrates_legacy_terminal_system_tail_to_notice() {
+        let terminal = peer_terminal_append(
+            "terminal-1",
+            "018f6f79-7a82-7c4e-a552-a3b86f9630f1",
+            PeerResponseTerminalProjectionStatus::Completed,
+        );
+        let legacy = legacy_session_with_system_context("base", std::slice::from_ref(&terminal));
+        let mut resumed: Session =
+            serde_json::from_value(serde_json::to_value(legacy).expect("serialize legacy session"))
+                .expect("deserialize legacy session");
+
+        let outcome = resumed
+            .reconcile_resumed_system_prompt("base".to_string(), Some("resume".to_string()))
+            .expect("migrate legacy terminal context");
+
+        assert_eq!(outcome, ResumedSystemPromptReconciliation::RewrittenBase);
+        assert_eq!(leading_system_content(&resumed), "base");
+        assert_eq!(terminal_notice_count(&resumed), 1);
+        let state = resumed.system_context_state().expect("typed state");
+        assert_eq!(state.applied, vec![terminal.clone()]);
+        assert!(state.seen.contains_key("terminal-1"));
+
+        resumed.append_system_context_blocks(std::slice::from_ref(&terminal));
+        assert_eq!(terminal_notice_count(&resumed), 1);
+        assert_eq!(leading_system_content(&resumed), "base");
+    }
+
+    #[test]
+    fn resume_migrates_legacy_terminal_but_preserves_roster_tail() {
+        let terminal = peer_terminal_append(
+            "terminal-1",
+            "018f6f79-7a82-7c4e-a552-a3b86f9630f1",
+            PeerResponseTerminalProjectionStatus::Completed,
+        );
+        let roster = roster_append();
+        let mut session =
+            legacy_session_with_system_context("old base", &[roster.clone(), terminal.clone()]);
+
+        let outcome = session
+            .reconcile_resumed_system_prompt("new base".to_string(), Some("resume".to_string()))
+            .expect("migrate mixed legacy context");
+
+        assert_eq!(outcome, ResumedSystemPromptReconciliation::RewrittenBase);
+        let system = leading_system_content(&session);
+        assert!(system.starts_with("new base"));
+        assert!(system.contains("peer roster: lead-1, w-1"));
+        assert!(!system.contains("Peer terminal response"));
+        assert_eq!(terminal_notice_count(&session), 1);
+        let state = session.system_context_state().expect("typed state");
+        assert_eq!(state.applied, vec![roster, terminal]);
+        assert!(state.seen.contains_key("comms:roster:v1"));
+        assert!(state.seen.contains_key("terminal-1"));
+    }
+
+    #[test]
+    fn terminal_migration_never_removes_base_owned_collision() {
+        let terminal = peer_terminal_append(
+            "terminal-1",
+            "018f6f79-7a82-7c4e-a552-a3b86f9630f1",
+            PeerResponseTerminalProjectionStatus::Completed,
+        );
+        let base = format!(
+            "base text{SYSTEM_CONTEXT_SEPARATOR}{}",
+            render_system_context_block(&terminal)
+        );
+        let mut session = Session::new();
+        session.set_system_prompt(base.clone());
+        session
+            .set_build_state(SessionBuildState {
+                assembled_system_prompt: Some(base.clone()),
+                ..Default::default()
+            })
+            .expect("build state");
+        session.append_system_context_blocks(std::slice::from_ref(&terminal));
+        let document_before =
+            serde_json::to_vec(&session).expect("serialize pre-reconcile collision session");
+
+        let outcome = session
+            .reconcile_resumed_system_prompt(base, Some("resume".to_string()))
+            .expect("reconcile base-owned collision");
+
+        assert_eq!(
+            outcome,
+            ResumedSystemPromptReconciliation::PreservedContinuation
+        );
+        assert_eq!(
+            serde_json::to_vec(&session).expect("serialize post-reconcile collision session"),
+            document_before,
+            "typed terminal state must never authorize rewriting base-owned bytes"
+        );
+        assert_eq!(terminal_notice_count(&session), 1);
+    }
+
+    #[test]
+    fn legacy_migration_fails_closed_on_typed_rendering_ambiguity() {
+        let terminal = peer_terminal_append(
+            "terminal-1",
+            "018f6f79-7a82-7c4e-a552-a3b86f9630f1",
+            PeerResponseTerminalProjectionStatus::Completed,
+        );
+        let ordinary_collision = PendingSystemContextAppend {
+            idempotency_key: Some("ordinary-collision".to_string()),
+            peer_response_terminal: None,
+            ..terminal.clone()
+        };
+        assert_eq!(
+            render_system_context_block(&ordinary_collision),
+            render_system_context_block(&terminal)
+        );
+        let mut session = legacy_session_with_system_context(
+            "base",
+            &[ordinary_collision.clone(), terminal.clone()],
+        );
+        let system_before = leading_system_content(&session);
+
+        let outcome = session
+            .reconcile_resumed_system_prompt("base".to_string(), Some("resume".to_string()))
+            .expect("migrate colliding typed tail");
+
+        assert_eq!(outcome, ResumedSystemPromptReconciliation::RewrittenBase);
+        assert_eq!(
+            leading_system_content(&session),
+            system_before,
+            "ambiguous identical terminal/non-terminal renderings must not authorize removal"
+        );
+        assert_eq!(terminal_notice_count(&session), 1);
+        let state = session.system_context_state().expect("typed state");
+        assert_eq!(state.applied, vec![ordinary_collision, terminal]);
+        assert!(state.seen.contains_key("ordinary-collision"));
+        assert!(state.seen.contains_key("terminal-1"));
+    }
+
+    #[test]
+    fn legacy_migration_handles_applied_only_active_boundary_terminal() {
+        let rendered_terminal = peer_terminal_append(
+            "terminal-a",
+            "018f6f79-7a82-7c4e-a552-a3b86f9630f1",
+            PeerResponseTerminalProjectionStatus::Completed,
+        );
+        let applied_only_terminal = peer_terminal_append(
+            "terminal-b",
+            "018f6f79-7a82-7c4e-a552-a3b86f9630f2",
+            PeerResponseTerminalProjectionStatus::Completed,
+        );
+        let mut session =
+            legacy_session_with_system_context("base", std::slice::from_ref(&rendered_terminal));
+        let mut state = session.system_context_state().expect("legacy typed state");
+        let accepted = system_context_authority::record_applied_system_context_blocks(
+            &mut state,
+            std::slice::from_ref(&applied_only_terminal),
+            &leading_system_content(&session),
+        );
+        assert_eq!(accepted, vec![applied_only_terminal.clone()]);
+        session
+            .set_system_context_state(state)
+            .expect("active-boundary applied-only state");
+
+        let outcome = session
+            .reconcile_resumed_system_prompt("base".to_string(), Some("resume".to_string()))
+            .expect("migrate partial legacy terminal tail");
+
+        assert_eq!(outcome, ResumedSystemPromptReconciliation::RewrittenBase);
+        assert_eq!(leading_system_content(&session), "base");
+        assert_eq!(terminal_notice_count(&session), 2);
+        let state = session.system_context_state().expect("typed state");
+        assert_eq!(
+            state.applied,
+            vec![rendered_terminal, applied_only_terminal]
+        );
+        assert!(state.seen.contains_key("terminal-a"));
+        assert!(state.seen.contains_key("terminal-b"));
+    }
+
+    #[test]
+    fn legacy_migration_caps_removal_at_typed_terminal_multiplicity() {
+        let terminal = peer_terminal_append(
+            "terminal-1",
+            "018f6f79-7a82-7c4e-a552-a3b86f9630f1",
+            PeerResponseTerminalProjectionStatus::Completed,
+        );
+        let mut session =
+            legacy_session_with_system_context("base", std::slice::from_ref(&terminal));
+        let rendered = render_system_context_block(&terminal);
+        session
+            .set_system_prompt_with_source(
+                format!(
+                    "base{SYSTEM_CONTEXT_SEPARATOR}{rendered}\
+                     {SYSTEM_CONTEXT_SEPARATOR}{rendered}"
+                ),
+                session_durable_config_authority::SessionSystemPromptSource::RuntimeContextAppend,
+            )
+            .expect("duplicate legacy terminal-shaped segment");
+
+        let outcome = session
+            .reconcile_resumed_system_prompt("base".to_string(), Some("resume".to_string()))
+            .expect("migrate duplicate legacy terminal-shaped suffix");
+
+        assert_eq!(outcome, ResumedSystemPromptReconciliation::RewrittenBase);
+        assert_eq!(
+            leading_system_content(&session),
+            format!("base{SYSTEM_CONTEXT_SEPARATOR}{rendered}"),
+            "one typed terminal record may remove only one matching suffix occurrence"
+        );
+        assert_eq!(terminal_notice_count(&session), 1);
+        let state = session.system_context_state().expect("typed state");
+        assert_eq!(state.applied, vec![terminal]);
+        assert!(state.seen.contains_key("terminal-1"));
+    }
+
     fn resumed_session_with_context_appended_prompt(base: &str) -> Session {
         let mut session = Session::new();
         session.set_system_prompt(base.to_string());
@@ -13829,6 +14504,8 @@ mod tests {
         session.set_system_prompt("base prompt".to_string());
         session.push(Message::User(UserMessage::text("hello".to_string())));
         let digest_before = transcript_messages_digest(session.messages()).unwrap();
+        let document_before =
+            serde_json::to_vec(&session).expect("serialize pre-reconcile session document");
 
         let outcome = session
             .reconcile_resumed_system_prompt("base prompt".to_string(), None)
@@ -13842,6 +14519,11 @@ mod tests {
             transcript_messages_digest(session.messages()).unwrap(),
             digest_before,
             "identical base must leave the transcript revision unchanged"
+        );
+        assert_eq!(
+            serde_json::to_vec(&session).expect("serialize post-reconcile session document"),
+            document_before,
+            "a session without legacy terminal context must be a byte-identical no-op"
         );
     }
 

--- a/meerkat-core/tests/document_cost_probe.rs
+++ b/meerkat-core/tests/document_cost_probe.rs
@@ -32,7 +32,7 @@ fn digest_table(label: &str, before: [u64; 8]) {
                 println!("    digest bytes by pass ({label}):");
                 printed = true;
             }
-            println!("      {name:<20} {:>12} B", delta);
+            println!("      {name:<20} {delta:>12} B");
         }
     }
     if !printed {
@@ -58,7 +58,7 @@ fn document_cost_probe() {
     let t = Instant::now();
     let session = Session::from_persisted_bytes(&bytes).expect("decode durable document");
     let decode = t.elapsed();
-    println!("\n  decode                {:>8.2?}", decode);
+    println!("\n  decode                {decode:>8.2?}");
     digest_table("decode", mark);
     println!("    live messages: {}", session.messages().len());
 

--- a/meerkat-models/tests/catalog_data.rs
+++ b/meerkat-models/tests/catalog_data.rs
@@ -957,6 +957,13 @@ mod schema {
             assert!(cache.get("minProperties").is_none());
 
             let keys = property_keys(&schema);
+            assert!(keys.contains("prompt_cache_enabled"));
+            assert!(keys.contains("prompt_cache_key"));
+            assert_eq!(
+                schema["properties"]["prompt_cache_enabled"]["type"],
+                "boolean"
+            );
+            assert_eq!(schema["properties"]["prompt_cache_key"]["type"], "string");
             for unsupported in ["seed", "frequency_penalty", "presence_penalty"] {
                 assert!(
                     !keys.contains(unsupported),

--- a/meerkat-openai/src/client.rs
+++ b/meerkat-openai/src/client.rs
@@ -596,13 +596,27 @@ impl OpenAiClient {
 
     /// Build request body for OpenAI Responses API
     fn build_request_body(&self, request: &LlmRequest) -> Result<Value, LlmError> {
+        let author_explicit_breakpoints = openai_tag(request).is_some_and(|tag| {
+            tag.prompt_cache_enabled != Some(false)
+                && tag.prompt_cache_options.is_some_and(|options| {
+                    options.mode
+                        == Some(
+                            meerkat_core::model_profile::capabilities::OpenAiPromptCacheMode::Explicit,
+                        )
+                })
+        });
         let (input, instructions) = if self.is_chatgpt_backend_wire() {
             Self::convert_to_responses_input_with_system_mode(
                 &request.messages,
                 SystemMessageMode::ExtractToInstructions,
+                author_explicit_breakpoints,
             )?
         } else {
-            (Self::convert_to_responses_input(&request.messages)?, None)
+            Self::convert_to_responses_input_with_system_mode(
+                &request.messages,
+                SystemMessageMode::IncludeInInput,
+                author_explicit_breakpoints,
+            )?
         };
         let reasoning_enabled = Self::request_supports_reasoning_payload(request);
 
@@ -668,43 +682,63 @@ impl OpenAiClient {
                     ),
                 });
             }
-            if let Some(retention) = tag.prompt_cache_retention
-                && crate::request_support::supports_prompt_cache_retention(
-                    &request.model,
-                    retention,
-                ) == Some(false)
-            {
-                return Err(LlmError::InvalidRequest {
-                    message: format!(
-                        "OpenAI model '{}' supports only '24h' prompt_cache_retention",
-                        request.model
-                    ),
-                });
-            }
-            if let Some(options) = tag.prompt_cache_options {
-                if let Some(mode) = options.mode
-                    && crate::request_support::supports_prompt_cache_mode(&request.model, mode)
-                        == Some(false)
+            if let Some(enabled) = tag.prompt_cache_enabled {
+                let required_mode = if enabled {
+                    meerkat_core::model_profile::capabilities::OpenAiPromptCacheMode::Implicit
+                } else {
+                    meerkat_core::model_profile::capabilities::OpenAiPromptCacheMode::Explicit
+                };
+                if crate::request_support::supports_prompt_cache_mode(&request.model, required_mode)
+                    == Some(false)
                 {
                     return Err(LlmError::InvalidRequest {
                         message: format!(
-                            "OpenAI model '{}' does not support prompt cache mode '{}'",
+                            "OpenAI model '{}' does not support the '{}' mode required by prompt_cache_enabled={enabled}",
                             request.model,
-                            mode.as_wire_str()
+                            required_mode.as_wire_str()
                         ),
                     });
                 }
-                if let Some(ttl) = options.ttl
-                    && crate::request_support::supports_prompt_cache_ttl(&request.model, ttl)
-                        == Some(false)
+            }
+            if tag.prompt_cache_enabled != Some(false) {
+                if let Some(retention) = tag.prompt_cache_retention
+                    && crate::request_support::supports_prompt_cache_retention(
+                        &request.model,
+                        retention,
+                    ) == Some(false)
                 {
                     return Err(LlmError::InvalidRequest {
                         message: format!(
-                            "OpenAI model '{}' does not support prompt cache TTL '{}'",
-                            request.model,
-                            ttl.as_wire_str()
+                            "OpenAI model '{}' supports only '24h' prompt_cache_retention",
+                            request.model
                         ),
                     });
+                }
+                if let Some(options) = tag.prompt_cache_options {
+                    if let Some(mode) = options.mode
+                        && crate::request_support::supports_prompt_cache_mode(&request.model, mode)
+                            == Some(false)
+                    {
+                        return Err(LlmError::InvalidRequest {
+                            message: format!(
+                                "OpenAI model '{}' does not support prompt cache mode '{}'",
+                                request.model,
+                                mode.as_wire_str()
+                            ),
+                        });
+                    }
+                    if let Some(ttl) = options.ttl
+                        && crate::request_support::supports_prompt_cache_ttl(&request.model, ttl)
+                            == Some(false)
+                    {
+                        return Err(LlmError::InvalidRequest {
+                            message: format!(
+                                "OpenAI model '{}' does not support prompt cache TTL '{}'",
+                                request.model,
+                                ttl.as_wire_str()
+                            ),
+                        });
+                    }
                 }
             }
         }
@@ -779,25 +813,36 @@ impl OpenAiClient {
                 body["store"] = Value::Bool(store);
             }
 
-            if let Some(prompt_cache_key) = tag.prompt_cache_key.as_ref() {
-                body["prompt_cache_key"] = Value::String(prompt_cache_key.clone());
-            }
+            if tag.prompt_cache_enabled == Some(false) {
+                // Durable Meerkat opt-out: explicit-only mode with no authored
+                // breakpoints performs no cache reads or writes. Keep this
+                // branch authoritative over explicit breakpoint authoring.
+                body["prompt_cache_options"] = serde_json::json!({"mode": "explicit"});
+            } else {
+                if let Some(prompt_cache_key) = tag.prompt_cache_key.as_ref() {
+                    body["prompt_cache_key"] = Value::String(prompt_cache_key.clone());
+                }
 
-            if let Some(retention) = tag.prompt_cache_retention {
-                body["prompt_cache_retention"] = Value::String(
-                    match retention {
-                        OpenAiPromptCacheRetention::InMemory => "in_memory",
-                        OpenAiPromptCacheRetention::TwentyFourHours => "24h",
-                    }
-                    .to_string(),
-                );
-            }
+                if let Some(retention) = tag.prompt_cache_retention {
+                    body["prompt_cache_retention"] = Value::String(
+                        match retention {
+                            OpenAiPromptCacheRetention::InMemory => "in_memory",
+                            OpenAiPromptCacheRetention::TwentyFourHours => "24h",
+                        }
+                        .to_string(),
+                    );
+                }
 
-            if let Some(options) = tag.prompt_cache_options {
-                body["prompt_cache_options"] =
-                    serde_json::to_value(options).map_err(|error| LlmError::InvalidRequest {
-                        message: format!("invalid prompt_cache_options: {error}"),
-                    })?;
+                if let Some(options) = tag.prompt_cache_options {
+                    body["prompt_cache_options"] =
+                        serde_json::to_value(options).map_err(|error| {
+                            LlmError::InvalidRequest {
+                                message: format!("invalid prompt_cache_options: {error}"),
+                            }
+                        })?;
+                } else if tag.prompt_cache_enabled == Some(true) {
+                    body["prompt_cache_options"] = serde_json::json!({"mode": "implicit"});
+                }
             }
 
             if reasoning_enabled && let Some(effort) = tag.reasoning_effort {
@@ -962,6 +1007,7 @@ impl OpenAiClient {
         Self::convert_to_responses_input_with_system_mode(
             messages,
             SystemMessageMode::IncludeInInput,
+            false,
         )
         .map(|(input, _)| input)
     }
@@ -987,6 +1033,34 @@ impl OpenAiClient {
                 "text": block.text_projection()
             }),
         }
+    }
+
+    fn author_responses_content_breakpoint(content: &mut Value) -> bool {
+        if let Some(parts) = content.as_array_mut() {
+            for part in parts.iter_mut().rev() {
+                if matches!(
+                    part.get("type").and_then(Value::as_str),
+                    Some("input_text" | "input_image" | "input_file")
+                ) {
+                    part["prompt_cache_breakpoint"] = serde_json::json!({"mode": "explicit"});
+                    return true;
+                }
+            }
+            return false;
+        }
+        if let Some(text) = content
+            .as_str()
+            .filter(|text| !text.is_empty())
+            .map(str::to_owned)
+        {
+            *content = serde_json::json!([{
+                "type": "input_text",
+                "text": text,
+                "prompt_cache_breakpoint": {"mode": "explicit"}
+            }]);
+            return true;
+        }
+        false
     }
 
     fn tool_result_responses_output(result: &ToolResult) -> Result<Value, LlmError> {
@@ -1081,6 +1155,7 @@ impl OpenAiClient {
     fn convert_to_responses_input_with_system_mode(
         messages: &[Message],
         system_mode: SystemMessageMode,
+        author_explicit_breakpoints: bool,
     ) -> Result<(Vec<Value>, Option<String>), LlmError> {
         let mut items = Vec::new();
         let mut instructions = Vec::new();
@@ -1107,6 +1182,9 @@ impl OpenAiClient {
                         "role": "user",
                         "content": Self::system_notice_responses_content(notice)
                     }));
+                    if author_explicit_breakpoints && let Some(item) = items.last_mut() {
+                        Self::author_responses_content_breakpoint(&mut item["content"]);
+                    }
                 }
                 Message::User(u) => {
                     if meerkat_core::has_non_text_content(&u.content) {
@@ -1126,6 +1204,9 @@ impl OpenAiClient {
                             "role": "user",
                             "content": u.text_content()
                         }));
+                    }
+                    if author_explicit_breakpoints && let Some(item) = items.last_mut() {
+                        Self::author_responses_content_breakpoint(&mut item["content"]);
                     }
                 }
                 Message::BlockAssistant(a) => {
@@ -1167,6 +1248,7 @@ impl OpenAiClient {
                     }
                 }
                 Message::ToolResults { results, .. } => {
+                    let first_result_item = items.len();
                     for r in results {
                         let output = Self::tool_result_responses_output(r)?;
                         items.push(serde_json::json!({
@@ -1174,6 +1256,13 @@ impl OpenAiClient {
                             "call_id": r.tool_use_id,
                             "output": output
                         }));
+                    }
+                    if author_explicit_breakpoints {
+                        for item in items[first_result_item..].iter_mut().rev() {
+                            if Self::author_responses_content_breakpoint(&mut item["output"]) {
+                                break;
+                            }
+                        }
                     }
                 }
             }
@@ -3779,8 +3868,9 @@ mod tests {
             tag.reasoning_mode = Some(OpenAiReasoningMode::Pro);
             tag.reasoning_context = Some(OpenAiReasoningContext::AllTurns);
             tag.text_verbosity = Some(OpenAiTextVerbosity::High);
+            tag.prompt_cache_key = Some("meerkat:session:stable".to_string());
             tag.prompt_cache_options = Some(OpenAiPromptCacheOptions {
-                mode: Some(OpenAiPromptCacheMode::Explicit),
+                mode: Some(OpenAiPromptCacheMode::Implicit),
                 ttl: Some(OpenAiPromptCacheTtl::ThirtyMinutes),
             });
         });
@@ -3791,9 +3881,14 @@ mod tests {
         assert_eq!(body["reasoning"]["mode"], "pro");
         assert_eq!(body["reasoning"]["context"], "all_turns");
         assert_eq!(body["text"]["verbosity"], "high");
+        assert_eq!(body["prompt_cache_key"], "meerkat:session:stable");
         assert_eq!(
             body["prompt_cache_options"],
-            serde_json::json!({"mode": "explicit", "ttl": "30m"})
+            serde_json::json!({"mode": "implicit", "ttl": "30m"})
+        );
+        assert!(
+            !body.to_string().contains("prompt_cache_breakpoint"),
+            "implicit mode must leave breakpoint placement to OpenAI"
         );
     }
 
@@ -3837,12 +3932,24 @@ mod tests {
             client.build_request_body(&cache),
             Err(LlmError::InvalidRequest { .. })
         ));
+
+        let enabled = LlmRequest::new(
+            "gpt-5.5",
+            vec![Message::User(UserMessage::text("Hello".to_string()))],
+        )
+        .with_openai_tag_merge(|tag| {
+            tag.prompt_cache_enabled = Some(true);
+        });
+        assert!(matches!(
+            client.build_request_body(&enabled),
+            Err(LlmError::InvalidRequest { .. })
+        ));
     }
 
     #[test]
-    fn prompt_cache_retention_and_options_are_independent() {
+    fn explicit_cache_mode_authors_append_monotone_responses_breakpoints() {
         let client = OpenAiClient::new("test-key".to_string());
-        let request = LlmRequest::new(
+        let first_request = LlmRequest::new(
             "gpt-5.6-sol",
             vec![Message::User(UserMessage::text("Hello".to_string()))],
         )
@@ -3853,12 +3960,141 @@ mod tests {
                 ttl: None,
             });
         });
-        let body = client.build_request_body(&request).expect("build request");
+        let first_body = client
+            .build_request_body(&first_request)
+            .expect("build first request");
+        let mut second_request = first_request;
+        second_request
+            .messages
+            .push(Message::User(UserMessage::text("Again".to_string())));
+        let second_body = client
+            .build_request_body(&second_request)
+            .expect("build growing request");
 
-        assert_eq!(body["prompt_cache_retention"], "24h");
+        assert_eq!(first_body["prompt_cache_retention"], "24h");
+        assert_eq!(
+            first_body["prompt_cache_options"],
+            serde_json::json!({"mode": "explicit"})
+        );
+        assert_eq!(
+            first_body["input"][0]["content"][0]["prompt_cache_breakpoint"],
+            serde_json::json!({"mode": "explicit"})
+        );
+        assert_eq!(
+            first_body["input"][0], second_body["input"][0],
+            "growing a conversation must not mutate an earlier marked prefix"
+        );
+        assert_eq!(
+            second_body["input"][1]["content"][0]["prompt_cache_breakpoint"],
+            serde_json::json!({"mode": "explicit"})
+        );
+    }
+
+    #[test]
+    fn explicit_responses_marks_final_supported_multimodal_part() {
+        let client = OpenAiClient::new("test-key".to_string());
+        let request = LlmRequest::new(
+            "gpt-5.6-sol",
+            vec![Message::User(UserMessage::with_blocks(vec![
+                ContentBlock::Text {
+                    text: "describe this".to_string(),
+                },
+                ContentBlock::Image {
+                    media_type: "image/png".to_string(),
+                    data: "iVBOR...".into(),
+                },
+            ]))],
+        )
+        .with_openai_tag_merge(|tag| {
+            tag.prompt_cache_options = Some(OpenAiPromptCacheOptions {
+                mode: Some(OpenAiPromptCacheMode::Explicit),
+                ttl: None,
+            });
+        });
+
+        let body = client.build_request_body(&request).expect("build request");
+        assert!(
+            body["input"][0]["content"][0]
+                .get("prompt_cache_breakpoint")
+                .is_none()
+        );
+        assert_eq!(
+            body["input"][0]["content"][1]["prompt_cache_breakpoint"],
+            serde_json::json!({"mode": "explicit"}),
+            "the marker belongs on the final supported multimodal part"
+        );
+    }
+
+    #[test]
+    fn explicit_responses_handles_no_boundary_and_empty_tail_tool_results() {
+        let client = OpenAiClient::new("test-key".to_string());
+        let explicit = |messages| {
+            LlmRequest::new("gpt-5.6-sol", messages).with_openai_tag_merge(|tag| {
+                tag.prompt_cache_options = Some(OpenAiPromptCacheOptions {
+                    mode: Some(OpenAiPromptCacheMode::Explicit),
+                    ttl: None,
+                });
+            })
+        };
+
+        let system_only = client
+            .build_request_body(&explicit(vec![Message::System(
+                meerkat_core::SystemMessage::new("system only"),
+            )]))
+            .expect("explicit mode without a markable boundary is valid");
+        assert!(!system_only.to_string().contains("prompt_cache_breakpoint"));
+
+        let tool_results = client
+            .build_request_body(&explicit(vec![
+                Message::User(UserMessage::text("run tools".to_string())),
+                Message::tool_results(vec![
+                    ToolResult::new(
+                        "call-1".to_string(),
+                        "large stable output".to_string(),
+                        false,
+                    ),
+                    ToolResult::new("call-2".to_string(), String::new(), false),
+                ]),
+            ]))
+            .expect("parallel tool results");
+        assert_eq!(
+            tool_results["input"][1]["output"][0]["prompt_cache_breakpoint"],
+            serde_json::json!({"mode":"explicit"}),
+            "an empty final result must fall back to the last cacheable result"
+        );
+        assert!(
+            tool_results["input"][2]["output"]
+                .to_string()
+                .find("prompt_cache_breakpoint")
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn durable_cache_disable_overrides_conflicting_cache_fields() {
+        let client = OpenAiClient::new("test-key".to_string());
+        let request = LlmRequest::new(
+            "gpt-5.6-sol",
+            vec![Message::User(UserMessage::text("Hello".to_string()))],
+        )
+        .with_openai_tag_merge(|tag| {
+            tag.prompt_cache_enabled = Some(false);
+            tag.prompt_cache_key = Some("identity:must-not-leak".to_string());
+            tag.prompt_cache_retention = Some(OpenAiPromptCacheRetention::InMemory);
+            tag.prompt_cache_options = Some(OpenAiPromptCacheOptions {
+                mode: Some(OpenAiPromptCacheMode::Implicit),
+                ttl: Some(OpenAiPromptCacheTtl::ThirtyMinutes),
+            });
+        });
+
+        let body = client
+            .build_request_body(&request)
+            .expect("disable must ignore inactive conflicting cache fields");
+        assert!(body.get("prompt_cache_key").is_none());
+        assert!(body.get("prompt_cache_retention").is_none());
         assert_eq!(
             body["prompt_cache_options"],
-            serde_json::json!({"mode": "explicit"})
+            serde_json::json!({"mode":"explicit"})
         );
     }
 

--- a/meerkat-openai/src/client_compatible.rs
+++ b/meerkat-openai/src/client_compatible.rs
@@ -196,9 +196,23 @@ impl OpenAiCompatibleClient {
     }
 
     fn build_chat_completions_body(&self, request: &LlmRequest) -> Result<Value, LlmError> {
+        let tag = crate::client::openai_tag(request);
+        let author_explicit_breakpoints = tag.is_some_and(|tag| {
+            tag.prompt_cache_enabled != Some(false)
+                && tag.prompt_cache_options.is_some_and(|options| {
+                    options.mode
+                        == Some(
+                            meerkat_core::model_profile::capabilities::OpenAiPromptCacheMode::Explicit,
+                        )
+                })
+        });
+        let messages = Self::convert_to_chat_messages_with_cache(
+            &request.messages,
+            author_explicit_breakpoints,
+        )?;
         let mut body = serde_json::json!({
             "model": self.remote_model,
-            "messages": Self::convert_to_chat_messages(&request.messages)?,
+            "messages": messages,
             "stream": true,
             "stream_options": { "include_usage": true },
             "max_completion_tokens": request.max_tokens,
@@ -230,7 +244,35 @@ impl OpenAiCompatibleClient {
             );
         }
 
-        if let Some(tag) = crate::client::openai_tag(request) {
+        if let Some(tag) = tag {
+            if tag.prompt_cache_enabled == Some(false) {
+                // Stable Meerkat opt-out. This remains authoritative over
+                // compatible Chat Completions breakpoint authoring.
+                body["prompt_cache_options"] = serde_json::json!({"mode": "explicit"});
+            } else {
+                if let Some(key) = tag.prompt_cache_key.as_ref() {
+                    body["prompt_cache_key"] = Value::String(key.clone());
+                }
+                if let Some(retention) = tag.prompt_cache_retention {
+                    body["prompt_cache_retention"] = Value::String(
+                        match retention {
+                            meerkat_core::lifecycle::run_primitive::OpenAiPromptCacheRetention::InMemory => "in_memory",
+                            meerkat_core::lifecycle::run_primitive::OpenAiPromptCacheRetention::TwentyFourHours => "24h",
+                        }
+                        .to_string(),
+                    );
+                }
+                if let Some(options) = tag.prompt_cache_options {
+                    body["prompt_cache_options"] =
+                        serde_json::to_value(options).map_err(|error| {
+                            LlmError::InvalidRequest {
+                                message: format!("invalid prompt_cache_options: {error}"),
+                            }
+                        })?;
+                } else if tag.prompt_cache_enabled == Some(true) {
+                    body["prompt_cache_options"] = serde_json::json!({"mode": "implicit"});
+                }
+            }
             if self.supports_reasoning {
                 if let Some(reasoning) = tag.reasoning.as_ref() {
                     let v = reasoning.as_value();
@@ -277,7 +319,43 @@ impl OpenAiCompatibleClient {
         Ok(body)
     }
 
+    fn author_chat_content_breakpoint(content: &mut Value) -> bool {
+        if let Some(parts) = content.as_array_mut() {
+            for part in parts.iter_mut().rev() {
+                if matches!(
+                    part.get("type").and_then(Value::as_str),
+                    Some("text" | "image_url" | "input_audio" | "file" | "refusal")
+                ) {
+                    part["prompt_cache_breakpoint"] = serde_json::json!({"mode": "explicit"});
+                    return true;
+                }
+            }
+            return false;
+        }
+        if let Some(text) = content
+            .as_str()
+            .filter(|text| !text.is_empty())
+            .map(str::to_owned)
+        {
+            *content = serde_json::json!([{
+                "type": "text",
+                "text": text,
+                "prompt_cache_breakpoint": {"mode": "explicit"}
+            }]);
+            return true;
+        }
+        false
+    }
+
+    #[cfg(test)]
     fn convert_to_chat_messages(messages: &[Message]) -> Result<Vec<Value>, LlmError> {
+        Self::convert_to_chat_messages_with_cache(messages, false)
+    }
+
+    fn convert_to_chat_messages_with_cache(
+        messages: &[Message],
+        author_explicit_breakpoints: bool,
+    ) -> Result<Vec<Value>, LlmError> {
         let mut out = Vec::new();
         for message in messages {
             match message {
@@ -292,6 +370,9 @@ impl OpenAiCompatibleClient {
                         "role": "user",
                         "content": Self::system_notice_chat_content(notice)
                     }));
+                    if author_explicit_breakpoints && let Some(message) = out.last_mut() {
+                        Self::author_chat_content_breakpoint(&mut message["content"]);
+                    }
                 }
                 Message::User(user) => {
                     if meerkat_core::has_non_text_content(&user.content) {
@@ -309,6 +390,9 @@ impl OpenAiCompatibleClient {
                             "role": "user",
                             "content": user.text_content()
                         }));
+                    }
+                    if author_explicit_breakpoints && let Some(message) = out.last_mut() {
+                        Self::author_chat_content_breakpoint(&mut message["content"]);
                     }
                 }
                 Message::BlockAssistant(assistant) => {
@@ -349,12 +433,20 @@ impl OpenAiCompatibleClient {
                     }));
                 }
                 Message::ToolResults { results, .. } => {
+                    let first_result_message = out.len();
                     for result in results {
                         out.push(serde_json::json!({
                             "role": "tool",
                             "tool_call_id": result.tool_use_id,
                             "content": result.text_content()
                         }));
+                    }
+                    if author_explicit_breakpoints {
+                        for message in out[first_result_message..].iter_mut().rev() {
+                            if Self::author_chat_content_breakpoint(&mut message["content"]) {
+                                break;
+                            }
+                        }
                     }
                 }
             }
@@ -510,8 +602,14 @@ impl LlmClient for OpenAiCompatibleClient {
                                     let usage = Usage {
                                         input_tokens: event_usage.prompt_tokens.unwrap_or(0),
                                         output_tokens: event_usage.completion_tokens.unwrap_or(0),
-                                        cache_creation_tokens: None,
-                                        cache_read_tokens: None,
+                                        cache_creation_tokens: event_usage
+                                            .prompt_tokens_details
+                                            .as_ref()
+                                            .and_then(|details| details.cache_write_tokens),
+                                        cache_read_tokens: event_usage
+                                            .prompt_tokens_details
+                                            .as_ref()
+                                            .and_then(|details| details.cached_tokens),
                                     };
                                     yield LlmEvent::UsageUpdate { usage };
                                 }
@@ -729,6 +827,16 @@ struct ChatUsage {
     prompt_tokens: Option<u64>,
     #[serde(default)]
     completion_tokens: Option<u64>,
+    #[serde(default)]
+    prompt_tokens_details: Option<ChatPromptTokensDetails>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ChatPromptTokensDetails {
+    #[serde(default)]
+    cached_tokens: Option<u64>,
+    #[serde(default)]
+    cache_write_tokens: Option<u64>,
 }
 
 #[cfg(test)]
@@ -1102,6 +1210,245 @@ mod tests {
 
         assert_eq!(body["reasoning"]["effort"], "xhigh");
         assert_eq!(body["reasoning_effort"], "xhigh");
+    }
+
+    #[test]
+    fn chat_completions_lowers_cache_policy_key_and_durable_disable() {
+        use meerkat_core::lifecycle::run_primitive::{
+            OpenAiPromptCacheOptions, OpenAiPromptCacheRetention,
+        };
+        use meerkat_core::model_profile::capabilities::{
+            OpenAiPromptCacheMode, OpenAiPromptCacheTtl,
+        };
+
+        let client = OpenAiCompatibleClient::new_with_options(
+            OpenAiCompatibleMode::ChatCompletions,
+            "gpt-5.6-sol".to_string(),
+            "http://localhost:11434/v1".to_string(),
+            None,
+            options(true, true, true, false),
+        );
+        let request = LlmRequest::new(
+            "gpt-5.6-sol",
+            vec![Message::User(UserMessage::text("hello".to_string()))],
+        )
+        .with_openai_tag_merge(|tag| {
+            tag.prompt_cache_enabled = Some(true);
+            tag.prompt_cache_key = Some("identity:parent-1".to_string());
+            tag.prompt_cache_options = Some(OpenAiPromptCacheOptions {
+                mode: Some(OpenAiPromptCacheMode::Implicit),
+                ttl: Some(OpenAiPromptCacheTtl::ThirtyMinutes),
+            });
+        });
+        let body = client
+            .build_chat_completions_body(&request)
+            .expect("cache-enabled body");
+        assert_eq!(body["prompt_cache_key"], "identity:parent-1");
+        assert_eq!(
+            body["prompt_cache_options"],
+            serde_json::json!({"mode":"implicit","ttl":"30m"})
+        );
+        assert!(
+            !body.to_string().contains("prompt_cache_breakpoint"),
+            "implicit mode must leave breakpoint placement to OpenAI"
+        );
+
+        let disabled = request.with_openai_tag_merge(|tag| {
+            tag.prompt_cache_enabled = Some(false);
+            tag.prompt_cache_retention = Some(OpenAiPromptCacheRetention::InMemory);
+        });
+        let disabled_body = client
+            .build_chat_completions_body(&disabled)
+            .expect("durable cache opt-out body");
+        assert!(disabled_body.get("prompt_cache_key").is_none());
+        assert!(disabled_body.get("prompt_cache_retention").is_none());
+        assert_eq!(
+            disabled_body["prompt_cache_options"],
+            serde_json::json!({"mode":"explicit"})
+        );
+    }
+
+    #[test]
+    fn chat_completions_explicit_breakpoints_are_append_monotone() {
+        use meerkat_core::lifecycle::run_primitive::OpenAiPromptCacheOptions;
+        use meerkat_core::model_profile::capabilities::OpenAiPromptCacheMode;
+
+        let client = OpenAiCompatibleClient::new_with_options(
+            OpenAiCompatibleMode::ChatCompletions,
+            "gpt-5.6-sol".to_string(),
+            "http://localhost:11434/v1".to_string(),
+            None,
+            options(true, true, true, false),
+        );
+        let first_request = LlmRequest::new(
+            "gpt-5.6-sol",
+            vec![Message::User(UserMessage::text("hello".to_string()))],
+        )
+        .with_openai_tag_merge(|tag| {
+            tag.prompt_cache_options = Some(OpenAiPromptCacheOptions {
+                mode: Some(OpenAiPromptCacheMode::Explicit),
+                ttl: None,
+            });
+        });
+        let first_body = client
+            .build_chat_completions_body(&first_request)
+            .expect("first explicit body");
+        let mut second_request = first_request;
+        second_request
+            .messages
+            .push(Message::User(UserMessage::text("again".to_string())));
+        let second_body = client
+            .build_chat_completions_body(&second_request)
+            .expect("growing explicit body");
+
+        assert_eq!(first_body["messages"][0], second_body["messages"][0]);
+        assert_eq!(
+            first_body["messages"][0]["content"][0]["prompt_cache_breakpoint"],
+            serde_json::json!({"mode":"explicit"})
+        );
+        assert_eq!(
+            second_body["messages"][1]["content"][0]["prompt_cache_breakpoint"],
+            serde_json::json!({"mode":"explicit"})
+        );
+    }
+
+    #[test]
+    fn chat_explicit_handles_no_boundary_and_marks_final_multimodal_part() {
+        use meerkat_core::lifecycle::run_primitive::OpenAiPromptCacheOptions;
+        use meerkat_core::model_profile::capabilities::OpenAiPromptCacheMode;
+
+        let client = OpenAiCompatibleClient::new_with_options(
+            OpenAiCompatibleMode::ChatCompletions,
+            "gpt-5.6-sol".to_string(),
+            "http://localhost:11434/v1".to_string(),
+            None,
+            options(true, true, true, false),
+        );
+        let explicit = |messages| {
+            LlmRequest::new("gpt-5.6-sol", messages).with_openai_tag_merge(|tag| {
+                tag.prompt_cache_options = Some(OpenAiPromptCacheOptions {
+                    mode: Some(OpenAiPromptCacheMode::Explicit),
+                    ttl: None,
+                });
+            })
+        };
+
+        let system_only = client
+            .build_chat_completions_body(&explicit(vec![Message::System(
+                meerkat_core::SystemMessage::new("system only"),
+            )]))
+            .expect("explicit mode without a markable boundary is valid");
+        assert!(!system_only.to_string().contains("prompt_cache_breakpoint"));
+
+        let multimodal = client
+            .build_chat_completions_body(&explicit(vec![Message::User(UserMessage::with_blocks(
+                vec![
+                    ContentBlock::Text {
+                        text: "describe this".to_string(),
+                    },
+                    ContentBlock::Image {
+                        media_type: "image/png".to_string(),
+                        data: ImageData::Inline {
+                            data: "iVBOR...".to_string(),
+                        },
+                    },
+                ],
+            ))]))
+            .expect("multimodal explicit body");
+        assert!(
+            multimodal["messages"][0]["content"][0]
+                .get("prompt_cache_breakpoint")
+                .is_none()
+        );
+        assert_eq!(
+            multimodal["messages"][0]["content"][1]["prompt_cache_breakpoint"],
+            serde_json::json!({"mode": "explicit"}),
+            "the marker belongs on the final supported multimodal part"
+        );
+    }
+
+    #[test]
+    fn chat_explicit_tool_results_mark_last_cacheable_result() {
+        use meerkat_core::lifecycle::run_primitive::OpenAiPromptCacheOptions;
+        use meerkat_core::model_profile::capabilities::OpenAiPromptCacheMode;
+
+        let client = OpenAiCompatibleClient::new_with_options(
+            OpenAiCompatibleMode::ChatCompletions,
+            "gpt-5.6-sol".to_string(),
+            "http://localhost:11434/v1".to_string(),
+            None,
+            options(true, true, true, false),
+        );
+        let request = LlmRequest::new(
+            "gpt-5.6-sol",
+            vec![
+                Message::User(UserMessage::text("run tools".to_string())),
+                Message::tool_results(vec![
+                    ToolResult::new(
+                        "call-1".to_string(),
+                        "large stable output".to_string(),
+                        false,
+                    ),
+                    ToolResult::new("call-2".to_string(), String::new(), false),
+                ]),
+            ],
+        )
+        .with_openai_tag_merge(|tag| {
+            tag.prompt_cache_options = Some(OpenAiPromptCacheOptions {
+                mode: Some(OpenAiPromptCacheMode::Explicit),
+                ttl: None,
+            });
+        });
+
+        let body = client
+            .build_chat_completions_body(&request)
+            .expect("parallel tool results");
+        assert_eq!(
+            body["messages"][1]["content"][0]["prompt_cache_breakpoint"],
+            serde_json::json!({"mode":"explicit"})
+        );
+        assert!(
+            body["messages"][2]["content"]
+                .to_string()
+                .find("prompt_cache_breakpoint")
+                .is_none()
+        );
+    }
+
+    #[tokio::test]
+    async fn chat_completions_maps_cache_read_and_write_usage() {
+        let payload = concat!(
+            "data: {\"choices\":[{\"delta\":{\"content\":\"ok\"},\"finish_reason\":\"stop\"}],\"usage\":{\"prompt_tokens\":100,\"completion_tokens\":2,\"prompt_tokens_details\":{\"cached_tokens\":80,\"cache_write_tokens\":20}}}\n\n",
+            "data: [DONE]\n\n"
+        )
+        .to_string();
+        let (base_url, handle) = spawn_chat_stub_server(payload).await;
+        let client = OpenAiCompatibleClient::new_with_options(
+            OpenAiCompatibleMode::ChatCompletions,
+            "gpt-5.6-sol".to_string(),
+            base_url,
+            None,
+            options(true, true, true, false),
+        );
+        let request = LlmRequest::new(
+            "gpt-5.6-sol",
+            vec![Message::User(UserMessage::text("hello".to_string()))],
+        );
+
+        let events: Vec<_> = client.stream(&request).collect().await;
+        let usage = events
+            .into_iter()
+            .filter_map(Result::ok)
+            .find_map(|event| match event {
+                LlmEvent::UsageUpdate { usage } => Some(usage),
+                _ => None,
+            })
+            .expect("usage update");
+        assert_eq!(usage.input_tokens, 100);
+        assert_eq!(usage.output_tokens, 2);
+        assert_eq!(usage.cache_read_tokens, Some(80));
+        assert_eq!(usage.cache_creation_tokens, Some(20));
+        handle.abort();
     }
 
     #[tokio::test]

--- a/meerkat/src/factory.rs
+++ b/meerkat/src/factory.rs
@@ -1128,24 +1128,26 @@ impl meerkat_core::ModelOperationalDefaultsResolver for RegistryBackedDefaultsRe
     }
 }
 
-fn provider_tool_defaults_for(
+fn provider_request_defaults_for(
     provider: Provider,
+    model: &str,
     config: &Config,
     model_profile: Option<&meerkat_core::model_profile::ModelProfile>,
     web_search_override: ToolCategoryOverride,
+    session_id: Option<&meerkat_core::SessionId>,
+    openai_cache_defaults_supported: bool,
 ) -> Option<meerkat_core::lifecycle::run_primitive::ProviderTag> {
     use meerkat_core::lifecycle::run_primitive::{
-        AnthropicProviderTag, GeminiProviderTag, OpaqueProviderBody, OpenAiProviderTag, ProviderTag,
+        AnthropicProviderTag, GeminiProviderTag, OpaqueProviderBody, OpenAiPromptCacheOptions,
+        OpenAiProviderTag, ProviderTag,
     };
-    if matches!(web_search_override, ToolCategoryOverride::Disable) {
-        return None;
-    }
-    if !model_profile.is_some_and(|profile| profile.supports_web_search) {
-        return None;
-    }
+    use meerkat_core::model_profile::capabilities::{OpenAiPromptCacheMode, OpenAiPromptCacheTtl};
+
+    let web_search_enabled = !matches!(web_search_override, ToolCategoryOverride::Disable)
+        && model_profile.is_some_and(|profile| profile.supports_web_search);
 
     match provider {
-        Provider::Anthropic if config.provider_tools.anthropic.web_search => {
+        Provider::Anthropic if web_search_enabled && config.provider_tools.anthropic.web_search => {
             Some(ProviderTag::Anthropic(AnthropicProviderTag {
                 web_search: Some(OpaqueProviderBody::from_value(&serde_json::json!({
                     "type": "web_search_20250305",
@@ -1154,15 +1156,46 @@ fn provider_tool_defaults_for(
                 ..Default::default()
             }))
         }
-        Provider::OpenAI if config.provider_tools.openai.web_search => {
-            Some(ProviderTag::OpenAi(OpenAiProviderTag {
-                web_search: Some(OpaqueProviderBody::from_value(
-                    &serde_json::json!({"type": "web_search"}),
-                )),
-                ..Default::default()
-            }))
+        Provider::OpenAI => {
+            let cache_capabilities = if openai_cache_defaults_supported {
+                meerkat_models::capabilities_for(Provider::OpenAI, model)
+                    .and_then(|capabilities| capabilities.openai_responses_params)
+            } else {
+                None
+            };
+            let prompt_cache_options = cache_capabilities.and_then(|capabilities| {
+                capabilities
+                    .prompt_cache_modes
+                    .contains(&OpenAiPromptCacheMode::Implicit)
+                    .then_some(OpenAiPromptCacheOptions {
+                        mode: Some(OpenAiPromptCacheMode::Implicit),
+                        ttl: capabilities
+                            .prompt_cache_ttls
+                            .contains(&OpenAiPromptCacheTtl::ThirtyMinutes)
+                            .then_some(OpenAiPromptCacheTtl::ThirtyMinutes),
+                    })
+            });
+            let prompt_cache_key = prompt_cache_options
+                .is_some()
+                .then(|| session_id.map(|id| format!("meerkat:session:{id}")))
+                .flatten();
+            let prompt_cache_enabled = prompt_cache_options.is_some().then_some(true);
+            let web_search =
+                (web_search_enabled && config.provider_tools.openai.web_search).then(|| {
+                    OpaqueProviderBody::from_value(&serde_json::json!({"type": "web_search"}))
+                });
+
+            (prompt_cache_options.is_some() || web_search.is_some()).then(|| {
+                ProviderTag::OpenAi(OpenAiProviderTag {
+                    web_search,
+                    prompt_cache_enabled,
+                    prompt_cache_key,
+                    prompt_cache_options,
+                    ..Default::default()
+                })
+            })
         }
-        Provider::Gemini if config.provider_tools.gemini.google_search => {
+        Provider::Gemini if web_search_enabled && config.provider_tools.gemini.google_search => {
             Some(ProviderTag::Gemini(GeminiProviderTag {
                 google_search: Some(OpaqueProviderBody::from_value(&serde_json::json!({}))),
                 ..Default::default()
@@ -1170,6 +1203,20 @@ fn provider_tool_defaults_for(
         }
         _ => None,
     }
+}
+
+fn openai_cache_defaults_supported(
+    config: &Config,
+    auth_binding: Option<&meerkat_core::AuthBindingRef>,
+) -> bool {
+    let Some(auth_binding) = auth_binding else {
+        return true;
+    };
+    if auth_binding.is_env_default() {
+        return true;
+    }
+    meerkat_core::resolve_explicit_auth_binding_target(config, auth_binding)
+        .is_ok_and(|target| target.backend.backend_kind == "openai_api")
 }
 
 /// Typed create-session model hints supplied by a public surface.
@@ -3571,11 +3618,34 @@ impl AgentFactory {
     /// (`SessionMetadata.tooling.web_search`). It MUST be threaded through so a
     /// model/provider hot-swap preserves a session's `--no-web-search` disable
     /// instead of silently re-enabling the provider-native web-search body.
+    ///
+    /// This source-compatible seam has no session identity, so it can resolve
+    /// model policy but cannot synthesize a routing-affinity key.
     pub fn request_policy_for_llm_identity(
         &self,
         config: &Config,
         identity: &SessionLlmIdentity,
         web_search: ToolCategoryOverride,
+    ) -> Result<meerkat_core::SessionLlmRequestPolicy, FactoryError> {
+        self.request_policy_for_llm_identity_inner(config, identity, web_search, None)
+    }
+
+    pub(crate) fn request_policy_for_session_llm_identity(
+        &self,
+        config: &Config,
+        identity: &SessionLlmIdentity,
+        web_search: ToolCategoryOverride,
+        session_id: &meerkat_core::SessionId,
+    ) -> Result<meerkat_core::SessionLlmRequestPolicy, FactoryError> {
+        self.request_policy_for_llm_identity_inner(config, identity, web_search, Some(session_id))
+    }
+
+    fn request_policy_for_llm_identity_inner(
+        &self,
+        config: &Config,
+        identity: &SessionLlmIdentity,
+        web_search: ToolCategoryOverride,
+        session_id: Option<&meerkat_core::SessionId>,
     ) -> Result<meerkat_core::SessionLlmRequestPolicy, FactoryError> {
         let registry = config
             .model_registry(meerkat_models::canonical())
@@ -3584,11 +3654,15 @@ impl AgentFactory {
         Ok(meerkat_core::SessionLlmRequestPolicy {
             model: identity.model.clone(),
             provider_params: identity.provider_params.clone(),
-            provider_tool_defaults: provider_tool_defaults_for(
+            provider_tool_defaults: provider_request_defaults_for(
                 identity.provider,
+                &identity.model,
                 config,
                 model_profile.as_ref(),
                 web_search,
+                session_id,
+                identity.provider != Provider::OpenAI
+                    || openai_cache_defaults_supported(config, identity.auth_binding.as_ref()),
             ),
         })
     }
@@ -4604,10 +4678,11 @@ impl AgentFactory {
             && config.model_fallback.enabled
         {
             let explicit_fallback_chain = !config.model_fallback.chain.is_empty();
-            let primary_request_policy = self.request_policy_for_llm_identity(
+            let primary_request_policy = self.request_policy_for_session_llm_identity(
                 config,
                 &resolved_llm_identity,
                 build_config.override_web_search,
+                session.id(),
             )?;
             let primary_target_profile = registry.profile_witness_for_provider(
                 resolved_llm_identity.provider,
@@ -4687,10 +4762,11 @@ impl AgentFactory {
                     Arc::new(adapter),
                     build_config.agent_llm_client_decorator.as_ref(),
                 );
-                let request_policy = self.request_policy_for_llm_identity(
+                let request_policy = self.request_policy_for_session_llm_identity(
                     config,
                     &identity,
                     build_config.override_web_search,
+                    session.id(),
                 )?;
                 candidates.push(ModelFallbackCandidate {
                     target_profile,
@@ -5864,11 +5940,15 @@ impl AgentFactory {
             .with_tools_config(config.tools.clone())
             .with_call_timeout_override(effective_call_timeout_override);
 
-        if let Some(defaults) = provider_tool_defaults_for(
+        if let Some(defaults) = provider_request_defaults_for(
             provider,
+            &model,
             config,
             model_profile.as_ref(),
             build_config.override_web_search,
+            Some(session.id()),
+            provider != Provider::OpenAI
+                || openai_cache_defaults_supported(config, build_config.auth_binding.as_ref()),
         ) {
             builder = builder.provider_tool_defaults(defaults);
         }
@@ -6537,6 +6617,9 @@ impl AgentFactory {
 mod tests {
     use super::*;
     use async_trait::async_trait;
+    use futures::stream;
+    use meerkat_client::{LlmDoneOutcome, LlmError, LlmEvent, LlmRequest};
+    use meerkat_core::StopReason;
     use meerkat_core::config::ModelFallbackTarget;
     #[cfg(feature = "skills")]
     use meerkat_core::skills::{
@@ -6834,6 +6917,46 @@ mod tests {
         }
 
         async fn health_check(&self) -> Result<(), meerkat_client::LlmError> {
+            Ok(())
+        }
+    }
+
+    struct CapturingLlmClient {
+        request: Arc<std::sync::Mutex<Option<LlmRequest>>>,
+    }
+
+    #[async_trait]
+    impl LlmClient for CapturingLlmClient {
+        fn project_replay_messages(
+            &self,
+            messages: &[meerkat_core::Message],
+        ) -> Result<Vec<meerkat_core::Message>, meerkat_client::LlmError> {
+            Ok(messages.to_vec())
+        }
+
+        fn stream<'a>(
+            &'a self,
+            request: &'a LlmRequest,
+        ) -> Pin<Box<dyn futures::Stream<Item = Result<LlmEvent, LlmError>> + Send + 'a>> {
+            *self.request.lock().expect("capture request") = Some(request.clone());
+            Box::pin(stream::iter(vec![
+                Ok(LlmEvent::TextDelta {
+                    delta: "ok".to_string(),
+                    meta: None,
+                }),
+                Ok(LlmEvent::Done {
+                    outcome: LlmDoneOutcome::Success {
+                        stop_reason: StopReason::EndTurn,
+                    },
+                }),
+            ]))
+        }
+
+        fn provider(&self) -> meerkat_core::Provider {
+            Provider::OpenAI
+        }
+
+        async fn health_check(&self) -> Result<(), LlmError> {
             Ok(())
         }
     }
@@ -7814,8 +7937,9 @@ mod tests {
     }
 
     #[test]
-    fn provider_tool_defaults_suppressed_on_web_search_disable() {
+    fn provider_request_defaults_suppress_only_web_search_on_disable() {
         let config = Config::default();
+        let session_id = meerkat_core::SessionId::new();
         // Profile advertises web-search support and config enables the provider
         // tool — without the override this would resolve the native body.
         let profile = meerkat_core::model_profile::ModelProfile {
@@ -7836,11 +7960,14 @@ mod tests {
             call_timeout_secs: None,
         };
 
-        let enabled = provider_tool_defaults_for(
+        let enabled = provider_request_defaults_for(
             Provider::OpenAI,
+            "gpt-5.4",
             &config,
             Some(&profile),
             ToolCategoryOverride::Inherit,
+            Some(&session_id),
+            true,
         );
         assert_eq!(
             enabled,
@@ -7857,15 +7984,272 @@ mod tests {
             "Inherit must leave owned web-search defaults intact"
         );
 
-        let disabled = provider_tool_defaults_for(
+        let disabled = provider_request_defaults_for(
             Provider::OpenAI,
+            "gpt-5.4",
             &config,
             Some(&profile),
             ToolCategoryOverride::Disable,
+            Some(&session_id),
+            true,
         );
         assert!(
             disabled.is_none(),
             "Disable must suppress the native web-search body even when profile+config would enable it"
+        );
+    }
+
+    #[test]
+    fn gpt_56_cache_defaults_are_stable_below_persisted_provider_params() {
+        use meerkat_core::lifecycle::run_primitive::{
+            OpenAiPromptCacheOptions, OpenAiProviderTag, ProviderParamsCarrier,
+            ProviderParamsOverride, ProviderTag,
+        };
+        use meerkat_core::model_profile::capabilities::{
+            OpenAiPromptCacheMode, OpenAiPromptCacheTtl,
+        };
+
+        let temp = tempfile::tempdir().unwrap();
+        let factory = AgentFactory::new(temp.path().join("sessions"));
+        let config = Config::default();
+        let session_id = meerkat_core::SessionId::parse("018f2f0d-7b1d-7a34-8c09-0a1b2c3d4e5f")
+            .expect("fixed session id");
+        let identity = SessionLlmIdentity {
+            model: "gpt-5.6-sol".to_string(),
+            provider: Provider::OpenAI,
+            self_hosted_server_id: None,
+            provider_params: None,
+            auth_binding: None,
+        };
+
+        let first = factory
+            .request_policy_for_session_llm_identity(
+                &config,
+                &identity,
+                ToolCategoryOverride::Disable,
+                &session_id,
+            )
+            .expect("first request policy");
+        let after_restart = factory
+            .request_policy_for_session_llm_identity(
+                &config,
+                &identity,
+                ToolCategoryOverride::Disable,
+                &session_id,
+            )
+            .expect("same durable session request policy");
+
+        assert!(
+            first.provider_params.is_none(),
+            "cache defaults must stay below persisted provider params so old resumed sessions inherit them"
+        );
+        assert_eq!(
+            first.provider_tool_defaults, after_restart.provider_tool_defaults,
+            "the cache bucket must be stable when the same durable session is rebuilt"
+        );
+        let Some(ProviderTag::OpenAi(defaults)) = first.provider_tool_defaults else {
+            panic!("GPT-5.6 must receive OpenAI request defaults");
+        };
+        assert_eq!(
+            defaults.prompt_cache_key.as_deref(),
+            Some("meerkat:session:018f2f0d-7b1d-7a34-8c09-0a1b2c3d4e5f")
+        );
+        assert_eq!(defaults.prompt_cache_enabled, Some(true));
+        assert_eq!(
+            defaults.prompt_cache_options,
+            Some(OpenAiPromptCacheOptions {
+                mode: Some(OpenAiPromptCacheMode::Implicit),
+                ttl: Some(OpenAiPromptCacheTtl::ThirtyMinutes),
+            })
+        );
+
+        let caller_key = "mobkit:identity:parent-1";
+        let caller_params = ProviderParamsOverride {
+            provider_tag: Some(ProviderTag::OpenAi(OpenAiProviderTag {
+                prompt_cache_key: Some(caller_key.to_string()),
+                ..Default::default()
+            })),
+            ..Default::default()
+        };
+        let effective = ProviderParamsCarrier {
+            params: caller_params,
+            tool_defaults: Some(ProviderTag::OpenAi(defaults.clone())),
+        }
+        .effective_params()
+        .expect("caller params and Meerkat defaults merge");
+        let Some(ProviderTag::OpenAi(effective)) = effective.provider_tag else {
+            panic!("effective OpenAI tag");
+        };
+        assert_eq!(
+            effective.prompt_cache_key.as_deref(),
+            Some(caller_key),
+            "a host with better identity granularity must override Meerkat's session floor"
+        );
+        assert_eq!(
+            effective.prompt_cache_options,
+            Some(OpenAiPromptCacheOptions {
+                mode: Some(OpenAiPromptCacheMode::Implicit),
+                ttl: Some(OpenAiPromptCacheTtl::ThirtyMinutes),
+            }),
+            "cache policy remains first-class when only the host key is explicit"
+        );
+
+        let disabled = ProviderParamsCarrier {
+            params: ProviderParamsOverride {
+                provider_tag: Some(ProviderTag::OpenAi(OpenAiProviderTag {
+                    prompt_cache_enabled: Some(false),
+                    ..Default::default()
+                })),
+                ..Default::default()
+            },
+            tool_defaults: Some(ProviderTag::OpenAi(defaults)),
+        }
+        .effective_params()
+        .expect("durable opt-out and Meerkat defaults merge");
+        let Some(ProviderTag::OpenAi(disabled)) = disabled.provider_tag else {
+            panic!("disabled OpenAI tag");
+        };
+        assert_eq!(
+            disabled.prompt_cache_enabled,
+            Some(false),
+            "explicit disable intent must win over default-on across resume and feature growth"
+        );
+    }
+
+    #[test]
+    fn gpt_56_cache_defaults_are_scoped_to_public_openai_backend() {
+        let temp = tempfile::tempdir().expect("temp sessions");
+        let factory = AgentFactory::new(temp.path().join("sessions"));
+        let mut config = Config::default();
+        let mut realm = inline_realm_section(&[("openai", "test-key")]);
+        realm
+            .backend
+            .get_mut("default_openai")
+            .expect("OpenAI backend")
+            .backend_kind = "chatgpt_backend".to_string();
+        realm
+            .auth
+            .get_mut("default_openai")
+            .expect("OpenAI auth")
+            .auth_method = "managed_chatgpt_oauth".to_string();
+        config.realm.insert("cache_test".to_string(), realm);
+        let auth_binding = configured_auth_binding("cache_test", "default_openai");
+        let target = meerkat_core::resolve_explicit_auth_binding_target(&config, &auth_binding)
+            .expect("valid ChatGPT backend binding");
+        assert_eq!(target.backend.backend_kind, "chatgpt_backend");
+
+        let identity = SessionLlmIdentity {
+            model: "gpt-5.6-sol".to_string(),
+            provider: Provider::OpenAI,
+            self_hosted_server_id: None,
+            provider_params: None,
+            auth_binding: Some(auth_binding),
+        };
+        let policy = factory
+            .request_policy_for_session_llm_identity(
+                &config,
+                &identity,
+                ToolCategoryOverride::Disable,
+                &SessionId::new(),
+            )
+            .expect("request policy");
+        assert!(
+            policy.provider_tool_defaults.is_none(),
+            "public OpenAI cache defaults must not leak onto the private ChatGPT backend wire"
+        );
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    #[tokio::test]
+    async fn resumed_gpt_56_agent_with_empty_provider_params_sends_cache_defaults() {
+        use meerkat_core::lifecycle::run_primitive::{OpenAiPromptCacheOptions, ProviderTag};
+        use meerkat_core::model_profile::capabilities::{
+            OpenAiPromptCacheMode, OpenAiPromptCacheTtl,
+        };
+
+        let session_id =
+            SessionId::parse("018f2f0d-7b1d-7a34-8c09-0a1b2c3d4e5f").expect("fixed session id");
+        let mut session = Session::with_id(session_id.clone());
+        session
+            .set_session_metadata(meerkat_core::SessionMetadata {
+                schema_version: meerkat_core::SESSION_METADATA_SCHEMA_VERSION,
+                model: "gpt-5.6-sol".to_string(),
+                max_tokens: 8_192,
+                structured_output_retries: 2,
+                provider: Provider::OpenAI,
+                self_hosted_server_id: None,
+                provider_params: None,
+                tooling: SessionTooling::default(),
+                keep_alive: false,
+                comms_name: None,
+                peer_meta: None,
+                realm_id: None,
+                instance_id: None,
+                backend: None,
+                config_generation: None,
+                auth_binding: None,
+                mob_member_binding: None,
+            })
+            .expect("persisted resume metadata");
+
+        let runtime = meerkat_runtime::MeerkatMachine::ephemeral();
+        let bindings = runtime
+            .prepare_bindings(session_id.clone())
+            .await
+            .expect("session runtime bindings");
+        let captured = Arc::new(std::sync::Mutex::new(None));
+        let mut build = AgentBuildConfig::new("ignored-by-resume");
+        build.resume_session = Some(session);
+        build.llm_client_override = Some(Arc::new(CapturingLlmClient {
+            request: Arc::clone(&captured),
+        }));
+        build.runtime_build_mode = RuntimeBuildMode::SessionOwned(bindings);
+        build.override_builtins = ToolCategoryOverride::Disable;
+
+        let temp = tempfile::tempdir().expect("temp session store");
+        let factory = AgentFactory::new(temp.path().join("sessions")).builtins(false);
+        let mut agent = factory
+            .build_agent(build, &Config::default())
+            .await
+            .expect("resumed GPT-5.6 agent");
+        agent.set_runtime_execution_kind(Some(
+            meerkat_core::lifecycle::RuntimeExecutionKind::ContentTurn,
+        ));
+        agent
+            .run(meerkat_core::ContentInput::Text(
+                "exercise cache defaults".into(),
+            ))
+            .await
+            .expect("resumed agent turn");
+
+        let request = captured
+            .lock()
+            .expect("captured request lock")
+            .clone()
+            .expect("provider request");
+        let Some(ProviderTag::OpenAi(tag)) = request.provider_params else {
+            panic!("effective OpenAI provider tag");
+        };
+        assert_eq!(
+            tag.prompt_cache_key.as_deref(),
+            Some("meerkat:session:018f2f0d-7b1d-7a34-8c09-0a1b2c3d4e5f")
+        );
+        assert_eq!(tag.prompt_cache_enabled, Some(true));
+        assert_eq!(
+            tag.prompt_cache_options,
+            Some(OpenAiPromptCacheOptions {
+                mode: Some(OpenAiPromptCacheMode::Implicit),
+                ttl: Some(OpenAiPromptCacheTtl::ThirtyMinutes),
+            })
+        );
+        assert!(
+            agent
+                .session()
+                .session_metadata()
+                .expect("session metadata")
+                .provider_params
+                .is_none(),
+            "derived cache defaults must not rewrite persisted provider params"
         );
     }
 

--- a/meerkat/src/session_runtime/llm_reconfigure.rs
+++ b/meerkat/src/session_runtime/llm_reconfigure.rs
@@ -720,7 +720,7 @@ impl SessionRuntimeLlmReconfigureHost {
             Err(_) => meerkat_core::ToolCategoryOverride::Inherit,
         };
         self.factory
-            .request_policy_for_llm_identity(&config, identity, web_search)
+            .request_policy_for_session_llm_identity(&config, identity, web_search, session_id)
             .map_err(|e| {
                 RuntimeDriverError::Internal(format!(
                     "Failed to build LLM request policy for session {session_id} identity hot-swap: {e}"


### PR DESCRIPTION
## Summary

- enable Anthropic automatic prompt caching by default on supported backends, with a moving conversation breakpoint, explicit policy overrides, Bedrock capability gating, and cache usage accounting
- enable public OpenAI API GPT-5.6 prompt caching by default with implicit 30-minute policy and a durable per-session routing key, while preserving caller overrides
- author cumulative deterministic OpenAI explicit breakpoints for both Responses and Chat Completions, including multimodal messages and parallel tool-result groups
- add a durable OpenAI cache opt-out that performs no cache reads or writes, and map Chat Completions cache-read/cache-write usage
- keep private ChatGPT and Azure OpenAI backend wires out of the automatic defaults until their contracts explicitly admit them
- preserve typed peer terminal outcomes as durable transcript-tail `SystemNotice` context instead of mutating the active system-prompt prefix
- regenerate public schemas and update provider/Rust documentation and the changelog

## Why

Production requests previously had no effective Anthropic breakpoint, so a stable prefix could not produce a write or read. OpenAI GPT-5.6 requests also relied on API defaults, with no stable routing-affinity key and no Meerkat-authored breakpoints when explicit mode was selected.

This patch implements both provider paths:

- Anthropic uses the supported request-wide automatic policy and advances the server-side breakpoint with the transcript.
- OpenAI public API GPT-5.6 sessions default to implicit caching plus a stable `meerkat:session:<SessionId>` key. Explicit mode now writes `prompt_cache_breakpoint` at append-monotone message boundaries on both OpenAI request APIs.

## Semantics and billing

- Anthropic five-minute cold cache writes bill input at 1.25x base price; reads bill cached input at 0.1x. Automatic lookup scans backward at most 20 cacheable blocks.
- OpenAI GPT-5.6 cache writes bill at 1.25x uncached input. Explicit mode can create up to four writes on a large cold transcript; normal transcript growth adds one new boundary per model invocation.
- `prompt_cache_enabled: false` is a durable OpenAI no-read/no-write opt-out.
- OpenAI recommends keeping traffic near 15 requests per minute per cache key. Tool-calling agents can make several model requests inside one user turn, so one tool-heavy turn can reach that guidance without concurrent users. Per-session and per-identity keys are both subject to the ceiling and should be monitored from actual request rate.
- OpenAI cache reads consider only the latest 50 breakpoints.

## Scope and caveats

- Host-supplied provider parameters remain authoritative. MobKit can override Meerkat's per-session key with a different stable partition.
- The automatic OpenAI defaults apply only to the public OpenAI API backend, not private ChatGPT or Azure OpenAI wires.
- The terminal-context change closes a latent unbounded-growth defect, but it is not presented as the cause of HomeCore's active latency anomaly.
- This patch does not prove every system-prompt writer stable. A timestamp, changing tool membership, or any other mutation before a breakpoint can still produce billable writes with no reads.
- Production cache-hit and latency improvement still require measurement after the Meerkat and downstream MobKit/HomeCore changes are released.

## Verification

- `meerkat-openai --all-targets`: 177 unit tests plus 15 OAuth integration tests passed
- `meerkat` factory slice: 119 tests passed
- full changed-package strict Clippy passed
- `make check`
- schema and SDK codegen freshness
- docs check and WASM check
- formatting and diff checks
- independent Anthropic and OpenAI adversarial reviews: no remaining blockers
