### PR TITLE
fix(storage): recover pre-floor realms without blocking fresh runs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,25 @@ via cargo-semver-checks against the published baselines).
 
 ## [Unreleased]
 
+### Fixed
+
+- Pre-0.8.10 durable SQLite realms now have one explicit current-binary bridge:
+  `rkat ... storage migrate --apply --bridge-pre-0-8-10`. The frozen,
+  fail-closed importer authenticates supported pre-floor schemas and rows
+  before installing current authority. JSONL and memory realms are rejected
+  without database mutation. Ordinary store opens remain strict.
+  The maintenance transaction preserves queued and nonterminal inputs without
+  scheduling or replaying them; a later session activation follows normal
+  recovery.
+- Fresh prompt-first runs and `rkat help` no longer fail only because their
+  default workspace-derived realm cannot open. No historical session from the
+  failed realm is loaded into the fresh run, and the explicit compatibility
+  bridge is not invoked automatically. The run receives a newly generated
+  durable SQLite realm under the same state root while workspace config, auth,
+  provider, and tool policy remain in force. Explicit realms, isolated runs,
+  resumes, and session commands stay fail-closed, and historical access remains
+  available only through the explicit pre-0.8.10 maintenance bridge.
+
 ## [0.8.12] - 2026-08-02
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2876,6 +2876,7 @@ dependencies = [
  "meerkat-schedule",
  "meerkat-session",
  "meerkat-skills",
+ "meerkat-sqlite",
  "meerkat-store",
  "meerkat-tools",
  "meerkat-workgraph",

--- a/docs/cli/commands.mdx
+++ b/docs/cli/commands.mdx
@@ -50,6 +50,28 @@ stable workspace realm id from that path, and store realm state under
 derived workspace identity and the default project-local state root.
 `--state-root` changes only where realm directories are stored.
 
+Fresh prompt-first runs and `rkat help` are fail-soft only at the default
+workspace storage boundary. If the workspace-derived realm cannot be opened,
+no historical session from that realm is loaded into the fresh run, and the
+explicit compatibility bridge is never invoked automatically. The ordinary
+strict open may already have completed supported manifest initialization or an
+earlier domain migration before a later store refuses. The CLI warns and
+creates a new generated realm using durable SQLite under the same resolved
+state root. The workspace's configuration, auth policy, provider selection,
+and tool policy remain in force; only persistence-owned state is isolated in
+the generated realm. The warning names both realms and prints the explicit
+recovery command:
+
+```bash
+rkat --state-root <ROOT> --realm <ORIGINAL_REALM> storage migrate --apply --bridge-pre-0-8-10
+```
+
+An explicit `--realm`, `--isolated`, every resume form, and all `session`
+commands remain fail-closed. Historical session access therefore stays an
+explicit maintenance operation. The fresh-run fallback is never an in-memory
+session and never makes a historical session from the failed workspace realm
+part of the new run.
+
 ## Common commands
 
 | Command | Purpose |
@@ -250,9 +272,19 @@ rkat session interrupt <SESSION_ID>
 
 This is the human/operator session surface. CLI-internal control-plane session APIs are not exposed here.
 
-Meerkat 0.8.11 supports durable state from 0.8.10 onward. Migrate older state
-offline with the older binary before repinning; the current CLI does not
-adopt or rewrite pre-floor session state.
+Meerkat supports ordinary durable-state opens from 0.8.10 onward. For an older
+SQLite realm, stop every process that can access it and run the explicit
+current maintenance bridge:
+
+```bash
+rkat --state-root <ROOT> --realm <REALM> storage migrate --apply --bridge-pre-0-8-10
+```
+
+The frozen importer fails closed on unsupported pre-floor shapes. Normal realm
+opens remain strict. JSONL and memory realms are rejected before any database
+is mutated. The maintenance transaction preserves queued and
+nonterminal input rows without scheduling or replaying them. A later session
+activation follows normal recovery.
 
 ## config
 
@@ -348,7 +380,7 @@ lease/lock/backup artifacts. Exit 0
 means no error-severity findings; exit 1 means errors were found.
 
 ```bash
-rkat storage migrate [--apply] [--json] [--root PATH]... [--adopt-root PATH] [--fence-wait-secs SECS]
+rkat storage migrate [--apply] [--bridge-pre-0-8-10] [--json] [--root PATH]... [--adopt-root PATH] [--fence-wait-secs SECS]
 ```
 
 `migrate` is dry-run by default, offline, resumable, and fail-closed. It
@@ -374,6 +406,16 @@ Per-mob databases under `mobs/` are report-only, and credential stores are
 never read, moved, or reported. Exit 0 = clean; exit 1 = errors or
 fail-closed refusals (split-brain without `--adopt-root`, unacquirable
 maintenance fence).
+
+`--bridge-pre-0-8-10` is an explicit `--apply`-only maintenance lane for
+SQLite realms. JSONL and memory realms are rejected before any database is
+mutated. While the realm fence is held, it runs a frozen importer before the
+normal store constructors. The importer accepts only authenticated, supported
+pre-floor schema and row shapes; unknown, ambiguous, or inconsistent state
+refuses instead of being inferred or stamped. The maintenance transaction preserves
+queued and nonterminal runtime inputs in the current representation without
+scheduling or replaying them. A later session activation follows normal
+recovery. Ordinary store opens never enter this bridge.
 
 ```bash
 rkat storage prune [--apply] [--older-than-days N] [--json] [--root PATH]...

--- a/docs/reference/session-contracts.mdx
+++ b/docs/reference/session-contracts.mdx
@@ -188,6 +188,16 @@ Sessions are realm-scoped.
   root before writing the manifest, so surfaces with different default
   roots racing the same realm converge on one copy instead of minting
   split-brain twins.
+- A fresh prompt-first CLI run or `rkat help` whose workspace-derived realm
+  cannot open may isolate storage into a newly generated durable SQLite realm
+  under the same resolved state root. No historical session from the failed
+  realm is loaded into the fresh run, and the compatibility bridge is never
+  invoked automatically. An ordinary supported initialization or migration
+  may have completed before a later store refused. The original workspace
+  config and auth/tool policy still govern the run. Explicit realms, isolated
+  runs, resumes, and session commands never take this fallback. Historical
+  session access requires the explicit fenced pre-0.8.10 bridge; there is no
+  in-memory compatibility fallback.
 
 ## Compaction contract
 
@@ -249,7 +259,17 @@ released document is accepted only when the same store transaction proves the
 released physical schema and exact source row or blob identity. Either path
 strips the historical proof fields and installs current store-issued authority;
 ordinary v3 reads never enter the importer, and no current write emits the old
-fields. State older than 0.8.10 must first be upgraded with an older binary.
+fields.
+
+State older than 0.8.10 in a SQLite realm is admitted only through the explicit
+offline command `rkat ... storage migrate --apply --bridge-pre-0-8-10`.
+JSONL and memory realms are rejected before any database is mutated. This is a
+frozen, fail-closed pre-floor importer: under the realm maintenance fence it
+authenticates supported historical schema and row shapes before installing
+current representation and authority. Ordinary store opens and v3 reads remain
+strict and never enter the bridge. The maintenance transaction preserves
+queued and nonterminal input rows without scheduling or replaying them. A later
+session activation follows normal recovery.
 
 ### Durable-tail recovery
 

--- a/meerkat-cli/src/main.rs
+++ b/meerkat-cli/src/main.rs
@@ -2133,6 +2133,11 @@ enum StorageCommands {
     /// synthesis); (4) deprecated leftovers — report-only. Per-mob databases under
     /// `mobs/` are report-only in v1.
     ///
+    /// `--bridge-pre-0-8-10` is an explicit, apply-only recovery path for
+    /// exact authenticated pre-floor schemas. It runs under the same realm
+    /// maintenance fence before normal strict migration. Unknown, ambiguous,
+    /// or malformed state is refused without a ledger stamp.
+    ///
     /// Credential stores are never read, moved, or reported by this
     /// command.
     ///
@@ -2143,6 +2148,12 @@ enum StorageCommands {
         /// Perform the fenced migration (default is a read-only dry-run)
         #[arg(long)]
         apply: bool,
+
+        /// Explicitly import authenticated durable schemas from before the
+        /// v0.8.10 compatibility floor before running normal migrations.
+        /// Requires --apply; ordinary opens and migrations remain strict.
+        #[arg(long, requires = "apply")]
+        bridge_pre_0_8_10: bool,
 
         /// Emit the migration report as pretty JSON
         #[arg(long)]
@@ -3936,7 +3947,13 @@ async fn handle_run_command(
     }
 
     let (config, config_base_dir) = load_config(scope).await?;
-    let (config, runtime_preload_skills) = resolve_runtime_skills(config, skills).await?;
+    let (mut config, runtime_preload_skills) = resolve_runtime_skills(config, skills).await?;
+    let PreparedFreshRunPersistence {
+        storage_scope,
+        manifest,
+        persistence,
+    } = prepare_fresh_run_persistence(scope).await?;
+    project_workspace_auth_chain_onto_fallback(&mut config, scope, &storage_scope);
 
     let model_was_explicit = model.is_some();
     let provider_was_explicit = provider.is_some();
@@ -4038,6 +4055,9 @@ async fn handle_run_command(
                 config_base_dir,
                 hooks_override,
                 auth_binding.clone(),
+                manifest,
+                persistence,
+                &storage_scope,
                 scope,
             )
             .await
@@ -7645,6 +7665,7 @@ async fn handle_storage_command(command: &StorageCommands, cli: &Cli) -> anyhow:
         StorageCommands::Doctor { json, roots } => handle_storage_doctor(cli, *json, roots).await,
         StorageCommands::Migrate {
             apply,
+            bridge_pre_0_8_10,
             json,
             roots,
             adopt_root,
@@ -7653,6 +7674,7 @@ async fn handle_storage_command(command: &StorageCommands, cli: &Cli) -> anyhow:
             handle_storage_migrate(
                 cli,
                 *apply,
+                *bridge_pre_0_8_10,
                 *json,
                 roots,
                 adopt_root.as_deref(),
@@ -7757,11 +7779,15 @@ async fn handle_storage_doctor(
 async fn handle_storage_migrate(
     cli: &Cli,
     apply: bool,
+    bridge_pre_0_8_10: bool,
     json: bool,
     extra_roots: &[PathBuf],
     adopt_root: Option<&Path>,
     fence_wait_secs: u64,
 ) -> anyhow::Result<()> {
+    if bridge_pre_0_8_10 && !apply {
+        anyhow::bail!("--bridge-pre-0-8-10 requires --apply");
+    }
     if adopt_root.is_some() && !apply {
         anyhow::bail!("--adopt-root requires --apply (split-brain resolution archives a copy)");
     }
@@ -7772,6 +7798,7 @@ async fn handle_storage_migrate(
         roots: storage_sweep_roots(cli, extra_roots),
         realm_filter: storage_realm_filter(cli)?,
         apply,
+        bridge_pre_0_8_10,
         adopt_root: adopt_root.map(Path::to_path_buf),
         fence_wait: Duration::from_secs(fence_wait_secs),
         // Ambient home resolution stays in this bootstrap module (the
@@ -8765,6 +8792,110 @@ async fn create_persistence_bundle(
     _scope: &RuntimeScope,
 ) -> anyhow::Result<(meerkat_store::RealmManifest, PersistenceBundle)> {
     anyhow::bail!("rkat built without session-store support")
+}
+
+struct PreparedFreshRunPersistence {
+    storage_scope: RuntimeScope,
+    manifest: meerkat_store::RealmManifest,
+    persistence: PersistenceBundle,
+}
+
+#[cfg(feature = "session-store")]
+fn workspace_fresh_run_storage_fallback_scope(
+    scope: &RuntimeScope,
+) -> anyhow::Result<Option<RuntimeScope>> {
+    if scope.origin_hint != RealmOrigin::Workspace {
+        return Ok(None);
+    }
+
+    let mut fallback = scope.clone();
+    let generated_realm = meerkat_core::connection::RealmId::parse(
+        &meerkat_core::runtime_bootstrap::generate_realm_id(),
+    )
+    .map_err(|error| anyhow::anyhow!("failed to generate fallback realm identity: {error}"))?;
+    fallback.locator.realm = generated_realm;
+    fallback.backend_hint = Some(RealmBackend::Sqlite);
+    fallback.origin_hint = RealmOrigin::Generated;
+    Ok(Some(fallback))
+}
+
+async fn prepare_fresh_run_persistence(
+    scope: &RuntimeScope,
+) -> anyhow::Result<PreparedFreshRunPersistence> {
+    match create_persistence_bundle(scope).await {
+        Ok((manifest, persistence)) => Ok(PreparedFreshRunPersistence {
+            storage_scope: scope.clone(),
+            manifest,
+            persistence,
+        }),
+        Err(original_error) => {
+            #[cfg(feature = "session-store")]
+            {
+                let Some(fallback_scope) = workspace_fresh_run_storage_fallback_scope(scope)?
+                else {
+                    return Err(original_error);
+                };
+                let original_realm = scope.locator.realm.as_str();
+                let fallback_realm = fallback_scope.locator.realm.as_str();
+                let (manifest, persistence) = create_persistence_bundle(&fallback_scope)
+                    .await
+                    .map_err(|fallback_error| {
+                        anyhow::anyhow!(
+                            "workspace realm '{original_realm}' storage failed to open ({original_error}); generated durable SQLite fallback realm '{fallback_realm}' also failed to open: {fallback_error}"
+                        )
+                })?;
+                eprintln!(
+                    "Warning: historical sessions from original workspace realm '{original_realm}' were not loaded into this fresh run because its storage could not be fully opened: {original_error}"
+                );
+                eprintln!(
+                    "Warning: fresh-run storage fell back to generated realm '{fallback_realm}' as durable SQLite under state root '{}'; workspace configuration and auth policy remain in force.",
+                    fallback_scope.locator.state_root.display()
+                );
+                eprintln!(
+                    "Warning: the compatibility bridge was not run automatically; recover historical sessions explicitly with: rkat --state-root '{}' --realm '{original_realm}' storage migrate --apply --bridge-pre-0-8-10",
+                    scope.locator.state_root.display()
+                );
+                Ok(PreparedFreshRunPersistence {
+                    storage_scope: fallback_scope,
+                    manifest,
+                    persistence,
+                })
+            }
+            #[cfg(not(feature = "session-store"))]
+            {
+                Err(original_error)
+            }
+        }
+    }
+}
+
+fn project_workspace_auth_chain_onto_fallback(
+    config: &mut Config,
+    workspace_scope: &RuntimeScope,
+    storage_scope: &RuntimeScope,
+) {
+    if workspace_scope.locator.realm == storage_scope.locator.realm {
+        return;
+    }
+
+    // The generated realm is persistence identity, not a new configuration
+    // authority. Project an empty in-memory head onto the original workspace
+    // connection chain so every implicit provider consumer (primary, model
+    // fallback, self-hosted, image generation, and web search) retains the
+    // workspace -> ancestors -> global -> env candidate order. If the
+    // workspace has no realm section, an unparented empty head preserves the
+    // existing global/env behavior instead of inventing a missing parent.
+    let parent = config
+        .realm
+        .contains_key(workspace_scope.locator.realm.as_str())
+        .then(|| workspace_scope.locator.realm.clone());
+    config.realm.insert(
+        storage_scope.locator.realm.as_str().to_string(),
+        meerkat_core::RealmConfigSection {
+            parent,
+            ..Default::default()
+        },
+    );
 }
 
 fn realm_store_path(manifest: &meerkat_store::RealmManifest, scope: &RuntimeScope) -> PathBuf {
@@ -10502,6 +10633,9 @@ async fn run_agent(
     config_base_dir: PathBuf,
     hooks_override: HookRunOverrides,
     auth_binding: Option<AuthBindingRef>,
+    manifest: meerkat_store::RealmManifest,
+    persistence: PersistenceBundle,
+    storage_scope: &RuntimeScope,
     scope: &RuntimeScope,
 ) -> anyhow::Result<()> {
     #[cfg(not(feature = "session-store"))]
@@ -10544,6 +10678,9 @@ async fn run_agent(
             config_base_dir,
             hooks_override,
             auth_binding,
+            manifest,
+            persistence,
+            storage_scope,
             scope,
         );
         anyhow::bail!("rkat built without session-store support");
@@ -10598,14 +10735,13 @@ async fn run_agent(
             find_project_root(&cwd).unwrap_or(cwd)
         });
 
-        let (manifest, persistence) = create_persistence_bundle(scope).await?;
         let session_store = persistence.session_store();
-        let mut factory = AgentFactory::new(realm_store_path(&manifest, scope))
+        let mut factory = AgentFactory::new(realm_store_path(&manifest, storage_scope))
             .session_store(session_store)
             .runtime_root(
                 meerkat_store::realm_paths_in(
-                    &scope.locator.state_root,
-                    scope.locator.realm.as_str(),
+                    &storage_scope.locator.state_root,
+                    storage_scope.locator.realm.as_str(),
                 )
                 .root,
             )
@@ -10630,7 +10766,7 @@ async fn run_agent(
             .map_or_else(|| "(none)".to_string(), |path| path.display().to_string());
         tracing::info!(
             "Using realm: {}, context root: {}, realm root: {}",
-            scope.locator.realm.as_str(),
+            storage_scope.locator.realm.as_str(),
             context_root,
             config_base_dir.display()
         );
@@ -10659,7 +10795,7 @@ async fn run_agent(
             Some(Arc::new(ScheduleToolDispatcher::new(schedule_service))
                 as Arc<dyn AgentToolDispatcher>);
         let default_workgraph_tools = Some(Arc::new(meerkat::WorkGraphToolSurface::new(
-            scoped_workgraph_service(scope, &persistence),
+            scoped_workgraph_service(storage_scope, &persistence),
         )) as Arc<dyn AgentToolDispatcher>);
         let (service, runtime_adapter) = build_cli_runtime_backed_service_with_defaults(
             factory,
@@ -10682,13 +10818,13 @@ async fn run_agent(
         #[cfg(feature = "mob")]
         let run_mob_tools = if effective_mob {
             let mob_surface = get_or_create_cli_persistent_surface_from_bundle(
-                scope,
+                storage_scope,
                 config.clone(),
                 manifest.clone(),
                 persistence.clone(),
             )
             .await?;
-            Some(prepare_run_mob_tools_from_surface(scope, mob_surface).await?)
+            Some(prepare_run_mob_tools_from_surface(storage_scope, mob_surface).await?)
         } else {
             None
         };
@@ -10774,7 +10910,7 @@ async fn run_agent(
             workgraph_tools: None,
             mob_tool_authority_context: None,
             preload_skills,
-            realm_id: Some(scope.locator.realm.clone()),
+            realm_id: Some(storage_scope.locator.realm.clone()),
             instance_id: scope.instance_id.clone(),
             backend: meerkat_core::RecoveryBackendKind::parse(manifest.backend.as_str()),
             config_generation: None,
@@ -10874,7 +11010,7 @@ async fn run_agent(
                 persistent_service: Some(service.clone()),
                 session_id: session_id.clone(),
                 runtime_adapter: runtime_adapter.clone(),
-                workgraph_service: Some(scoped_workgraph_service(scope, &persistence)),
+                workgraph_service: Some(scoped_workgraph_service(storage_scope, &persistence)),
                 event_tx: output_pipeline.event_sender(),
             });
             runtime_adapter
@@ -10949,7 +11085,7 @@ async fn run_agent(
                     completion_outcome_to_cli_runtime_turn_result(
                         completion,
                         &session_id,
-                        &scope.locator.realm,
+                        &storage_scope.locator.realm,
                         true,
                     )
                 }
@@ -11005,7 +11141,15 @@ async fn run_agent(
         // Output the result
         match result {
             CliRuntimeTurnResult::Completed(result) => {
-                print_completed_run_result(*result, &output, stream, scope, false).await?;
+                let storage_fell_back = storage_scope.locator.realm != scope.locator.realm;
+                print_completed_run_result(
+                    *result,
+                    &output,
+                    stream,
+                    storage_scope,
+                    storage_fell_back,
+                )
+                .await?;
             }
             CliRuntimeTurnResult::CallbackPending(pending) => {
                 print_cli_callback_pending(&pending, Some(output.format.as_str()))?;
@@ -17242,6 +17386,161 @@ mod tests {
         }
     }
 
+    #[test]
+    fn fresh_run_storage_fallback_is_workspace_only_and_forces_durable_sqlite() {
+        let state_root = tempfile::tempdir().expect("tempdir");
+        let mut workspace_scope = test_scope(state_root.path().to_path_buf(), "ws-original");
+        workspace_scope.origin_hint = RealmOrigin::Workspace;
+
+        let fallback = workspace_fresh_run_storage_fallback_scope(&workspace_scope)
+            .expect("fallback scope resolution")
+            .expect("workspace fresh run is eligible");
+        assert_ne!(fallback.locator.realm, workspace_scope.locator.realm);
+        assert!(fallback.locator.realm.as_str().starts_with("realm-"));
+        assert_eq!(
+            fallback.locator.state_root,
+            workspace_scope.locator.state_root
+        );
+        assert_eq!(
+            fallback.layout.state_root(),
+            workspace_scope.layout.state_root()
+        );
+        assert_eq!(fallback.backend_hint, Some(RealmBackend::Sqlite));
+        assert_eq!(fallback.origin_hint, RealmOrigin::Generated);
+
+        let explicit_scope = test_scope(state_root.path().to_path_buf(), "explicit-realm");
+        assert!(
+            workspace_fresh_run_storage_fallback_scope(&explicit_scope)
+                .expect("explicit scope check")
+                .is_none(),
+            "an explicit --realm scope must remain fail-closed"
+        );
+
+        let mut isolated_scope = test_scope(state_root.path().to_path_buf(), "isolated-realm");
+        isolated_scope.origin_hint = RealmOrigin::Generated;
+        assert!(
+            workspace_fresh_run_storage_fallback_scope(&isolated_scope)
+                .expect("isolated scope check")
+                .is_none(),
+            "an --isolated scope must remain fail-closed"
+        );
+    }
+
+    fn test_openai_env_realm_section(
+        binding_id: &str,
+        env_name: &str,
+    ) -> meerkat_core::RealmConfigSection {
+        let mut section = meerkat_core::RealmConfigSection {
+            default_binding: Some(binding_id.to_string()),
+            ..Default::default()
+        };
+        section.backend.insert(
+            "openai_api".to_string(),
+            meerkat_core::BackendProfileConfig {
+                provider: "openai".to_string(),
+                backend_kind: "openai_api".to_string(),
+                base_url: None,
+                options: serde_json::Value::Null,
+            },
+        );
+        section.auth.insert(
+            "openai_env".to_string(),
+            meerkat_core::AuthProfileConfig {
+                provider: "openai".to_string(),
+                auth_method: "api_key".to_string(),
+                source: meerkat_core::CredentialSourceSpec::Env {
+                    env: env_name.to_string(),
+                    fallback: Vec::new(),
+                },
+                constraints: Default::default(),
+                metadata_defaults: Default::default(),
+            },
+        );
+        section.binding.insert(
+            binding_id.to_string(),
+            meerkat_core::ProviderBindingConfig {
+                backend_profile: "openai_api".to_string(),
+                auth_profile: "openai_env".to_string(),
+                default_model: None,
+                policy: Default::default(),
+                provider_default: true,
+            },
+        );
+        section
+    }
+
+    #[test]
+    fn fallback_auth_projection_preserves_workspace_global_env_candidate_order() {
+        let state_root = tempfile::tempdir().expect("tempdir");
+        let mut workspace_scope = test_scope(state_root.path().to_path_buf(), "ws-original");
+        workspace_scope.origin_hint = RealmOrigin::Workspace;
+        let fallback_scope = workspace_fresh_run_storage_fallback_scope(&workspace_scope)
+            .expect("fallback scope resolution")
+            .expect("workspace fresh run is eligible");
+        let mut config = Config::default();
+        config.realm.insert(
+            workspace_scope.locator.realm.as_str().to_string(),
+            test_openai_env_realm_section("workspace_openai", "WORKSPACE_OPENAI_KEY"),
+        );
+        config.realm.insert(
+            "global".to_string(),
+            test_openai_env_realm_section("global_openai", "GLOBAL_OPENAI_KEY"),
+        );
+
+        project_workspace_auth_chain_onto_fallback(&mut config, &workspace_scope, &fallback_scope);
+        assert_eq!(
+            config.realm[fallback_scope.locator.realm.as_str()].parent,
+            Some(workspace_scope.locator.realm.clone())
+        );
+        let candidates = meerkat_core::resolve_auth_binding_candidates_for_provider(
+            &config,
+            meerkat_core::Provider::OpenAI,
+            None,
+            Some(&fallback_scope.locator.realm),
+            true,
+        )
+        .expect("fallback auth candidates resolve");
+        let owners = candidates
+            .iter()
+            .map(|candidate| candidate.auth_binding.realm.as_str())
+            .collect::<Vec<_>>();
+        assert_eq!(owners, ["ws-original", "global", "env_default"]);
+    }
+
+    #[test]
+    fn fallback_auth_projection_without_workspace_section_preserves_global_then_env() {
+        let state_root = tempfile::tempdir().expect("tempdir");
+        let mut workspace_scope = test_scope(state_root.path().to_path_buf(), "ws-absent");
+        workspace_scope.origin_hint = RealmOrigin::Workspace;
+        let fallback_scope = workspace_fresh_run_storage_fallback_scope(&workspace_scope)
+            .expect("fallback scope resolution")
+            .expect("workspace fresh run is eligible");
+        let mut config = Config::default();
+        config.realm.insert(
+            "global".to_string(),
+            test_openai_env_realm_section("global_openai", "GLOBAL_OPENAI_KEY"),
+        );
+
+        project_workspace_auth_chain_onto_fallback(&mut config, &workspace_scope, &fallback_scope);
+        assert_eq!(
+            config.realm[fallback_scope.locator.realm.as_str()].parent,
+            None
+        );
+        let candidates = meerkat_core::resolve_auth_binding_candidates_for_provider(
+            &config,
+            meerkat_core::Provider::OpenAI,
+            None,
+            Some(&fallback_scope.locator.realm),
+            true,
+        )
+        .expect("fallback auth candidates resolve");
+        let owners = candidates
+            .iter()
+            .map(|candidate| candidate.auth_binding.realm.as_str())
+            .collect::<Vec<_>>();
+        assert_eq!(owners, ["global", "env_default"]);
+    }
+
     #[cfg(all(feature = "anthropic", feature = "openai", feature = "gemini"))]
     fn test_auth_refresh_coordinator() -> Arc<dyn meerkat_providers::auth_store::RefreshCoordinator>
     {
@@ -20994,6 +21293,44 @@ default_model = "gemma"
         let run = Cli::try_parse_from(["rkat", "--isolated", "run", "hello"])
             .expect("--isolated run parses");
         assert!(storage_global_usage_conflict(&run).is_none());
+    }
+
+    #[test]
+    fn test_storage_pre_floor_bridge_requires_explicit_apply() {
+        let error = match Cli::try_parse_from(["rkat", "storage", "migrate", "--bridge-pre-0-8-10"])
+        {
+            Err(error) => error,
+            Ok(_) => panic!("the pre-floor bridge must not run during a dry-run"),
+        };
+        assert_eq!(
+            error.kind(),
+            clap::error::ErrorKind::MissingRequiredArgument
+        );
+        let rendered = error.to_string();
+        assert!(rendered.contains("--apply"), "{rendered}");
+
+        let cli = Cli::try_parse_from([
+            "rkat",
+            "storage",
+            "migrate",
+            "--apply",
+            "--bridge-pre-0-8-10",
+        ])
+        .expect("the explicit fenced bridge invocation parses");
+        match cli.command.expect("storage command") {
+            Commands::Storage {
+                command:
+                    StorageCommands::Migrate {
+                        apply,
+                        bridge_pre_0_8_10,
+                        ..
+                    },
+            } => {
+                assert!(apply);
+                assert!(bridge_pre_0_8_10);
+            }
+            _ => unreachable!("expected storage migrate command"),
+        }
     }
 
     #[test]

--- a/meerkat-cli/src/storage_migrate.rs
+++ b/meerkat-cli/src/storage_migrate.rs
@@ -15,6 +15,9 @@
 //!    predecessors. Dry-run reads recorded versions only and reports row
 //!    presence; it does not certify a missing row as fresh or promise a
 //!    future stamp.
+//!    `--bridge-pre-0-8-10` adds an explicit, fenced import before this
+//!    normal strict path. The importer authenticates exact historical schema
+//!    prefixes and refuses unknown or malformed state atomically.
 //! 2. **State-root adoption (report-only):** the dual-root resolver already
 //!    uses realms where they lie; the report states each realm's root.
 //! 3. **Split-brain reconciliation (manual, fail-closed):** a realm id under
@@ -57,6 +60,10 @@ pub(crate) struct MigrateOptions {
     pub roots: Vec<PathBuf>,
     pub realm_filter: Option<String>,
     pub apply: bool,
+    /// Opt-in, fail-closed import for authenticated durable schemas from
+    /// before the v0.8.10 compatibility floor. Ordinary migration never
+    /// enables this bridge implicitly.
+    pub bridge_pre_0_8_10: bool,
     pub adopt_root: Option<PathBuf>,
     pub fence_wait: Duration,
     /// Legacy pre-realm `<home>/.rkat/sessions` directory to probe
@@ -204,9 +211,15 @@ pub(crate) async fn run_storage_migrate(options: MigrateOptions) -> MigrateRepor
         if copies.len() > 1 {
             continue; // unresolved twin; already reported
         }
-        report
-            .realms
-            .push(migrate_realm(realm, options.apply, options.fence_wait).await);
+        report.realms.push(
+            migrate_realm(
+                realm,
+                options.apply,
+                options.bridge_pre_0_8_10,
+                options.fence_wait,
+            )
+            .await,
+        );
     }
 
     // ── Case 5: deprecated leftovers (report-only). ──────────────────────
@@ -445,6 +458,7 @@ fn mob_report_only_entries(realm_dir: &Path, entry: &mut RealmMigrateReport) {
 async fn migrate_realm(
     realm: &RealmDirEntry,
     apply: bool,
+    bridge_pre_0_8_10: bool,
     fence_wait: Duration,
 ) -> RealmMigrateReport {
     let mut entry = RealmMigrateReport::new(realm.realm_id.clone(), realm.dir.clone());
@@ -465,6 +479,19 @@ async fn migrate_realm(
         return entry;
     }
     let backend = realm.backend.clone().unwrap_or_default();
+    if bridge_pre_0_8_10 && backend != "sqlite" {
+        let selected = if backend.is_empty() {
+            "<missing>"
+        } else {
+            backend.as_str()
+        };
+        entry.errors.push(format!(
+            "--bridge-pre-0-8-10 is supported only for realms whose manifest selects backend \
+             'sqlite'; realm '{}' selects backend '{selected}'",
+            realm.realm_id
+        ));
+        return entry;
+    }
     match backend.as_str() {
         "memory" => {
             entry
@@ -503,7 +530,7 @@ async fn migrate_realm(
         return entry;
     }
 
-    apply_realm(realm, &backend, fence_wait, &mut entry).await;
+    apply_realm(realm, &backend, bridge_pre_0_8_10, fence_wait, &mut entry).await;
     mob_report_only_entries(&realm.dir, &mut entry);
     entry
 }
@@ -527,12 +554,14 @@ async fn dry_run_realm(realm: &RealmDirEntry, _backend: &str, entry: &mut RealmM
     }
 }
 
-/// Apply: fence the realm and run every store's normal constructor. The
-/// guarded ledger migrations are the structural verification.
+/// Apply: fence the realm, optionally run the explicit pre-floor importer,
+/// then run every store's normal constructor. The guarded ledger migrations
+/// are the structural verification.
 #[cfg(feature = "session-store")]
 async fn apply_realm(
     realm: &RealmDirEntry,
-    _backend: &str,
+    backend: &str,
+    bridge_pre_0_8_10: bool,
     fence_wait: Duration,
     entry: &mut RealmMigrateReport,
 ) {
@@ -579,6 +608,108 @@ async fn apply_realm(
             Vec::new()
         }
     };
+
+    let mut bridge_report = None;
+    let fence = if bridge_pre_0_8_10 {
+        let bridge_root = realm.state_root.clone();
+        let bridge_realm = realm.realm_id.clone();
+        let bridged = tokio::task::spawn_blocking(move || {
+            let result =
+                meerkat::bridge_pre_0_8_10_realm_storage_in(&bridge_root, &bridge_realm, &fence);
+            (fence, result)
+        })
+        .await;
+        match bridged {
+            Ok((fence, Ok(report))) => {
+                bridge_report = Some(report);
+                fence
+            }
+            Ok((_fence, Err(error))) => {
+                entry
+                    .errors
+                    .push(format!("pre-v0.8.10 bridge failed: {error}"));
+                return;
+            }
+            Err(join_error) => {
+                entry
+                    .errors
+                    .push(format!("pre-v0.8.10 bridge task failed: {join_error}"));
+                return;
+            }
+        }
+    } else {
+        fence
+    };
+    if let Some(bridge_report) = bridge_report {
+        for database in &bridge_report.inactive_databases {
+            entry.notes.push(format!(
+                "pre-v0.8.10 bridge: skipped inactive database {} because the realm manifest's \
+                 selected backend does not authorize it",
+                database.display()
+            ));
+        }
+        let mut changed = 0_usize;
+        for domain in bridge_report.domains.iter().filter(|domain| {
+            domain.ledger_established
+                || domain.from_version != domain.to_version
+                || domain.prepared_rows > 0
+        }) {
+            changed += 1;
+            let prepared = if domain.prepared_rows == 0 {
+                String::new()
+            } else {
+                format!(
+                    " and rewrote {} legacy durable payload row(s)",
+                    domain.prepared_rows
+                )
+            };
+            if domain.ledger_established && domain.from_version == domain.to_version {
+                entry.notes.push(format!(
+                    "pre-v0.8.10 bridge: authenticated exact current version {} for domain '{}' \
+                     in {} and established its missing ledger row{}",
+                    domain.to_version,
+                    domain.domain,
+                    domain.database.display(),
+                    prepared
+                ));
+            } else if domain.ledger_established {
+                entry.notes.push(format!(
+                    "pre-v0.8.10 bridge: authenticated and migrated domain '{}' in {} from \
+                     version {} to {}, then established its ledger row{}",
+                    domain.domain,
+                    domain.database.display(),
+                    domain.from_version,
+                    domain.to_version,
+                    prepared
+                ));
+            } else if domain.from_version != domain.to_version {
+                entry.notes.push(format!(
+                    "pre-v0.8.10 bridge: authenticated and migrated already-ledgered domain '{}' \
+                     in {} from version {} to {}{}",
+                    domain.domain,
+                    domain.database.display(),
+                    domain.from_version,
+                    domain.to_version,
+                    prepared
+                ));
+            } else {
+                entry.notes.push(format!(
+                    "pre-v0.8.10 bridge: rewrote {} legacy durable payload row(s) in \
+                     already-current domain '{}' in {}",
+                    domain.prepared_rows,
+                    domain.domain,
+                    domain.database.display()
+                ));
+            }
+        }
+        if changed == 0 {
+            entry.notes.push(
+                "pre-v0.8.10 bridge: no domain required pre-floor import; normal strict \
+                 migration continued"
+                    .to_string(),
+            );
+        }
+    }
 
     // Case 1: normal constructors via the facade bundle (sessions, schedule,
     // runtime, workgraph, blobs) — plus the stores the bundle does not own.
@@ -632,7 +763,8 @@ async fn apply_realm(
         .dir
         .join("sessions_jsonl")
         .join("session_index.sqlite3");
-    if index_db.is_file()
+    if backend == "jsonl"
+        && index_db.is_file()
         && let Err(error) = tokio::task::spawn_blocking(move || {
             meerkat_store::index::SqliteSessionIndex::open(index_db)
         })
@@ -696,6 +828,7 @@ async fn apply_realm(
 async fn apply_realm(
     _realm: &RealmDirEntry,
     _backend: &str,
+    _bridge_pre_0_8_10: bool,
     _fence_wait: Duration,
     entry: &mut RealmMigrateReport,
 ) {

--- a/meerkat-cli/tests/storage_migrate.rs
+++ b/meerkat-cli/tests/storage_migrate.rs
@@ -29,13 +29,21 @@ const SESSIONS_DDL: &str = "CREATE TABLE sessions (
 )";
 
 fn write_manifest(state_root: &Path, realm_id: &str) -> meerkat_store::RealmPaths {
+    write_manifest_with_backend(state_root, realm_id, "sqlite")
+}
+
+fn write_manifest_with_backend(
+    state_root: &Path,
+    realm_id: &str,
+    backend: &str,
+) -> meerkat_store::RealmPaths {
     let paths = meerkat_store::realm_paths_in(state_root, realm_id);
     std::fs::create_dir_all(&paths.root).unwrap();
     std::fs::write(
         &paths.manifest_path,
         serde_json::to_vec_pretty(&serde_json::json!({
             "realm_id": realm_id,
-            "backend": "sqlite",
+            "backend": backend,
             "origin": "explicit",
             "created_at": "0",
         }))
@@ -64,6 +72,192 @@ fn create_unledgered_owned_fixture_realm(state_root: &Path, realm_id: &str) -> P
     )));
     insert_session(&conn, &session);
     paths.sessions_sqlite_path
+}
+
+struct ExactPreFloorFixture {
+    database: PathBuf,
+    session_id: String,
+    session_source: Vec<u8>,
+    runtime_id: String,
+    input_id: String,
+    input_source: Vec<u8>,
+}
+
+/// Exact pre-floor session-store and runtime-store v1 schemas in their
+/// shared database. The valid variant carries a frozen released-v2 Session
+/// and one unversioned queued text prompt. The malformed variant proves that
+/// the explicit bridge rolls back DDL, row conversion, and the ledger stamp.
+fn create_exact_pre_floor_session_realm(
+    state_root: &Path,
+    realm_id: &str,
+    malformed: bool,
+) -> ExactPreFloorFixture {
+    let paths = write_manifest(state_root, realm_id);
+    let mut conn = Connection::open(&paths.sessions_sqlite_path).unwrap();
+    let tx = conn.transaction().unwrap();
+    let session_v1 = meerkat_store::sqlite_store::SESSION_STORE_DOMAIN
+        .migrations
+        .first()
+        .expect("session v1 migration");
+    (session_v1.apply)(&tx).unwrap();
+    let runtime_v1 = meerkat_runtime::store::sqlite::RUNTIME_STORE_DOMAIN
+        .migrations
+        .first()
+        .expect("runtime v1 migration");
+    (runtime_v1.apply)(&tx).unwrap();
+    tx.commit().unwrap();
+
+    let mut session = Session::new();
+    session.push(Message::User(UserMessage::text(
+        "exact pre-floor session fixture",
+    )));
+    let session_id = session.id().to_string();
+    let mut document = serde_json::to_value(&session).unwrap();
+    document["version"] = serde_json::json!(2);
+    if malformed {
+        document["messages"] = serde_json::json!("not-an-array");
+    } else {
+        let _released_session =
+            meerkat_core::import_released_0810_session(&serde_json::to_vec(&document).unwrap())
+                .expect("fixture must be an exact released-v2 session document");
+    }
+    let source = serde_json::to_vec(&document).unwrap();
+    conn.execute(
+        "INSERT INTO sessions (session_id, created_at_ms, updated_at_ms, message_count, \
+         total_tokens, metadata_json, session_json) VALUES (?1, 0, 0, 1, 0, ?2, ?3)",
+        rusqlite::params![
+            &session_id,
+            serde_json::to_string(session.metadata()).unwrap(),
+            &source
+        ],
+    )
+    .unwrap();
+
+    // Frozen pre-v0.8.10 wire bytes. This fixture is deliberately authored
+    // without today's StoredInputState serializer so current defaults or
+    // field additions cannot make the historical bridge test pass by drift.
+    let input_id = "019e20e6-b011-7000-8000-000000000001".to_string();
+    let legacy = serde_json::json!({
+        "input_id": input_id,
+        "current_state": "queued",
+        "policy": {
+            "version": 1,
+            "decision": {
+                "apply_mode": "stage_run_start",
+                "wake_mode": "wake_if_idle",
+                "queue_mode": "fifo",
+                "consume_point": "on_run_complete",
+                "drain_policy": "queue_next_turn",
+                "routing_disposition": "queue",
+                "record_transcript": true,
+                "emit_operator_content": true,
+                "policy_version": 1
+            }
+        },
+        "runtime_semantics": {
+            "boundary": "run_start",
+            "execution_kind": "content_turn",
+            "peer_response_terminal_apply_intent": null
+        },
+        "durability": "durable",
+        "idempotency_key": "queued-pre-floor-idempotency",
+        "attempt_count": 0,
+        "recovery_count": 0,
+        "history": [{
+            "timestamp": "2026-05-13T10:00:00.000200Z",
+            "from": "accepted",
+            "to": "queued",
+            "reason": "QueueAccepted"
+        }],
+        "persisted_input": {
+            "input_type": "prompt",
+            "header": {
+                "id": input_id,
+                "timestamp": "2026-05-13T10:00:00.000000Z",
+                "source": { "type": "operator" },
+                "durability": "durable",
+                "visibility": {
+                    "transcript_eligible": true,
+                    "operator_eligible": true
+                },
+                "idempotency_key": "queued-pre-floor-idempotency",
+                "correlation_id": "019e20e6-b011-7000-8000-100000000001"
+            },
+            "text": "queued pre-floor prompt",
+            "turn_metadata": {}
+        },
+        "created_at": "2026-05-13T10:00:00.000100Z",
+        "updated_at": "2026-05-13T10:00:00.000200Z"
+    });
+    assert!(legacy.get("stored_input_state_version").is_none());
+    assert!(legacy.get("admission_sequence").is_none());
+    assert!(legacy.get("recovery_lane").is_none());
+    assert!(legacy["persisted_input"].get("blocks").is_none());
+    assert_eq!(
+        legacy["input_id"],
+        legacy["persisted_input"]["header"]["id"]
+    );
+    assert_eq!(
+        legacy["durability"],
+        legacy["persisted_input"]["header"]["durability"]
+    );
+    assert_eq!(
+        legacy["idempotency_key"],
+        legacy["persisted_input"]["header"]["idempotency_key"]
+    );
+    assert_eq!(
+        legacy["policy"]["version"],
+        legacy["policy"]["decision"]["policy_version"]
+    );
+    assert_eq!(legacy["policy"]["decision"]["routing_disposition"], "queue");
+    assert_eq!(legacy["runtime_semantics"]["boundary"], "run_start");
+    assert_eq!(
+        legacy["runtime_semantics"]["execution_kind"],
+        "content_turn"
+    );
+    assert_eq!(legacy["history"].as_array().unwrap().len(), 1);
+    assert_eq!(legacy["history"][0]["from"], "accepted");
+    assert_eq!(legacy["history"][0]["to"], "queued");
+    assert_eq!(legacy["history"][0]["reason"], "QueueAccepted");
+    let input_source = serde_json::to_vec(&legacy).unwrap();
+    let runtime_id =
+        meerkat_runtime::identifiers::LogicalRuntimeId::for_session(session.id()).to_string();
+    let runtime_state_source = serde_json::to_vec(&serde_json::json!({
+        "record_version": 1,
+        "runtime_state": "idle",
+        "binding": {
+            "agent_runtime_id": null,
+            "fence_token": null,
+            "runtime_generation": null,
+            "runtime_epoch_id": null
+        }
+    }))
+    .unwrap();
+    conn.execute(
+        "INSERT INTO runtime_states (runtime_id, runtime_state_json) VALUES (?1, ?2)",
+        rusqlite::params![&runtime_id, &runtime_state_source],
+    )
+    .unwrap();
+    conn.execute(
+        "INSERT INTO runtime_session_snapshots (runtime_id, session_snapshot) VALUES (?1, ?2)",
+        rusqlite::params![&runtime_id, &source],
+    )
+    .unwrap();
+    conn.execute(
+        "INSERT INTO runtime_input_states (runtime_id, input_id, state_json) \
+         VALUES (?1, ?2, ?3)",
+        rusqlite::params![&runtime_id, &input_id, &input_source],
+    )
+    .unwrap();
+
+    ExactPreFloorFixture {
+        database: paths.sessions_sqlite_path,
+        session_id,
+        session_source: source,
+        runtime_id,
+        input_id,
+        input_source,
+    }
 }
 
 fn insert_session(conn: &Connection, session: &Session) {
@@ -232,6 +426,546 @@ fn migrate_refuses_unledgered_owned_sessions_without_mutation() {
         .unwrap(),
         0,
         "refusal created the ledger"
+    );
+}
+
+#[test]
+fn fresh_workspace_runs_use_durable_sqlite_fallback_without_touching_legacy_realm() {
+    let temp = TempDir::new().unwrap();
+    let project = temp.path().join("project");
+    std::fs::create_dir_all(&project).unwrap();
+    let state_root = temp.path().join("realms");
+    let workspace_realm = meerkat_core::derive_workspace_realm_id(&project);
+    let legacy_database = create_unledgered_owned_fixture_realm(&state_root, &workspace_realm);
+    let legacy_before = std::fs::read(&legacy_database).unwrap();
+    let state_root_arg = state_root.to_str().unwrap();
+
+    let invocations = [
+        (
+            vec![
+                "--state-root",
+                state_root_arg,
+                "fresh fallback prompt",
+                "--json",
+            ],
+            true,
+        ),
+        (
+            vec![
+                "--state-root",
+                state_root_arg,
+                "help",
+                "Give me a WorkGraph example",
+                "--json",
+            ],
+            true,
+        ),
+        (
+            vec!["--state-root", state_root_arg, "plain fallback prompt"],
+            false,
+        ),
+        (
+            vec![
+                "--state-root",
+                state_root_arg,
+                "help",
+                "Give me a plain WorkGraph example",
+            ],
+            false,
+        ),
+    ];
+    let mut fallback_realms = Vec::new();
+    for (index, (args, json_output)) in invocations.iter().enumerate() {
+        let output = run_rkat(&temp, args);
+        assert_success(&output, &format!("fresh fallback invocation {index}"));
+        let warning = String::from_utf8_lossy(&output.stderr);
+        assert!(
+            warning.contains(&format!(
+                "historical sessions from original workspace realm '{workspace_realm}' were not loaded into this fresh run"
+            )),
+            "warning did not identify the original realm excluded from the fresh run:\n{warning}"
+        );
+        assert!(
+            warning.contains("fresh-run storage fell back to generated realm")
+                && warning.contains("durable SQLite")
+                && warning.contains("workspace configuration and auth policy remain in force"),
+            "warning did not state the fallback durability and config boundary:\n{warning}"
+        );
+        assert!(
+            warning.contains(&format!(
+                "rkat --state-root '{}' --realm '{workspace_realm}' storage migrate --apply --bridge-pre-0-8-10",
+                state_root.display()
+            )),
+            "warning did not provide the explicit recovery command:\n{warning}"
+        );
+
+        let (session_ref, reported_session_id) = if *json_output {
+            let result = parse_json(&output);
+            (
+                result["session_ref"]
+                    .as_str()
+                    .expect("fresh fallback JSON must expose a realm-qualified session ref")
+                    .to_string(),
+                result["session_id"]
+                    .as_str()
+                    .expect("fresh fallback JSON must expose a session id")
+                    .to_string(),
+            )
+        } else {
+            let summary = warning
+                .lines()
+                .find(|line| line.starts_with("[Session: ") && line.contains(" | Ref: "))
+                .expect("plain fallback output must print a full realm-qualified session ref");
+            let reported_session_id = summary
+                .strip_prefix("[Session: ")
+                .and_then(|rest| rest.split_once(" | Ref: "))
+                .map(|(session_id, _)| session_id.to_string())
+                .expect("plain fallback summary must expose the full session id");
+            let session_ref = summary
+                .split_once(" | Ref: ")
+                .and_then(|(_, rest)| rest.split_once(" | "))
+                .map(|(session_ref, _)| session_ref.to_string())
+                .expect("plain fallback summary must expose the session ref");
+            (session_ref, reported_session_id)
+        };
+        let (fallback_realm, session_id) = session_ref
+            .split_once(':')
+            .expect("session ref must contain realm and session identity");
+        assert!(fallback_realm.starts_with("realm-"), "{session_ref}");
+        assert_ne!(fallback_realm, workspace_realm, "{session_ref}");
+        assert_eq!(reported_session_id, session_id, "{session_ref}");
+
+        let fallback_paths = meerkat_store::realm_paths_in(&state_root, fallback_realm);
+        let manifest: meerkat_store::RealmManifest = serde_json::from_slice(
+            &std::fs::read(&fallback_paths.manifest_path).expect("fallback manifest"),
+        )
+        .expect("valid fallback manifest");
+        assert_eq!(manifest.backend, meerkat_store::RealmBackend::Sqlite);
+        assert_eq!(manifest.origin, meerkat_store::RealmOrigin::Generated);
+        assert_eq!(manifest.realm.as_str(), fallback_realm);
+
+        let list = run_rkat(
+            &temp,
+            &[
+                "--state-root",
+                state_root_arg,
+                "--realm",
+                fallback_realm,
+                "session",
+                "list",
+            ],
+        );
+        assert_success(&list, "list session in generated fallback realm");
+        assert!(
+            String::from_utf8_lossy(&list.stdout).contains(session_id),
+            "fallback session was not durable\nstdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&list.stdout),
+            String::from_utf8_lossy(&list.stderr)
+        );
+        fallback_realms.push(fallback_realm.to_string());
+        assert_eq!(
+            std::fs::read(&legacy_database).unwrap(),
+            legacy_before,
+            "fresh fallback invocation mutated the failed workspace database"
+        );
+    }
+    assert_eq!(
+        fallback_realms
+            .iter()
+            .collect::<std::collections::BTreeSet<_>>()
+            .len(),
+        invocations.len(),
+        "each failed fresh open must mint a new isolated storage realm"
+    );
+
+    let explicit = run_rkat(
+        &temp,
+        &[
+            "--state-root",
+            state_root_arg,
+            "--realm",
+            &workspace_realm,
+            "explicit realms stay strict",
+            "--json",
+        ],
+    );
+    assert_eq!(explicit.status.code(), Some(1));
+    let explicit_stderr = String::from_utf8_lossy(&explicit.stderr);
+    assert!(
+        explicit_stderr.contains("Failed to open realm persistence backend"),
+        "explicit realm did not report its original open failure:\n{explicit_stderr}"
+    );
+    assert!(
+        !explicit_stderr.contains("fresh-run storage fell back"),
+        "explicit --realm must never fall back:\n{explicit_stderr}"
+    );
+    assert_eq!(std::fs::read(&legacy_database).unwrap(), legacy_before);
+
+    let strict_workspace_invocations = [
+        vec![
+            "--state-root",
+            state_root_arg,
+            "run",
+            "--resume",
+            "last",
+            "resume stays strict",
+            "--json",
+        ],
+        vec!["--state-root", state_root_arg, "session", "list"],
+    ];
+    for args in &strict_workspace_invocations {
+        let output = run_rkat(&temp, args);
+        assert_eq!(
+            output.status.code(),
+            Some(1),
+            "resume and session commands must fail closed\nstdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+        assert!(
+            !String::from_utf8_lossy(&output.stderr).contains("fresh-run storage fell back"),
+            "resume and session commands must never enter fresh-run fallback"
+        );
+        assert_eq!(std::fs::read(&legacy_database).unwrap(), legacy_before);
+    }
+}
+
+#[test]
+fn explicit_pre_floor_bridge_migrates_then_reopens_idempotently() {
+    let temp = TempDir::new().unwrap();
+    let state_root = temp.path().join("realms");
+    let fixture = create_exact_pre_floor_session_realm(&state_root, "pre-floor", false);
+
+    let apply = run_rkat(
+        &temp,
+        &[
+            "--state-root",
+            state_root.to_str().unwrap(),
+            "--realm",
+            "pre-floor",
+            "storage",
+            "migrate",
+            "--apply",
+            "--bridge-pre-0-8-10",
+            "--json",
+        ],
+    );
+    assert_success(&apply, "explicit pre-floor bridge");
+    let report = parse_json(&apply);
+    let realms = report["realms"].as_array().expect("realms array");
+    assert_eq!(realms.len(), 1, "{report:#}");
+    assert!(
+        realms[0]["notes"]
+            .as_array()
+            .expect("notes")
+            .iter()
+            .any(|note| note.as_str().is_some_and(|note| {
+                note.contains("pre-v0.8.10 bridge") && note.contains("session-store")
+            })),
+        "{report:#}"
+    );
+    assert!(
+        realms[0]["notes"]
+            .as_array()
+            .expect("notes")
+            .iter()
+            .any(|note| note.as_str().is_some_and(|note| {
+                note.contains("pre-v0.8.10 bridge")
+                    && note.contains("runtime-store")
+                    && note.contains("rewrote 1 legacy durable payload row(s)")
+            })),
+        "{report:#}"
+    );
+    let session_ledger = ledger_entries(&realms[0], "session-store", "sessions.sqlite3");
+    assert_eq!(session_ledger.len(), 1, "{report:#}");
+    assert_eq!(session_ledger[0]["action"], "stamped", "{report:#}");
+    assert_eq!(session_ledger[0]["after"], 3, "{report:#}");
+    let runtime_ledger = ledger_entries(&realms[0], "runtime-store", "sessions.sqlite3");
+    assert_eq!(runtime_ledger.len(), 1, "{report:#}");
+    assert_eq!(runtime_ledger[0]["action"], "stamped", "{report:#}");
+    assert_eq!(runtime_ledger[0]["after"], 2, "{report:#}");
+
+    let list = run_rkat(
+        &temp,
+        &[
+            "--state-root",
+            state_root.to_str().unwrap(),
+            "--realm",
+            "pre-floor",
+            "session",
+            "list",
+        ],
+    );
+    assert_success(&list, "strict session list after pre-floor bridge");
+    assert!(
+        String::from_utf8_lossy(&list.stdout).contains(&fixture.session_id),
+        "session list omitted imported session\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&list.stdout),
+        String::from_utf8_lossy(&list.stderr)
+    );
+
+    let conn = Connection::open(&fixture.database).unwrap();
+    let queued_bytes: Vec<u8> = conn
+        .query_row(
+            "SELECT state_json FROM runtime_input_states \
+             WHERE runtime_id = ?1 AND input_id = ?2",
+            rusqlite::params![&fixture.runtime_id, &fixture.input_id],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_ne!(
+        queued_bytes, fixture.input_source,
+        "bridge left the legacy unversioned queued payload untouched"
+    );
+    let queued: serde_json::Value = serde_json::from_slice(&queued_bytes).unwrap();
+    assert_eq!(queued["current_state"], "queued", "{queued:#}");
+    assert_eq!(queued["attempt_count"], 0, "{queued:#}");
+    assert!(
+        queued["admission_sequence"].as_u64().is_some(),
+        "{queued:#}"
+    );
+    assert_eq!(queued["recovery_lane"], "queue", "{queued:#}");
+    assert!(queued["terminal_outcome"].is_null(), "{queued:#}");
+    assert_eq!(
+        queued["persisted_input"]["content"], "queued pre-floor prompt",
+        "{queued:#}"
+    );
+    assert!(
+        queued["persisted_input"].get("text").is_none(),
+        "{queued:#}"
+    );
+    assert!(
+        queued["stored_input_state_version"].as_u64().is_some(),
+        "{queued:#}"
+    );
+    drop(conn);
+
+    let again = run_rkat(
+        &temp,
+        &[
+            "--state-root",
+            state_root.to_str().unwrap(),
+            "--realm",
+            "pre-floor",
+            "storage",
+            "migrate",
+            "--apply",
+            "--bridge-pre-0-8-10",
+            "--json",
+        ],
+    );
+    assert_success(&again, "idempotent pre-floor bridge rerun");
+    let report = parse_json(&again);
+    let realm = &report["realms"][0];
+    assert!(
+        realm["notes"]
+            .as_array()
+            .expect("notes")
+            .iter()
+            .any(|note| note
+                .as_str()
+                .is_some_and(|note| note.contains("no domain required pre-floor import"))),
+        "{report:#}"
+    );
+    assert_eq!(
+        ledger_entries(realm, "session-store", "sessions.sqlite3")[0]["action"],
+        "already-current",
+        "{report:#}"
+    );
+    let conn = Connection::open(&fixture.database).unwrap();
+    let queued_after_rerun: Vec<u8> = conn
+        .query_row(
+            "SELECT state_json FROM runtime_input_states \
+             WHERE runtime_id = ?1 AND input_id = ?2",
+            rusqlite::params![&fixture.runtime_id, &fixture.input_id],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(
+        queued_after_rerun, queued_bytes,
+        "idempotent bridge rerun changed or replayed queued work"
+    );
+}
+
+#[test]
+fn explicit_pre_floor_bridge_rolls_back_malformed_session() {
+    let temp = TempDir::new().unwrap();
+    let state_root = temp.path().join("realms");
+    let fixture = create_exact_pre_floor_session_realm(&state_root, "malformed-pre-floor", true);
+
+    let apply = run_rkat(
+        &temp,
+        &[
+            "--state-root",
+            state_root.to_str().unwrap(),
+            "--realm",
+            "malformed-pre-floor",
+            "storage",
+            "migrate",
+            "--apply",
+            "--bridge-pre-0-8-10",
+            "--json",
+        ],
+    );
+    assert_eq!(
+        apply.status.code(),
+        Some(1),
+        "malformed bridge must fail\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&apply.stdout),
+        String::from_utf8_lossy(&apply.stderr)
+    );
+    let report = parse_json(&apply);
+    assert!(
+        report["realms"][0]["errors"]
+            .as_array()
+            .expect("errors")
+            .iter()
+            .any(|error| error
+                .as_str()
+                .is_some_and(|error| error.contains("pre-v0.8.10 bridge failed"))),
+        "{report:#}"
+    );
+
+    let conn = Connection::open(&fixture.database).unwrap();
+    assert_eq!(
+        conn.query_row(
+            "SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = 'meerkat_schema'",
+            [],
+            |row| row.get::<_, i64>(0),
+        )
+        .unwrap(),
+        0,
+        "failed bridge stamped a schema ledger"
+    );
+    assert_eq!(
+        conn.query_row(
+            "SELECT COUNT(*) FROM sqlite_master \
+             WHERE type = 'table' AND name = 'session_strand_links'",
+            [],
+            |row| row.get::<_, i64>(0),
+        )
+        .unwrap(),
+        0,
+        "failed bridge committed migration DDL"
+    );
+    let stored: Vec<u8> = conn
+        .query_row(
+            "SELECT session_json FROM sessions WHERE session_id = ?1",
+            rusqlite::params![&fixture.session_id],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(
+        stored, fixture.session_source,
+        "failed bridge changed the source row"
+    );
+    let queued: Vec<u8> = conn
+        .query_row(
+            "SELECT state_json FROM runtime_input_states \
+             WHERE runtime_id = ?1 AND input_id = ?2",
+            rusqlite::params![&fixture.runtime_id, &fixture.input_id],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(
+        queued, fixture.input_source,
+        "failed bridge converted queued runtime work after an earlier domain refusal"
+    );
+}
+
+#[test]
+fn explicit_pre_floor_bridge_rejects_non_sqlite_realms() {
+    for backend in ["jsonl", "memory"] {
+        let temp = TempDir::new().unwrap();
+        let state_root = temp.path().join("realms");
+        let realm_id = format!("pre-floor-{backend}");
+        write_manifest_with_backend(&state_root, &realm_id, backend);
+
+        let apply = run_rkat(
+            &temp,
+            &[
+                "--state-root",
+                state_root.to_str().unwrap(),
+                "--realm",
+                &realm_id,
+                "storage",
+                "migrate",
+                "--apply",
+                "--bridge-pre-0-8-10",
+                "--json",
+            ],
+        );
+        assert_eq!(
+            apply.status.code(),
+            Some(1),
+            "{backend} bridge must fail\nstdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&apply.stdout),
+            String::from_utf8_lossy(&apply.stderr)
+        );
+        let report = parse_json(&apply);
+        let realm = &report["realms"][0];
+        assert_eq!(realm["backend"], backend, "{report:#}");
+        assert!(
+            realm["errors"]
+                .as_array()
+                .expect("errors")
+                .iter()
+                .any(|error| error.as_str().is_some_and(|error| {
+                    error.contains("--bridge-pre-0-8-10")
+                        && error.contains("backend 'sqlite'")
+                        && error.contains(&format!("backend '{backend}'"))
+                })),
+            "{report:#}"
+        );
+    }
+}
+
+#[test]
+fn sqlite_apply_does_not_open_inactive_jsonl_session_index() {
+    let temp = TempDir::new().unwrap();
+    let state_root = temp.path().join("realms");
+    let paths = write_manifest(&state_root, "sqlite-with-inactive-jsonl");
+    meerkat_store::SqliteSessionStore::open(&paths.sessions_sqlite_path).unwrap();
+    let jsonl_dir = paths.root.join("sessions_jsonl");
+    std::fs::create_dir_all(&jsonl_dir).unwrap();
+    let index = jsonl_dir.join("session_index.sqlite3");
+    Connection::open(&index).unwrap();
+
+    let apply = run_rkat(
+        &temp,
+        &[
+            "--state-root",
+            state_root.to_str().unwrap(),
+            "--realm",
+            "sqlite-with-inactive-jsonl",
+            "storage",
+            "migrate",
+            "--apply",
+            "--json",
+        ],
+    );
+    assert_success(&apply, "sqlite migration with inactive JSONL index");
+
+    let conn = Connection::open(index).unwrap();
+    assert_eq!(
+        conn.query_row(
+            "SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = 'session_index'",
+            [],
+            |row| row.get::<_, i64>(0),
+        )
+        .unwrap(),
+        0,
+        "SQLite migration opened the inactive JSONL session index"
+    );
+    assert_eq!(
+        conn.query_row(
+            "SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = 'meerkat_schema'",
+            [],
+            |row| row.get::<_, i64>(0),
+        )
+        .unwrap(),
+        0,
+        "SQLite migration stamped the inactive JSONL session index"
     );
 }
 

--- a/meerkat-core/src/image_generation.rs
+++ b/meerkat-core/src/image_generation.rs
@@ -9,6 +9,7 @@ use crate::lifecycle::run_primitive::ModelId;
 use crate::model_profile::catalog::ImageGenerationModelProfile;
 use serde::{Deserialize, Deserializer, Serialize};
 use serde_json::Value;
+use std::cell::Cell;
 use std::num::NonZeroU32;
 use uuid::Uuid;
 
@@ -611,8 +612,46 @@ pub enum ImageGenerationWarning {
     },
 }
 
+thread_local! {
+    static PRE_FLOOR_PROVIDER_IMAGE_METADATA_IMPORT_ACTIVE: Cell<bool> = const { Cell::new(false) };
+}
+
+struct PreFloorProviderImageMetadataImportGuard {
+    previously_active: bool,
+}
+
+impl Drop for PreFloorProviderImageMetadataImportGuard {
+    fn drop(&mut self) {
+        PRE_FLOOR_PROVIDER_IMAGE_METADATA_IMPORT_ACTIVE
+            .with(|active| active.set(self.previously_active));
+    }
+}
+
+/// Runs a synchronous, explicit pre-floor persistence import operation.
+///
+/// While the operation is active on the current thread, only
+/// [`ProviderImageMetadata`] accepts the historical `open_ai` discriminator.
+/// The decoded value is the current `OpenAi` variant, so every subsequent
+/// serialization emits canonical `openai`. Ordinary deserialization remains
+/// strict. This narrow seam exists only for realm maintenance code importing
+/// authenticated historical persistence.
+///
+/// The scope is thread-local and restored on return or unwind. Do not return
+/// deferred work from `operation`: the scope ends when this function returns.
+#[doc(hidden)]
+pub fn with_pre_floor_provider_image_metadata_import<T>(operation: impl FnOnce() -> T) -> T {
+    let previously_active =
+        PRE_FLOOR_PROVIDER_IMAGE_METADATA_IMPORT_ACTIVE.with(|active| active.replace(true));
+    let _guard = PreFloorProviderImageMetadataImportGuard { previously_active };
+    operation()
+}
+
+fn pre_floor_provider_image_metadata_import_is_active() -> bool {
+    PRE_FLOOR_PROVIDER_IMAGE_METADATA_IMPORT_ACTIVE.with(Cell::get)
+}
+
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 #[serde(tag = "provider", rename_all = "snake_case")]
 pub enum ProviderImageMetadata {
     NotEmitted,
@@ -622,6 +661,50 @@ pub enum ProviderImageMetadata {
     #[serde(rename = "openai")]
     OpenAi(OpenAiImageMetadata),
     Gemini(GeminiImageMetadata),
+}
+
+impl<'de> Deserialize<'de> for ProviderImageMetadata {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        #[serde(deny_unknown_fields)]
+        struct PreFloorOpenAiImageMetadata {
+            target_model: String,
+            response_id: Option<String>,
+            image_generation_call_id: Option<String>,
+        }
+
+        #[derive(Deserialize)]
+        #[serde(tag = "provider", rename_all = "snake_case")]
+        enum WireProviderImageMetadata {
+            NotEmitted,
+            #[serde(rename = "openai")]
+            OpenAi(OpenAiImageMetadata),
+            #[serde(rename = "open_ai")]
+            PreFloorOpenAi(PreFloorOpenAiImageMetadata),
+            Gemini(GeminiImageMetadata),
+        }
+
+        match WireProviderImageMetadata::deserialize(deserializer)? {
+            WireProviderImageMetadata::NotEmitted => Ok(Self::NotEmitted),
+            WireProviderImageMetadata::OpenAi(metadata) => Ok(Self::OpenAi(metadata)),
+            WireProviderImageMetadata::PreFloorOpenAi(metadata)
+                if pre_floor_provider_image_metadata_import_is_active() =>
+            {
+                Ok(Self::OpenAi(OpenAiImageMetadata {
+                    target_model: metadata.target_model,
+                    response_id: metadata.response_id,
+                    image_generation_call_id: metadata.image_generation_call_id,
+                }))
+            }
+            WireProviderImageMetadata::PreFloorOpenAi(_) => Err(serde::de::Error::custom(
+                "legacy ProviderImageMetadata discriminator `open_ai` is accepted only by the explicit pre-floor maintenance importer",
+            )),
+            WireProviderImageMetadata::Gemini(metadata) => Ok(Self::Gemini(metadata)),
+        }
+    }
 }
 
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
@@ -1116,6 +1199,7 @@ impl SessionModelRoutingStatus {
 mod tests {
     use super::*;
     use crate::blob::{BlobId, BlobRef};
+    use crate::types::ProviderMeta;
     use serde::de::DeserializeOwned;
     use std::fmt::Debug;
 
@@ -1130,6 +1214,123 @@ mod tests {
         let encoded = serde_json::to_string(&value).unwrap();
         let decoded: T = serde_json::from_str(&encoded).unwrap();
         assert_eq!(decoded, value);
+    }
+
+    #[test]
+    fn provider_image_metadata_rejects_pre_floor_discriminator_by_default() {
+        let legacy = r#"{
+            "provider": "open_ai",
+            "target_model": "gpt-image-1",
+            "response_id": "response-1",
+            "image_generation_call_id": "call-1"
+        }"#;
+
+        let error = serde_json::from_str::<ProviderImageMetadata>(legacy).unwrap_err();
+        assert!(
+            error
+                .to_string()
+                .contains("explicit pre-floor maintenance importer"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn scoped_pre_floor_import_canonicalizes_only_image_metadata() {
+        #[derive(Debug, Serialize, Deserialize)]
+        struct PersistenceEnvelope {
+            image_metadata: ProviderImageMetadata,
+            unrelated_provider_metadata: ProviderMeta,
+        }
+
+        let legacy = r#"{
+            "image_metadata": {
+                "provider": "open_ai",
+                "target_model": "gpt-image-1",
+                "response_id": "response-1",
+                "image_generation_call_id": "call-1"
+            },
+            "unrelated_provider_metadata": {
+                "provider": "open_ai",
+                "id": "reasoning-1",
+                "encrypted_content": "opaque",
+                "phase": "reasoning"
+            }
+        }"#;
+
+        let imported = with_pre_floor_provider_image_metadata_import(|| {
+            serde_json::from_str::<PersistenceEnvelope>(legacy)
+        })
+        .unwrap();
+        assert!(matches!(
+            imported.image_metadata,
+            ProviderImageMetadata::OpenAi(_)
+        ));
+        assert!(matches!(
+            imported.unrelated_provider_metadata,
+            ProviderMeta::OpenAi { .. }
+        ));
+
+        let canonical = serde_json::to_value(imported).unwrap();
+        assert_eq!(canonical["image_metadata"]["provider"], "openai");
+        assert_eq!(
+            canonical["unrelated_provider_metadata"]["provider"],
+            "open_ai"
+        );
+
+        assert!(serde_json::from_str::<PersistenceEnvelope>(legacy).is_err());
+    }
+
+    #[test]
+    fn scoped_pre_floor_import_rejects_duplicate_provider_discriminators() {
+        for ambiguous in [
+            r#"{
+                "provider": "openai",
+                "provider": "open_ai",
+                "target_model": "gpt-image-1"
+            }"#,
+            r#"{
+                "provider": "open_ai",
+                "provider": "openai",
+                "target_model": "gpt-image-1"
+            }"#,
+        ] {
+            let error = with_pre_floor_provider_image_metadata_import(|| {
+                serde_json::from_str::<ProviderImageMetadata>(ambiguous)
+            })
+            .unwrap_err();
+            assert!(
+                error.to_string().contains("duplicate field `provider`"),
+                "ambiguous discriminator was not rejected as a duplicate: {error}"
+            );
+        }
+    }
+
+    #[test]
+    fn scoped_pre_floor_import_rejects_unknown_legacy_image_metadata_fields() {
+        let legacy_with_unknown_field = r#"{
+            "provider": "open_ai",
+            "target_model": "gpt-image-1",
+            "response_id": "response-1",
+            "image_generation_call_id": "call-1",
+            "unrecognized_source_field": "must-not-be-dropped"
+        }"#;
+
+        let error = with_pre_floor_provider_image_metadata_import(|| {
+            serde_json::from_str::<ProviderImageMetadata>(legacy_with_unknown_field)
+        })
+        .unwrap_err();
+        assert!(
+            error
+                .to_string()
+                .contains("unknown field `unrecognized_source_field`"),
+            "unexpected error: {error}"
+        );
+
+        let canonical_with_unknown_field = legacy_with_unknown_field.replace("open_ai", "openai");
+        assert!(
+            serde_json::from_str::<ProviderImageMetadata>(&canonical_with_unknown_field).is_ok(),
+            "current canonical decoding behavior must remain unchanged"
+        );
     }
 
     fn source_image() -> ImageSourceRef {

--- a/meerkat-memory/src/hnsw.rs
+++ b/meerkat-memory/src/hnsw.rs
@@ -198,7 +198,7 @@ impl EmbeddingModel for BagOfWordsEmbeddingModel {
 /// Version 2 is the released 0.8.10 floor and current shape. The historical
 /// v1 step remains only as an ingredient of the direct current initializer;
 /// a ledger-v1 or unledgered owned schema is refused.
-const MEMORY_DOMAIN: meerkat_sqlite::SchemaDomain = meerkat_sqlite::SchemaDomain {
+pub const MEMORY_DOMAIN: meerkat_sqlite::SchemaDomain = meerkat_sqlite::SchemaDomain {
     name: "memory",
     migrations: &[
         meerkat_sqlite::Migration {

--- a/meerkat-memory/src/lib.rs
+++ b/meerkat-memory/src/lib.rs
@@ -11,7 +11,7 @@ pub mod hnsw;
 pub mod simple;
 pub mod tool;
 
-pub use hnsw::{BagOfWordsEmbeddingModel, HnswMemoryStore, default_ranking_policy};
+pub use hnsw::{BagOfWordsEmbeddingModel, HnswMemoryStore, MEMORY_DOMAIN, default_ranking_policy};
 pub use simple::SimpleMemoryStore;
 pub use tool::MemorySearchDispatcher;
 

--- a/meerkat-runtime/src/store/sqlite.rs
+++ b/meerkat-runtime/src/store/sqlite.rs
@@ -100,6 +100,1798 @@ CREATE TABLE IF NOT EXISTS runtime_mob_host_revocations (
     receipt_json BLOB NOT NULL
 )";
 
+    // Exact runtime catalog created by the pre-ledger opener immediately
+    // before distributed mob host persistence added its two tables. Existing
+    // files were not guaranteed to reopen after that addition, so this
+    // 9-table shape is a real historical predecessor of the released
+    // 0.8.10 11-table catalog. Keep this frozen and use it only as an explicit
+    // maintenance source oracle.
+    const CREATE_PRE_MOB_HOST_RUNTIME_SCHEMA_SQL: &str = r"
+CREATE TABLE IF NOT EXISTS runtime_input_states (
+    runtime_id TEXT NOT NULL,
+    input_id TEXT NOT NULL,
+    state_json BLOB NOT NULL,
+    PRIMARY KEY (runtime_id, input_id)
+);
+CREATE TABLE IF NOT EXISTS runtime_boundary_receipts (
+    runtime_id TEXT NOT NULL,
+    run_id TEXT NOT NULL,
+    sequence INTEGER NOT NULL,
+    receipt_json BLOB NOT NULL,
+    PRIMARY KEY (runtime_id, run_id, sequence)
+);
+CREATE TABLE IF NOT EXISTS runtime_session_snapshots (
+    runtime_id TEXT PRIMARY KEY,
+    session_snapshot BLOB NOT NULL
+);
+CREATE TABLE IF NOT EXISTS runtime_states (
+    runtime_id TEXT PRIMARY KEY,
+    runtime_state_json BLOB NOT NULL
+);
+CREATE TABLE IF NOT EXISTS runtime_ops_lifecycle (
+    runtime_id TEXT PRIMARY KEY,
+    state_json BLOB NOT NULL
+);
+CREATE TABLE IF NOT EXISTS runtime_retired_ops_epochs (
+    runtime_id TEXT NOT NULL,
+    epoch_id TEXT NOT NULL,
+    PRIMARY KEY (runtime_id, epoch_id)
+);
+CREATE TABLE IF NOT EXISTS runtime_auth_oauth_flow_state (
+    id TEXT PRIMARY KEY,
+    state_json BLOB NOT NULL
+);
+CREATE TABLE IF NOT EXISTS runtime_projection_quarantine (
+    runtime_id TEXT PRIMARY KEY
+);
+CREATE TABLE IF NOT EXISTS runtime_compaction_projection_outbox (
+    runtime_id TEXT NOT NULL,
+    session_id TEXT NOT NULL,
+    parent_revision TEXT NOT NULL,
+    revision TEXT NOT NULL,
+    commit_fingerprint TEXT NOT NULL,
+    intent_json BLOB NOT NULL,
+    state TEXT NOT NULL CHECK (state IN ('pending', 'finalized')),
+    PRIMARY KEY (runtime_id, session_id, parent_revision, revision, commit_fingerprint)
+)";
+
+    const CREATE_RUNTIME_MOB_HOST_SCHEMA_SQL: &str = r"
+CREATE TABLE IF NOT EXISTS runtime_mob_host_bindings (
+    mob_id TEXT PRIMARY KEY,
+    record_json BLOB NOT NULL
+);
+CREATE TABLE IF NOT EXISTS runtime_mob_host_revocations (
+    mob_id TEXT PRIMARY KEY,
+    receipt_json BLOB NOT NULL
+)";
+
+    fn pre_0_8_10_input_import_error(
+        runtime_id: &str,
+        input_id: &str,
+        detail: impl Into<String>,
+    ) -> rusqlite::Error {
+        rusqlite::Error::ToSqlConversionFailure(Box::new(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            format!(
+                "pre-0.8.10 runtime input {runtime_id}/{input_id} failed frozen maintenance import: {}",
+                detail.into()
+            ),
+        )))
+    }
+
+    struct DuplicateRejectingJsonValue(serde_json::Value);
+
+    struct DuplicateRejectingJsonVisitor;
+
+    impl<'de> serde::de::Visitor<'de> for DuplicateRejectingJsonVisitor {
+        type Value = DuplicateRejectingJsonValue;
+
+        fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            formatter.write_str("a JSON value without duplicate object keys")
+        }
+
+        fn visit_bool<E: serde::de::Error>(self, value: bool) -> Result<Self::Value, E> {
+            Ok(DuplicateRejectingJsonValue(serde_json::Value::Bool(value)))
+        }
+
+        fn visit_i64<E: serde::de::Error>(self, value: i64) -> Result<Self::Value, E> {
+            Ok(DuplicateRejectingJsonValue(serde_json::Value::Number(
+                value.into(),
+            )))
+        }
+
+        fn visit_u64<E: serde::de::Error>(self, value: u64) -> Result<Self::Value, E> {
+            Ok(DuplicateRejectingJsonValue(serde_json::Value::Number(
+                value.into(),
+            )))
+        }
+
+        fn visit_f64<E: serde::de::Error>(self, value: f64) -> Result<Self::Value, E> {
+            serde_json::Number::from_f64(value)
+                .map(serde_json::Value::Number)
+                .map(DuplicateRejectingJsonValue)
+                .ok_or_else(|| E::custom("JSON number is not finite"))
+        }
+
+        fn visit_str<E: serde::de::Error>(self, value: &str) -> Result<Self::Value, E> {
+            Ok(DuplicateRejectingJsonValue(serde_json::Value::String(
+                value.to_string(),
+            )))
+        }
+
+        fn visit_string<E: serde::de::Error>(self, value: String) -> Result<Self::Value, E> {
+            Ok(DuplicateRejectingJsonValue(serde_json::Value::String(
+                value,
+            )))
+        }
+
+        fn visit_none<E: serde::de::Error>(self) -> Result<Self::Value, E> {
+            Ok(DuplicateRejectingJsonValue(serde_json::Value::Null))
+        }
+
+        fn visit_unit<E: serde::de::Error>(self) -> Result<Self::Value, E> {
+            Ok(DuplicateRejectingJsonValue(serde_json::Value::Null))
+        }
+
+        fn visit_some<D: serde::Deserializer<'de>>(
+            self,
+            deserializer: D,
+        ) -> Result<Self::Value, D::Error> {
+            serde::Deserialize::deserialize(deserializer)
+        }
+
+        fn visit_seq<A: serde::de::SeqAccess<'de>>(
+            self,
+            mut sequence: A,
+        ) -> Result<Self::Value, A::Error> {
+            let mut values = Vec::new();
+            while let Some(value) = sequence.next_element::<DuplicateRejectingJsonValue>()? {
+                values.push(value.0);
+            }
+            Ok(DuplicateRejectingJsonValue(serde_json::Value::Array(
+                values,
+            )))
+        }
+
+        fn visit_map<A: serde::de::MapAccess<'de>>(
+            self,
+            mut object: A,
+        ) -> Result<Self::Value, A::Error> {
+            let mut seen = HashSet::new();
+            let mut values = serde_json::Map::new();
+            while let Some(key) = object.next_key::<String>()? {
+                if !seen.insert(key.clone()) {
+                    return Err(serde::de::Error::custom(format!(
+                        "duplicate JSON object key `{key}`"
+                    )));
+                }
+                let value = object.next_value::<DuplicateRejectingJsonValue>()?;
+                values.insert(key, value.0);
+            }
+            Ok(DuplicateRejectingJsonValue(serde_json::Value::Object(
+                values,
+            )))
+        }
+    }
+
+    impl<'de> serde::Deserialize<'de> for DuplicateRejectingJsonValue {
+        fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+            deserializer.deserialize_any(DuplicateRejectingJsonVisitor)
+        }
+    }
+
+    fn parse_pre_0_8_10_json(bytes: &[u8]) -> Result<serde_json::Value, serde_json::Error> {
+        serde_json::from_slice::<DuplicateRejectingJsonValue>(bytes).map(|value| value.0)
+    }
+
+    const PRE_0_8_10_INPUT_STATE_KEYS: &[&str] = &[
+        "input_id",
+        "current_state",
+        "policy",
+        "runtime_semantics",
+        "terminal_outcome",
+        "durability",
+        "idempotency_key",
+        "attempt_count",
+        "recovery_count",
+        "history",
+        "persisted_input",
+        "last_run_id",
+        "last_boundary_sequence",
+        "created_at",
+        "updated_at",
+    ];
+
+    const RELEASED_V3_INPUT_STATE_KEYS: &[&str] = &[
+        "stored_input_state_version",
+        "input_id",
+        "current_state",
+        "policy",
+        "runtime_semantics",
+        "terminal_outcome",
+        "durability",
+        "attempt_count",
+        "recovery_count",
+        "history",
+        "persisted_input",
+        "last_run_id",
+        "last_boundary_sequence",
+        "admission_sequence",
+        "created_at",
+        "updated_at",
+    ];
+
+    const PRE_0_8_10_POLICY_KEYS: &[&str] = &["version", "decision"];
+    const PRE_0_8_10_POLICY_DECISION_KEYS: &[&str] = &[
+        "apply_mode",
+        "wake_mode",
+        "queue_mode",
+        "consume_point",
+        "drain_policy",
+        "routing_disposition",
+        "record_transcript",
+        "emit_operator_content",
+        "policy_version",
+    ];
+    const PRE_0_8_10_RUNTIME_SEMANTICS_KEYS: &[&str] = &[
+        "boundary",
+        "execution_kind",
+        "peer_response_terminal_apply_intent",
+        "execution_handling_mode",
+    ];
+    const RELEASED_V3_RUNTIME_SEMANTICS_KEYS: &[&str] = &[
+        "boundary",
+        "execution_kind",
+        "execution_handling_mode",
+        "peer_response_terminal_apply_intent",
+        "live_interrupt_required",
+    ];
+    const PRE_0_8_10_HISTORY_ENTRY_KEYS: &[&str] = &["timestamp", "from", "to", "reason"];
+    const PRE_0_8_10_PROMPT_KEYS: &[&str] = &["input_type", "header", "text", "turn_metadata"];
+
+    const PRE_0_8_10_SIMPLE_CONTINUATION_KEYS: &[&str] =
+        &["input_type", "header", "reason", "handling_mode"];
+    const RELEASED_V3_PROMPT_KEYS: &[&str] = &["input_type", "header", "content", "turn_metadata"];
+    const PRE_0_8_10_HEADER_KEYS: &[&str] = &[
+        "id",
+        "timestamp",
+        "source",
+        "durability",
+        "visibility",
+        "idempotency_key",
+        "correlation_id",
+    ];
+    const RELEASED_V3_HEADER_KEYS: &[&str] =
+        &["id", "timestamp", "source", "durability", "visibility"];
+    const PRE_0_8_10_SOURCE_KEYS: &[&str] = &["type"];
+    const PRE_0_8_10_VISIBILITY_KEYS: &[&str] = &["transcript_eligible", "operator_eligible"];
+    const PRE_0_8_10_TURN_METADATA_KEYS: &[&str] = &["additional_instructions"];
+    const PRE_0_8_10_TURN_INSTRUCTION_KEYS: &[&str] = &["kind", "body"];
+
+    fn reject_unknown_pre_0_8_10_keys(
+        runtime_id: &str,
+        input_id: &str,
+        owner: &str,
+        object: &serde_json::Map<String, serde_json::Value>,
+        allowed: &[&str],
+    ) -> Result<(), rusqlite::Error> {
+        let unknown = object
+            .keys()
+            .filter(|key| !allowed.contains(&key.as_str()))
+            .cloned()
+            .collect::<Vec<_>>();
+        if unknown.is_empty() {
+            Ok(())
+        } else {
+            Err(pre_0_8_10_input_import_error(
+                runtime_id,
+                input_id,
+                format!("{owner} carries unsupported fields {unknown:?}"),
+            ))
+        }
+    }
+
+    fn pre_0_8_10_object<'a>(
+        runtime_id: &str,
+        input_id: &str,
+        owner: &str,
+        value: &'a serde_json::Value,
+    ) -> Result<&'a serde_json::Map<String, serde_json::Value>, rusqlite::Error> {
+        value.as_object().ok_or_else(|| {
+            pre_0_8_10_input_import_error(
+                runtime_id,
+                input_id,
+                format!("{owner} is not a JSON object"),
+            )
+        })
+    }
+
+    fn pre_0_8_10_required_field<'a>(
+        runtime_id: &str,
+        input_id: &str,
+        owner: &str,
+        object: &'a serde_json::Map<String, serde_json::Value>,
+        field: &str,
+    ) -> Result<&'a serde_json::Value, rusqlite::Error> {
+        object.get(field).ok_or_else(|| {
+            pre_0_8_10_input_import_error(
+                runtime_id,
+                input_id,
+                format!("{owner} is missing required field `{field}`"),
+            )
+        })
+    }
+
+    fn require_pre_0_8_10_keys(
+        runtime_id: &str,
+        input_id: &str,
+        owner: &str,
+        object: &serde_json::Map<String, serde_json::Value>,
+        required: &[&str],
+    ) -> Result<(), rusqlite::Error> {
+        reject_unknown_pre_0_8_10_keys(runtime_id, input_id, owner, object, required)?;
+        let missing = required
+            .iter()
+            .filter(|key| !object.contains_key(**key))
+            .copied()
+            .collect::<Vec<_>>();
+        if missing.is_empty() {
+            Ok(())
+        } else {
+            Err(pre_0_8_10_input_import_error(
+                runtime_id,
+                input_id,
+                format!("{owner} is missing required fields {missing:?}"),
+            ))
+        }
+    }
+
+    fn validate_pre_0_8_10_policy_shape(
+        runtime_id: &str,
+        input_id: &str,
+        row: &serde_json::Map<String, serde_json::Value>,
+    ) -> Result<(), rusqlite::Error> {
+        let policy = row.get("policy").ok_or_else(|| {
+            pre_0_8_10_input_import_error(runtime_id, input_id, "row has no policy snapshot")
+        })?;
+        let policy = pre_0_8_10_object(runtime_id, input_id, "policy snapshot", policy)?;
+        require_pre_0_8_10_keys(
+            runtime_id,
+            input_id,
+            "policy snapshot",
+            policy,
+            PRE_0_8_10_POLICY_KEYS,
+        )?;
+        let decision = pre_0_8_10_object(
+            runtime_id,
+            input_id,
+            "policy decision",
+            pre_0_8_10_required_field(runtime_id, input_id, "policy snapshot", policy, "decision")?,
+        )?;
+        require_pre_0_8_10_keys(
+            runtime_id,
+            input_id,
+            "policy decision",
+            decision,
+            PRE_0_8_10_POLICY_DECISION_KEYS,
+        )
+    }
+
+    fn validate_pre_0_8_10_runtime_semantics_shape(
+        runtime_id: &str,
+        input_id: &str,
+        row: &serde_json::Map<String, serde_json::Value>,
+        released_v3: bool,
+    ) -> Result<(), rusqlite::Error> {
+        let semantics = row.get("runtime_semantics").ok_or_else(|| {
+            pre_0_8_10_input_import_error(
+                runtime_id,
+                input_id,
+                "row has no runtime semantics stamp",
+            )
+        })?;
+        let semantics = pre_0_8_10_object(runtime_id, input_id, "runtime semantics", semantics)?;
+        if released_v3 {
+            require_pre_0_8_10_keys(
+                runtime_id,
+                input_id,
+                "runtime semantics",
+                semantics,
+                RELEASED_V3_RUNTIME_SEMANTICS_KEYS,
+            )?;
+        } else {
+            reject_unknown_pre_0_8_10_keys(
+                runtime_id,
+                input_id,
+                "runtime semantics",
+                semantics,
+                PRE_0_8_10_RUNTIME_SEMANTICS_KEYS,
+            )?;
+            for key in [
+                "boundary",
+                "execution_kind",
+                "peer_response_terminal_apply_intent",
+            ] {
+                if !semantics.contains_key(key) {
+                    return Err(pre_0_8_10_input_import_error(
+                        runtime_id,
+                        input_id,
+                        format!("runtime semantics is missing required field `{key}`"),
+                    ));
+                }
+            }
+            if semantics
+                .get("execution_handling_mode")
+                .is_some_and(|value| !value.is_null())
+            {
+                return Err(pre_0_8_10_input_import_error(
+                    runtime_id,
+                    input_id,
+                    "released execution_handling_mode is not null",
+                ));
+            }
+        }
+        Ok(())
+    }
+
+    fn validate_pre_0_8_10_history_shape(
+        runtime_id: &str,
+        input_id: &str,
+        row: &serde_json::Map<String, serde_json::Value>,
+    ) -> Result<(), rusqlite::Error> {
+        let history = row
+            .get("history")
+            .and_then(serde_json::Value::as_array)
+            .ok_or_else(|| {
+                pre_0_8_10_input_import_error(
+                    runtime_id,
+                    input_id,
+                    "row history is not a JSON array",
+                )
+            })?;
+        if history.is_empty() {
+            return Err(pre_0_8_10_input_import_error(
+                runtime_id,
+                input_id,
+                "row history is empty",
+            ));
+        }
+        for (index, entry) in history.iter().enumerate() {
+            let entry = pre_0_8_10_object(
+                runtime_id,
+                input_id,
+                &format!("history entry {index}"),
+                entry,
+            )?;
+            require_pre_0_8_10_keys(
+                runtime_id,
+                input_id,
+                &format!("history entry {index}"),
+                entry,
+                PRE_0_8_10_HISTORY_ENTRY_KEYS,
+            )?;
+            if !entry
+                .get("reason")
+                .is_some_and(serde_json::Value::is_string)
+            {
+                return Err(pre_0_8_10_input_import_error(
+                    runtime_id,
+                    input_id,
+                    format!("history entry {index} has no string reason"),
+                ));
+            }
+        }
+        Ok(())
+    }
+
+    fn validate_pre_0_8_10_terminal_shape(
+        runtime_id: &str,
+        input_id: &str,
+        row: &serde_json::Map<String, serde_json::Value>,
+    ) -> Result<(), rusqlite::Error> {
+        let Some(terminal) = row.get("terminal_outcome") else {
+            return Ok(());
+        };
+        let terminal = pre_0_8_10_object(runtime_id, input_id, "terminal outcome", terminal)?;
+        match terminal
+            .get("outcome_type")
+            .and_then(serde_json::Value::as_str)
+        {
+            Some("consumed") => require_pre_0_8_10_keys(
+                runtime_id,
+                input_id,
+                "consumed terminal outcome",
+                terminal,
+                &["outcome_type"],
+            ),
+            Some("abandoned") => {
+                require_pre_0_8_10_keys(
+                    runtime_id,
+                    input_id,
+                    "abandoned terminal outcome",
+                    terminal,
+                    &["outcome_type", "reason"],
+                )?;
+                let reason = pre_0_8_10_object(
+                    runtime_id,
+                    input_id,
+                    "abandon reason",
+                    pre_0_8_10_required_field(
+                        runtime_id,
+                        input_id,
+                        "abandoned terminal outcome",
+                        terminal,
+                        "reason",
+                    )?,
+                )?;
+                require_pre_0_8_10_keys(
+                    runtime_id,
+                    input_id,
+                    "abandon reason",
+                    reason,
+                    &["max_attempts_exhausted"],
+                )?;
+                let details = pre_0_8_10_object(
+                    runtime_id,
+                    input_id,
+                    "max-attempts abandon reason",
+                    pre_0_8_10_required_field(
+                        runtime_id,
+                        input_id,
+                        "abandon reason",
+                        reason,
+                        "max_attempts_exhausted",
+                    )?,
+                )?;
+                require_pre_0_8_10_keys(
+                    runtime_id,
+                    input_id,
+                    "max-attempts abandon reason",
+                    details,
+                    &["attempts"],
+                )
+            }
+            Some(other) => Err(pre_0_8_10_input_import_error(
+                runtime_id,
+                input_id,
+                format!("terminal outcome `{other}` is outside the frozen corpus"),
+            )),
+            None => Err(pre_0_8_10_input_import_error(
+                runtime_id,
+                input_id,
+                "terminal outcome has no outcome_type discriminator",
+            )),
+        }
+    }
+
+    fn validate_pre_0_8_10_header_shape(
+        runtime_id: &str,
+        input_id: &str,
+        header: &serde_json::Value,
+        released_v3: bool,
+    ) -> Result<(), rusqlite::Error> {
+        let header = pre_0_8_10_object(runtime_id, input_id, "input header", header)?;
+        if released_v3 {
+            require_pre_0_8_10_keys(
+                runtime_id,
+                input_id,
+                "input header",
+                header,
+                RELEASED_V3_HEADER_KEYS,
+            )?;
+        } else {
+            reject_unknown_pre_0_8_10_keys(
+                runtime_id,
+                input_id,
+                "input header",
+                header,
+                PRE_0_8_10_HEADER_KEYS,
+            )?;
+            for key in ["id", "timestamp", "source", "durability", "visibility"] {
+                if !header.contains_key(key) {
+                    return Err(pre_0_8_10_input_import_error(
+                        runtime_id,
+                        input_id,
+                        format!("input header is missing required field `{key}`"),
+                    ));
+                }
+            }
+            if header.contains_key("idempotency_key") != header.contains_key("correlation_id") {
+                return Err(pre_0_8_10_input_import_error(
+                    runtime_id,
+                    input_id,
+                    "released input header must carry idempotency_key and correlation_id together",
+                ));
+            }
+            for key in ["idempotency_key", "correlation_id"] {
+                if header.get(key).is_some_and(|value| !value.is_string()) {
+                    return Err(pre_0_8_10_input_import_error(
+                        runtime_id,
+                        input_id,
+                        format!("released input header field `{key}` is not a string"),
+                    ));
+                }
+            }
+        }
+        let source = pre_0_8_10_object(
+            runtime_id,
+            input_id,
+            "input source",
+            pre_0_8_10_required_field(runtime_id, input_id, "input header", header, "source")?,
+        )?;
+        require_pre_0_8_10_keys(
+            runtime_id,
+            input_id,
+            "input source",
+            source,
+            PRE_0_8_10_SOURCE_KEYS,
+        )?;
+        match source.get("type").and_then(serde_json::Value::as_str) {
+            Some("operator" | "system") => {}
+            other => {
+                return Err(pre_0_8_10_input_import_error(
+                    runtime_id,
+                    input_id,
+                    format!("input source {other:?} is outside the frozen corpus"),
+                ));
+            }
+        }
+        let visibility = pre_0_8_10_object(
+            runtime_id,
+            input_id,
+            "input visibility",
+            pre_0_8_10_required_field(runtime_id, input_id, "input header", header, "visibility")?,
+        )?;
+        require_pre_0_8_10_keys(
+            runtime_id,
+            input_id,
+            "input visibility",
+            visibility,
+            PRE_0_8_10_VISIBILITY_KEYS,
+        )
+    }
+
+    fn validate_pre_0_8_10_turn_metadata_shape(
+        runtime_id: &str,
+        input_id: &str,
+        metadata: &serde_json::Value,
+    ) -> Result<(), rusqlite::Error> {
+        let metadata = pre_0_8_10_object(runtime_id, input_id, "turn metadata", metadata)?;
+        reject_unknown_pre_0_8_10_keys(
+            runtime_id,
+            input_id,
+            "turn metadata",
+            metadata,
+            PRE_0_8_10_TURN_METADATA_KEYS,
+        )?;
+        let Some(instructions) = metadata.get("additional_instructions") else {
+            return Ok(());
+        };
+        let instructions = instructions.as_array().ok_or_else(|| {
+            pre_0_8_10_input_import_error(
+                runtime_id,
+                input_id,
+                "additional_instructions is not an array",
+            )
+        })?;
+        if instructions.is_empty() {
+            return Err(pre_0_8_10_input_import_error(
+                runtime_id,
+                input_id,
+                "additional_instructions is empty",
+            ));
+        }
+        for (index, instruction) in instructions.iter().enumerate() {
+            let instruction = pre_0_8_10_object(
+                runtime_id,
+                input_id,
+                &format!("turn instruction {index}"),
+                instruction,
+            )?;
+            require_pre_0_8_10_keys(
+                runtime_id,
+                input_id,
+                &format!("turn instruction {index}"),
+                instruction,
+                PRE_0_8_10_TURN_INSTRUCTION_KEYS,
+            )?;
+            if instruction.get("kind").and_then(serde_json::Value::as_str) != Some("system")
+                || !instruction
+                    .get("body")
+                    .is_some_and(serde_json::Value::is_string)
+            {
+                return Err(pre_0_8_10_input_import_error(
+                    runtime_id,
+                    input_id,
+                    format!("turn instruction {index} is outside the frozen system/body shape"),
+                ));
+            }
+        }
+        Ok(())
+    }
+
+    fn validate_pre_0_8_10_persisted_input_shape(
+        runtime_id: &str,
+        input_id: &str,
+        row: &serde_json::Map<String, serde_json::Value>,
+        released_v3: bool,
+    ) -> Result<(), rusqlite::Error> {
+        let persisted = row.get("persisted_input").ok_or_else(|| {
+            pre_0_8_10_input_import_error(runtime_id, input_id, "row has no persisted input")
+        })?;
+        let persisted = pre_0_8_10_object(runtime_id, input_id, "persisted input", persisted)?;
+        match persisted
+            .get("input_type")
+            .and_then(serde_json::Value::as_str)
+        {
+            Some("prompt") => {
+                let keys = if released_v3 {
+                    RELEASED_V3_PROMPT_KEYS
+                } else {
+                    PRE_0_8_10_PROMPT_KEYS
+                };
+                reject_unknown_pre_0_8_10_keys(
+                    runtime_id,
+                    input_id,
+                    "persisted prompt",
+                    persisted,
+                    keys,
+                )?;
+                for key in [
+                    "input_type",
+                    "header",
+                    if released_v3 { "content" } else { "text" },
+                ] {
+                    if !persisted.contains_key(key) {
+                        return Err(pre_0_8_10_input_import_error(
+                            runtime_id,
+                            input_id,
+                            format!("persisted prompt is missing required field `{key}`"),
+                        ));
+                    }
+                }
+                let content_key = if released_v3 { "content" } else { "text" };
+                if !persisted
+                    .get(content_key)
+                    .is_some_and(serde_json::Value::is_string)
+                {
+                    return Err(pre_0_8_10_input_import_error(
+                        runtime_id,
+                        input_id,
+                        format!("persisted prompt {content_key} is not a string"),
+                    ));
+                }
+                validate_pre_0_8_10_header_shape(
+                    runtime_id,
+                    input_id,
+                    pre_0_8_10_required_field(
+                        runtime_id,
+                        input_id,
+                        "persisted prompt",
+                        persisted,
+                        "header",
+                    )?,
+                    released_v3,
+                )?;
+                if let Some(metadata) = persisted.get("turn_metadata") {
+                    validate_pre_0_8_10_turn_metadata_shape(runtime_id, input_id, metadata)?;
+                } else if released_v3 {
+                    return Err(pre_0_8_10_input_import_error(
+                        runtime_id,
+                        input_id,
+                        "released v3 prompt has no turn_metadata object",
+                    ));
+                }
+                Ok(())
+            }
+            Some("continuation") if !released_v3 => {
+                require_pre_0_8_10_keys(
+                    runtime_id,
+                    input_id,
+                    "persisted continuation",
+                    persisted,
+                    PRE_0_8_10_SIMPLE_CONTINUATION_KEYS,
+                )?;
+                validate_pre_0_8_10_header_shape(
+                    runtime_id,
+                    input_id,
+                    pre_0_8_10_required_field(
+                        runtime_id,
+                        input_id,
+                        "persisted continuation",
+                        persisted,
+                        "header",
+                    )?,
+                    false,
+                )?;
+                if persisted.get("reason").and_then(serde_json::Value::as_str)
+                    != Some("detached_background_op_completed")
+                    || persisted
+                        .get("handling_mode")
+                        .and_then(serde_json::Value::as_str)
+                        != Some("steer")
+                {
+                    return Err(pre_0_8_10_input_import_error(
+                        runtime_id,
+                        input_id,
+                        "continuation is outside the frozen detached-background steer shape",
+                    ));
+                }
+                Ok(())
+            }
+            Some(other) => Err(pre_0_8_10_input_import_error(
+                runtime_id,
+                input_id,
+                format!("input type `{other}` is outside the frozen recovery corpus"),
+            )),
+            None => Err(pre_0_8_10_input_import_error(
+                runtime_id,
+                input_id,
+                "persisted input has no input_type discriminator",
+            )),
+        }
+    }
+
+    fn validate_pre_0_8_10_wire_shape(
+        runtime_id: &str,
+        input_id: &str,
+        encoded: &serde_json::Value,
+        released_v3: bool,
+    ) -> Result<(), rusqlite::Error> {
+        let row = pre_0_8_10_object(runtime_id, input_id, "input-state row", encoded)?;
+        reject_unknown_pre_0_8_10_keys(
+            runtime_id,
+            input_id,
+            "input-state row",
+            row,
+            if released_v3 {
+                RELEASED_V3_INPUT_STATE_KEYS
+            } else {
+                PRE_0_8_10_INPUT_STATE_KEYS
+            },
+        )?;
+        if released_v3 {
+            require_pre_0_8_10_keys(
+                runtime_id,
+                input_id,
+                "released v3 input-state row",
+                row,
+                RELEASED_V3_INPUT_STATE_KEYS,
+            )?;
+        } else {
+            for key in [
+                "input_id",
+                "current_state",
+                "policy",
+                "runtime_semantics",
+                "durability",
+                "attempt_count",
+                "recovery_count",
+                "history",
+                "persisted_input",
+                "created_at",
+                "updated_at",
+            ] {
+                if !row.contains_key(key) {
+                    return Err(pre_0_8_10_input_import_error(
+                        runtime_id,
+                        input_id,
+                        format!("input-state row is missing required field `{key}`"),
+                    ));
+                }
+            }
+            for key in ["idempotency_key", "last_run_id", "last_boundary_sequence"] {
+                if row.get(key).is_some_and(serde_json::Value::is_null) {
+                    return Err(pre_0_8_10_input_import_error(
+                        runtime_id,
+                        input_id,
+                        format!("released input-state field `{key}` is explicitly null"),
+                    ));
+                }
+            }
+        }
+        validate_pre_0_8_10_policy_shape(runtime_id, input_id, row)?;
+        validate_pre_0_8_10_runtime_semantics_shape(runtime_id, input_id, row, released_v3)?;
+        validate_pre_0_8_10_history_shape(runtime_id, input_id, row)?;
+        validate_pre_0_8_10_terminal_shape(runtime_id, input_id, row)?;
+        validate_pre_0_8_10_persisted_input_shape(runtime_id, input_id, row, released_v3)
+    }
+
+    fn validate_pre_0_8_10_row_identity(
+        runtime_id: &str,
+        input_id: &str,
+        stored: &StoredInputState,
+    ) -> Result<(), rusqlite::Error> {
+        if stored.state.input_id.to_string() != input_id {
+            return Err(pre_0_8_10_input_import_error(
+                runtime_id,
+                input_id,
+                format!(
+                    "embedded input id `{}` does not match the owning row",
+                    stored.state.input_id
+                ),
+            ));
+        }
+        if let Some(input) = stored.state.persisted_input.as_ref() {
+            if input.id() != &stored.state.input_id {
+                return Err(pre_0_8_10_input_import_error(
+                    runtime_id,
+                    input_id,
+                    format!(
+                        "persisted input header id `{}` does not match the state/row identity",
+                        input.id()
+                    ),
+                ));
+            }
+            if stored.state.durability != Some(input.header().durability) {
+                return Err(pre_0_8_10_input_import_error(
+                    runtime_id,
+                    input_id,
+                    "state durability does not match persisted input header durability",
+                ));
+            }
+            if stored.state.idempotency_key != input.header().idempotency_key {
+                return Err(pre_0_8_10_input_import_error(
+                    runtime_id,
+                    input_id,
+                    "state idempotency key does not match persisted input header idempotency key",
+                ));
+            }
+            match input {
+                crate::input::Input::Prompt(prompt)
+                    if prompt.header.durability == crate::input::InputDurability::Durable
+                        && prompt.header.visibility.transcript_eligible
+                        && prompt.header.visibility.operator_eligible
+                        && matches!(
+                            prompt.header.source,
+                            crate::input::InputOrigin::Operator | crate::input::InputOrigin::System
+                        ) => {}
+                crate::input::Input::Continuation(continuation)
+                    if continuation.header.durability == crate::input::InputDurability::Derived
+                        && !continuation.header.visibility.transcript_eligible
+                        && !continuation.header.visibility.operator_eligible
+                        && matches!(
+                            continuation.header.source,
+                            crate::input::InputOrigin::System
+                        )
+                        && continuation.header.idempotency_key.is_none()
+                        && continuation.header.correlation_id.is_none() => {}
+                _ => {
+                    return Err(pre_0_8_10_input_import_error(
+                        runtime_id,
+                        input_id,
+                        "persisted input header origin/durability/visibility is outside the frozen corpus",
+                    ));
+                }
+            }
+        }
+        if let Some(policy) = stored.state.policy.as_ref()
+            && policy.version != policy.decision.policy_version
+        {
+            return Err(pre_0_8_10_input_import_error(
+                runtime_id,
+                input_id,
+                "policy snapshot version does not match decision policy_version",
+            ));
+        }
+        Ok(())
+    }
+
+    fn authorize_pre_0_8_10_row(
+        runtime_id: &str,
+        input_id: &str,
+        stored: StoredInputState,
+    ) -> Result<InputStatePersistenceRecord, rusqlite::Error> {
+        InputStatePersistenceRecord::from_machine_snapshot(stored)
+            .map_err(|error| pre_0_8_10_input_import_error(runtime_id, input_id, error))
+    }
+
+    fn validate_pre_0_8_10_lifecycle(
+        runtime_id: &str,
+        input_id: &str,
+        stored: &StoredInputState,
+    ) -> Result<chrono::DateTime<chrono::Utc>, rusqlite::Error> {
+        if stored.state.recovery_count != 0 {
+            return Err(pre_0_8_10_input_import_error(
+                runtime_id,
+                input_id,
+                "input recovery_count is outside the frozen zero-recovery corpus",
+            ));
+        }
+        let history = &stored.state.history;
+        let first = history.first().ok_or_else(|| {
+            pre_0_8_10_input_import_error(runtime_id, input_id, "input history is empty")
+        })?;
+        if first.from != crate::input_state::InputLifecycleState::Accepted
+            || first.to != crate::input_state::InputLifecycleState::Queued
+            || first.reason.as_deref() != Some("QueueAccepted")
+        {
+            return Err(pre_0_8_10_input_import_error(
+                runtime_id,
+                input_id,
+                "input history does not start with exact Accepted -> Queued QueueAccepted",
+            ));
+        }
+        for pair in history.windows(2) {
+            if pair[0].to != pair[1].from || pair[0].timestamp > pair[1].timestamp {
+                return Err(pre_0_8_10_input_import_error(
+                    runtime_id,
+                    input_id,
+                    "input history is not a coherent monotonic lifecycle chain",
+                ));
+            }
+        }
+        let Some(last) = history.last() else {
+            return Err(pre_0_8_10_input_import_error(
+                runtime_id,
+                input_id,
+                "input history lost its validated non-empty tail",
+            ));
+        };
+        if last.to != stored.seed.phase || last.timestamp != stored.state.updated_at {
+            return Err(pre_0_8_10_input_import_error(
+                runtime_id,
+                input_id,
+                "input history tail does not bind current_state and updated_at",
+            ));
+        }
+        if stored.state.created_at > first.timestamp {
+            return Err(pre_0_8_10_input_import_error(
+                runtime_id,
+                input_id,
+                "input created_at is after its initial QueueAccepted history entry",
+            ));
+        }
+        if stored
+            .state
+            .persisted_input
+            .as_ref()
+            .is_some_and(|input| input.header().timestamp > stored.state.created_at)
+        {
+            return Err(pre_0_8_10_input_import_error(
+                runtime_id,
+                input_id,
+                "persisted input header timestamp is after state created_at",
+            ));
+        }
+
+        use crate::input_state::{InputAbandonReason, InputLifecycleState, InputTerminalOutcome};
+        match stored.seed.phase {
+            InputLifecycleState::Queued => {
+                if stored.seed.terminal_outcome.is_some()
+                    || stored.seed.last_run_id.is_some()
+                    || stored.seed.last_boundary_sequence.is_some()
+                    || stored.seed.attempt_count >= 3
+                    || history.len() != 1 + 2 * stored.seed.attempt_count as usize
+                {
+                    return Err(pre_0_8_10_input_import_error(
+                        runtime_id,
+                        input_id,
+                        "queued input carries non-corpus lifecycle facts",
+                    ));
+                }
+                for attempt in 0..stored.seed.attempt_count as usize {
+                    let staged = &history[1 + attempt * 2];
+                    let rolled_back = &history[2 + attempt * 2];
+                    let staged_run_id = staged
+                        .reason
+                        .as_deref()
+                        .and_then(|reason| reason.strip_prefix("StageForRun("))
+                        .and_then(|reason| reason.strip_suffix(')'));
+                    if staged.from != InputLifecycleState::Queued
+                        || staged.to != InputLifecycleState::Staged
+                        || staged_run_id.is_none_or(|run_id| uuid::Uuid::parse_str(run_id).is_err())
+                        || rolled_back.from != InputLifecycleState::Staged
+                        || rolled_back.to != InputLifecycleState::Queued
+                        || rolled_back.reason.as_deref() != Some("RollbackStaged")
+                    {
+                        return Err(pre_0_8_10_input_import_error(
+                            runtime_id,
+                            input_id,
+                            "queued input retry history is outside the frozen corpus",
+                        ));
+                    }
+                }
+            }
+            InputLifecycleState::Consumed => {
+                let phases = [
+                    (InputLifecycleState::Accepted, InputLifecycleState::Queued),
+                    (InputLifecycleState::Queued, InputLifecycleState::Staged),
+                    (InputLifecycleState::Staged, InputLifecycleState::Applied),
+                    (
+                        InputLifecycleState::Applied,
+                        InputLifecycleState::AppliedPendingConsumption,
+                    ),
+                    (
+                        InputLifecycleState::AppliedPendingConsumption,
+                        InputLifecycleState::Consumed,
+                    ),
+                ];
+                let run_id = stored
+                    .seed
+                    .last_run_id
+                    .as_ref()
+                    .map(std::string::ToString::to_string);
+                if stored.seed.attempt_count != 1
+                    || stored.seed.terminal_outcome != Some(InputTerminalOutcome::Consumed)
+                    || stored.seed.last_run_id.is_none()
+                    || stored.seed.last_boundary_sequence != Some(0)
+                    || history.len() != phases.len()
+                    || !history
+                        .iter()
+                        .zip(phases)
+                        .all(|(entry, (from, to))| entry.from == from && entry.to == to)
+                    || history[1].reason.as_deref()
+                        != run_id
+                            .as_deref()
+                            .map(|run_id| format!("StageForRun({run_id})"))
+                            .as_deref()
+                    || history[2].reason.as_deref()
+                        != run_id
+                            .as_deref()
+                            .map(|run_id| format!("MarkApplied({run_id})"))
+                            .as_deref()
+                    || history[3].reason.as_deref()
+                        != Some("MarkAppliedPendingConsumption(boundary_sequence=0)")
+                    || history[4].reason.as_deref() != Some("Consume")
+                {
+                    return Err(pre_0_8_10_input_import_error(
+                        runtime_id,
+                        input_id,
+                        "consumed input lifecycle is outside the frozen corpus",
+                    ));
+                }
+            }
+            InputLifecycleState::Abandoned => {
+                if stored.seed.attempt_count != 3
+                    || !matches!(
+                        stored.seed.terminal_outcome,
+                        Some(InputTerminalOutcome::Abandoned {
+                            reason: InputAbandonReason::MaxAttemptsExhausted { attempts: 3 }
+                        })
+                    )
+                    || stored.seed.last_run_id.is_none()
+                    || stored.seed.last_boundary_sequence.is_some()
+                    || history.len() != 7
+                {
+                    return Err(pre_0_8_10_input_import_error(
+                        runtime_id,
+                        input_id,
+                        "abandoned input lifecycle is outside the frozen corpus",
+                    ));
+                }
+                for attempt in 0..3 {
+                    let staged = &history[1 + attempt * 2];
+                    let completed = &history[2 + attempt * 2];
+                    let staged_run_id = staged
+                        .reason
+                        .as_deref()
+                        .and_then(|reason| reason.strip_prefix("StageForRun("))
+                        .and_then(|reason| reason.strip_suffix(')'));
+                    let expected_to = if attempt == 2 {
+                        InputLifecycleState::Abandoned
+                    } else {
+                        InputLifecycleState::Queued
+                    };
+                    if staged.from != InputLifecycleState::Queued
+                        || staged.to != InputLifecycleState::Staged
+                        || staged_run_id.is_none_or(|run_id| uuid::Uuid::parse_str(run_id).is_err())
+                        || completed.from != InputLifecycleState::Staged
+                        || completed.to != expected_to
+                        || (attempt < 2 && completed.reason.as_deref() != Some("RollbackStaged"))
+                        || (attempt == 2
+                            && (completed.reason.as_deref()
+                                != Some("RollbackStaged\u{2192}Abandon(attempts=3)")
+                                || staged_run_id
+                                    != stored
+                                        .seed
+                                        .last_run_id
+                                        .as_ref()
+                                        .map(std::string::ToString::to_string)
+                                        .as_deref()))
+                    {
+                        return Err(pre_0_8_10_input_import_error(
+                            runtime_id,
+                            input_id,
+                            "abandoned input retry history is outside the frozen corpus",
+                        ));
+                    }
+                }
+            }
+            other => {
+                return Err(pre_0_8_10_input_import_error(
+                    runtime_id,
+                    input_id,
+                    format!("non-corpus input lifecycle phase {other:?}"),
+                ));
+            }
+        }
+        Ok(first.timestamp)
+    }
+
+    fn frozen_runtime_semantics_match(
+        stored: crate::ingress_types::RuntimeInputSemantics,
+        generated: crate::ingress_types::RuntimeInputSemantics,
+    ) -> bool {
+        stored.boundary == generated.boundary
+            && stored.execution_kind == generated.execution_kind
+            && stored.execution_handling_mode == generated.execution_handling_mode
+            && stored.peer_response_terminal_apply_intent
+                == generated.peer_response_terminal_apply_intent
+    }
+
+    fn generated_projection_for_pre_0_8_10_row(
+        runtime_id: &str,
+        input_id: &str,
+        stored: &StoredInputState,
+    ) -> Result<crate::policy_table::GeneratedAdmissionProjection, rusqlite::Error> {
+        let input = stored.state.persisted_input.as_ref().ok_or_else(|| {
+            pre_0_8_10_input_import_error(
+                runtime_id,
+                input_id,
+                "released row has no persisted input for generated admission validation",
+            )
+        })?;
+        let policy = stored.state.policy.as_ref().ok_or_else(|| {
+            pre_0_8_10_input_import_error(
+                runtime_id,
+                input_id,
+                "released row has no policy snapshot",
+            )
+        })?;
+        let semantics = stored.state.runtime_semantics.ok_or_else(|| {
+            pre_0_8_10_input_import_error(
+                runtime_id,
+                input_id,
+                "released row has no runtime semantics stamp",
+            )
+        })?;
+        if input.header().visibility.transcript_eligible != policy.decision.record_transcript
+            || input.header().visibility.operator_eligible != policy.decision.emit_operator_content
+        {
+            return Err(pre_0_8_10_input_import_error(
+                runtime_id,
+                input_id,
+                "persisted input visibility disagrees with the frozen policy projection",
+            ));
+        }
+
+        let mut matched: Option<crate::policy_table::GeneratedAdmissionProjection> = None;
+        for runtime_idle in [true, false] {
+            let candidate =
+                crate::policy_table::generated_admission_projection_for_input(input, runtime_idle)
+                    .map_err(|error| pre_0_8_10_input_import_error(runtime_id, input_id, error))?;
+            if candidate.policy == policy.decision
+                && frozen_runtime_semantics_match(semantics, candidate.runtime_semantics)
+            {
+                if let Some(previous) = matched.as_ref()
+                    && (previous.policy != candidate.policy
+                        || previous.runtime_semantics != candidate.runtime_semantics)
+                {
+                    return Err(pre_0_8_10_input_import_error(
+                        runtime_id,
+                        input_id,
+                        "released admission facts match multiple current generated projections",
+                    ));
+                }
+                matched = Some(candidate);
+            }
+        }
+        matched.ok_or_else(|| {
+            pre_0_8_10_input_import_error(
+                runtime_id,
+                input_id,
+                "released policy/runtime semantics disagree with generated admission authority",
+            )
+        })
+    }
+
+    struct PreFloorNoopWake;
+
+    impl std::task::Wake for PreFloorNoopWake {
+        fn wake(self: Arc<Self>) {}
+    }
+
+    fn accept_pre_0_8_10_input_immediately(
+        runtime_id: &str,
+        input_id: &str,
+        driver: &mut crate::driver::ephemeral::EphemeralRuntimeDriver,
+        input: crate::input::Input,
+    ) -> Result<crate::accept::AcceptOutcome, rusqlite::Error> {
+        let waker = std::task::Waker::from(Arc::new(PreFloorNoopWake));
+        let mut context = std::task::Context::from_waker(&waker);
+        let mut future = Box::pin(crate::traits::RuntimeDriver::accept_input(driver, input));
+        match std::future::Future::poll(future.as_mut(), &mut context) {
+            std::task::Poll::Ready(result) => result.map_err(|error| {
+                pre_0_8_10_input_import_error(runtime_id, input_id, error.to_string())
+            }),
+            std::task::Poll::Pending => Err(pre_0_8_10_input_import_error(
+                runtime_id,
+                input_id,
+                "generated admission unexpectedly suspended during offline maintenance",
+            )),
+        }
+    }
+
+    struct PreFloorQueuedRow {
+        runtime_id: String,
+        input_id: String,
+        source_bytes: Vec<u8>,
+        stored: StoredInputState,
+    }
+
+    fn register_pre_floor_idempotency_owner(
+        owners: &mut HashSet<(String, String)>,
+        runtime_id: &str,
+        input_id: &str,
+        stored: &StoredInputState,
+    ) -> Result<(), rusqlite::Error> {
+        let Some(key) = stored.state.idempotency_key.as_ref() else {
+            return Ok(());
+        };
+        if owners.insert((runtime_id.to_string(), key.to_string())) {
+            Ok(())
+        } else {
+            Err(pre_0_8_10_input_import_error(
+                runtime_id,
+                input_id,
+                format!("duplicate idempotency owner for key `{key}` within one runtime"),
+            ))
+        }
+    }
+
+    /// Prepare exact pre-0.8.10 runtime input rows for the explicit offline
+    /// schema bridge.
+    ///
+    /// This callback must run while `bridge_unledgered_domain` owns an
+    /// immediate transaction. It accepts only the two shapes proven in the
+    /// affected pre-floor corpus: text-only prompts and simple continuations.
+    /// Every rewritten row is decoded through the current typed persistence
+    /// contract, authorized by the generated machine seed authority, encoded
+    /// canonically, and replaced behind an exact-byte fence. The callback only
+    /// rewrites durable bytes. It neither opens nor resumes a runtime, so
+    /// queued and other nonterminal rows are preserved without replay.
+    pub fn prepare_pre_0_8_10_runtime_input_states(
+        tx: &rusqlite::Transaction<'_>,
+    ) -> Result<meerkat_sqlite::MaintenancePrepareReport, rusqlite::Error> {
+        let ledger_version = meerkat_sqlite::domain_version(tx, RUNTIME_STORE_DOMAIN.name)
+            .map_err(|error| {
+                pre_0_8_10_input_import_error(
+                    RUNTIME_STORE_DOMAIN.name,
+                    "<ledger>",
+                    error.to_string(),
+                )
+            })?;
+        if !matches!(ledger_version, None | Some(1 | 2)) {
+            return Err(pre_0_8_10_input_import_error(
+                RUNTIME_STORE_DOMAIN.name,
+                "<ledger>",
+                format!("unsupported runtime-store ledger version {ledger_version:?}"),
+            ));
+        }
+        let target_current = ledger_version == Some(2);
+        let rows = {
+            let mut statement = tx.prepare(
+                "SELECT inputs.runtime_id, inputs.input_id, inputs.state_json,
+                        typeof(inputs.state_json),
+                        EXISTS (
+                            SELECT 1 FROM runtime_states
+                            WHERE runtime_states.runtime_id = inputs.runtime_id
+                        ),
+                        EXISTS (
+                            SELECT 1 FROM runtime_session_snapshots
+                            WHERE runtime_session_snapshots.runtime_id = inputs.runtime_id
+                        )
+                 FROM runtime_input_states AS inputs
+                 ORDER BY inputs.runtime_id, inputs.input_id",
+            )?;
+            statement
+                .query_map([], |row| {
+                    Ok((
+                        row.get::<_, String>(0)?,
+                        row.get::<_, String>(1)?,
+                        row.get::<_, JsonColumnBytes>(2)?.into_bytes(),
+                        row.get::<_, String>(3)?,
+                        row.get::<_, bool>(4)?,
+                        row.get::<_, bool>(5)?,
+                    ))
+                })?
+                .collect::<Result<Vec<_>, _>>()?
+        };
+
+        let mut replacements = Vec::new();
+        let mut queued_by_runtime =
+            std::collections::BTreeMap::<String, Vec<PreFloorQueuedRow>>::new();
+        let mut queued_history_timestamps = HashSet::new();
+        let mut idempotency_owners = HashSet::new();
+        for (
+            runtime_id,
+            input_id,
+            source_bytes,
+            storage_class,
+            has_runtime_state,
+            has_session_snapshot,
+        ) in rows
+        {
+            if storage_class != "blob" {
+                return Err(pre_0_8_10_input_import_error(
+                    &runtime_id,
+                    &input_id,
+                    format!("state_json storage class is `{storage_class}`, expected `blob`"),
+                ));
+            }
+            if !has_runtime_state || !has_session_snapshot {
+                return Err(pre_0_8_10_input_import_error(
+                    &runtime_id,
+                    &input_id,
+                    format!(
+                        "owning runtime fragments are incomplete: runtime_state={has_runtime_state} session_snapshot={has_session_snapshot}"
+                    ),
+                ));
+            }
+            let mut encoded: serde_json::Value =
+                parse_pre_0_8_10_json(&source_bytes).map_err(|error| {
+                    pre_0_8_10_input_import_error(&runtime_id, &input_id, error.to_string())
+                })?;
+            let version = encoded
+                .as_object()
+                .ok_or_else(|| {
+                    pre_0_8_10_input_import_error(
+                        &runtime_id,
+                        &input_id,
+                        "input-state row is not a JSON object",
+                    )
+                })?
+                .get("stored_input_state_version")
+                .cloned();
+
+            if let Some(version) = version {
+                let version = version.as_u64().ok_or_else(|| {
+                    pre_0_8_10_input_import_error(
+                        &runtime_id,
+                        &input_id,
+                        "stored_input_state_version is not an unsigned integer",
+                    )
+                })?;
+                match version {
+                    3 => {
+                        validate_pre_0_8_10_wire_shape(&runtime_id, &input_id, &encoded, true)?;
+                        let stored: StoredInputState =
+                            serde_json::from_value(encoded).map_err(|error| {
+                                pre_0_8_10_input_import_error(
+                                    &runtime_id,
+                                    &input_id,
+                                    error.to_string(),
+                                )
+                            })?;
+                        validate_pre_0_8_10_row_identity(&runtime_id, &input_id, &stored)?;
+                        register_pre_floor_idempotency_owner(
+                            &mut idempotency_owners,
+                            &runtime_id,
+                            &input_id,
+                            &stored,
+                        )?;
+                        validate_pre_0_8_10_lifecycle(&runtime_id, &input_id, &stored)?;
+                        if stored.seed.phase != crate::input_state::InputLifecycleState::Consumed
+                            || stored.seed.admission_sequence != Some(1_000_000_000)
+                        {
+                            return Err(pre_0_8_10_input_import_error(
+                                &runtime_id,
+                                &input_id,
+                                "released v3 row is not one of the frozen consumed prompt rows with exact admission sequence",
+                            ));
+                        }
+                        let projection = generated_projection_for_pre_0_8_10_row(
+                            &runtime_id,
+                            &input_id,
+                            &stored,
+                        )?;
+                        if stored.state.runtime_semantics != Some(projection.runtime_semantics) {
+                            return Err(pre_0_8_10_input_import_error(
+                                &runtime_id,
+                                &input_id,
+                                "released v3 runtime semantics are not exact generated output",
+                            ));
+                        }
+                        authorize_pre_0_8_10_row(&runtime_id, &input_id, stored)?;
+                    }
+                    5 if target_current => {
+                        let stored: StoredInputState =
+                            serde_json::from_value(encoded).map_err(|error| {
+                                pre_0_8_10_input_import_error(
+                                    &runtime_id,
+                                    &input_id,
+                                    error.to_string(),
+                                )
+                            })?;
+                        validate_pre_0_8_10_row_identity(&runtime_id, &input_id, &stored)?;
+                        register_pre_floor_idempotency_owner(
+                            &mut idempotency_owners,
+                            &runtime_id,
+                            &input_id,
+                            &stored,
+                        )?;
+                        let record = authorize_pre_0_8_10_row(&runtime_id, &input_id, stored)?;
+                        let canonical =
+                            serde_json::to_vec(record.as_stored()).map_err(|error| {
+                                pre_0_8_10_input_import_error(
+                                    &runtime_id,
+                                    &input_id,
+                                    error.to_string(),
+                                )
+                            })?;
+                        if canonical != source_bytes {
+                            return Err(pre_0_8_10_input_import_error(
+                                &runtime_id,
+                                &input_id,
+                                "target-v2 current row is not exact canonical v5 output",
+                            ));
+                        }
+                    }
+                    other => {
+                        return Err(pre_0_8_10_input_import_error(
+                            &runtime_id,
+                            &input_id,
+                            format!(
+                                "stored input state version {other} is not admitted at runtime-store ledger {ledger_version:?}"
+                            ),
+                        ));
+                    }
+                }
+                continue;
+            }
+
+            validate_pre_0_8_10_wire_shape(&runtime_id, &input_id, &encoded, false)?;
+            let row = encoded.as_object_mut().ok_or_else(|| {
+                pre_0_8_10_input_import_error(
+                    &runtime_id,
+                    &input_id,
+                    "input-state row is not a JSON object",
+                )
+            })?;
+            let persisted_input = row
+                .get_mut("persisted_input")
+                .and_then(serde_json::Value::as_object_mut)
+                .ok_or_else(|| {
+                    pre_0_8_10_input_import_error(
+                        &runtime_id,
+                        &input_id,
+                        "row has no persisted input object",
+                    )
+                })?;
+            match persisted_input
+                .get("input_type")
+                .and_then(serde_json::Value::as_str)
+            {
+                Some("prompt") => {
+                    let text = persisted_input.remove("text").ok_or_else(|| {
+                        pre_0_8_10_input_import_error(
+                            &runtime_id,
+                            &input_id,
+                            "legacy prompt has no text owner",
+                        )
+                    })?;
+                    if !text.is_string() {
+                        return Err(pre_0_8_10_input_import_error(
+                            &runtime_id,
+                            &input_id,
+                            "legacy prompt text owner is not a string",
+                        ));
+                    }
+                    persisted_input.insert("content".to_string(), text);
+                }
+                Some("continuation") => {}
+                Some(other) => {
+                    return Err(pre_0_8_10_input_import_error(
+                        &runtime_id,
+                        &input_id,
+                        format!("input type `{other}` is outside the frozen recovery corpus"),
+                    ));
+                }
+                None => {
+                    return Err(pre_0_8_10_input_import_error(
+                        &runtime_id,
+                        &input_id,
+                        "persisted input has no input_type discriminator",
+                    ));
+                }
+            }
+            row.insert(
+                "stored_input_state_version".to_string(),
+                serde_json::json!(3),
+            );
+
+            let stored: StoredInputState = serde_json::from_value(encoded).map_err(|error| {
+                pre_0_8_10_input_import_error(&runtime_id, &input_id, error.to_string())
+            })?;
+            validate_pre_0_8_10_row_identity(&runtime_id, &input_id, &stored)?;
+            register_pre_floor_idempotency_owner(
+                &mut idempotency_owners,
+                &runtime_id,
+                &input_id,
+                &stored,
+            )?;
+            let initial_queue_timestamp =
+                validate_pre_0_8_10_lifecycle(&runtime_id, &input_id, &stored)?;
+            let projection =
+                generated_projection_for_pre_0_8_10_row(&runtime_id, &input_id, &stored)?;
+            let mut stored = stored;
+            stored.state.runtime_semantics = Some(projection.runtime_semantics);
+
+            if stored.seed.phase == crate::input_state::InputLifecycleState::Queued {
+                if !queued_history_timestamps.insert((runtime_id.clone(), initial_queue_timestamp))
+                {
+                    return Err(pre_0_8_10_input_import_error(
+                        &runtime_id,
+                        &input_id,
+                        "duplicate initial QueueAccepted timestamp within one runtime",
+                    ));
+                }
+                queued_by_runtime
+                    .entry(runtime_id.clone())
+                    .or_default()
+                    .push(PreFloorQueuedRow {
+                        runtime_id,
+                        input_id,
+                        source_bytes,
+                        stored,
+                    });
+                continue;
+            }
+
+            let replacement = authorize_pre_0_8_10_row(&runtime_id, &input_id, stored)?;
+            let replacement_bytes =
+                serde_json::to_vec(replacement.as_stored()).map_err(|error| {
+                    pre_0_8_10_input_import_error(&runtime_id, &input_id, error.to_string())
+                })?;
+            replacements.push((runtime_id, input_id, source_bytes, replacement_bytes));
+        }
+
+        for (runtime_id, mut queued) in queued_by_runtime {
+            queued.sort_by(|left, right| left.input_id.cmp(&right.input_id));
+            let mut driver = crate::driver::ephemeral::EphemeralRuntimeDriver::new(
+                crate::identifiers::LogicalRuntimeId::new(runtime_id.clone()),
+            );
+            for mut queued in queued {
+                let input = queued
+                    .stored
+                    .state
+                    .persisted_input
+                    .as_ref()
+                    .ok_or_else(|| {
+                        pre_0_8_10_input_import_error(
+                            &queued.runtime_id,
+                            &queued.input_id,
+                            "validated queued row lost its persisted input",
+                        )
+                    })?
+                    .clone();
+                let durable_policy = queued
+                    .stored
+                    .state
+                    .policy
+                    .as_ref()
+                    .ok_or_else(|| {
+                        pre_0_8_10_input_import_error(
+                            &queued.runtime_id,
+                            &queued.input_id,
+                            "validated queued row lost its policy snapshot",
+                        )
+                    })?
+                    .decision
+                    .clone();
+                let durable_semantics = queued.stored.state.runtime_semantics.ok_or_else(|| {
+                    pre_0_8_10_input_import_error(
+                        &queued.runtime_id,
+                        &queued.input_id,
+                        "validated queued row lost its runtime semantics",
+                    )
+                })?;
+                let outcome = accept_pre_0_8_10_input_immediately(
+                    &queued.runtime_id,
+                    &queued.input_id,
+                    &mut driver,
+                    input.clone(),
+                )?;
+                let crate::accept::AcceptOutcome::Accepted {
+                    input_id: admitted_input_id,
+                    policy,
+                    state,
+                    seed,
+                } = outcome
+                else {
+                    return Err(pre_0_8_10_input_import_error(
+                        &queued.runtime_id,
+                        &queued.input_id,
+                        "generated admission did not accept the frozen queued input",
+                    ));
+                };
+                let emitted_semantics = state.runtime_semantics.ok_or_else(|| {
+                    pre_0_8_10_input_import_error(
+                        &queued.runtime_id,
+                        &queued.input_id,
+                        "generated admission emitted no runtime semantics",
+                    )
+                })?;
+                let predecessor_lane = crate::accept::handling_mode_from_policy(&durable_policy);
+                let requested_lane = input
+                    .handling_mode()
+                    .unwrap_or(meerkat_core::types::HandlingMode::Queue);
+                // These lane comparisons authenticate agreement among the
+                // frozen policy, input request, and generated result. They do
+                // not mint successor authority: the only lane and sequence
+                // copied below come from the generated driver's seed.
+                if admitted_input_id != queued.stored.state.input_id
+                    || policy != durable_policy
+                    || emitted_semantics != durable_semantics
+                    || requested_lane != predecessor_lane
+                    || seed.phase != crate::input_state::InputLifecycleState::Queued
+                    || seed.attempt_count != 0
+                    || seed.terminal_outcome.is_some()
+                    || seed.last_run_id.is_some()
+                    || seed.last_boundary_sequence.is_some()
+                    || seed.recovery_lane != Some(predecessor_lane)
+                    || seed.admission_sequence.is_none()
+                {
+                    return Err(pre_0_8_10_input_import_error(
+                        &queued.runtime_id,
+                        &queued.input_id,
+                        "generated admission witnesses disagree with frozen policy, semantics, identity, or lane",
+                    ));
+                }
+                queued.stored.seed.recovery_lane = seed.recovery_lane;
+                queued.stored.seed.admission_sequence = seed.admission_sequence;
+                let replacement =
+                    authorize_pre_0_8_10_row(&queued.runtime_id, &queued.input_id, queued.stored)?;
+                let replacement_bytes =
+                    serde_json::to_vec(replacement.as_stored()).map_err(|error| {
+                        pre_0_8_10_input_import_error(
+                            &queued.runtime_id,
+                            &queued.input_id,
+                            error.to_string(),
+                        )
+                    })?;
+                replacements.push((
+                    queued.runtime_id,
+                    queued.input_id,
+                    queued.source_bytes,
+                    replacement_bytes,
+                ));
+            }
+        }
+
+        let changed = replacements.len();
+        for (runtime_id, input_id, source_bytes, replacement_bytes) in replacements {
+            let changed = tx.execute(
+                "UPDATE runtime_input_states
+                 SET state_json = ?1
+                 WHERE runtime_id = ?2 AND input_id = ?3 AND state_json = ?4",
+                params![replacement_bytes, &runtime_id, &input_id, &source_bytes],
+            )?;
+            if changed != 1 {
+                return Err(pre_0_8_10_input_import_error(
+                    &runtime_id,
+                    &input_id,
+                    "source row changed inside the maintenance transaction",
+                ));
+            }
+            let successor = tx.query_row(
+                "SELECT state_json FROM runtime_input_states
+                 WHERE runtime_id = ?1 AND input_id = ?2",
+                params![&runtime_id, &input_id],
+                |row| Ok(row.get::<_, JsonColumnBytes>(0)?.into_bytes()),
+            )?;
+            if successor != replacement_bytes {
+                return Err(pre_0_8_10_input_import_error(
+                    &runtime_id,
+                    &input_id,
+                    "successor row differs from the exact authorized bytes after update",
+                ));
+            }
+        }
+        Ok(meerkat_sqlite::MaintenancePrepareReport { changed })
+    }
+
     fn migration_0001_runtime_schema(
         tx: &rusqlite::Transaction<'_>,
     ) -> Result<(), rusqlite::Error> {
@@ -1192,6 +2984,11 @@ END";
     fn migration_0002_current_runtime_schema(
         tx: &rusqlite::Transaction<'_>,
     ) -> Result<(), rusqlite::Error> {
+        // Some exact pre-ledger predecessors were last opened before mob host
+        // persistence added these idempotent base tables. Materialize them in
+        // the version-2 transaction so both authenticated version-1 catalogs
+        // converge on the same current schema.
+        tx.execute_batch(CREATE_RUNTIME_MOB_HOST_SCHEMA_SQL)?;
         migrate_released_context_append_input_payloads(tx)?;
         retire_released_terminal_input_payloads(tx)?;
         tx.execute_batch(CREATE_RUNTIME_SESSION_AUTHORITY_SQL)?;
@@ -1221,6 +3018,45 @@ END";
         migration_0001_runtime_schema(tx)?;
         migration_0002_current_runtime_schema(tx)
     }
+
+    const PRE_MOB_HOST_RUNTIME_OBJECTS: &[meerkat_sqlite::SchemaObject] = &[
+        meerkat_sqlite::SchemaObject {
+            kind: meerkat_sqlite::SchemaObjectKind::Table,
+            name: "runtime_input_states",
+        },
+        meerkat_sqlite::SchemaObject {
+            kind: meerkat_sqlite::SchemaObjectKind::Table,
+            name: "runtime_boundary_receipts",
+        },
+        meerkat_sqlite::SchemaObject {
+            kind: meerkat_sqlite::SchemaObjectKind::Table,
+            name: "runtime_session_snapshots",
+        },
+        meerkat_sqlite::SchemaObject {
+            kind: meerkat_sqlite::SchemaObjectKind::Table,
+            name: "runtime_states",
+        },
+        meerkat_sqlite::SchemaObject {
+            kind: meerkat_sqlite::SchemaObjectKind::Table,
+            name: "runtime_ops_lifecycle",
+        },
+        meerkat_sqlite::SchemaObject {
+            kind: meerkat_sqlite::SchemaObjectKind::Table,
+            name: "runtime_retired_ops_epochs",
+        },
+        meerkat_sqlite::SchemaObject {
+            kind: meerkat_sqlite::SchemaObjectKind::Table,
+            name: "runtime_auth_oauth_flow_state",
+        },
+        meerkat_sqlite::SchemaObject {
+            kind: meerkat_sqlite::SchemaObjectKind::Table,
+            name: "runtime_projection_quarantine",
+        },
+        meerkat_sqlite::SchemaObject {
+            kind: meerkat_sqlite::SchemaObjectKind::Table,
+            name: "runtime_compaction_projection_outbox",
+        },
+    ];
 
     const RELEASED_0_8_10_RUNTIME_OBJECTS: &[meerkat_sqlite::SchemaObject] = &[
         meerkat_sqlite::SchemaObject {
@@ -1269,13 +3105,36 @@ END";
         },
     ];
 
+    fn build_pre_mob_host_runtime_schema(
+        tx: &rusqlite::Transaction<'_>,
+    ) -> Result<(), rusqlite::Error> {
+        tx.execute_batch(CREATE_PRE_MOB_HOST_RUNTIME_SCHEMA_SQL)
+    }
+
     fn verify_released_0_8_10_runtime_schema(conn: &Connection) -> Result<(), String> {
-        meerkat_sqlite::verify_released_schema_fingerprint(
+        let released_error = match meerkat_sqlite::verify_released_schema_fingerprint(
             conn,
             &RUNTIME_STORE_DOMAIN,
             RELEASED_0_8_10_RUNTIME_OBJECTS,
             migration_0001_runtime_schema,
-        )
+        ) {
+            Ok(()) => return Ok(()),
+            Err(error) => error,
+        };
+
+        match meerkat_sqlite::verify_released_schema_fingerprint(
+            conn,
+            &RUNTIME_STORE_DOMAIN,
+            PRE_MOB_HOST_RUNTIME_OBJECTS,
+            build_pre_mob_host_runtime_schema,
+        ) {
+            Ok(()) => Ok(()),
+            Err(pre_mob_error) => Err(format!(
+                "catalog matches neither exact released 0.8.10 runtime schema \
+                 ({released_error}) nor \
+                 exact pre-mob-host runtime schema ({pre_mob_error})"
+            )),
+        }
     }
 
     /// The runtime store's schema domain in the per-file migration ledger.
@@ -1593,6 +3452,26 @@ END";
             conn
         }
 
+        fn pre_mob_host_unledgered_v1() -> Connection {
+            let mut conn = Connection::open_in_memory().expect("open");
+            let tx = conn.transaction().expect("tx");
+            build_pre_mob_host_runtime_schema(&tx).expect("pre-mob-host schema");
+            tx.commit().expect("commit");
+            conn
+        }
+
+        fn table_exists(conn: &Connection, table: &str) -> bool {
+            conn.query_row(
+                "SELECT EXISTS(
+                     SELECT 1 FROM main.sqlite_schema
+                     WHERE type = 'table' AND name = ?1
+                 )",
+                [table],
+                |row| row.get::<_, bool>(0),
+            )
+            .expect("table presence")
+        }
+
         #[test]
         fn exact_released_v1_upgrades_to_current() {
             let mut conn = released_v1();
@@ -1600,6 +3479,69 @@ END";
                 .expect("upgrade");
             assert_eq!(report.from_version, 1);
             assert_eq!(report.to_version, 2);
+        }
+
+        #[test]
+        fn exact_pre_mob_host_unledgered_v1_bridges_to_current() {
+            let mut conn = pre_mob_host_unledgered_v1();
+            let report = meerkat_sqlite::bridge_unledgered_domain(
+                &mut conn,
+                &RUNTIME_STORE_DOMAIN,
+                RUNTIME_STORE_DOMAIN.supported_version(),
+                &[1],
+                Some(prepare_pre_0_8_10_runtime_input_states),
+            )
+            .expect("bridge exact pre-mob-host predecessor");
+
+            assert_eq!(report.from_version, 1);
+            assert_eq!(report.to_version, 2);
+            assert_eq!(report.prepared, 0);
+            assert_eq!(
+                meerkat_sqlite::domain_version(&conn, RUNTIME_STORE_DOMAIN.name).expect("ledger"),
+                Some(2)
+            );
+            assert!(table_exists(&conn, "runtime_mob_host_bindings"));
+            assert!(table_exists(&conn, "runtime_mob_host_revocations"));
+            meerkat_sqlite::preflight_schema_eligibility(&conn, &RUNTIME_STORE_DOMAIN)
+                .expect("current catalog");
+        }
+
+        #[test]
+        fn near_miss_pre_mob_host_catalog_is_refused_without_mutation() {
+            let mut conn = pre_mob_host_unledgered_v1();
+            conn.execute_batch("ALTER TABLE runtime_states ADD COLUMN candidate_only BLOB")
+                .expect("near-miss catalog");
+
+            let error = meerkat_sqlite::bridge_unledgered_domain(
+                &mut conn,
+                &RUNTIME_STORE_DOMAIN,
+                RUNTIME_STORE_DOMAIN.supported_version(),
+                &[1],
+                Some(prepare_pre_0_8_10_runtime_input_states),
+            )
+            .expect_err("refuse unauthenticated catalog");
+
+            assert!(matches!(
+                error,
+                meerkat_sqlite::SqliteStoreError::UnledgeredSchemaNoMatch { .. }
+            ));
+            assert_eq!(
+                meerkat_sqlite::domain_version(&conn, RUNTIME_STORE_DOMAIN.name).expect("ledger"),
+                None
+            );
+            assert!(!table_exists(&conn, "runtime_mob_host_bindings"));
+            assert!(!table_exists(&conn, "runtime_mob_host_revocations"));
+            let columns = conn
+                .prepare("PRAGMA table_info(runtime_states)")
+                .expect("prepare")
+                .query_map([], |row| row.get::<_, String>(1))
+                .expect("query")
+                .collect::<Result<Vec<_>, _>>()
+                .expect("columns");
+            assert_eq!(
+                columns,
+                vec!["runtime_id", "runtime_state_json", "candidate_only"]
+            );
         }
 
         #[test]
@@ -1625,6 +3567,769 @@ END";
                     Some(1)
                 );
             }
+        }
+    }
+
+    #[cfg(test)]
+    mod pre_0_8_10_input_bridge_tests {
+        use super::*;
+        use crate::input::{Input, InputDurability};
+        use crate::input_state::{InputLifecycleState, StoredInputState};
+        use meerkat_core::types::HandlingMode;
+
+        const LOW_INPUT_ID: &str = "019e20e6-b011-7000-8000-000000000001";
+        const HIGH_INPUT_ID: &str = "019e20e6-b011-7000-8000-000000000002";
+        const THIRD_INPUT_ID: &str = "019e20e6-b011-7000-8000-000000000003";
+        const RUN_ID: &str = "019e20e6-b011-7000-8000-100000000001";
+
+        fn prompt_policy() -> serde_json::Value {
+            serde_json::json!({
+                "version": 1,
+                "decision": {
+                    "apply_mode": "stage_run_start",
+                    "wake_mode": "wake_if_idle",
+                    "queue_mode": "fifo",
+                    "consume_point": "on_run_complete",
+                    "drain_policy": "queue_next_turn",
+                    "routing_disposition": "queue",
+                    "record_transcript": true,
+                    "emit_operator_content": true,
+                    "policy_version": 1
+                }
+            })
+        }
+
+        fn continuation_policy() -> serde_json::Value {
+            serde_json::json!({
+                "version": 1,
+                "decision": {
+                    "apply_mode": "stage_run_boundary",
+                    "wake_mode": "wake_if_idle",
+                    "queue_mode": "fifo",
+                    "consume_point": "on_run_complete",
+                    "drain_policy": "steer_batch",
+                    "routing_disposition": "steer",
+                    "record_transcript": false,
+                    "emit_operator_content": false,
+                    "policy_version": 1
+                }
+            })
+        }
+
+        fn legacy_prompt_row_with(
+            input_id: &str,
+            queue_timestamp: &str,
+            turn_metadata: Option<serde_json::Value>,
+        ) -> (String, Vec<u8>) {
+            let mut persisted_input = serde_json::json!({
+                "input_type": "prompt",
+                "header": {
+                    "id": input_id,
+                    "timestamp": "2026-05-13T10:00:00.000000Z",
+                    "source": { "type": "operator" },
+                    "durability": "durable",
+                    "visibility": {
+                        "transcript_eligible": true,
+                        "operator_eligible": true
+                    }
+                },
+                "text": "queued prompt"
+            });
+            if let Some(turn_metadata) = turn_metadata {
+                persisted_input["turn_metadata"] = turn_metadata;
+            }
+            let row = serde_json::json!({
+                "input_id": input_id,
+                "current_state": "queued",
+                "policy": prompt_policy(),
+                "runtime_semantics": {
+                    "boundary": "run_start",
+                    "execution_kind": "content_turn",
+                    "peer_response_terminal_apply_intent": null
+                },
+                "durability": "durable",
+                "attempt_count": 0,
+                "recovery_count": 0,
+                "history": [{
+                    "timestamp": queue_timestamp,
+                    "from": "accepted",
+                    "to": "queued",
+                    "reason": "QueueAccepted"
+                }],
+                "persisted_input": persisted_input,
+                "created_at": "2026-05-13T10:00:00.000100Z",
+                "updated_at": queue_timestamp
+            });
+            (
+                input_id.to_string(),
+                serde_json::to_vec(&row).expect("legacy prompt row"),
+            )
+        }
+
+        fn legacy_prompt_row() -> (String, Vec<u8>) {
+            legacy_prompt_row_with(HIGH_INPUT_ID, "2026-05-13T10:00:00.000200Z", None)
+        }
+
+        fn legacy_continuation_row_with(
+            input_id: &str,
+            queue_timestamp: &str,
+        ) -> (String, Vec<u8>) {
+            let row = serde_json::json!({
+                "input_id": input_id,
+                "current_state": "queued",
+                "policy": continuation_policy(),
+                "runtime_semantics": {
+                    "boundary": "run_checkpoint",
+                    "execution_kind": "resume_pending",
+                    "peer_response_terminal_apply_intent": null
+                },
+                "durability": "derived",
+                "attempt_count": 1,
+                "recovery_count": 0,
+                "history": [
+                    {
+                        "timestamp": queue_timestamp,
+                        "from": "accepted",
+                        "to": "queued",
+                        "reason": "QueueAccepted"
+                    },
+                    {
+                        "timestamp": "2026-05-13T10:00:00.000500Z",
+                        "from": "queued",
+                        "to": "staged",
+                        "reason": format!("StageForRun({RUN_ID})")
+                    },
+                    {
+                        "timestamp": "2026-05-13T10:00:00.000600Z",
+                        "from": "staged",
+                        "to": "queued",
+                        "reason": "RollbackStaged"
+                    }
+                ],
+                "persisted_input": {
+                    "input_type": "continuation",
+                    "header": {
+                        "id": input_id,
+                        "timestamp": "2026-05-13T10:00:00.000000Z",
+                        "source": { "type": "system" },
+                        "durability": "derived",
+                        "visibility": {
+                            "transcript_eligible": false,
+                            "operator_eligible": false
+                        }
+                    },
+                    "reason": "detached_background_op_completed",
+                    "handling_mode": "steer"
+                },
+                "created_at": "2026-05-13T10:00:00.000100Z",
+                "updated_at": "2026-05-13T10:00:00.000600Z"
+            });
+            (
+                input_id.to_string(),
+                serde_json::to_vec(&row).expect("legacy continuation row"),
+            )
+        }
+
+        fn legacy_continuation_row() -> (String, Vec<u8>) {
+            legacy_continuation_row_with(LOW_INPUT_ID, "2026-05-13T10:00:00.000300Z")
+        }
+
+        fn released_v3_consumed_prompt_row(input_id: &str) -> (String, Vec<u8>) {
+            let row = serde_json::json!({
+                "stored_input_state_version": 3,
+                "input_id": input_id,
+                "current_state": "consumed",
+                "policy": prompt_policy(),
+                "runtime_semantics": {
+                    "boundary": "run_start",
+                    "execution_kind": "content_turn",
+                    "execution_handling_mode": null,
+                    "peer_response_terminal_apply_intent": null,
+                    "live_interrupt_required": false
+                },
+                "terminal_outcome": { "outcome_type": "consumed" },
+                "durability": "durable",
+                "attempt_count": 1,
+                "recovery_count": 0,
+                "history": [
+                    {
+                        "timestamp": "2026-05-13T10:00:00.000200Z",
+                        "from": "accepted",
+                        "to": "queued",
+                        "reason": "QueueAccepted"
+                    },
+                    {
+                        "timestamp": "2026-05-13T10:00:00.000300Z",
+                        "from": "queued",
+                        "to": "staged",
+                        "reason": format!("StageForRun({RUN_ID})")
+                    },
+                    {
+                        "timestamp": "2026-05-13T10:00:00.000400Z",
+                        "from": "staged",
+                        "to": "applied",
+                        "reason": format!("MarkApplied({RUN_ID})")
+                    },
+                    {
+                        "timestamp": "2026-05-13T10:00:00.000400Z",
+                        "from": "applied",
+                        "to": "applied_pending_consumption",
+                        "reason": "MarkAppliedPendingConsumption(boundary_sequence=0)"
+                    },
+                    {
+                        "timestamp": "2026-05-13T10:00:00.000500Z",
+                        "from": "applied_pending_consumption",
+                        "to": "consumed",
+                        "reason": "Consume"
+                    }
+                ],
+                "persisted_input": {
+                    "input_type": "prompt",
+                    "header": {
+                        "id": input_id,
+                        "timestamp": "2026-05-13T10:00:00.000000Z",
+                        "source": { "type": "operator" },
+                        "durability": "durable",
+                        "visibility": {
+                            "transcript_eligible": true,
+                            "operator_eligible": true
+                        }
+                    },
+                    "content": "released v3 prompt",
+                    "turn_metadata": {}
+                },
+                "last_run_id": RUN_ID,
+                "last_boundary_sequence": 0,
+                "admission_sequence": 1000000000,
+                "created_at": "2026-05-13T10:00:00.000100Z",
+                "updated_at": "2026-05-13T10:00:00.000500Z"
+            });
+            (
+                input_id.to_string(),
+                serde_json::to_vec(&row).expect("released v3 row"),
+            )
+        }
+
+        fn insert_row(conn: &Connection, runtime_id: &str, input_id: &str, bytes: &[u8]) {
+            conn.execute(
+                "INSERT OR IGNORE INTO runtime_states (runtime_id, runtime_state_json)
+                 VALUES (?1, ?2)",
+                params![runtime_id, b"{}".as_slice()],
+            )
+            .expect("insert runtime owner");
+            conn.execute(
+                "INSERT OR IGNORE INTO runtime_session_snapshots (runtime_id, session_snapshot)
+                 VALUES (?1, ?2)",
+                params![runtime_id, b"{}".as_slice()],
+            )
+            .expect("insert session owner");
+            conn.execute(
+                "INSERT INTO runtime_input_states (runtime_id, input_id, state_json)
+                 VALUES (?1, ?2, ?3)",
+                params![runtime_id, input_id, bytes],
+            )
+            .expect("insert row");
+        }
+
+        fn load_row(conn: &Connection, runtime_id: &str, input_id: &str) -> Vec<u8> {
+            conn.query_row(
+                "SELECT state_json FROM runtime_input_states
+                 WHERE runtime_id = ?1 AND input_id = ?2",
+                params![runtime_id, input_id],
+                |row| Ok(row.get::<_, JsonColumnBytes>(0)?.into_bytes()),
+            )
+            .expect("load row")
+        }
+
+        #[test]
+        fn maintenance_prepare_canonicalizes_exact_prompt_and_continuation_without_replay() {
+            let mut conn = Connection::open_in_memory().expect("open");
+            conn.execute_batch(CREATE_RUNTIME_SCHEMA_SQL)
+                .expect("runtime v1 schema");
+            let (prompt_id, prompt_source) = legacy_prompt_row();
+            let (continuation_id, continuation_source) = legacy_continuation_row();
+            let (metadata_id, metadata_source) = legacy_prompt_row_with(
+                THIRD_INPUT_ID,
+                "2026-05-13T10:00:00.000700Z",
+                Some(serde_json::json!({
+                    "additional_instructions": [{
+                        "kind": "system",
+                        "body": "This is a scheduled run."
+                    }]
+                })),
+            );
+            insert_row(&conn, "runtime", &prompt_id, &prompt_source);
+            insert_row(&conn, "runtime", &continuation_id, &continuation_source);
+            insert_row(&conn, "metadata-runtime", &metadata_id, &metadata_source);
+            let (v3_id, v3_bytes) =
+                released_v3_consumed_prompt_row("019e20e6-b011-7000-8000-000000000004");
+            insert_row(&conn, "v3-runtime", &v3_id, &v3_bytes);
+
+            let tx = conn.transaction().expect("tx");
+            let report =
+                prepare_pre_0_8_10_runtime_input_states(&tx).expect("prepare exact corpus");
+            assert_eq!(report.changed, 3);
+            tx.commit().expect("commit");
+
+            let prompt_bytes = load_row(&conn, "runtime", &prompt_id);
+            let prompt: StoredInputState =
+                serde_json::from_slice(&prompt_bytes).expect("decode canonical prompt");
+            assert_eq!(prompt.seed.phase, InputLifecycleState::Queued);
+            assert_eq!(prompt.seed.recovery_lane, Some(HandlingMode::Queue));
+            assert!(prompt.seed.admission_sequence.is_some());
+            assert!(matches!(
+                prompt.state.persisted_input.as_ref(),
+                Some(Input::Prompt(prompt))
+                    if prompt.content == meerkat_core::types::ContentInput::Text(
+                        "queued prompt".to_string()
+                    )
+            ));
+            assert_eq!(
+                prompt_bytes,
+                serde_json::to_vec(&prompt).expect("canonical prompt bytes")
+            );
+
+            let continuation_bytes = load_row(&conn, "runtime", &continuation_id);
+            let continuation: StoredInputState =
+                serde_json::from_slice(&continuation_bytes).expect("decode canonical continuation");
+            assert_eq!(continuation.seed.phase, InputLifecycleState::Queued);
+            assert_eq!(continuation.seed.recovery_lane, Some(HandlingMode::Steer));
+            assert!(
+                continuation.seed.admission_sequence < prompt.seed.admission_sequence,
+                "v0.6.34 input_id order must override inverse QueueAccepted timestamp order"
+            );
+            assert!(matches!(
+                continuation.state.persisted_input.as_ref(),
+                Some(Input::Continuation(continuation))
+                    if continuation.reason == "detached_background_op_completed"
+            ));
+            assert_eq!(
+                continuation_bytes,
+                serde_json::to_vec(&continuation).expect("canonical continuation bytes")
+            );
+            assert_eq!(
+                load_row(&conn, "v3-runtime", &v3_id),
+                v3_bytes,
+                "released v3 rows remain byte-identical"
+            );
+
+            let mut recovered = crate::driver::ephemeral::EphemeralRuntimeDriver::new(
+                crate::identifiers::LogicalRuntimeId::new("runtime"),
+            );
+            for stored in [continuation.clone(), prompt.clone()] {
+                recovered
+                    .recover_input_state_persistence_record(stored)
+                    .expect("current persistent recovery accepts imported row");
+            }
+            assert_eq!(
+                recovered.admission_order(),
+                vec![
+                    continuation.state.input_id.clone(),
+                    prompt.state.input_id.clone()
+                ]
+            );
+            assert_eq!(
+                recovered.input_recovery_lane(&continuation.state.input_id),
+                Some(HandlingMode::Steer)
+            );
+            assert_eq!(
+                recovered.input_recovery_lane(&prompt.state.input_id),
+                Some(HandlingMode::Queue)
+            );
+        }
+
+        #[test]
+        fn maintenance_prepare_refuses_ambiguous_shape_before_any_row_mutation() {
+            let mut conn = Connection::open_in_memory().expect("open");
+            conn.execute_batch(CREATE_RUNTIME_SCHEMA_SQL)
+                .expect("runtime v1 schema");
+            let (valid_id, valid_source) = legacy_prompt_row();
+            let (invalid_id, invalid_source) = legacy_prompt_row();
+            let mut invalid: serde_json::Value =
+                serde_json::from_slice(&invalid_source).expect("invalid candidate");
+            invalid["persisted_input"]["content"] = serde_json::json!("second owner");
+            let invalid_source = serde_json::to_vec(&invalid).expect("ambiguous row");
+            insert_row(&conn, "a-runtime", &valid_id, &valid_source);
+            insert_row(&conn, "z-runtime", &invalid_id, &invalid_source);
+
+            let tx = conn.transaction().expect("tx");
+            let error = prepare_pre_0_8_10_runtime_input_states(&tx)
+                .expect_err("ambiguous prompt must refuse");
+            assert!(error.to_string().contains("unsupported fields"));
+            tx.commit()
+                .expect("validation failure must leave the transaction committable");
+
+            assert_eq!(load_row(&conn, "a-runtime", &valid_id), valid_source);
+            assert_eq!(load_row(&conn, "z-runtime", &invalid_id), invalid_source);
+        }
+
+        #[test]
+        fn maintenance_prepare_refuses_non_simple_continuation_and_non_null_blocks() {
+            for (label, mutate) in [
+                (
+                    "continuation-sidecar",
+                    (|value: &mut serde_json::Value| {
+                        value["persisted_input"]["request_id"] = serde_json::json!("request-1");
+                    }) as fn(&mut serde_json::Value),
+                ),
+                (
+                    "multimodal-prompt",
+                    (|value: &mut serde_json::Value| {
+                        value["persisted_input"]["blocks"] = serde_json::json!([]);
+                    }) as fn(&mut serde_json::Value),
+                ),
+                ("explicit-null-blocks", |value: &mut serde_json::Value| {
+                    value["persisted_input"]["blocks"] = serde_json::Value::Null;
+                }),
+            ] {
+                let mut conn = Connection::open_in_memory().expect("open");
+                conn.execute_batch(CREATE_RUNTIME_SCHEMA_SQL)
+                    .expect("runtime v1 schema");
+                let (input_id, source) = if label == "continuation-sidecar" {
+                    legacy_continuation_row()
+                } else {
+                    legacy_prompt_row()
+                };
+                let mut candidate: serde_json::Value =
+                    serde_json::from_slice(&source).expect("candidate");
+                mutate(&mut candidate);
+                let candidate = serde_json::to_vec(&candidate).expect("candidate bytes");
+                insert_row(&conn, "runtime", &input_id, &candidate);
+
+                let tx = conn.transaction().expect("tx");
+                let error = prepare_pre_0_8_10_runtime_input_states(&tx)
+                    .expect_err("unsupported legacy shape must refuse");
+                assert!(
+                    error.to_string().contains("unsupported fields")
+                        || error.to_string().contains("multimodal legacy prompt"),
+                    "unexpected {label} error: {error}"
+                );
+            }
+        }
+
+        #[test]
+        fn maintenance_prepare_refuses_duplicate_nested_keys_without_mutation() {
+            let mut conn = Connection::open_in_memory().expect("open");
+            conn.execute_batch(CREATE_RUNTIME_SCHEMA_SQL)
+                .expect("runtime v1 schema");
+            let (input_id, source) = legacy_prompt_row();
+            let source = String::from_utf8(source).expect("JSON text");
+            let duplicated = source.replacen(
+                "\"persisted_input\":{",
+                "\"persisted_input\":{\"input_type\":\"prompt\",",
+                1,
+            );
+            assert_ne!(duplicated, source, "fixture must inject a duplicate key");
+            insert_row(&conn, "runtime", &input_id, duplicated.as_bytes());
+
+            let tx = conn.transaction().expect("tx");
+            let error = prepare_pre_0_8_10_runtime_input_states(&tx)
+                .expect_err("duplicate object key must refuse");
+            assert!(error.to_string().contains("duplicate JSON object key"));
+            tx.commit()
+                .expect("duplicate-key preflight must leave the transaction committable");
+            assert_eq!(load_row(&conn, "runtime", &input_id), duplicated.as_bytes());
+        }
+
+        #[test]
+        fn maintenance_prepare_refuses_v4_and_preexisting_v5_at_source_boundary() {
+            for version in [4, 5] {
+                let mut conn = Connection::open_in_memory().expect("open");
+                conn.execute_batch(CREATE_RUNTIME_SCHEMA_SQL)
+                    .expect("runtime v1 schema");
+                let (input_id, source) = legacy_prompt_row();
+                let mut candidate: serde_json::Value =
+                    serde_json::from_slice(&source).expect("candidate");
+                candidate["stored_input_state_version"] = serde_json::json!(version);
+                let candidate = serde_json::to_vec(&candidate).expect("candidate bytes");
+                insert_row(&conn, "runtime", &input_id, &candidate);
+
+                let tx = conn.transaction().expect("tx");
+                let error = prepare_pre_0_8_10_runtime_input_states(&tx)
+                    .expect_err("preexisting current version must refuse at source boundary");
+                assert!(error.to_string().contains(&format!("version {version}")));
+                tx.commit().expect("refusal leaves transaction committable");
+                assert_eq!(load_row(&conn, "runtime", &input_id), candidate);
+            }
+        }
+
+        #[test]
+        fn maintenance_prepare_refuses_tampered_or_nonterminal_released_v3_rows() {
+            for (label, mutate) in [
+                (
+                    "nonterminal",
+                    (|value: &mut serde_json::Value| {
+                        value["current_state"] = serde_json::json!("queued");
+                    }) as fn(&mut serde_json::Value),
+                ),
+                ("semantic-tamper", |value: &mut serde_json::Value| {
+                    value["runtime_semantics"]["live_interrupt_required"] = serde_json::json!(true);
+                }),
+                (
+                    "null-admission-sequence",
+                    |value: &mut serde_json::Value| {
+                        value["admission_sequence"] = serde_json::Value::Null;
+                    },
+                ),
+                (
+                    "terminal-invalid-carrier",
+                    |value: &mut serde_json::Value| {
+                        value["durability"] = serde_json::json!("derived");
+                        value["persisted_input"]["header"]["durability"] =
+                            serde_json::json!("derived");
+                    },
+                ),
+            ] {
+                let mut conn = Connection::open_in_memory().expect("open");
+                conn.execute_batch(CREATE_RUNTIME_SCHEMA_SQL)
+                    .expect("runtime v1 schema");
+                let (input_id, source) = released_v3_consumed_prompt_row(THIRD_INPUT_ID);
+                let mut candidate: serde_json::Value =
+                    serde_json::from_slice(&source).expect("candidate");
+                mutate(&mut candidate);
+                let candidate = serde_json::to_vec(&candidate).expect("candidate bytes");
+                insert_row(&conn, "runtime", &input_id, &candidate);
+
+                let tx = conn.transaction().expect("tx");
+                let error = prepare_pre_0_8_10_runtime_input_states(&tx)
+                    .expect_err("tampered released v3 must refuse");
+                tx.commit().expect("refusal leaves transaction committable");
+                assert_eq!(load_row(&conn, "runtime", &input_id), candidate);
+                assert!(!error.to_string().is_empty(), "empty {label} error");
+            }
+        }
+
+        #[test]
+        fn maintenance_prepare_refuses_text_storage_for_released_v3_bytes() {
+            let mut conn = Connection::open_in_memory().expect("open");
+            conn.execute_batch(CREATE_RUNTIME_SCHEMA_SQL)
+                .expect("runtime v1 schema");
+            let (input_id, source) = released_v3_consumed_prompt_row(THIRD_INPUT_ID);
+            insert_row(&conn, "runtime", &input_id, &source);
+            let source_text = String::from_utf8(source.clone()).expect("source text");
+            conn.execute(
+                "UPDATE runtime_input_states SET state_json = ?1
+                 WHERE runtime_id = 'runtime' AND input_id = ?2",
+                params![source_text, &input_id],
+            )
+            .expect("store as SQLite TEXT");
+
+            let tx = conn.transaction().expect("tx");
+            let error = prepare_pre_0_8_10_runtime_input_states(&tx)
+                .expect_err("TEXT storage class must refuse");
+            assert!(error.to_string().contains("storage class is `text`"));
+            tx.commit().expect("refusal leaves transaction committable");
+            assert_eq!(
+                conn.query_row(
+                    "SELECT typeof(state_json) FROM runtime_input_states
+                     WHERE runtime_id = 'runtime' AND input_id = ?1",
+                    params![&input_id],
+                    |row| row.get::<_, String>(0),
+                )
+                .expect("storage class"),
+                "text"
+            );
+        }
+
+        #[test]
+        fn maintenance_prepare_target_v2_rerun_accepts_only_its_canonical_v5_successor() {
+            let mut conn = Connection::open_in_memory().expect("open");
+            conn.execute_batch(CREATE_RUNTIME_SCHEMA_SQL)
+                .expect("runtime v1 schema");
+            let (input_id, source) = legacy_prompt_row();
+            insert_row(&conn, "runtime", &input_id, &source);
+
+            let tx = conn.transaction().expect("first tx");
+            assert_eq!(
+                prepare_pre_0_8_10_runtime_input_states(&tx)
+                    .expect("first prepare")
+                    .changed,
+                1
+            );
+            tx.commit().expect("first commit");
+            let successor = load_row(&conn, "runtime", &input_id);
+            assert_eq!(
+                serde_json::from_slice::<serde_json::Value>(&successor).expect("successor json")["stored_input_state_version"],
+                5
+            );
+
+            conn.execute_batch(
+                "CREATE TABLE meerkat_schema (
+                     domain TEXT PRIMARY KEY,
+                     version INTEGER NOT NULL
+                 );
+                 INSERT INTO meerkat_schema (domain, version)
+                 VALUES ('runtime-store', 2);",
+            )
+            .expect("target ledger");
+            let tx = conn.transaction().expect("rerun tx");
+            assert_eq!(
+                prepare_pre_0_8_10_runtime_input_states(&tx)
+                    .expect("target-v2 rerun")
+                    .changed,
+                0
+            );
+            tx.commit().expect("rerun commit");
+            assert_eq!(load_row(&conn, "runtime", &input_id), successor);
+        }
+
+        #[test]
+        fn maintenance_prepare_refuses_nested_unknown_null_and_crossbinds_without_mutation() {
+            for (label, mutate) in [
+                (
+                    "nested-instruction-unknown",
+                    (|value: &mut serde_json::Value| {
+                        value["persisted_input"]["turn_metadata"] = serde_json::json!({
+                            "additional_instructions": [{
+                                "kind": "system",
+                                "body": "frozen",
+                                "unknown": true
+                            }]
+                        });
+                    }) as fn(&mut serde_json::Value),
+                ),
+                ("header-null", |value: &mut serde_json::Value| {
+                    value["persisted_input"]["header"]["idempotency_key"] = serde_json::Value::Null;
+                    value["persisted_input"]["header"]["correlation_id"] = serde_json::Value::Null;
+                }),
+                ("payload-id-mismatch", |value: &mut serde_json::Value| {
+                    value["persisted_input"]["header"]["id"] = serde_json::json!(LOW_INPUT_ID);
+                }),
+                (
+                    "policy-version-mismatch",
+                    |value: &mut serde_json::Value| {
+                        value["policy"]["version"] = serde_json::json!(2);
+                    },
+                ),
+                ("history-unknown", |value: &mut serde_json::Value| {
+                    value["history"][0]["unknown"] = serde_json::json!(true);
+                }),
+            ] {
+                let mut conn = Connection::open_in_memory().expect("open");
+                conn.execute_batch(CREATE_RUNTIME_SCHEMA_SQL)
+                    .expect("runtime v1 schema");
+                let (input_id, source) = legacy_prompt_row();
+                let mut candidate: serde_json::Value =
+                    serde_json::from_slice(&source).expect("candidate");
+                mutate(&mut candidate);
+                let candidate = serde_json::to_vec(&candidate).expect("candidate bytes");
+                insert_row(&conn, "runtime", &input_id, &candidate);
+
+                let tx = conn.transaction().expect("tx");
+                let error = prepare_pre_0_8_10_runtime_input_states(&tx)
+                    .expect_err("invalid nested/cross-bound row must refuse");
+                tx.commit().expect("refusal leaves transaction committable");
+                assert_eq!(load_row(&conn, "runtime", &input_id), candidate);
+                assert!(!error.to_string().is_empty(), "empty {label} error");
+            }
+        }
+
+        #[test]
+        fn maintenance_prepare_refuses_duplicate_queue_timestamp_per_runtime() {
+            let mut conn = Connection::open_in_memory().expect("open");
+            conn.execute_batch(CREATE_RUNTIME_SCHEMA_SQL)
+                .expect("runtime v1 schema");
+            let timestamp = "2026-05-13T10:00:00.000300Z";
+            let (first_id, first) = legacy_prompt_row_with(LOW_INPUT_ID, timestamp, None);
+            let (second_id, second) = legacy_prompt_row_with(HIGH_INPUT_ID, timestamp, None);
+            insert_row(&conn, "runtime", &first_id, &first);
+            insert_row(&conn, "runtime", &second_id, &second);
+
+            let tx = conn.transaction().expect("tx");
+            let error = prepare_pre_0_8_10_runtime_input_states(&tx)
+                .expect_err("duplicate historical timestamp must refuse");
+            assert!(
+                error
+                    .to_string()
+                    .contains("duplicate initial QueueAccepted")
+            );
+            tx.commit().expect("preflight refusal is committable");
+            assert_eq!(load_row(&conn, "runtime", &first_id), first);
+            assert_eq!(load_row(&conn, "runtime", &second_id), second);
+        }
+
+        #[test]
+        fn maintenance_prepare_refuses_duplicate_idempotency_owner_per_runtime() {
+            let mut conn = Connection::open_in_memory().expect("open");
+            conn.execute_batch(CREATE_RUNTIME_SCHEMA_SQL)
+                .expect("runtime v1 schema");
+            let mut rows = [
+                legacy_prompt_row_with(LOW_INPUT_ID, "2026-05-13T10:00:00.000200Z", None),
+                legacy_prompt_row_with(HIGH_INPUT_ID, "2026-05-13T10:00:00.000300Z", None),
+            ];
+            for (ordinal, (input_id, bytes)) in rows.iter_mut().enumerate() {
+                let mut row: serde_json::Value = serde_json::from_slice(bytes).expect("candidate");
+                row["idempotency_key"] = serde_json::json!("duplicate-owner");
+                row["persisted_input"]["header"]["idempotency_key"] =
+                    serde_json::json!("duplicate-owner");
+                row["persisted_input"]["header"]["correlation_id"] =
+                    serde_json::json!(format!("019e20e6-b011-7000-8000-00000000001{ordinal}"));
+                *bytes = serde_json::to_vec(&row).expect("candidate bytes");
+                insert_row(&conn, "runtime", input_id, bytes);
+            }
+
+            let tx = conn.transaction().expect("tx");
+            let error = prepare_pre_0_8_10_runtime_input_states(&tx)
+                .expect_err("duplicate idempotency owner must refuse");
+            assert!(
+                error.to_string().contains("duplicate idempotency owner"),
+                "unexpected duplicate-owner error: {error}"
+            );
+            tx.commit().expect("preflight refusal is committable");
+            for (input_id, bytes) in rows {
+                assert_eq!(load_row(&conn, "runtime", &input_id), bytes);
+            }
+        }
+
+        #[test]
+        fn maintenance_prepare_refuses_orphan_runtime_fragments() {
+            let mut conn = Connection::open_in_memory().expect("open");
+            conn.execute_batch(CREATE_RUNTIME_SCHEMA_SQL)
+                .expect("runtime v1 schema");
+            let (input_id, source) = legacy_prompt_row();
+            conn.execute(
+                "INSERT INTO runtime_input_states (runtime_id, input_id, state_json)
+                 VALUES ('orphan-runtime', ?1, ?2)",
+                params![&input_id, &source],
+            )
+            .expect("insert orphan input");
+
+            let tx = conn.transaction().expect("tx");
+            let error = prepare_pre_0_8_10_runtime_input_states(&tx)
+                .expect_err("orphan runtime fragments must refuse");
+            assert!(
+                error
+                    .to_string()
+                    .contains("runtime fragments are incomplete")
+            );
+            tx.commit().expect("orphan refusal is committable");
+            assert_eq!(load_row(&conn, "orphan-runtime", &input_id), source);
+        }
+
+        #[test]
+        fn maintenance_prepare_rereads_exact_successor_and_caller_can_roll_back() {
+            let mut conn = Connection::open_in_memory().expect("open");
+            conn.execute_batch(CREATE_RUNTIME_SCHEMA_SQL)
+                .expect("runtime v1 schema");
+            let (input_id, source) = legacy_prompt_row();
+            insert_row(&conn, "runtime", &input_id, &source);
+            conn.execute_batch(
+                "CREATE TRIGGER corrupt_pre_floor_successor
+                 AFTER UPDATE OF state_json ON runtime_input_states
+                 BEGIN
+                     UPDATE runtime_input_states
+                     SET state_json = state_json || ' '
+                     WHERE runtime_id = NEW.runtime_id AND input_id = NEW.input_id;
+                 END;",
+            )
+            .expect("corrupting trigger");
+
+            let tx = conn.transaction().expect("tx");
+            let error = prepare_pre_0_8_10_runtime_input_states(&tx)
+                .expect_err("successor corruption must be observed");
+            assert!(error.to_string().contains("successor row differs"));
+            tx.rollback().expect("caller rollback");
+            assert_eq!(load_row(&conn, "runtime", &input_id), source);
         }
     }
 
@@ -18501,4 +21206,6 @@ ORDER BY runtime_id";
 }
 
 #[cfg(feature = "sqlite-store")]
-pub use inner::SqliteRuntimeStore;
+pub use inner::{
+    RUNTIME_STORE_DOMAIN, SqliteRuntimeStore, prepare_pre_0_8_10_runtime_input_states,
+};

--- a/meerkat-sqlite/src/error.rs
+++ b/meerkat-sqlite/src/error.rs
@@ -73,6 +73,33 @@ pub enum SqliteStoreError {
         objects: Vec<String>,
     },
 
+    /// Explicit maintenance could not authenticate an unledgered owned
+    /// catalog as any exact migration prefix or frozen predecessor through
+    /// the requested target. No preparation, migration, or ledger mutation
+    /// has run.
+    #[error(
+        "unledgered schema domain `{domain}` does not match any authorized source catalog \
+         through version {target_version}; found owned objects {objects:?}"
+    )]
+    UnledgeredSchemaNoMatch {
+        domain: String,
+        target_version: i64,
+        objects: Vec<String>,
+    },
+
+    /// Explicit maintenance found more than one exact authorized source
+    /// version for an unledgered catalog. Inferring a version would be
+    /// ambiguous, so the file remains untouched.
+    #[error(
+        "unledgered schema domain `{domain}` ambiguously matches source versions {matches:?} \
+         through requested target version {target_version}"
+    )]
+    UnledgeredSchemaAmbiguous {
+        domain: String,
+        target_version: i64,
+        matches: Vec<i64>,
+    },
+
     /// A registered migration failed while being applied. The surrounding
     /// transaction is rolled back; the file is left at its prior version.
     #[error("migration {version} (`{name}`) for domain `{domain}` failed: {source}")]

--- a/meerkat-sqlite/src/ledger.rs
+++ b/meerkat-sqlite/src/ledger.rs
@@ -310,6 +310,36 @@ impl LedgerReport {
     }
 }
 
+/// Result returned by an explicit maintenance preparation callback.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct MaintenancePrepareReport {
+    /// Number of durable records rewritten by the callback.
+    pub changed: usize,
+}
+
+/// Outcome of [`bridge_unledgered_domain`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct MaintenanceBridgeReport {
+    /// Authenticated schema version before maintenance.
+    pub from_version: i64,
+    /// Schema version after maintenance.
+    pub to_version: i64,
+    /// Number of records rewritten by the optional preparation callback.
+    pub prepared: usize,
+}
+
+impl MaintenanceBridgeReport {
+    /// True when this call advanced the schema ledger.
+    pub fn migrated(&self) -> bool {
+        self.to_version > self.from_version
+    }
+
+    /// True when this call advanced the schema or rewrote durable records.
+    pub fn changed(&self) -> bool {
+        self.migrated() || self.prepared > 0
+    }
+}
+
 /// Read a domain's ledger version without applying anything.
 ///
 /// `Ok(None)` means the file has no ledger table or no row for the domain.
@@ -482,12 +512,414 @@ pub fn apply_domain_migrations(
          ON CONFLICT(domain) DO UPDATE SET version = excluded.version",
         rusqlite::params![domain.name, supported],
     )?;
+    verify_ledger_stamp(&tx, domain.name, supported)?;
     tx.commit()?;
 
     Ok(LedgerReport {
         from_version: current,
         to_version: supported,
     })
+}
+
+/// Explicitly authenticate and migrate an unledgered historical domain.
+///
+/// This is an offline maintenance bridge, not an ambient-open fallback.
+/// Under one `BEGIN IMMEDIATE` transaction it identifies an owned catalog as
+/// exactly one caller-authorized, code-derived migration prefix or frozen
+/// released-predecessor catalog, runs `prepare` when supplied, applies the
+/// remaining registered migrations, verifies both the exact target prefix
+/// and the domain's ordinary target verifier, and only then creates and
+/// stamps the ledger row. The callback and every migration retain transaction
+/// custody.
+///
+/// `recoverable_source_versions` is an explicit authority boundary for
+/// unledgered inference. Catalog equality alone cannot prove whether a
+/// data-only migration ran, so prefixes absent from this list are never
+/// inferred even when their DDL fingerprint matches. A registered frozen
+/// predecessor verifier is an additional exact source oracle for its version;
+/// a version that matches both its generated prefix and frozen verifier is
+/// counted once. Existing eligible rows below the target are upgraded. A row
+/// already at the target is a verified no-op when no preparation callback is
+/// supplied; with a callback, its data preparation, target verification, and
+/// unchanged ledger stamp are committed atomically. A missing row with no
+/// owned objects is also a no-op so normal fresh-domain initialization remains
+/// the sole owner of that case. Unknown and ambiguous catalogs are refused
+/// without mutation.
+pub fn bridge_unledgered_domain(
+    conn: &mut Connection,
+    domain: &SchemaDomain,
+    target_version: i64,
+    recoverable_source_versions: &[i64],
+    prepare: Option<fn(&Transaction<'_>) -> Result<MaintenancePrepareReport, rusqlite::Error>>,
+) -> Result<MaintenanceBridgeReport, SqliteStoreError> {
+    domain.validate()?;
+    let supported = domain.supported_version();
+    if target_version > supported {
+        return Err(SqliteStoreError::SchemaFromTheFuture {
+            domain: domain.name.to_string(),
+            found: target_version,
+            supported,
+        });
+    }
+    if !domain.accepts_existing_version(target_version) {
+        return Err(unsupported_predecessor(domain, target_version));
+    }
+    validate_recoverable_source_versions(domain, target_version, recoverable_source_versions)?;
+
+    let tx = conn.transaction_with_behavior(rusqlite::TransactionBehavior::Immediate)?;
+    let current = if ledger_table_exists(&tx)? {
+        validate_ledger_shape(&tx)?;
+        read_version(&tx, domain.name)?
+    } else {
+        None
+    };
+
+    let mut inferred_oracles = None;
+    let from_version = if let Some(found) = current {
+        if found > target_version {
+            return Err(SqliteStoreError::SchemaFromTheFuture {
+                domain: domain.name.to_string(),
+                found,
+                supported: target_version,
+            });
+        }
+        if !domain.accepts_existing_version(found) {
+            return Err(unsupported_predecessor(domain, found));
+        }
+        domain.verify_predecessor(&tx, found)?;
+        if found == target_version && prepare.is_none() {
+            return Ok(MaintenanceBridgeReport {
+                from_version: found,
+                to_version: found,
+                prepared: 0,
+            });
+        }
+        found
+    } else {
+        let objects = find_owned_objects(&tx, domain)?;
+        if objects.is_empty() {
+            return Ok(MaintenanceBridgeReport {
+                from_version: 0,
+                to_version: 0,
+                prepared: 0,
+            });
+        }
+
+        let oracles = build_migration_prefix_oracles(domain, target_version)?;
+        let actual = domain_catalog_fingerprint(&tx, domain).map_err(|detail| {
+            SqliteStoreError::UnledgeredSchemaNoMatch {
+                domain: domain.name.to_string(),
+                target_version,
+                objects: vec![detail],
+            }
+        })?;
+        let mut matches = oracles
+            .iter()
+            .filter_map(|(version, fingerprint)| {
+                (recoverable_source_versions.contains(version) && fingerprint == &actual)
+                    .then_some(*version)
+            })
+            .collect::<Vec<_>>();
+        // A frozen predecessor verifier may intentionally authenticate more
+        // than one exact released physical catalog for the same logical
+        // version. This covers pre-ledger stores whose idempotent opener grew
+        // new tables without a version marker. It remains fail-closed: only a
+        // caller-authorized version with a registered frozen verifier can add
+        // a match, and duplicate evidence for the same version is collapsed
+        // before ambiguity is judged.
+        for predecessor in domain.released_predecessors.iter().filter(|predecessor| {
+            recoverable_source_versions.contains(&predecessor.version)
+                && predecessor.version <= target_version
+        }) {
+            if (predecessor.verify)(&tx).is_ok() && !matches.contains(&predecessor.version) {
+                matches.push(predecessor.version);
+            }
+        }
+        matches.sort_unstable();
+        let matched = match matches.as_slice() {
+            [version] => *version,
+            [] => {
+                return Err(SqliteStoreError::UnledgeredSchemaNoMatch {
+                    domain: domain.name.to_string(),
+                    target_version,
+                    objects,
+                });
+            }
+            _ => {
+                return Err(SqliteStoreError::UnledgeredSchemaAmbiguous {
+                    domain: domain.name.to_string(),
+                    target_version,
+                    matches,
+                });
+            }
+        };
+        inferred_oracles = Some(oracles);
+        matched
+    };
+
+    let oracles = match inferred_oracles {
+        Some(oracles) => oracles,
+        None => build_migration_prefix_oracles(domain, target_version)?,
+    };
+    validate_domain_trigger_isolation(&tx, domain, from_version)?;
+
+    let prepared = match prepare {
+        Some(prepare) => {
+            run_with_custody(&tx, domain, from_version, "maintenance-prepare", prepare)?.changed
+        }
+        None => 0,
+    };
+    for migration in domain
+        .migrations
+        .iter()
+        .filter(|migration| migration.version > from_version && migration.version <= target_version)
+    {
+        run_with_custody(
+            &tx,
+            domain,
+            migration.version,
+            migration.name,
+            migration.apply,
+        )?;
+    }
+
+    let target = oracles
+        .iter()
+        .find_map(|(version, fingerprint)| (*version == target_version).then_some(fingerprint))
+        .ok_or_else(|| SqliteStoreError::InvalidMigrationList {
+            domain: domain.name.to_string(),
+            detail: format!(
+                "migration-prefix oracle did not produce requested target version {target_version}"
+            ),
+        })?;
+    let converged = domain_catalog_fingerprint(&tx, domain).map_err(|detail| {
+        SqliteStoreError::SchemaFingerprintMismatch {
+            domain: domain.name.to_string(),
+            version: target_version,
+            detail,
+        }
+    })?;
+    if &converged != target {
+        return Err(SqliteStoreError::SchemaFingerprintMismatch {
+            domain: domain.name.to_string(),
+            version: target_version,
+            detail: format!(
+                "migration-prefix catalog differs: expected {target:?}, found {converged:?}"
+            ),
+        });
+    }
+    domain.verify_predecessor(&tx, target_version)?;
+
+    if current != Some(target_version) {
+        if !ledger_table_exists(&tx)? {
+            tx.execute_batch(CREATE_LEDGER_SQL)?;
+            validate_ledger_shape(&tx)?;
+        }
+        tx.execute(
+            "INSERT INTO main.meerkat_schema (domain, version) VALUES (?1, ?2)
+             ON CONFLICT(domain) DO UPDATE SET version = excluded.version",
+            rusqlite::params![domain.name, target_version],
+        )?;
+    }
+    verify_ledger_stamp(&tx, domain.name, target_version)?;
+    tx.commit()?;
+
+    Ok(MaintenanceBridgeReport {
+        from_version,
+        to_version: target_version,
+        prepared,
+    })
+}
+
+fn validate_recoverable_source_versions(
+    domain: &SchemaDomain,
+    target_version: i64,
+    versions: &[i64],
+) -> Result<(), SqliteStoreError> {
+    let mut previous = None;
+    for &version in versions {
+        if version <= 0 || version > target_version {
+            return Err(SqliteStoreError::InvalidMigrationList {
+                domain: domain.name.to_string(),
+                detail: format!(
+                    "recoverable source version {version} is outside 1..={target_version}"
+                ),
+            });
+        }
+        if previous.is_some_and(|prior| prior >= version) {
+            return Err(SqliteStoreError::InvalidMigrationList {
+                domain: domain.name.to_string(),
+                detail: "recoverable source versions must be strictly increasing".to_string(),
+            });
+        }
+        previous = Some(version);
+    }
+    Ok(())
+}
+
+fn verify_ledger_stamp(
+    conn: &Connection,
+    domain: &str,
+    expected: i64,
+) -> Result<(), SqliteStoreError> {
+    let found = read_version(conn, domain)?;
+    if found != Some(expected) {
+        return Err(malformed(format!(
+            "domain `{domain}` stamp did not persist exact version {expected}; found {found:?}"
+        )));
+    }
+    Ok(())
+}
+
+fn validate_domain_trigger_isolation(
+    conn: &Connection,
+    domain: &SchemaDomain,
+    source_version: i64,
+) -> Result<(), SqliteStoreError> {
+    let all_objects = all_domain_objects(domain);
+    let allowed_triggers = all_objects
+        .iter()
+        .filter(|object| object.kind == SchemaObjectKind::Trigger)
+        .map(|object| object.name)
+        .collect::<Vec<_>>();
+    let mut statement = conn
+        .prepare(
+            "SELECT 'main', name FROM main.sqlite_schema
+             WHERE type = 'trigger' AND tbl_name = ?1 COLLATE NOCASE
+             UNION ALL
+             SELECT 'temp', name FROM temp.sqlite_schema
+             WHERE type = 'trigger' AND tbl_name = ?1 COLLATE NOCASE
+             ORDER BY 1, 2",
+        )
+        .map_err(SqliteStoreError::Sqlite)?;
+    let mut refused = Vec::new();
+    for target in all_objects.iter().filter(|object| {
+        matches!(
+            object.kind,
+            SchemaObjectKind::Table | SchemaObjectKind::View
+        )
+    }) {
+        let rows = statement
+            .query_map([target.name], |row| {
+                Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+            })
+            .map_err(SqliteStoreError::Sqlite)?;
+        for row in rows {
+            let (schema, trigger) = row.map_err(SqliteStoreError::Sqlite)?;
+            let declared = schema == "main"
+                && allowed_triggers
+                    .iter()
+                    .any(|allowed| allowed.eq_ignore_ascii_case(&trigger));
+            if !declared {
+                refused.push(format!("{schema}.{trigger} on {}", target.name));
+            }
+        }
+    }
+    refused.sort();
+    refused.dedup();
+    if !refused.is_empty() {
+        return Err(SqliteStoreError::SchemaFingerprintMismatch {
+            domain: domain.name.to_string(),
+            version: source_version,
+            detail: format!(
+                "undeclared or TEMP triggers can intercept maintenance writes: {refused:?}"
+            ),
+        });
+    }
+    Ok(())
+}
+
+fn run_with_custody<T>(
+    tx: &Transaction<'_>,
+    domain: &SchemaDomain,
+    version: i64,
+    name: &str,
+    body: fn(&Transaction<'_>) -> Result<T, rusqlite::Error>,
+) -> Result<T, SqliteStoreError> {
+    tx.execute_batch(CUSTODY_SAVEPOINT_SQL)?;
+    let body_result = body(tx);
+    if tx.is_autocommit() || tx.execute_batch(CUSTODY_RELEASE_SQL).is_err() {
+        return Err(SqliteStoreError::MigrationBrokeTransaction {
+            domain: domain.name.to_string(),
+            version,
+            name: name.to_string(),
+        });
+    }
+    body_result.map_err(|source| SqliteStoreError::MigrationFailed {
+        domain: domain.name.to_string(),
+        version,
+        name: name.to_string(),
+        source,
+    })
+}
+
+fn build_migration_prefix_oracles(
+    domain: &SchemaDomain,
+    target_version: i64,
+) -> Result<Vec<(i64, DomainCatalogFingerprint)>, SqliteStoreError> {
+    let mut expected = Connection::open_in_memory().map_err(SqliteStoreError::Sqlite)?;
+    let tx = expected
+        .transaction_with_behavior(rusqlite::TransactionBehavior::Immediate)
+        .map_err(SqliteStoreError::Sqlite)?;
+    let mut oracles = Vec::with_capacity(target_version as usize);
+    for migration in domain
+        .migrations
+        .iter()
+        .filter(|migration| migration.version <= target_version)
+    {
+        (migration.apply)(&tx).map_err(|source| SqliteStoreError::MigrationFailed {
+            domain: domain.name.to_string(),
+            version: migration.version,
+            name: format!("migration-prefix-oracle:{}", migration.name),
+            source,
+        })?;
+        let fingerprint = domain_catalog_fingerprint(&tx, domain).map_err(|detail| {
+            SqliteStoreError::InvalidMigrationList {
+                domain: domain.name.to_string(),
+                detail: format!(
+                    "migration-prefix oracle version {} is inconsistent with ownership: {detail}",
+                    migration.version
+                ),
+            }
+        })?;
+        oracles.push((migration.version, fingerprint));
+    }
+    Ok(oracles)
+}
+
+#[derive(Debug, PartialEq, Eq)]
+struct DomainCatalogFingerprint {
+    names: Vec<(String, String)>,
+    objects: Vec<CatalogObjectFingerprint>,
+}
+
+fn domain_catalog_fingerprint(
+    conn: &Connection,
+    domain: &SchemaDomain,
+) -> Result<DomainCatalogFingerprint, String> {
+    let all_objects = all_domain_objects(domain);
+    let names = catalog_names(conn, &all_objects).map_err(|error| error.to_string())?;
+    let declared = all_objects
+        .iter()
+        .map(|object| (object.name, object))
+        .collect::<BTreeMap<_, _>>();
+    let mut objects = Vec::with_capacity(names.len());
+    for (kind, name) in &names {
+        let Some(object) = declared.get(name.as_str()) else {
+            return Err(format!("undeclared owned object `{name}`"));
+        };
+        if kind != object.kind.sqlite_name() {
+            return Err(format!(
+                "owned object `{name}` has kind `{kind}`, expected `{}`",
+                object.kind.sqlite_name()
+            ));
+        }
+        objects.push(
+            catalog_fingerprint(conn, object)
+                .map_err(|error| format!("fingerprint object `{name}`: {error}"))?,
+        );
+    }
+    Ok(DomainCatalogFingerprint { names, objects })
 }
 
 static EXPECTED_CURRENT_CATALOGS: OnceLock<Mutex<BTreeMap<String, Result<String, String>>>> =
@@ -899,10 +1331,168 @@ fn index_fingerprint(
 }
 
 fn normalize_schema_sql(sql: &str) -> String {
-    sql.split_whitespace()
-        .collect::<Vec<_>>()
-        .join(" ")
-        .replace(" IF NOT EXISTS ", " ")
+    #[derive(Clone, Copy)]
+    enum LexState {
+        Normal,
+        SingleQuoted,
+        DoubleQuoted,
+        BacktickQuoted,
+        BracketQuoted,
+        LineComment,
+        BlockComment,
+    }
+
+    let bytes = sql.as_bytes();
+    let mut collapsed = Vec::with_capacity(bytes.len());
+    let mut state = LexState::Normal;
+    let mut index = 0;
+    while index < bytes.len() {
+        let byte = bytes[index];
+        match state {
+            LexState::Normal => {
+                if byte.is_ascii_whitespace() {
+                    if collapsed.last().is_some_and(|last| *last != b' ') {
+                        collapsed.push(b' ');
+                    }
+                } else {
+                    collapsed.push(byte);
+                    state = match byte {
+                        b'\'' => LexState::SingleQuoted,
+                        b'"' => LexState::DoubleQuoted,
+                        b'`' => LexState::BacktickQuoted,
+                        b'[' => LexState::BracketQuoted,
+                        b'-' if bytes.get(index + 1) == Some(&b'-') => LexState::LineComment,
+                        b'/' if bytes.get(index + 1) == Some(&b'*') => LexState::BlockComment,
+                        _ => LexState::Normal,
+                    };
+                }
+            }
+            LexState::SingleQuoted | LexState::DoubleQuoted | LexState::BacktickQuoted => {
+                collapsed.push(byte);
+                let delimiter = match state {
+                    LexState::SingleQuoted => b'\'',
+                    LexState::DoubleQuoted => b'"',
+                    LexState::BacktickQuoted => b'`',
+                    _ => unreachable!(),
+                };
+                if byte == delimiter {
+                    if bytes.get(index + 1) == Some(&delimiter) {
+                        index += 1;
+                        collapsed.push(delimiter);
+                    } else {
+                        state = LexState::Normal;
+                    }
+                }
+            }
+            LexState::BracketQuoted => {
+                collapsed.push(byte);
+                if byte == b']' {
+                    if bytes.get(index + 1) == Some(&b']') {
+                        index += 1;
+                        collapsed.push(b']');
+                    } else {
+                        state = LexState::Normal;
+                    }
+                }
+            }
+            LexState::LineComment => {
+                collapsed.push(byte);
+                if byte == b'\n' || byte == b'\r' {
+                    state = LexState::Normal;
+                }
+            }
+            LexState::BlockComment => {
+                collapsed.push(byte);
+                if byte == b'*' && bytes.get(index + 1) == Some(&b'/') {
+                    index += 1;
+                    collapsed.push(b'/');
+                    state = LexState::Normal;
+                }
+            }
+        }
+        index += 1;
+    }
+
+    const IF_NOT_EXISTS: &[u8] = b"IF NOT EXISTS";
+    let mut normalized = Vec::with_capacity(collapsed.len());
+    let mut state = LexState::Normal;
+    let mut index = 0;
+    while index < collapsed.len() {
+        let byte = collapsed[index];
+        if matches!(state, LexState::Normal)
+            && collapsed
+                .get(index..index + IF_NOT_EXISTS.len())
+                .is_some_and(|candidate| candidate.eq_ignore_ascii_case(IF_NOT_EXISTS))
+            && (index == 0 || !is_sql_identifier_byte(collapsed[index - 1]))
+            && collapsed
+                .get(index + IF_NOT_EXISTS.len())
+                .is_none_or(|after| !is_sql_identifier_byte(*after))
+        {
+            index += IF_NOT_EXISTS.len();
+            if collapsed.get(index) == Some(&b' ') {
+                index += 1;
+            }
+            continue;
+        }
+        normalized.push(byte);
+        match state {
+            LexState::Normal => {
+                state = match byte {
+                    b'\'' => LexState::SingleQuoted,
+                    b'"' => LexState::DoubleQuoted,
+                    b'`' => LexState::BacktickQuoted,
+                    b'[' => LexState::BracketQuoted,
+                    b'-' if collapsed.get(index + 1) == Some(&b'-') => LexState::LineComment,
+                    b'/' if collapsed.get(index + 1) == Some(&b'*') => LexState::BlockComment,
+                    _ => LexState::Normal,
+                };
+            }
+            LexState::SingleQuoted | LexState::DoubleQuoted | LexState::BacktickQuoted => {
+                let delimiter = match state {
+                    LexState::SingleQuoted => b'\'',
+                    LexState::DoubleQuoted => b'"',
+                    LexState::BacktickQuoted => b'`',
+                    _ => unreachable!(),
+                };
+                if byte == delimiter {
+                    if collapsed.get(index + 1) == Some(&delimiter) {
+                        index += 1;
+                        normalized.push(delimiter);
+                    } else {
+                        state = LexState::Normal;
+                    }
+                }
+            }
+            LexState::BracketQuoted => {
+                if byte == b']' {
+                    if collapsed.get(index + 1) == Some(&b']') {
+                        index += 1;
+                        normalized.push(b']');
+                    } else {
+                        state = LexState::Normal;
+                    }
+                }
+            }
+            LexState::LineComment => {
+                if byte == b'\n' || byte == b'\r' {
+                    state = LexState::Normal;
+                }
+            }
+            LexState::BlockComment => {
+                if byte == b'*' && collapsed.get(index + 1) == Some(&b'/') {
+                    index += 1;
+                    normalized.push(b'/');
+                    state = LexState::Normal;
+                }
+            }
+        }
+        index += 1;
+    }
+    String::from_utf8(normalized).unwrap_or_else(|_| sql.to_string())
+}
+
+fn is_sql_identifier_byte(byte: u8) -> bool {
+    byte.is_ascii_alphanumeric() || byte == b'_'
 }
 
 fn unsupported_predecessor(domain: &SchemaDomain, found: i64) -> SqliteStoreError {
@@ -1013,6 +1603,28 @@ fn validate_ledger_shape(conn: &Connection) -> Result<(), SqliteStoreError> {
         return Err(malformed(
             "table lacks the pinned `domain`/`version` columns".to_string(),
         ));
+    }
+    let mut trigger_stmt = conn.prepare(
+        "SELECT 'main', name FROM main.sqlite_schema
+         WHERE type = 'trigger' AND tbl_name = 'meerkat_schema' COLLATE NOCASE
+         UNION ALL
+         SELECT 'temp', name FROM temp.sqlite_schema
+         WHERE type = 'trigger' AND tbl_name = 'meerkat_schema' COLLATE NOCASE
+         ORDER BY 1, 2",
+    )?;
+    let triggers = trigger_stmt
+        .query_map([], |row| {
+            Ok(format!(
+                "{}.{}",
+                row.get::<_, String>(0)?,
+                row.get::<_, String>(1)?
+            ))
+        })?
+        .collect::<Result<Vec<_>, _>>()?;
+    if !triggers.is_empty() {
+        return Err(malformed(format!(
+            "table has attached triggers {triggers:?}; ledger writes must be isolated"
+        )));
     }
     Ok(())
 }
@@ -1388,6 +2000,631 @@ mod tests {
             .collect::<Result<_, _>>()
             .expect("columns");
         assert_eq!(columns, vec!["x"], "refusal mutated unknown schema");
+    }
+
+    #[test]
+    fn maintenance_bridge_authenticates_exact_v1_and_migrates_to_v2() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let mut conn = temp_conn(&dir);
+        conn.execute_batch("CREATE TABLE t1 (x INTEGER)")
+            .expect("historical unledgered v1");
+
+        let report =
+            bridge_unledgered_domain(&mut conn, &DOMAIN_V2, 2, &[1], None).expect("bridge");
+        assert_eq!(
+            report,
+            MaintenanceBridgeReport {
+                from_version: 1,
+                to_version: 2,
+                prepared: 0,
+            }
+        );
+        assert_eq!(
+            domain_version(&conn, DOMAIN_V2.name).expect("ledger"),
+            Some(2)
+        );
+        let columns = conn
+            .prepare("PRAGMA table_info(t1)")
+            .expect("prepare")
+            .query_map([], |row| row.get::<_, String>(1))
+            .expect("query")
+            .collect::<Result<Vec<_>, _>>()
+            .expect("columns");
+        assert_eq!(columns, vec!["x", "y"]);
+
+        let second = bridge_unledgered_domain(&mut conn, &DOMAIN_V2, 2, &[1], None)
+            .expect("idempotent bridge");
+        assert_eq!(
+            second,
+            MaintenanceBridgeReport {
+                from_version: 2,
+                to_version: 2,
+                prepared: 0,
+            }
+        );
+    }
+
+    #[test]
+    fn maintenance_bridge_prepares_and_upgrades_existing_v1_row() {
+        fn normalize_existing(
+            tx: &Transaction<'_>,
+        ) -> Result<MaintenancePrepareReport, rusqlite::Error> {
+            let changed = tx.execute("UPDATE t1 SET x = x + 1", [])?;
+            Ok(MaintenancePrepareReport { changed })
+        }
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let mut conn = temp_conn(&dir);
+        apply_domain_migrations(&mut conn, &DOMAIN_V1).expect("ledgered v1");
+        conn.execute("INSERT INTO t1 (x) VALUES (7)", [])
+            .expect("historical data");
+
+        let report =
+            bridge_unledgered_domain(&mut conn, &DOMAIN_V2, 2, &[1], Some(normalize_existing))
+                .expect("bridge ledgered predecessor");
+        assert_eq!(
+            report,
+            MaintenanceBridgeReport {
+                from_version: 1,
+                to_version: 2,
+                prepared: 1,
+            }
+        );
+        assert_eq!(
+            domain_version(&conn, DOMAIN_V2.name).expect("ledger"),
+            Some(2)
+        );
+        assert_eq!(
+            conn.query_row("SELECT x FROM t1", [], |row| row.get::<_, i64>(0))
+                .expect("prepared row"),
+            8
+        );
+        conn.execute("INSERT INTO t1 (x, y) VALUES (9, 'migrated')", [])
+            .expect("v2 shape");
+    }
+
+    #[test]
+    fn maintenance_bridge_prepares_existing_target_and_reports_durable_changes() {
+        fn normalize_target(
+            tx: &Transaction<'_>,
+        ) -> Result<MaintenancePrepareReport, rusqlite::Error> {
+            let changed = tx.execute("UPDATE t1 SET x = x + 1", [])?;
+            Ok(MaintenancePrepareReport { changed })
+        }
+        fn mutate_then_fail(
+            tx: &Transaction<'_>,
+        ) -> Result<MaintenancePrepareReport, rusqlite::Error> {
+            tx.execute("UPDATE t1 SET x = 99", [])?;
+            tx.execute_batch("THIS IS NOT SQL")?;
+            Ok(MaintenancePrepareReport { changed: 1 })
+        }
+        fn rolls_back_then_begins_and_fails(
+            tx: &Transaction<'_>,
+        ) -> Result<MaintenancePrepareReport, rusqlite::Error> {
+            tx.execute_batch("UPDATE t1 SET x = 99; ROLLBACK; BEGIN; THIS IS NOT SQL")?;
+            Ok(MaintenancePrepareReport { changed: 1 })
+        }
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let mut conn = temp_conn(&dir);
+        apply_domain_migrations(&mut conn, &DOMAIN_V2).expect("ledgered target");
+        conn.execute("INSERT INTO t1 (x, y) VALUES (7, 'target')", [])
+            .expect("target data");
+
+        let report =
+            bridge_unledgered_domain(&mut conn, &DOMAIN_V2, 2, &[1], Some(normalize_target))
+                .expect("prepare target");
+        assert_eq!(
+            report,
+            MaintenanceBridgeReport {
+                from_version: 2,
+                to_version: 2,
+                prepared: 1,
+            }
+        );
+        assert!(!report.migrated());
+        assert!(report.changed());
+        assert_eq!(
+            conn.query_row("SELECT x FROM t1", [], |row| row.get::<_, i64>(0))
+                .expect("prepared target row"),
+            8
+        );
+        assert_eq!(
+            domain_version(&conn, DOMAIN_V2.name).expect("ledger"),
+            Some(2)
+        );
+
+        let err = bridge_unledgered_domain(&mut conn, &DOMAIN_V2, 2, &[1], Some(mutate_then_fail))
+            .expect_err("target prepare failure");
+        assert!(matches!(
+            err,
+            SqliteStoreError::MigrationFailed { ref name, .. }
+                if name == "maintenance-prepare"
+        ));
+        assert_eq!(
+            conn.query_row("SELECT x FROM t1", [], |row| row.get::<_, i64>(0))
+                .expect("row after rollback"),
+            8
+        );
+
+        let err = bridge_unledgered_domain(
+            &mut conn,
+            &DOMAIN_V2,
+            2,
+            &[1],
+            Some(rolls_back_then_begins_and_fails),
+        )
+        .expect_err("target custody loss");
+        assert!(matches!(
+            err,
+            SqliteStoreError::MigrationBrokeTransaction { ref name, .. }
+                if name == "maintenance-prepare"
+        ));
+        assert_eq!(
+            conn.query_row("SELECT x FROM t1", [], |row| row.get::<_, i64>(0))
+                .expect("row after custody refusal"),
+            8
+        );
+        assert_eq!(
+            domain_version(&conn, DOMAIN_V2.name).expect("ledger"),
+            Some(2)
+        );
+    }
+
+    #[test]
+    fn maintenance_bridge_refuses_target_that_only_matches_migration_oracle() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let mut conn = temp_conn(&dir);
+        conn.execute_batch("CREATE TABLE t1 (x INTEGER)")
+            .expect("historical unledgered v1");
+
+        let err = bridge_unledgered_domain(&mut conn, &DOMAIN_V2_ALT_INITIALIZER, 2, &[1], None)
+            .expect_err("ordinary target verifier must reject drift");
+        assert!(matches!(
+            err,
+            SqliteStoreError::SchemaFingerprintMismatch { version: 2, .. }
+        ));
+        assert!(!ledger_table_exists(&conn).expect("ledger presence"));
+        let columns = conn
+            .prepare("PRAGMA table_info(t1)")
+            .expect("prepare")
+            .query_map([], |row| row.get::<_, String>(1))
+            .expect("query")
+            .collect::<Result<Vec<_>, _>>()
+            .expect("columns");
+        assert_eq!(
+            columns,
+            vec!["x"],
+            "target-verifier refusal did not roll back"
+        );
+    }
+
+    #[test]
+    fn maintenance_bridge_refuses_catalog_outside_source_allowlist_across_data_only_gap() {
+        fn no_op(_tx: &Transaction<'_>) -> Result<(), rusqlite::Error> {
+            Ok(())
+        }
+        const DATA_ONLY_GAP: SchemaDomain = SchemaDomain {
+            name: "data-only-gap-domain",
+            migrations: &[
+                Migration {
+                    version: 1,
+                    name: "base",
+                    apply: create_t1,
+                },
+                Migration {
+                    version: 2,
+                    name: "data-only",
+                    apply: no_op,
+                },
+                Migration {
+                    version: 3,
+                    name: "add-y",
+                    apply: add_column_guarded,
+                },
+            ],
+            initialize_current: initialize_v2,
+            allowed_existing_versions: &[3],
+            released_predecessors: &[],
+            owned_objects: &[SchemaObject {
+                kind: SchemaObjectKind::Table,
+                name: "t1",
+            }],
+            retired_objects: &[],
+        };
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let mut conn = temp_conn(&dir);
+        conn.execute_batch("CREATE TABLE t1 (x INTEGER)")
+            .expect("v1-or-v2 catalog");
+        let err = bridge_unledgered_domain(&mut conn, &DATA_ONLY_GAP, 3, &[3], None)
+            .expect_err("excluded historical prefixes must not be inferred");
+        assert!(matches!(
+            err,
+            SqliteStoreError::UnledgeredSchemaNoMatch { .. }
+        ));
+        assert!(!ledger_table_exists(&conn).expect("ledger presence"));
+        let columns = conn
+            .prepare("PRAGMA table_info(t1)")
+            .expect("prepare")
+            .query_map([], |row| row.get::<_, String>(1))
+            .expect("query")
+            .collect::<Result<Vec<_>, _>>()
+            .expect("columns");
+        assert_eq!(columns, vec!["x"]);
+
+        let err = bridge_unledgered_domain(&mut conn, &DATA_ONLY_GAP, 3, &[2, 1], None)
+            .expect_err("unordered source authority must be refused");
+        assert!(matches!(err, SqliteStoreError::InvalidMigrationList { .. }));
+    }
+
+    #[test]
+    fn maintenance_bridge_leaves_fresh_domain_for_normal_initializer() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let mut conn = temp_conn(&dir);
+        let report =
+            bridge_unledgered_domain(&mut conn, &DOMAIN_V2, 2, &[1], None).expect("fresh no-op");
+        assert_eq!(
+            report,
+            MaintenanceBridgeReport {
+                from_version: 0,
+                to_version: 0,
+                prepared: 0,
+            }
+        );
+        assert!(!ledger_table_exists(&conn).expect("ledger presence"));
+        assert!(
+            find_owned_objects(&conn, &DOMAIN_V2)
+                .expect("objects")
+                .is_empty()
+        );
+    }
+
+    #[test]
+    fn maintenance_bridge_refuses_malformed_historical_shape_without_mutation() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let mut conn = temp_conn(&dir);
+        conn.execute_batch("CREATE TABLE t1 (x INTEGER, candidate_only BLOB)")
+            .expect("candidate schema");
+
+        let err = bridge_unledgered_domain(&mut conn, &DOMAIN_V2, 2, &[1], None)
+            .expect_err("refuse unauthenticated shape");
+        assert!(matches!(
+            err,
+            SqliteStoreError::UnledgeredSchemaNoMatch {
+                target_version: 2,
+                ..
+            }
+        ));
+        assert!(!ledger_table_exists(&conn).expect("ledger presence"));
+        let columns = conn
+            .prepare("PRAGMA table_info(t1)")
+            .expect("prepare")
+            .query_map([], |row| row.get::<_, String>(1))
+            .expect("query")
+            .collect::<Result<Vec<_>, _>>()
+            .expect("columns");
+        assert_eq!(columns, vec!["x", "candidate_only"]);
+    }
+
+    #[test]
+    fn maintenance_bridge_fingerprint_preserves_sql_literal_whitespace() {
+        fn create_exact(tx: &Transaction<'_>) -> Result<(), rusqlite::Error> {
+            tx.execute_batch("CREATE TABLE literal_t (x TEXT CHECK(x <> 'a  b'))")
+        }
+        const LITERAL_DOMAIN: SchemaDomain = SchemaDomain {
+            name: "literal-fingerprint-domain",
+            migrations: &[Migration {
+                version: 1,
+                name: "base",
+                apply: create_exact,
+            }],
+            initialize_current: create_exact,
+            allowed_existing_versions: &[1],
+            released_predecessors: &[],
+            owned_objects: &[SchemaObject {
+                kind: SchemaObjectKind::Table,
+                name: "literal_t",
+            }],
+            retired_objects: &[],
+        };
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let mut conn = temp_conn(&dir);
+        conn.execute_batch("CREATE TABLE literal_t (x TEXT CHECK(x <> 'a b'))")
+            .expect("semantic mismatch");
+        let err = bridge_unledgered_domain(&mut conn, &LITERAL_DOMAIN, 1, &[1], None)
+            .expect_err("literal whitespace must remain fingerprint-significant");
+        assert!(matches!(
+            err,
+            SqliteStoreError::UnledgeredSchemaNoMatch { .. }
+        ));
+        assert!(!ledger_table_exists(&conn).expect("ledger presence"));
+
+        assert_eq!(
+            normalize_schema_sql("CREATE  TABLE IF NOT EXISTS t (x CHECK(x <> 'IF NOT  EXISTS'))"),
+            "CREATE TABLE t (x CHECK(x <> 'IF NOT  EXISTS'))"
+        );
+    }
+
+    #[test]
+    fn maintenance_bridge_rolls_back_prepare_failure() {
+        fn mutate_then_fail(
+            tx: &Transaction<'_>,
+        ) -> Result<MaintenancePrepareReport, rusqlite::Error> {
+            tx.execute("UPDATE t1 SET x = 99", [])?;
+            tx.execute_batch("THIS IS NOT SQL")?;
+            Ok(MaintenancePrepareReport { changed: 1 })
+        }
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let mut conn = temp_conn(&dir);
+        conn.execute_batch("CREATE TABLE t1 (x INTEGER); INSERT INTO t1 VALUES (7)")
+            .expect("historical unledgered v1");
+
+        let err = bridge_unledgered_domain(&mut conn, &DOMAIN_V2, 2, &[1], Some(mutate_then_fail))
+            .expect_err("prepare must fail");
+        assert!(matches!(
+            err,
+            SqliteStoreError::MigrationFailed { ref name, .. }
+                if name == "maintenance-prepare"
+        ));
+        assert_eq!(
+            conn.query_row("SELECT x FROM t1", [], |row| row.get::<_, i64>(0))
+                .expect("original row"),
+            7
+        );
+        assert!(!ledger_table_exists(&conn).expect("ledger presence"));
+        let columns = conn
+            .prepare("PRAGMA table_info(t1)")
+            .expect("prepare")
+            .query_map([], |row| row.get::<_, String>(1))
+            .expect("query")
+            .collect::<Result<Vec<_>, _>>()
+            .expect("columns");
+        assert_eq!(columns, vec!["x"]);
+    }
+
+    #[test]
+    fn maintenance_bridge_reports_custody_loss_before_callback_error() {
+        fn commits_then_fails(
+            tx: &Transaction<'_>,
+        ) -> Result<MaintenancePrepareReport, rusqlite::Error> {
+            tx.execute_batch("UPDATE t1 SET x = 99; COMMIT; THIS IS NOT SQL")?;
+            Ok(MaintenancePrepareReport { changed: 1 })
+        }
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let mut conn = temp_conn(&dir);
+        conn.execute_batch("CREATE TABLE t1 (x INTEGER); INSERT INTO t1 VALUES (7)")
+            .expect("historical unledgered v1");
+        let err =
+            bridge_unledgered_domain(&mut conn, &DOMAIN_V2, 2, &[1], Some(commits_then_fails))
+                .expect_err("custody must dominate callback error");
+        assert!(matches!(
+            err,
+            SqliteStoreError::MigrationBrokeTransaction { ref name, .. }
+                if name == "maintenance-prepare"
+        ));
+        assert_eq!(domain_version(&conn, DOMAIN_V2.name).expect("ledger"), None);
+    }
+
+    #[test]
+    fn maintenance_bridge_refuses_undeclared_trigger_on_owned_table_before_prepare() {
+        fn prepare_successor(
+            tx: &Transaction<'_>,
+        ) -> Result<MaintenancePrepareReport, rusqlite::Error> {
+            let changed = tx.execute("UPDATE t1 SET x = 8 WHERE x = 7", [])?;
+            Ok(MaintenancePrepareReport { changed })
+        }
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let mut conn = temp_conn(&dir);
+        conn.execute_batch(
+            "CREATE TABLE t1 (x INTEGER);
+             INSERT INTO t1 VALUES (7);
+             CREATE TRIGGER replace_prepared_successor
+             AFTER UPDATE ON t1
+             BEGIN
+                 UPDATE t1 SET x = 99 WHERE rowid = NEW.rowid;
+             END",
+        )
+        .expect("intercepting trigger");
+
+        let err = bridge_unledgered_domain(&mut conn, &DOMAIN_V2, 2, &[1], Some(prepare_successor))
+            .expect_err("undeclared trigger must be refused before prepare");
+        assert!(matches!(
+            err,
+            SqliteStoreError::SchemaFingerprintMismatch { version: 1, .. }
+        ));
+        assert_eq!(
+            conn.query_row("SELECT x FROM t1", [], |row| row.get::<_, i64>(0))
+                .expect("original row"),
+            7
+        );
+        assert!(!ledger_table_exists(&conn).expect("ledger presence"));
+    }
+
+    #[test]
+    fn maintenance_bridge_refuses_undeclared_instead_of_trigger_on_owned_view_before_prepare() {
+        fn create_owned_view(tx: &Transaction<'_>) -> Result<(), rusqlite::Error> {
+            tx.execute_batch(
+                "CREATE TABLE view_base (x INTEGER);
+                 CREATE VIEW owned_view AS SELECT x FROM view_base",
+            )
+        }
+        fn prepare_view(tx: &Transaction<'_>) -> Result<MaintenancePrepareReport, rusqlite::Error> {
+            let changed = tx.execute("UPDATE owned_view SET x = 8 WHERE x = 7", [])?;
+            Ok(MaintenancePrepareReport { changed })
+        }
+        const VIEW_DOMAIN: SchemaDomain = SchemaDomain {
+            name: "view-bridge-domain",
+            migrations: &[Migration {
+                version: 1,
+                name: "base",
+                apply: create_owned_view,
+            }],
+            initialize_current: create_owned_view,
+            allowed_existing_versions: &[1],
+            released_predecessors: &[],
+            owned_objects: &[
+                SchemaObject {
+                    kind: SchemaObjectKind::Table,
+                    name: "view_base",
+                },
+                SchemaObject {
+                    kind: SchemaObjectKind::View,
+                    name: "owned_view",
+                },
+            ],
+            retired_objects: &[],
+        };
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let mut conn = temp_conn(&dir);
+        conn.execute_batch(
+            "CREATE TABLE view_base (x INTEGER);
+             CREATE VIEW owned_view AS SELECT x FROM view_base;
+             INSERT INTO view_base VALUES (7);
+             CREATE TRIGGER replace_view_update
+             INSTEAD OF UPDATE ON owned_view
+             BEGIN
+                 UPDATE view_base SET x = 99 WHERE x = OLD.x;
+             END",
+        )
+        .expect("intercepting view trigger");
+
+        let err = bridge_unledgered_domain(&mut conn, &VIEW_DOMAIN, 1, &[1], Some(prepare_view))
+            .expect_err("undeclared view trigger must be refused before prepare");
+        assert!(matches!(
+            err,
+            SqliteStoreError::SchemaFingerprintMismatch { version: 1, .. }
+        ));
+        assert_eq!(
+            conn.query_row("SELECT x FROM view_base", [], |row| row.get::<_, i64>(0))
+                .expect("original row"),
+            7
+        );
+        assert!(!ledger_table_exists(&conn).expect("ledger presence"));
+    }
+
+    #[test]
+    fn maintenance_bridge_refuses_ambiguous_prefix_without_mutation() {
+        fn no_op(_tx: &Transaction<'_>) -> Result<(), rusqlite::Error> {
+            Ok(())
+        }
+        const AMBIGUOUS: SchemaDomain = SchemaDomain {
+            name: "ambiguous-bridge-domain",
+            migrations: &[
+                Migration {
+                    version: 1,
+                    name: "base",
+                    apply: create_t1,
+                },
+                Migration {
+                    version: 2,
+                    name: "data-only",
+                    apply: no_op,
+                },
+            ],
+            initialize_current: create_t1,
+            allowed_existing_versions: &[2],
+            released_predecessors: &[],
+            owned_objects: &[SchemaObject {
+                kind: SchemaObjectKind::Table,
+                name: "t1",
+            }],
+            retired_objects: &[],
+        };
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let mut conn = temp_conn(&dir);
+        conn.execute_batch("CREATE TABLE t1 (x INTEGER)")
+            .expect("ambiguous schema");
+        let err = bridge_unledgered_domain(&mut conn, &AMBIGUOUS, 2, &[1, 2], None)
+            .expect_err("refuse ambiguity");
+        assert!(matches!(
+            err,
+            SqliteStoreError::UnledgeredSchemaAmbiguous { ref matches, .. }
+                if matches == &[1, 2]
+        ));
+        assert!(!ledger_table_exists(&conn).expect("ledger presence"));
+    }
+
+    #[test]
+    fn maintenance_bridge_refuses_malformed_ledger_before_owned_schema_contact() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let mut conn = temp_conn(&dir);
+        conn.execute_batch(
+            "CREATE TABLE t1 (x INTEGER);
+             CREATE TABLE meerkat_schema (domain TEXT, version INTEGER)",
+        )
+        .expect("malformed ledger");
+        let err = bridge_unledgered_domain(&mut conn, &DOMAIN_V2, 2, &[1], None)
+            .expect_err("refuse malformed ledger");
+        assert!(matches!(err, SqliteStoreError::LedgerMalformed { .. }));
+        let columns = conn
+            .prepare("PRAGMA table_info(t1)")
+            .expect("prepare")
+            .query_map([], |row| row.get::<_, String>(1))
+            .expect("query")
+            .collect::<Result<Vec<_>, _>>()
+            .expect("columns");
+        assert_eq!(columns, vec!["x"]);
+    }
+
+    #[test]
+    fn maintenance_bridge_refuses_mixed_case_trigger_that_mutates_foreign_ledger_row() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let mut conn = temp_conn(&dir);
+        conn.execute_batch(
+            "CREATE TABLE t1 (x INTEGER);
+             CREATE TABLE meerkat_schema (
+                 domain TEXT PRIMARY KEY,
+                 version INTEGER NOT NULL
+             );
+             INSERT INTO meerkat_schema (domain, version) VALUES ('foreign-domain', 7);
+             CREATE TRIGGER mutate_foreign_schema_row
+             AFTER INSERT ON MEERKAT_SCHEMA
+             BEGIN
+                 UPDATE MEERKAT_SCHEMA
+                 SET version = 999
+                 WHERE domain = 'foreign-domain';
+             END",
+        )
+        .expect("hostile ledger trigger");
+
+        let err = bridge_unledgered_domain(&mut conn, &DOMAIN_V2, 2, &[1], None)
+            .expect_err("mixed-case ledger trigger must be refused");
+        assert!(matches!(err, SqliteStoreError::LedgerMalformed { .. }));
+        let row_count = conn
+            .query_row(
+                "SELECT COUNT(*) FROM main.meerkat_schema WHERE domain = ?1",
+                [DOMAIN_V2.name],
+                |row| row.get::<_, i64>(0),
+            )
+            .expect("raw ledger count");
+        assert_eq!(row_count, 0);
+        let foreign_version = conn
+            .query_row(
+                "SELECT version FROM main.meerkat_schema WHERE domain = 'foreign-domain'",
+                [],
+                |row| row.get::<_, i64>(0),
+            )
+            .expect("foreign ledger row");
+        assert_eq!(foreign_version, 7);
+        let columns = conn
+            .prepare("PRAGMA table_info(t1)")
+            .expect("prepare")
+            .query_map([], |row| row.get::<_, String>(1))
+            .expect("query")
+            .collect::<Result<Vec<_>, _>>()
+            .expect("columns");
+        assert_eq!(
+            columns,
+            vec!["x"],
+            "failed stamp did not roll back migration"
+        );
     }
 
     #[test]

--- a/meerkat-sqlite/src/lib.rs
+++ b/meerkat-sqlite/src/lib.rs
@@ -54,8 +54,9 @@ pub use error::{SqliteErrorClass, SqliteStoreError, classify_sqlite_error, is_bu
 pub use fence::{ExclusiveFence, OperationGuard, fence_lock_path};
 pub use json_column::JsonColumnBytes;
 pub use ledger::{
-    LedgerReport, Migration, SchemaDomain, SchemaObject, SchemaObjectKind, SchemaPredecessor,
-    apply_domain_migrations, domain_version, preflight_schema_eligibility,
+    LedgerReport, MaintenanceBridgeReport, MaintenancePrepareReport, Migration, SchemaDomain,
+    SchemaObject, SchemaObjectKind, SchemaPredecessor, apply_domain_migrations,
+    bridge_unledgered_domain, domain_version, preflight_schema_eligibility,
     verify_released_schema_fingerprint,
 };
 pub use profile::{

--- a/meerkat-store/src/doctor.rs
+++ b/meerkat-store/src/doctor.rs
@@ -86,7 +86,8 @@ pub const FINDING_ORPHANED_LEASE: &str = "orphaned-lease";
 pub const FINDING_ACTIVE_LEASE: &str = "active-lease";
 /// A lease file that does not parse (blocks destructive prune).
 pub const FINDING_UNPARSEABLE_LEASE: &str = "unparseable-lease";
-/// An existing database file with no migration ledger (pre-arc; expected).
+/// An existing database file with no migration ledger. Current store opens
+/// may refuse it when the domain already owns schema objects.
 pub const FINDING_NO_SCHEMA_LEDGER: &str = "no-schema-ledger";
 /// A `*.pre-<version>-<timestamp>` migration backup artifact.
 pub const FINDING_BACKUP_ARTIFACT: &str = "backup-artifact";
@@ -900,11 +901,13 @@ fn inspect_database(
         Ok(None) => {
             diagnosis.findings.push(
                 StorageFinding::new(
-                    FindingSeverity::Info,
+                    FindingSeverity::Warning,
                     FINDING_NO_SCHEMA_LEDGER,
-                    "existing database has no meerkat_schema ledger (written before the \
-                     migration-ledger arc; expected — the owning store baselines it on next \
-                     write open)",
+                    "existing database has no meerkat_schema ledger; current store opens \
+                     initialize only domains that own no existing objects and refuse \
+                     unversioned owned schemas. If this state predates the 0.8.10 durable-state \
+                     floor, run `rkat storage migrate --apply --bridge-pre-0-8-10` once before \
+                     retrying the original command",
                 )
                 .with_path(db_path.to_path_buf())
                 .with_realm(realm),
@@ -2951,6 +2954,18 @@ mod tests {
             codes(&diagnosis).contains(&FINDING_NO_SCHEMA_LEDGER),
             "{diagnosis:?}"
         );
+        let no_ledger = diagnosis
+            .findings
+            .iter()
+            .find(|finding| finding.code == FINDING_NO_SCHEMA_LEDGER)
+            .expect("missing-ledger finding");
+        assert_eq!(no_ledger.severity, FindingSeverity::Warning);
+        assert!(
+            no_ledger
+                .message
+                .contains("refuse unversioned owned schemas")
+        );
+        assert!(no_ledger.message.contains("--bridge-pre-0-8-10"));
         let future = diagnosis
             .findings
             .iter()

--- a/meerkat-store/src/error.rs
+++ b/meerkat-store/src/error.rs
@@ -110,6 +110,22 @@ pub enum StoreError {
         supported: i64,
     },
 
+    /// The file has no ledger row for a schema domain but already contains
+    /// objects owned by that domain. This is not a fresh domain and cannot be
+    /// authenticated as the released predecessor, so normal opens refuse it.
+    #[cfg(not(target_arch = "wasm32"))]
+    #[error(
+        "schema domain '{domain}' has no ledger row but already owns objects {objects:?}; \
+         refusing to infer or stamp an unversioned schema. For a realm last written before \
+         the 0.8.10 durable-state floor, run the explicit current-binary bridge once \
+         (`rkat --state-root <ROOT> --realm <REALM> storage migrate --apply \
+         --bridge-pre-0-8-10`), then retry the original command"
+    )]
+    UnledgeredDomainObjects {
+        domain: String,
+        objects: Vec<String>,
+    },
+
     /// The exclusive maintenance fence is held for this database; storage is
     /// under offline maintenance.
     #[cfg(not(target_arch = "wasm32"))]
@@ -185,6 +201,9 @@ impl From<meerkat_sqlite::SqliteStoreError> for StoreError {
                 supported,
             },
             E::MaintenanceFenceHeld { path } => StoreError::MaintenanceFenceHeld { path },
+            E::UnledgeredDomainObjects { domain, objects } => {
+                StoreError::UnledgeredDomainObjects { domain, objects }
+            }
             // A malformed ledger IS on-disk corruption of the file's
             // migration bookkeeping.
             E::LedgerMalformed { detail } => StoreError::CorruptLedger { detail },
@@ -192,7 +211,8 @@ impl From<meerkat_sqlite::SqliteStoreError> for StoreError {
             | E::MigrationBrokeTransaction { .. }
             | E::UnsupportedSchemaPredecessor { .. }
             | E::SchemaFingerprintMismatch { .. }
-            | E::UnledgeredDomainObjects { .. }
+            | E::UnledgeredSchemaNoMatch { .. }
+            | E::UnledgeredSchemaAmbiguous { .. }
             | E::WalNotEstablished { .. }
             | E::InvalidMigrationList { .. }
             | E::OpenRefused { .. }) => StoreError::Internal(other.to_string()),
@@ -289,6 +309,27 @@ mod tests {
             StoreError::from(err),
             StoreError::CorruptLedger { detail } if detail == "domain row count"
         ));
+    }
+
+    #[test]
+    fn unledgered_owned_objects_preserve_typed_bridge_guidance() {
+        let err = meerkat_sqlite::SqliteStoreError::UnledgeredDomainObjects {
+            domain: "session-store".to_string(),
+            objects: vec!["table:sessions (expected table)".to_string()],
+        };
+        let mapped = StoreError::from(err);
+        assert!(matches!(
+            &mapped,
+            StoreError::UnledgeredDomainObjects { domain, objects }
+                if domain == "session-store"
+                    && objects == &["table:sessions (expected table)".to_string()]
+        ));
+        let message = mapped.to_string();
+        assert!(
+            message.contains("explicit current-binary bridge"),
+            "{message}"
+        );
+        assert!(message.contains("--bridge-pre-0-8-10"), "{message}");
     }
 
     #[test]

--- a/meerkat-store/src/lib.rs
+++ b/meerkat-store/src/lib.rs
@@ -69,7 +69,9 @@ pub use realm::FilesystemRealmConfigSource;
 #[cfg(not(target_arch = "wasm32"))]
 #[allow(deprecated)]
 // the ambient no-`_in` wrappers stay exported through their deprecation window
-pub use realm::{ExternalRealmManifest, RealmManifestPin, ensure_realm_manifest_pin_in};
+pub use realm::{
+    ExternalRealmManifest, RealmManifestPin, ensure_realm_manifest_pin_in, read_realm_manifest_pin,
+};
 #[cfg(not(target_arch = "wasm32"))]
 #[allow(deprecated)]
 // the ambient no-`_in` wrappers stay exported through their deprecation window

--- a/meerkat-store/src/realm.rs
+++ b/meerkat-store/src/realm.rs
@@ -1222,6 +1222,19 @@ impl RealmManifestPin {
     }
 }
 
+/// Read and validate an existing realm manifest without creating or updating
+/// any realm state.
+///
+/// This is the synchronous, read-only counterpart used by offline maintenance
+/// while the caller already holds the realm fence. It preserves provider pins
+/// and the future-format refusal instead of reinterpreting them as built-in
+/// disk manifests.
+#[cfg(not(target_arch = "wasm32"))]
+pub fn read_realm_manifest_pin(path: &Path) -> Result<RealmManifestPin, StoreError> {
+    let bytes = std::fs::read(path).map_err(StoreError::Io)?;
+    parse_manifest_pin_bytes(&bytes)
+}
+
 /// Provider-aware manifest parse: external pins are returned, not refused.
 fn parse_manifest_pin_bytes(bytes: &[u8]) -> Result<RealmManifestPin, StoreError> {
     let persisted: PersistedRealmManifest =

--- a/meerkat-tools/src/builtin/mod.rs
+++ b/meerkat-tools/src/builtin/mod.rs
@@ -51,7 +51,7 @@ pub use memory_store::MemoryTaskStore;
 #[cfg(not(target_arch = "wasm32"))]
 pub use project::{ensure_rkat_dir, ensure_rkat_dir_async, find_project_root};
 #[cfg(all(feature = "sqlite", not(target_arch = "wasm32")))]
-pub use sqlite_store::SqliteTaskStore;
+pub use sqlite_store::{SqliteTaskStore, TOOLS_TASKS_DOMAIN};
 pub use store::TaskStore;
 
 use async_trait::async_trait;

--- a/meerkat-tools/src/builtin/sqlite_store.rs
+++ b/meerkat-tools/src/builtin/sqlite_store.rs
@@ -32,7 +32,7 @@ fn migration_0001_tasks_schema(tx: &Transaction<'_>) -> Result<(), rusqlite::Err
 }
 
 /// The task store's schema domain in the per-file migration ledger.
-const TOOLS_TASKS_DOMAIN: meerkat_sqlite::SchemaDomain = meerkat_sqlite::SchemaDomain {
+pub const TOOLS_TASKS_DOMAIN: meerkat_sqlite::SchemaDomain = meerkat_sqlite::SchemaDomain {
     name: "tools-tasks",
     migrations: &[meerkat_sqlite::Migration {
         version: 1,

--- a/meerkat-tools/src/lib.rs
+++ b/meerkat-tools/src/lib.rs
@@ -59,6 +59,8 @@ pub use builtin::{
 };
 #[cfg(not(target_arch = "wasm32"))]
 pub use builtin::{FileTaskStore, ensure_rkat_dir, ensure_rkat_dir_async, find_project_root};
+#[cfg(all(feature = "sqlite", not(target_arch = "wasm32")))]
+pub use builtin::{SqliteTaskStore, TOOLS_TASKS_DOMAIN};
 pub use control_plane::{CatalogControlDispatcher, CatalogControlVisibilityProvider};
 pub use dispatcher::EmptyToolDispatcher;
 #[cfg(not(target_arch = "wasm32"))]

--- a/meerkat-workgraph/src/lib.rs
+++ b/meerkat-workgraph/src/lib.rs
@@ -31,12 +31,12 @@ pub use rest_contract::{
     workgraph_rest_response_schema,
 };
 pub use service::WorkGraphService;
-#[cfg(not(target_arch = "wasm32"))]
-pub use store::SqliteWorkGraphStore;
 pub use store::{
     DisabledWorkGraphStore, MemoryWorkGraphStore, WorkGraphEventFilter, WorkGraphStore,
     WorkGraphStoreKind,
 };
+#[cfg(not(target_arch = "wasm32"))]
+pub use store::{SqliteWorkGraphStore, WORKGRAPH_DOMAIN, prepare_pre_0_8_10_workgraph_attention};
 pub use surface::wire_workgraph_tools;
 pub use tool_surface::{
     WORKGRAPH_ATTENTION_DISPATCH_CONTEXT_KEY, WorkGraphToolSurface,

--- a/meerkat-workgraph/src/store.rs
+++ b/meerkat-workgraph/src/store.rs
@@ -1836,6 +1836,149 @@ fn migration_0002_attention_query_columns(tx: &Transaction<'_>) -> Result<(), ru
     Ok(())
 }
 
+#[cfg(not(target_arch = "wasm32"))]
+fn pre_0_8_10_attention_import_error(
+    binding_id: &str,
+    detail: impl std::fmt::Display,
+) -> rusqlite::Error {
+    rusqlite::Error::ToSqlConversionFailure(Box::new(std::io::Error::new(
+        std::io::ErrorKind::InvalidData,
+        format!("pre-v0.8.10 workgraph attention row `{binding_id}`: {detail}"),
+    )))
+}
+
+/// Reconcile the exact v2 attention projection published before the schema
+/// ledger existed.
+///
+/// The explicit maintenance bridge authenticates the catalog before calling
+/// this function. A physical v1 source has no projection columns and is left
+/// for migration 0002. A physical v2 source is data-bearing: every non-NULL
+/// projection must already agree with its typed `attention_json` authority,
+/// while NULL projections written by an older mixed-version process are
+/// backfilled. Any disagreement is refused inside the bridge transaction.
+#[cfg(not(target_arch = "wasm32"))]
+pub fn prepare_pre_0_8_10_workgraph_attention(
+    tx: &Transaction<'_>,
+) -> Result<meerkat_sqlite::MaintenancePrepareReport, rusqlite::Error> {
+    let columns = tx
+        .prepare("PRAGMA table_info(workgraph_attention)")?
+        .query_map([], |row| row.get::<_, String>(1))?
+        .collect::<Result<Vec<_>, _>>()?;
+    let has_status = columns.iter().any(|name| name == "status");
+    let has_target_key = columns.iter().any(|name| name == "target_key");
+    match (has_status, has_target_key) {
+        (false, false) => {
+            return Ok(meerkat_sqlite::MaintenancePrepareReport::default());
+        }
+        (true, true) => {}
+        _ => {
+            return Err(pre_0_8_10_attention_import_error(
+                "<catalog>",
+                "status and target_key projection columns are not an exact pair",
+            ));
+        }
+    }
+
+    struct ProjectionRepair {
+        realm_id: String,
+        namespace: String,
+        binding_id: String,
+        source_status: Option<String>,
+        source_target_key: Option<String>,
+        expected_status: String,
+        expected_target_key: String,
+    }
+
+    let repairs = {
+        let mut statement = tx.prepare(
+            "SELECT realm_id, namespace, binding_id, attention_json, status, target_key
+               FROM workgraph_attention
+              ORDER BY realm_id, namespace, binding_id",
+        )?;
+        let rows = statement.query_map([], |row| {
+            Ok((
+                row.get::<_, String>(0)?,
+                row.get::<_, String>(1)?,
+                row.get::<_, String>(2)?,
+                row.get::<_, String>(3)?,
+                row.get::<_, Option<String>>(4)?,
+                row.get::<_, Option<String>>(5)?,
+            ))
+        })?;
+        let mut repairs = Vec::new();
+        for row in rows {
+            let (realm_id, namespace, binding_id, attention_json, status, target_key) = row?;
+            let binding: WorkAttentionBinding = serde_json::from_str(&attention_json)
+                .map_err(|error| pre_0_8_10_attention_import_error(&binding_id, error))?;
+            let expected_status = binding.status.status_key().to_string();
+            let expected_target_key = binding.target.target_key();
+            if status
+                .as_deref()
+                .is_some_and(|value| value != expected_status)
+            {
+                return Err(pre_0_8_10_attention_import_error(
+                    &binding_id,
+                    format!(
+                        "status projection `{}` disagrees with typed authority `{expected_status}`",
+                        status.as_deref().unwrap_or_default()
+                    ),
+                ));
+            }
+            if target_key
+                .as_deref()
+                .is_some_and(|value| value != expected_target_key)
+            {
+                return Err(pre_0_8_10_attention_import_error(
+                    &binding_id,
+                    format!(
+                        "target_key projection `{}` disagrees with typed authority `{expected_target_key}`",
+                        target_key.as_deref().unwrap_or_default()
+                    ),
+                ));
+            }
+            if status.is_none() || target_key.is_none() {
+                repairs.push(ProjectionRepair {
+                    realm_id,
+                    namespace,
+                    binding_id,
+                    source_status: status,
+                    source_target_key: target_key,
+                    expected_status,
+                    expected_target_key,
+                });
+            }
+        }
+        repairs
+    };
+
+    let changed = repairs.len();
+    for repair in repairs {
+        let updated = tx.execute(
+            "UPDATE workgraph_attention
+                SET status = ?4, target_key = ?5
+              WHERE realm_id = ?1 AND namespace = ?2 AND binding_id = ?3
+                AND status IS ?6 AND target_key IS ?7",
+            params![
+                repair.realm_id,
+                repair.namespace,
+                repair.binding_id,
+                repair.expected_status,
+                repair.expected_target_key,
+                repair.source_status,
+                repair.source_target_key,
+            ],
+        )?;
+        if updated != 1 {
+            return Err(pre_0_8_10_attention_import_error(
+                &repair.binding_id,
+                "source projection changed inside the maintenance transaction",
+            ));
+        }
+    }
+
+    Ok(meerkat_sqlite::MaintenancePrepareReport { changed })
+}
+
 /// Occupancy probe for the active-binding-per-target invariant, run INSIDE
 /// the same immediate write transaction as the mutation it guards so the
 /// check is race-free next to the data. NULL-column rows (written by older
@@ -2879,6 +3022,205 @@ mod legacy_schema_tests {
     use super::*;
     use crate::{AttentionDelegatedAuthority, AttentionProjectionPolicy, WorkAttentionMode};
     use meerkat_core::SessionId;
+
+    fn test_attention(binding_id: &str) -> WorkAttentionBinding {
+        WorkAttentionBinding {
+            binding_id: WorkAttentionBindingId::new(binding_id).expect("binding id"),
+            work_ref: crate::WorkItemRef {
+                realm_id: "realm".to_string(),
+                namespace: WorkNamespace::default(),
+                item_id: WorkItemId::generated(),
+            },
+            target: crate::WorkAttentionTarget::Session {
+                session_id: SessionId::new(),
+            },
+            mode: WorkAttentionMode::Pursue,
+            status: WorkAttentionStatus::Active,
+            machine_state: Default::default(),
+            delegated_authority: AttentionDelegatedAuthority::AddEvidence,
+            projection_policy: AttentionProjectionPolicy::default(),
+            created_at: chrono::Utc::now(),
+            updated_at: chrono::Utc::now(),
+        }
+    }
+
+    fn create_unledgered_v2_workgraph(path: &Path) -> Connection {
+        let mut conn = Connection::open(path).expect("open raw");
+        let tx = conn.transaction().expect("begin schema transaction");
+        migration_0001_workgraph_schema(&tx).expect("create v1 workgraph schema");
+        migration_0002_attention_query_columns(&tx).expect("create v2 workgraph schema");
+        tx.commit().expect("commit v2 workgraph schema");
+        conn
+    }
+
+    #[test]
+    fn explicit_bridge_authenticates_v2_and_repairs_null_attention_projections() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("workgraph.sqlite3");
+        let mut conn = create_unledgered_v2_workgraph(&path);
+        let binding = test_attention("legacy-v2-binding");
+        let expected_status = binding.status.status_key().to_string();
+        let expected_target_key = binding.target.target_key();
+        conn.execute(
+            "INSERT INTO workgraph_attention
+                (realm_id, namespace, binding_id, revision, updated_at_utc, attention_json)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+            params![
+                binding.work_ref.realm_id,
+                binding.work_ref.namespace.as_str(),
+                binding.binding_id.as_str(),
+                binding.machine_state.revision,
+                binding.updated_at.to_rfc3339(),
+                serde_json::to_string(&binding).expect("serialize binding"),
+            ],
+        )
+        .expect("insert mixed-version row");
+
+        let report = meerkat_sqlite::bridge_unledgered_domain(
+            &mut conn,
+            &WORKGRAPH_DOMAIN,
+            WORKGRAPH_DOMAIN.supported_version(),
+            &[1, 2],
+            Some(prepare_pre_0_8_10_workgraph_attention),
+        )
+        .expect("bridge exact v2 catalog");
+        assert_eq!(report.from_version, 2);
+        assert_eq!(report.to_version, 2);
+        assert_eq!(report.prepared, 1);
+        let projections = conn
+            .query_row(
+                "SELECT status, target_key FROM workgraph_attention WHERE binding_id = ?1",
+                [binding.binding_id.as_str()],
+                |row| Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?)),
+            )
+            .expect("read repaired projections");
+        assert_eq!(projections, (expected_status, expected_target_key));
+        assert_eq!(
+            meerkat_sqlite::domain_version(&conn, WORKGRAPH_DOMAIN.name).expect("ledger"),
+            Some(2)
+        );
+
+        let rerun = meerkat_sqlite::bridge_unledgered_domain(
+            &mut conn,
+            &WORKGRAPH_DOMAIN,
+            WORKGRAPH_DOMAIN.supported_version(),
+            &[1, 2],
+            Some(prepare_pre_0_8_10_workgraph_attention),
+        )
+        .expect("idempotent target rerun");
+        assert_eq!(rerun.from_version, 2);
+        assert_eq!(rerun.to_version, 2);
+        assert_eq!(rerun.prepared, 0);
+    }
+
+    #[test]
+    fn explicit_bridge_refuses_non_null_attention_projection_mismatch_without_mutation() {
+        for (case, wrong_status, wrong_target) in [
+            ("status", Some("stopped"), None),
+            ("target_key", None, Some("session:wrong")),
+        ] {
+            let dir = tempfile::tempdir().expect("tempdir");
+            let path = dir.path().join(format!("workgraph-{case}.sqlite3"));
+            let mut conn = create_unledgered_v2_workgraph(&path);
+            let binding = test_attention(&format!("legacy-v2-{case}"));
+            let expected_status = binding.status.status_key().to_string();
+            let expected_target_key = binding.target.target_key();
+            let source_status = wrong_status.unwrap_or(&expected_status).to_string();
+            let source_target_key = wrong_target.unwrap_or(&expected_target_key).to_string();
+            let source_json = serde_json::to_string(&binding).expect("serialize binding");
+            conn.execute(
+                "INSERT INTO workgraph_attention
+                    (realm_id, namespace, binding_id, revision, updated_at_utc, attention_json,
+                     status, target_key)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
+                params![
+                    binding.work_ref.realm_id,
+                    binding.work_ref.namespace.as_str(),
+                    binding.binding_id.as_str(),
+                    binding.machine_state.revision,
+                    binding.updated_at.to_rfc3339(),
+                    source_json,
+                    source_status,
+                    source_target_key,
+                ],
+            )
+            .expect("insert mismatched projection");
+
+            let error = meerkat_sqlite::bridge_unledgered_domain(
+                &mut conn,
+                &WORKGRAPH_DOMAIN,
+                WORKGRAPH_DOMAIN.supported_version(),
+                &[1, 2],
+                Some(prepare_pre_0_8_10_workgraph_attention),
+            )
+            .expect_err("non-null projection mismatch must be refused");
+            assert!(
+                error.to_string().contains("disagrees with typed authority"),
+                "unexpected {case} refusal: {error}"
+            );
+            let unchanged = conn
+                .query_row(
+                    "SELECT attention_json, status, target_key
+                       FROM workgraph_attention WHERE binding_id = ?1",
+                    [binding.binding_id.as_str()],
+                    |row| {
+                        Ok((
+                            row.get::<_, String>(0)?,
+                            row.get::<_, String>(1)?,
+                            row.get::<_, String>(2)?,
+                        ))
+                    },
+                )
+                .expect("read refused source");
+            assert_eq!(unchanged, (source_json, source_status, source_target_key));
+            assert_eq!(
+                meerkat_sqlite::domain_version(&conn, WORKGRAPH_DOMAIN.name).expect("ledger"),
+                None,
+                "refused {case} row must not be stamped"
+            );
+        }
+    }
+
+    #[test]
+    fn explicit_bridge_refuses_near_miss_v2_catalog_before_preparation() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("workgraph.sqlite3");
+        let mut conn = create_unledgered_v2_workgraph(&path);
+        conn.execute_batch(
+            "DROP INDEX idx_workgraph_attention_scope_status;
+             CREATE INDEX idx_workgraph_attention_scope_status
+                 ON workgraph_attention (realm_id, namespace, status);",
+        )
+        .expect("install near-miss index");
+
+        let error = meerkat_sqlite::bridge_unledgered_domain(
+            &mut conn,
+            &WORKGRAPH_DOMAIN,
+            WORKGRAPH_DOMAIN.supported_version(),
+            &[1, 2],
+            Some(prepare_pre_0_8_10_workgraph_attention),
+        )
+        .expect_err("near-miss catalog must be refused");
+        assert!(
+            error
+                .to_string()
+                .contains("does not match any authorized source catalog"),
+            "unexpected near-miss refusal: {error}"
+        );
+        assert_eq!(
+            meerkat_sqlite::domain_version(&conn, WORKGRAPH_DOMAIN.name).expect("ledger"),
+            None
+        );
+        let index_sql: String = conn
+            .query_row(
+                "SELECT sql FROM sqlite_schema
+                  WHERE type = 'index' AND name = 'idx_workgraph_attention_scope_status'",
+                [],
+                |row| row.get(0),
+            )
+            .expect("near-miss index remains");
+        assert!(index_sql.ends_with("(realm_id, namespace, status)"));
+    }
 
     /// The released v2 floor is exact: an unledgered v1 attention table is
     /// refused without schema/data mutation or a ledger stamp.

--- a/meerkat/Cargo.toml
+++ b/meerkat/Cargo.toml
@@ -50,6 +50,7 @@ chrono = { workspace = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 tokio = { workspace = true }
+meerkat-sqlite = { workspace = true }
 meerkat-providers = { workspace = true, default-features = false, features = [
     "oauth",
     "refresh-file-lock",

--- a/meerkat/src/lib.rs
+++ b/meerkat/src/lib.rs
@@ -293,9 +293,12 @@ pub use persistence::PersistenceBundle;
 #[cfg(feature = "session-store")]
 pub use persistence::PersistenceError;
 #[cfg(all(feature = "session-store", not(target_arch = "wasm32")))]
-pub use persistence::open_realm_persistence_in;
-#[cfg(all(feature = "session-store", not(target_arch = "wasm32")))]
 pub use persistence::open_realm_persistence_with_provider;
+#[cfg(all(feature = "session-store", not(target_arch = "wasm32")))]
+pub use persistence::{
+    PreV0810DomainBridgeReport, PreV0810RealmBridgeReport, bridge_pre_0_8_10_realm_storage_in,
+    open_realm_persistence_in,
+};
 #[cfg(all(feature = "session-store", not(target_arch = "wasm32")))]
 pub use storage_provider::{
     DiskStorageProvider, RealmOpenContext, RealmStorageProvider, RealmStoreSet,

--- a/meerkat/src/persistence.rs
+++ b/meerkat/src/persistence.rs
@@ -63,6 +63,19 @@ pub enum PersistenceError {
     #[cfg(all(feature = "session-store", not(target_arch = "wasm32")))]
     #[error(transparent)]
     FirstStart(meerkat_store::realm::RealmFirstStartError),
+    /// The explicit pre-floor importer is intentionally scoped to the
+    /// co-tenanted SQLite realm layout it can authenticate end to end.
+    #[cfg(all(feature = "session-store", not(target_arch = "wasm32")))]
+    #[error(
+        "the explicit pre-v0.8.10 bridge supports only SQLite realms; realm '{realm_id}' uses the '{backend}' backend"
+    )]
+    PreV0810BridgeBackend { realm_id: String, backend: String },
+    /// The explicit bridge never follows realm-layout symlinks. A linked
+    /// database could otherwise redirect maintenance writes outside the
+    /// realm covered by the caller's fence.
+    #[cfg(all(feature = "session-store", not(target_arch = "wasm32")))]
+    #[error("the explicit pre-v0.8.10 bridge refuses symlinked realm path '{path}'")]
+    PreV0810BridgeSymlink { path: PathBuf },
     /// A `Durable` storage slot resolved to a non-persistent store without
     /// the realm manifest declaring that domain ephemeral (fail-closed
     /// durability; see `storage_provider`).
@@ -357,6 +370,360 @@ pub(crate) fn layout_for_explicit_state_root(
     };
     let resolved = meerkat_core::StorageLayout::resolve(inputs, &realm_config)?;
     Ok(resolved.layout)
+}
+
+/// One schema domain considered by the explicit pre-0.8.10 storage bridge.
+///
+/// A `0 -> 0` result means the database exists but this domain owns no
+/// objects, so the bridge left fresh-domain initialization to the ordinary
+/// store constructor. For equal non-zero versions, `ledger_established` and
+/// `prepared_rows` distinguish exact-current stamping or payload preparation
+/// from a true idempotent no-op.
+#[cfg(all(feature = "session-store", not(target_arch = "wasm32")))]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PreV0810DomainBridgeReport {
+    /// Database file containing the domain.
+    pub database: PathBuf,
+    /// Stable ledger domain name.
+    pub domain: String,
+    /// Authenticated source schema version.
+    pub from_version: i64,
+    /// Schema version after the bridge.
+    pub to_version: i64,
+    /// Whether this call established the domain's previously missing ledger
+    /// row. This is false for existing-ledger upgrades and idempotent re-runs.
+    pub ledger_established: bool,
+    /// Durable records rewritten by the domain's scoped preparation callback.
+    pub prepared_rows: usize,
+}
+
+#[cfg(all(feature = "session-store", not(target_arch = "wasm32")))]
+impl PreV0810DomainBridgeReport {
+    /// True when this call established a ledger row, advanced a schema, or
+    /// rewrote a durable payload.
+    pub fn changed(&self) -> bool {
+        self.ledger_established || self.from_version != self.to_version || self.prepared_rows != 0
+    }
+}
+
+/// Result of the explicit pre-0.8.10 bridge across the SQLite files that
+/// already exist in one realm.
+#[cfg(all(feature = "session-store", not(target_arch = "wasm32")))]
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct PreV0810RealmBridgeReport {
+    /// Domains considered, in dependency-safe bridge order.
+    pub domains: Vec<PreV0810DomainBridgeReport>,
+    /// Existing SQLite companions skipped because the realm manifest names a
+    /// different durable authority.
+    pub inactive_databases: Vec<PathBuf>,
+}
+
+#[cfg(all(feature = "session-store", not(target_arch = "wasm32")))]
+fn record_pre_v0_8_10_domain(
+    report: &mut PreV0810RealmBridgeReport,
+    database: &Path,
+    domain: &meerkat_sqlite::SchemaDomain,
+    ledger_before: Option<i64>,
+    result: meerkat_sqlite::MaintenanceBridgeReport,
+) {
+    report.domains.push(PreV0810DomainBridgeReport {
+        database: database.to_path_buf(),
+        domain: domain.name.to_string(),
+        from_version: result.from_version,
+        to_version: result.to_version,
+        ledger_established: ledger_before.is_none() && result.to_version != 0,
+        prepared_rows: result.prepared,
+    });
+}
+
+#[cfg(all(feature = "session-store", not(target_arch = "wasm32")))]
+fn census_pre_v0_8_10_domains(
+    database: &Path,
+    domains: &[&meerkat_sqlite::SchemaDomain],
+) -> Result<(), PersistenceError> {
+    if !database.is_file() {
+        return Ok(());
+    }
+    let conn = meerkat_sqlite::open(database, meerkat_sqlite::ConnectionProfile::ReadOnly)
+        .map_err(StoreError::from)?;
+    for domain in domains {
+        if let Some(found) =
+            meerkat_sqlite::domain_version(&conn, domain.name).map_err(StoreError::from)?
+            && found > domain.supported_version()
+        {
+            return Err(PersistenceError::Store(StoreError::SchemaFromTheFuture {
+                domain: domain.name.to_string(),
+                found,
+                supported: domain.supported_version(),
+            }));
+        }
+    }
+    Ok(())
+}
+
+#[cfg(all(feature = "session-store", not(target_arch = "wasm32")))]
+fn refuse_pre_v0_8_10_bridge_symlink(path: &Path) -> Result<(), PersistenceError> {
+    match std::fs::symlink_metadata(path) {
+        Ok(metadata) if metadata.file_type().is_symlink() => {
+            Err(PersistenceError::PreV0810BridgeSymlink {
+                path: path.to_path_buf(),
+            })
+        }
+        Ok(_) => Ok(()),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(StoreError::Io(error).into()),
+    }
+}
+
+/// Authenticate and migrate exact pre-0.8.10 SQLite schemas in one realm.
+///
+/// This is an explicit offline maintenance operation. `fence` must cover the
+/// exact requested realm; its admission lock and fixed database inventory are
+/// validated before the manifest or any database is read. Ordinary realm
+/// opens remain strict and never invoke this bridge. Only existing database
+/// files are opened, always with the maintenance-write profile, and every
+/// domain bridge is transactionally authenticated by its owning migration
+/// manifest before it is stamped.
+#[cfg(all(feature = "session-store", not(target_arch = "wasm32")))]
+pub fn bridge_pre_0_8_10_realm_storage_in(
+    realms_root: &Path,
+    realm_id: &str,
+    fence: &meerkat_store::migrate::RealmMaintenanceFence,
+) -> Result<PreV0810RealmBridgeReport, PersistenceError> {
+    // Validate the public identity before deriving its sanitized directory.
+    let requested_realm = meerkat_core::RealmId::parse(realm_id)
+        .map_err(|_| StoreError::InvalidRealmSlug(realm_id.to_string()))?;
+
+    let paths = realm_paths_in(realms_root, realm_id);
+    refuse_pre_v0_8_10_bridge_symlink(&paths.root)?;
+    refuse_pre_v0_8_10_bridge_symlink(&paths.manifest_path)?;
+    refuse_pre_v0_8_10_bridge_symlink(&paths.root.join("memory"))?;
+    let inventory = meerkat_store::migrate::enumerate_realm_sqlite_inventory(&paths.root);
+    if let Some(path) = inventory.symlinks.first() {
+        return Err(PersistenceError::PreV0810BridgeSymlink { path: path.clone() });
+    }
+    let expected_admission = meerkat_sqlite::fence_lock_path(
+        &meerkat_store::migrate::realm_write_admission_target(&paths.root),
+    );
+    let covers_fixed_inventory = meerkat_store::migrate::REALM_SQLITE_FILES
+        .iter()
+        .map(|relative| paths.root.join(relative))
+        .all(|database| fence.fenced_databases().contains(&database));
+    let contains_foreign_database = fence
+        .fenced_databases()
+        .iter()
+        .any(|database| !database.starts_with(&paths.root));
+    if fence.admission_lock_path() != expected_admission
+        || !covers_fixed_inventory
+        || contains_foreign_database
+    {
+        return Err(PersistenceError::Store(StoreError::Internal(format!(
+            "maintenance fence does not cover requested realm directory '{}'",
+            paths.root.display()
+        ))));
+    }
+
+    let manifest_pin = meerkat_store::read_realm_manifest_pin(&paths.manifest_path)?;
+    if manifest_pin.realm() != &requested_realm {
+        return Err(PersistenceError::Store(StoreError::RealmIdentityMismatch {
+            requested: requested_realm.as_str().to_string(),
+            existing: manifest_pin.realm().as_str().to_string(),
+        }));
+    }
+    let manifest = match manifest_pin {
+        meerkat_store::RealmManifestPin::Builtin(manifest) => manifest,
+        meerkat_store::RealmManifestPin::External(manifest) => {
+            return Err(PersistenceError::Store(StoreError::ExternalProviderRealm {
+                realm_id: manifest.realm.as_str().to_string(),
+                provider: manifest.provider,
+            }));
+        }
+    };
+
+    if !matches!(manifest.backend, RealmBackend::Sqlite) {
+        return Err(PersistenceError::PreV0810BridgeBackend {
+            realm_id: realm_id.to_string(),
+            backend: manifest.backend.as_str().to_string(),
+        });
+    }
+
+    // Cross-file census before the first write: malformed ledgers and any
+    // future-version active domain abort the whole explicit bridge before an
+    // earlier domain can be stamped or migrated.
+    census_pre_v0_8_10_domains(
+        &paths.sessions_sqlite_path,
+        &[
+            &meerkat_store::sqlite_store::SESSION_STORE_DOMAIN,
+            &meerkat_runtime::store::sqlite::RUNTIME_STORE_DOMAIN,
+            &meerkat_store::schedule_sqlite_store::SCHEDULE_STORE_DOMAIN,
+        ],
+    )?;
+    census_pre_v0_8_10_domains(
+        &paths.root.join("workgraph.sqlite3"),
+        &[&meerkat_workgraph::WORKGRAPH_DOMAIN],
+    )?;
+    census_pre_v0_8_10_domains(&paths.jobs_sqlite_path, &[&meerkat_jobs::JOBS_DOMAIN])?;
+    #[cfg(feature = "memory-store-session")]
+    census_pre_v0_8_10_domains(
+        &paths.root.join("memory").join("memory.sqlite3"),
+        &[&meerkat_memory::MEMORY_DOMAIN],
+    )?;
+    census_pre_v0_8_10_domains(
+        &paths.root.join("tasks.db"),
+        &[&meerkat_tools::TOOLS_TASKS_DOMAIN],
+    )?;
+
+    let mut report = PreV0810RealmBridgeReport::default();
+
+    if paths.runtime_sqlite_path.is_file() {
+        report
+            .inactive_databases
+            .push(paths.runtime_sqlite_path.clone());
+    }
+
+    // The SQLite realm backend co-tenants these three domains in the session
+    // database. Session migration runs first because runtime migration imports
+    // session snapshots; scheduling follows both runtime authorities.
+    if paths.sessions_sqlite_path.is_file() {
+        let database = &paths.sessions_sqlite_path;
+        let mut conn = meerkat_sqlite::open(
+            database,
+            meerkat_sqlite::ConnectionProfile::Maintenance { write: true },
+        )
+        .map_err(StoreError::from)?;
+
+        let domain = &meerkat_store::sqlite_store::SESSION_STORE_DOMAIN;
+        let ledger_before =
+            meerkat_sqlite::domain_version(&conn, domain.name).map_err(StoreError::from)?;
+        let result = meerkat_core::with_pre_floor_provider_image_metadata_import(|| {
+            meerkat_sqlite::bridge_unledgered_domain(
+                &mut conn,
+                domain,
+                domain.supported_version(),
+                &[1],
+                None,
+            )
+        })
+        .map_err(StoreError::from)?;
+        record_pre_v0_8_10_domain(&mut report, database, domain, ledger_before, result);
+
+        let domain = &meerkat_runtime::store::sqlite::RUNTIME_STORE_DOMAIN;
+        let ledger_before =
+            meerkat_sqlite::domain_version(&conn, domain.name).map_err(StoreError::from)?;
+        let result = meerkat_core::with_pre_floor_provider_image_metadata_import(|| {
+            meerkat_sqlite::bridge_unledgered_domain(
+                &mut conn,
+                domain,
+                domain.supported_version(),
+                &[1],
+                Some(meerkat_runtime::store::sqlite::prepare_pre_0_8_10_runtime_input_states),
+            )
+        })
+        .map_err(StoreError::from)?;
+        record_pre_v0_8_10_domain(&mut report, database, domain, ledger_before, result);
+
+        let domain = &meerkat_store::schedule_sqlite_store::SCHEDULE_STORE_DOMAIN;
+        let ledger_before =
+            meerkat_sqlite::domain_version(&conn, domain.name).map_err(StoreError::from)?;
+        let result = meerkat_sqlite::bridge_unledgered_domain(
+            &mut conn,
+            domain,
+            domain.supported_version(),
+            &[1],
+            None,
+        )
+        .map_err(StoreError::from)?;
+        record_pre_v0_8_10_domain(&mut report, database, domain, ledger_before, result);
+    }
+
+    let workgraph_db = paths.root.join("workgraph.sqlite3");
+    if workgraph_db.is_file() {
+        let mut conn = meerkat_sqlite::open(
+            &workgraph_db,
+            meerkat_sqlite::ConnectionProfile::Maintenance { write: true },
+        )
+        .map_err(StoreError::from)?;
+        let domain = &meerkat_workgraph::WORKGRAPH_DOMAIN;
+        let ledger_before =
+            meerkat_sqlite::domain_version(&conn, domain.name).map_err(StoreError::from)?;
+        let result = meerkat_sqlite::bridge_unledgered_domain(
+            &mut conn,
+            domain,
+            domain.supported_version(),
+            &[1, 2],
+            Some(meerkat_workgraph::prepare_pre_0_8_10_workgraph_attention),
+        )
+        .map_err(StoreError::from)?;
+        record_pre_v0_8_10_domain(&mut report, &workgraph_db, domain, ledger_before, result);
+    }
+
+    if paths.jobs_sqlite_path.is_file() {
+        let database = &paths.jobs_sqlite_path;
+        let mut conn = meerkat_sqlite::open(
+            database,
+            meerkat_sqlite::ConnectionProfile::Maintenance { write: true },
+        )
+        .map_err(StoreError::from)?;
+        let domain = &meerkat_jobs::JOBS_DOMAIN;
+        let ledger_before =
+            meerkat_sqlite::domain_version(&conn, domain.name).map_err(StoreError::from)?;
+        let result = meerkat_sqlite::bridge_unledgered_domain(
+            &mut conn,
+            domain,
+            domain.supported_version(),
+            &[1],
+            None,
+        )
+        .map_err(StoreError::from)?;
+        record_pre_v0_8_10_domain(&mut report, database, domain, ledger_before, result);
+    }
+
+    #[cfg(feature = "memory-store-session")]
+    {
+        let memory_db = paths.root.join("memory").join("memory.sqlite3");
+        if memory_db.is_file() {
+            let mut conn = meerkat_sqlite::open(
+                &memory_db,
+                meerkat_sqlite::ConnectionProfile::Maintenance { write: true },
+            )
+            .map_err(StoreError::from)?;
+            let domain = &meerkat_memory::MEMORY_DOMAIN;
+            let ledger_before =
+                meerkat_sqlite::domain_version(&conn, domain.name).map_err(StoreError::from)?;
+            let result = meerkat_sqlite::bridge_unledgered_domain(
+                &mut conn,
+                domain,
+                domain.supported_version(),
+                &[1],
+                None,
+            )
+            .map_err(StoreError::from)?;
+            record_pre_v0_8_10_domain(&mut report, &memory_db, domain, ledger_before, result);
+        }
+    }
+
+    let tasks_db = paths.root.join("tasks.db");
+    if tasks_db.is_file() {
+        let mut conn = meerkat_sqlite::open(
+            &tasks_db,
+            meerkat_sqlite::ConnectionProfile::Maintenance { write: true },
+        )
+        .map_err(StoreError::from)?;
+        let domain = &meerkat_tools::TOOLS_TASKS_DOMAIN;
+        let ledger_before =
+            meerkat_sqlite::domain_version(&conn, domain.name).map_err(StoreError::from)?;
+        let result = meerkat_sqlite::bridge_unledgered_domain(
+            &mut conn,
+            domain,
+            domain.supported_version(),
+            &[1],
+            None,
+        )
+        .map_err(StoreError::from)?;
+        record_pre_v0_8_10_domain(&mut report, &tasks_db, domain, ledger_before, result);
+    }
+
+    Ok(report)
 }
 
 #[cfg(all(feature = "session-store", not(target_arch = "wasm32")))]
@@ -669,7 +1036,509 @@ mod tests {
     use meerkat_runtime::store::RuntimeStoreError;
     use meerkat_store::MemoryStore;
     use meerkat_store::{MemoryBlobStore, SessionFilter, SessionStoreError};
+    #[cfg(not(target_arch = "wasm32"))]
+    use std::time::Duration;
     use tempfile::TempDir;
+
+    #[cfg(not(target_arch = "wasm32"))]
+    fn create_unledgered_prefix(
+        database: &Path,
+        domains: &[&meerkat_sqlite::SchemaDomain],
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        if let Some(parent) = database.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        let mut conn = meerkat_sqlite::open(
+            database,
+            meerkat_sqlite::ConnectionProfile::Primary { create: true },
+        )?;
+        let tx = conn.transaction()?;
+        for domain in domains {
+            (domain.migrations[0].apply)(&tx)?;
+        }
+        tx.commit()?;
+        Ok(())
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    fn write_builtin_manifest(
+        paths: &meerkat_store::RealmPaths,
+        realm_id: &str,
+        backend: RealmBackend,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        std::fs::create_dir_all(&paths.root)?;
+        let manifest = RealmManifest {
+            realm: meerkat_core::RealmId::parse(realm_id).expect("test realm id is valid"),
+            backend,
+            origin: RealmOrigin::Explicit,
+            created_at: "1970-01-01T00:00:00Z".to_string(),
+            manifest_format: 1,
+            provider: None,
+            ephemeral_domains: Vec::new(),
+        };
+        std::fs::write(&paths.manifest_path, serde_json::to_vec_pretty(&manifest)?)?;
+        Ok(())
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    #[test]
+    fn explicit_pre_floor_bridge_orchestrates_existing_realm_databases_in_order()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let temp = TempDir::new()?;
+        let realm_id = "legacy-realm";
+        let paths = realm_paths_in(temp.path(), realm_id);
+        write_builtin_manifest(&paths, realm_id, RealmBackend::Sqlite)?;
+
+        create_unledgered_prefix(
+            &paths.sessions_sqlite_path,
+            &[
+                &meerkat_store::sqlite_store::SESSION_STORE_DOMAIN,
+                &meerkat_runtime::store::sqlite::RUNTIME_STORE_DOMAIN,
+                &meerkat_store::schedule_sqlite_store::SCHEDULE_STORE_DOMAIN,
+            ],
+        )?;
+        create_unledgered_prefix(
+            &paths.runtime_sqlite_path,
+            &[&meerkat_runtime::store::sqlite::RUNTIME_STORE_DOMAIN],
+        )?;
+        let conn = meerkat_sqlite::open(
+            &paths.runtime_sqlite_path,
+            meerkat_sqlite::ConnectionProfile::Primary { create: false },
+        )?;
+        conn.execute_batch(
+            "CREATE TABLE meerkat_schema (
+                 domain TEXT PRIMARY KEY,
+                 version INTEGER NOT NULL
+             );
+             INSERT INTO meerkat_schema (domain, version)
+             VALUES ('runtime-store', 1);",
+        )?;
+        drop(conn);
+        create_unledgered_prefix(
+            &paths.root.join("workgraph.sqlite3"),
+            &[&meerkat_workgraph::WORKGRAPH_DOMAIN],
+        )?;
+        create_unledgered_prefix(&paths.jobs_sqlite_path, &[&meerkat_jobs::JOBS_DOMAIN])?;
+        #[cfg(feature = "memory-store-session")]
+        create_unledgered_prefix(
+            &paths.root.join("memory").join("memory.sqlite3"),
+            &[&meerkat_memory::MEMORY_DOMAIN],
+        )?;
+        create_unledgered_prefix(
+            &paths.root.join("tasks.db"),
+            &[&meerkat_tools::TOOLS_TASKS_DOMAIN],
+        )?;
+
+        let fence = meerkat_store::migrate::RealmMaintenanceFence::acquire(
+            &paths.root,
+            Duration::from_secs(1),
+        )?;
+        let report = bridge_pre_0_8_10_realm_storage_in(temp.path(), realm_id, &fence)?;
+        drop(fence);
+
+        let mut expected = vec![
+            ("session-store", 1, 3),
+            ("runtime-store", 1, 2),
+            ("schedule-store", 1, 2),
+            ("workgraph", 1, 2),
+            ("jobs", 1, 2),
+        ];
+        #[cfg(feature = "memory-store-session")]
+        expected.push(("memory", 1, 2));
+        expected.push(("tools-tasks", 1, 1));
+
+        let actual = report
+            .domains
+            .iter()
+            .map(|entry| (entry.domain.as_str(), entry.from_version, entry.to_version))
+            .collect::<Vec<_>>();
+        assert_eq!(actual, expected);
+        assert!(report.domains.iter().all(|entry| entry.ledger_established));
+        assert_eq!(
+            report.inactive_databases,
+            vec![paths.runtime_sqlite_path.clone()],
+            "the standalone runtime is not authoritative for a SQLite realm"
+        );
+
+        for entry in &report.domains {
+            let conn =
+                meerkat_sqlite::open(&entry.database, meerkat_sqlite::ConnectionProfile::ReadOnly)?;
+            assert_eq!(
+                meerkat_sqlite::domain_version(&conn, &entry.domain)?,
+                Some(entry.to_version),
+                "{} must be stamped only after convergence",
+                entry.domain
+            );
+        }
+
+        let fence = meerkat_store::migrate::RealmMaintenanceFence::acquire(
+            &paths.root,
+            Duration::from_secs(1),
+        )?;
+        let rerun = bridge_pre_0_8_10_realm_storage_in(temp.path(), realm_id, &fence)?;
+        drop(fence);
+        assert_eq!(rerun.domains.len(), report.domains.len());
+        assert!(
+            rerun.domains.iter().all(|entry| {
+                !entry.ledger_established && entry.from_version == entry.to_version
+            }),
+            "an already bridged realm must be an idempotent no-op"
+        );
+        assert_eq!(rerun.inactive_databases, report.inactive_databases);
+
+        let conn = meerkat_sqlite::open(
+            &paths.runtime_sqlite_path,
+            meerkat_sqlite::ConnectionProfile::ReadOnly,
+        )?;
+        assert_eq!(
+            meerkat_sqlite::domain_version(&conn, "runtime-store")?,
+            Some(1),
+            "the inactive standalone runtime must remain byte-authority untouched"
+        );
+
+        Ok(())
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    #[test]
+    fn explicit_pre_floor_bridge_census_refuses_future_later_domain_before_session_mutation()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let temp = TempDir::new()?;
+        let realm_id = "future-runtime-realm";
+        let paths = realm_paths_in(temp.path(), realm_id);
+        write_builtin_manifest(&paths, realm_id, RealmBackend::Sqlite)?;
+        create_unledgered_prefix(
+            &paths.sessions_sqlite_path,
+            &[
+                &meerkat_store::sqlite_store::SESSION_STORE_DOMAIN,
+                &meerkat_runtime::store::sqlite::RUNTIME_STORE_DOMAIN,
+                &meerkat_store::schedule_sqlite_store::SCHEDULE_STORE_DOMAIN,
+            ],
+        )?;
+        let conn = meerkat_sqlite::open(
+            &paths.sessions_sqlite_path,
+            meerkat_sqlite::ConnectionProfile::Primary { create: false },
+        )?;
+        conn.execute_batch(
+            "CREATE TABLE meerkat_schema (
+                 domain TEXT PRIMARY KEY,
+                 version INTEGER NOT NULL
+             );
+             INSERT INTO meerkat_schema (domain, version)
+             VALUES ('runtime-store', 99);",
+        )?;
+        drop(conn);
+
+        let fence = meerkat_store::migrate::RealmMaintenanceFence::acquire(
+            &paths.root,
+            Duration::from_secs(1),
+        )?;
+        let error = bridge_pre_0_8_10_realm_storage_in(temp.path(), realm_id, &fence)
+            .expect_err("future runtime domain must abort the pre-write census");
+        drop(fence);
+        assert!(matches!(
+            error,
+            PersistenceError::Store(StoreError::SchemaFromTheFuture {
+                ref domain,
+                found: 99,
+                supported: 2,
+            }) if domain == "runtime-store"
+        ));
+
+        let conn = meerkat_sqlite::open(
+            &paths.sessions_sqlite_path,
+            meerkat_sqlite::ConnectionProfile::ReadOnly,
+        )?;
+        assert_eq!(
+            meerkat_sqlite::domain_version(&conn, "session-store")?,
+            None,
+            "the earlier session domain must not be stamped"
+        );
+        let session_v2_object: i64 = conn.query_row(
+            "SELECT EXISTS(
+                 SELECT 1 FROM sqlite_schema
+                 WHERE type = 'table' AND name = 'session_strand_links'
+             )",
+            [],
+            |row| row.get(0),
+        )?;
+        assert_eq!(
+            session_v2_object, 0,
+            "the earlier session domain must not be migrated"
+        );
+
+        Ok(())
+    }
+
+    #[cfg(all(not(target_arch = "wasm32"), feature = "jsonl-store"))]
+    #[test]
+    fn explicit_pre_floor_bridge_refuses_jsonl_before_mutating_any_database()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let temp = TempDir::new()?;
+        let realm_id = "legacy-jsonl-realm";
+        let paths = realm_paths_in(temp.path(), realm_id);
+        write_builtin_manifest(&paths, realm_id, RealmBackend::Jsonl)?;
+        create_unledgered_prefix(
+            &paths.sessions_sqlite_path,
+            &[&meerkat_store::sqlite_store::SESSION_STORE_DOMAIN],
+        )?;
+        create_unledgered_prefix(
+            &paths.runtime_sqlite_path,
+            &[&meerkat_runtime::store::sqlite::RUNTIME_STORE_DOMAIN],
+        )?;
+
+        let fence = meerkat_store::migrate::RealmMaintenanceFence::acquire(
+            &paths.root,
+            Duration::from_secs(1),
+        )?;
+        let error = bridge_pre_0_8_10_realm_storage_in(temp.path(), realm_id, &fence)
+            .expect_err("JSONL realms are outside the explicit bridge authority");
+        drop(fence);
+        assert_eq!(
+            error.to_string(),
+            format!(
+                "the explicit pre-v0.8.10 bridge supports only SQLite realms; realm '{realm_id}' uses the 'jsonl' backend"
+            )
+        );
+
+        for (database, domain) in [
+            (&paths.sessions_sqlite_path, "session-store"),
+            (&paths.runtime_sqlite_path, "runtime-store"),
+        ] {
+            let conn = meerkat_sqlite::open(database, meerkat_sqlite::ConnectionProfile::ReadOnly)?;
+            assert_eq!(meerkat_sqlite::domain_version(&conn, domain)?, None);
+        }
+
+        Ok(())
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    #[test]
+    fn explicit_pre_floor_bridge_refuses_memory_before_mutating_any_database()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let temp = TempDir::new()?;
+        let realm_id = "legacy-memory-realm";
+        let paths = realm_paths_in(temp.path(), realm_id);
+        write_builtin_manifest(&paths, realm_id, RealmBackend::Memory)?;
+        create_unledgered_prefix(
+            &paths.sessions_sqlite_path,
+            &[&meerkat_store::sqlite_store::SESSION_STORE_DOMAIN],
+        )?;
+        create_unledgered_prefix(
+            &paths.runtime_sqlite_path,
+            &[&meerkat_runtime::store::sqlite::RUNTIME_STORE_DOMAIN],
+        )?;
+        create_unledgered_prefix(
+            &paths.root.join("workgraph.sqlite3"),
+            &[&meerkat_workgraph::WORKGRAPH_DOMAIN],
+        )?;
+        create_unledgered_prefix(&paths.jobs_sqlite_path, &[&meerkat_jobs::JOBS_DOMAIN])?;
+        #[cfg(feature = "memory-store-session")]
+        create_unledgered_prefix(
+            &paths.root.join("memory").join("memory.sqlite3"),
+            &[&meerkat_memory::MEMORY_DOMAIN],
+        )?;
+        create_unledgered_prefix(
+            &paths.root.join("tasks.db"),
+            &[&meerkat_tools::TOOLS_TASKS_DOMAIN],
+        )?;
+
+        let fence = meerkat_store::migrate::RealmMaintenanceFence::acquire(
+            &paths.root,
+            Duration::from_secs(1),
+        )?;
+        let error = bridge_pre_0_8_10_realm_storage_in(temp.path(), realm_id, &fence)
+            .expect_err("memory realms are outside the explicit bridge authority");
+        drop(fence);
+        assert_eq!(
+            error.to_string(),
+            format!(
+                "the explicit pre-v0.8.10 bridge supports only SQLite realms; realm '{realm_id}' uses the 'memory' backend"
+            )
+        );
+
+        let mut untouched = vec![
+            (paths.sessions_sqlite_path.clone(), "session-store"),
+            (paths.runtime_sqlite_path.clone(), "runtime-store"),
+            (paths.root.join("workgraph.sqlite3"), "workgraph"),
+            (paths.jobs_sqlite_path.clone(), "jobs"),
+            (paths.root.join("tasks.db"), "tools-tasks"),
+        ];
+        #[cfg(feature = "memory-store-session")]
+        untouched.push((paths.root.join("memory").join("memory.sqlite3"), "memory"));
+        for (database, domain) in untouched {
+            let conn =
+                meerkat_sqlite::open(&database, meerkat_sqlite::ConnectionProfile::ReadOnly)?;
+            assert_eq!(meerkat_sqlite::domain_version(&conn, domain)?, None);
+        }
+
+        Ok(())
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    #[test]
+    fn explicit_pre_floor_bridge_refuses_a_fence_for_another_realm_without_mutation()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let temp = TempDir::new()?;
+        let realm_id = "target-realm";
+        let paths = realm_paths_in(temp.path(), realm_id);
+        write_builtin_manifest(&paths, realm_id, RealmBackend::Sqlite)?;
+        create_unledgered_prefix(
+            &paths.sessions_sqlite_path,
+            &[&meerkat_store::sqlite_store::SESSION_STORE_DOMAIN],
+        )?;
+
+        let other_paths = realm_paths_in(temp.path(), "other-realm");
+        std::fs::create_dir_all(&other_paths.root)?;
+        let fence = meerkat_store::migrate::RealmMaintenanceFence::acquire(
+            &other_paths.root,
+            Duration::from_secs(1),
+        )?;
+        let error = bridge_pre_0_8_10_realm_storage_in(temp.path(), realm_id, &fence)
+            .expect_err("a fence for another realm must refuse");
+        drop(fence);
+        assert!(error.to_string().contains("does not cover requested realm"));
+
+        let conn = meerkat_sqlite::open(
+            &paths.sessions_sqlite_path,
+            meerkat_sqlite::ConnectionProfile::ReadOnly,
+        )?;
+        assert_eq!(
+            meerkat_sqlite::domain_version(&conn, "session-store")?,
+            None
+        );
+
+        Ok(())
+    }
+
+    #[cfg(all(unix, not(target_arch = "wasm32")))]
+    #[test]
+    fn explicit_pre_floor_bridge_refuses_symlinked_database_without_touching_target()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let temp = TempDir::new()?;
+        let realm_id = "linked-database-realm";
+        let paths = realm_paths_in(temp.path(), realm_id);
+        write_builtin_manifest(&paths, realm_id, RealmBackend::Sqlite)?;
+
+        let external_dir = temp.path().join("external");
+        let external_database = external_dir.join("sessions.sqlite3");
+        create_unledgered_prefix(
+            &external_database,
+            &[&meerkat_store::sqlite_store::SESSION_STORE_DOMAIN],
+        )?;
+        let external_before = std::fs::read(&external_database)?;
+        std::os::unix::fs::symlink(&external_database, &paths.sessions_sqlite_path)?;
+
+        let fence = meerkat_store::migrate::RealmMaintenanceFence::acquire(
+            &paths.root,
+            Duration::from_secs(1),
+        )?;
+        let error = bridge_pre_0_8_10_realm_storage_in(temp.path(), realm_id, &fence)
+            .expect_err("a symlinked database must refuse before any bridge write");
+        drop(fence);
+        assert!(matches!(
+            error,
+            PersistenceError::PreV0810BridgeSymlink { ref path }
+                if path == &paths.sessions_sqlite_path
+        ));
+        assert_eq!(
+            std::fs::read(&external_database)?,
+            external_before,
+            "the symlink target must remain byte-identical"
+        );
+        assert!(
+            std::fs::symlink_metadata(&paths.sessions_sqlite_path)?
+                .file_type()
+                .is_symlink()
+        );
+
+        Ok(())
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    #[test]
+    fn explicit_pre_floor_bridge_refuses_manifest_identity_alias_without_mutation()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let temp = TempDir::new()?;
+        let requested_realm = "alias.realm";
+        let paths = realm_paths_in(temp.path(), requested_realm);
+        write_builtin_manifest(&paths, "alias_realm", RealmBackend::Sqlite)?;
+        create_unledgered_prefix(
+            &paths.sessions_sqlite_path,
+            &[&meerkat_store::sqlite_store::SESSION_STORE_DOMAIN],
+        )?;
+
+        let fence = meerkat_store::migrate::RealmMaintenanceFence::acquire(
+            &paths.root,
+            Duration::from_secs(1),
+        )?;
+        let error = bridge_pre_0_8_10_realm_storage_in(temp.path(), requested_realm, &fence)
+            .expect_err("a path-aliasing manifest identity must refuse");
+        drop(fence);
+        assert!(matches!(
+            error,
+            PersistenceError::Store(StoreError::RealmIdentityMismatch { .. })
+        ));
+
+        let conn = meerkat_sqlite::open(
+            &paths.sessions_sqlite_path,
+            meerkat_sqlite::ConnectionProfile::ReadOnly,
+        )?;
+        assert_eq!(
+            meerkat_sqlite::domain_version(&conn, "session-store")?,
+            None
+        );
+
+        Ok(())
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    #[test]
+    fn explicit_pre_floor_bridge_refuses_external_provider_pin_without_mutation()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let temp = TempDir::new()?;
+        let realm_id = "external-realm";
+        let paths = realm_paths_in(temp.path(), realm_id);
+        std::fs::create_dir_all(&paths.root)?;
+        std::fs::write(
+            &paths.manifest_path,
+            serde_json::to_vec_pretty(&serde_json::json!({
+                "realm_id": realm_id,
+                "backend": "external:test-provider",
+                "origin": "explicit",
+                "created_at": "1970-01-01T00:00:00Z",
+                "manifest_format": 2,
+                "provider": "test-provider"
+            }))?,
+        )?;
+        create_unledgered_prefix(
+            &paths.sessions_sqlite_path,
+            &[&meerkat_store::sqlite_store::SESSION_STORE_DOMAIN],
+        )?;
+
+        let fence = meerkat_store::migrate::RealmMaintenanceFence::acquire(
+            &paths.root,
+            Duration::from_secs(1),
+        )?;
+        let error = bridge_pre_0_8_10_realm_storage_in(temp.path(), realm_id, &fence)
+            .expect_err("an external-provider pin must refuse disk bridge");
+        drop(fence);
+        assert!(matches!(
+            error,
+            PersistenceError::Store(StoreError::ExternalProviderRealm { .. })
+        ));
+
+        let conn = meerkat_sqlite::open(
+            &paths.sessions_sqlite_path,
+            meerkat_sqlite::ConnectionProfile::ReadOnly,
+        )?;
+        assert_eq!(
+            meerkat_sqlite::domain_version(&conn, "session-store")?,
+            None
+        );
+
+        Ok(())
+    }
 
     struct WrappedStore {
         inner: Arc<dyn SessionStore>,


### PR DESCRIPTION
## Summary

- Keep fresh workspace runs available when historical persistence cannot open. Both `rkat "prompt"` and `rkat help "prompt"` fall back to a new durable generated realm while preserving workspace config and auth inheritance.
- Keep explicit realm selection, session resume, and session commands strict.
- Add an explicit SQLite-only `storage migrate --apply --bridge-pre-0-8-10` path that authenticates exact historical schemas before stamping or migrating them.
- Import legacy runtime input state without replay, preserve queued work, handle the released WorkGraph v2 catalog, and scope the old image metadata alias to the maintenance bridge.
- Refuse symlinked realm inventory before bridge writes.

## Validation

- Built the final `rkat` binary successfully.
- Migrated a pristine copy of the reported realm: 666 runtime input rows, 655 legacy rows rewritten, all seven active storage domains converged, and no bridge errors.
- Verified fresh bare prompt and `help` fallback behavior in plain and JSON integration tests, with strict continuation behavior retained.
- Focused SQLite, runtime importer, WorkGraph, facade, CLI migration, image compatibility, auth projection, docs, clippy, and symlink no-mutation checks passed.
- The live realm was never modified.

Broad release lanes are intentionally left to PR and release CI for speed.