### PR TITLE
fix(mob): keep member status from blocking lifecycle commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -196,6 +196,10 @@ via cargo-semver-checks against the published baselines).
 
 ### Fixed
 
+- **Member-status observation cannot wedge the mob command lane.** A busy
+  member's execution snapshot is bounded to 250 ms; timeout degrades the
+  progress projection to typed `Unknown` instead of holding lifecycle
+  commands such as objective completion behind an unbounded read.
 - **P0: scheduled deliveries longer than the 60s lease were reclaimed
   mid-flight**, dispatching a duplicate turn every ~60s under
   `MisfirePolicy::CatchUpWithin` (a production fleet measured its largest

--- a/meerkat-mob/src/runtime/actor.rs
+++ b/meerkat-mob/src/runtime/actor.rs
@@ -119,6 +119,10 @@ pub(super) const RETIRE_LOCAL_TRUST_CLEANUP_CONCURRENCY: usize = 32;
 
 const STARTUP_FAILURE_AUTONOMOUS_STOP_POLL_INTERVAL: Duration = Duration::from_millis(25);
 const STARTUP_FAILURE_AUTONOMOUS_STOP_DEADLINE: Duration = Duration::from_secs(10);
+/// A status projection is observational and must never hold the single mob
+/// actor behind a slow or wedged session-runtime read. Unknown progress is a
+/// truthful result; delaying lifecycle commands is not.
+const MEMBER_PROGRESS_OBSERVATION_TIMEOUT: Duration = Duration::from_millis(250);
 
 /// Actor-owned task termination policy at a `JoinError` boundary.
 ///
@@ -10195,9 +10199,13 @@ impl MobActor {
 
         let progress = if include_local_session_details {
             match current_bridge_session_id.as_ref() {
-                Some(session_id) => match self.session_service.execution_snapshot(session_id).await
+                Some(session_id) => match tokio::time::timeout(
+                    MEMBER_PROGRESS_OBSERVATION_TIMEOUT,
+                    self.session_service.execution_snapshot(session_id),
+                )
+                .await
                 {
-                    Ok(Some(snapshot)) => {
+                    Ok(Ok(Some(snapshot))) => {
                         let run_open = snapshot.active_run_id.is_some() && !snapshot.turn_terminal;
                         let pending_operations = snapshot
                             .pending_operation_ids
@@ -10296,7 +10304,7 @@ impl MobActor {
                             health,
                         })
                     }
-                    Ok(None) | Err(_) => Some(super::handle::MemberProgressSnapshot {
+                    Ok(Ok(None) | Err(_)) | Err(_) => Some(super::handle::MemberProgressSnapshot {
                         run_state: super::handle::MemberRunState::Unknown,
                         in_flight_work: 0,
                         last_progress_at_ms: 0,

--- a/meerkat-mob/src/runtime/tests.rs
+++ b/meerkat-mob/src/runtime/tests.rs
@@ -1499,6 +1499,8 @@ struct MockSessionService {
     inject_calls: Arc<AtomicU64>,
     flow_turn_in_flight: Arc<AtomicU64>,
     flow_turn_max_in_flight: Arc<AtomicU64>,
+    execution_snapshot_delay_ms: AtomicU64,
+    execution_snapshot_started: tokio::sync::Notify,
     create_session_delay_ms: AtomicU64,
     load_persisted_session_delay_ms: AtomicU64,
     load_persisted_session_started: tokio::sync::Notify,
@@ -1593,6 +1595,8 @@ impl MockSessionService {
             inject_calls: Arc::new(AtomicU64::new(0)),
             flow_turn_in_flight: Arc::new(AtomicU64::new(0)),
             flow_turn_max_in_flight: Arc::new(AtomicU64::new(0)),
+            execution_snapshot_delay_ms: AtomicU64::new(0),
+            execution_snapshot_started: tokio::sync::Notify::new(),
             create_session_delay_ms: AtomicU64::new(0),
             load_persisted_session_delay_ms: AtomicU64::new(0),
             load_persisted_session_started: tokio::sync::Notify::new(),
@@ -2043,6 +2047,15 @@ impl MockSessionService {
     fn set_load_persisted_session_delay_ms(&self, delay_ms: u64) {
         self.load_persisted_session_delay_ms
             .store(delay_ms, Ordering::Relaxed);
+    }
+
+    fn set_execution_snapshot_delay_ms(&self, delay_ms: u64) {
+        self.execution_snapshot_delay_ms
+            .store(delay_ms, Ordering::Relaxed);
+    }
+
+    async fn wait_for_execution_snapshot(&self) {
+        self.execution_snapshot_started.notified().await;
     }
 
     async fn wait_for_load_persisted_session(&self) {
@@ -3369,6 +3382,18 @@ impl MobSessionService for MockSessionService {
         _authority: meerkat_runtime::MachineSessionControlAuthority,
     ) -> Result<(), SessionError> {
         SessionService::cancel_after_boundary(self, session_id).await
+    }
+
+    async fn execution_snapshot(
+        &self,
+        _session_id: &SessionId,
+    ) -> Result<Option<meerkat_core::agent::AgentExecutionSnapshot>, SessionError> {
+        self.execution_snapshot_started.notify_one();
+        let delay_ms = self.execution_snapshot_delay_ms.load(Ordering::Relaxed);
+        if delay_ms > 0 {
+            tokio::time::sleep(Duration::from_millis(delay_ms)).await;
+        }
+        Ok(None)
     }
 
     async fn archive_with_mob_lifecycle_authority(
@@ -46113,6 +46138,68 @@ async fn test_member_status_round_trips_through_machine_command_surface() {
         snapshot.current_bridge_session_id.as_ref(),
         Some(receipt.bridge_session_id().expect("session-backed")),
         "machine-routed member_status should preserve the active session binding"
+    );
+}
+
+#[tokio::test]
+async fn test_busy_member_execution_snapshot_cannot_block_mob_lifecycle_commands() {
+    let (handle, service) = create_test_mob(sample_definition()).await;
+    handle
+        .spawn(
+            ProfileName::from("worker"),
+            AgentIdentity::from("w-busy-status"),
+            None,
+        )
+        .await
+        .expect("spawn worker");
+    let objective_id = handle
+        .member_status(&AgentIdentity::from("w-busy-status"))
+        .await
+        .expect("initial member status")
+        .kickoff
+        .and_then(|kickoff| kickoff.objective_id)
+        .expect("spawned worker should have a kickoff objective");
+    service.set_execution_snapshot_delay_ms(5_000);
+
+    let status_handle = handle.clone();
+    let status_started_at = Instant::now();
+    let status_task = tokio::spawn(async move {
+        status_handle
+            .member_status(&AgentIdentity::from("w-busy-status"))
+            .await
+    });
+    tokio::time::timeout(
+        Duration::from_secs(1),
+        service.wait_for_execution_snapshot(),
+    )
+    .await
+    .expect("member status should begin the execution observation");
+
+    tokio::time::timeout(
+        Duration::from_secs(1),
+        handle.conclude_objective(
+            &AgentIdentity::from("w-busy-status"),
+            objective_id,
+            "worker completed while its status observation was busy",
+        ),
+    )
+    .await
+    .expect("a busy status observation must not hold the mob command lane")
+    .expect("objective conclusion should succeed after the bounded observation");
+
+    let snapshot = tokio::time::timeout(Duration::from_secs(1), status_task)
+        .await
+        .expect("member status should return promptly")
+        .expect("member status task should not panic")
+        .expect("member status should return an observation");
+    assert!(
+        status_started_at.elapsed() < Duration::from_secs(1),
+        "member status must degrade to unknown instead of awaiting the busy session turn"
+    );
+    assert_eq!(
+        snapshot.progress.map(|progress| progress.run_state),
+        Some(crate::runtime::handle::MemberRunState::Unknown),
+        "a timed-out execution observation must be represented truthfully as unknown"
     );
 }
 


### PR DESCRIPTION
## Summary

- bound slow member execution snapshot observation to 250 ms inside the single MobActor lane
- degrade unavailable or timed-out progress observation to Unknown
- keep lifecycle commands such as conclude_objective responsive while a member turn is busy
- add a deterministic regression that holds snapshot observation for 5 seconds and proves lifecycle completion remains bounded

## Root cause

machine_member_material awaited MobSessionService::execution_snapshot without a deadline inside the serialized actor loop. A slow child observation therefore held the entire mob control lane and queued member listing and objective completion behind it.

## Verification

- focused regression: passed
- make fmt-check: passed
- scoped all-target/all-feature check: passed
- scoped all-target/all-feature Clippy with warnings denied: passed
- exact-tree pre-push architecture audits, generated machine/TLA verification, generated-header audit, and hook contract tests: passed
- broad deterministic pre-push phase intentionally skipped under the explicit one-off release instruction after the above gates; merged base CI was green and the delta is isolated to member observation