### PR TITLE
docs: name the pattern that trips the fail-closed registration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,24 @@ checks that this section EXISTS, not that it covers every break.**
   foreign route now fails closed. An embedder that relied on displacement gets
   `CommsRuntimeError::InprocRegistrationRejected` where it used to get a working
   runtime. This is the intended fix, and it is a behaviour break.
+  **IF YOUR TEST SUITE JUST WENT RED, START HERE.** The pattern that trips is
+  a suite that constructs MORE THAN ONE RUNTIME IN A SINGLE PROCESS UNDER THE
+  SAME PARTICIPANT NAME - typically a shared `build_test_runtime()` helper
+  called once per test. Before this release the second and later registrations
+  silently displaced the first and handed back a working runtime, so every test
+  after the first was running against a route it had taken from its
+  predecessor. That was never isolation; it was a collision that happened to be
+  survivable. This release refuses it, so those tests now fail at construction.
+  **The message will not lead you here on its own.** It reads
+  `the participant name already has a live route under a different public key
+  ed25519:...`, which names the key and sends you to key management, rotation
+  or trust config - none of which is the problem. The fix is to give each
+  runtime its own participant name, or to retire the previous route
+  (`CommsRuntime::retire_inproc_route`, or `publish_replacing` when you hold
+  the predecessor handle deliberately).
+  Production code is usually unaffected: one runtime per process has no second
+  registration to collide with. Reported from the field by an adopter whose
+  21 failing tests were all this, and whose production path was not.
 - `meerkat_core::ops::ToolAccessPolicy` gains a `ReadOnly` variant. The enum is
   not `#[non_exhaustive]`, so exhaustive matches break.
   **READ THIS BEFORE ENABLING READ-ONLY ANYWHERE: it makes rollback one-way for


### PR DESCRIPTION
An adopter hit the 0.8.23 fail-closed inproc registration within hours of the release: 21 tests, all failing at runtime construction.

Their diagnosis was right, and the release notes were the gap. The `### Breaking` entry declared the **mechanism** (registration that used to displace a live foreign route now fails closed) but not the **pattern** that triggers it - and a mechanism does not help someone who does not yet know which of their own behaviours is the trigger.

The shape: a suite that builds more than one runtime in one process under a shared participant name, usually via a single test helper. Before 0.8.23 the later registrations displaced the earlier ones, so every test after the first ran against a route it had taken from its predecessor. Not isolation - a collision that happened to be survivable.

Worse, **the error message actively misdirects**. It reads `the participant name already has a live route under a different public key ed25519:...`, which names the key and sends the reader to key management, rotation, or trust config. None of those is the answer.

This entry now names the pattern, points at `retire_inproc_route` / `publish_replacing` as the deliberate hand-over path, and records that production is usually unaffected (one runtime per process has no second registration to collide with) so nobody reads a red test suite as a production outage.

Docs only. Does not touch the v0.8.23 tag or any published artifact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LAnqZ9RgX2u1qPpiiz5tSG