### PR TITLE
0.8.17: preserve comms FIFO across drain replacement

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -90,6 +90,10 @@ threads-required = "num-cpus"
 filter = 'test(~test_resume_restores_missing_sessions_with_tool_wiring)'
 threads-required = "num-cpus"
 
+[[profile.default.overrides]]
+filter = 'test(~test_turn_driven_submit_work_steer_queues_when_exact_boundary_is_unavailable) or test(~test_member_send_steer_queues_when_exact_boundary_is_unavailable)'
+threads-required = "num-cpus"
+
 [[profile.fast.overrides]]
 # Raw SQLite writes are observed through filesystem notification with a
 # five-second safety sweep. Keep this wall-clock fallback contract away from

--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -77,6 +77,15 @@ threads-required = "num-cpus"
 filter = 'test(~test_resume_restores_missing_sessions_with_tool_wiring)'
 threads-required = "num-cpus"
 
+[[profile.fast.overrides]]
+# These queued-fallback regressions deliberately hold one runtime apply at a
+# boundary while proving that a second durable admission progresses after the
+# release. Running them beside the full mob shard can starve the Tokio workers
+# long enough to consume the assertion budget without exercising a product
+# failure. Reserve the lane while preserving each test's internal concurrency.
+filter = 'test(~test_turn_driven_submit_work_steer_queues_when_exact_boundary_is_unavailable) or test(~test_member_send_steer_queues_when_exact_boundary_is_unavailable)'
+threads-required = "num-cpus"
+
 [[profile.default.overrides]]
 filter = 'test(~test_resume_restores_missing_sessions_with_tool_wiring)'
 threads-required = "num-cpus"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,18 @@ via cargo-semver-checks against the published baselines).
 
 ## [Unreleased]
 
+### Fixed
+
+- Runtime comms drains now admit one classified input at a time, preserving
+  the durable FIFO tail when a drain task is cancelled or replaced.
+- Automatic mob-member rematerialization no longer replays persisted system
+  prompt configuration as a new System message. Explicit resume-time prompt
+  changes still append in transcript order.
+
+Meerkat 0.8.17 should be paired with MobKit 0.8.13. The pair repairs the
+0.8.16 member-input admission regression and prevents configured prompts from
+being duplicated across automatic rematerialization.
+
 ## [0.8.15] - 2026-08-03
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ via cargo-semver-checks against the published baselines).
 - Automatic mob-member rematerialization no longer replays persisted system
   prompt configuration as a new System message. Explicit resume-time prompt
   changes still append in transcript order.
+- Audited transcript-history hydration now accepts an exact live revision even
+  when a slim HeadCanonical materialization does not carry endpoint row-lineage
+  metadata. Prefix-extension cases remain fail-closed on exact row lineage.
 
 Meerkat 0.8.17 should be paired with MobKit 0.8.13. The pair repairs the
 0.8.16 member-input admission regression and prevents configured prompts from

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,9 +20,18 @@ via cargo-semver-checks against the published baselines).
 - Automatic mob-member rematerialization no longer replays persisted system
   prompt configuration as a new System message. Explicit resume-time prompt
   changes still append in transcript order.
-- Audited transcript-history hydration now accepts an exact live revision even
-  when a slim HeadCanonical materialization does not carry endpoint row-lineage
-  metadata. Prefix-extension cases remain fail-closed on exact row lineage.
+- Audited transcript-history hydration and rewrite now accept a semantically
+  identical live prefix when adapter rematerialization changed only physical
+  row bookkeeping. Exact row lineage remains the fast path; the typed
+  content-addressed append path reanchors current row authority and still
+  rejects divergent semantic prefixes.
+
+### Known limitations
+
+- The stock MobKit console Steer lane can accept an input while stripping its
+  content, and a steer racing member retirement may be lost. Ordinary queued
+  MobHandle, flow, and application-chat delivery lanes are unaffected. This is
+  planned for the next paired release.
 
 Meerkat 0.8.17 should be paired with MobKit 0.8.13. The pair repairs the
 0.8.16 member-input admission regression and prevents configured prompts from

--- a/meerkat-comms/src/runtime/comms_runtime.rs
+++ b/meerkat-comms/src/runtime/comms_runtime.rs
@@ -536,6 +536,184 @@ impl Drop for InteractionStream {
     }
 }
 
+fn classified_entry_to_interaction(
+    entry: crate::inbox::ClassifiedInboxEntry,
+) -> Option<meerkat_core::ClassifiedInboxInteraction> {
+    use crate::agent::types::MessageIntent;
+    use crate::types::MessageKind;
+
+    let ingress = entry.ingress_fact;
+    let lifecycle_peer = entry.lifecycle_peer;
+    let from_peer = entry.from_peer.unwrap_or_else(|| "unknown".to_string());
+    let from_peer_id = ingress.route.as_ref().map(|route| route.peer_id);
+    let rendered_text = entry.text_projection.clone();
+
+    match entry.item {
+        crate::types::InboxItem::External { envelope } => {
+            // Runtime lifecycle dismissal does NOT flow through a peer message
+            // body. A peer-controlled string can never stop the local executor;
+            // dismissal must arrive as a typed lifecycle signal owned by the
+            // runtime authority. Extract handling_mode before consuming the
+            // kind. `send_response` may omit this field, so the sender side
+            // defaults it from the original request mode.
+            let envelope_handling_mode = match &envelope.kind {
+                MessageKind::Message {
+                    handling_mode: Some(mode),
+                    ..
+                }
+                | MessageKind::IncarnationFencedMessage {
+                    handling_mode: Some(mode),
+                    ..
+                }
+                | MessageKind::Request {
+                    handling_mode: Some(mode),
+                    ..
+                }
+                | MessageKind::Response {
+                    handling_mode: Some(mode),
+                    ..
+                } => *mode,
+                MessageKind::Response {
+                    handling_mode: None,
+                    ..
+                }
+                | MessageKind::Message {
+                    handling_mode: None,
+                    ..
+                }
+                | MessageKind::IncarnationFencedMessage {
+                    handling_mode: None,
+                    ..
+                }
+                | MessageKind::Request {
+                    handling_mode: None,
+                    ..
+                }
+                | MessageKind::Lifecycle { .. }
+                | MessageKind::Ack { .. } => meerkat_core::types::HandlingMode::Queue,
+            };
+            // Sender-declared content taint travels with the content facts
+            // (signed-when-present on the envelope); extract it before the kind
+            // is consumed below.
+            let sender_taint = envelope.kind.content_taint();
+            let objective_id = envelope.kind.objective_id();
+            let content = match envelope.kind {
+                MessageKind::Message {
+                    body,
+                    blocks,
+                    content_taint: _,
+                    handling_mode: _,
+                    objective_id: _,
+                } => meerkat_core::InteractionContent::Message { body, blocks },
+                MessageKind::IncarnationFencedMessage {
+                    body,
+                    blocks,
+                    content_taint: _,
+                    handling_mode: _,
+                    objective_id: _,
+                    expected_recipient,
+                } => meerkat_core::InteractionContent::IncarnationFencedMessage {
+                    body,
+                    blocks,
+                    expected_recipient,
+                },
+                MessageKind::Request {
+                    intent,
+                    params,
+                    blocks,
+                    reply_endpoint: _,
+                    content_taint: _,
+                    handling_mode: _,
+                    objective_id: _,
+                } => {
+                    let typed_intent = MessageIntent::from(intent.as_str());
+                    meerkat_core::InteractionContent::Request {
+                        intent: typed_intent.to_string(),
+                        params,
+                        blocks,
+                    }
+                }
+                MessageKind::Lifecycle { kind, params } => {
+                    meerkat_core::InteractionContent::Request {
+                        intent: kind.to_string(),
+                        params,
+                        blocks: None,
+                    }
+                }
+                MessageKind::Response {
+                    in_reply_to,
+                    status,
+                    result,
+                    blocks,
+                    content_taint: _,
+                    handling_mode: _,
+                    objective_id: _,
+                } => {
+                    let core_status = match status {
+                        crate::types::Status::Accepted => meerkat_core::ResponseStatus::Accepted,
+                        crate::types::Status::Completed => meerkat_core::ResponseStatus::Completed,
+                        crate::types::Status::Failed => meerkat_core::ResponseStatus::Failed,
+                    };
+                    meerkat_core::InteractionContent::Response {
+                        in_reply_to: meerkat_core::InteractionId(in_reply_to),
+                        status: core_status,
+                        result,
+                        blocks,
+                    }
+                }
+                MessageKind::Ack { .. } => {
+                    // Acks should never reach classified drain.
+                    return None;
+                }
+            };
+
+            Some(meerkat_core::ClassifiedInboxInteraction {
+                interaction: meerkat_core::InboxInteraction {
+                    id: meerkat_core::InteractionId(envelope.id),
+                    from_route: from_peer_id,
+                    from: from_peer,
+                    content,
+                    rendered_text,
+                    handling_mode: envelope_handling_mode,
+                    render_metadata: None,
+                    sender_taint,
+                    objective_id,
+                },
+                ingress,
+                lifecycle_peer,
+                response_terminality: entry.response_terminality,
+            })
+        }
+        crate::types::InboxItem::PlainEvent {
+            body,
+            source,
+            handling_mode,
+            objective_id,
+            interaction_id,
+            blocks,
+            render_metadata,
+            ..
+        } => Some(meerkat_core::ClassifiedInboxInteraction {
+            interaction: meerkat_core::InboxInteraction {
+                id: meerkat_core::InteractionId(interaction_id.unwrap_or_else(uuid::Uuid::new_v4)),
+                from_route: None,
+                from: format!("event:{source}"),
+                content: meerkat_core::InteractionContent::Message { body, blocks },
+                rendered_text,
+                handling_mode,
+                render_metadata,
+                // Plain events are host-injected, not peer envelopes: no
+                // sender declaration exists.
+                sender_taint: None,
+                objective_id,
+            },
+            ingress,
+            lifecycle_peer,
+            response_terminality: entry.response_terminality,
+        }),
+    }
+}
+
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 impl CoreCommsRuntime for CommsRuntime {
@@ -1358,202 +1536,23 @@ impl CoreCommsRuntime for CommsRuntime {
         &self,
     ) -> Result<Vec<meerkat_core::ClassifiedInboxInteraction>, meerkat_core::CommsCapabilityError>
     {
-        use crate::agent::types::MessageIntent;
-        use crate::types::MessageKind;
-
         let mut inbox = self.inbox.lock().await;
         let classified_entries = inbox.try_drain_classified();
-
-        if classified_entries.is_empty() {
-            return Ok(Vec::new());
-        }
-
-        // Use stored classification metadata — NO trust re-check.
-        // Snapshot semantics: classification was fixed at enqueue time.
         Ok(classified_entries
             .into_iter()
-            .filter_map(|entry| {
-                let ingress = entry.ingress_fact;
-                let lifecycle_peer = entry.lifecycle_peer;
-                let from_peer = entry.from_peer.unwrap_or_else(|| "unknown".to_string());
-                let from_peer_id = ingress.route.as_ref().map(|route| route.peer_id);
-                let rendered_text = entry.text_projection.clone();
-
-                match entry.item {
-                    crate::types::InboxItem::External { envelope } => {
-                        // Runtime lifecycle dismissal does NOT flow through a
-                        // peer message body. A peer-controlled string can never
-                        // stop the local executor; dismissal must arrive as a
-                        // typed lifecycle signal owned by the runtime authority.
-                        // Extract handling_mode before consuming the kind.
-                        // `send_response` may omit this field, so the sender
-                        // side defaults it from the original request mode.
-                        let envelope_handling_mode = match &envelope.kind {
-                            MessageKind::Message {
-                                handling_mode: Some(mode),
-                                ..
-                            }
-                            | MessageKind::IncarnationFencedMessage {
-                                handling_mode: Some(mode),
-                                ..
-                            }
-                            | MessageKind::Request {
-                                handling_mode: Some(mode),
-                                ..
-                            }
-                            | MessageKind::Response {
-                                handling_mode: Some(mode),
-                                ..
-                            } => *mode,
-                            MessageKind::Response {
-                                handling_mode: None,
-                                ..
-                            }
-                            | MessageKind::Message {
-                                handling_mode: None,
-                                ..
-                            }
-                            | MessageKind::IncarnationFencedMessage {
-                                handling_mode: None,
-                                ..
-                            }
-                            | MessageKind::Request {
-                                handling_mode: None,
-                                ..
-                            }
-                            | MessageKind::Lifecycle { .. }
-                            | MessageKind::Ack { .. } => meerkat_core::types::HandlingMode::Queue,
-                        };
-                        // Sender-declared content taint travels with the
-                        // content facts (signed-when-present on the envelope);
-                        // extract it before the kind is consumed below.
-                        let sender_taint = envelope.kind.content_taint();
-                        let objective_id = envelope.kind.objective_id();
-                        let content = match envelope.kind {
-                            MessageKind::Message {
-                                body,
-                                blocks,
-                                content_taint: _,
-                                handling_mode: _,
-                                objective_id: _,
-                            } => meerkat_core::InteractionContent::Message { body, blocks },
-                            MessageKind::IncarnationFencedMessage {
-                                body,
-                                blocks,
-                                content_taint: _,
-                                handling_mode: _,
-                                objective_id: _,
-                                expected_recipient,
-                            } => meerkat_core::InteractionContent::IncarnationFencedMessage {
-                                body,
-                                blocks,
-                                expected_recipient,
-                            },
-                            MessageKind::Request {
-                                intent,
-                                params,
-                                blocks,
-                                reply_endpoint: _,
-                                content_taint: _,
-                                handling_mode: _,
-                                objective_id: _,
-                            } => {
-                                let typed_intent = MessageIntent::from(intent.as_str());
-                                meerkat_core::InteractionContent::Request {
-                                    intent: typed_intent.to_string(),
-                                    params,
-                                    blocks,
-                                }
-                            }
-                            MessageKind::Lifecycle { kind, params } => {
-                                meerkat_core::InteractionContent::Request {
-                                    intent: kind.to_string(),
-                                    params,
-                                    blocks: None,
-                                }
-                            }
-                            MessageKind::Response {
-                                in_reply_to,
-                                status,
-                                result,
-                                blocks,
-                                content_taint: _,
-                                handling_mode: _,
-                                objective_id: _,
-                            } => {
-                                let core_status = match status {
-                                    crate::types::Status::Accepted => {
-                                        meerkat_core::ResponseStatus::Accepted
-                                    }
-                                    crate::types::Status::Completed => {
-                                        meerkat_core::ResponseStatus::Completed
-                                    }
-                                    crate::types::Status::Failed => {
-                                        meerkat_core::ResponseStatus::Failed
-                                    }
-                                };
-                                meerkat_core::InteractionContent::Response {
-                                    in_reply_to: meerkat_core::InteractionId(in_reply_to),
-                                    status: core_status,
-                                    result,
-                                    blocks,
-                                }
-                            }
-                            MessageKind::Ack { .. } => {
-                                // Acks should never reach classified drain
-                                return None;
-                            }
-                        };
-
-                        Some(meerkat_core::ClassifiedInboxInteraction {
-                            interaction: meerkat_core::InboxInteraction {
-                                id: meerkat_core::InteractionId(envelope.id),
-                                from_route: from_peer_id,
-                                from: from_peer,
-                                content,
-                                rendered_text,
-                                handling_mode: envelope_handling_mode,
-                                render_metadata: None,
-                                sender_taint,
-                                objective_id,
-                            },
-                            ingress,
-                            lifecycle_peer,
-                            response_terminality: entry.response_terminality,
-                        })
-                    }
-                    crate::types::InboxItem::PlainEvent {
-                        body,
-                        source,
-                        handling_mode,
-                        objective_id,
-                        interaction_id,
-                        blocks,
-                        render_metadata,
-                        ..
-                    } => Some(meerkat_core::ClassifiedInboxInteraction {
-                        interaction: meerkat_core::InboxInteraction {
-                            id: meerkat_core::InteractionId(
-                                interaction_id.unwrap_or_else(uuid::Uuid::new_v4),
-                            ),
-                            from_route: None,
-                            from: format!("event:{source}"),
-                            content: meerkat_core::InteractionContent::Message { body, blocks },
-                            rendered_text,
-                            handling_mode,
-                            render_metadata,
-                            // Plain events are host-injected, not peer
-                            // envelopes: no sender declaration exists.
-                            sender_taint: None,
-                            objective_id,
-                        },
-                        ingress,
-                        lifecycle_peer,
-                        response_terminality: entry.response_terminality,
-                    }),
-                }
-            })
+            .filter_map(classified_entry_to_interaction)
             .collect())
+    }
+
+    async fn try_recv_classified_inbox_interaction(
+        &self,
+    ) -> Result<Option<meerkat_core::ClassifiedInboxInteraction>, meerkat_core::CommsCapabilityError>
+    {
+        let mut inbox = self.inbox.lock().await;
+        // Use stored classification metadata — NO trust re-check.
+        // Snapshot semantics: classification was fixed at enqueue time.
+        Ok(std::iter::from_fn(|| inbox.try_recv_one_classified())
+            .find_map(classified_entry_to_interaction))
     }
 
     async fn peer_ingress_queue_snapshot(

--- a/meerkat-core/src/agent.rs
+++ b/meerkat-core/src/agent.rs
@@ -1702,6 +1702,20 @@ pub trait CommsRuntime: Send + Sync {
         ))
     }
 
+    /// Receive at most one classified inbox interaction.
+    ///
+    /// Session-backed drain loops must use this cancellation-safe dequeue
+    /// surface before awaiting admission. Removing a whole batch and then
+    /// awaiting each admission can strand the unprocessed tail in task-local
+    /// memory if the drain task is aborted or replaced.
+    async fn try_recv_classified_inbox_interaction(
+        &self,
+    ) -> Result<Option<crate::interaction::ClassifiedInboxInteraction>, CommsCapabilityError> {
+        Err(CommsCapabilityError::Unsupported(
+            "try_recv_classified_inbox_interaction".to_string(),
+        ))
+    }
+
     /// Drain canonical peer/event ingress candidates.
     ///
     /// This remains the live runtime drain bridge for call sites that consume

--- a/meerkat-core/src/session.rs
+++ b/meerkat-core/src/session.rs
@@ -1133,9 +1133,12 @@ impl<'de> Deserialize<'de> for Session {
                 })?
                 .row_prefix()
                 .clone();
-            if !session.install_exact_message_row_lineage(endpoint_prefix, exact_live_prefix) {
+            if !session
+                .install_exact_message_row_lineage(endpoint_prefix, exact_live_prefix.clone())
+                && !session.install_exact_message_row_prefix(exact_live_prefix)
+            {
                 return Err(<D::Error as serde::de::Error>::custom(
-                    "failed to install exact live message-row authority",
+                    "failed to install live message-row authority",
                 ));
             }
             session.transcript_history_metadata_validation =
@@ -1430,9 +1433,11 @@ impl Session {
             })?
             .row_prefix()
             .clone();
-        if !self.install_exact_message_row_lineage(endpoint_prefix, exact_live_prefix) {
+        if !self.install_exact_message_row_lineage(endpoint_prefix, exact_live_prefix.clone())
+            && !self.install_exact_message_row_prefix(exact_live_prefix)
+        {
             return Err(TranscriptEditError::HistoryStateMalformed(
-                "failed to install exact live message-row authority".to_string(),
+                "failed to install live message-row authority".to_string(),
             ));
         }
         self.transcript_history_metadata_validation =
@@ -5746,6 +5751,14 @@ impl Session {
                     })?;
                 let parent_advance = if exact_append_prefix == parent_row_prefix {
                     TranscriptParentAdvance::ExactAppend { appended }
+                } else if self
+                    .transcript_prefix_digest(endpoint.message_count())
+                    .map_err(|error| {
+                        TranscriptEditError::HistoryStateMalformed(error.to_string())
+                    })?
+                    == state.head()
+                {
+                    TranscriptParentAdvance::ContentAddressedAppend { appended }
                 } else {
                     return Err(TranscriptEditError::HistoryStateMalformed(
                         "live rewrite parent is not an exact audited append".to_string(),
@@ -6571,9 +6584,14 @@ mod tests {
             .as_object_mut()
             .ok_or_else(|| std::io::Error::other("session metadata is not an object"))?
             .remove(SESSION_TRANSCRIPT_HISTORY_STATE_KEY);
+        slim_document["messages"][0]["created_at"] =
+            serde_json::Value::String("2020-01-01T00:00:00Z".to_string());
         let mut replay: Session = serde_json::from_value(slim_document)?;
         replay.push(Message::User(UserMessage::text("appended".to_string())));
         let live_revision = replay.transcript_content_digest()?;
+        let current_row_prefix =
+            crate::SessionMessageRowPrefixAccumulator::from_messages(replay.messages())?;
+        assert!(replay.install_exact_message_row_prefix(current_row_prefix));
 
         assert_ne!(state.head(), live_revision);
         assert!(
@@ -6581,6 +6599,26 @@ mod tests {
             "the audited endpoint content digest must prove the live transcript prefix"
         );
         replay.install_validated_audited_transcript_history_preserving_live(validated)?;
+        replay.commit_transcript_rewrite(
+            TranscriptRewriteSelection::MessageRange { start: 1, end: 2 },
+            vec![Message::User(UserMessage::text("repaired".to_string()))],
+            TranscriptRewriteReason::new("unit-test"),
+            Some("unit-test".to_string()),
+            Some(live_revision),
+        )?;
+        let repaired = replay
+            .transcript_history_state()?
+            .ok_or_else(|| std::io::Error::other("repaired history missing"))?;
+        assert_eq!(
+            repaired.parent_transition(1),
+            Some(TranscriptRewriteParentTransition::ContentAddressedAppend),
+            "adapter-rematerialized rows must reanchor lineage explicitly"
+        );
+        let restored: Session = serde_json::from_slice(&serde_json::to_vec(&replay)?)?;
+        assert_eq!(
+            restored.transcript_content_digest()?,
+            replay.transcript_content_digest()?
+        );
 
         Ok(())
     }

--- a/meerkat-core/src/session.rs
+++ b/meerkat-core/src/session.rs
@@ -4936,8 +4936,11 @@ impl Session {
     pub(crate) fn live_transcript_extends_history_head(
         &self,
         state: &TranscriptHistoryState,
-        _live_revision: &str,
+        live_revision: &str,
     ) -> Result<bool, TranscriptEditError> {
+        if state.head() == live_revision {
+            return Ok(true);
+        }
         let current_count = u64::try_from(self.messages.len()).map_err(|_| {
             TranscriptEditError::HistoryStateMalformed(
                 "live transcript row count exceeds u64".to_string(),
@@ -6493,6 +6496,41 @@ impl PersistedSessionMetadataView {
 #[cfg(test)]
 #[allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
 mod tests {
+
+    #[test]
+    fn audited_history_install_accepts_exact_live_revision_without_row_lineage()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let mut source = Session::new();
+        source.push(Message::User(UserMessage::text("before".to_string())));
+        source.commit_transcript_rewrite(
+            TranscriptRewriteSelection::MessageRange { start: 0, end: 1 },
+            vec![Message::User(UserMessage::text("after".to_string()))],
+            TranscriptRewriteReason::new("unit-test"),
+            Some("unit-test".to_string()),
+            None,
+        )?;
+
+        let state = source
+            .transcript_history_state()?
+            .ok_or_else(|| std::io::Error::other("source history missing"))?;
+        let validated = ValidatedTranscriptHistory::seal_owned(state.clone())?;
+        let mut slim_document = serde_json::to_value(&source)?;
+        slim_document["metadata"]
+            .as_object_mut()
+            .ok_or_else(|| std::io::Error::other("session metadata is not an object"))?
+            .remove(SESSION_TRANSCRIPT_HISTORY_STATE_KEY);
+        let mut replay: Session = serde_json::from_value(slim_document)?;
+        let live_revision = replay.transcript_content_digest()?;
+
+        assert_eq!(state.head(), live_revision);
+        assert!(
+            !replay.live_transcript_extends_history_head(&state, "")?,
+            "the replay fixture must lack the exact endpoint row lineage"
+        );
+        replay.install_validated_audited_transcript_history_preserving_live(validated)?;
+
+        Ok(())
+    }
 
     /// Ordinary append does not consult or rewrite transcript-history
     /// metadata, regardless of whether the session's parsed-graph cache is

--- a/meerkat-core/src/session.rs
+++ b/meerkat-core/src/session.rs
@@ -4951,7 +4951,18 @@ impl Session {
                 "compact transcript graph has no final endpoint witness".to_string(),
             )
         })?;
-        Ok(self.exact_message_row_lineage_extends(endpoint.row_prefix(), current_count))
+        if self.exact_message_row_lineage_extends(endpoint.row_prefix(), current_count) {
+            return Ok(true);
+        }
+
+        let live_prefix_revision = self
+            .transcript_prefix_digest(endpoint.message_count())
+            .map_err(|error| {
+                TranscriptEditError::HistoryStateMalformed(format!(
+                    "failed to derive live transcript prefix revision: {error}"
+                ))
+            })?;
+        Ok(live_prefix_revision == state.head())
     }
 
     /// Load exact compaction projection intents carried to the runtime's
@@ -6521,11 +6532,53 @@ mod tests {
             .remove(SESSION_TRANSCRIPT_HISTORY_STATE_KEY);
         let mut replay: Session = serde_json::from_value(slim_document)?;
         let live_revision = replay.transcript_content_digest()?;
+        let endpoint = state
+            .final_endpoint_witness()
+            .ok_or_else(|| std::io::Error::other("history endpoint missing"))?;
 
         assert_eq!(state.head(), live_revision);
         assert!(
-            !replay.live_transcript_extends_history_head(&state, "")?,
+            !replay.exact_message_row_lineage_extends(
+                endpoint.row_prefix(),
+                u64::try_from(replay.messages().len())?,
+            ),
             "the replay fixture must lack the exact endpoint row lineage"
+        );
+        replay.install_validated_audited_transcript_history_preserving_live(validated)?;
+
+        Ok(())
+    }
+
+    #[test]
+    fn audited_history_install_accepts_live_append_without_row_lineage()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let mut source = Session::new();
+        source.push(Message::User(UserMessage::text("before".to_string())));
+        source.commit_transcript_rewrite(
+            TranscriptRewriteSelection::MessageRange { start: 0, end: 1 },
+            vec![Message::User(UserMessage::text("after".to_string()))],
+            TranscriptRewriteReason::new("unit-test"),
+            Some("unit-test".to_string()),
+            None,
+        )?;
+
+        let state = source
+            .transcript_history_state()?
+            .ok_or_else(|| std::io::Error::other("source history missing"))?;
+        let validated = ValidatedTranscriptHistory::seal_owned(state.clone())?;
+        let mut slim_document = serde_json::to_value(&source)?;
+        slim_document["metadata"]
+            .as_object_mut()
+            .ok_or_else(|| std::io::Error::other("session metadata is not an object"))?
+            .remove(SESSION_TRANSCRIPT_HISTORY_STATE_KEY);
+        let mut replay: Session = serde_json::from_value(slim_document)?;
+        replay.push(Message::User(UserMessage::text("appended".to_string())));
+        let live_revision = replay.transcript_content_digest()?;
+
+        assert_ne!(state.head(), live_revision);
+        assert!(
+            replay.live_transcript_extends_history_head(&state, &live_revision)?,
+            "the audited endpoint content digest must prove the live transcript prefix"
         );
         replay.install_validated_audited_transcript_history_preserving_live(validated)?;
 

--- a/meerkat-core/src/session/import_0810.rs
+++ b/meerkat-core/src/session/import_0810.rs
@@ -949,9 +949,11 @@ fn install_imported_history(
         })?
         .row_prefix()
         .clone();
-    if !session.install_exact_message_row_lineage(endpoint_prefix, exact_live_prefix) {
+    if !session.install_exact_message_row_lineage(endpoint_prefix, exact_live_prefix.clone())
+        && !session.install_exact_message_row_prefix(exact_live_prefix)
+    {
         return Err(Released0810ImportError::TranscriptHistory(
-            "failed to install imported message-row lineage".to_string(),
+            "failed to install imported message-row authority".to_string(),
         ));
     }
     session

--- a/meerkat-core/src/session/transcript_history/graph.rs
+++ b/meerkat-core/src/session/transcript_history/graph.rs
@@ -61,19 +61,23 @@ pub struct TranscriptRewriteCommit {
     pub committed_at: SystemTime,
 }
 
-/// Exact-byte relationship from one audited rewrite endpoint to the next
-/// commit's parent.
+/// Relationship from one audited rewrite endpoint to the next commit's
+/// parent.
 ///
 /// This evidence is aligned one-for-one with [`TranscriptHistoryState::commits`]
 /// and is validated against the retained bodies before a
 /// [`ValidatedTranscriptHistory`] may expose it. Current writers emit only
-/// `ExactAppend`; `ExactSplice` preserves a frozen same-cardinality
-/// relationship decoded by the explicit 0.8.10 importer.
+/// `ExactAppend` is the ordinary byte-lineage path. `ContentAddressedAppend`
+/// is the typed adapter-rematerialization path: semantic prefix identity proves
+/// the append while the current durable row prefix becomes the new structural
+/// baseline. `ExactSplice` preserves a frozen same-cardinality relationship
+/// decoded by the explicit 0.8.10 importer.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[serde(rename_all = "snake_case")]
 pub enum TranscriptRewriteParentTransition {
     ExactAppend,
+    ContentAddressedAppend,
     ExactSplice,
 }
 
@@ -644,15 +648,22 @@ impl TranscriptRevisionAnchor {
 
 /// Exact delta from the preceding audited child to the next rewrite parent.
 ///
-/// Current writers construct only [`Self::ExactAppend`]. [`Self::ExactSplice`]
-/// preserves an already-imported released 0.8.10 edge so historical audit
-/// materialization remains exact without assigning semantic privilege to any
-/// message role or transcript position.
+/// Current writers prefer [`Self::ExactAppend`].
+/// [`Self::ContentAddressedAppend`] explicitly reanchors physical row lineage
+/// after a proved adapter rematerialization whose semantic prefix is unchanged.
+/// [`Self::ExactSplice`] preserves an already-imported released 0.8.10 edge so
+/// historical audit materialization remains exact without assigning semantic
+/// privilege to any message role or transcript position.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[serde(tag = "kind", rename_all = "snake_case", deny_unknown_fields)]
 pub enum TranscriptParentAdvance {
     ExactAppend {
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        #[cfg_attr(feature = "schema", schemars(with = "Vec<serde_json::Value>"))]
+        appended: Vec<Message>,
+    },
+    ContentAddressedAppend {
         #[serde(default, skip_serializing_if = "Vec::is_empty")]
         #[cfg_attr(feature = "schema", schemars(with = "Vec<serde_json::Value>"))]
         appended: Vec<Message>,
@@ -671,14 +682,16 @@ impl TranscriptParentAdvance {
     #[must_use]
     pub fn appended(&self) -> &[Message] {
         match self {
-            Self::ExactAppend { appended } | Self::ExactSplice { appended, .. } => appended,
+            Self::ExactAppend { appended }
+            | Self::ContentAddressedAppend { appended }
+            | Self::ExactSplice { appended, .. } => appended,
         }
     }
 
     #[must_use]
     pub fn exact_splice(&self) -> Option<(usize, &[Message])> {
         match self {
-            Self::ExactAppend { .. } => None,
+            Self::ExactAppend { .. } | Self::ContentAddressedAppend { .. } => None,
             Self::ExactSplice {
                 at, replacement, ..
             } => Some((*at, replacement)),
@@ -689,6 +702,9 @@ impl TranscriptParentAdvance {
     pub fn transition(&self) -> TranscriptRewriteParentTransition {
         match self {
             Self::ExactAppend { .. } => TranscriptRewriteParentTransition::ExactAppend,
+            Self::ContentAddressedAppend { .. } => {
+                TranscriptRewriteParentTransition::ContentAddressedAppend
+            }
             Self::ExactSplice { .. } => TranscriptRewriteParentTransition::ExactSplice,
         }
     }
@@ -2220,14 +2236,21 @@ impl TranscriptHistoryState {
         if live.len() < endpoint.messages.len() {
             return Ok(None);
         }
-        let advance = if live[..endpoint.messages.len()] == endpoint.messages {
-            TranscriptParentAdvance::ExactAppend {
+        if live[..endpoint.messages.len()] == endpoint.messages {
+            let advance = TranscriptParentAdvance::ExactAppend {
                 appended: live[endpoint.messages.len()..].to_vec(),
-            }
-        } else {
+            };
+            return row_prefix_after_parent_advance(endpoint_witness.row_prefix(), &advance)
+                .map(Some);
+        }
+        let live_prefix_revision = transcript_messages_digest(&live[..endpoint.messages.len()])
+            .map_err(|error| TranscriptEditError::HistoryStateMalformed(error.to_string()))?;
+        if live_prefix_revision != self.head() {
             return Ok(None);
-        };
-        row_prefix_after_parent_advance(endpoint_witness.row_prefix(), &advance).map(Some)
+        }
+        SessionMessageRowPrefixAccumulator::from_messages(live)
+            .map(Some)
+            .map_err(|error| TranscriptEditError::HistoryStateMalformed(error.to_string()))
     }
 
     #[must_use]
@@ -2481,6 +2504,13 @@ fn parent_advance_from_materialized(
             appended: parent.messages[base.messages.len()..].to_vec(),
         });
     }
+    let semantic_prefix = transcript_messages_digest(&parent.messages[..base.messages.len()])
+        .map_err(|error| TranscriptEditError::HistoryStateMalformed(error.to_string()))?;
+    if source == MaterializedParentAdvanceSource::CurrentAudit && semantic_prefix == base.revision {
+        return Ok(TranscriptParentAdvance::ContentAddressedAppend {
+            appended: parent.messages[base.messages.len()..].to_vec(),
+        });
+    }
     if source == MaterializedParentAdvanceSource::CurrentAudit {
         return Err(TranscriptEditError::HistoryStateMalformed(format!(
             "current rewrite occurrence {rewrite_generation} parent is not an exact append"
@@ -2518,6 +2548,12 @@ fn row_prefix_after_parent_advance(
 ) -> Result<SessionMessageRowPrefixAccumulator, TranscriptEditError> {
     let advanced = match advance {
         TranscriptParentAdvance::ExactAppend { .. } => base.clone(),
+        TranscriptParentAdvance::ContentAddressedAppend { .. } => {
+            return Err(TranscriptEditError::HistoryStateMalformed(
+                "content-addressed append requires an explicit current row-lineage baseline"
+                    .to_string(),
+            ));
+        }
         TranscriptParentAdvance::ExactSplice {
             at, replacement, ..
         } => {
@@ -2567,8 +2603,13 @@ fn edge_from_materialized_bodies(
 ) -> Result<TranscriptRevisionEdge, TranscriptEditError> {
     let parent_advance =
         parent_advance_from_materialized(base, parent, commit.rewrite_generation, source)?;
-    let parent_row_prefix =
-        row_prefix_after_parent_advance(base_witness.row_prefix(), &parent_advance)?;
+    let parent_row_prefix = match &parent_advance {
+        TranscriptParentAdvance::ContentAddressedAppend { .. } => {
+            SessionMessageRowPrefixAccumulator::from_messages(&parent.messages)
+                .map_err(|error| TranscriptEditError::HistoryStateMalformed(error.to_string()))?
+        }
+        _ => row_prefix_after_parent_advance(base_witness.row_prefix(), &parent_advance)?,
+    };
     let (at, end) = commit.selection.bounds();
     let removed_len = end.checked_sub(at).ok_or_else(|| {
         TranscriptEditError::HistoryStateMalformed("rewrite selection is inverted".to_string())
@@ -2623,7 +2664,10 @@ fn apply_parent_advance(
     advance: &TranscriptParentAdvance,
 ) -> Result<(), TranscriptEditError> {
     match advance {
-        TranscriptParentAdvance::ExactAppend { appended } => messages.extend_from_slice(appended),
+        TranscriptParentAdvance::ExactAppend { appended }
+        | TranscriptParentAdvance::ContentAddressedAppend { appended } => {
+            messages.extend_from_slice(appended);
+        }
         TranscriptParentAdvance::ExactSplice {
             at,
             replacement,

--- a/meerkat-core/src/session/transcript_history/validate.rs
+++ b/meerkat-core/src/session/transcript_history/validate.rs
@@ -535,8 +535,9 @@ pub(super) fn validate_transcript_revision_edge(
     }
     let (base_parent_prefix, appended) = match edge.parent_advance() {
         TranscriptParentAdvance::ExactAppend { appended } => {
-            (expected_base_witness.row_prefix().clone(), appended)
+            (Some(expected_base_witness.row_prefix().clone()), appended)
         }
+        TranscriptParentAdvance::ContentAddressedAppend { appended } => (None, appended),
         TranscriptParentAdvance::ExactSplice {
             at,
             replacement,
@@ -575,7 +576,7 @@ pub(super) fn validate_transcript_revision_edge(
                 .row_prefix()
                 .replace_serialized_range(at, end, &replacement_rows)
                 .map_err(|error| TranscriptEditError::HistoryStateMalformed(error.to_string()))?;
-            (spliced, appended)
+            (Some(spliced), appended)
         }
     };
     let serialized = appended
@@ -583,14 +584,16 @@ pub(super) fn validate_transcript_revision_edge(
         .map(serde_json::to_vec)
         .collect::<Result<Vec<_>, _>>()
         .map_err(|error| TranscriptEditError::HistoryStateMalformed(error.to_string()))?;
-    let expected_parent_prefix = base_parent_prefix
-        .extend_serialized_rows(&serialized)
-        .map_err(|error| TranscriptEditError::HistoryStateMalformed(error.to_string()))?;
-    if &expected_parent_prefix != edge.parent_row_prefix() {
-        return Err(TranscriptEditError::HistoryStateMalformed(format!(
-            "rewrite occurrence {} parent row prefix does not exactly bind its typed advance",
-            edge.rewrite_generation()
-        )));
+    if let Some(base_parent_prefix) = base_parent_prefix {
+        let expected_parent_prefix = base_parent_prefix
+            .extend_serialized_rows(&serialized)
+            .map_err(|error| TranscriptEditError::HistoryStateMalformed(error.to_string()))?;
+        if &expected_parent_prefix != edge.parent_row_prefix() {
+            return Err(TranscriptEditError::HistoryStateMalformed(format!(
+                "rewrite occurrence {} parent row prefix does not exactly bind its typed advance",
+                edge.rewrite_generation()
+            )));
+        }
     }
     let (start, end) = commit.selection.bounds();
     if start != edge.rewrite().at() || start > end || end > commit.messages_before {

--- a/meerkat-mob/src/build.rs
+++ b/meerkat-mob/src/build.rs
@@ -133,6 +133,20 @@ pub struct BuildResumedAgentConfigParams<'a> {
     pub base: BuildAgentConfigParams<'a>,
     pub(crate) expected_session_id: &'a SessionId,
     pub resumed_session: Session,
+    pub(crate) system_prompt_intent: ResumeSystemPromptIntent,
+}
+
+/// Whether a resume operation authors a new System message or only
+/// rematerializes the existing durable transcript.
+///
+/// Persisted member configuration may still be needed to rebuild the live
+/// executor, but replaying that configuration is not new transcript intent.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ResumeSystemPromptIntent {
+    /// Preserve the System messages already present in the durable session.
+    PreservePersisted,
+    /// Append an explicitly supplied prompt as new ordered transcript input.
+    AppendExplicit,
 }
 
 /// Build an [`AgentBuildConfig`] from a mob profile.
@@ -362,9 +376,13 @@ pub async fn build_resumed_agent_config(
         base,
         expected_session_id,
         resumed_session,
+        system_prompt_intent,
     } = params;
     let inherited_tool_filter = base.inherited_tool_filter.clone();
-    let explicit_resume_system_prompt = base.system_prompt_override.is_some();
+    let explicit_resume_system_prompt = matches!(
+        system_prompt_intent,
+        ResumeSystemPromptIntent::AppendExplicit
+    ) && base.system_prompt_override.is_some();
     if resumed_session.id() != expected_session_id {
         return Err(MobError::Internal(format!(
             "resume session id mismatch: expected '{}', got '{}'",
@@ -1628,6 +1646,7 @@ mod tests {
             },
             expected_session_id: &session_id,
             resumed_session,
+            system_prompt_intent: ResumeSystemPromptIntent::PreservePersisted,
         })
         .await
         .expect("build_resumed_agent_config");
@@ -1692,6 +1711,7 @@ mod tests {
             },
             expected_session_id: &session_id,
             resumed_session,
+            system_prompt_intent: ResumeSystemPromptIntent::AppendExplicit,
         })
         .await
         .expect("build_resumed_agent_config");
@@ -1718,6 +1738,66 @@ mod tests {
         assert!(
             config.resume_session.is_some(),
             "the durable session remains the sole transcript authority",
+        );
+    }
+
+    #[tokio::test]
+    async fn test_build_resumed_agent_config_does_not_replay_persisted_prompt_configuration() {
+        let def = sample_definition();
+        let lead = def.profiles[&ProfileName::from("lead")]
+            .as_inline()
+            .unwrap();
+        let session_id = SessionId::new();
+        let current_prompt = "current MobKit-assembled system prompt";
+        let mut resumed_session = resumed_session_with_metadata(session_id.clone());
+        resumed_session.append_system_message(current_prompt.to_string());
+
+        let config = build_resumed_agent_config(BuildResumedAgentConfigParams {
+            base: BuildAgentConfigParams {
+                mob_id: &def.id,
+                profile_name: &ProfileName::from("lead"),
+                agent_identity: &AgentIdentity::from("lead-1"),
+                profile: lead,
+                definition: &def,
+                external_tools: None,
+                context: None,
+                labels: None,
+                additional_instructions: Some(vec!["persisted section".to_string()]),
+                shell_env: None,
+                mob_tool_authority_context: None,
+                tool_access_policy: None,
+                inherited_tool_filter: None,
+                system_prompt_override: Some(crate::runtime::SpawnSystemPromptOverride::Replace(
+                    current_prompt.to_string(),
+                )),
+            },
+            expected_session_id: &session_id,
+            resumed_session,
+            system_prompt_intent: ResumeSystemPromptIntent::PreservePersisted,
+        })
+        .await
+        .expect("build_resumed_agent_config");
+
+        assert_eq!(
+            config.system_prompt,
+            SystemPromptOverride::Inherit,
+            "automatic rematerialization must not append persisted member configuration",
+        );
+        assert!(
+            config.additional_instructions.is_none(),
+            "automatic rematerialization must not replay persisted prompt sections",
+        );
+        assert_eq!(
+            config
+                .resume_session
+                .as_ref()
+                .expect("resumed session")
+                .messages()
+                .iter()
+                .filter(|message| matches!(message, meerkat_core::Message::System(system) if system.content == current_prompt))
+                .count(),
+            1,
+            "the durable transcript remains the sole prompt authority",
         );
     }
 
@@ -1753,6 +1833,7 @@ mod tests {
             },
             expected_session_id: &session_id,
             resumed_session,
+            system_prompt_intent: ResumeSystemPromptIntent::PreservePersisted,
         })
         .await
         .expect("build_resumed_agent_config");
@@ -1843,6 +1924,7 @@ mod tests {
             },
             expected_session_id: &session_id,
             resumed_session,
+            system_prompt_intent: ResumeSystemPromptIntent::PreservePersisted,
         })
         .await
         .expect("build_resumed_agent_config");
@@ -1942,6 +2024,7 @@ mod tests {
             },
             expected_session_id: &session_id,
             resumed_session,
+            system_prompt_intent: ResumeSystemPromptIntent::PreservePersisted,
         })
         .await
         .expect_err("malformed canonical visibility must fail closed");
@@ -2398,6 +2481,7 @@ mod tests {
             },
             expected_session_id: &session_id,
             resumed_session,
+            system_prompt_intent: ResumeSystemPromptIntent::PreservePersisted,
         })
         .await
         .expect("build_resumed_agent_config");

--- a/meerkat-mob/src/runtime/actor.rs
+++ b/meerkat-mob/src/runtime/actor.rs
@@ -3611,6 +3611,7 @@ impl DeferredResumeProvision {
             },
             expected_session_id: &resume_id,
             resumed_session: stored_session,
+            system_prompt_intent: build::ResumeSystemPromptIntent::AppendExplicit,
         })
         .await?;
         config.keep_alive = keep_alive;
@@ -11393,6 +11394,7 @@ impl MobActor {
             },
             expected_session_id: bridge_session_id,
             resumed_session: stored_session,
+            system_prompt_intent: build::ResumeSystemPromptIntent::PreservePersisted,
         })
         .await?;
         config.keep_alive = entry.runtime_mode == crate::MobRuntimeMode::AutonomousHost;
@@ -23381,6 +23383,8 @@ impl MobActor {
                             },
                             expected_session_id: &resume_id,
                             resumed_session: stored_session,
+                            system_prompt_intent:
+                                build::ResumeSystemPromptIntent::AppendExplicit,
                         },
                     )
                     .await?;

--- a/meerkat-mob/src/runtime/builder.rs
+++ b/meerkat-mob/src/runtime/builder.rs
@@ -8874,6 +8874,7 @@ impl MobBuilder {
                         },
                         expected_session_id: &bridge_session_id,
                         resumed_session: stored_session,
+                        system_prompt_intent: build::ResumeSystemPromptIntent::PreservePersisted,
                     })
                     .await;
                 let mut resumed_config = match resumed_config {

--- a/meerkat-mob/src/runtime/host_materialize.rs
+++ b/meerkat-mob/src/runtime/host_materialize.rs
@@ -2396,6 +2396,7 @@ impl HostMemberMaterializer {
                     base,
                     expected_session_id: session_id,
                     resumed_session: session,
+                    system_prompt_intent: crate::build::ResumeSystemPromptIntent::PreservePersisted,
                 })
                 .await?
             }

--- a/meerkat-mob/src/runtime/tests.rs
+++ b/meerkat-mob/src/runtime/tests.rs
@@ -22956,6 +22956,7 @@ async fn test_build_resumed_agent_config_rejects_mismatched_session_identity() {
             },
             expected_session_id: &wrong_session_id,
             resumed_session: resumed,
+            system_prompt_intent: crate::build::ResumeSystemPromptIntent::PreservePersisted,
         })
         .await
         .expect_err("resume helper must validate the target session identity");
@@ -51114,6 +51115,63 @@ async fn test_cold_restart_restores_per_spawn_profile_override_without_customize
     assert!(
         last_names.contains(&"planner".to_string()),
         "restored member build must carry the per-spawn declarative MCP servers: {mcp_creates:?}"
+    );
+}
+
+#[tokio::test]
+async fn test_cold_restart_does_not_replay_persisted_system_prompt_configuration() {
+    let service = Arc::new(MockSessionService::new());
+    let _ = service.enable_runtime_adapter();
+    let storage = MobStorage::in_memory();
+    let events = storage.events.clone();
+    let runtime_metadata = storage.runtime_metadata.clone();
+    let handle = MobBuilder::new(sample_definition(), storage)
+        .with_session_service(service.clone())
+        .create()
+        .await
+        .expect("create mob");
+
+    let prompt = "configured once, retained across rematerialization";
+    let mut spec = SpawnMemberSpec::new("worker", "w-prompt-restore");
+    spec.system_prompt_override = Some(SpawnSystemPromptOverride::Replace(prompt.to_string()));
+    let spawned = handle.spawn_spec(spec).await.expect("spawn worker");
+    let session_id = handle
+        .resolve_bridge_session_id(&spawned.agent_identity)
+        .await
+        .expect("bridge session id");
+
+    handle.stop().await.expect("stop");
+    MobSessionService::discard_live_session(service.as_ref(), &session_id)
+        .await
+        .expect("discard live session");
+
+    let resumed = MobBuilder::for_resume(MobStorage::with_events_and_runtime_metadata(
+        events,
+        runtime_metadata,
+    ))
+    .with_session_service(service.clone())
+    .resume()
+    .await
+    .expect("resume");
+    resumed
+        .resume()
+        .await
+        .expect("rebuild stopped member session");
+
+    let restored = service
+        .live_session_clone(&session_id)
+        .await
+        .expect("restored live session");
+    assert_eq!(
+        restored
+            .messages()
+            .iter()
+            .filter(
+                |message| matches!(message, Message::System(system) if system.content == prompt)
+            )
+            .count(),
+        1,
+        "automatic rematerialization must not append persisted prompt configuration",
     );
 }
 

--- a/meerkat-mob/src/runtime/tests.rs
+++ b/meerkat-mob/src/runtime/tests.rs
@@ -41481,6 +41481,13 @@ impl RuntimeBackedRealCommsSessionService {
             .store(enabled, Ordering::Relaxed);
     }
 
+    async fn reset_keep_alive_notifier(&self, session_id: &SessionId) {
+        self.keep_alive_notifiers
+            .write()
+            .await
+            .insert(session_id.clone(), Arc::new(tokio::sync::Notify::new()));
+    }
+
     fn set_append_system_context_delay_ms(&self, delay_ms: u64) {
         self.append_system_context_delay_ms
             .store(delay_ms, Ordering::Relaxed);
@@ -44593,6 +44600,11 @@ async fn test_default_peer_response_inherits_request_steer_while_requester_runni
         "runtime-start barrier fired without recording the busy requester prompt; prompts={requester_prompts:?}"
     );
     service.set_keep_alive_turns_complete_immediately(false);
+    // Install a fresh notifier before releasing the content barrier. The
+    // kickoff path may have left a stored Notify permit on the original test
+    // notifier, which would let this turn finish and make the response race a
+    // second apply instead of exercising the active-requester boundary.
+    service.reset_keep_alive_notifier(&sid_requester).await;
     service
         .clear_runtime_turn_content_barrier(&sid_requester)
         .await;
@@ -47221,6 +47233,26 @@ async fn test_discarded_live_session_revived_by_machine_authorized_dispatch() {
         .expect("session-backed member")
         .clone();
 
+    // Production-shaped prompt history: automatic rematerialization must
+    // preserve every persisted System row, including byte-identical repeats.
+    // These are transcript events, not configuration entries to normalize.
+    let expected_before_revival = {
+        let mut persisted_sessions = service.persisted_sessions.write().await;
+        let persisted = persisted_sessions
+            .get_mut(&bridge_session_id)
+            .expect("durable bridge session");
+        for _ in 0..12 {
+            persisted.append_system_message("repeated runtime instruction".to_string());
+        }
+        let expected = persisted.messages().to_vec();
+        service
+            .live_session_data
+            .write()
+            .await
+            .insert(bridge_session_id.clone(), persisted.clone());
+        expected
+    };
+
     // Model the #34 fail-closed discard: the live session (and with it the
     // comms runtime) is dropped out from under MobMachine while the durable
     // snapshot stays loadable and the member stays Active.
@@ -47251,6 +47283,15 @@ async fn test_discarded_live_session_revived_by_machine_authorized_dispatch() {
             .await
             .expect("has_live_session"),
         "revival must rebuild the live session under the unchanged binding"
+    );
+    let revived = service
+        .live_session_clone(&bridge_session_id)
+        .await
+        .expect("revived bridge session");
+    assert_eq!(
+        revived.messages(),
+        expected_before_revival,
+        "machine-authorized revival must preserve repeated System rows byte-for-byte and in order",
     );
     let turn_prompts = service.start_turn_prompts.read().await.clone();
     assert!(

--- a/meerkat-mob/src/runtime/tests.rs
+++ b/meerkat-mob/src/runtime/tests.rs
@@ -43597,7 +43597,7 @@ async fn test_active_autonomous_direct_steer_falls_back_when_exact_boundary_is_u
         .clear_runtime_turn_content_barrier(&sid_worker)
         .await;
     service.release_one_runtime_turn();
-    tokio::time::timeout(Duration::from_secs(2), async {
+    tokio::time::timeout(Duration::from_secs(10), async {
         loop {
             let prompts = service.applied_runtime_prompts(&sid_worker).await;
             if prompts.iter().skip(active_apply_count).any(|prompt| {
@@ -43711,7 +43711,7 @@ async fn test_active_internal_submit_work_steer_falls_back_when_exact_boundary_i
         .clear_runtime_turn_content_barrier(&sid_worker)
         .await;
     service.release_one_runtime_turn();
-    tokio::time::timeout(Duration::from_secs(2), async {
+    tokio::time::timeout(Duration::from_secs(10), async {
         loop {
             let prompts = service.applied_runtime_prompts(&sid_worker).await;
             if prompts.iter().skip(active_apply_count).any(|prompt| {

--- a/meerkat-mob/src/runtime/tests.rs
+++ b/meerkat-mob/src/runtime/tests.rs
@@ -44049,6 +44049,7 @@ async fn test_turn_driven_submit_work_steer_queues_when_exact_boundary_is_unavai
 
     service.set_block_session_reads(false);
     service.release_session_reads();
+    service.set_block_runtime_turns(false);
     service.release_one_runtime_turn();
     tokio::time::timeout(Duration::from_secs(2), async {
         loop {

--- a/meerkat-mob/src/runtime/tests.rs
+++ b/meerkat-mob/src/runtime/tests.rs
@@ -44051,7 +44051,7 @@ async fn test_turn_driven_submit_work_steer_queues_when_exact_boundary_is_unavai
     service.release_session_reads();
     service.set_block_runtime_turns(false);
     service.release_one_runtime_turn();
-    tokio::time::timeout(Duration::from_secs(2), async {
+    tokio::time::timeout(Duration::from_secs(10), async {
         loop {
             let prompts = service.applied_runtime_prompts(&sid_worker).await;
             if prompts.iter().skip(prompt_baseline + 1).any(|prompt| {
@@ -44164,7 +44164,7 @@ async fn test_member_send_steer_queues_when_exact_boundary_is_unavailable() {
     service.release_session_reads();
     service.set_block_runtime_turns(false);
     service.release_runtime_turns();
-    tokio::time::timeout(Duration::from_secs(2), async {
+    tokio::time::timeout(Duration::from_secs(10), async {
         loop {
             let prompts = service.applied_runtime_prompts(&sid_worker).await;
             if prompts.iter().skip(prompt_baseline + 1).any(|prompt| {

--- a/meerkat-runtime/src/comms_drain.rs
+++ b/meerkat-runtime/src/comms_drain.rs
@@ -157,8 +157,9 @@ pub fn spawn_comms_drain(
             // indistinguishable from an idle inbox and triggering the
             // idle/dismiss lifecycle branch below). Empty-because-error must be
             // distinguishable from empty-because-idle before deciding to idle.
-            let candidates = match comms_runtime.drain_classified_inbox_interactions().await {
-                Ok(candidates) => candidates,
+            let candidates = match comms_runtime.try_recv_classified_inbox_interaction().await {
+                Ok(Some(candidate)) => vec![candidate],
+                Ok(None) => Vec::new(),
                 Err(err) => {
                     // A classified-drain fault is NOT an idle inbox. Fail closed
                     // with the typed `Failed` terminal owned by the drain
@@ -6670,7 +6671,7 @@ mod tests {
     use meerkat_core::interaction::{PeerIngressConvention, PeerIngressIdentity};
     use meerkat_core::types::HandlingMode;
     use serde_json::json;
-    use std::collections::{HashMap, HashSet};
+    use std::collections::{HashMap, HashSet, VecDeque};
     use uuid::Uuid;
 
     struct ExhaustedDirectedTurnObservation;
@@ -7800,6 +7801,14 @@ mod tests {
                 .into_iter()
                 .collect())
         }
+        async fn try_recv_classified_inbox_interaction(
+            &self,
+        ) -> Result<
+            Option<meerkat_core::interaction::ClassifiedInboxInteraction>,
+            meerkat_core::agent::CommsCapabilityError,
+        > {
+            Ok(self.candidate.lock().expect("candidate mutex").take())
+        }
 
         fn mark_interaction_complete(&self, _id: &InteractionId) {
             self.completed_count
@@ -7929,6 +7938,108 @@ mod tests {
         }
     }
 
+    struct PrefixPausingRuntime {
+        notify: Arc<tokio::sync::Notify>,
+        candidates: std::sync::Mutex<VecDeque<PeerInputCandidate>>,
+        received: std::sync::Mutex<Vec<InteractionId>>,
+        receive_calls: std::sync::atomic::AtomicUsize,
+        pause_before_receive: usize,
+        paused: std::sync::Mutex<Option<tokio::sync::oneshot::Sender<()>>>,
+    }
+
+    impl PrefixPausingRuntime {
+        fn new(
+            candidates: Vec<PeerInputCandidate>,
+            pause_before_receive: usize,
+            paused: tokio::sync::oneshot::Sender<()>,
+        ) -> Self {
+            Self {
+                notify: Arc::new(tokio::sync::Notify::new()),
+                candidates: std::sync::Mutex::new(candidates.into()),
+                received: std::sync::Mutex::new(Vec::new()),
+                receive_calls: std::sync::atomic::AtomicUsize::new(0),
+                pause_before_receive,
+                paused: std::sync::Mutex::new(Some(paused)),
+            }
+        }
+
+        fn remaining(&self) -> usize {
+            self.candidates.lock().expect("candidate mutex").len()
+        }
+
+        fn received(&self) -> Vec<InteractionId> {
+            self.received.lock().expect("received mutex").clone()
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl CommsRuntime for PrefixPausingRuntime {
+        async fn drain_messages(&self) -> Vec<String> {
+            Vec::new()
+        }
+
+        fn inbox_notify(&self) -> Arc<tokio::sync::Notify> {
+            self.notify.clone()
+        }
+
+        async fn try_recv_classified_inbox_interaction(
+            &self,
+        ) -> Result<
+            Option<meerkat_core::interaction::ClassifiedInboxInteraction>,
+            meerkat_core::agent::CommsCapabilityError,
+        > {
+            let call = self
+                .receive_calls
+                .fetch_add(1, std::sync::atomic::Ordering::SeqCst)
+                + 1;
+            if call == self.pause_before_receive {
+                if let Some(paused) = self.paused.lock().expect("paused mutex").take() {
+                    let _ = paused.send(());
+                }
+                std::future::pending::<()>().await;
+            }
+            let candidate = self.candidates.lock().expect("candidate mutex").pop_front();
+            if let Some(candidate) = candidate.as_ref() {
+                self.received
+                    .lock()
+                    .expect("received mutex")
+                    .push(candidate.interaction.id);
+            }
+            Ok(candidate)
+        }
+    }
+
+    fn actionable_message_candidate(index: usize) -> PeerInputCandidate {
+        let id = InteractionId(Uuid::new_v4());
+        let peer_id = PeerId::new();
+        let sender = format!("fan-in-worker-{index}");
+        PeerInputCandidate {
+            interaction: InboxInteraction {
+                objective_id: None,
+                sender_taint: None,
+                id,
+                from_route: Some(peer_id),
+                from: sender.clone(),
+                content: InteractionContent::Message {
+                    body: format!("DONE {index}"),
+                    blocks: None,
+                },
+                rendered_text: format!("DONE {index}"),
+                handling_mode: HandlingMode::Steer,
+                render_metadata: None,
+            },
+            ingress: PeerIngressFact::peer(
+                id,
+                PeerInputClass::ActionableMessage,
+                meerkat_core::PeerIngressKind::Message,
+                Some(meerkat_core::PeerIngressAuthDecision::Required),
+                PeerIngressIdentity::new(peer_id, sender, PeerIngressConvention::Message),
+            ),
+            lifecycle_peer: None,
+            response_terminality: None,
+        }
+    }
+
     #[async_trait::async_trait]
     impl CommsRuntime for ClassifiedDrainOutcomeRuntime {
         async fn drain_messages(&self) -> Vec<String> {
@@ -7951,6 +8062,21 @@ mod tests {
                 ))
             } else {
                 Ok(Vec::new())
+            }
+        }
+
+        async fn try_recv_classified_inbox_interaction(
+            &self,
+        ) -> Result<
+            Option<meerkat_core::interaction::ClassifiedInboxInteraction>,
+            meerkat_core::agent::CommsCapabilityError,
+        > {
+            if self.fail_classified_drain {
+                Err(meerkat_core::agent::CommsCapabilityError::Unsupported(
+                    "synthetic classification fault".to_string(),
+                ))
+            } else {
+                Ok(None)
             }
         }
     }
@@ -8037,6 +8163,86 @@ mod tests {
                 .await
                 .is_err(),
             "an empty (Ok) inbox must idle, not exit promptly"
+        );
+    }
+
+    #[tokio::test]
+    async fn abort_after_fan_in_prefix_preserves_fifo_tail_for_replacement_drain() {
+        const FAN_IN: usize = 69;
+        const PREFIX: usize = 24;
+
+        let adapter = Arc::new(MeerkatMachine::ephemeral());
+        let session_id = SessionId::new();
+        adapter
+            .register_session(session_id.clone())
+            .await
+            .expect("register session");
+
+        let candidates = (0..FAN_IN)
+            .map(actionable_message_candidate)
+            .collect::<Vec<_>>();
+        let expected_order = candidates
+            .iter()
+            .map(|candidate| candidate.interaction.id)
+            .collect::<Vec<_>>();
+        let (paused_tx, paused_rx) = tokio::sync::oneshot::channel();
+        let runtime = Arc::new(PrefixPausingRuntime::new(candidates, PREFIX + 1, paused_tx));
+        let runtime_dyn: Arc<dyn CommsRuntime> = runtime.clone();
+
+        let first_drain = spawn_authorized_test_comms_drain(
+            adapter.clone(),
+            session_id.clone(),
+            runtime_dyn.clone(),
+            Duration::from_secs(60),
+        )
+        .await;
+        tokio::time::timeout(Duration::from_secs(2), paused_rx)
+            .await
+            .expect("first drain must reach the deterministic replacement seam")
+            .expect("pause sender must remain live");
+
+        first_drain.abort();
+        let cancelled = first_drain
+            .await
+            .expect_err("first drain must be cancelled");
+        assert!(cancelled.is_cancelled());
+        assert_eq!(
+            runtime.remaining(),
+            FAN_IN - PREFIX,
+            "aborting after a prefix must leave the unstarted FIFO tail in the inbox"
+        );
+        assert_eq!(
+            adapter
+                .meerkat_machine_spine_snapshot(&session_id)
+                .await
+                .expect("registered session snapshot")
+                .ledger
+                .input_count,
+            PREFIX,
+            "the first drain must admit exactly the completed prefix"
+        );
+
+        let replacement = spawn_comms_drain(
+            adapter.clone(),
+            session_id.clone(),
+            runtime_dyn,
+            Some(Duration::from_millis(10)),
+        );
+        tokio::time::timeout(Duration::from_secs(2), replacement)
+            .await
+            .expect("replacement drain must consume the retained tail")
+            .expect("replacement drain must not panic");
+
+        let snapshot = adapter
+            .meerkat_machine_spine_snapshot(&session_id)
+            .await
+            .expect("registered session snapshot");
+        assert_eq!(snapshot.ledger.input_count, FAN_IN);
+        assert_eq!(runtime.remaining(), 0);
+        assert_eq!(
+            runtime.received(),
+            expected_order,
+            "replacement must resume at the exact next interaction without loss, duplication, or reordering"
         );
     }
 
@@ -14261,6 +14467,15 @@ mod tests {
                 .take()
                 .into_iter()
                 .collect())
+        }
+
+        async fn try_recv_classified_inbox_interaction(
+            &self,
+        ) -> Result<
+            Option<meerkat_core::interaction::ClassifiedInboxInteraction>,
+            meerkat_core::agent::CommsCapabilityError,
+        > {
+            Ok(self.candidate.lock().expect("candidate mutex").take())
         }
 
         fn mark_interaction_complete(&self, _id: &InteractionId) {

--- a/meerkat-runtime/src/meerkat_machine_tests.rs
+++ b/meerkat-runtime/src/meerkat_machine_tests.rs
@@ -4210,6 +4210,13 @@ impl CommsRuntime for FakeDrainRuntime {
     {
         Ok(Vec::new())
     }
+
+    async fn try_recv_classified_inbox_interaction(
+        &self,
+    ) -> Result<Option<meerkat_core::interaction::ClassifiedInboxInteraction>, CommsCapabilityError>
+    {
+        Ok(None)
+    }
 }
 
 async fn spawn_test_comms_drain(

--- a/meerkat-runtime/tests/meerkat_machine.rs
+++ b/meerkat-runtime/tests/meerkat_machine.rs
@@ -4253,6 +4253,15 @@ async fn unregister_session_aborts_spawned_drain_and_clears_suppression() {
         > {
             Ok(Vec::new())
         }
+
+        async fn try_recv_classified_inbox_interaction(
+            &self,
+        ) -> Result<
+            Option<meerkat_core::interaction::ClassifiedInboxInteraction>,
+            meerkat_core::agent::CommsCapabilityError,
+        > {
+            Ok(None)
+        }
     }
 
     let adapter = Arc::new(MeerkatMachine::ephemeral());
@@ -4336,6 +4345,15 @@ async fn idle_non_host_sessions_do_not_spawn_background_comms_drains() {
         > {
             Ok(Vec::new())
         }
+
+        async fn try_recv_classified_inbox_interaction(
+            &self,
+        ) -> Result<
+            Option<meerkat_core::interaction::ClassifiedInboxInteraction>,
+            meerkat_core::agent::CommsCapabilityError,
+        > {
+            Ok(None)
+        }
     }
 
     let adapter = Arc::new(MeerkatMachine::ephemeral());
@@ -4405,6 +4423,15 @@ async fn attached_sessions_do_not_spawn_comms_drains_without_keep_alive() {
             meerkat_core::agent::CommsCapabilityError,
         > {
             Ok(Vec::new())
+        }
+
+        async fn try_recv_classified_inbox_interaction(
+            &self,
+        ) -> Result<
+            Option<meerkat_core::interaction::ClassifiedInboxInteraction>,
+            meerkat_core::agent::CommsCapabilityError,
+        > {
+            Ok(None)
         }
     }
 

--- a/meerkat-runtime/tests/meerkat_machine.rs
+++ b/meerkat-runtime/tests/meerkat_machine.rs
@@ -2780,12 +2780,6 @@ async fn ensure_session_with_executor_upgrades_registered_session() {
     )
     .await;
 
-    let state = adapter.runtime_state(&sid).await.unwrap();
-    assert_eq!(state, RuntimeState::Attached);
-
-    let active = adapter.list_active_inputs(&sid).await.unwrap();
-    assert!(active.is_empty(), "queued work should drain after upgrade");
-
     let is = wait_for_input_state(
         &adapter,
         &sid,
@@ -2799,6 +2793,12 @@ async fn ensure_session_with_executor_upgrades_registered_session() {
         InputLifecycleState::Consumed,
         "the pre-upgrade queued input should be processed once the loop is attached"
     );
+
+    let state = adapter.runtime_state(&sid).await.unwrap();
+    assert_eq!(state, RuntimeState::Attached);
+
+    let active = adapter.list_active_inputs(&sid).await.unwrap();
+    assert!(active.is_empty(), "queued work should drain after upgrade");
 }
 
 #[tokio::test]

--- a/meerkat-session/src/persistent.rs
+++ b/meerkat-session/src/persistent.rs
@@ -2527,6 +2527,34 @@ impl<B: SessionAgentBuilder + 'static> PersistentSessionService<B> {
         Ok(replay.session)
     }
 
+    /// Read one committed session body without leaking the narrow
+    /// HeadCanonical checkpoint-to-boundary commit window to observers.
+    ///
+    /// Ordinary reads remain lock-free. If the physical head moved after the
+    /// RuntimeStore authority was sampled, wait for the runtime-owned outer
+    /// turn boundary and retry exactly once. A mismatch with no completing
+    /// turn behind it is returned unchanged, preserving fail-closed behavior
+    /// for stale or contradictory authority.
+    async fn load_authoritative_session_base_for_observation(
+        &self,
+        id: &SessionId,
+    ) -> Result<Option<Session>, SessionError> {
+        match self.load_authoritative_session_base(id).await {
+            Err(SessionError::Store(error))
+                if error
+                    .downcast_ref::<SessionStoreError>()
+                    .is_some_and(|error| {
+                        matches!(error, SessionStoreError::TranscriptRevisionConflict { .. })
+                    }) =>
+            {
+                let _turn_finalization_guard =
+                    self.acquire_runtime_turn_finalization_guard(id).await;
+                self.load_authoritative_session_base(id).await
+            }
+            result => result,
+        }
+    }
+
     async fn load_authoritative_session_base_with_replay_info(
         &self,
         id: &SessionId,
@@ -9205,7 +9233,7 @@ impl<B: SessionAgentBuilder + 'static> SessionServiceHistoryExt for PersistentSe
         query: SessionHistoryQuery,
     ) -> Result<SessionHistoryPage, SessionError> {
         let session = self
-            .load_authoritative_session_base(id)
+            .load_authoritative_session_base_for_observation(id)
             .await?
             .ok_or_else(|| SessionError::NotFound { id: id.clone() })?;
         Ok(SessionHistoryPage::from_messages(
@@ -9221,7 +9249,7 @@ impl<B: SessionAgentBuilder + 'static> SessionServiceHistoryExt for PersistentSe
         query: SessionTranscriptRevisionQuery,
     ) -> Result<SessionTranscriptRevisionPage, SessionError> {
         let session = self
-            .load_authoritative_session_base(id)
+            .load_authoritative_session_base_for_observation(id)
             .await?
             .ok_or_else(|| SessionError::NotFound { id: id.clone() })?;
         let head_revision = session.transcript_revision().map_err(|err| {
@@ -9305,7 +9333,7 @@ impl<B: SessionAgentBuilder + 'static> SessionServiceHistoryExt for PersistentSe
         query: SessionTranscriptRevisionListQuery,
     ) -> Result<SessionTranscriptRevisionList, SessionError> {
         let session = self
-            .load_authoritative_session_base(id)
+            .load_authoritative_session_base_for_observation(id)
             .await?
             .ok_or_else(|| SessionError::NotFound { id: id.clone() })?;
         let head_revision = session.transcript_revision().map_err(|err| {


### PR DESCRIPTION
## Summary

- dequeue at most one classified peer interaction before each awaited durable admission
- preserve the unstarted FIFO tail when a comms drain task is aborted or replaced
- retain at-most-once transfer for the current candidate
- keep the explicit legacy batch-drain API as one atomic snapshot

## Production evidence

OB3 observed partial loss under 69-worker and 91-worker fan-in despite successful transport receipts. The old drain removed the whole classified inbox into a task-local vector, then awaited admissions sequentially. Cancellation after a prefix left the remaining tail unreachable. HomeCore independently reproduced the same wake seam at 17-member schedule scale.

## Verification

- mandatory installed pre-push gate passed
- deterministic 69-input prefix-abort regression passed
- exact FIFO order and no loss or duplication asserted
- focused Meerkat comms and runtime checks and clippy passed
- legacy authenticated-content batch conversion regression passed

OB3 will run the production-shaped 69-board and sweep-burst validation against exact head `6a38ecf9dff8c01ee944ecf0eb7f21135abe0bca`.
