### PR TITLE
fix(runtime): preserve fresh steer content

### DIFF
--- a/meerkat-mob/src/runtime/actor.rs
+++ b/meerkat-mob/src/runtime/actor.rs
@@ -1904,6 +1904,100 @@ fn unresolved_kickoff_member_ids(
         .collect()
 }
 
+fn normalize_submit_work_handling_mode_during_kickoff(
+    state: &mob_dsl::MobMachineState,
+    agent_identity: &AgentIdentity,
+    runtime_mode: crate::MobRuntimeMode,
+    requested: meerkat_core::types::HandlingMode,
+) -> meerkat_core::types::HandlingMode {
+    if runtime_mode != crate::MobRuntimeMode::AutonomousHost
+        || requested != meerkat_core::types::HandlingMode::Steer
+    {
+        return requested;
+    }
+
+    let identity = mob_dsl::AgentIdentity::from_domain(agent_identity);
+    if state.member_kickoff_pending.contains(&identity)
+        || state.member_kickoff_starting.contains(&identity)
+    {
+        // A machine-owned kickoff is startup work, not a caller turn that can
+        // safely consume transient Steer context. Preserve the caller input as
+        // the next durable conversation turn instead of attaching it to a
+        // kickoff that may already be inside its only model request.
+        meerkat_core::types::HandlingMode::Queue
+    } else {
+        requested
+    }
+}
+
+#[cfg(test)]
+#[test]
+fn unresolved_autonomous_kickoff_queues_steer_without_affecting_other_modes() {
+    let identity = AgentIdentity::from("review:singleton");
+    let dsl_identity = mob_dsl::AgentIdentity::from_domain(&identity);
+    let mut state = mob_dsl::MobMachineState::default();
+
+    let normalized = |state: &mob_dsl::MobMachineState,
+                      runtime_mode: crate::MobRuntimeMode,
+                      requested: meerkat_core::types::HandlingMode| {
+        normalize_submit_work_handling_mode_during_kickoff(
+            state,
+            &identity,
+            runtime_mode,
+            requested,
+        )
+    };
+
+    state.member_kickoff_pending.insert(dsl_identity.clone());
+    assert_eq!(
+        normalized(
+            &state,
+            crate::MobRuntimeMode::AutonomousHost,
+            meerkat_core::types::HandlingMode::Steer
+        ),
+        meerkat_core::types::HandlingMode::Queue,
+    );
+    assert_eq!(
+        normalized(
+            &state,
+            crate::MobRuntimeMode::TurnDriven,
+            meerkat_core::types::HandlingMode::Steer
+        ),
+        meerkat_core::types::HandlingMode::Steer,
+    );
+    assert_eq!(
+        normalized(
+            &state,
+            crate::MobRuntimeMode::AutonomousHost,
+            meerkat_core::types::HandlingMode::Queue
+        ),
+        meerkat_core::types::HandlingMode::Queue,
+    );
+
+    state.member_kickoff_pending.remove(&dsl_identity);
+    state.member_kickoff_starting.insert(dsl_identity.clone());
+    assert_eq!(
+        normalized(
+            &state,
+            crate::MobRuntimeMode::AutonomousHost,
+            meerkat_core::types::HandlingMode::Steer
+        ),
+        meerkat_core::types::HandlingMode::Queue,
+    );
+
+    state.member_kickoff_starting.remove(&dsl_identity);
+    state.member_kickoff_callback_pending.insert(dsl_identity);
+    assert_eq!(
+        normalized(
+            &state,
+            crate::MobRuntimeMode::AutonomousHost,
+            meerkat_core::types::HandlingMode::Steer
+        ),
+        meerkat_core::types::HandlingMode::Steer,
+        "callback-pending is already a terminal kickoff boundary",
+    );
+}
+
 #[derive(Debug, Clone)]
 enum SubmitWorkIngressAuthority {
     Runtime {
@@ -44986,7 +45080,7 @@ impl MobActor {
             injected_context,
             mut interaction_id,
             objective_id,
-            handling_mode,
+            mut handling_mode,
             external_delivery_identity,
             turn_metadata,
             event_tx,
@@ -45119,6 +45213,23 @@ impl MobActor {
         } else {
             entry.fence_token
         };
+
+        let requested_handling_mode = handling_mode;
+        handling_mode = normalize_submit_work_handling_mode_during_kickoff(
+            self.dsl_authority.state(),
+            &domain_identity,
+            entry.runtime_mode,
+            handling_mode,
+        );
+        if handling_mode != requested_handling_mode {
+            tracing::debug!(
+                agent_identity = %agent_identity,
+                runtime_id = %entry.agent_runtime_id,
+                requested_handling_mode = ?requested_handling_mode,
+                execution_handling_mode = ?handling_mode,
+                "queued Steer behind unresolved machine-owned kickoff"
+            );
+        }
 
         if let Some(identity) = &external_delivery_identity {
             identity.validate()?;

--- a/meerkat-mob/src/runtime/tests.rs
+++ b/meerkat-mob/src/runtime/tests.rs
@@ -43733,6 +43733,78 @@ async fn test_active_internal_submit_work_steer_falls_back_when_exact_boundary_i
 }
 
 #[tokio::test]
+async fn test_idle_internal_submit_work_steer_preserves_exact_content() {
+    let _serial = lock_real_comms_tests();
+    let (handle, service) =
+        create_test_mob_with_runtime_backed_real_comms(sample_definition()).await;
+    service.set_keep_alive_turns_complete_immediately(true);
+
+    let member_id = AgentIdentity::from("w-idle-internal-steer");
+    let session_id = handle
+        .spawn(ProfileName::from("lead"), member_id.clone(), None)
+        .await
+        .expect("spawn worker")
+        .bridge_session_id()
+        .expect("session-backed")
+        .clone();
+
+    handle
+        .wait_for_ready(Some(Duration::from_secs(2)))
+        .await
+        .expect("startup should settle");
+    handle
+        .wait_for_members_kickoff_complete(
+            std::slice::from_ref(&member_id),
+            Some(Duration::from_secs(2)),
+        )
+        .await
+        .expect("kickoff should resolve before idle steer");
+
+    let prompt_baseline = service.applied_runtime_prompts(&session_id).await.len();
+    let entry = handle
+        .get_member(&member_id)
+        .await
+        .expect("read member")
+        .expect("member exists");
+    let marker = "idle identity bridge steer must preserve this exact content";
+    handle
+        .submit_work_with_mode(
+            entry.agent_runtime_id,
+            entry.fence_token,
+            WorkRef::new(),
+            WorkSpec::new(marker, WorkOrigin::Internal),
+            HandlingMode::Steer,
+        )
+        .await
+        .expect("idle internal steer should be admitted");
+
+    let delivery = tokio::time::timeout(Duration::from_secs(5), async {
+        loop {
+            let prompts = service.applied_runtime_prompts(&session_id).await;
+            if prompts
+                .iter()
+                .skip(prompt_baseline)
+                .any(|prompt| prompt.text_content().starts_with(marker))
+            {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(25)).await;
+        }
+    })
+    .await;
+    assert!(
+        delivery.is_ok(),
+        "idle internal steer must reach the model with exact content; applied prompts: {:?}",
+        service.applied_runtime_prompts(&session_id).await
+    );
+
+    tokio::time::timeout(Duration::from_secs(2), handle.stop())
+        .await
+        .expect("stop timeout after idle internal steer assertion")
+        .expect("stop after idle internal steer assertion");
+}
+
+#[tokio::test]
 async fn internal_submit_work_carries_stable_delivery_identity_to_runtime_admission() {
     let _serial = lock_real_comms_tests();
     let (handle, service) =

--- a/meerkat-runtime/src/meerkat_machine/dispatch_ingress.rs
+++ b/meerkat-runtime/src/meerkat_machine/dispatch_ingress.rs
@@ -418,7 +418,7 @@ impl MeerkatMachine {
                 tracing::debug!(
                     session_id = %session_id,
                     input_id = %input_id,
-                    "no active run is available for exact live-boundary context; retaining queued fallback"
+                    "no active run is available for exact live-boundary context; retaining same-boundary Steer batching for the fresh runtime turn"
                 );
                 return Ok((
                     held_mutation_gate,

--- a/meerkat-runtime/src/meerkat_machine_tests.rs
+++ b/meerkat-runtime/src/meerkat_machine_tests.rs
@@ -3816,6 +3816,13 @@ async fn idle_explicit_steer_peer_request_runs_through_runtime_loop() {
                 Some(meerkat_core::types::HandlingMode::Queue),
                 "idle steer is an admission lane; fresh turn execution must be normalized for the session-service path"
             );
+            assert!(
+                primitive
+                    .model_projection_content_input()
+                    .text_content()
+                    .contains("Inspect this host and respond"),
+                "idle Steer normalization must retain its exact durable content in the model projection"
+            );
             self.calls.fetch_add(1, Ordering::SeqCst);
             Ok(CoreApplyOutput::with_run_result(
                 RunBoundaryReceiptDraft {

--- a/meerkat-runtime/src/runtime_loop.rs
+++ b/meerkat-runtime/src/runtime_loop.rs
@@ -5210,6 +5210,8 @@ async fn process_queue(
             else {
                 return false;
             };
+            let fresh_steer_batch = prebound_run_id.is_none()
+                && batch.source() == crate::meerkat_machine::driver::RuntimeLoopBatchSource::Steer;
 
             // Dequeue the batch members from the physical queues. The physical
             // projection must exactly match the machine-selected batch; partial
@@ -5242,7 +5244,24 @@ async fn process_queue(
                 .map(|(staged_input_id, _)| staged_input_id.clone())
                 .collect::<Vec<_>>();
             let semantics =
-                crate::meerkat_machine::machine_batch_runtime_semantics(&d, &staged_ids);
+                crate::meerkat_machine::machine_batch_runtime_semantics(&d, &staged_ids).map(
+                    |mut semantics| {
+                        if fresh_steer_batch {
+                            // Steer is an admission lane, not the execution mode of
+                            // a fresh turn. Normalize the already authorized whole
+                            // same-boundary batch only for its run primitive. This
+                            // preserves batching and makes every durable input a
+                            // conversation append; an active prebound run still
+                            // projects Steer as transient request context.
+                            for semantics in &mut semantics {
+                                semantics.execution_handling_mode =
+                                    Some(meerkat_core::types::HandlingMode::Queue);
+                                semantics.live_interrupt_required = false;
+                            }
+                        }
+                        semantics
+                    },
+                );
             let projections =
                 crate::meerkat_machine::machine_batch_primitive_projections(&d, &staged_inputs);
             let primitive = match (semantics, projections) {


### PR DESCRIPTION
## Summary

- preserve durably admitted Steer content when no active run exists
- normalize the generated whole same-boundary Steer batch only for fresh-turn execution, so its inputs become ordinary conversation appends without splitting the batch
- queue Steer behind an unresolved autonomous kickoff so a newly materialized member cannot consume an empty kickoff while dropping the caller's durable content
- retain transient live-boundary projection for an actual prebound active run
- add deterministic runtime and Mob regressions for exact content, idle normalization, same-boundary fanout, and kickoff-state handling

## Root cause

A no-current-run Steer stayed stamped as live transient context until fresh-turn primitive construction. The primitive therefore omitted its durable conversation append even though no live boundary existed, producing an empty model input after rematerialization.

Normalizing one admission eagerly was also incorrect because it could split a same-boundary Steer batch across Queue and Steer lanes. The runtime fix waits for generated whole-batch authority and normalizes only the fresh primitive's execution semantics.

OB3 then proved a second first-wake race on the original PR head: materialization starts an autonomous kickoff before the external Steer arrives. While that machine-owned kickoff is pending or starting, Steer cannot safely be transient because the kickoff's only model boundary may already be in flight. The Mob ownership boundary now normalizes only that unresolved-kickoff case to durable Queue. Callback-pending, TurnDriven, ordinary Queue, and genuinely active prebound Steer semantics are unchanged.

## Verification

- focused runtime, Mob, batching, and kickoff-state regressions passed
- scoped all-feature clippy passed with warnings denied
- normal pre-push hook passed against exact commit `0d4b572a5ef246f8cbe8f3377d89de87dfa1cb76`, including formal-machine gates, workspace tests, cold restart, and e2e-fast
- hosted BuildBuddy Turbo S passed 62/62 against the corrected source: https://app.buildbuddy.io/invocation/6fd2caa4-ff5c-4d79-9a10-ed030092c928
- OB3 forced-rematerialization and paired MobKit first-wake acceptance are running against the exact corrected head

The separate resident-member burst ping disappearance remains independently tracked and is not claimed fixed by this PR.
