### PR TITLE
Migrate all SDK RPC wrappers to generated contracts

### DIFF
--- a/artifacts/schemas/rpc-methods.json
+++ b/artifacts/schemas/rpc-methods.json
@@ -378,7 +378,7 @@
     {
       "description": "Queue a runtime-backed external event",
       "name": "session/external_event",
-      "params_type": "SessionExternalEventEnvelope",
+      "params_type": "SessionExternalEventParams",
       "result_type": "RuntimeAcceptResult"
     },
     {

--- a/artifacts/schemas/wire-types.json
+++ b/artifacts/schemas/wire-types.json
@@ -106679,6 +106679,265 @@
     ],
     "title": "SessionExternalEventEnvelope"
   },
+  "SessionExternalEventParams": {
+    "$defs": {
+      "PeerCorrelationId": {
+        "description": "Canonical correlation identifier for the peer request/response lifecycle.\n\nOn the sender side, `PeerCorrelationId` is both the outbound request\nenvelope id and the reservation key for any stream subscription. On the\nreceiver side, every response envelope carries it as `in_reply_to`. The\nsender routes a reply back to its originating request by matching on this\nid — no local id-translation map.\n\nWrapping it in a newtype prevents raw-`Uuid` confusion at every site that\nfires a DSL input, inserts into the subscriber registry, or closes out an\ninbound request.",
+        "type": "string"
+      },
+      "PeerId": {
+        "description": "Canonical runtime identity for a peer.\n\n`PeerId` is the routing key: the router and trust store key by `PeerId`,\nnever by `PeerName`. Two peers may legitimately share a display `PeerName`\n(per the Wave-B V5 dogma note), but their `PeerId`s never collide — the\nunderlying UUID is globally unique.\n\nConstructed freshly (`PeerId::new`) for a peer minted locally, parsed\nfrom a hyphenated UUID (`PeerId::parse`) when we've been given an identity\nover the wire, or derived from a 32-byte Ed25519 public key when a transport\nstill authenticates by raw signing key.",
+        "type": "string"
+      },
+      "PeerName": {
+        "description": "Display-only slug for a peer.\n\n`PeerName` is **not** a routing key after Wave-B V5: the router resolves\nsends by [`PeerId`], and trust stores are keyed by [`PeerId`]. `PeerName`\nis retained so human-facing surfaces (CLI, REST `comms.peers`, logs) can\nrender a recognisable handle next to the opaque id.",
+        "type": "string"
+      },
+      "PeerResponseTerminalStatusWire": {
+        "description": "Terminal status for dedicated correlated peer-response ingress.",
+        "enum": [
+          "completed",
+          "failed",
+          "cancelled"
+        ],
+        "type": "string"
+      },
+      "WireContentBlock": {
+        "description": "Wire-safe content block (no `source_path` — internal only).",
+        "oneOf": [
+          {
+            "properties": {
+              "text": {
+                "type": "string"
+              },
+              "type": {
+                "const": "text",
+                "type": "string"
+              }
+            },
+            "required": [
+              "type",
+              "text"
+            ],
+            "type": "object"
+          },
+          {
+            "oneOf": [
+              {
+                "properties": {
+                  "data": {
+                    "type": "string"
+                  },
+                  "source": {
+                    "const": "inline",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "source",
+                  "data"
+                ],
+                "type": "object"
+              },
+              {
+                "properties": {
+                  "blob_id": {
+                    "type": "string"
+                  },
+                  "source": {
+                    "const": "blob",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "source",
+                  "blob_id"
+                ],
+                "type": "object"
+              }
+            ],
+            "properties": {
+              "media_type": {
+                "type": "string"
+              },
+              "type": {
+                "const": "image",
+                "type": "string"
+              }
+            },
+            "required": [
+              "type",
+              "media_type"
+            ],
+            "type": "object"
+          },
+          {
+            "oneOf": [
+              {
+                "properties": {
+                  "data": {
+                    "type": "string"
+                  },
+                  "source": {
+                    "const": "inline",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "source",
+                  "data"
+                ],
+                "type": "object"
+              },
+              {
+                "properties": {
+                  "source": {
+                    "const": "uri",
+                    "type": "string"
+                  },
+                  "uri": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "source",
+                  "uri"
+                ],
+                "type": "object"
+              }
+            ],
+            "properties": {
+              "duration_ms": {
+                "format": "uint64",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "media_type": {
+                "type": "string"
+              },
+              "type": {
+                "const": "video",
+                "type": "string"
+              }
+            },
+            "required": [
+              "type",
+              "media_type",
+              "duration_ms"
+            ],
+            "type": "object"
+          },
+          {
+            "description": "Structured JSON tool output, materialized as inline JSON for SDK\nconsumers (the core side keeps it as opaque `Box<RawValue>`).",
+            "properties": {
+              "data": true,
+              "type": {
+                "const": "structured",
+                "type": "string"
+              }
+            },
+            "required": [
+              "type",
+              "data"
+            ],
+            "type": "object"
+          },
+          {
+            "description": "Forward-compatibility for unknown block types.",
+            "properties": {
+              "type": {
+                "const": "unknown",
+                "type": "string"
+              }
+            },
+            "required": [
+              "type"
+            ],
+            "type": "object"
+          }
+        ]
+      }
+    },
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "description": "Complete request payload for `session/external_event`.\n\nThe event envelope is flattened on the wire, but the session selector is\npart of the RPC method contract and must therefore be present in the\ncatalogued params type rather than supplied by an undocumented wrapper\nextension.",
+    "oneOf": [
+      {
+        "description": "Generic external JSON event admitted as `Input::ExternalEvent`.",
+        "properties": {
+          "blocks": {
+            "items": {
+              "$ref": "#/$defs/WireContentBlock"
+            },
+            "type": [
+              "array",
+              "null"
+            ]
+          },
+          "event_type": {
+            "type": "string"
+          },
+          "kind": {
+            "const": "generic_json",
+            "type": "string"
+          },
+          "payload": true
+        },
+        "required": [
+          "kind",
+          "event_type",
+          "payload"
+        ],
+        "type": "object"
+      },
+      {
+        "description": "Reserved typed semantic. Callers must use the dedicated\n`session/peer_response_terminal` / `/peer-response-terminal` surface\ninstead of routing terminal peer responses through the generic event\ningress.",
+        "properties": {
+          "display_name": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/PeerName"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "kind": {
+            "const": "peer_response_terminal",
+            "type": "string"
+          },
+          "peer_id": {
+            "$ref": "#/$defs/PeerId"
+          },
+          "request_id": {
+            "$ref": "#/$defs/PeerCorrelationId"
+          },
+          "result": true,
+          "status": {
+            "$ref": "#/$defs/PeerResponseTerminalStatusWire"
+          }
+        },
+        "required": [
+          "kind",
+          "peer_id",
+          "request_id",
+          "status",
+          "result"
+        ],
+        "type": "object"
+      }
+    ],
+    "properties": {
+      "session_id": {
+        "type": "string"
+      }
+    },
+    "required": [
+      "session_id"
+    ],
+    "title": "SessionExternalEventParams",
+    "type": "object"
+  },
   "SessionForkResult": {
     "$defs": {
       "AuthoredCacheBreakpoint": {

--- a/docs/api/rpc.mdx
+++ b/docs/api/rpc.mdx
@@ -125,7 +125,7 @@ subset.
 | `events/list_since` | Events | `EventsListSinceParams` | `EventsListSinceResult` | List replayable events after a typed cursor |
 | `events/snapshot` | Events | `EventsSnapshotParams` | `EventsSnapshotResult` | Read a point-in-time snapshot with its replay cursor |
 | `session/archive` | Session | `ArchiveSessionParams` | `Value` | Remove session from runtime |
-| `session/external_event` | Session | `SessionExternalEventEnvelope` | `RuntimeAcceptResult` | Queue a runtime-backed external event |
+| `session/external_event` | Session | `SessionExternalEventParams` | `RuntimeAcceptResult` | Queue a runtime-backed external event |
 | `session/peer_response_terminal` | Session | `SessionPeerResponseTerminalParams` | `RuntimeAcceptResult` | Admit a correlated terminal peer response through the typed runtime ingress |
 | `session/inject_context` | Session | `InjectSystemContextParams` | `InjectSystemContextResult` | Append one ordinary durable ordered System message at the admitted transcript boundary |
 | `session/input_status` | Session | `SessionInputStateParams` | `SessionInputStateResult` | Read an input's stored runtime state (terminal outcome, run association) by input id or idempotency key |

--- a/meerkat-contracts/src/emit.rs
+++ b/meerkat-contracts/src/emit.rs
@@ -183,6 +183,7 @@ pub fn emit_all_schemas(output_dir: &std::path::Path) -> Result<(), Box<dyn std:
         "RuntimeStateResult": schema_for!(crate::wire::RuntimeStateResult),
         "PeerResponseTerminalStatusWire": schema_for!(crate::wire::PeerResponseTerminalStatusWire),
         "SessionExternalEventEnvelope": schema_for!(crate::wire::SessionExternalEventEnvelope),
+        "SessionExternalEventParams": schema_for!(crate::wire::SessionExternalEventParams),
         "RealtimeTurningMode": schema_for!(crate::wire::RealtimeTurningMode),
         "RealtimeInputKind": schema_for!(crate::wire::RealtimeInputKind),
         "RealtimeOutputKind": schema_for!(crate::wire::RealtimeOutputKind),

--- a/meerkat-contracts/src/lib.rs
+++ b/meerkat-contracts/src/lib.rs
@@ -369,6 +369,7 @@ pub use wire::{
     ServerCapabilities,
     ServerInfo,
     SessionExternalEventEnvelope,
+    SessionExternalEventParams,
     SessionInputStateParams,
     SessionInputStateResult,
     SessionInputStateSelector,

--- a/meerkat-contracts/src/rpc_catalog.rs
+++ b/meerkat-contracts/src/rpc_catalog.rs
@@ -482,7 +482,7 @@ pub fn rpc_method_catalog(options: RpcMethodCatalogOptions) -> Vec<RpcMethodDesc
             RpcMethodDescriptor::typed(
                 "session/external_event",
                 "Queue a runtime-backed external event",
-                "SessionExternalEventEnvelope",
+                "SessionExternalEventParams",
                 "RuntimeAcceptResult",
             ),
             RpcMethodDescriptor::typed(
@@ -1391,6 +1391,18 @@ mod tests {
         assert!(
             schema_light.is_empty(),
             "RPC methods without a typed result contract: {schema_light:?}"
+        );
+    }
+
+    #[test]
+    fn external_event_catalog_owns_the_complete_request_payload() {
+        let methods = rpc_method_catalog(RpcMethodCatalogOptions::documented_surface());
+        assert!(
+            methods.iter().any(|method| {
+                method.name == "session/external_event"
+                    && method.params_type == Some("SessionExternalEventParams")
+            }),
+            "session/external_event must advertise the complete params contract"
         );
     }
 

--- a/meerkat-contracts/src/wire/mod.rs
+++ b/meerkat-contracts/src/wire/mod.rs
@@ -211,6 +211,7 @@ pub use runtime::{
     RuntimeAcceptResult,
     RuntimeStateResult,
     SessionExternalEventEnvelope,
+    SessionExternalEventParams,
     SessionPeerResponseTerminalParams,
     // Re-export of the `StructuredProviderExtension` core relocation
     // from C-1 — external callers can still import via the wire path.

--- a/meerkat-contracts/src/wire/runtime.rs
+++ b/meerkat-contracts/src/wire/runtime.rs
@@ -83,6 +83,20 @@ pub enum SessionExternalEventEnvelope {
     },
 }
 
+/// Complete request payload for `session/external_event`.
+///
+/// The event envelope is flattened on the wire, but the session selector is
+/// part of the RPC method contract and must therefore be present in the
+/// catalogued params type rather than supplied by an undocumented wrapper
+/// extension.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+pub struct SessionExternalEventParams {
+    pub session_id: String,
+    #[serde(flatten)]
+    pub event: SessionExternalEventEnvelope,
+}
+
 /// Public runtime state projection used by RPC surfaces.
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]

--- a/meerkat-rpc/src/handlers/event.rs
+++ b/meerkat-rpc/src/handlers/event.rs
@@ -10,17 +10,10 @@ use crate::session_runtime::SessionRuntime;
 use meerkat_contracts::{
     EventsLatestCursorParams, EventsLatestCursorResult, EventsListSinceParams,
     EventsSnapshotParams, PeerResponseTerminalStatusWire, SessionExternalEventEnvelope,
+    SessionExternalEventParams,
 };
 
 use super::{RpcResponseExt, parse_params, parse_session_id_for_runtime};
-
-/// Parameters for `session/external_event`.
-#[derive(Debug, Deserialize)]
-pub struct ExternalEventParams {
-    pub session_id: String,
-    #[serde(flatten)]
-    pub event: SessionExternalEventEnvelope,
-}
 
 /// Parameters for `session/peer_response_terminal`.
 #[derive(Debug, Deserialize)]
@@ -42,7 +35,7 @@ pub async fn handle_external_event(
     params: Option<&RawValue>,
     runtime: Arc<SessionRuntime>,
 ) -> RpcResponse {
-    let params: ExternalEventParams = match parse_params(params) {
+    let params: SessionExternalEventParams = match parse_params(params) {
         Ok(p) => p,
         Err(resp) => return resp,
     };
@@ -211,7 +204,7 @@ mod tests {
     #[test]
     fn test_external_event_params_deserialization() {
         let json = r#"{"session_id":"sid_123","kind":"generic_json","event_type":"github","payload":{"event":"email","from":"john"}}"#;
-        let params: ExternalEventParams = serde_json::from_str(json).unwrap();
+        let params: SessionExternalEventParams = serde_json::from_str(json).unwrap();
         assert_eq!(params.session_id, "sid_123");
         assert!(matches!(
             params.event,
@@ -233,7 +226,7 @@ mod tests {
     #[test]
     fn test_external_event_params_reject_variant_deserialization() {
         let json = r#"{"session_id":"sid_123","kind":"peer_response_terminal","peer_id":"00000000-0000-4000-8000-000000000161","display_name":"analyst","request_id":"00000000-0000-4000-8000-000000000162","status":"completed","result":{"token":"amber"}}"#;
-        let params: ExternalEventParams = serde_json::from_str(json).unwrap();
+        let params: SessionExternalEventParams = serde_json::from_str(json).unwrap();
         assert!(matches!(
             params.event,
             SessionExternalEventEnvelope::PeerResponseTerminal { .. }

--- a/scripts/test_verify_rpc_signature_parity.py
+++ b/scripts/test_verify_rpc_signature_parity.py
@@ -1,13 +1,13 @@
 #!/usr/bin/env python3
-"""Focused policy tests for the RPC signature-parity ratchet."""
+"""Mutation-sensitive tests for generated RPC transport coupling."""
 
 from __future__ import annotations
 
 import importlib.util
 import sys
+import tempfile
 import unittest
 from pathlib import Path
-
 
 SCRIPT = Path(__file__).with_name("verify_rpc_signature_parity.py")
 SPEC = importlib.util.spec_from_file_location("verify_rpc_signature_parity", SCRIPT)
@@ -16,27 +16,169 @@ parity = importlib.util.module_from_spec(SPEC)
 sys.modules[SPEC.name] = parity
 SPEC.loader.exec_module(parity)
 
+GENERATOR = SCRIPT.parent.parent / "tools/sdk-codegen/generate.py"
+GENERATOR_SPEC = importlib.util.spec_from_file_location("sdk_codegen", GENERATOR)
+assert GENERATOR_SPEC and GENERATOR_SPEC.loader
+sdk_codegen = importlib.util.module_from_spec(GENERATOR_SPEC)
+sys.modules[GENERATOR_SPEC.name] = sdk_codegen
+GENERATOR_SPEC.loader.exec_module(sdk_codegen)
 
-class BaselineTrainExpiryTests(unittest.TestCase):
-    def test_0_8_24_train_keeps_exact_reviewed_baseline(self) -> None:
-        self.assertIsNone(
-            parity.baseline_train_expiry_failure("0.8.24", "0.8.25", 239)
+CATALOG = {"demo/get": {"params": "DemoParams", "result": "DemoResult"}}
+GENERATED = {"DemoParams", "DemoResult"}
+
+
+class GeneratedTransportTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temp = tempfile.TemporaryDirectory()
+        self.root = Path(self.temp.name)
+        (self.root / "sdks/typescript/src/generated").mkdir(parents=True)
+        (self.root / "sdks/python/meerkat/generated").mkdir(parents=True)
+        (self.root / "artifacts/schemas").mkdir(parents=True)
+
+    def tearDown(self) -> None:
+        self.temp.cleanup()
+
+    def write_ts(self, contracts: str, client: str) -> None:
+        (self.root / "sdks/typescript/src/generated/rpc_contracts.ts").write_text(
+            contracts
+        )
+        (self.root / "sdks/typescript/src/client.ts").write_text(client)
+
+    def write_py(self, contracts: str, client: str) -> None:
+        (self.root / "sdks/python/meerkat/generated/rpc_contracts.py").write_text(
+            contracts
+        )
+        (self.root / "sdks/python/meerkat/client.py").write_text(client)
+
+    def test_typescript_requires_the_actual_generic_transport(self) -> None:
+        self.write_ts(
+            '"demo/get": { params: DemoParams; result: '
+            "(DemoResult) & Record<string, unknown>; };",
+            "type _RpcSignature = [DemoParams, DemoResult];\n",
+        )
+        failures = parity.check_generated_transport_contracts(
+            self.root, CATALOG, sdk="ts", generated=GENERATED
+        )
+        self.assertTrue(any("not generic" in failure for failure in failures))
+        self.assertTrue(any("marker" in failure for failure in failures))
+
+    def test_typescript_missing_method_entry_fails(self) -> None:
+        self.write_ts(
+            "",
+            "request<M extends RpcMethodName>(method: M, "
+            'params: RpcMethodContracts[M]["params"]): '
+            'Promise<RpcMethodContracts[M]["result"]> { throw 0; }',
+        )
+        failures = parity.check_generated_transport_contracts(
+            self.root, CATALOG, sdk="ts", generated=GENERATED
+        )
+        self.assertIn("ts: generated RPC contract missing `demo/get`", failures)
+
+    def test_python_requires_binding_to_generated_overloads(self) -> None:
+        self.write_py(
+            'method: Literal["demo/get"], params: DemoParams, /, '
+            ") -> Awaitable[DemoResult]: ...",
+            "async def _request_impl(self): pass\n",
+        )
+        failures = parity.check_generated_transport_contracts(
+            self.root, CATALOG, sdk="py", generated=GENERATED
+        )
+        self.assertTrue(any("not bound" in failure for failure in failures))
+
+    def test_catalog_bound_transports_pass(self) -> None:
+        self.write_ts(
+            '"demo/get": { params: DemoParams; result: '
+            "(DemoResult) & Record<string, unknown>; };",
+            "request<M extends RpcMethodName>(method: M, "
+            'params: RpcMethodContracts[M]["params"]): '
+            'Promise<RpcMethodContracts[M]["result"]> { throw 0; }',
+        )
+        self.write_py(
+            'method: Literal["demo/get"], params: DemoParams, /, '
+            ") -> Awaitable[DemoResult]: ...",
+            "_request: RpcRequest\n"
+            "self._request = cast(RpcRequest, self._request_impl)\n"
+            "async def _request_impl(self): pass\n",
+        )
+        self.assertEqual(
+            parity.check_generated_transport_contracts(
+                self.root, CATALOG, sdk="ts", generated=GENERATED
+            ),
+            [],
+        )
+        self.assertEqual(
+            parity.check_generated_transport_contracts(
+                self.root, CATALOG, sdk="py", generated=GENERATED
+            ),
+            [],
         )
 
-    def test_0_8_25_train_blocks_until_all_wrappers_migrate(self) -> None:
-        failure = parity.baseline_train_expiry_failure("0.8.25", "0.8.25", 239)
-        self.assertIsNotNone(failure)
-        assert failure is not None
-        self.assertIn("migrate all 239", failure)
+    def test_python_required_params_are_checked_at_the_send_site(self) -> None:
+        (self.root / "artifacts/schemas/wire-types.json").write_text(
+            '{"DemoParams":{"type":"object","properties":'
+            '{"session_id":{"type":"string"}},'
+            '"required":["session_id"]}}'
+        )
+        self.write_py(
+            'method: Literal["demo/get"], params: DemoParams, /, '
+            ") -> Awaitable[DemoResult]: ...",
+            "class Demo:\n"
+            "    async def send(self):\n"
+            '        return await self._request("demo/get", '
+            '{"sessoin_id": "s1"})\n',
+        )
+        failures = parity.check_python_required_param_shapes(self.root, CATALOG)
+        self.assertTrue(any("params shape drift" in failure for failure in failures))
 
-    def test_0_8_25_train_passes_after_baseline_is_empty(self) -> None:
-        self.assertIsNone(
-            parity.baseline_train_expiry_failure("0.8.25", "0.8.25", 0)
+        self.write_py(
+            'method: Literal["demo/get"], params: DemoParams, /, '
+            ") -> Awaitable[DemoResult]: ...",
+            "class Demo:\n"
+            "    async def send(self):\n"
+            '        payload: DemoParams = {"sessoin_id": "s1"}\n'
+            '        return await self._request("demo/get", payload)\n',
+        )
+        failures = parity.check_python_required_param_shapes(self.root, CATALOG)
+        self.assertTrue(any("params shape drift" in failure for failure in failures))
+
+        self.write_py(
+            'method: Literal["demo/get"], params: DemoParams, /, '
+            ") -> Awaitable[DemoResult]: ...",
+            "class Demo:\n"
+            "    async def send(self):\n"
+            '        return await self._request("demo/get", '
+            '{"session_id": "s1"})\n',
+        )
+        self.assertEqual(
+            parity.check_python_required_param_shapes(self.root, CATALOG), []
         )
 
-    def test_current_policy_marker_names_the_0_8_24_train(self) -> None:
-        self.assertEqual(parity.BASELINE_HAND_ROLLED_CURRENT_TRAIN, "0.8.24")
-        self.assertEqual(parity.BASELINE_HAND_ROLLED_EXPIRES_AT_TRAIN, "0.8.25")
+    def test_outer_object_fields_are_merged_into_one_of_variants(self) -> None:
+        schema = {
+            "type": "object",
+            "properties": {"session_id": {"type": "string"}},
+            "required": ["session_id"],
+            "oneOf": [
+                {
+                    "type": "object",
+                    "properties": {"kind": {"const": "generic_json"}},
+                    "required": ["kind"],
+                },
+                {
+                    "type": "object",
+                    "properties": {"kind": {"const": "peer_response_terminal"}},
+                    "required": ["kind"],
+                },
+            ],
+        }
+        typed = sdk_codegen._one_of_typed_dict_variants(schema, schema)
+        self.assertIsNotNone(typed)
+        assert typed is not None
+        _, variants = typed
+        self.assertEqual(len(variants), 2)
+        for _, variant in variants:
+            self.assertIn("session_id", variant["properties"])
+            self.assertIn("session_id", variant["required"])
 
 
 if __name__ == "__main__":

--- a/scripts/verify-rpc-surface-alignment.sh
+++ b/scripts/verify-rpc-surface-alignment.sh
@@ -6,11 +6,12 @@
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+PYTHON="${PYTHON:-$(command -v python3.11 2>/dev/null || command -v python3)}"
 
 green() { printf '\033[0;32m%s\033[0m\n' "$*"; }
 
-python3 "$ROOT/scripts/verify_rpc_surface_alignment.py" "$ROOT"
-python3 "$ROOT/scripts/test_verify_rpc_signature_parity.py"
-python3 "$ROOT/scripts/verify_rpc_signature_parity.py" "$ROOT"
+"$PYTHON" "$ROOT/scripts/verify_rpc_surface_alignment.py" "$ROOT"
+"$PYTHON" "$ROOT/scripts/test_verify_rpc_signature_parity.py"
+"$PYTHON" "$ROOT/scripts/verify_rpc_signature_parity.py" "$ROOT"
 
 green "RPC surface alignment check passed"

--- a/scripts/verify_rpc_signature_parity.py
+++ b/scripts/verify_rpc_signature_parity.py
@@ -11,28 +11,22 @@ declared param/result SHAPE (the typed refs the catalog descriptors carry):
      type must equal the catalog's ``params_type``/``result_type`` exactly.
      A doc that drifts on shape (not just on name) fails.
 
-  2. **SDK wrappers** (TypeScript + Python): for every catalog method we
-     locate the wrapper send-site(s) — actual ``request("method", ...)`` call
-     expressions or ``method: "..."`` JSON-RPC envelope literals, not prose —
-     and, where the catalog's param/result type is available in that SDK's
-     *generated* type module (``sdks/*/generated/``), require the enclosing
-     wrapper function to reference the generated type identifier. A wrapper
-     that hand-rolls its own ad-hoc shape for a method whose generated type
-     exists fails.
+  2. **SDK transports** (TypeScript + Python): generated method maps bind every
+     catalog method to its generated params/result refs at the actual request
+     boundary. Wrapper-local marker aliases do not count and are rejected.
 
 Catalog truth is read from the committed ``artifacts/schemas/rpc-methods.json``
 artifact (emitted from ``meerkat_contracts::rpc_method_catalog`` by
 ``make regen-schemas``); the sibling gate already pins that artifact against
 the Rust catalog source, so this script never compiles anything.
 
-Wrappers that hand-rolled shapes *before this gate existed* are grandfathered
-in an explicit ratchet baseline below. The baseline only shrinks: adding a new
-hand-rolled wrapper fails, and a baseline entry whose wrapper becomes
-generated-typed fails as stale until the entry is deleted.
+Historical wrappers follow the same generated transport rule as new wrappers.
+There is no grandfathered baseline or expiry waiver.
 """
 
 from __future__ import annotations
 
+import ast
 import json
 import pathlib
 import re
@@ -51,298 +45,15 @@ SDK_SEND_SITE_EXCLUSIONS = {
     "web-auth": set(),
 }
 
-# ---------------------------------------------------------------------------
-# RATCHET BASELINE — wrappers that hand-roll a shape although the generated
-# SDK type for the catalog ref exists. These predate this gate. Do NOT add
-# entries; delete an entry once its wrapper references the generated type.
-# Key: (sdk, method, side) where side is "params" or "result".
-# ---------------------------------------------------------------------------
-BASELINE_HAND_ROLLED: set[tuple[str, str, str]] = {
-    ("py", "auth/login/complete", "result"),
-    ("py", "auth/login/device_start", "result"),
-    ("py", "auth/login/start", "result"),
-    ("py", "auth/logout", "result"),
-    ("py", "auth/profile/create", "result"),
-    ("py", "auth/profile/delete", "result"),
-    ("py", "auth/profile/get", "result"),
-    ("py", "auth/profile/list", "result"),
-    ("py", "auth/status/get", "result"),
-    ("py", "comms/peers", "params"),
-    ("py", "comms/peers", "result"),
-    ("py", "comms/send", "params"),
-    ("py", "live/close", "params"),
-    ("py", "live/commit_input", "params"),
-    ("py", "live/commit_input", "result"),
-    ("py", "live/interrupt", "params"),
-    ("py", "live/interrupt", "result"),
-    ("py", "live/open", "params"),
-    ("py", "live/open", "result"),
-    ("py", "live/refresh", "params"),
-    ("py", "live/send_input", "params"),
-    ("py", "live/send_input", "result"),
-    ("py", "live/status", "params"),
-    ("py", "live/status", "result"),
-    ("py", "live/truncate", "params"),
-    ("py", "live/truncate", "result"),
-    ("py", "live/webrtc/answer", "params"),
-    ("py", "live/webrtc/answer", "result"),
-    ("py", "mcp/add", "params"),
-    ("py", "mcp/reload", "params"),
-    ("py", "mcp/remove", "params"),
-    ("py", "mob/append_system_context", "params"),
-    ("py", "mob/append_system_context", "result"),
-    ("py", "mob/cancel_all_work", "params"),
-    ("py", "mob/cancel_all_work", "result"),
-    ("py", "mob/cancel_work", "params"),
-    ("py", "mob/cancel_work", "result"),
-    ("py", "mob/create", "params"),
-    ("py", "mob/create", "result"),
-    ("py", "mob/destroy", "params"),
-    ("py", "mob/destroy", "result"),
-    ("py", "mob/ensure_member", "params"),
-    ("py", "mob/ensure_member", "result"),
-    ("py", "mob/events", "params"),
-    ("py", "mob/events", "result"),
-    ("py", "mob/flow_cancel", "params"),
-    ("py", "mob/flow_cancel", "result"),
-    ("py", "mob/flow_run", "params"),
-    ("py", "mob/flow_run", "result"),
-    ("py", "mob/flow_status", "params"),
-    ("py", "mob/flow_status", "result"),
-    ("py", "mob/flows", "params"),
-    ("py", "mob/flows", "result"),
-    ("py", "mob/force_cancel", "params"),
-    ("py", "mob/force_cancel", "result"),
-    ("py", "mob/fork_helper", "params"),
-    ("py", "mob/fork_helper", "result"),
-    ("py", "mob/ingress_interaction", "params"),
-    ("py", "mob/ingress_interaction", "result"),
-    ("py", "mob/lifecycle", "params"),
-    ("py", "mob/lifecycle", "result"),
-    ("py", "mob/list", "result"),
-    ("py", "mob/list_members_matching", "params"),
-    ("py", "mob/list_members_matching", "result"),
-    ("py", "mob/member_send", "params"),
-    ("py", "mob/member_send", "result"),
-    ("py", "mob/members", "params"),
-    ("py", "mob/members", "result"),
-    ("py", "mob/profile/create", "params"),
-    ("py", "mob/profile/create", "result"),
-    ("py", "mob/profile/delete", "params"),
-    ("py", "mob/profile/delete", "result"),
-    ("py", "mob/profile/get", "params"),
-    ("py", "mob/profile/get", "result"),
-    ("py", "mob/profile/list", "result"),
-    ("py", "mob/profile/update", "params"),
-    ("py", "mob/profile/update", "result"),
-    ("py", "mob/reconcile", "params"),
-    ("py", "mob/reconcile", "result"),
-    ("py", "mob/respawn", "params"),
-    ("py", "mob/respawn", "result"),
-    ("py", "mob/retire", "params"),
-    ("py", "mob/retire", "result"),
-    ("py", "mob/rotate_supervisor", "params"),
-    ("py", "mob/snapshot", "params"),
-    ("py", "mob/snapshot", "result"),
-    ("py", "mob/spawn", "params"),
-    ("py", "mob/spawn", "result"),
-    ("py", "mob/spawn_helper", "params"),
-    ("py", "mob/spawn_helper", "result"),
-    ("py", "mob/status", "params"),
-    ("py", "mob/status", "result"),
-    ("py", "mob/stream_close", "params"),
-    ("py", "mob/stream_close", "result"),
-    ("py", "mob/stream_open", "params"),
-    ("py", "mob/stream_open", "result"),
-    ("py", "mob/submit_work", "params"),
-    ("py", "mob/submit_work", "result"),
-    ("py", "mob/turn_start", "result"),
-    ("py", "mob/unwire", "params"),
-    ("py", "mob/unwire", "result"),
-    ("py", "mob/wait_kickoff", "params"),
-    ("py", "mob/wait_kickoff", "result"),
-    ("py", "mob/wait_ready", "params"),
-    ("py", "mob/wait_ready", "result"),
-    ("py", "mob/wire", "params"),
-    ("py", "mob/wire", "result"),
-    ("py", "mob/wire_members_batch", "params"),
-    ("py", "models/catalog", "result"),
-    ("py", "realm/get", "result"),
-    ("py", "realm/list", "result"),
-    ("py", "schedule/delete", "params"),
-    ("py", "schedule/get", "params"),
-    ("py", "schedule/list", "params"),
-    ("py", "schedule/list", "result"),
-    ("py", "schedule/occurrences", "params"),
-    ("py", "schedule/occurrences", "result"),
-    ("py", "schedule/pause", "params"),
-    ("py", "schedule/resume", "params"),
-    ("py", "schedule/update", "params"),
-    ("py", "session/external_event", "result"),
-    ("py", "session/history", "result"),
-    ("py", "session/peer_response_terminal", "result"),
-    ("py", "session/read", "result"),
-    ("py", "session/stream_close", "params"),
-    ("py", "session/stream_close", "result"),
-    ("py", "session/stream_open", "params"),
-    ("py", "session/stream_open", "result"),
-    ("py", "turn/start", "result"),
-    ("ts", "auth/login/complete", "result"),
-    ("ts", "auth/login/device_start", "result"),
-    ("ts", "auth/login/start", "result"),
-    ("ts", "auth/logout", "result"),
-    ("ts", "auth/profile/create", "result"),
-    ("ts", "auth/profile/delete", "result"),
-    ("ts", "auth/profile/get", "result"),
-    ("ts", "auth/profile/list", "result"),
-    ("ts", "auth/status/get", "result"),
-    ("ts", "comms/peers", "params"),
-    ("ts", "comms/send", "params"),
-    ("ts", "mob/append_system_context", "params"),
-    ("ts", "mob/append_system_context", "result"),
-    ("ts", "mob/cancel_all_work", "params"),
-    ("ts", "mob/cancel_all_work", "result"),
-    ("ts", "mob/cancel_work", "params"),
-    ("ts", "mob/cancel_work", "result"),
-    ("ts", "mob/create", "params"),
-    ("ts", "mob/create", "result"),
-    ("ts", "mob/destroy", "params"),
-    ("ts", "mob/destroy", "result"),
-    ("ts", "mob/ensure_member", "params"),
-    ("ts", "mob/ensure_member", "result"),
-    ("ts", "mob/events", "params"),
-    ("ts", "mob/events", "result"),
-    ("ts", "mob/flow_cancel", "params"),
-    ("ts", "mob/flow_cancel", "result"),
-    ("ts", "mob/flow_run", "params"),
-    ("ts", "mob/flow_run", "result"),
-    ("ts", "mob/flow_status", "params"),
-    ("ts", "mob/flows", "params"),
-    ("ts", "mob/flows", "result"),
-    ("ts", "mob/force_cancel", "params"),
-    ("ts", "mob/force_cancel", "result"),
-    ("ts", "mob/fork_helper", "params"),
-    ("ts", "mob/fork_helper", "result"),
-    ("ts", "mob/ingress_interaction", "params"),
-    ("ts", "mob/ingress_interaction", "result"),
-    ("ts", "mob/lifecycle", "params"),
-    ("ts", "mob/lifecycle", "result"),
-    ("ts", "mob/list", "result"),
-    ("ts", "mob/list_members_matching", "params"),
-    ("ts", "mob/list_members_matching", "result"),
-    ("ts", "mob/member_send", "params"),
-    ("ts", "mob/member_send", "result"),
-    ("ts", "mob/members", "params"),
-    ("ts", "mob/members", "result"),
-    ("ts", "mob/profile/create", "params"),
-    ("ts", "mob/profile/create", "result"),
-    ("ts", "mob/profile/delete", "params"),
-    ("ts", "mob/profile/delete", "result"),
-    ("ts", "mob/profile/get", "params"),
-    ("ts", "mob/profile/get", "result"),
-    ("ts", "mob/profile/list", "result"),
-    ("ts", "mob/profile/update", "params"),
-    ("ts", "mob/profile/update", "result"),
-    ("ts", "mob/reconcile", "params"),
-    ("ts", "mob/reconcile", "result"),
-    ("ts", "mob/respawn", "params"),
-    ("ts", "mob/respawn", "result"),
-    ("ts", "mob/retire", "params"),
-    ("ts", "mob/retire", "result"),
-    ("ts", "mob/rotate_supervisor", "params"),
-    ("ts", "mob/snapshot", "params"),
-    ("ts", "mob/snapshot", "result"),
-    ("ts", "mob/spawn", "params"),
-    ("ts", "mob/spawn", "result"),
-    ("ts", "mob/spawn_helper", "params"),
-    ("ts", "mob/spawn_helper", "result"),
-    ("ts", "mob/status", "params"),
-    ("ts", "mob/status", "result"),
-    ("ts", "mob/stream_close", "params"),
-    ("ts", "mob/stream_close", "result"),
-    ("ts", "mob/stream_open", "params"),
-    ("ts", "mob/stream_open", "result"),
-    ("ts", "mob/submit_work", "params"),
-    ("ts", "mob/submit_work", "result"),
-    ("ts", "mob/turn_start", "params"),
-    ("ts", "mob/turn_start", "result"),
-    ("ts", "mob/unwire", "params"),
-    ("ts", "mob/unwire", "result"),
-    ("ts", "mob/wait_kickoff", "params"),
-    ("ts", "mob/wait_kickoff", "result"),
-    ("ts", "mob/wait_ready", "params"),
-    ("ts", "mob/wait_ready", "result"),
-    ("ts", "mob/wire", "params"),
-    ("ts", "mob/wire", "result"),
-    ("ts", "mob/wire_members_batch", "params"),
-    ("ts", "mob/wire_members_batch", "result"),
-    ("ts", "models/catalog", "result"),
-    ("ts", "realm/get", "result"),
-    ("ts", "realm/list", "result"),
-    ("ts", "schedule/delete", "params"),
-    ("ts", "schedule/get", "params"),
-    ("ts", "schedule/list", "params"),
-    ("ts", "schedule/list", "result"),
-    ("ts", "schedule/occurrences", "params"),
-    ("ts", "schedule/occurrences", "result"),
-    ("ts", "schedule/pause", "params"),
-    ("ts", "schedule/resume", "params"),
-    ("ts", "schedule/update", "params"),
-    ("ts", "session/external_event", "result"),
-    ("ts", "session/history", "result"),
-    ("ts", "session/peer_response_terminal", "result"),
-    ("ts", "session/read", "result"),
-    ("ts", "session/stream_close", "params"),
-    ("ts", "session/stream_close", "result"),
-    ("ts", "session/stream_open", "params"),
-    ("ts", "session/stream_open", "result"),
-    ("ts", "turn/start", "result"),
-}
-
-# The remaining grandfathered wrappers are owned debt, not a permanent escape
-# hatch. New generated wrappers must remove entries; the whole baseline expires
-# unless renewed with an explicit owner decision.
-#
-# 2026-08-18 sdk-contracts owner review: all 239 entries remain active
-# generated-type mismatches (ts=110, py=129), and the gate reports no stale
-# entries that can be deleted without migrating their wrappers. Keep the exact
-# reviewed cap through 0.8.24 only. Opening the 0.8.25 train must migrate all
-# 239 wrappers; see RELEASE-0.8.25.md.
-BASELINE_HAND_ROLLED_OWNER = "sdk-contracts"
-BASELINE_HAND_ROLLED_CURRENT_TRAIN = "0.8.24"
-BASELINE_HAND_ROLLED_EXPIRES_AT_TRAIN = "0.8.25"
-BASELINE_HAND_ROLLED_MAX_ENTRIES = 239
+# There is intentionally no grandfathered baseline. Every SDK wrapper whose
+# catalog type exists in the generated module must reference that generated
+# type, so newly introduced and historical wrappers follow the same rule.
 
 
 def split_type_refs(type_ref: str | None) -> list[str]:
     if not type_ref:
         return []
     return [part.strip() for part in type_ref.split("|") if part.strip()]
-
-
-def release_version_tuple(version: str) -> tuple[int, int, int]:
-    """Return the release-ordering portion of a Cargo semantic version."""
-    match = re.fullmatch(r"(\d+)\.(\d+)\.(\d+)(?:[-+].*)?", version)
-    if not match:
-        raise ValueError(f"invalid semantic version: {version}")
-    return tuple(int(part) for part in match.groups())
-
-
-def baseline_train_expiry_failure(
-    current_train: str,
-    expiry_train: str,
-    baseline_size: int,
-) -> str | None:
-    """Fail the grandfathered baseline when the named release train opens."""
-    current = release_version_tuple(current_train)
-    expiry = release_version_tuple(expiry_train)
-    if baseline_size and current >= expiry:
-        return (
-            "baseline policy: BASELINE_HAND_ROLLED expired at the "
-            f"{expiry_train} train opening (current train {current_train}); "
-            f"migrate all {baseline_size} grandfathered wrappers before continuing"
-        )
-    return None
 
 
 def load_catalog(root: pathlib.Path) -> dict[str, dict[str, str | None]]:
@@ -383,9 +94,7 @@ def check_docs(
 ) -> list[str]:
     docs_path = root / "docs" / "api" / "rpc.mdx"
     docs_text = docs_path.read_text(encoding="utf-8")
-    overview = re.search(
-        r"## Method overview(.*?)\n## ", docs_text, flags=re.DOTALL
-    )
+    overview = re.search(r"## Method overview(.*?)\n## ", docs_text, flags=re.DOTALL)
     if overview is None:
         return ["docs: could not locate '## Method overview' section in rpc.mdx"]
 
@@ -506,7 +215,6 @@ def mask_ts(text: str) -> str:
     out = list(text)
     i = 0
     n = len(text)
-    template_depth: list[int] = []  # brace depth inside `${ ... }` per template
 
     def blank(idx: int) -> None:
         if out[idx] != "\n":
@@ -687,9 +395,7 @@ def ts_function_spans(masked: str) -> list[TsFunction]:
     return spans
 
 
-def innermost_ts_function(
-    spans: list[TsFunction], offset: int
-) -> TsFunction | None:
+def innermost_ts_function(spans: list[TsFunction], offset: int) -> TsFunction | None:
     best: TsFunction | None = None
     for span in spans:
         if span.start <= offset < span.body_end:
@@ -859,9 +565,7 @@ def web_auth_send_sites(
             body = masked[func.start : func.body_end]
             tokens = set(re.findall(r"[A-Za-z_$][\w$]*", body))
             referenced = {
-                resolved_imports[token]
-                for token in tokens
-                if token in resolved_imports
+                resolved_imports[token] for token in tokens if token in resolved_imports
             }
             wrapper = func.name
         line = text.count("\n", 0, match.start()) + 1
@@ -958,9 +662,7 @@ def py_send_sites(
                     if re.fullmatch(r"[A-Za-z_][\w\[\], .|]*", node.value or " "):
                         names.update(re.findall(r"[A-Za-z_]\w*", node.value))
             return {
-                resolved_imports[name]
-                for name in names
-                if name in resolved_imports
+                resolved_imports[name] for name in names if name in resolved_imports
             }
 
         def record(method: str, lineno: int) -> None:
@@ -1011,9 +713,445 @@ def py_send_sites(
     return sites
 
 
+def _rpc_schema_documents(root: pathlib.Path) -> list[dict]:
+    documents: list[dict] = []
+    for name in ("params.json", "wire-types.json", "runtime-host.json"):
+        path = root / "artifacts" / "schemas" / name
+        if path.exists():
+            value = json.loads(path.read_text(encoding="utf-8"))
+            if isinstance(value, dict):
+                documents.append(value)
+    return documents
+
+
+def _find_named_schema(documents: list[dict], name: str) -> dict | None:
+    for document in documents:
+        direct = document.get(name)
+        if isinstance(direct, dict):
+            return direct
+        defs = document.get("$defs")
+        if isinstance(defs, dict) and isinstance(defs.get(name), dict):
+            return defs[name]
+        for value in document.values():
+            if not isinstance(value, dict):
+                continue
+            local_defs = value.get("$defs")
+            if isinstance(local_defs, dict) and isinstance(local_defs.get(name), dict):
+                return local_defs[name]
+    return None
+
+
+def _required_key_variants(
+    schema: dict | None,
+    documents: list[dict],
+    seen: frozenset[str] = frozenset(),
+) -> list[frozenset[str]]:
+    if not isinstance(schema, dict):
+        return [frozenset()]
+    ref = schema.get("$ref")
+    if isinstance(ref, str):
+        name = ref.rsplit("/", 1)[-1]
+        if name in seen:
+            return [frozenset()]
+        return _required_key_variants(
+            _find_named_schema(documents, name), documents, seen | {name}
+        )
+
+    outer = frozenset(key for key in schema.get("required", []) if isinstance(key, str))
+    for branch_key in ("oneOf", "anyOf"):
+        branches = schema.get(branch_key)
+        if isinstance(branches, list) and branches:
+            variants = [
+                outer | required
+                for branch in branches
+                for required in _required_key_variants(branch, documents, seen)
+            ]
+            return list(dict.fromkeys(variants))
+
+    branches = schema.get("allOf")
+    if isinstance(branches, list) and branches:
+        variants = [outer]
+        for branch in branches:
+            variants = [
+                current | required
+                for current in variants
+                for required in _required_key_variants(branch, documents, seen)
+            ]
+        return list(dict.fromkeys(variants))
+    return [outer]
+
+
+def _annotation_names(annotation: ast.expr | None) -> set[str]:
+    if annotation is None:
+        return set()
+    return {node.id for node in ast.walk(annotation) if isinstance(node, ast.Name)} | {
+        node.attr for node in ast.walk(annotation) if isinstance(node, ast.Attribute)
+    }
+
+
+def _python_payload_shape(
+    expression: ast.expr,
+    function: ast.FunctionDef | ast.AsyncFunctionDef,
+    before_line: int,
+    seen: frozenset[str] = frozenset(),
+) -> tuple[set[str], set[str]]:
+    if isinstance(expression, ast.Dict):
+        keys: set[str] = set()
+        annotations: set[str] = set()
+        for key, value in zip(expression.keys, expression.values):
+            if isinstance(key, ast.Constant) and isinstance(key.value, str):
+                keys.add(key.value)
+            elif key is None:
+                nested_keys, nested_annotations = _python_payload_shape(
+                    value, function, before_line, seen
+                )
+                keys.update(nested_keys)
+                annotations.update(nested_annotations)
+        return keys, annotations
+
+    if isinstance(expression, ast.DictComp):
+        keys: set[str] = set()
+        annotations: set[str] = set()
+        for generator in expression.generators:
+            iterator = generator.iter
+            if (
+                isinstance(iterator, ast.Call)
+                and isinstance(iterator.func, ast.Attribute)
+                and iterator.func.attr == "items"
+            ):
+                nested_keys, nested_annotations = _python_payload_shape(
+                    iterator.func.value, function, before_line, seen
+                )
+                keys.update(nested_keys)
+                annotations.update(nested_annotations)
+        return keys, annotations
+
+    if isinstance(expression, ast.Call):
+        keys = {keyword.arg for keyword in expression.keywords if keyword.arg}
+        annotations: set[str] = set()
+        for keyword in expression.keywords:
+            if keyword.arg is None:
+                nested_keys, nested_annotations = _python_payload_shape(
+                    keyword.value, function, before_line, seen
+                )
+                keys.update(nested_keys)
+                annotations.update(nested_annotations)
+        if expression.args:
+            nested_keys, nested_annotations = _python_payload_shape(
+                expression.args[0], function, before_line, seen
+            )
+            keys.update(nested_keys)
+            annotations.update(nested_annotations)
+        return keys, annotations
+
+    if isinstance(expression, ast.BoolOp):
+        keys: set[str] = set()
+        annotations: set[str] = set()
+        for value in expression.values:
+            nested_keys, nested_annotations = _python_payload_shape(
+                value, function, before_line, seen
+            )
+            keys.update(nested_keys)
+            annotations.update(nested_annotations)
+        return keys, annotations
+
+    if isinstance(expression, ast.Attribute) and expression.attr == "__dict__":
+        return _python_payload_shape(expression.value, function, before_line, seen)
+
+    if not isinstance(expression, ast.Name) or expression.id in seen:
+        return set(), set()
+
+    name = expression.id
+    keys: set[str] = set()
+    annotations: set[str] = set()
+    for argument in (*function.args.args, *function.args.kwonlyargs):
+        if argument.arg == name:
+            annotations.update(_annotation_names(argument.annotation))
+
+    for node in ast.walk(function):
+        if getattr(node, "lineno", before_line) >= before_line:
+            continue
+        value: ast.expr | None = None
+        if isinstance(node, ast.AnnAssign) and isinstance(node.target, ast.Name):
+            if node.target.id == name:
+                value = node.value
+        elif isinstance(node, ast.Assign):
+            if any(
+                isinstance(target, ast.Name) and target.id == name
+                for target in node.targets
+            ):
+                value = node.value
+            for target in node.targets:
+                if (
+                    isinstance(target, ast.Subscript)
+                    and isinstance(target.value, ast.Name)
+                    and target.value.id == name
+                    and isinstance(target.slice, ast.Constant)
+                    and isinstance(target.slice.value, str)
+                ):
+                    keys.add(target.slice.value)
+        elif (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and isinstance(node.func.value, ast.Name)
+            and node.func.value.id == name
+            and node.func.attr == "update"
+            and node.args
+        ):
+            value = node.args[0]
+
+        if value is not None:
+            nested_keys, nested_annotations = _python_payload_shape(
+                value, function, before_line, seen | {name}
+            )
+            keys.update(nested_keys)
+            annotations.update(nested_annotations)
+    return keys, annotations
+
+
+def check_python_required_param_shapes(
+    root: pathlib.Path, catalog: dict[str, dict[str, str | None]]
+) -> list[str]:
+    """Require every literal Python send to satisfy a generated params shape.
+
+    This is intentionally AST-based rather than an annotation-presence check:
+    dictionary literals, named payloads, constructor calls, and conditional
+    key additions are inspected at the actual request call. Direct pass-through
+    is accepted only when the public argument itself names the catalog params
+    type; the transport cast alone can never satisfy this gate.
+    """
+    documents = _rpc_schema_documents(root)
+    required_by_method: dict[str, list[frozenset[str]]] = {}
+    refs_by_method: dict[str, set[str]] = {}
+    for method, descriptor in catalog.items():
+        refs = set(split_type_refs(descriptor["params"]))
+        refs_by_method[method] = refs
+        variants: list[frozenset[str]] = []
+        for ref in refs:
+            if ref in UNTYPED_REFS:
+                variants.append(frozenset())
+                continue
+            variants.extend(
+                _required_key_variants(_find_named_schema(documents, ref), documents)
+            )
+        required_by_method[method] = variants or [frozenset()]
+
+    failures: list[str] = []
+    package = root / "sdks" / "python" / "meerkat"
+    for path in sorted(package.glob("*.py")):
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        functions = [
+            node
+            for node in ast.walk(tree)
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+        ]
+
+        def innermost(lineno: int):
+            candidates = [
+                function
+                for function in functions
+                if function.lineno <= lineno <= (function.end_lineno or function.lineno)
+            ]
+            return min(
+                candidates,
+                key=lambda function: (function.end_lineno or 0) - function.lineno,
+                default=None,
+            )
+
+        for node in ast.walk(tree):
+            if not (
+                isinstance(node, ast.Call)
+                and isinstance(node.func, ast.Attribute)
+                and node.func.attr in ("_request", "request")
+                and len(node.args) >= 2
+                and isinstance(node.args[0], ast.Constant)
+                and isinstance(node.args[0].value, str)
+                and node.args[0].value in catalog
+            ):
+                continue
+            function = innermost(node.lineno)
+            if function is None:
+                continue
+            method = node.args[0].value
+            keys, annotations = _python_payload_shape(
+                node.args[1], function, node.lineno
+            )
+            if any(required <= keys for required in required_by_method[method]):
+                continue
+            if annotations & refs_by_method[method]:
+                continue
+            expected = " or ".join(
+                "{" + ", ".join(sorted(required)) + "}"
+                for required in required_by_method[method]
+            )
+            failures.append(
+                f"py: `{method}` params shape drift at "
+                f"{path.relative_to(root)}:{node.lineno} - payload keys "
+                f"{sorted(keys)} do not satisfy generated required fields "
+                f"{expected}; a transport cast or unrelated type reference "
+                "does not count"
+            )
+    return failures
+
+
 # ---------------------------------------------------------------------------
 # Enforcement.
 # ---------------------------------------------------------------------------
+
+
+def _compact_type(value: str) -> str:
+    return re.sub(r"\s+", " ", value).strip()
+
+
+def _expected_contract_type(
+    type_ref: str | None,
+    generated: set[str],
+    *,
+    sdk: str,
+    params: bool,
+) -> str:
+    if not type_ref:
+        return (
+            "Record<string, never>"
+            if sdk == "ts" and params
+            else ("Record<string, unknown>" if sdk == "ts" else "dict[str, Any]")
+        )
+    rendered: list[str] = []
+    for part in split_type_refs(type_ref):
+        if part == "Value" or part not in generated:
+            rendered.append(
+                "Record<string, unknown>"
+                if sdk == "ts" and params
+                else "unknown"
+                if sdk == "ts"
+                else "dict[str, Any]"
+                if params
+                else "Any"
+            )
+        else:
+            rendered.append(part)
+    joined = " | ".join(rendered)
+    if sdk == "ts" and not params and joined != "unknown":
+        return f"({joined}) & Record<string, unknown>"
+    return joined
+
+
+def check_generated_transport_contracts(
+    root: pathlib.Path,
+    catalog: dict[str, dict[str, str | None]],
+    *,
+    sdk: str,
+    generated: set[str],
+) -> list[str]:
+    failures: list[str] = []
+    if sdk == "ts":
+        contracts_path = root / "sdks/typescript/src/generated/rpc_contracts.ts"
+        client_path = root / "sdks/typescript/src/client.ts"
+        contracts = contracts_path.read_text(encoding="utf-8")
+        client = client_path.read_text(encoding="utf-8")
+        entries = {
+            name: (_compact_type(params), _compact_type(result))
+            for name, params, result in re.findall(
+                r'^\s*"([^"]+)":\s*\{\s*params:\s*(.*?);\s*'
+                r"result:\s*(.*?);\s*\};",
+                contracts,
+                flags=re.MULTILINE | re.DOTALL,
+            )
+        }
+        transport_patterns = (
+            r"request<M extends RpcMethodName>",
+            r"params:\s*RpcMethodContracts\[M\]\[\"params\"\]",
+            r"Promise<RpcMethodContracts\[M\]\[\"result\"\]>",
+        )
+        for pattern in transport_patterns:
+            if re.search(pattern, client) is None:
+                failures.append(
+                    "ts: client request transport is not generic over the "
+                    f"generated RpcMethodContracts map (missing `{pattern}`)"
+                )
+    else:
+        contracts_path = root / "sdks/python/meerkat/generated/rpc_contracts.py"
+        client_path = root / "sdks/python/meerkat/client.py"
+        contracts = contracts_path.read_text(encoding="utf-8")
+        client = client_path.read_text(encoding="utf-8")
+        entries = {
+            name: (_compact_type(params), _compact_type(result))
+            for name, params, result in re.findall(
+                r"method:\s*Literal\[\"([^\"]+)\"\],\s*"
+                r"params:\s*(.*?),\s*/,.+?Awaitable\[(.*?)\]",
+                contracts,
+                flags=re.DOTALL,
+            )
+        }
+        transport_patterns = (
+            r"_request:\s*RpcRequest",
+            r"self\._request\s*=\s*cast\(RpcRequest,\s*self\._request_impl\)",
+            r"async def _request_impl\(",
+        )
+        for pattern in transport_patterns:
+            if re.search(pattern, client) is None:
+                failures.append(
+                    "py: client request transport is not bound to the generated "
+                    f"RpcRequest overloads (missing `{pattern}`)"
+                )
+
+    expected_names = set(catalog)
+    actual_names = set(entries)
+    for name in sorted(expected_names - actual_names):
+        failures.append(f"{sdk}: generated RPC contract missing `{name}`")
+    for name in sorted(actual_names - expected_names):
+        failures.append(
+            f"{sdk}: generated RPC contract contains non-catalog method `{name}`"
+        )
+    for name in sorted(expected_names & actual_names):
+        actual_params, actual_result = entries[name]
+        expected_params = _expected_contract_type(
+            catalog[name]["params"], generated, sdk=sdk, params=True
+        )
+        expected_result = _expected_contract_type(
+            catalog[name]["result"], generated, sdk=sdk, params=False
+        )
+        if actual_params != expected_params:
+            failures.append(
+                f"{sdk}: `{name}` params contract drift - expected "
+                f"`{expected_params}`, generated `{actual_params}`"
+            )
+        if actual_result != expected_result:
+            failures.append(
+                f"{sdk}: `{name}` result contract drift - expected "
+                f"`{expected_result}`, generated `{actual_result}`"
+            )
+
+    marker_patterns = (
+        "_RpcSignature",
+        "_RpcGeneratedSignature",
+        "_rpc_signature",
+        "_rpc_generated_signature",
+    )
+    for marker in marker_patterns:
+        if marker in client:
+            failures.append(
+                f"{sdk}: obsolete wrapper-local marker `{marker}` is forbidden; "
+                "bind the actual request transport instead"
+            )
+    return failures
+
+
+def check_send_site_coverage(
+    sdk: str,
+    catalog: dict[str, dict[str, str | None]],
+    sites: dict[str, list[SendSite]],
+) -> list[str]:
+    failures: list[str] = []
+    exclusions = SDK_SEND_SITE_EXCLUSIONS[sdk]
+    for method in sorted(catalog):
+        if not sites.get(method) and method not in exclusions:
+            failures.append(
+                f"{sdk}: no structural send-site found for catalog method `{method}`"
+            )
+        if sites.get(method) and method in exclusions:
+            failures.append(f"{sdk}: `{method}` has a send-site but remains excluded")
+    return failures
 
 
 def check_sdk(
@@ -1033,7 +1171,7 @@ def check_sdk(
             if method not in exclusions:
                 failures.append(
                     f"{sdk}: no structural send-site found for catalog method "
-                    f"`{method}` (expected a request(\"{method}\", ...) call "
+                    f'`{method}` (expected a request("{method}", ...) call '
                     "or a JSON-RPC envelope literal in the SDK source)"
                 )
             continue
@@ -1056,17 +1194,9 @@ def check_sdk(
                 continue
             enforced += 1
             compliant = any(
-                all(ref in site.referenced for ref in refs)
-                for site in method_sites
+                all(ref in site.referenced for ref in refs) for site in method_sites
             )
-            key = (sdk, method, side)
-            if compliant and key in BASELINE_HAND_ROLLED:
-                failures.append(
-                    f"{sdk}: `{method}` {side} — baseline entry is stale: the "
-                    f"wrapper now references the generated type(s) "
-                    f"{refs}; delete {key!r} from BASELINE_HAND_ROLLED"
-                )
-            elif not compliant and key not in BASELINE_HAND_ROLLED:
+            if not compliant:
                 locations = ", ".join(
                     f"{s.wrapper} ({s.file}:{s.line})" for s in method_sites
                 )
@@ -1100,10 +1230,15 @@ def main() -> int:
     py_sites_map = py_send_sites(root, catalog, py_gen)
     web_auth_sites = web_auth_send_sites(root, catalog, web_gen)
 
-    ts_failures, ts_enforced, ts_untracked = check_sdk("ts", catalog, ts_sites, ts_gen)
-    py_failures, py_enforced, py_untracked = check_sdk(
-        "py", catalog, py_sites_map, py_gen
+    ts_failures = check_generated_transport_contracts(
+        root, catalog, sdk="ts", generated=ts_gen
     )
+    ts_failures.extend(check_send_site_coverage("ts", catalog, ts_sites))
+    py_failures = check_generated_transport_contracts(
+        root, catalog, sdk="py", generated=py_gen
+    )
+    py_failures.extend(check_send_site_coverage("py", catalog, py_sites_map))
+    py_failures.extend(check_python_required_param_shapes(root, catalog))
     auth_catalog = {
         method: descriptor
         for method, descriptor in catalog.items()
@@ -1116,53 +1251,20 @@ def main() -> int:
     failures.extend(py_failures)
     failures.extend(web_failures)
 
-    # Baseline keys must stay real: every entry must refer to a live method.
-    for sdk, method, side in sorted(BASELINE_HAND_ROLLED):
-        if method not in catalog:
-            failures.append(
-                f"{sdk}: baseline entry ({sdk!r}, {method!r}, {side!r}) refers "
-                "to a method that is no longer in the catalog — delete it"
-            )
-
-    if not BASELINE_HAND_ROLLED_OWNER:
-        failures.append("baseline policy: BASELINE_HAND_ROLLED_OWNER must be set")
-    try:
-        train_failure = baseline_train_expiry_failure(
-            BASELINE_HAND_ROLLED_CURRENT_TRAIN,
-            BASELINE_HAND_ROLLED_EXPIRES_AT_TRAIN,
-            len(BASELINE_HAND_ROLLED),
-        )
-    except ValueError as error:
-        failures.append(f"baseline policy: {error}")
-    else:
-        if train_failure:
-            failures.append(train_failure)
-    if len(BASELINE_HAND_ROLLED) > BASELINE_HAND_ROLLED_MAX_ENTRIES:
-        failures.append(
-            "baseline policy: BASELINE_HAND_ROLLED grew to "
-            f"{len(BASELINE_HAND_ROLLED)} entries, above the ratchet cap "
-            f"{BASELINE_HAND_ROLLED_MAX_ENTRIES}"
-        )
-
     if failures:
         print("RPC signature parity violations:")
         for failure in failures:
             print(f"  - {failure}")
         return 1
 
-    baseline_count = len(BASELINE_HAND_ROLLED)
     print(
         "RPC signature parity OK: "
         f"{len(catalog)} methods; docs typed columns match the catalog; "
-        f"ts={ts_enforced} py={py_enforced} web-auth={web_enforced} "
-        "generated-typed sides enforced "
-        f"({baseline_count} grandfathered hand-rolled, "
-        f"owner={BASELINE_HAND_ROLLED_OWNER} "
-        f"train={BASELINE_HAND_ROLLED_CURRENT_TRAIN} "
-        f"expires-at-train={BASELINE_HAND_ROLLED_EXPIRES_AT_TRAIN}, "
-        f"ts={ts_untracked} py={py_untracked} web-auth={web_untracked} "
-        "sides untracked because the "
-        "generated SDK type does not exist yet)."
+        "TypeScript and Python request transports are bound to generated "
+        "method contracts; wrapper-local marker aliases are absent; "
+        f"web-auth={web_enforced} generated-typed sides enforced "
+        f"({web_untracked} sides untracked because the generated Web SDK "
+        "type does not exist yet)."
     )
     return 0
 

--- a/sdks/python/meerkat/client.py
+++ b/sdks/python/meerkat/client.py
@@ -20,7 +20,6 @@ Example::
 from __future__ import annotations
 
 import asyncio
-from dataclasses import fields, is_dataclass
 import json
 import logging
 import os
@@ -28,48 +27,49 @@ import platform
 import shutil
 import tarfile
 import tempfile
+import urllib.request
 import warnings
 import zipfile
+from dataclasses import fields, is_dataclass
 from pathlib import Path
 from typing import Any, Literal, NotRequired, TypedDict, cast
 from urllib.error import URLError
-import urllib.request
 
 from .errors import CapabilityUnavailableError, MeerkatError
 from .event_envelope import parse_agent_event_envelope
 from .events import Usage
-from .generated.types import CONTRACT_VERSION
-from .generated.version_compat import (
-    is_compatible_with as _generated_is_compatible_with,
-)
+from .generated.rpc_contracts import RpcRequest
 from .generated.types import (
+    CONTRACT_VERSION,
+    ApprovalDecideParams,
+    ApprovalGetParams,
+    ApprovalRequestParams,
+    ArtifactDownloadParams,
+    ArtifactIdParams,
+    AttentionListRequest,
+    AttentionListResult,
     BridgeLiveControlOutcome,
     BridgeLiveControlVerb,
     CallbackToolDefinition,
-    SkillListResponse,
-    AttentionListRequest,
-    AttentionListResult,
     CapabilitiesResponse,
+    CommsSendResult,
     ConfigPatchParams,
     ConfigSetParams,
     ConfigWriteResult,
-    CommsSendResult,
-    InterruptResult,
-    ServerCapabilities,
-    SkillEntry,
-    SkillKey as WireSkillKey,
-    SkillSourceProvenance,
-    WorkEventsResult,
-    WorkItemsResult,
+    CreateProfileParams,
+    CreateScheduleRequest,
+    DeviceStartParams,
+    EventsLatestCursorParams,
+    EventsListSinceParams,
+    EventsSnapshotParams,
     GoalStatusRequest,
     GoalStatusResult,
+    InterruptResult,
     JobArtifactRef,
     JobHealthCoverage,
     JobHealthSummary,
     JobProgress,
     JobRunner,
-    JobSummary,
-    JobTerminalResult,
     JobsArtifactsParams,
     JobsArtifactsResult,
     JobsCancelParams,
@@ -87,35 +87,29 @@ from .generated.types import (
     JobsRetryResult,
     JobsSubscribeParams,
     JobsSubscribeResult,
+    JobSummary,
     JobsUnsubscribeParams,
     JobsUnsubscribeResult,
+    JobTerminalResult,
     LiveCloseResult,
     LiveCloseStatus,
     LiveOpenResult,
     LiveRefreshResult,
     LiveRefreshStatus,
     LiveStatusResult,
+    LoginStartParams,
     McpServerConfig,
     MobBindHostParams,
     MobBindHostResult,
+    MobConcludeObjectiveParams,
+    MobConcludeObjectiveResult,
     MobDefinitionInput,
     MobFlowRunResult,
     MobGrantScopesParams,
-    MobGrantScopesResult,
-    MobGrantsResult,
     MobHardCancelParams,
-    MobHardCancelResult,
     MobHostStatus,
-    MobHostsResult,
     MobIdParams,
-    MobMemberParams,
-    MobMemberHistoryParams,
-    MobMemberHistoryResult,
-    MobMemberLiveChannelParams,
-    MobMemberLiveControlParams,
-    MobMemberLiveOpenParams,
-    MobMemberLiveStatusParams,
-    MobMemberStatusResult,
+    MobIngressInteractionParams,
     MobkitJobCancelAckParams,
     MobkitJobCheckpointParams,
     MobkitJobCompleteParams,
@@ -123,119 +117,80 @@ from .generated.types import (
     MobkitJobHeartbeatParams,
     MobkitJobMutationResult,
     MobkitJobProgressParams,
+    MobMemberHistoryParams,
+    MobMemberHistoryResult,
+    MobMemberLiveChannelParams,
+    MobMemberLiveControlParams,
+    MobMemberLiveOpenParams,
+    MobMemberLiveStatusParams,
+    MobMemberParams,
     MobRevokeHostParams,
     MobRevokeHostResult,
     MobRevokeScopesParams,
-    MobRevokeScopesResult,
+    MobRotateSupervisorResult,
     MobRouteInstallsResult,
     MobRunParams,
     MobRunResult,
     MobRunResultParams,
-    MobSpawnManyParams,
     MobSpawnManyFailedResult,
+    MobSpawnManyParams,
     MobSpawnManyResult,
     MobSpawnManyResultEntry,
     MobSpawnManySpawnedResult,
     MobSpawnSpecParams,
-    MobRotateSupervisorResult,
-    MobConcludeObjectiveParams,
-    MobConcludeObjectiveResult,
     MobTurnStartParams,
+    MobUnwireParams,
+    MobWireParams,
     MobWireMembersBatchEdge,
     MobWireMembersBatchResult,
     MonitorsStartParams,
     MonitorsStartResult,
     PublicTurnToolOverlay,
     RealtimeTurningMode,
+    ScheduleToolCallParams,
+    ServerCapabilities,
+    SkillEntry,
+    SkillListResponse,
+    SkillSourceProvenance,
+    ToolsRegisterParams,
+    ToolsRegisterResult,
+    UpdateScheduleParams,
     WireAuthBindingRef,
     WireContentInput,
     WireHistoryRow,
-    WireHostBindPhase,
     WireHostBindingDescriptor,
+    WireHostBindPhase,
     WireHostCapabilityFlags,
     WireLiveChannelCapabilities,
+    WireMemberHistoryPageBody,
     WireMemberLaunchMode,
+    WireMemberProgressSnapshot,
     WireMobBackendKind,
     WireMobProfile,
     WireMobRuntimeMode,
-    WireRuntimeBinding,
-    WireToolAccessPolicy,
-    WireToolFilter,
-    WireMemberProgressSnapshot,
-    WireMemberHistoryPageBody,
     WireProjectionProvenance,
     WireReachability,
     WireRouteInstallObligation,
-    ToolsRegisterParams,
-    ToolsRegisterResult,
+    WireRuntimeBinding,
+    WireToolAccessPolicy,
+    WireToolFilter,
+    WorkEventsResult,
+    WorkItemsResult,
 )
 from .generated.types import (
-    ApprovalDecideParams as RpcApprovalDecideParams,
-    ApprovalGetParams as RpcApprovalGetParams,
-    ApprovalListParams as RpcApprovalListParams,
-    ApprovalListResult as RpcApprovalListResult,
-    ApprovalRecord as RpcApprovalRecord,
-    ApprovalRequestParams as RpcApprovalRequestParams,
-    ArchiveSessionParams as RpcArchiveSessionParams,
-    ArtifactDownloadParams as RpcArtifactDownloadParams,
-    ArtifactDownloadResult as RpcArtifactDownloadResult,
-    ArtifactIdParams as RpcArtifactIdParams,
-    ArtifactListParams as RpcArtifactListParams,
-    ArtifactListResult as RpcArtifactListResult,
-    ArtifactRecord as RpcArtifactRecord,
-    BindingIdParams as RpcBindingIdParams,
-    BlobGetParams as RpcBlobGetParams,
-    BlobPayload as RpcBlobPayload,
-    CreateProfileParams as RpcCreateProfileParams,
-    CreateScheduleRequest as RpcCreateScheduleRequest,
-    DeferredCreateResult as RpcDeferredCreateResult,
-    DeviceCompleteParams as RpcDeviceCompleteParams,
-    DeviceStartParams as RpcDeviceStartParams,
-    EventsLatestCursorParams as RpcEventsLatestCursorParams,
-    EventsLatestCursorResult as RpcEventsLatestCursorResult,
-    EventsListSinceParams as RpcEventsListSinceParams,
-    EventsListSinceResult as RpcEventsListSinceResult,
-    EventsSnapshotParams as RpcEventsSnapshotParams,
-    EventsSnapshotResult as RpcEventsSnapshotResult,
-    ForkSessionAtParams as RpcForkSessionAtParams,
-    ForkSessionReplaceParams as RpcForkSessionReplaceParams,
-    HelpRequest as RpcHelpRequest,
-    HelpResponse as RpcHelpResponse,
-    InjectSystemContextParams as RpcInjectSystemContextParams,
-    InjectSystemContextResult as RpcInjectSystemContextResult,
-    InterruptParams as RpcInterruptParams,
-    ListSessionTranscriptRevisionsParams as RpcListSessionTranscriptRevisionsParams,
-    SessionInputStateParams as RpcSessionInputStateParams,
-    SessionInputStateResult as RpcSessionInputStateResult,
-    ListSessionsParams as RpcListSessionsParams,
-    ListSessionsResult as RpcListSessionsResult,
-    LoginCompleteParams as RpcLoginCompleteParams,
-    LoginStartParams as RpcLoginStartParams,
-    ExportAtifParams as RpcExportAtifParams,
-    ProvisionApiKeyParams as RpcProvisionApiKeyParams,
-    ReadSessionHistoryParams as RpcReadSessionHistoryParams,
-    ReadSessionParams as RpcReadSessionParams,
-    ReadSessionTranscriptRevisionParams as RpcReadSessionTranscriptRevisionParams,
-    RealmIdParams as RpcRealmIdParams,
-    RestoreSessionTranscriptRevisionParams as RpcRestoreSessionTranscriptRevisionParams,
-    RewriteSessionTranscriptParams as RpcRewriteSessionTranscriptParams,
-    RuntimeHostCapabilities as RpcRuntimeHostCapabilities,
-    RuntimeHostHealth as RpcRuntimeHostHealth,
-    RuntimeHostInfo as RpcRuntimeHostInfo,
-    Schedule as RpcSchedule,
-    ScheduleToolCallParams as RpcScheduleToolCallParams,
-    ScheduleToolsResult as RpcScheduleToolsResult,
-    SessionExternalEventEnvelope as RpcSessionExternalEventEnvelope,
     SessionForkResult as RpcSessionForkResult,
-    SessionPeerResponseTerminalParams as RpcSessionPeerResponseTerminalParams,
-    SessionTranscriptRewriteResult as RpcSessionTranscriptRewriteResult,
+)
+from .generated.types import (
+    SkillKey as WireSkillKey,
+)
+from .generated.types import (
     SystemPromptUpdateResult as RpcSystemPromptUpdateResult,
+)
+from .generated.types import (
     UpdateSystemPromptParams as RpcUpdateSystemPromptParams,
-    WireDeviceCompleteResult as RpcWireDeviceCompleteResult,
-    WireProvisionApiKeyResult as RpcWireProvisionApiKeyResult,
-    WireRunResult as RpcWireRunResult,
-    WireSessionTranscriptRevision as RpcWireSessionTranscriptRevision,
-    WireSessionTranscriptRevisionList as RpcWireSessionTranscriptRevisionList,
+)
+from .generated.version_compat import (
+    is_compatible_with as _generated_is_compatible_with,
 )
 from .mob import (
     Mob,
@@ -269,28 +224,12 @@ from .types import (
     BlobPayload,
     Capability,
     ConfigEnvelope,
-    DeletedMobProfile,
-    ExtractionError,
-    ExternalEventOutcome,
     ContentBlock,
     ContentInput,
-    ModelsCatalogResponse,
-    MobControlScope,
-    MobEventsResult,
-    MobGrantRecord,
-    MobMemberLiveTransport,
-    MobProfile,
-    HelpExecutionMode,
-    PeerCorrelationId,
-    PeerId,
-    ScheduleListResult,
-    ScheduleOccurrenceRecord,
-    ScheduleOccurrencesResult,
-    ScheduleRecord,
-    ScheduleToolsResult,
-    ScheduleToolCall,
+    DeletedMobProfile,
     EventEnvelope,
-    McpLiveOpResponse,
+    ExternalEventOutcome,
+    ExtractionError,
     ForkAuthoredCacheBreakpoint,
     ForkCacheBreakpointBoundary,
     ForkCacheInheritance,
@@ -302,43 +241,55 @@ from .types import (
     ForkCacheProvider,
     ForkCacheTtl,
     ForkPoint,
+    HelpExecutionMode,
+    McpLiveOpResponse,
+    MobControlScope,
+    MobEventsResult,
+    MobGrantRecord,
+    MobMemberLiveTransport,
+    MobProfile,
+    ModelsCatalogResponse,
+    PeerCorrelationId,
+    PeerId,
+    ReadyWorkFilter,
     ResolvedModelCapabilities,
     RunResult,
+    ScheduleListResult,
+    ScheduleOccurrenceRecord,
+    ScheduleOccurrencesResult,
+    ScheduleRecord,
+    ScheduleToolsResult,
     SchemaWarning,
-    SessionDetails,
     SessionAssistantBlock,
     SessionContentBlock,
     SessionContentInput,
+    SessionDetails,
     SessionForkResult,
     SessionHistory,
+    SessionMessage,
+    SessionSummary,
+    SessionToolResult,
     SessionTranscriptRevision,
     SessionTranscriptRevisionEntry,
     SessionTranscriptRevisionList,
     SessionTranscriptRewriteResult,
-    SystemPromptUpdateResult,
-    SystemPromptVersionIdentity,
-    SessionSummary,
-    SessionMessage,
-    SessionToolResult,
-    SkillKey,
     SkillQuarantineDiagnostic,
     SkillRef,
     SkillRuntimeDiagnostics,
     SourceHealthSnapshot,
     StoredMobProfile,
     SystemPromptOverride,
+    SystemPromptUpdateResult,
+    SystemPromptVersionIdentity,
     TranscriptEditRunningBehavior,
     TranscriptReplacement,
     TranscriptRewriteInputMessage,
     TranscriptRewriteReason,
     TranscriptRewriteSelection,
     TranscriptUserRole,
-    ReadyWorkFilter,
     WorkGraphEvent,
     WorkGraphEventFilter,
-    WorkGraphEventsResponse,
     WorkGraphIdParams,
-    WorkGraphItemsResponse,
     WorkGraphSnapshot,
     WorkGraphSnapshotFilter,
     WorkItem,
@@ -553,6 +504,8 @@ class MeerkatClient:
         await client.close()
     """
 
+    _request: RpcRequest
+
     def __init__(self, rkat_path: str = "rkat-rpc"):
         self._rkat_path = rkat_path
         self._legacy_rpc_subcommand = False
@@ -563,6 +516,7 @@ class MeerkatClient:
         self._dispatcher: _StdoutDispatcher | None = None
         self._tool_registry = ToolRegistry()
         self._tool_registration_errors: dict[str, MeerkatError] = {}
+        self._request = cast(RpcRequest, self._request_impl)
 
     # -- Tool registration -------------------------------------------------
 
@@ -848,53 +802,57 @@ class MeerkatClient:
     async def get_realm(self, realm_id: str) -> dict[str, Any]:
         """Fetch one realm's full WireRealmConnectionSet. Delegates to
         `realm/get`."""
-        _rpc_signature: RpcRealmIdParams
         return await self._request("realm/get", {"realm_id": realm_id})
 
     async def list_auth_profiles(self, realm_id: str) -> dict[str, Any]:
         """List auth profiles / backend profiles / bindings for one
         realm. Delegates to `auth/profile/list`."""
-        _rpc_signature: RpcRealmIdParams
         return await self._request("auth/profile/list", {"realm_id": realm_id})
 
     async def get_auth_profile(
         self, realm_id: str, binding_id: str, profile_id: str | None = None
     ) -> dict[str, Any]:
         """Fetch a binding-scoped auth profile via `auth/profile/get`."""
-        _rpc_signature: RpcBindingIdParams
         params: dict[str, Any] = {"realm_id": realm_id, "binding_id": binding_id}
         if profile_id is not None:
             params["profile_id"] = profile_id
         return await self._request("auth/profile/get", params)
 
-    async def create_auth_profile(self, params: dict[str, Any]) -> dict[str, Any]:
+    async def create_auth_profile(self, params: CreateProfileParams) -> dict[str, Any]:
         """Create binding-scoped credentials via `auth/profile/create`."""
-        _rpc_signature: RpcCreateProfileParams
-        return await self._request("auth/profile/create", params)
+        return await self._request("auth/profile/create", _wire_params(params))
 
     async def delete_auth_profile(
         self, realm_id: str, binding_id: str, profile_id: str | None = None
     ) -> None:
         """Clear a profile's persisted credentials via
         `auth/profile/delete`."""
-        _rpc_signature: RpcBindingIdParams
         params: dict[str, Any] = {"realm_id": realm_id, "binding_id": binding_id}
         if profile_id is not None:
             params["profile_id"] = profile_id
         await self._request("auth/profile/delete", params)
 
     async def auth_login_start(
-        self, provider: str, redirect_uri: str = "http://127.0.0.1:0/callback"
+        self,
+        provider: str,
+        redirect_uri: str = "http://127.0.0.1:0/callback",
+        *,
+        realm_id: str,
+        binding_id: str,
+        profile_id: str | None = None,
     ) -> dict[str, Any]:
         """Start an OAuth authorization-code login via
         `auth/login/start`. Returns `{authorize_url, state}`; client directs
         user to the URL then calls `auth_login_complete` once the redirect
         carries a code."""
-        _rpc_signature: RpcLoginStartParams
-        return await self._request(
-            "auth/login/start",
-            {"provider": provider, "redirect_uri": redirect_uri},
+        params = LoginStartParams(
+            binding_id=binding_id,
+            provider=provider,
+            realm_id=realm_id,
+            redirect_uri=redirect_uri,
+            profile_id=profile_id,
         )
+        return await self._request("auth/login/start", _wire_params(params))
 
     async def auth_login_complete(
         self,
@@ -910,7 +868,6 @@ class MeerkatClient:
         """Exchange an authorization code for tokens via
         `auth/login/complete`. Tokens land in the server-side credential
         source for the resolved binding."""
-        _rpc_signature: RpcLoginCompleteParams
         params: dict[str, Any] = {
             "provider": provider,
             "code": code,
@@ -923,12 +880,24 @@ class MeerkatClient:
             params["profile_id"] = profile_id
         return await self._request("auth/login/complete", params)
 
-    async def auth_login_device_start(self, provider: str) -> dict[str, Any]:
+    async def auth_login_device_start(
+        self,
+        provider: str,
+        *,
+        realm_id: str,
+        binding_id: str,
+        profile_id: str | None = None,
+    ) -> dict[str, Any]:
         """Start an OAuth device-code flow via
         `auth/login/device_start`. Returns the user_code to display +
         verification_uri + interval."""
-        _rpc_signature: RpcDeviceStartParams
-        return await self._request("auth/login/device_start", {"provider": provider})
+        params = DeviceStartParams(
+            binding_id=binding_id,
+            provider=provider,
+            realm_id=realm_id,
+            profile_id=profile_id,
+        )
+        return await self._request("auth/login/device_start", _wire_params(params))
 
     async def auth_login_device_complete(
         self,
@@ -942,7 +911,6 @@ class MeerkatClient:
         """Poll once for device-code completion via
         `auth/login/device_complete`. Returns `{state: "pending" |
         "slow_down" | "access_denied" | "expired" | "ready", ...}`."""
-        _rpc_signature: RpcDeviceCompleteParams | RpcWireDeviceCompleteResult
         params: dict[str, Any] = {
             "provider": provider,
             "device_code": device_code,
@@ -966,7 +934,6 @@ class MeerkatClient:
         the Console-scope OAuth flow first; hands the resulting
         access_token here; the server POSTs to Anthropic's
         create_api_key endpoint and persists the returned key."""
-        _rpc_signature: RpcProvisionApiKeyParams | RpcWireProvisionApiKeyResult
         params: dict[str, Any] = {
             "access_token": access_token,
             "realm_id": realm_id,
@@ -981,7 +948,6 @@ class MeerkatClient:
     ) -> dict[str, Any]:
         """Report persisted-credential status for a binding via
         `auth/status/get`."""
-        _rpc_signature: RpcBindingIdParams
         params: dict[str, Any] = {"realm_id": realm_id, "binding_id": binding_id}
         if profile_id is not None:
             params["profile_id"] = profile_id
@@ -992,7 +958,6 @@ class MeerkatClient:
     ) -> dict[str, Any]:
         """Revoke + delete a binding's persisted credentials via
         `auth/logout`."""
-        _rpc_signature: RpcBindingIdParams
         params: dict[str, Any] = {"realm_id": realm_id, "binding_id": binding_id}
         if profile_id is not None:
             params["profile_id"] = profile_id
@@ -1044,7 +1009,6 @@ class MeerkatClient:
             )
             print(session.text)
         """
-        _rpc_signature: RpcDeferredCreateResult | RpcWireRunResult
         params = self._build_create_params(
             prompt,
             injected_context=injected_context,
@@ -1127,7 +1091,6 @@ class MeerkatClient:
                 session_id = stream.session_id
                 result = stream.result
         """
-        _rpc_signature: RpcDeferredCreateResult | RpcWireRunResult
         if not self._dispatcher or not self._process or not self._process.stdin:
             raise MeerkatError("NOT_CONNECTED", "Client not connected")
         params = self._build_create_params(
@@ -1230,7 +1193,6 @@ class MeerkatClient:
             )
             result = await deferred.start_turn("Begin")
         """
-        _rpc_signature: RpcDeferredCreateResult | RpcWireRunResult
         params = self._build_create_params(
             prompt,
             injected_context=injected_context,
@@ -1282,7 +1244,6 @@ class MeerkatClient:
         max_tokens: int | None = None,
     ) -> RunResult:
         """Ask Meerkat usage help through the dedicated ``help/ask`` RPC."""
-        _rpc_signature: RpcHelpRequest | RpcHelpResponse
         params: dict[str, Any] = {
             "question": question,
             "execution_mode": execution_mode,
@@ -1308,7 +1269,6 @@ class MeerkatClient:
         offset: int | None = None,
     ) -> list[SessionSummary]:
         """List active sessions."""
-        _rpc_signature: RpcListSessionsParams | RpcListSessionsResult
         params: dict[str, Any] = {}
         if labels is not None:
             params["labels"] = labels
@@ -1331,7 +1291,6 @@ class MeerkatClient:
 
     async def read_session(self, session_id: str) -> SessionDetails:
         """Read detailed session state."""
-        _rpc_signature: RpcReadSessionParams
         result = await self._request("session/read", {"session_id": session_id})
         return self._parse_session_details(result)
 
@@ -1344,7 +1303,6 @@ class MeerkatClient:
         blocks: list[ContentBlock] | None = None,
     ) -> ExternalEventOutcome:
         """Append a durable external event input to a session runtime."""
-        _rpc_signature: RpcSessionExternalEventEnvelope
         params: dict[str, Any] = {
             "session_id": session_id,
             "kind": "generic_json",
@@ -1366,7 +1324,6 @@ class MeerkatClient:
         display_name: str | None = None,
     ) -> ExternalEventOutcome:
         """Admit a correlated terminal peer response through the typed ingress."""
-        _rpc_signature: RpcSessionPeerResponseTerminalParams
         params: dict[str, Any] = {
             "session_id": session_id,
             "peer_id": str(peer_id),
@@ -1387,7 +1344,6 @@ class MeerkatClient:
         idempotency_key: str | None = None,
     ) -> dict[str, Any]:
         """Append one ordinary durable System message to a session."""
-        _rpc_signature: RpcInjectSystemContextParams | RpcInjectSystemContextResult
         params = {
             "session_id": session_id,
             "content": {"type": "text", "text": text},
@@ -1411,7 +1367,6 @@ class MeerkatClient:
         reconciliation query for interrupted work after a host restart
         (terminal outcome, resolving run id, boundary sequence).
         """
-        _rpc_signature: RpcSessionInputStateParams | RpcSessionInputStateResult
         if (input_id is None) == (idempotency_key is None):
             raise ValueError(
                 "exactly one of input_id or idempotency_key must be provided"
@@ -1433,7 +1388,6 @@ class MeerkatClient:
         limit: int | None = None,
     ) -> SessionHistory:
         """Read paginated session transcript history."""
-        _rpc_signature: RpcReadSessionHistoryParams
         params: dict[str, Any] = {"session_id": session_id, "offset": offset}
         if limit is not None:
             params["limit"] = limit
@@ -1449,7 +1403,6 @@ class MeerkatClient:
         model_name: str | None = None,
     ) -> dict[str, Any]:
         """Export the session's durable event log as an ATIF trajectory."""
-        _rpc_signature: RpcExportAtifParams
         params: dict[str, Any] = {"session_id": session_id}
         if agent_name is not None:
             params["agent_name"] = agent_name
@@ -1468,9 +1421,6 @@ class MeerkatClient:
         limit: int | None = None,
     ) -> SessionTranscriptRevision:
         """Read paginated transcript history for a retained revision."""
-        _rpc_signature: (
-            RpcReadSessionTranscriptRevisionParams | RpcWireSessionTranscriptRevision
-        )
         params: dict[str, Any] = {
             "session_id": session_id,
             "revision": revision,
@@ -1489,10 +1439,6 @@ class MeerkatClient:
         limit: int | None = None,
     ) -> SessionTranscriptRevisionList:
         """List retained transcript revision commits with the current head."""
-        _rpc_signature: (
-            RpcListSessionTranscriptRevisionsParams
-            | RpcWireSessionTranscriptRevisionList
-        )
         params: dict[str, Any] = {"session_id": session_id}
         if offset is not None:
             params["offset"] = offset
@@ -1510,7 +1456,6 @@ class MeerkatClient:
         tool_access_policy: WireToolAccessPolicy | dict[str, Any] | None = None,
     ) -> SessionForkResult:
         """Fork an idle session at a transcript message index."""
-        _rpc_signature: RpcForkSessionAtParams | RpcSessionForkResult
         params: dict[str, Any] = {
             "session_id": session_id,
             "message_index": message_index,
@@ -1534,7 +1479,6 @@ class MeerkatClient:
         tool_access_policy: WireToolAccessPolicy | dict[str, Any] | None = None,
     ) -> SessionForkResult:
         """Fork an idle session and apply a typed transcript replacement."""
-        _rpc_signature: RpcForkSessionReplaceParams | RpcSessionForkResult
         params: dict[str, Any] = {
             "session_id": session_id,
             "message_index": message_index,
@@ -1561,9 +1505,6 @@ class MeerkatClient:
         running_behavior: TranscriptEditRunningBehavior | None = None,
     ) -> SessionTranscriptRewriteResult:
         """Commit a typed same-session transcript rewrite."""
-        _rpc_signature: (
-            RpcRewriteSessionTranscriptParams | RpcSessionTranscriptRewriteResult
-        )
         params: dict[str, Any] = {
             "session_id": session_id,
             "selection": selection,
@@ -1594,7 +1535,6 @@ class MeerkatClient:
         expected_parent_revision: str | None = None,
     ) -> SystemPromptUpdateResult:
         """Explicitly replace one durable versioned system-prompt key."""
-        _rpc_signature: RpcUpdateSystemPromptParams | RpcSystemPromptUpdateResult
         params = RpcUpdateSystemPromptParams(
             session_id=session_id,
             key=key,
@@ -1621,10 +1561,6 @@ class MeerkatClient:
         running_behavior: TranscriptEditRunningBehavior | None = None,
     ) -> SessionTranscriptRewriteResult:
         """Commit a typed rewrite that restores a retained transcript revision."""
-        _rpc_signature: (
-            RpcRestoreSessionTranscriptRevisionParams
-            | RpcSessionTranscriptRewriteResult
-        )
         params: dict[str, Any] = {
             "session_id": session_id,
             "revision": revision,
@@ -1640,7 +1576,6 @@ class MeerkatClient:
         return self._parse_session_transcript_rewrite_result(raw)
 
     async def get_blob(self, blob_id: str) -> BlobPayload:
-        _rpc_signature: RpcBlobGetParams | RpcBlobPayload
         raw = await self._request("blob/get", {"blob_id": blob_id})
         context = "Invalid blob/get response"
         return BlobPayload(
@@ -1650,15 +1585,12 @@ class MeerkatClient:
         )
 
     async def get_runtime_host_info(self) -> dict[str, Any]:
-        _rpc_signature: RpcRuntimeHostInfo
         return await self._request("runtime/host_info", {})
 
     async def get_runtime_host_capabilities(self) -> dict[str, Any]:
-        _rpc_signature: RpcRuntimeHostCapabilities
         return await self._request("runtime/capabilities", {})
 
     async def get_runtime_host_health(self) -> dict[str, Any]:
-        _rpc_signature: RpcRuntimeHostHealth
         return await self._request("runtime/health", {})
 
     @staticmethod
@@ -1748,10 +1680,14 @@ class MeerkatClient:
 
     async def jobs_list(self, params: JobsListParams) -> JobsListResult:
         raw = await self._request("jobs/list", _wire_params(params))
-        jobs = self._require_present_list_field(raw, "jobs", "Invalid jobs/list response")
+        jobs = self._require_present_list_field(
+            raw, "jobs", "Invalid jobs/list response"
+        )
         return JobsListResult(
             jobs=[
-                self._parse_job_summary(job, f"Invalid jobs/list response jobs[{index}]")
+                self._parse_job_summary(
+                    job, f"Invalid jobs/list response jobs[{index}]"
+                )
                 for index, job in enumerate(jobs)
             ]
         )
@@ -1771,28 +1707,46 @@ class MeerkatClient:
             if progress_raw is None
             else JobProgress(
                 cursor=self._require_non_negative_integer_field(
-                    self._require_dict(progress_raw, "progress", "Invalid jobs/progress response"),
+                    self._require_dict(
+                        progress_raw, "progress", "Invalid jobs/progress response"
+                    ),
                     "cursor",
                     "Invalid jobs/progress response",
                 ),
                 detail=self._require_present_string_field(
-                    self._require_dict(progress_raw, "progress", "Invalid jobs/progress response"),
+                    self._require_dict(
+                        progress_raw, "progress", "Invalid jobs/progress response"
+                    ),
                     "detail",
                     "Invalid jobs/progress response",
                 ),
             )
         )
         return JobsProgressResult(
-            job_id=self._require_string_field(raw, "job_id", "Invalid jobs/progress response"),
-            phase=cast(Any, self._require_string_field(raw, "phase", "Invalid jobs/progress response")),
+            job_id=self._require_string_field(
+                raw, "job_id", "Invalid jobs/progress response"
+            ),
+            phase=cast(
+                Any,
+                self._require_string_field(
+                    raw, "phase", "Invalid jobs/progress response"
+                ),
+            ),
             progress=progress,
         )
 
     async def jobs_result(self, params: JobsResultParams) -> JobsResultResult:
         raw = await self._request("jobs/result", _wire_params(params))
         return JobsResultResult(
-            job_id=self._require_string_field(raw, "job_id", "Invalid jobs/result response"),
-            phase=cast(Any, self._require_string_field(raw, "phase", "Invalid jobs/result response")),
+            job_id=self._require_string_field(
+                raw, "job_id", "Invalid jobs/result response"
+            ),
+            phase=cast(
+                Any,
+                self._require_string_field(
+                    raw, "phase", "Invalid jobs/result response"
+                ),
+            ),
             result=cast(JobTerminalResult | None, raw.get("result")),
         )
 
@@ -1802,11 +1756,15 @@ class MeerkatClient:
             raw, "artifacts", "Invalid jobs/artifacts response"
         )
         return JobsArtifactsResult(
-            job_id=self._require_string_field(raw, "job_id", "Invalid jobs/artifacts response"),
+            job_id=self._require_string_field(
+                raw, "job_id", "Invalid jobs/artifacts response"
+            ),
             artifacts=[
                 JobArtifactRef(
                     reference=self._require_string_field(
-                        self._require_dict(item, "artifact", "Invalid jobs/artifacts response"),
+                        self._require_dict(
+                            item, "artifact", "Invalid jobs/artifacts response"
+                        ),
                         "reference",
                         "Invalid jobs/artifacts response",
                     )
@@ -1862,9 +1820,7 @@ class MeerkatClient:
             )
         )
 
-    async def jobs_subscribe(
-        self, params: JobsSubscribeParams
-    ) -> JobsSubscribeResult:
+    async def jobs_subscribe(self, params: JobsSubscribeParams) -> JobsSubscribeResult:
         result = self._parse_job_get_result(
             await self._request("jobs/subscribe", _wire_params(params)),
             "Invalid jobs/subscribe response",
@@ -1947,49 +1903,41 @@ class MeerkatClient:
             ).job
         )
 
-    async def request_approval(self, params: dict[str, Any]) -> dict[str, Any]:
-        _rpc_signature: RpcApprovalRecord | RpcApprovalRequestParams
-        return await self._request("approval/request", params)
+    async def request_approval(self, params: ApprovalRequestParams) -> dict[str, Any]:
+        return await self._request("approval/request", _wire_params(params))
 
     async def list_approvals(
         self, params: dict[str, Any] | None = None
     ) -> dict[str, Any]:
-        _rpc_signature: RpcApprovalListParams | RpcApprovalListResult
         return await self._request("approval/list", params or {})
 
-    async def get_approval(self, params: dict[str, Any]) -> dict[str, Any]:
-        _rpc_signature: RpcApprovalGetParams | RpcApprovalRecord
-        return await self._request("approval/get", params)
+    async def get_approval(self, params: ApprovalGetParams) -> dict[str, Any]:
+        return await self._request("approval/get", _wire_params(params))
 
-    async def decide_approval(self, params: dict[str, Any]) -> dict[str, Any]:
-        _rpc_signature: RpcApprovalDecideParams | RpcApprovalRecord
-        return await self._request("approval/decide", params)
+    async def decide_approval(self, params: ApprovalDecideParams) -> dict[str, Any]:
+        return await self._request("approval/decide", _wire_params(params))
 
     async def list_artifacts(
         self, params: dict[str, Any] | None = None
     ) -> dict[str, Any]:
-        _rpc_signature: RpcArtifactListParams | RpcArtifactListResult
         return await self._request("artifact/list", params or {})
 
-    async def get_artifact(self, params: dict[str, Any]) -> dict[str, Any]:
-        _rpc_signature: RpcArtifactIdParams | RpcArtifactRecord
-        return await self._request("artifact/get", params)
+    async def get_artifact(self, params: ArtifactIdParams) -> dict[str, Any]:
+        return await self._request("artifact/get", _wire_params(params))
 
-    async def download_artifact(self, params: dict[str, Any]) -> dict[str, Any]:
-        _rpc_signature: RpcArtifactDownloadParams | RpcArtifactDownloadResult
-        return await self._request("artifact/download", params)
+    async def download_artifact(self, params: ArtifactDownloadParams) -> dict[str, Any]:
+        return await self._request("artifact/download", _wire_params(params))
 
-    async def latest_event_cursor(self, params: dict[str, Any]) -> dict[str, Any]:
-        _rpc_signature: RpcEventsLatestCursorParams | RpcEventsLatestCursorResult
-        return await self._request("events/latest_cursor", params)
+    async def latest_event_cursor(
+        self, params: EventsLatestCursorParams
+    ) -> dict[str, Any]:
+        return await self._request("events/latest_cursor", _wire_params(params))
 
-    async def list_events_since(self, params: dict[str, Any]) -> dict[str, Any]:
-        _rpc_signature: RpcEventsListSinceParams | RpcEventsListSinceResult
-        return await self._request("events/list_since", params)
+    async def list_events_since(self, params: EventsListSinceParams) -> dict[str, Any]:
+        return await self._request("events/list_since", _wire_params(params))
 
-    async def event_snapshot(self, params: dict[str, Any]) -> dict[str, Any]:
-        _rpc_signature: RpcEventsSnapshotParams | RpcEventsSnapshotResult
-        return await self._request("events/snapshot", params)
+    async def event_snapshot(self, params: EventsSnapshotParams) -> dict[str, Any]:
+        return await self._request("events/snapshot", _wire_params(params))
 
     # -- Capabilities ------------------------------------------------------
 
@@ -2043,13 +1991,11 @@ class MeerkatClient:
         raw = await self._request("models/catalog", {})
         return self._parse_models_catalog(raw)
 
-    async def create_schedule(self, request: dict[str, Any]) -> ScheduleRecord:
-        _rpc_signature: RpcCreateScheduleRequest | RpcSchedule
-        raw = await self._request("schedule/create", request)
+    async def create_schedule(self, request: CreateScheduleRequest) -> ScheduleRecord:
+        raw = await self._request("schedule/create", _wire_params(request))
         return self._parse_schedule_record(raw, "Invalid schedule/create response")
 
     async def get_schedule(self, schedule_id: str) -> ScheduleRecord:
-        _rpc_signature: RpcSchedule
         raw = await self._request("schedule/get", {"schedule_id": schedule_id})
         return self._parse_schedule_record(raw, "Invalid schedule/get response")
 
@@ -2087,23 +2033,19 @@ class MeerkatClient:
             ],
         }
 
-    async def update_schedule(self, request: dict[str, Any]) -> ScheduleRecord:
-        _rpc_signature: RpcSchedule
-        raw = await self._request("schedule/update", request)
+    async def update_schedule(self, request: UpdateScheduleParams) -> ScheduleRecord:
+        raw = await self._request("schedule/update", _wire_params(request))
         return self._parse_schedule_record(raw, "Invalid schedule/update response")
 
     async def pause_schedule(self, schedule_id: str) -> ScheduleRecord:
-        _rpc_signature: RpcSchedule
         raw = await self._request("schedule/pause", {"schedule_id": schedule_id})
         return self._parse_schedule_record(raw, "Invalid schedule/pause response")
 
     async def resume_schedule(self, schedule_id: str) -> ScheduleRecord:
-        _rpc_signature: RpcSchedule
         raw = await self._request("schedule/resume", {"schedule_id": schedule_id})
         return self._parse_schedule_record(raw, "Invalid schedule/resume response")
 
     async def delete_schedule(self, schedule_id: str) -> ScheduleRecord:
-        _rpc_signature: RpcSchedule
         raw = await self._request("schedule/delete", {"schedule_id": schedule_id})
         return self._parse_schedule_record(raw, "Invalid schedule/delete response")
 
@@ -2139,7 +2081,6 @@ class MeerkatClient:
         }
 
     async def list_schedule_tools(self) -> ScheduleToolsResult:
-        _rpc_signature: RpcScheduleToolsResult
         raw = await self._request("schedule/tools", {})
         raw = self._require_dict(raw, "response", "Invalid schedule/tools response")
         return {
@@ -2155,9 +2096,10 @@ class MeerkatClient:
             ]
         }
 
-    async def call_schedule_tool(self, request: ScheduleToolCall) -> dict[str, Any]:
-        _rpc_signature: RpcScheduleToolCallParams
-        return await self._request("schedule/call", dict(request))
+    async def call_schedule_tool(
+        self, request: ScheduleToolCallParams
+    ) -> dict[str, Any]:
+        return await self._request("schedule/call", _wire_params(request))
 
     async def get_workgraph_item(
         self,
@@ -2815,8 +2757,10 @@ class MeerkatClient:
             )
         }
 
-    async def mob_ingress_interaction(self, params: dict[str, Any]) -> dict[str, Any]:
-        return await self._request("mob/ingress_interaction", params)
+    async def mob_ingress_interaction(
+        self, params: MobIngressInteractionParams
+    ) -> dict[str, Any]:
+        return await self._request("mob/ingress_interaction", _wire_params(params))
 
     async def retire_mob_member(self, mob_id: str, agent_identity: str) -> None:
         await self._request(
@@ -2894,7 +2838,6 @@ class MeerkatClient:
             scopes=scopes,
             expires_at_ms=expires_at_ms,
         )
-        _rpc_signature: MobGrantScopesParams | MobGrantScopesResult
         result = await self._request("mob/grant_scopes", _wire_params(params))
         context = "Invalid mob/grant_scopes response"
         record = self._require_dict(result.get("record"), "record", context)
@@ -2912,7 +2855,6 @@ class MeerkatClient:
             principal=principal,
             scopes=scopes,
         )
-        _rpc_signature: MobRevokeScopesParams | MobRevokeScopesResult
         result = await self._request("mob/revoke_scopes", _wire_params(params))
         return self._require_bool_field(
             result,
@@ -2923,7 +2865,6 @@ class MeerkatClient:
     async def list_mob_grants(self, mob_id: str) -> list[MobGrantRecord]:
         """List typed control-scope grants, including optional expiry metadata."""
         params = MobIdParams(mob_id=mob_id)
-        _rpc_signature: MobIdParams | MobGrantsResult
         result = await self._request("mob/grants", _wire_params(params))
         context = "Invalid mob/grants response"
         grants = self._require_present_list_field(result, "grants", context)
@@ -2956,7 +2897,6 @@ class MeerkatClient:
     async def mob_hosts(self, mob_id: str) -> list[MobHostStatus]:
         """List tracked member hosts with committed authority facts."""
         params = MobIdParams(mob_id=mob_id)
-        _rpc_signature: MobIdParams | MobHostsResult
         result = await self._request("mob/hosts", _wire_params(params))
         context = "Invalid mob/hosts response"
         hosts = self._require_present_list_field(result, "hosts", context)
@@ -3041,7 +2981,6 @@ class MeerkatClient:
             agent_identity=agent_identity,
             reason=reason,
         )
-        _rpc_signature: MobHardCancelParams | MobHardCancelResult
         result = await self._request("mob/hard_cancel_member", _wire_params(params))
         return self._require_bool_field(
             result,
@@ -3200,7 +3139,6 @@ class MeerkatClient:
     async def mob_member_status(
         self, mob_id: str, agent_identity: str
     ) -> MobMemberSnapshot:
-        _rpc_signature: MobMemberStatusResult
         params = MobMemberParams(mob_id=mob_id, agent_identity=agent_identity)
         result = await self._request("mob/member_status", _wire_value(params))
         resolved_capabilities = self._parse_resolved_model_capabilities(
@@ -3562,12 +3500,12 @@ class MeerkatClient:
     async def wire_mob_members(
         self, mob_id: str, member: str, peer: str | dict[str, Any]
     ) -> None:
-        payload = (
-            {"mob_id": mob_id, "member": member, "peer": {"local": peer}}
-            if isinstance(peer, str)
-            else {"mob_id": mob_id, "member": member, "peer": peer}
+        payload = MobWireParams(
+            mob_id=mob_id,
+            member=member,
+            peer={"local": peer} if isinstance(peer, str) else peer,
         )
-        await self._request("mob/wire", payload)
+        await self._request("mob/wire", _wire_params(payload))
 
     async def mob_wire_members_batch(
         self,
@@ -3584,12 +3522,12 @@ class MeerkatClient:
     async def unwire_mob_members(
         self, mob_id: str, member: str, peer: str | dict[str, Any]
     ) -> None:
-        payload = (
-            {"mob_id": mob_id, "member": member, "peer": {"local": peer}}
-            if isinstance(peer, str)
-            else {"mob_id": mob_id, "member": member, "peer": peer}
+        payload = MobUnwireParams(
+            mob_id=mob_id,
+            member=member,
+            peer={"local": peer} if isinstance(peer, str) else peer,
         )
-        await self._request("mob/unwire", payload)
+        await self._request("mob/unwire", _wire_params(payload))
 
     async def mob_lifecycle(self, mob_id: str, action: MobLifecycleAction) -> None:
         """Drive a mob through a typed lifecycle transition.
@@ -4044,11 +3982,9 @@ class MeerkatClient:
         )
 
     async def _interrupt(self, session_id: str) -> InterruptResult:
-        _rpc_signature: RpcInterruptParams
         return await self._request("turn/interrupt", {"session_id": session_id})
 
     async def _archive(self, session_id: str) -> None:
-        _rpc_signature: RpcArchiveSessionParams
         await self._request("session/archive", {"session_id": session_id})
 
     async def _send(self, session_id: str, **kwargs: Any) -> CommsSendResult:
@@ -4566,7 +4502,7 @@ class MeerkatClient:
 
     # -- Transport ---------------------------------------------------------
 
-    async def _request(self, method: str, params: dict[str, Any]) -> dict[str, Any]:
+    async def _request_impl(self, method: str, params: dict[str, Any]) -> Any:
         if not self._process or not self._process.stdin or not self._dispatcher:
             raise MeerkatError("NOT_CONNECTED", "Client not connected")
         fault = self._dispatcher.transport_fault
@@ -6619,27 +6555,19 @@ class MeerkatClient:
         result: dict[str, Any],
         context: str,
     ) -> MobHelperResult:
-        output = MeerkatClient._require_present_string_field(
-            result, "output", context
-        )
+        output = MeerkatClient._require_present_string_field(result, "output", context)
         tokens_used = MeerkatClient._require_non_negative_integer_field(
             result, "tokens_used", context
         )
         agent_identity = MeerkatClient._require_string_field(
             result, "agent_identity", context
         )
-        member_ref = MeerkatClient._require_string_field(
-            result, "member_ref", context
-        )
+        member_ref = MeerkatClient._require_string_field(result, "member_ref", context)
         bounded_result = MeerkatClient._parse_bounded_helper_result(
             result.get("bounded_result"), context
         )
-        session_id = MeerkatClient._require_string_field(
-            result, "session_id", context
-        )
-        usage_raw = MeerkatClient._require_dict(
-            result.get("usage"), "usage", context
-        )
+        session_id = MeerkatClient._require_string_field(result, "session_id", context)
+        usage_raw = MeerkatClient._require_dict(result.get("usage"), "usage", context)
         usage = Usage(
             input_tokens=MeerkatClient._require_non_negative_integer_field(
                 usage_raw,
@@ -7924,9 +7852,7 @@ class MeerkatClient:
             return {}
         value = raw[field]
         if not isinstance(value, dict):
-            raise MeerkatError(
-                "INVALID_RESPONSE", f"{context}: {field} must be object"
-            )
+            raise MeerkatError("INVALID_RESPONSE", f"{context}: {field} must be object")
         if not all(
             isinstance(key, str) and isinstance(item, str)
             for key, item in value.items()
@@ -7955,9 +7881,7 @@ class MeerkatClient:
             total_tokens=MeerkatClient._require_non_negative_integer_field(
                 s, "total_tokens", context
             ),
-            labels=MeerkatClient._parse_optional_string_map_field(
-                s, "labels", context
-            ),
+            labels=MeerkatClient._parse_optional_string_map_field(s, "labels", context),
             is_active=MeerkatClient._require_bool_field(s, "is_active", context),
         )
 
@@ -7966,9 +7890,7 @@ class MeerkatClient:
         context = "Invalid session/read response"
         data = MeerkatClient._require_dict(s, "result", context)
         return SessionDetails(
-            session_id=MeerkatClient._require_string_field(
-                data, "session_id", context
-            ),
+            session_id=MeerkatClient._require_string_field(data, "session_id", context),
             session_ref=MeerkatClient._optional_string_field(
                 data, "session_ref", context
             ),

--- a/sdks/python/meerkat/generated/rpc_contracts.py
+++ b/sdks/python/meerkat/generated/rpc_contracts.py
@@ -1,0 +1,1586 @@
+"""Generated RPC method contracts for meerkat-sdk.
+
+Source: artifacts/schemas/rpc-methods.json
+"""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable
+from typing import Any, Literal, Protocol, overload
+
+from .types import (
+    ApprovalDecideParams,
+    ApprovalGetParams,
+    ApprovalListParams,
+    ApprovalListResult,
+    ApprovalRecord,
+    ApprovalRequestParams,
+    ArchiveSessionParams,
+    ArtifactDownloadParams,
+    ArtifactDownloadResult,
+    ArtifactIdParams,
+    ArtifactListParams,
+    ArtifactListResult,
+    ArtifactRecord,
+    AttentionListRequest,
+    AttentionListResult,
+    BindingIdParams,
+    BlobGetParams,
+    BlobPayload,
+    BridgeLiveControlOutcome,
+    CapabilitiesResponse,
+    CommsPeersParams,
+    CommsPeersResult,
+    CommsSendParams,
+    CommsSendResult,
+    ConfigEnvelope,
+    ConfigPatchParams,
+    ConfigSetParams,
+    ConfigWriteResult,
+    CreateProfileParams,
+    CreateScheduleRequest,
+    DeferredCreateResult,
+    DeviceCompleteParams,
+    DeviceStartParams,
+    EventsLatestCursorParams,
+    EventsLatestCursorResult,
+    EventsListSinceParams,
+    EventsListSinceResult,
+    EventsSnapshotParams,
+    EventsSnapshotResult,
+    ExportAtifParams,
+    ForkSessionAtParams,
+    ForkSessionReplaceParams,
+    GoalStatusRequest,
+    GoalStatusResult,
+    HelpRequest,
+    HelpResponse,
+    InjectSystemContextParams,
+    InjectSystemContextResult,
+    InterruptParams,
+    InterruptResult,
+    JobsArtifactsParams,
+    JobsArtifactsResult,
+    JobsCancelParams,
+    JobsCancelResult,
+    JobsGetParams,
+    JobsGetResult,
+    JobsHealthResult,
+    JobsListParams,
+    JobsListResult,
+    JobsProgressParams,
+    JobsProgressResult,
+    JobsResultParams,
+    JobsResultResult,
+    JobsRetryParams,
+    JobsRetryResult,
+    JobsSubscribeParams,
+    JobsSubscribeResult,
+    JobsUnsubscribeParams,
+    JobsUnsubscribeResult,
+    ListSchedulesParams,
+    ListSessionTranscriptRevisionsParams,
+    ListSessionsParams,
+    ListSessionsResult,
+    LiveChannelParams,
+    LiveCloseResult,
+    LiveCommitInputParams,
+    LiveCommitInputResult,
+    LiveInterruptResult,
+    LiveOpenParams,
+    LiveOpenResult,
+    LiveRefreshResult,
+    LiveSendInputParams,
+    LiveSendInputResult,
+    LiveStatusResult,
+    LiveTruncateParams,
+    LiveTruncateResult,
+    LiveWebrtcAnswerParams,
+    LiveWebrtcAnswerResult,
+    LoginCompleteParams,
+    LoginStartParams,
+    McpAddParams,
+    McpLiveOpResponse,
+    McpReloadParams,
+    McpRemoveParams,
+    MobAppendSystemContextParams,
+    MobAppendSystemContextResult,
+    MobBindHostParams,
+    MobBindHostResult,
+    MobCancelAllWorkParams,
+    MobCancelAllWorkResult,
+    MobCancelWorkParams,
+    MobCancelWorkResult,
+    MobConcludeObjectiveParams,
+    MobConcludeObjectiveResult,
+    MobCreateParams,
+    MobCreateResult,
+    MobDestroyResult,
+    MobEnsureMemberParams,
+    MobEnsureMemberResult,
+    MobEventsParams,
+    MobEventsResult,
+    MobFlowCancelParams,
+    MobFlowCancelResult,
+    MobFlowRunParams,
+    MobFlowRunResult,
+    MobFlowStatusParams,
+    MobFlowStatusResult,
+    MobFlowsResult,
+    MobForceCancelResult,
+    MobForkHelperParams,
+    MobGrantScopesParams,
+    MobGrantScopesResult,
+    MobGrantsResult,
+    MobHardCancelParams,
+    MobHardCancelResult,
+    MobHelperResult,
+    MobHostsResult,
+    MobIdParams,
+    MobIngressInteractionParams,
+    MobIngressInteractionResult,
+    MobLifecycleParams,
+    MobLifecycleResult,
+    MobListMembersMatchingParams,
+    MobListMembersMatchingResult,
+    MobListResult,
+    MobMemberHistoryParams,
+    MobMemberHistoryResult,
+    MobMemberLiveChannelParams,
+    MobMemberLiveControlParams,
+    MobMemberLiveOpenParams,
+    MobMemberLiveStatusParams,
+    MobMemberParams,
+    MobMemberSendParams,
+    MobMemberSendResult,
+    MobMemberStatusResult,
+    MobMembersResult,
+    MobProfileCreateParams,
+    MobProfileDeleteParams,
+    MobProfileDeleteResult,
+    MobProfileListResult,
+    MobProfileLookupResult,
+    MobProfileNameParams,
+    MobProfileUpdateParams,
+    MobReconcileParams,
+    MobReconcileResult,
+    MobRespawnParams,
+    MobRespawnResult,
+    MobRetireResult,
+    MobRevokeHostParams,
+    MobRevokeHostResult,
+    MobRevokeScopesParams,
+    MobRevokeScopesResult,
+    MobRotateSupervisorResult,
+    MobRouteInstallsResult,
+    MobRunParams,
+    MobRunResult,
+    MobRunResultParams,
+    MobSnapshotResult,
+    MobSpawnHelperParams,
+    MobSpawnManyParams,
+    MobSpawnManyResult,
+    MobSpawnParams,
+    MobSpawnResult,
+    MobStatusResult,
+    MobStreamCloseParams,
+    MobStreamCloseResult,
+    MobStreamOpenParams,
+    MobStreamOpenResult,
+    MobSubmitWorkParams,
+    MobSubmitWorkResult,
+    MobTurnStartParams,
+    MobUnwireParams,
+    MobUnwireResult,
+    MobWaitMembersResult,
+    MobWaitParams,
+    MobWireMembersBatchParams,
+    MobWireMembersBatchResult,
+    MobWireParams,
+    MobWireResult,
+    MobkitJobCancelAckParams,
+    MobkitJobCheckpointParams,
+    MobkitJobCompleteParams,
+    MobkitJobFailParams,
+    MobkitJobHeartbeatParams,
+    MobkitJobMutationResult,
+    MobkitJobProgressParams,
+    ModelsCatalogResponse,
+    MonitorsStartParams,
+    MonitorsStartResult,
+    ProvisionApiKeyParams,
+    ReadSessionHistoryParams,
+    ReadSessionParams,
+    ReadSessionTranscriptRevisionParams,
+    ReadyWorkFilter,
+    RealmIdParams,
+    RestoreSessionTranscriptRevisionParams,
+    RewriteSessionTranscriptParams,
+    RuntimeAcceptResult,
+    RuntimeHostCapabilities,
+    RuntimeHostHealth,
+    RuntimeHostInfo,
+    Schedule,
+    ScheduleIdParams,
+    ScheduleListResult,
+    ScheduleOccurrencesParams,
+    ScheduleOccurrencesResult,
+    ScheduleToolCallParams,
+    ScheduleToolsResult,
+    ServerCapabilities,
+    SessionExternalEventParams,
+    SessionForkResult,
+    SessionInputStateParams,
+    SessionInputStateResult,
+    SessionPeerResponseTerminalParams,
+    SessionStreamCloseParams,
+    SessionStreamCloseResult,
+    SessionStreamOpenParams,
+    SessionStreamOpenResult,
+    SessionTranscriptRewriteResult,
+    SkillListResponse,
+    SystemPromptUpdateResult,
+    ToolsRegisterParams,
+    ToolsRegisterResult,
+    UpdateScheduleParams,
+    UpdateSystemPromptParams,
+    WireAuthProfileCleared,
+    WireAuthProfileCreated,
+    WireAuthProfileDetail,
+    WireAuthProfilesList,
+    WireAuthStatusDetail,
+    WireDeviceCompleteResult,
+    WireDeviceStart,
+    WireLoginReady,
+    WireLoginStart,
+    WireProvisionApiKeyResult,
+    WireRealmConnectionSet,
+    WireRealmList,
+    WireRunResult,
+    WireSessionHistory,
+    WireSessionInfo,
+    WireSessionTranscriptRevision,
+    WireSessionTranscriptRevisionList,
+    WorkEventsResult,
+    WorkGraphEventFilter,
+    WorkGraphIdParams,
+    WorkGraphSnapshot,
+    WorkGraphSnapshotFilter,
+    WorkItem,
+    WorkItemFilter,
+    WorkItemsResult,
+)
+
+
+class RpcRequest(Protocol):
+    @overload
+    def __call__(
+        self,
+        method: Literal["initialize"],
+        params: dict[str, Any],
+        /,
+    ) -> Awaitable[ServerCapabilities]: ...
+
+    @overload
+    def __call__(
+        self,
+        method: Literal["tools/register"],
+        params: ToolsRegisterParams,
+        /,
+    ) -> Awaitable[ToolsRegisterResult]: ...
+
+    @overload
+    def __call__(
+        self,
+        method: Literal["jobs/get"],
+        params: JobsGetParams,
+        /,
+    ) -> Awaitable[JobsGetResult]: ...
+
+    @overload
+    def __call__(
+        self,
+        method: Literal["jobs/list"],
+        params: JobsListParams,
+        /,
+    ) -> Awaitable[JobsListResult]: ...
+
+    @overload
+    def __call__(
+        self,
+        method: Literal["jobs/cancel"],
+        params: JobsCancelParams,
+        /,
+    ) -> Awaitable[JobsCancelResult]: ...
+
+    @overload
+    def __call__(
+        self,
+        method: Literal["jobs/progress"],
+        params: JobsProgressParams,
+        /,
+    ) -> Awaitable[JobsProgressResult]: ...
+
+    @overload
+    def __call__(
+        self,
+        method: Literal["jobs/result"],
+        params: JobsResultParams,
+        /,
+    ) -> Awaitable[JobsResultResult]: ...
+
+    @overload
+    def __call__(
+        self,
+        method: Literal["jobs/artifacts"],
+        params: JobsArtifactsParams,
+        /,
+    ) -> Awaitable[JobsArtifactsResult]: ...
+
+    @overload
+    def __call__(
+        self,
+        method: Literal["jobs/retry"],
+        params: JobsRetryParams,
+        /,
+    ) -> Awaitable[JobsRetryResult]: ...
+
+    @overload
+    def __call__(
+        self,
+        method: Literal["jobs/health"],
+        params: dict[str, Any],
+        /,
+    ) -> Awaitable[JobsHealthResult]: ...
+
+    @overload
+    def __call__(
+        self,
+        method: Literal["monitors/start"],
+        params: MonitorsStartParams,
+        /,
+    ) -> Awaitable[MonitorsStartResult]: ...
+
+    @overload
+    def __call__(
+        self,
+        method: Literal["jobs/subscribe"],
+        params: JobsSubscribeParams,
+        /,
+    ) -> Awaitable[JobsSubscribeResult]: ...
+
+    @overload
+    def __call__(
+        self,
+        method: Literal["jobs/unsubscribe"],
+        params: JobsUnsubscribeParams,
+        /,
+    ) -> Awaitable[JobsUnsubscribeResult]: ...
+
+    @overload
+    def __call__(
+        self,
+        method: Literal["mobkit/jobs/heartbeat"],
+        params: MobkitJobHeartbeatParams,
+        /,
+    ) -> Awaitable[MobkitJobMutationResult]: ...
+
+    @overload
+    def __call__(
+        self,
+        method: Literal["mobkit/jobs/progress"],
+        params: MobkitJobProgressParams,
+        /,
+    ) -> Awaitable[MobkitJobMutationResult]: ...
+
+    @overload
+    def __call__(
+        self,
+        method: Literal["mobkit/jobs/checkpoint"],
+        params: MobkitJobCheckpointParams,
+        /,
+    ) -> Awaitable[MobkitJobMutationResult]: ...
+
+    @overload
+    def __call__(
+        self,
+        method: Literal["mobkit/jobs/complete"],
+        params: MobkitJobCompleteParams,
+        /,
+    ) -> Awaitable[MobkitJobMutationResult]: ...
+
+    @overload
+    def __call__(
+        self,
+        method: Literal["mobkit/jobs/fail"],
+        params: MobkitJobFailParams,
+        /,
+    ) -> Awaitable[MobkitJobMutationResult]: ...
+
+    @overload
+    def __call__(
+        self,
+        method: Literal["mobkit/jobs/cancel_ack"],
+        params: MobkitJobCancelAckParams,
+        /,
+    ) -> Awaitable[MobkitJobMutationResult]: ...
+
+    @overload
+    def __call__(
+        self,
+        method: Literal["session/create"],
+        params: dict[str, Any],
+        /,
+    ) -> Awaitable[WireRunResult | DeferredCreateResult]: ...
+
+    @overload
+    def __call__(
+        self,
+        method: Literal["session/list"],
+        params: ListSessionsParams,
+        /,
+    ) -> Awaitable[ListSessionsResult]: ...
+
+    @overload
+    def __call__(
+        self,
+        method: Literal["session/read"],
+        params: ReadSessionParams,
+        /,
+    ) -> Awaitable[WireSessionInfo]: ...
+
+    @overload
+    def __call__(
+        self,
+        method: Literal["session/history"],
+        params: ReadSessionHistoryParams,
+        /,
+    ) -> Awaitable[WireSessionHistory]: ...
+
+    @overload
+    def __call__(
+        self,
+        method: Literal["session/export_atif"],
+        params: ExportAtifParams,
+        /,
+    ) -> Awaitable[Any]: ...
+
+    @overload
+    def __call__(
+        self,
+        method: Literal["session/fork_at"],
+        params: ForkSessionAtParams,
+        /,
+    ) -> Awaitable[SessionForkResult]: ...
+
+    @overload
+    def __call__(
+        self,
+        method: Literal["session/fork_replace"],
+        params: ForkSessionReplaceParams,
+        /,
+    ) -> Awaitable[SessionForkResult]: ...
+
+    @overload
+    def __call__(
+        self,
+        method: Literal["session/rewrite_transcript"],
+        params: RewriteSessionTranscriptParams,
+        /,
+    ) -> Awaitable[SessionTranscriptRewriteResult]: ...
+
+    @overload
+    def __call__(
+        self,
+        method: Literal["session/update_system_prompt"],
+        params: UpdateSystemPromptParams,
+        /,
+    ) -> Awaitable[SystemPromptUpdateResult]: ...
+
+    @overload
+    def __call__(
+        self,
+        method: Literal["session/transcript_revision"],
+        params: ReadSessionTranscriptRevisionParams,
+        /,
+    ) -> Awaitable[WireSessionTranscriptRevision]: ...
+
+    @overload
+    def __call__(
+        self,
+        method: Literal["session/transcript_revisions"],
+        params: ListSessionTranscriptRevisionsParams,
+        /,
+    ) -> Awaitable[WireSessionTranscriptRevisionList]: ...
+
+    @overload
+    def __call__(
+        self,
+        method: Literal["session/restore_transcript_revision"],
+        params: RestoreSessionTranscriptRevisionParams,
+        /,
+    ) -> Awaitable[SessionTranscriptRewriteResult]: ...
+
+    @overload
+    def __call__(
+        self,
+        method: Literal["session/archive"],
+        params: ArchiveSessionParams,
+        /,
+    ) -> Awaitable[Any]: ...
+
+    @overload
+    def __call__(
+        self,
+        method: Literal["turn/start"],
+        params: dict[str, Any],
+        /,
+    ) -> Awaitable[WireRunResult]: ...
+
+    @overload
+    def __call__(
+        self,
+        method: Literal["turn/interrupt"],
+        params: InterruptParams,
+        /,
+    ) -> Awaitable[InterruptResult]: ...
+
+    @overload
+    def __call__(
+        self,
+        method: Literal["config/get"],
+        params: dict[str, Any],
+        /,
+    ) -> Awaitable[ConfigEnvelope]: ...
+
+    @overload
+    def __call__(
+        self,
+        method: Literal["config/set"],
+        params: ConfigSetParams,
+        /,
+    ) -> Awaitable[ConfigWriteResult]: ...
+
+    @overload
+    def __call__(
+        self,
+        method: Literal["config/patch"],
+        params: ConfigPatchParams,
+        /,
+    ) -> Awaitable[ConfigWriteResult]: ...
+
+    @overload
+    def __call__(
+        self,
+        method: Literal["capabilities/get"],
+        params: dict[str, Any],
+        /,
+    ) -> Awaitable[CapabilitiesResponse]: ...
+
+    @overload
+    def __call__(
+        self,
+        method: Literal["runtime/host_info"],
+        params: dict[str, Any],
+        /,
+    ) -> Awaitable[RuntimeHostInfo]: ...
+
+    @overload
+    def __call__(
+        self,
+        method: Literal["runtime/capabilities"],
+        params: dict[str, Any],
+        /,
+    ) -> Awaitable[RuntimeHostCapabilities]: ...
+
+    @overload
+    def __call__(
+        self,
+        method: Literal["runtime/health"],
+        params: dict[str, Any],
+        /,
+    ) -> Awaitable[RuntimeHostHealth]: ...
+
+    @overload
+    def __call__(
+        self,
+        method: Literal["approval/request"],
+        params: ApprovalRequestParams,
+        /,
+    ) -> Awaitable[ApprovalRecord]: ...
+
+    @overload
+    def __call__(
+        self,
+        method: Literal["approval/list"],
+        params: ApprovalListParams,
+        /,
+    ) -> Awaitable[ApprovalListResult]: ...
+
+    @overload
+    def __call__(
+        self,
+        method: Literal["approval/get"],
+        params: ApprovalGetParams,
+        /,
+    ) -> Awaitable[ApprovalRecord]: ...
+
+    @overload
+    def __call__(
+        self,
+        method: Literal["approval/decide"],
+        params: ApprovalDecideParams,
+        /,
+    ) -> Awaitable[ApprovalRecord]: ...
+
+    @overload
+    def __call__(
+        self,
+        method: Literal["models/catalog"],
+        params: dict[str, Any],
+        /,
+    ) -> Awaitable[ModelsCatalogResponse]: ...
+
+    @overload
+    def __call__(
+        self,
+        method: Literal["auth/profile/list"],
+        params: RealmIdParams,
+        /,
+    ) -> Awaitable[WireAuthProfilesList]: ...
+
+    @overload
+    def __call__(
+        self,
+        method: Literal["auth/profile/get"],
+        params: BindingIdParams,
+        /,
+    ) -> Awaitable[WireAuthProfileDetail]: ...
+
+    @overload
+    def __call__(
+        self,
+        method: Literal["auth/profile/create"],
+        params: CreateProfileParams,
+        /,
+    ) -> Awaitable[WireAuthProfileCreated]: ...
+
+    @overload
+    def __call__(
+        self,
+        method: Literal["auth/profile/delete"],
+        params: BindingIdParams,
+        /,
+    ) -> Awaitable[WireAuthProfileCleared]: ...
+
+    @overload
+    def __call__(
+        self,
+        method: Literal["auth/login/start"],
+        params: LoginStartParams,
+        /,
+    ) -> Awaitable[WireLoginStart]: ...
+
+    @overload
+    def __call__(
+        self,
+        method: Literal["auth/login/complete"],
+        params: LoginCompleteParams,
+        /,
+    ) -> Awaitable[WireLoginReady]: ...
+
+    @overload
+    def __call__(
+        self,
+        method: Literal["auth/login/device_start"],
+        params: DeviceStartParams,
+        /,
+    ) -> Awaitable[WireDeviceStart]: ...
+
+    @overload
+    def __call__(
+        self,
+        method: Literal["auth/login/device_complete"],
+        params: DeviceCompleteParams,
+        /,
+    ) -> Awaitable[WireDeviceCompleteResult]: ...
+
+    @overload
+    def __call__(
+        self,
+        method: Literal["auth/login/provision_api_key"],
+        params: ProvisionApiKeyParams,
+        /,
+    ) -> Awaitable[WireProvisionApiKeyResult]: ...
+
+    @overload
+    def __call__(
+        self,
+        method: Literal["auth/status/get"],
+        params: BindingIdParams,
+        /,
+    ) -> Awaitable[WireAuthStatusDetail]: ...
+
+    @overload
+    def __call__(
+        self,
+        method: Literal["auth/logout"],
+        params: BindingIdParams,
+        /,
+    ) -> Awaitable[WireAuthProfileCleared]: ...
+
+    @overload
+    def __call__(
+        self,
+        method: Literal["realm/list"],
+        params: dict[str, Any],
+        /,
+    ) -> Awaitable[WireRealmList]: ...
+
+    @overload
+    def __call__(
+        self,
+        method: Literal["realm/get"],
+        params: RealmIdParams,
+        /,
+    ) -> Awaitable[WireRealmConnectionSet]: ...
+
+    @overload
+    def __call__(
+        self,
+        method: Literal["help/ask"],
+        params: HelpRequest,
+        /,
+    ) -> Awaitable[HelpResponse]: ...
+
+    @overload
+    def __call__(
+        self,
+        method: Literal["blob/get"],
+        params: BlobGetParams,
+        /,
+    ) -> Awaitable[BlobPayload]: ...
+
+    @overload
+    def __call__(
+        self,
+        method: Literal["artifact/list"],
+        params: ArtifactListParams,
+        /,
+    ) -> Awaitable[ArtifactListResult]: ...
+
+    @overload
+    def __call__(
+        self,
+        method: Literal["artifact/get"],
+        params: ArtifactIdParams,
+        /,
+    ) -> Awaitable[ArtifactRecord]: ...
+
+    @overload
+    def __call__(
+        self,
+        method: Literal["artifact/download"],
+        params: ArtifactDownloadParams,
+        /,
+    ) -> Awaitable[ArtifactDownloadResult]: ...
+
+    @overload
+    def __call__(
+        self,
+        method: Literal["session/external_event"],
+        params: SessionExternalEventParams,
+        /,
+    ) -> Awaitable[RuntimeAcceptResult]: ...
+
+    @overload
+    def __call__(
+        self,
+        method: Literal["session/peer_response_terminal"],
+        params: SessionPeerResponseTerminalParams,
+        /,
+    ) -> Awaitable[RuntimeAcceptResult]: ...
+
+    @overload
+    def __call__(
+        self,
+        method: Literal["session/inject_context"],
+        params: InjectSystemContextParams,
+        /,
+    ) -> Awaitable[InjectSystemContextResult]: ...
+
+    @overload
+    def __call__(
+        self,
+        method: Literal["session/input_status"],
+        params: SessionInputStateParams,
+        /,
+    ) -> Awaitable[SessionInputStateResult]: ...
+
+    @overload
+    def __call__(
+        self,
+        method: Literal["events/latest_cursor"],
+        params: EventsLatestCursorParams,
+        /,
+    ) -> Awaitable[EventsLatestCursorResult]: ...
+
+    @overload
+    def __call__(
+        self,
+        method: Literal["events/list_since"],
+        params: EventsListSinceParams,
+        /,
+    ) -> Awaitable[EventsListSinceResult]: ...
+
+    @overload
+    def __call__(
+        self,
+        method: Literal["events/snapshot"],
+        params: EventsSnapshotParams,
+        /,
+    ) -> Awaitable[EventsSnapshotResult]: ...
+
+    @overload
+    def __call__(
+        self,
+        method: Literal["session/stream_open"],
+        params: SessionStreamOpenParams,
+        /,
+    ) -> Awaitable[SessionStreamOpenResult]: ...
+
+    @overload
+    def __call__(
+        self,
+        method: Literal["session/stream_close"],
+        params: SessionStreamCloseParams,
+        /,
+    ) -> Awaitable[SessionStreamCloseResult]: ...
+
+    @overload
+    def __call__(
+        self,
+        method: Literal["schedule/create"],
+        params: CreateScheduleRequest,
+        /,
+    ) -> Awaitable[Schedule]: ...
+
+    @overload
+    def __call__(
+        self,
+        method: Literal["schedule/get"],
+        params: ScheduleIdParams,
+        /,
+    ) -> Awaitable[Schedule]: ...
+
+    @overload
+    def __call__(
+        self,
+        method: Literal["schedule/list"],
+        params: ListSchedulesParams,
+        /,
+    ) -> Awaitable[ScheduleListResult]: ...
+
+    @overload
+    def __call__(
+        self,
+        method: Literal["schedule/update"],
+        params: UpdateScheduleParams,
+        /,
+    ) -> Awaitable[Schedule]: ...
+
+    @overload
+    def __call__(
+        self,
+        method: Literal["schedule/pause"],
+        params: ScheduleIdParams,
+        /,
+    ) -> Awaitable[Schedule]: ...
+
+    @overload
+    def __call__(
+        self,
+        method: Literal["schedule/resume"],
+        params: ScheduleIdParams,
+        /,
+    ) -> Awaitable[Schedule]: ...
+
+    @overload
+    def __call__(
+        self,
+        method: Literal["schedule/delete"],
+        params: ScheduleIdParams,
+        /,
+    ) -> Awaitable[Schedule]: ...
+
+    @overload
+    def __call__(
+        self,
+        method: Literal["schedule/occurrences"],
+        params: ScheduleOccurrencesParams,
+        /,
+    ) -> Awaitable[ScheduleOccurrencesResult]: ...
+
+    @overload
+    def __call__(
+        self,
+        method: Literal["schedule/tools"],
+        params: dict[str, Any],
+        /,
+    ) -> Awaitable[ScheduleToolsResult]: ...
+
+    @overload
+    def __call__(
+        self,
+        method: Literal["schedule/call"],
+        params: ScheduleToolCallParams,
+        /,
+    ) -> Awaitable[Any]: ...
+
+    @overload
+    def __call__(
+        self,
+        method: Literal["workgraph/get"],
+        params: WorkGraphIdParams,
+        /,
+    ) -> Awaitable[WorkItem]: ...
+
+    @overload
+    def __call__(
+        self,
+        method: Literal["workgraph/list"],
+        params: WorkItemFilter,
+        /,
+    ) -> Awaitable[WorkItemsResult]: ...
+
+    @overload
+    def __call__(
+        self,
+        method: Literal["workgraph/ready"],
+        params: ReadyWorkFilter,
+        /,
+    ) -> Awaitable[WorkItemsResult]: ...
+
+    @overload
+    def __call__(
+        self,
+        method: Literal["workgraph/snapshot"],
+        params: WorkGraphSnapshotFilter,
+        /,
+    ) -> Awaitable[WorkGraphSnapshot]: ...
+
+    @overload
+    def __call__(
+        self,
+        method: Literal["workgraph/events"],
+        params: WorkGraphEventFilter,
+        /,
+    ) -> Awaitable[WorkEventsResult]: ...
+
+    @overload
+    def __call__(
+        self,
+        method: Literal["workgraph/goal/status"],
+        params: GoalStatusRequest,
+        /,
+    ) -> Awaitable[GoalStatusResult]: ...
+
+    @overload
+    def __call__(
+        self,
+        method: Literal["workgraph/attention/list"],
+        params: AttentionListRequest,
+        /,
+    ) -> Awaitable[AttentionListResult]: ...
+
+    @overload
+    def __call__(
+        self,
+        method: Literal["skills/list"],
+        params: dict[str, Any],
+        /,
+    ) -> Awaitable[SkillListResponse]: ...
+
+    @overload
+    def __call__(
+        self,
+        method: Literal["live/open"],
+        params: LiveOpenParams,
+        /,
+    ) -> Awaitable[LiveOpenResult]: ...
+
+    @overload
+    def __call__(
+        self,
+        method: Literal["live/status"],
+        params: LiveChannelParams,
+        /,
+    ) -> Awaitable[LiveStatusResult]: ...
+
+    @overload
+    def __call__(
+        self,
+        method: Literal["live/close"],
+        params: LiveChannelParams,
+        /,
+    ) -> Awaitable[LiveCloseResult]: ...
+
+    @overload
+    def __call__(
+        self,
+        method: Literal["live/send_input"],
+        params: LiveSendInputParams,
+        /,
+    ) -> Awaitable[LiveSendInputResult]: ...
+
+    @overload
+    def __call__(
+        self,
+        method: Literal["live/commit_input"],
+        params: LiveCommitInputParams,
+        /,
+    ) -> Awaitable[LiveCommitInputResult]: ...
+
+    @overload
+    def __call__(
+        self,
+        method: Literal["live/interrupt"],
+        params: LiveChannelParams,
+        /,
+    ) -> Awaitable[LiveInterruptResult]: ...
+
+    @overload
+    def __call__(
+        self,
+        method: Literal["live/truncate"],
+        params: LiveTruncateParams,
+        /,
+    ) -> Awaitable[LiveTruncateResult]: ...
+
+    @overload
+    def __call__(
+        self,
+        method: Literal["live/refresh"],
+        params: LiveChannelParams,
+        /,
+    ) -> Awaitable[LiveRefreshResult]: ...
+
+    @overload
+    def __call__(
+        self,
+        method: Literal["live/webrtc/answer"],
+        params: LiveWebrtcAnswerParams,
+        /,
+    ) -> Awaitable[LiveWebrtcAnswerResult]: ...
+
+    @overload
+    def __call__(
+        self,
+        method: Literal["mob/create"],
+        params: MobCreateParams,
+        /,
+    ) -> Awaitable[MobCreateResult]: ...
+
+    @overload
+    def __call__(
+        self,
+        method: Literal["mob/list"],
+        params: dict[str, Any],
+        /,
+    ) -> Awaitable[MobListResult]: ...
+
+    @overload
+    def __call__(
+        self,
+        method: Literal["mob/status"],
+        params: MobIdParams,
+        /,
+    ) -> Awaitable[MobStatusResult]: ...
+
+    @overload
+    def __call__(
+        self,
+        method: Literal["mob/lifecycle"],
+        params: MobLifecycleParams,
+        /,
+    ) -> Awaitable[MobLifecycleResult]: ...
+
+    @overload
+    def __call__(
+        self,
+        method: Literal["mob/spawn"],
+        params: MobSpawnParams,
+        /,
+    ) -> Awaitable[MobSpawnResult]: ...
+
+    @overload
+    def __call__(
+        self,
+        method: Literal["mob/spawn_many"],
+        params: MobSpawnManyParams,
+        /,
+    ) -> Awaitable[MobSpawnManyResult]: ...
+
+    @overload
+    def __call__(
+        self,
+        method: Literal["mob/ensure_member"],
+        params: MobEnsureMemberParams,
+        /,
+    ) -> Awaitable[MobEnsureMemberResult]: ...
+
+    @overload
+    def __call__(
+        self,
+        method: Literal["mob/reconcile"],
+        params: MobReconcileParams,
+        /,
+    ) -> Awaitable[MobReconcileResult]: ...
+
+    @overload
+    def __call__(
+        self,
+        method: Literal["mob/list_members_matching"],
+        params: MobListMembersMatchingParams,
+        /,
+    ) -> Awaitable[MobListMembersMatchingResult]: ...
+
+    @overload
+    def __call__(
+        self,
+        method: Literal["mob/retire"],
+        params: MobMemberParams,
+        /,
+    ) -> Awaitable[MobRetireResult]: ...
+
+    @overload
+    def __call__(
+        self,
+        method: Literal["mob/respawn"],
+        params: MobRespawnParams,
+        /,
+    ) -> Awaitable[MobRespawnResult]: ...
+
+    @overload
+    def __call__(
+        self,
+        method: Literal["mob/wire"],
+        params: MobWireParams,
+        /,
+    ) -> Awaitable[MobWireResult]: ...
+
+    @overload
+    def __call__(
+        self,
+        method: Literal["mob/wire_members_batch"],
+        params: MobWireMembersBatchParams,
+        /,
+    ) -> Awaitable[MobWireMembersBatchResult]: ...
+
+    @overload
+    def __call__(
+        self,
+        method: Literal["mob/unwire"],
+        params: MobUnwireParams,
+        /,
+    ) -> Awaitable[MobUnwireResult]: ...
+
+    @overload
+    def __call__(
+        self,
+        method: Literal["mob/members"],
+        params: MobIdParams,
+        /,
+    ) -> Awaitable[MobMembersResult]: ...
+
+    @overload
+    def __call__(
+        self,
+        method: Literal["mob/events"],
+        params: MobEventsParams,
+        /,
+    ) -> Awaitable[MobEventsResult]: ...
+
+    @overload
+    def __call__(
+        self,
+        method: Literal["mob/member_send"],
+        params: MobMemberSendParams,
+        /,
+    ) -> Awaitable[MobMemberSendResult]: ...
+
+    @overload
+    def __call__(
+        self,
+        method: Literal["mob/ingress_interaction"],
+        params: MobIngressInteractionParams,
+        /,
+    ) -> Awaitable[MobIngressInteractionResult]: ...
+
+    @overload
+    def __call__(
+        self,
+        method: Literal["mob/append_system_context"],
+        params: MobAppendSystemContextParams,
+        /,
+    ) -> Awaitable[MobAppendSystemContextResult]: ...
+
+    @overload
+    def __call__(
+        self,
+        method: Literal["mob/flows"],
+        params: MobIdParams,
+        /,
+    ) -> Awaitable[MobFlowsResult]: ...
+
+    @overload
+    def __call__(
+        self,
+        method: Literal["mob/flow_run"],
+        params: MobFlowRunParams,
+        /,
+    ) -> Awaitable[MobFlowRunResult]: ...
+
+    @overload
+    def __call__(
+        self,
+        method: Literal["mob/run"],
+        params: MobRunParams,
+        /,
+    ) -> Awaitable[MobFlowRunResult]: ...
+
+    @overload
+    def __call__(
+        self,
+        method: Literal["mob/flow_status"],
+        params: MobFlowStatusParams,
+        /,
+    ) -> Awaitable[MobFlowStatusResult]: ...
+
+    @overload
+    def __call__(
+        self,
+        method: Literal["mob/run_result"],
+        params: MobRunResultParams,
+        /,
+    ) -> Awaitable[MobRunResult]: ...
+
+    @overload
+    def __call__(
+        self,
+        method: Literal["mob/flow_cancel"],
+        params: MobFlowCancelParams,
+        /,
+    ) -> Awaitable[MobFlowCancelResult]: ...
+
+    @overload
+    def __call__(
+        self,
+        method: Literal["mob/spawn_helper"],
+        params: MobSpawnHelperParams,
+        /,
+    ) -> Awaitable[MobHelperResult]: ...
+
+    @overload
+    def __call__(
+        self,
+        method: Literal["mob/fork_helper"],
+        params: MobForkHelperParams,
+        /,
+    ) -> Awaitable[MobHelperResult]: ...
+
+    @overload
+    def __call__(
+        self,
+        method: Literal["mob/force_cancel"],
+        params: MobMemberParams,
+        /,
+    ) -> Awaitable[MobForceCancelResult]: ...
+
+    @overload
+    def __call__(
+        self,
+        method: Literal["mob/turn_start"],
+        params: MobTurnStartParams,
+        /,
+    ) -> Awaitable[WireRunResult]: ...
+
+    @overload
+    def __call__(
+        self,
+        method: Literal["mob/member_status"],
+        params: MobMemberParams,
+        /,
+    ) -> Awaitable[MobMemberStatusResult]: ...
+
+    @overload
+    def __call__(
+        self,
+        method: Literal["mob/snapshot"],
+        params: MobIdParams,
+        /,
+    ) -> Awaitable[MobSnapshotResult]: ...
+
+    @overload
+    def __call__(
+        self,
+        method: Literal["mob/destroy"],
+        params: MobIdParams,
+        /,
+    ) -> Awaitable[MobDestroyResult]: ...
+
+    @overload
+    def __call__(
+        self,
+        method: Literal["mob/rotate_supervisor"],
+        params: MobIdParams,
+        /,
+    ) -> Awaitable[MobRotateSupervisorResult]: ...
+
+    @overload
+    def __call__(
+        self,
+        method: Literal["mob/submit_work"],
+        params: MobSubmitWorkParams,
+        /,
+    ) -> Awaitable[MobSubmitWorkResult]: ...
+
+    @overload
+    def __call__(
+        self,
+        method: Literal["mob/conclude_objective"],
+        params: MobConcludeObjectiveParams,
+        /,
+    ) -> Awaitable[MobConcludeObjectiveResult]: ...
+
+    @overload
+    def __call__(
+        self,
+        method: Literal["mob/cancel_work"],
+        params: MobCancelWorkParams,
+        /,
+    ) -> Awaitable[MobCancelWorkResult]: ...
+
+    @overload
+    def __call__(
+        self,
+        method: Literal["mob/cancel_all_work"],
+        params: MobCancelAllWorkParams,
+        /,
+    ) -> Awaitable[MobCancelAllWorkResult]: ...
+
+    @overload
+    def __call__(
+        self,
+        method: Literal["mob/wait_kickoff"],
+        params: MobWaitParams,
+        /,
+    ) -> Awaitable[MobWaitMembersResult]: ...
+
+    @overload
+    def __call__(
+        self,
+        method: Literal["mob/wait_ready"],
+        params: MobWaitParams,
+        /,
+    ) -> Awaitable[MobWaitMembersResult]: ...
+
+    @overload
+    def __call__(
+        self,
+        method: Literal["mob/profile/create"],
+        params: MobProfileCreateParams,
+        /,
+    ) -> Awaitable[MobProfileLookupResult]: ...
+
+    @overload
+    def __call__(
+        self,
+        method: Literal["mob/profile/get"],
+        params: MobProfileNameParams,
+        /,
+    ) -> Awaitable[MobProfileLookupResult]: ...
+
+    @overload
+    def __call__(
+        self,
+        method: Literal["mob/profile/list"],
+        params: dict[str, Any],
+        /,
+    ) -> Awaitable[MobProfileListResult]: ...
+
+    @overload
+    def __call__(
+        self,
+        method: Literal["mob/profile/update"],
+        params: MobProfileUpdateParams,
+        /,
+    ) -> Awaitable[MobProfileLookupResult]: ...
+
+    @overload
+    def __call__(
+        self,
+        method: Literal["mob/profile/delete"],
+        params: MobProfileDeleteParams,
+        /,
+    ) -> Awaitable[MobProfileDeleteResult]: ...
+
+    @overload
+    def __call__(
+        self,
+        method: Literal["mob/stream_open"],
+        params: MobStreamOpenParams,
+        /,
+    ) -> Awaitable[MobStreamOpenResult]: ...
+
+    @overload
+    def __call__(
+        self,
+        method: Literal["mob/stream_close"],
+        params: MobStreamCloseParams,
+        /,
+    ) -> Awaitable[MobStreamCloseResult]: ...
+
+    @overload
+    def __call__(
+        self,
+        method: Literal["mob/grant_scopes"],
+        params: MobGrantScopesParams,
+        /,
+    ) -> Awaitable[MobGrantScopesResult]: ...
+
+    @overload
+    def __call__(
+        self,
+        method: Literal["mob/revoke_scopes"],
+        params: MobRevokeScopesParams,
+        /,
+    ) -> Awaitable[MobRevokeScopesResult]: ...
+
+    @overload
+    def __call__(
+        self,
+        method: Literal["mob/grants"],
+        params: MobIdParams,
+        /,
+    ) -> Awaitable[MobGrantsResult]: ...
+
+    @overload
+    def __call__(
+        self,
+        method: Literal["mob/member_history"],
+        params: MobMemberHistoryParams,
+        /,
+    ) -> Awaitable[MobMemberHistoryResult]: ...
+
+    @overload
+    def __call__(
+        self,
+        method: Literal["mob/hosts"],
+        params: MobIdParams,
+        /,
+    ) -> Awaitable[MobHostsResult]: ...
+
+    @overload
+    def __call__(
+        self,
+        method: Literal["mob/route_installs"],
+        params: MobIdParams,
+        /,
+    ) -> Awaitable[MobRouteInstallsResult]: ...
+
+    @overload
+    def __call__(
+        self,
+        method: Literal["mob/bind_host"],
+        params: MobBindHostParams,
+        /,
+    ) -> Awaitable[MobBindHostResult]: ...
+
+    @overload
+    def __call__(
+        self,
+        method: Literal["mob/revoke_host"],
+        params: MobRevokeHostParams,
+        /,
+    ) -> Awaitable[MobRevokeHostResult]: ...
+
+    @overload
+    def __call__(
+        self,
+        method: Literal["mob/hard_cancel_member"],
+        params: MobHardCancelParams,
+        /,
+    ) -> Awaitable[MobHardCancelResult]: ...
+
+    @overload
+    def __call__(
+        self,
+        method: Literal["mob/member_live_open"],
+        params: MobMemberLiveOpenParams,
+        /,
+    ) -> Awaitable[LiveOpenResult]: ...
+
+    @overload
+    def __call__(
+        self,
+        method: Literal["mob/member_live_close"],
+        params: MobMemberLiveChannelParams,
+        /,
+    ) -> Awaitable[LiveCloseResult]: ...
+
+    @overload
+    def __call__(
+        self,
+        method: Literal["mob/member_live_status"],
+        params: MobMemberLiveStatusParams,
+        /,
+    ) -> Awaitable[LiveStatusResult]: ...
+
+    @overload
+    def __call__(
+        self,
+        method: Literal["mob/member_live_control"],
+        params: MobMemberLiveControlParams,
+        /,
+    ) -> Awaitable[BridgeLiveControlOutcome]: ...
+
+    @overload
+    def __call__(
+        self,
+        method: Literal["mcp/add"],
+        params: McpAddParams,
+        /,
+    ) -> Awaitable[McpLiveOpResponse]: ...
+
+    @overload
+    def __call__(
+        self,
+        method: Literal["mcp/remove"],
+        params: McpRemoveParams,
+        /,
+    ) -> Awaitable[McpLiveOpResponse]: ...
+
+    @overload
+    def __call__(
+        self,
+        method: Literal["mcp/reload"],
+        params: McpReloadParams,
+        /,
+    ) -> Awaitable[McpLiveOpResponse]: ...
+
+    @overload
+    def __call__(
+        self,
+        method: Literal["comms/send"],
+        params: CommsSendParams,
+        /,
+    ) -> Awaitable[CommsSendResult]: ...
+
+    @overload
+    def __call__(
+        self,
+        method: Literal["comms/peers"],
+        params: CommsPeersParams,
+        /,
+    ) -> Awaitable[CommsPeersResult]: ...

--- a/sdks/python/meerkat/generated/types.py
+++ b/sdks/python/meerkat/generated/types.py
@@ -518,6 +518,30 @@ class SessionExternalEventEnvelopePeerResponseTerminal(TypedDict, total=False):
 
 SessionExternalEventEnvelope = SessionExternalEventEnvelopeGenericJson | SessionExternalEventEnvelopePeerResponseTerminal
 
+# Complete request payload for `session/external_event`.
+#
+# The event envelope is flattened on the wire, but the session selector is
+# part of the RPC method contract and must therefore be present in the
+# catalogued params type rather than supplied by an undocumented wrapper
+# extension.
+class SessionExternalEventParamsGenericJson(TypedDict, total=False):
+    session_id: Required[str]
+    blocks: NotRequired[Optional[list[WireContentBlock]]]
+    event_type: Required[str]
+    kind: Required[Literal['generic_json']]
+    payload: Required[Any]
+
+class SessionExternalEventParamsPeerResponseTerminal(TypedDict, total=False):
+    session_id: Required[str]
+    display_name: NotRequired[Optional[PeerName]]
+    kind: Required[Literal['peer_response_terminal']]
+    peer_id: Required[PeerId]
+    request_id: Required[str]
+    result: Required[Any]
+    status: Required[Literal['completed', 'failed', 'cancelled']]
+
+SessionExternalEventParams = SessionExternalEventParamsGenericJson | SessionExternalEventParamsPeerResponseTerminal
+
 # `auth/login/device_complete` success body.
 class WireDeviceCompleteResultPending(TypedDict, total=False):
     state: Required[Literal['pending']]

--- a/sdks/typescript/src/client.ts
+++ b/sdks/typescript/src/client.ts
@@ -46,6 +46,10 @@ import {
   meerkatErrorFromJsonRpcCode,
 } from "./generated/errors.js";
 import { isCompatibleWith } from "./generated/version_compat.js";
+import type {
+  RpcMethodContracts,
+  RpcMethodName,
+} from "./generated/rpc_contracts.js";
 import {
   CONTRACT_VERSION,
   type CallbackToolDefinition,
@@ -221,7 +225,7 @@ import type {
   Schedule as RpcSchedule,
   ScheduleToolCallParams as RpcScheduleToolCallParams,
   ScheduleToolsResult as RpcScheduleToolsResult,
-  SessionExternalEventEnvelope as RpcSessionExternalEventEnvelope,
+  SessionExternalEventParams as RpcSessionExternalEventParams,
   SessionForkResult as RpcSessionForkResult,
   SessionPeerResponseTerminalParams as RpcSessionPeerResponseTerminalParams,
   SessionTranscriptRewriteResult as RpcSessionTranscriptRewriteResult,
@@ -232,6 +236,104 @@ import type {
   WireRunResult as RpcWireRunResult,
   WireSessionTranscriptRevision as RpcWireSessionTranscriptRevision,
   WireSessionTranscriptRevisionList as RpcWireSessionTranscriptRevisionList,
+  CommsPeersParams as RpcCommsPeersParams,
+  CommsSendParams as RpcCommsSendParams,
+  ListSchedulesParams as RpcListSchedulesParams,
+  MobAppendSystemContextParams as RpcMobAppendSystemContextParams,
+  MobAppendSystemContextResult as RpcMobAppendSystemContextResult,
+  MobCancelAllWorkParams as RpcMobCancelAllWorkParams,
+  MobCancelAllWorkResult as RpcMobCancelAllWorkResult,
+  MobCancelWorkParams as RpcMobCancelWorkParams,
+  MobCancelWorkResult as RpcMobCancelWorkResult,
+  MobCreateParams as RpcMobCreateParams,
+  MobCreateResult as RpcMobCreateResult,
+  MobDestroyResult as RpcMobDestroyResult,
+  MobEnsureMemberParams as RpcMobEnsureMemberParams,
+  MobEnsureMemberResult as RpcMobEnsureMemberResult,
+  MobEventsParams as RpcMobEventsParams,
+  MobEventsResult as RpcMobEventsResult,
+  MobFlowCancelParams as RpcMobFlowCancelParams,
+  MobFlowCancelResult as RpcMobFlowCancelResult,
+  MobFlowRunParams as RpcMobFlowRunParams,
+  MobFlowStatusParams as RpcMobFlowStatusParams,
+  MobFlowsResult as RpcMobFlowsResult,
+  MobForceCancelResult as RpcMobForceCancelResult,
+  MobForkHelperParams as RpcMobForkHelperParams,
+  MobHelperResult as RpcMobHelperResult,
+  MobIngressInteractionParams as RpcMobIngressInteractionParams,
+  MobIngressInteractionResult as RpcMobIngressInteractionResult,
+  MobLifecycleParams as RpcMobLifecycleParams,
+  MobLifecycleResult as RpcMobLifecycleResult,
+  MobListMembersMatchingParams as RpcMobListMembersMatchingParams,
+  MobListMembersMatchingResult as RpcMobListMembersMatchingResult,
+  MobListResult as RpcMobListResult,
+  MobMemberSendParams as RpcMobMemberSendParams,
+  MobMemberSendResult as RpcMobMemberSendResult,
+  MobMembersResult as RpcMobMembersResult,
+  MobProfileCreateParams as RpcMobProfileCreateParams,
+  MobProfileDeleteParams as RpcMobProfileDeleteParams,
+  MobProfileDeleteResult as RpcMobProfileDeleteResult,
+  MobProfileListResult as RpcMobProfileListResult,
+  MobProfileLookupResult as RpcMobProfileLookupResult,
+  MobProfileNameParams as RpcMobProfileNameParams,
+  MobProfileUpdateParams as RpcMobProfileUpdateParams,
+  MobReconcileParams as RpcMobReconcileParams,
+  MobReconcileResult as RpcMobReconcileResult,
+  MobRespawnParams as RpcMobRespawnParams,
+  MobRespawnResult as RpcMobRespawnResult,
+  MobRetireResult as RpcMobRetireResult,
+  MobSnapshotResult as RpcMobSnapshotResult,
+  MobSpawnHelperParams as RpcMobSpawnHelperParams,
+  MobSpawnParams as RpcMobSpawnParams,
+  MobSpawnResult as RpcMobSpawnResult,
+  MobStatusResult as RpcMobStatusResult,
+  MobStreamCloseParams as RpcMobStreamCloseParams,
+  MobStreamCloseResult as RpcMobStreamCloseResult,
+  MobStreamOpenParams as RpcMobStreamOpenParams,
+  MobStreamOpenResult as RpcMobStreamOpenResult,
+  MobSubmitWorkParams as RpcMobSubmitWorkParams,
+  MobSubmitWorkResult as RpcMobSubmitWorkResult,
+  MobUnwireParams as RpcMobUnwireParams,
+  MobUnwireResult as RpcMobUnwireResult,
+  MobWaitMembersResult as RpcMobWaitMembersResult,
+  MobWaitParams as RpcMobWaitParams,
+  MobWireMembersBatchParams as RpcMobWireMembersBatchParams,
+  MobWireMembersBatchResult as RpcMobWireMembersBatchResult,
+  MobWireParams as RpcMobWireParams,
+  MobWireResult as RpcMobWireResult,
+  ModelsCatalogResponse as RpcModelsCatalogResponse,
+  RuntimeAcceptResult as RpcRuntimeAcceptResult,
+  ScheduleIdParams as RpcScheduleIdParams,
+  ScheduleListResult as RpcScheduleListResult,
+  ScheduleOccurrencesParams as RpcScheduleOccurrencesParams,
+  ScheduleOccurrencesResult as RpcScheduleOccurrencesResult,
+  SessionStreamCloseParams as RpcSessionStreamCloseParams,
+  SessionStreamCloseResult as RpcSessionStreamCloseResult,
+  SessionStreamOpenParams as RpcSessionStreamOpenParams,
+  SessionStreamOpenResult as RpcSessionStreamOpenResult,
+  UpdateScheduleParams as RpcUpdateScheduleParams,
+  WireAuthProfileCleared as RpcWireAuthProfileCleared,
+  WireAuthProfileCreated as RpcWireAuthProfileCreated,
+  WireAuthProfileDetail as RpcWireAuthProfileDetail,
+  WireAuthProfilesList as RpcWireAuthProfilesList,
+  WireAuthStatusDetail as RpcWireAuthStatusDetail,
+  WireDeviceStart as RpcWireDeviceStart,
+  WireLoginReady as RpcWireLoginReady,
+  WireLoginStart as RpcWireLoginStart,
+  WireRealmConnectionSet as RpcWireRealmConnectionSet,
+  WireRealmList as RpcWireRealmList,
+  WireSessionHistory as RpcWireSessionHistory,
+  WireSessionInfo as RpcWireSessionInfo,
+  WireContentBlock as RpcWireContentBlock,
+  WireContentInput as RpcWireContentInput,
+  WireTranscriptReplacement as RpcWireTranscriptReplacement,
+  TranscriptRewriteMessage as RpcTranscriptRewriteMessage,
+  MobProfileInput as RpcMobProfileInput,
+  MobDefinitionInput as RpcMobDefinitionInput,
+  MobMemberSpecWire as RpcMobMemberSpecWire,
+  MobReconcileOptionsWire as RpcMobReconcileOptionsWire,
+  ContentBlock as RpcCommsContentBlock,
+  CommsPeerRequestParams as RpcCommsPeerRequestParams,
 } from "./generated/types.js";
 import { DeferredSession, Session } from "./session.js";
 import {
@@ -502,8 +604,123 @@ function setIfDefined<T extends object, K extends keyof T>(
   }
 }
 
-function mobSpawnPayload(mobId: string, spec: SpawnSpec): Record<string, unknown> {
-  const payload: Record<string, unknown> = {
+function toWireContentBlock(
+  block: ContentBlock,
+): RpcWireContentBlock & RpcCommsContentBlock {
+  if (block.type === "text") return block;
+  if (block.type === "image") {
+    return block.source === "blob"
+      ? block
+      : { ...block, source: "inline" };
+  }
+  return block.source === "uri"
+    ? block
+    : { ...block, source: "inline" };
+}
+
+function toWireContentInput(
+  content: string | readonly ContentBlock[],
+): RpcWireContentInput {
+  return typeof content === "string"
+    ? content
+    : content.map(toWireContentBlock);
+}
+
+type DeepMutable<T> = T extends readonly (infer Item)[]
+  ? DeepMutable<Item>[]
+  : T extends object
+    ? { -readonly [Key in keyof T]: DeepMutable<T[Key]> }
+    : T;
+
+function toMutableWire<T>(value: T): DeepMutable<T> {
+  if (Array.isArray(value)) {
+    return value.map((item) => toMutableWire(item)) as DeepMutable<T>;
+  }
+  if (value !== null && typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value).map(([key, item]) => [key, toMutableWire(item)]),
+    ) as DeepMutable<T>;
+  }
+  return value as DeepMutable<T>;
+}
+
+function toWirePeerRequestParams(
+  params: Extract<CommsCommand, { kind: "peer_request" }>["params"],
+): RpcCommsPeerRequestParams {
+  const mutable = toMutableWire(params);
+  if (
+    !("command" in params) ||
+    params.command !== "deliver_member_input"
+  ) {
+    return mutable as RpcCommsPeerRequestParams;
+  }
+  return {
+    ...mutable,
+    content: toWireContentInput(params.content),
+    injected_context: params.injected_context?.map(toWireContentInput),
+  } as RpcCommsPeerRequestParams;
+}
+
+function toWireCommsSendParams(
+  sessionId: string,
+  command: CommsCommand,
+): RpcCommsSendParams {
+  switch (command.kind) {
+    case "input":
+    case "peer_message":
+      return {
+        ...command,
+        session_id: sessionId,
+        blocks: command.blocks?.map(toWireContentBlock),
+      };
+    case "peer_request":
+      return {
+        ...command,
+        session_id: sessionId,
+        params: toWirePeerRequestParams(command.params),
+        blocks: command.blocks?.map(toWireContentBlock),
+      };
+    case "peer_lifecycle":
+    case "peer_response":
+      return { ...command, session_id: sessionId };
+  }
+}
+
+function toWireMobProfile(profile: MobProfile): RpcMobProfileInput {
+  const { resume_overrides, skills, ...rest } = profile;
+  const payload: RpcMobProfileInput = { ...rest };
+  setIfDefined(
+    payload,
+    "resume_overrides",
+    resume_overrides ? [...resume_overrides] : undefined,
+  );
+  setIfDefined(payload, "skills", skills ? [...skills] : undefined);
+  return payload;
+}
+
+function toWireMobDefinition(
+  definition: MobCreateOptions["definition"],
+): RpcMobDefinitionInput {
+  const { models, flows, skills, ...rest } = definition;
+  const payload: RpcMobDefinitionInput = {
+    ...rest,
+    profiles: Object.fromEntries(
+      Object.entries(definition.profiles).map(([name, binding]) => [
+        name,
+        "realm_profile" in binding
+          ? { realm_profile: binding.realm_profile }
+          : toWireMobProfile(binding),
+      ]),
+    ),
+  };
+  setIfDefined(payload, "models", models ? { ...models } : undefined);
+  setIfDefined(payload, "flows", flows ? { ...flows } : undefined);
+  setIfDefined(payload, "skills", skills ? { ...skills } : undefined);
+  return payload;
+}
+
+function mobSpawnPayload(mobId: string, spec: SpawnSpec): RpcMobSpawnParams {
+  const payload: RpcMobSpawnParams = {
     mob_id: mobId,
     profile: spec.profile,
     agent_identity: spec.agentIdentity,
@@ -516,7 +733,7 @@ function mobSpawnPayload(mobId: string, spec: SpawnSpec): Record<string, unknown
   setIfDefined(payload, "additional_instructions", spec.additionalInstructions);
   setIfDefined(payload, "placement", spec.placement);
   setIfDefined(payload, "binding", spec.binding);
-  setIfDefined(payload, "shell_env", spec.shellEnv);
+  setIfDefined(payload, "shell_env", spec.shellEnv ? { ...spec.shellEnv } : undefined);
   setIfDefined(payload, "auto_wire_parent", spec.autoWireParent);
   setIfDefined(payload, "launch_mode", spec.launchMode);
   setIfDefined(payload, "tool_access_policy", spec.toolAccessPolicy);
@@ -704,7 +921,7 @@ export class MeerkatClient {
       const params: ToolsRegisterParams = {
         tools: [{ name, description, input_schema: inputSchema }],
       };
-      const result = await this.request<ToolsRegisterResult>(
+      const result = await this.request(
         "tools/register",
         params,
       );
@@ -861,7 +1078,7 @@ export class MeerkatClient {
         }),
       );
       const params: ToolsRegisterParams = { tools };
-      const result = await this.request<ToolsRegisterResult>(
+      const result = await this.request(
         "tools/register",
         params,
       );
@@ -969,7 +1186,6 @@ export class MeerkatClient {
     prompt: string | ContentBlock[],
     options?: SessionOptions,
   ): Promise<Session> {
-    type _RpcSignature = [RpcDeferredCreateResult, RpcWireRunResult];
     const params = MeerkatClient.buildCreateParams(prompt, options);
     const raw = await this.request("session/create", params);
     const result = MeerkatClient.parseRunResult(raw);
@@ -985,7 +1201,6 @@ export class MeerkatClient {
     prompt: string | ContentBlock[],
     options?: SessionOptions,
   ): EventStream {
-    type _RpcSignature = [RpcDeferredCreateResult, RpcWireRunResult];
     if (!this.process?.stdin) {
       throw new MeerkatError("NOT_CONNECTED", "Client not connected");
     }
@@ -1047,7 +1262,6 @@ export class MeerkatClient {
     prompt: string | ContentBlock[],
     options?: SessionOptions,
   ): Promise<DeferredSession> {
-    type _RpcSignature = [RpcDeferredCreateResult, RpcWireRunResult];
     const params = MeerkatClient.buildCreateParams(prompt, options);
     params.initial_turn = "deferred";
     const raw = await this.request("session/create", params);
@@ -1060,8 +1274,7 @@ export class MeerkatClient {
   }
 
   async askHelp(question: string, options?: HelpOptions): Promise<RunResult> {
-    type _RpcSignature = [RpcHelpRequest, RpcHelpResponse];
-    const params: Record<string, unknown> = { question };
+    const params: RpcHelpRequest = { question };
     if (options?.prompt !== undefined) params.prompt = options.prompt;
     if (options?.executionMode !== undefined) {
       params.execution_mode = options.executionMode;
@@ -1076,7 +1289,6 @@ export class MeerkatClient {
   // -- Session queries ----------------------------------------------------
 
   async listSessions(options?: SessionListOptions): Promise<SessionInfo[]> {
-    type _RpcSignature = [RpcListSessionsParams, RpcListSessionsResult];
     const params: Record<string, unknown> = {};
     if (options?.labels) params.labels = options.labels;
     if (options?.limit !== undefined) params.limit = options.limit;
@@ -1090,7 +1302,6 @@ export class MeerkatClient {
   }
 
   async readSession(sessionId: string): Promise<SessionInfo> {
-    type _RpcSignature = [RpcReadSessionParams];
     const raw = await this.request("session/read", { session_id: sessionId });
     return MeerkatClient.parseSessionInfo(raw);
   }
@@ -1101,15 +1312,14 @@ export class MeerkatClient {
     payload: unknown,
     options?: { blocks?: ContentBlock[] },
   ): Promise<Record<string, unknown>> {
-    type _RpcSignature = [RpcSessionExternalEventEnvelope];
-    const params: Record<string, unknown> = {
+    const params: RpcSessionExternalEventParams = {
       session_id: sessionId,
       kind: "generic_json",
       event_type: eventType,
       payload,
     };
     if (options?.blocks !== undefined) {
-      params.blocks = options.blocks;
+      params.blocks = options.blocks.map(toWireContentBlock);
     }
     return this.request("session/external_event", params);
   }
@@ -1122,8 +1332,7 @@ export class MeerkatClient {
     result: unknown,
     options?: PeerResponseTerminalOptions,
   ): Promise<Record<string, unknown>> {
-    type _RpcSignature = [RpcSessionPeerResponseTerminalParams];
-    const params: Record<string, unknown> = {
+    const params: RpcSessionPeerResponseTerminalParams = {
       session_id: sessionId,
       peer_id: peerId,
       request_id: requestId,
@@ -1141,8 +1350,7 @@ export class MeerkatClient {
     text: string,
     options?: SessionIngressOptions,
   ): Promise<RpcInjectSystemContextResult> {
-    type _RpcSignature = [RpcInjectSystemContextParams, RpcInjectSystemContextResult];
-    const params: Record<string, unknown> = {
+    const params: RpcInjectSystemContextParams = {
       session_id: sessionId,
       content: { type: "text", text },
     };
@@ -1172,8 +1380,7 @@ export class MeerkatClient {
     sessionId: string,
     selector: { inputId: string } | { idempotencyKey: string },
   ): Promise<Record<string, unknown> | null> {
-    type _RpcSignature = [RpcSessionInputStateParams, RpcSessionInputStateResult];
-    const params: Record<string, unknown> = {
+    const params: RpcSessionInputStateParams = {
       session_id: sessionId,
       selector:
         "inputId" in selector
@@ -1188,8 +1395,7 @@ export class MeerkatClient {
     sessionId: string,
     options?: { offset?: number; limit?: number },
   ): Promise<SessionHistory> {
-    type _RpcSignature = [RpcReadSessionHistoryParams];
-    const params: Record<string, unknown> = {
+    const params: RpcReadSessionHistoryParams = {
       session_id: sessionId,
       offset: options?.offset ?? 0,
     };
@@ -1205,8 +1411,7 @@ export class MeerkatClient {
     sessionId: string,
     options?: { agentName?: string; agentVersion?: string; modelName?: string },
   ): Promise<Record<string, unknown>> {
-    type _RpcSignature = [RpcExportAtifParams];
-    const params: Record<string, unknown> = { session_id: sessionId };
+    const params: RpcExportAtifParams = { session_id: sessionId };
     if (options?.agentName !== undefined) {
       params.agent_name = options.agentName;
     }
@@ -1216,7 +1421,12 @@ export class MeerkatClient {
     if (options?.modelName !== undefined) {
       params.model_name = options.modelName;
     }
-    return await this.request("session/export_atif", params);
+    const result = await this.request("session/export_atif", params);
+    return MeerkatClient.requireRecord(
+      result,
+      "result",
+      "Invalid session/export_atif response",
+    );
   }
 
   async readSessionTranscriptRevision(
@@ -1224,8 +1434,7 @@ export class MeerkatClient {
     revision: string,
     options?: { offset?: number; limit?: number },
   ): Promise<SessionTranscriptRevision> {
-    type _RpcSignature = [RpcReadSessionTranscriptRevisionParams, RpcWireSessionTranscriptRevision];
-    const params: Record<string, unknown> = {
+    const params: RpcReadSessionTranscriptRevisionParams = {
       session_id: sessionId,
       revision,
       offset: options?.offset ?? 0,
@@ -1241,8 +1450,7 @@ export class MeerkatClient {
     sessionId: string,
     options?: { offset?: number; limit?: number },
   ): Promise<SessionTranscriptRevisionList> {
-    type _RpcSignature = [RpcListSessionTranscriptRevisionsParams, RpcWireSessionTranscriptRevisionList];
-    const params: Record<string, unknown> = {
+    const params: RpcListSessionTranscriptRevisionsParams = {
       session_id: sessionId,
     };
     if (options?.offset !== undefined) {
@@ -1260,8 +1468,7 @@ export class MeerkatClient {
     messageIndex: number,
     options?: TranscriptForkOptions,
   ): Promise<SessionForkResult> {
-    type _RpcSignature = [RpcForkSessionAtParams, RpcSessionForkResult];
-    const params: Record<string, unknown> = {
+    const params: RpcForkSessionAtParams = {
       session_id: sessionId,
       message_index: messageIndex,
     };
@@ -1271,7 +1478,7 @@ export class MeerkatClient {
     if (options?.toolAccessPolicy !== undefined) {
       params.tool_access_policy = options.toolAccessPolicy;
     }
-    const raw = await this.request<RpcSessionForkResult>("session/fork_at", params);
+    const raw = await this.request("session/fork_at", params);
     return MeerkatClient.parseSessionForkResult(raw);
   }
 
@@ -1281,8 +1488,7 @@ export class MeerkatClient {
     replacement: TranscriptReplacement,
     options?: TranscriptForkOptions,
   ): Promise<SessionForkResult> {
-    type _RpcSignature = [RpcForkSessionReplaceParams, RpcSessionForkResult];
-    const params: Record<string, unknown> = {
+    const params: RpcForkSessionReplaceParams = {
       session_id: sessionId,
       message_index: messageIndex,
       replacement: MeerkatClient.serializeTranscriptReplacement(replacement),
@@ -1293,7 +1499,7 @@ export class MeerkatClient {
     if (options?.toolAccessPolicy !== undefined) {
       params.tool_access_policy = options.toolAccessPolicy;
     }
-    const raw = await this.request<RpcSessionForkResult>("session/fork_replace", params);
+    const raw = await this.request("session/fork_replace", params);
     return MeerkatClient.parseSessionForkResult(raw);
   }
 
@@ -1304,8 +1510,7 @@ export class MeerkatClient {
     reason: TranscriptRewriteReason,
     options?: TranscriptRewriteOptions,
   ): Promise<SessionTranscriptRewriteResult> {
-    type _RpcSignature = [RpcRewriteSessionTranscriptParams, RpcSessionTranscriptRewriteResult];
-    const params: Record<string, unknown> = {
+    const params: RpcRewriteSessionTranscriptParams = {
       session_id: sessionId,
       selection,
       replacement: replacement.map((message) =>
@@ -1349,7 +1554,7 @@ export class MeerkatClient {
     if (options?.expectedParentRevision !== undefined) {
       params.expected_parent_revision = options.expectedParentRevision;
     }
-    const raw = await this.request<RpcSystemPromptUpdateResult>(
+    const raw = await this.request(
       "session/update_system_prompt",
       params,
     );
@@ -1362,8 +1567,7 @@ export class MeerkatClient {
     reason: TranscriptRewriteReason,
     options?: TranscriptRewriteOptions,
   ): Promise<SessionTranscriptRewriteResult> {
-    type _RpcSignature = [RpcRestoreSessionTranscriptRevisionParams, RpcSessionTranscriptRewriteResult];
-    const params: Record<string, unknown> = {
+    const params: RpcRestoreSessionTranscriptRevisionParams = {
       session_id: sessionId,
       revision,
       reason,
@@ -1440,19 +1644,19 @@ export class MeerkatClient {
   }
 
   async mcpAdd(params: McpAddParams): Promise<McpLiveOpResponse> {
-    const raw = await this.request("mcp/add", params as unknown as Record<string, unknown>);
+    const raw = await this.request("mcp/add", params);
     return MeerkatClient.parseMcpLiveOpResponse(raw);
   }
 
   async mcpRemove(params: McpRemoveParams): Promise<McpLiveOpResponse> {
-    const raw = await this.request("mcp/remove", params as unknown as Record<string, unknown>);
+    const raw = await this.request("mcp/remove", params);
     return MeerkatClient.parseMcpLiveOpResponse(raw);
   }
 
   async mcpReload(params: McpReloadParams): Promise<McpLiveOpResponse> {
     const raw = await this.request(
       "mcp/reload",
-      params as unknown as Record<string, unknown>,
+      params,
     );
     return MeerkatClient.parseMcpLiveOpResponse(raw);
   }
@@ -1480,7 +1684,6 @@ export class MeerkatClient {
   }
 
   async getBlob(blobId: string): Promise<BlobPayload> {
-    type _RpcSignature = [RpcBlobGetParams, RpcBlobPayload];
     const result = await this.request("blob/get", { blob_id: blobId });
     const context = "Invalid blob/get response";
     return {
@@ -1491,17 +1694,14 @@ export class MeerkatClient {
   }
 
   async getRuntimeHostInfo(): Promise<Record<string, unknown>> {
-    type _RpcSignature = [RpcRuntimeHostInfo];
     return this.request("runtime/host_info", {});
   }
 
   async getRuntimeHostCapabilities(): Promise<Record<string, unknown>> {
-    type _RpcSignature = [RpcRuntimeHostCapabilities];
     return this.request("runtime/capabilities", {});
   }
 
   async getRuntimeHostHealth(): Promise<Record<string, unknown>> {
-    type _RpcSignature = [RpcRuntimeHostHealth];
     return this.request("runtime/health", {});
   }
 
@@ -1586,72 +1786,62 @@ export class MeerkatClient {
   }
 
   async requestApproval(
-    params: Record<string, unknown>,
-  ): Promise<Record<string, unknown>> {
-    type _RpcSignature = [RpcApprovalRecord, RpcApprovalRequestParams];
+    params: RpcApprovalRequestParams,
+  ): Promise<RpcApprovalRecord> {
     return this.request("approval/request", params);
   }
 
   async listApprovals(
-    params: Record<string, unknown> = {},
-  ): Promise<Record<string, unknown>> {
-    type _RpcSignature = [RpcApprovalListParams, RpcApprovalListResult];
+    params: RpcApprovalListParams = {},
+  ): Promise<RpcApprovalListResult> {
     return this.request("approval/list", params);
   }
 
   async getApproval(
-    params: Record<string, unknown>,
-  ): Promise<Record<string, unknown>> {
-    type _RpcSignature = [RpcApprovalGetParams, RpcApprovalRecord];
+    params: RpcApprovalGetParams,
+  ): Promise<RpcApprovalRecord> {
     return this.request("approval/get", params);
   }
 
   async decideApproval(
-    params: Record<string, unknown>,
-  ): Promise<Record<string, unknown>> {
-    type _RpcSignature = [RpcApprovalDecideParams, RpcApprovalRecord];
+    params: RpcApprovalDecideParams,
+  ): Promise<RpcApprovalRecord> {
     return this.request("approval/decide", params);
   }
 
   async listArtifacts(
-    params: Record<string, unknown> = {},
-  ): Promise<Record<string, unknown>> {
-    type _RpcSignature = [RpcArtifactListParams, RpcArtifactListResult];
+    params: RpcArtifactListParams = {},
+  ): Promise<RpcArtifactListResult> {
     return this.request("artifact/list", params);
   }
 
   async getArtifact(
-    params: Record<string, unknown>,
-  ): Promise<Record<string, unknown>> {
-    type _RpcSignature = [RpcArtifactIdParams, RpcArtifactRecord];
+    params: RpcArtifactIdParams,
+  ): Promise<RpcArtifactRecord> {
     return this.request("artifact/get", params);
   }
 
   async downloadArtifact(
-    params: Record<string, unknown>,
-  ): Promise<Record<string, unknown>> {
-    type _RpcSignature = [RpcArtifactDownloadParams, RpcArtifactDownloadResult];
+    params: RpcArtifactDownloadParams,
+  ): Promise<RpcArtifactDownloadResult> {
     return this.request("artifact/download", params);
   }
 
   async latestEventCursor(
-    params: Record<string, unknown>,
-  ): Promise<Record<string, unknown>> {
-    type _RpcSignature = [RpcEventsLatestCursorParams, RpcEventsLatestCursorResult];
+    params: RpcEventsLatestCursorParams,
+  ): Promise<RpcEventsLatestCursorResult> {
     return this.request("events/latest_cursor", params);
   }
 
   async listEventsSince(
-    params: Record<string, unknown>,
-  ): Promise<Record<string, unknown>> {
-    type _RpcSignature = [RpcEventsListSinceParams, RpcEventsListSinceResult];
+    params: RpcEventsListSinceParams,
+  ): Promise<RpcEventsListSinceResult> {
     return this.request("events/list_since", params);
   }
 
   async eventSnapshot(
-    params: Record<string, unknown>,
-  ): Promise<Record<string, unknown>> {
-    type _RpcSignature = [RpcEventsSnapshotParams, RpcEventsSnapshotResult];
+    params: RpcEventsSnapshotParams,
+  ): Promise<RpcEventsSnapshotResult> {
     return this.request("events/snapshot", params);
   }
 
@@ -1661,13 +1851,11 @@ export class MeerkatClient {
   }
 
   async createSchedule(request: CreateScheduleRequest): Promise<Schedule> {
-    type _RpcSignature = [RpcCreateScheduleRequest, RpcSchedule];
     const result = await this.request("schedule/create", MeerkatClient.toWireCreateScheduleRequest(request));
     return MeerkatClient.parseSchedule(result);
   }
 
   async getSchedule(scheduleId: string): Promise<Schedule> {
-    type _RpcSignature = [RpcSchedule];
     const result = await this.request("schedule/get", { schedule_id: scheduleId });
     return MeerkatClient.parseSchedule(result);
   }
@@ -1691,7 +1879,6 @@ export class MeerkatClient {
   }
 
   async updateSchedule(request: UpdateScheduleRequest): Promise<Schedule> {
-    type _RpcSignature = [RpcSchedule];
     const params = {
       schedule_id: request.scheduleId,
       ...MeerkatClient.toWireUpdateSchedulePatch(request.update),
@@ -1701,19 +1888,16 @@ export class MeerkatClient {
   }
 
   async pauseSchedule(scheduleId: string): Promise<Schedule> {
-    type _RpcSignature = [RpcSchedule];
     const result = await this.request("schedule/pause", { schedule_id: scheduleId });
     return MeerkatClient.parseSchedule(result);
   }
 
   async resumeSchedule(scheduleId: string): Promise<Schedule> {
-    type _RpcSignature = [RpcSchedule];
     const result = await this.request("schedule/resume", { schedule_id: scheduleId });
     return MeerkatClient.parseSchedule(result);
   }
 
   async deleteSchedule(scheduleId: string): Promise<Schedule> {
-    type _RpcSignature = [RpcSchedule];
     const result = await this.request("schedule/delete", { schedule_id: scheduleId });
     return MeerkatClient.parseSchedule(result);
   }
@@ -1722,7 +1906,7 @@ export class MeerkatClient {
     scheduleId: string,
     options?: ScheduleOccurrencesOptions,
   ): Promise<ScheduleOccurrencesResult> {
-    const params: Record<string, unknown> = { schedule_id: scheduleId };
+    const params: RpcScheduleOccurrencesParams = { schedule_id: scheduleId };
     if (options?.includeTerminal !== undefined) {
       params.include_terminal = options.includeTerminal;
     }
@@ -1740,7 +1924,6 @@ export class MeerkatClient {
   }
 
   async listScheduleTools(): Promise<ScheduleToolsResult> {
-    type _RpcSignature = [RpcScheduleToolsResult];
     const result = await this.request("schedule/tools", {});
     const data = MeerkatClient.requireRecord(
       result,
@@ -1755,11 +1938,15 @@ export class MeerkatClient {
   }
 
   async callScheduleTool(request: ScheduleToolCallRequest): Promise<Record<string, unknown>> {
-    type _RpcSignature = [RpcScheduleToolCallParams];
-    return this.request("schedule/call", {
+    const result = await this.request("schedule/call", {
       name: request.name,
       arguments: request.arguments ?? {},
     });
+    return MeerkatClient.requireRecord(
+      result,
+      "result",
+      "Invalid schedule/call response",
+    );
   }
 
   async getWorkGraphItem(
@@ -1834,7 +2021,9 @@ export class MeerkatClient {
 
   async createMob(options: MobCreateOptions): Promise<Mob> {
     this.requireCapability("mob");
-    const result = await this.request("mob/create", options);
+    const result = await this.request("mob/create", {
+      definition: toWireMobDefinition(options.definition),
+    });
     return new Mob(
       this,
       MeerkatClient.requireStringField(
@@ -1939,7 +2128,7 @@ export class MeerkatClient {
     const result = await this.request("mob/member_send", {
       mob_id: mobId,
       agent_identity: agentIdentity,
-      content,
+      content: toWireContentInput(content),
       handling_mode: options?.handlingMode,
       render_metadata: options?.renderMetadata,
     });
@@ -2013,7 +2202,7 @@ export class MeerkatClient {
       mob_id: mobId,
       specs: specs.map(mobSpawnManySpecPayload),
     };
-    const result = await this.request<MobSpawnManyResult>(
+    const result = await this.request(
       "mob/spawn_many",
       params,
     );
@@ -2141,7 +2330,6 @@ export class MeerkatClient {
     scopes: MobControlScope[],
     expiresAtMs?: number,
   ): Promise<MobGrantRecord> {
-    type _RpcSignature = [RpcMobGrantScopesParams, RpcMobGrantScopesResult];
     const result = await this.request("mob/grant_scopes", {
       mob_id: mobId,
       principal,
@@ -2164,7 +2352,6 @@ export class MeerkatClient {
     principal: string,
     scopes?: MobControlScope[],
   ): Promise<boolean> {
-    type _RpcSignature = [RpcMobRevokeScopesParams, RpcMobRevokeScopesResult];
     const result = await this.request("mob/revoke_scopes", {
       mob_id: mobId,
       principal,
@@ -2184,7 +2371,6 @@ export class MeerkatClient {
    * preserve the generated `expires_at_ms` wire field verbatim.
    */
   async listMobGrants(mobId: string): Promise<MobGrantRecord[]> {
-    type _RpcSignature = [RpcMobIdParams, RpcMobGrantsResult];
     const result = await this.request("mob/grants", { mob_id: mobId });
     const context = "Invalid mob/grants response";
     const grants = result.grants;
@@ -2262,7 +2448,6 @@ export class MeerkatClient {
     agentIdentity: string,
     opts?: { fromIndex?: number; limit?: number },
   ): Promise<RpcMobMemberHistoryResult> {
-    type _RpcSignature = [RpcMobMemberHistoryParams, RpcMobMemberHistoryResult];
     const result = await this.request("mob/member_history", {
       mob_id: mobId,
       agent_identity: agentIdentity,
@@ -2354,7 +2539,6 @@ export class MeerkatClient {
 
   /** List tracked member hosts with bind phase and declared capabilities. */
   async mobHosts(mobId: string): Promise<RpcMobHostStatus[]> {
-    type _RpcSignature = [RpcMobIdParams, RpcMobHostsResult];
     const result = await this.request("mob/hosts", { mob_id: mobId });
     const hosts = result.hosts;
     if (!Array.isArray(hosts)) {
@@ -2373,7 +2557,6 @@ export class MeerkatClient {
 
   /** Outstanding cross-host route-install obligations. */
   async mobRouteInstalls(mobId: string): Promise<RpcMobRouteInstallsResult> {
-    type _RpcSignature = [RpcMobIdParams, RpcMobRouteInstallsResult];
     const result = await this.request("mob/route_installs", { mob_id: mobId });
     const context = "Invalid mob/route_installs response";
     const outstanding = MeerkatClient.requireRecordArray(
@@ -2395,7 +2578,6 @@ export class MeerkatClient {
     mobId: string,
     descriptor: RpcWireHostBindingDescriptor,
   ): Promise<RpcMobBindHostResult> {
-    type _RpcSignature = [RpcMobBindHostParams, RpcMobBindHostResult];
     const result = await this.request("mob/bind_host", {
       mob_id: mobId,
       descriptor,
@@ -2415,7 +2597,6 @@ export class MeerkatClient {
     mobId: string,
     hostId: string,
   ): Promise<RpcMobRevokeHostResult> {
-    type _RpcSignature = [RpcMobRevokeHostParams, RpcMobRevokeHostResult];
     const result = await this.request("mob/revoke_host", {
       mob_id: mobId,
       host_id: hostId,
@@ -2432,7 +2613,6 @@ export class MeerkatClient {
     agentIdentity: string,
     reason: string,
   ): Promise<boolean> {
-    type _RpcSignature = [RpcMobHardCancelParams, RpcMobHardCancelResult];
     const result = await this.request("mob/hard_cancel_member", {
       mob_id: mobId,
       agent_identity: agentIdentity,
@@ -2453,7 +2633,6 @@ export class MeerkatClient {
     agentIdentity: string,
     opts?: MobMemberLiveOpenOptions,
   ): Promise<RpcLiveOpenResult> {
-    type _RpcSignature = [RpcMobMemberLiveOpenParams, RpcLiveOpenResult];
     const result = await this.request("mob/member_live_open", {
       mob_id: mobId,
       agent_identity: agentIdentity,
@@ -2472,7 +2651,6 @@ export class MeerkatClient {
     agentIdentity: string,
     channelId: string,
   ): Promise<RpcLiveCloseResult> {
-    type _RpcSignature = [RpcMobMemberLiveChannelParams, RpcLiveCloseResult];
     const result = await this.request("mob/member_live_close", {
       mob_id: mobId,
       agent_identity: agentIdentity,
@@ -2487,7 +2665,6 @@ export class MeerkatClient {
     agentIdentity: string,
     channelId?: string,
   ): Promise<RpcLiveStatusResult> {
-    type _RpcSignature = [RpcMobMemberLiveStatusParams, RpcLiveStatusResult];
     const result = await this.request("mob/member_live_status", {
       mob_id: mobId,
       agent_identity: agentIdentity,
@@ -2506,7 +2683,6 @@ export class MeerkatClient {
     channelId: string,
     verb: RpcBridgeLiveControlVerb,
   ): Promise<RpcBridgeLiveControlOutcome> {
-    type _RpcSignature = [RpcMobMemberLiveControlParams, RpcBridgeLiveControlOutcome];
     const result = await this.request("mob/member_live_control", {
       mob_id: mobId,
       agent_identity: agentIdentity,
@@ -2546,7 +2722,8 @@ export class MeerkatClient {
     const result = await this.request("mob/respawn", {
       mob_id: mobId,
       agent_identity: agentIdentity,
-      initial_message: initialMessage,
+      initial_message:
+        initialMessage === undefined ? undefined : toWireContentInput(initialMessage),
     });
     const respawnContext = "Invalid mob/respawn response";
     const respawnRecord = MeerkatClient.requireRecord(result, "result", respawnContext);
@@ -2621,9 +2798,7 @@ export class MeerkatClient {
       mob_id: mobId,
       agent_identity: agentIdentity,
     };
-    const result = await this.request<
-      Partial<MobMemberStatusResult> & Record<string, unknown>
-    >("mob/member_status", params);
+    const result = await this.request("mob/member_status", params);
     const snapshot: MobMemberSnapshot = {
       status: MeerkatClient.parseWireMobMemberStatus(
         result.status,
@@ -2799,23 +2974,23 @@ export class MeerkatClient {
    */
   async mobSubmitWork(args: {
     memberRef: string;
-    content: unknown;
+    content: ContentInput;
     workRef?: string;
     origin?: "external" | "internal";
     injectedContext?: ContentInput[];
     transientTurnContext?: string;
     objectiveId?: string;
   }): Promise<{ mobId: string; workRef: string; memberRef: string; objectiveId?: string }> {
-    const params: Record<string, unknown> = {
+    const params: RpcMobSubmitWorkParams = {
       member_ref: args.memberRef,
-      content: args.content,
+      content: toWireContentInput(args.content),
       origin: args.origin ?? "external",
     };
     if (args.workRef !== undefined) {
       params.work_ref = args.workRef;
     }
     if (args.injectedContext !== undefined && args.injectedContext.length > 0) {
-      params.injected_context = args.injectedContext;
+      params.injected_context = args.injectedContext.map(toWireContentInput);
     }
     if (args.transientTurnContext !== undefined) {
       params.transient_turn_context = args.transientTurnContext;
@@ -2900,7 +3075,7 @@ export class MeerkatClient {
     mobId: string,
     options?: MobKickoffWaitOptions,
   ): Promise<MobKickoffMemberSnapshot[]> {
-    const params: Record<string, unknown> = { mob_id: mobId };
+    const params: RpcMobWaitParams = { mob_id: mobId };
     if (options?.memberIds !== undefined) {
       params.member_ids = options.memberIds;
     }
@@ -2955,7 +3130,7 @@ export class MeerkatClient {
     mobId: string,
     options?: MobReadyWaitOptions,
   ): Promise<MobReadyMemberSnapshot[]> {
-    const params: Record<string, unknown> = { mob_id: mobId };
+    const params: RpcMobWaitParams = { mob_id: mobId };
     if (options?.memberIds !== undefined) {
       params.member_ids = options.memberIds;
     }
@@ -3121,7 +3296,7 @@ export class MeerkatClient {
     mobId: string,
     options?: MobEventsOptions,
   ): Promise<MobEventsResult> {
-    const params: Record<string, unknown> = { mob_id: mobId };
+    const params: RpcMobEventsParams = { mob_id: mobId };
     if (options?.afterCursor !== undefined) {
       params.after_cursor = options.afterCursor;
     }
@@ -3147,15 +3322,15 @@ export class MeerkatClient {
   }
 
   async mobIngressInteraction(
-    params: Record<string, unknown>,
-  ): Promise<Record<string, unknown>> {
+    params: RpcMobIngressInteractionParams,
+  ): Promise<RpcMobIngressInteractionResult> {
     return this.request("mob/ingress_interaction", params);
   }
 
   async createMobProfile(name: string, profile: MobProfile): Promise<MobProfileLookupResult> {
     const raw = await this.request("mob/profile/create", {
       name,
-      profile,
+      profile: toWireMobProfile(profile),
     });
     return MeerkatClient.parseMobProfileLookup(raw);
   }
@@ -3181,7 +3356,7 @@ export class MeerkatClient {
   ): Promise<MobProfileLookupResult> {
     const raw = await this.request("mob/profile/update", {
       name,
-      profile,
+      profile: toWireMobProfile(profile),
       expected_revision: expectedRevision,
     });
     return MeerkatClient.parseMobProfileLookup(raw);
@@ -3281,21 +3456,37 @@ export class MeerkatClient {
   }
 
   private async openEventSubscription<T>(
-    openMethod: string,
-    params: Record<string, unknown>,
-    closeMethod: string,
+    openMethod: "session/stream_open",
+    params: RpcSessionStreamOpenParams,
+    closeMethod: "session/stream_close",
+    parse: (raw: Record<string, unknown>) => T,
+  ): Promise<EventSubscription<T>>;
+  private async openEventSubscription<T>(
+    openMethod: "mob/stream_open",
+    params: RpcMobStreamOpenParams,
+    closeMethod: "mob/stream_close",
+    parse: (raw: Record<string, unknown>) => T,
+  ): Promise<EventSubscription<T>>;
+  private async openEventSubscription<T>(
+    openMethod: "session/stream_open" | "mob/stream_open",
+    params: RpcSessionStreamOpenParams | RpcMobStreamOpenParams,
+    closeMethod: "session/stream_close" | "mob/stream_close",
     parse: (raw: Record<string, unknown>) => T,
   ): Promise<EventSubscription<T>> {
     const result = this.process?.stdin
       ? await (async () => {
           this.requestId++;
           const requestId = this.requestId;
-          const responsePromise = this.registerRequest(requestId);
+          const responsePromise = this.registerRequest<
+            RpcSessionStreamOpenResult | RpcMobStreamOpenResult
+          >(requestId);
           const rpcRequest = { jsonrpc: "2.0", id: requestId, method: openMethod, params };
           this.process!.stdin!.write(JSON.stringify(rpcRequest) + "\n");
           return responsePromise;
         })()
-      : await this.request(openMethod, params);
+      : openMethod === "session/stream_open"
+        ? await this.request("session/stream_open", params as RpcSessionStreamOpenParams)
+        : await this.request("mob/stream_open", params as RpcMobStreamOpenParams);
     const streamId = String(result.stream_id ?? "");
     if (!streamId) {
       throw new MeerkatError("INVALID_RESPONSE", `${openMethod} did not return stream_id`);
@@ -3316,7 +3507,11 @@ export class MeerkatClient {
       closeRemote: async (id: string) => {
         // Await stream-close authority before tearing down local dispatch:
         // a rejected close must leave the subscription delivering events.
-        await this.request(closeMethod, { stream_id: id });
+        if (closeMethod === "session/stream_close") {
+          await this.request("session/stream_close", { stream_id: id });
+        } else {
+          await this.request("mob/stream_close", { stream_id: id });
+        }
         this.streamQueues.delete(id);
       },
       parseEvent: parse,
@@ -3587,9 +3782,9 @@ export class MeerkatClient {
     });
   }
 
+
   /** @internal */
   async _interrupt(sessionId: string): Promise<InterruptResult> {
-    type _RpcSignature = [RpcInterruptParams];
     return (await this.request("turn/interrupt", {
       session_id: sessionId,
     })) as unknown as InterruptResult;
@@ -3597,7 +3792,6 @@ export class MeerkatClient {
 
   /** @internal */
   async _archive(sessionId: string): Promise<void> {
-    type _RpcSignature = [RpcArchiveSessionParams];
     await this.request("session/archive", { session_id: sessionId });
   }
 
@@ -3674,7 +3868,10 @@ export class MeerkatClient {
    * boundary.
    */
   async send(sessionId: string, command: CommsCommand): Promise<CommsSendResult> {
-    const result = await this.request("comms/send", { session_id: sessionId, ...command });
+    const result = await this.request(
+      "comms/send",
+      toWireCommsSendParams(sessionId, command),
+    );
     return MeerkatClient.parseCommsSendReceipt(result);
   }
 
@@ -3694,8 +3891,8 @@ export class MeerkatClient {
   /** Idempotent spawn: spawns or returns the existing member entry. */
   async mobEnsureMember(
     mobId: string,
-    spec: Record<string, unknown>,
-  ): Promise<Record<string, unknown>> {
+    spec: RpcMobMemberSpecWire,
+  ): Promise<RpcMobEnsureMemberResult> {
     return await this.request("mob/ensure_member", {
       mob_id: mobId,
       spec,
@@ -3705,10 +3902,10 @@ export class MeerkatClient {
   /** Declarative reconcile: converge roster to the desired spec list. */
   async mobReconcile(
     mobId: string,
-    desired: Record<string, unknown>[],
-    options?: Record<string, unknown>,
-  ): Promise<Record<string, unknown>> {
-    const params: Record<string, unknown> = { mob_id: mobId, desired };
+    desired: RpcMobMemberSpecWire[],
+    options?: RpcMobReconcileOptionsWire,
+  ): Promise<RpcMobReconcileResult> {
+    const params: RpcMobReconcileParams = { mob_id: mobId, desired };
     if (options !== undefined) params.options = options;
     return await this.request("mob/reconcile", params);
   }
@@ -3731,7 +3928,7 @@ export class MeerkatClient {
   // schemas regenerated into `./generated/types.ts`. See I52/I53.
 
   async liveOpen(params: LiveOpenParams): Promise<LiveOpenResult> {
-    const result = await this.request("live/open", params as unknown as Record<string, unknown>);
+    const result = await this.request("live/open", params);
     return MeerkatClient.parseLiveOpenResult(result, "Invalid live/open response");
   }
 
@@ -3740,7 +3937,7 @@ export class MeerkatClient {
   ): Promise<LiveWebrtcAnswerResult> {
     const result = await this.request(
       "live/webrtc/answer",
-      params as unknown as Record<string, unknown>,
+      params,
     );
     return result as unknown as LiveWebrtcAnswerResult;
   }
@@ -3748,19 +3945,18 @@ export class MeerkatClient {
   async liveStatus(params: LiveChannelParams): Promise<LiveStatusResult> {
     const result = await this.request(
       "live/status",
-      params as unknown as Record<string, unknown>,
+      params,
     );
     return MeerkatClient.parseLiveStatusResult(result, "Invalid live/status response");
   }
 
   async liveClose(params: LiveChannelParams): Promise<LiveCloseResult> {
-    const result = await this.request("live/close", params as unknown as Record<string, unknown>);
+    const result = await this.request("live/close", params);
     return MeerkatClient.parseLiveCloseResult(result);
   }
 
   async liveSendInput(params: LiveSendInputParams): Promise<void> {
-    type _RpcSignature = [RpcLiveSendInputResult];
-    await this.request("live/send_input", params as unknown as Record<string, unknown>);
+    await this.request("live/send_input", params);
   }
 
   /**
@@ -3784,7 +3980,6 @@ export class MeerkatClient {
     mime: string,
     dataBase64: string,
   ): Promise<void> {
-    type _RpcSignature = [RpcLiveSendInputResult];
     await this.request("live/send_input", {
       channel_id: channelId,
       chunk: {
@@ -3813,7 +4008,6 @@ export class MeerkatClient {
     dataBase64: string,
     timestampMs: number,
   ): Promise<void> {
-    type _RpcSignature = [RpcLiveSendInputResult];
     await this.request("live/send_input", {
       channel_id: channelId,
       chunk: {
@@ -3826,19 +4020,17 @@ export class MeerkatClient {
   }
 
   async liveCommitInput(params: LiveCommitInputParams): Promise<void> {
-    type _RpcSignature = [RpcLiveCommitInputResult];
-    await this.request("live/commit_input", params as unknown as Record<string, unknown>);
+    await this.request("live/commit_input", params);
   }
 
   async liveInterrupt(params: LiveChannelParams): Promise<void> {
-    type _RpcSignature = [RpcLiveInterruptResult];
-    await this.request("live/interrupt", params as unknown as Record<string, unknown>);
+    await this.request("live/interrupt", params);
   }
 
   async liveTruncate(params: LiveTruncateParams): Promise<void> {
-    type _RpcSignature = [RpcLiveTruncateResult];
-    await this.request("live/truncate", params as unknown as Record<string, unknown>);
+    await this.request("live/truncate", params);
   }
+
 
   /**
    * Apply mutable session config (instructions / tools / audio) to an open
@@ -3867,7 +4059,7 @@ export class MeerkatClient {
   async liveRefresh(params: LiveChannelParams): Promise<LiveRefreshResult> {
     const result = await this.request(
       "live/refresh",
-      params as unknown as Record<string, unknown>,
+      params,
     );
     return MeerkatClient.parseLiveRefreshResult(result);
   }
@@ -3931,12 +4123,10 @@ export class MeerkatClient {
   }
 
   async realmGet(realmId: string): Promise<unknown> {
-    type _RpcSignature = [RpcRealmIdParams];
     return this.request("realm/get", { realm_id: realmId });
   }
 
   async authProfileList(realmId: string): Promise<unknown> {
-    type _RpcSignature = [RpcRealmIdParams];
     return this.request("auth/profile/list", { realm_id: realmId });
   }
 
@@ -3945,8 +4135,7 @@ export class MeerkatClient {
     bindingId: string,
     profileId?: string,
   ): Promise<unknown> {
-    type _RpcSignature = [RpcBindingIdParams];
-    const params: Record<string, unknown> = {
+    const params: RpcBindingIdParams = {
       realm_id: realmId,
       binding_id: bindingId,
     };
@@ -3954,8 +4143,7 @@ export class MeerkatClient {
     return this.request("auth/profile/get", params);
   }
 
-  async authProfileCreate(params: Record<string, unknown>): Promise<unknown> {
-    type _RpcSignature = [RpcCreateProfileParams];
+  async authProfileCreate(params: RpcCreateProfileParams): Promise<RpcWireAuthProfileCreated> {
     return this.request("auth/profile/create", params);
   }
 
@@ -3964,8 +4152,7 @@ export class MeerkatClient {
     bindingId: string,
     profileId?: string,
   ): Promise<unknown> {
-    type _RpcSignature = [RpcBindingIdParams];
-    const params: Record<string, unknown> = {
+    const params: RpcBindingIdParams = {
       realm_id: realmId,
       binding_id: bindingId,
     };
@@ -3973,34 +4160,29 @@ export class MeerkatClient {
     return this.request("auth/profile/delete", params);
   }
 
-  async authLoginStart(params: Record<string, unknown>): Promise<unknown> {
-    type _RpcSignature = [RpcLoginStartParams];
+  async authLoginStart(params: RpcLoginStartParams): Promise<RpcWireLoginStart> {
     return this.request("auth/login/start", params);
   }
 
-  async authLoginComplete(params: Record<string, unknown>): Promise<unknown> {
-    type _RpcSignature = [RpcLoginCompleteParams];
+  async authLoginComplete(params: RpcLoginCompleteParams): Promise<RpcWireLoginReady> {
     return this.request("auth/login/complete", params);
   }
 
   async authLoginDeviceStart(
-    params: Record<string, unknown>,
-  ): Promise<unknown> {
-    type _RpcSignature = [RpcDeviceStartParams];
+    params: RpcDeviceStartParams,
+  ): Promise<RpcWireDeviceStart> {
     return this.request("auth/login/device_start", params);
   }
 
   async authLoginDeviceComplete(
-    params: Record<string, unknown>,
-  ): Promise<unknown> {
-    type _RpcSignature = [RpcDeviceCompleteParams, RpcWireDeviceCompleteResult];
+    params: RpcDeviceCompleteParams,
+  ): Promise<RpcWireDeviceCompleteResult> {
     return this.request("auth/login/device_complete", params);
   }
 
   async authLoginProvisionApiKey(
-    params: Record<string, unknown>,
-  ): Promise<unknown> {
-    type _RpcSignature = [RpcProvisionApiKeyParams, RpcWireProvisionApiKeyResult];
+    params: RpcProvisionApiKeyParams,
+  ): Promise<RpcWireProvisionApiKeyResult> {
     return this.request("auth/login/provision_api_key", params);
   }
 
@@ -4009,8 +4191,7 @@ export class MeerkatClient {
     bindingId: string,
     profileId?: string,
   ): Promise<unknown> {
-    type _RpcSignature = [RpcBindingIdParams];
-    const params: Record<string, unknown> = {
+    const params: RpcBindingIdParams = {
       realm_id: realmId,
       binding_id: bindingId,
     };
@@ -4023,8 +4204,7 @@ export class MeerkatClient {
     bindingId: string,
     profileId?: string,
   ): Promise<unknown> {
-    type _RpcSignature = [RpcBindingIdParams];
-    const params: Record<string, unknown> = {
+    const params: RpcBindingIdParams = {
       realm_id: realmId,
       binding_id: bindingId,
     };
@@ -4172,7 +4352,10 @@ export class MeerkatClient {
     };
   }
 
-  private request<T = Record<string, unknown>>(method: string, params: unknown): Promise<T> {
+  private request<M extends RpcMethodName>(
+    method: M,
+    params: RpcMethodContracts[M]["params"],
+  ): Promise<RpcMethodContracts[M]["result"]> {
     if (this.transportFault) {
       throw this.transportFault;
     }
@@ -4183,7 +4366,7 @@ export class MeerkatClient {
     this.requestId++;
     const id = this.requestId;
     const rpcRequest = { jsonrpc: "2.0", id, method, params };
-    const promise = this.registerRequest<T>(id);
+    const promise = this.registerRequest<RpcMethodContracts[M]["result"]>(id);
     this.process.stdin!.write(JSON.stringify(rpcRequest) + "\n");
     return promise;
   }
@@ -6323,7 +6506,9 @@ export class MeerkatClient {
     };
   }
 
-  private static toWireCreateScheduleRequest(request: CreateScheduleRequest): Record<string, unknown> {
+  private static toWireCreateScheduleRequest(
+    request: CreateScheduleRequest,
+  ): RpcCreateScheduleRequest {
     return {
       name: request.name,
       description: request.description,
@@ -6680,18 +6865,18 @@ export class MeerkatClient {
 
   static serializeTranscriptReplacement(
     replacement: TranscriptReplacement,
-  ): Record<string, unknown> {
+  ): RpcWireTranscriptReplacement {
     switch (replacement.type) {
       case "message":
         return {
           type: "message",
-          message: replacement.message,
+          message: MeerkatClient.serializeTranscriptRewriteMessage(replacement.message),
         };
       case "user_content_block":
         return {
           type: "user_content_block",
           block_index: replacement.blockIndex,
-          block: replacement.block,
+          block: toWireContentBlock(replacement.block),
         };
       case "assistant_block":
         return {
@@ -6704,7 +6889,7 @@ export class MeerkatClient {
           type: "tool_result_content_block",
           result_index: replacement.resultIndex,
           block_index: replacement.blockIndex,
-          block: replacement.block,
+          block: toWireContentBlock(replacement.block),
         };
     }
     throw new Error(
@@ -6815,7 +7000,7 @@ export class MeerkatClient {
 
   static serializeTranscriptRewriteMessage(
     message: TranscriptRewriteInputMessage,
-  ): Record<string, unknown> {
+  ): RpcTranscriptRewriteMessage {
     const camel = message as SessionMessage;
     if (camel.createdAt !== undefined) {
       const payload: Record<string, unknown> = {
@@ -6857,7 +7042,9 @@ export class MeerkatClient {
           is_error: result.isError,
         }));
       }
-      return payload;
+      // SessionMessage.raw was accepted by the fail-closed transcript parser
+      // above; this branch only restores the exact snake_case wire spelling.
+      return payload as unknown as RpcTranscriptRewriteMessage;
     }
     return { ...(message as TranscriptRewriteMessage) };
   }

--- a/sdks/typescript/src/generated/rpc_contracts.ts
+++ b/sdks/typescript/src/generated/rpc_contracts.ts
@@ -1,0 +1,929 @@
+// Generated RPC method contracts for @rkat/sdk.
+// Source: artifacts/schemas/rpc-methods.json
+import type {
+  ApprovalDecideParams,
+  ApprovalGetParams,
+  ApprovalListParams,
+  ApprovalListResult,
+  ApprovalRecord,
+  ApprovalRequestParams,
+  ArchiveSessionParams,
+  ArtifactDownloadParams,
+  ArtifactDownloadResult,
+  ArtifactIdParams,
+  ArtifactListParams,
+  ArtifactListResult,
+  ArtifactRecord,
+  AttentionListRequest,
+  AttentionListResult,
+  BindingIdParams,
+  BlobGetParams,
+  BlobPayload,
+  BridgeLiveControlOutcome,
+  CapabilitiesResponse,
+  CommsPeersParams,
+  CommsPeersResult,
+  CommsSendParams,
+  CommsSendResult,
+  ConfigEnvelope,
+  ConfigPatchParams,
+  ConfigSetParams,
+  ConfigWriteResult,
+  CreateProfileParams,
+  CreateScheduleRequest,
+  DeferredCreateResult,
+  DeviceCompleteParams,
+  DeviceStartParams,
+  EventsLatestCursorParams,
+  EventsLatestCursorResult,
+  EventsListSinceParams,
+  EventsListSinceResult,
+  EventsSnapshotParams,
+  EventsSnapshotResult,
+  ExportAtifParams,
+  ForkSessionAtParams,
+  ForkSessionReplaceParams,
+  GoalStatusRequest,
+  GoalStatusResult,
+  HelpRequest,
+  HelpResponse,
+  InjectSystemContextParams,
+  InjectSystemContextResult,
+  InterruptParams,
+  InterruptResult,
+  JobsArtifactsParams,
+  JobsArtifactsResult,
+  JobsCancelParams,
+  JobsCancelResult,
+  JobsGetParams,
+  JobsGetResult,
+  JobsHealthResult,
+  JobsListParams,
+  JobsListResult,
+  JobsProgressParams,
+  JobsProgressResult,
+  JobsResultParams,
+  JobsResultResult,
+  JobsRetryParams,
+  JobsRetryResult,
+  JobsSubscribeParams,
+  JobsSubscribeResult,
+  JobsUnsubscribeParams,
+  JobsUnsubscribeResult,
+  ListSchedulesParams,
+  ListSessionTranscriptRevisionsParams,
+  ListSessionsParams,
+  ListSessionsResult,
+  LiveChannelParams,
+  LiveCloseResult,
+  LiveCommitInputParams,
+  LiveCommitInputResult,
+  LiveInterruptResult,
+  LiveOpenParams,
+  LiveOpenResult,
+  LiveRefreshResult,
+  LiveSendInputParams,
+  LiveSendInputResult,
+  LiveStatusResult,
+  LiveTruncateParams,
+  LiveTruncateResult,
+  LiveWebrtcAnswerParams,
+  LiveWebrtcAnswerResult,
+  LoginCompleteParams,
+  LoginStartParams,
+  McpAddParams,
+  McpLiveOpResponse,
+  McpReloadParams,
+  McpRemoveParams,
+  MobAppendSystemContextParams,
+  MobAppendSystemContextResult,
+  MobBindHostParams,
+  MobBindHostResult,
+  MobCancelAllWorkParams,
+  MobCancelAllWorkResult,
+  MobCancelWorkParams,
+  MobCancelWorkResult,
+  MobConcludeObjectiveParams,
+  MobConcludeObjectiveResult,
+  MobCreateParams,
+  MobCreateResult,
+  MobDestroyResult,
+  MobEnsureMemberParams,
+  MobEnsureMemberResult,
+  MobEventsParams,
+  MobEventsResult,
+  MobFlowCancelParams,
+  MobFlowCancelResult,
+  MobFlowRunParams,
+  MobFlowRunResult,
+  MobFlowStatusParams,
+  MobFlowStatusResult,
+  MobFlowsResult,
+  MobForceCancelResult,
+  MobForkHelperParams,
+  MobGrantScopesParams,
+  MobGrantScopesResult,
+  MobGrantsResult,
+  MobHardCancelParams,
+  MobHardCancelResult,
+  MobHelperResult,
+  MobHostsResult,
+  MobIdParams,
+  MobIngressInteractionParams,
+  MobIngressInteractionResult,
+  MobLifecycleParams,
+  MobLifecycleResult,
+  MobListMembersMatchingParams,
+  MobListMembersMatchingResult,
+  MobListResult,
+  MobMemberHistoryParams,
+  MobMemberHistoryResult,
+  MobMemberLiveChannelParams,
+  MobMemberLiveControlParams,
+  MobMemberLiveOpenParams,
+  MobMemberLiveStatusParams,
+  MobMemberParams,
+  MobMemberSendParams,
+  MobMemberSendResult,
+  MobMemberStatusResult,
+  MobMembersResult,
+  MobProfileCreateParams,
+  MobProfileDeleteParams,
+  MobProfileDeleteResult,
+  MobProfileListResult,
+  MobProfileLookupResult,
+  MobProfileNameParams,
+  MobProfileUpdateParams,
+  MobReconcileParams,
+  MobReconcileResult,
+  MobRespawnParams,
+  MobRespawnResult,
+  MobRetireResult,
+  MobRevokeHostParams,
+  MobRevokeHostResult,
+  MobRevokeScopesParams,
+  MobRevokeScopesResult,
+  MobRotateSupervisorResult,
+  MobRouteInstallsResult,
+  MobRunParams,
+  MobRunResult,
+  MobRunResultParams,
+  MobSnapshotResult,
+  MobSpawnHelperParams,
+  MobSpawnManyParams,
+  MobSpawnManyResult,
+  MobSpawnParams,
+  MobSpawnResult,
+  MobStatusResult,
+  MobStreamCloseParams,
+  MobStreamCloseResult,
+  MobStreamOpenParams,
+  MobStreamOpenResult,
+  MobSubmitWorkParams,
+  MobSubmitWorkResult,
+  MobTurnStartParams,
+  MobUnwireParams,
+  MobUnwireResult,
+  MobWaitMembersResult,
+  MobWaitParams,
+  MobWireMembersBatchParams,
+  MobWireMembersBatchResult,
+  MobWireParams,
+  MobWireResult,
+  MobkitJobCancelAckParams,
+  MobkitJobCheckpointParams,
+  MobkitJobCompleteParams,
+  MobkitJobFailParams,
+  MobkitJobHeartbeatParams,
+  MobkitJobMutationResult,
+  MobkitJobProgressParams,
+  ModelsCatalogResponse,
+  MonitorsStartParams,
+  MonitorsStartResult,
+  ProvisionApiKeyParams,
+  ReadSessionHistoryParams,
+  ReadSessionParams,
+  ReadSessionTranscriptRevisionParams,
+  ReadyWorkFilter,
+  RealmIdParams,
+  RestoreSessionTranscriptRevisionParams,
+  RewriteSessionTranscriptParams,
+  RuntimeAcceptResult,
+  RuntimeHostCapabilities,
+  RuntimeHostHealth,
+  RuntimeHostInfo,
+  Schedule,
+  ScheduleIdParams,
+  ScheduleListResult,
+  ScheduleOccurrencesParams,
+  ScheduleOccurrencesResult,
+  ScheduleToolCallParams,
+  ScheduleToolsResult,
+  ServerCapabilities,
+  SessionExternalEventParams,
+  SessionForkResult,
+  SessionInputStateParams,
+  SessionInputStateResult,
+  SessionPeerResponseTerminalParams,
+  SessionStreamCloseParams,
+  SessionStreamCloseResult,
+  SessionStreamOpenParams,
+  SessionStreamOpenResult,
+  SessionTranscriptRewriteResult,
+  SkillListResponse,
+  SystemPromptUpdateResult,
+  ToolsRegisterParams,
+  ToolsRegisterResult,
+  UpdateScheduleParams,
+  UpdateSystemPromptParams,
+  WireAuthProfileCleared,
+  WireAuthProfileCreated,
+  WireAuthProfileDetail,
+  WireAuthProfilesList,
+  WireAuthStatusDetail,
+  WireDeviceCompleteResult,
+  WireDeviceStart,
+  WireLoginReady,
+  WireLoginStart,
+  WireProvisionApiKeyResult,
+  WireRealmConnectionSet,
+  WireRealmList,
+  WireRunResult,
+  WireSessionHistory,
+  WireSessionInfo,
+  WireSessionTranscriptRevision,
+  WireSessionTranscriptRevisionList,
+  WorkEventsResult,
+  WorkGraphEventFilter,
+  WorkGraphIdParams,
+  WorkGraphSnapshot,
+  WorkGraphSnapshotFilter,
+  WorkItem,
+  WorkItemFilter,
+  WorkItemsResult,
+} from "./types.js";
+
+export interface RpcMethodContracts {
+  "initialize": {
+    params: Record<string, never>;
+    result: (ServerCapabilities) & Record<string, unknown>;
+  };
+  "tools/register": {
+    params: ToolsRegisterParams;
+    result: (ToolsRegisterResult) & Record<string, unknown>;
+  };
+  "jobs/get": {
+    params: JobsGetParams;
+    result: (JobsGetResult) & Record<string, unknown>;
+  };
+  "jobs/list": {
+    params: JobsListParams;
+    result: (JobsListResult) & Record<string, unknown>;
+  };
+  "jobs/cancel": {
+    params: JobsCancelParams;
+    result: (JobsCancelResult) & Record<string, unknown>;
+  };
+  "jobs/progress": {
+    params: JobsProgressParams;
+    result: (JobsProgressResult) & Record<string, unknown>;
+  };
+  "jobs/result": {
+    params: JobsResultParams;
+    result: (JobsResultResult) & Record<string, unknown>;
+  };
+  "jobs/artifacts": {
+    params: JobsArtifactsParams;
+    result: (JobsArtifactsResult) & Record<string, unknown>;
+  };
+  "jobs/retry": {
+    params: JobsRetryParams;
+    result: (JobsRetryResult) & Record<string, unknown>;
+  };
+  "jobs/health": {
+    params: Record<string, never>;
+    result: (JobsHealthResult) & Record<string, unknown>;
+  };
+  "monitors/start": {
+    params: MonitorsStartParams;
+    result: (MonitorsStartResult) & Record<string, unknown>;
+  };
+  "jobs/subscribe": {
+    params: JobsSubscribeParams;
+    result: (JobsSubscribeResult) & Record<string, unknown>;
+  };
+  "jobs/unsubscribe": {
+    params: JobsUnsubscribeParams;
+    result: (JobsUnsubscribeResult) & Record<string, unknown>;
+  };
+  "mobkit/jobs/heartbeat": {
+    params: MobkitJobHeartbeatParams;
+    result: (MobkitJobMutationResult) & Record<string, unknown>;
+  };
+  "mobkit/jobs/progress": {
+    params: MobkitJobProgressParams;
+    result: (MobkitJobMutationResult) & Record<string, unknown>;
+  };
+  "mobkit/jobs/checkpoint": {
+    params: MobkitJobCheckpointParams;
+    result: (MobkitJobMutationResult) & Record<string, unknown>;
+  };
+  "mobkit/jobs/complete": {
+    params: MobkitJobCompleteParams;
+    result: (MobkitJobMutationResult) & Record<string, unknown>;
+  };
+  "mobkit/jobs/fail": {
+    params: MobkitJobFailParams;
+    result: (MobkitJobMutationResult) & Record<string, unknown>;
+  };
+  "mobkit/jobs/cancel_ack": {
+    params: MobkitJobCancelAckParams;
+    result: (MobkitJobMutationResult) & Record<string, unknown>;
+  };
+  "session/create": {
+    params: Record<string, unknown>;
+    result: (WireRunResult | DeferredCreateResult) & Record<string, unknown>;
+  };
+  "session/list": {
+    params: ListSessionsParams;
+    result: (ListSessionsResult) & Record<string, unknown>;
+  };
+  "session/read": {
+    params: ReadSessionParams;
+    result: (WireSessionInfo) & Record<string, unknown>;
+  };
+  "session/history": {
+    params: ReadSessionHistoryParams;
+    result: (WireSessionHistory) & Record<string, unknown>;
+  };
+  "session/export_atif": {
+    params: ExportAtifParams;
+    result: unknown;
+  };
+  "session/fork_at": {
+    params: ForkSessionAtParams;
+    result: (SessionForkResult) & Record<string, unknown>;
+  };
+  "session/fork_replace": {
+    params: ForkSessionReplaceParams;
+    result: (SessionForkResult) & Record<string, unknown>;
+  };
+  "session/rewrite_transcript": {
+    params: RewriteSessionTranscriptParams;
+    result: (SessionTranscriptRewriteResult) & Record<string, unknown>;
+  };
+  "session/update_system_prompt": {
+    params: UpdateSystemPromptParams;
+    result: (SystemPromptUpdateResult) & Record<string, unknown>;
+  };
+  "session/transcript_revision": {
+    params: ReadSessionTranscriptRevisionParams;
+    result: (WireSessionTranscriptRevision) & Record<string, unknown>;
+  };
+  "session/transcript_revisions": {
+    params: ListSessionTranscriptRevisionsParams;
+    result: (WireSessionTranscriptRevisionList) & Record<string, unknown>;
+  };
+  "session/restore_transcript_revision": {
+    params: RestoreSessionTranscriptRevisionParams;
+    result: (SessionTranscriptRewriteResult) & Record<string, unknown>;
+  };
+  "session/archive": {
+    params: ArchiveSessionParams;
+    result: unknown;
+  };
+  "turn/start": {
+    params: Record<string, unknown>;
+    result: (WireRunResult) & Record<string, unknown>;
+  };
+  "turn/interrupt": {
+    params: InterruptParams;
+    result: (InterruptResult) & Record<string, unknown>;
+  };
+  "config/get": {
+    params: Record<string, never>;
+    result: (ConfigEnvelope) & Record<string, unknown>;
+  };
+  "config/set": {
+    params: ConfigSetParams;
+    result: (ConfigWriteResult) & Record<string, unknown>;
+  };
+  "config/patch": {
+    params: ConfigPatchParams;
+    result: (ConfigWriteResult) & Record<string, unknown>;
+  };
+  "capabilities/get": {
+    params: Record<string, never>;
+    result: (CapabilitiesResponse) & Record<string, unknown>;
+  };
+  "runtime/host_info": {
+    params: Record<string, never>;
+    result: (RuntimeHostInfo) & Record<string, unknown>;
+  };
+  "runtime/capabilities": {
+    params: Record<string, never>;
+    result: (RuntimeHostCapabilities) & Record<string, unknown>;
+  };
+  "runtime/health": {
+    params: Record<string, never>;
+    result: (RuntimeHostHealth) & Record<string, unknown>;
+  };
+  "approval/request": {
+    params: ApprovalRequestParams;
+    result: (ApprovalRecord) & Record<string, unknown>;
+  };
+  "approval/list": {
+    params: ApprovalListParams;
+    result: (ApprovalListResult) & Record<string, unknown>;
+  };
+  "approval/get": {
+    params: ApprovalGetParams;
+    result: (ApprovalRecord) & Record<string, unknown>;
+  };
+  "approval/decide": {
+    params: ApprovalDecideParams;
+    result: (ApprovalRecord) & Record<string, unknown>;
+  };
+  "models/catalog": {
+    params: Record<string, never>;
+    result: (ModelsCatalogResponse) & Record<string, unknown>;
+  };
+  "auth/profile/list": {
+    params: RealmIdParams;
+    result: (WireAuthProfilesList) & Record<string, unknown>;
+  };
+  "auth/profile/get": {
+    params: BindingIdParams;
+    result: (WireAuthProfileDetail) & Record<string, unknown>;
+  };
+  "auth/profile/create": {
+    params: CreateProfileParams;
+    result: (WireAuthProfileCreated) & Record<string, unknown>;
+  };
+  "auth/profile/delete": {
+    params: BindingIdParams;
+    result: (WireAuthProfileCleared) & Record<string, unknown>;
+  };
+  "auth/login/start": {
+    params: LoginStartParams;
+    result: (WireLoginStart) & Record<string, unknown>;
+  };
+  "auth/login/complete": {
+    params: LoginCompleteParams;
+    result: (WireLoginReady) & Record<string, unknown>;
+  };
+  "auth/login/device_start": {
+    params: DeviceStartParams;
+    result: (WireDeviceStart) & Record<string, unknown>;
+  };
+  "auth/login/device_complete": {
+    params: DeviceCompleteParams;
+    result: (WireDeviceCompleteResult) & Record<string, unknown>;
+  };
+  "auth/login/provision_api_key": {
+    params: ProvisionApiKeyParams;
+    result: (WireProvisionApiKeyResult) & Record<string, unknown>;
+  };
+  "auth/status/get": {
+    params: BindingIdParams;
+    result: (WireAuthStatusDetail) & Record<string, unknown>;
+  };
+  "auth/logout": {
+    params: BindingIdParams;
+    result: (WireAuthProfileCleared) & Record<string, unknown>;
+  };
+  "realm/list": {
+    params: Record<string, never>;
+    result: (WireRealmList) & Record<string, unknown>;
+  };
+  "realm/get": {
+    params: RealmIdParams;
+    result: (WireRealmConnectionSet) & Record<string, unknown>;
+  };
+  "help/ask": {
+    params: HelpRequest;
+    result: (HelpResponse) & Record<string, unknown>;
+  };
+  "blob/get": {
+    params: BlobGetParams;
+    result: (BlobPayload) & Record<string, unknown>;
+  };
+  "artifact/list": {
+    params: ArtifactListParams;
+    result: (ArtifactListResult) & Record<string, unknown>;
+  };
+  "artifact/get": {
+    params: ArtifactIdParams;
+    result: (ArtifactRecord) & Record<string, unknown>;
+  };
+  "artifact/download": {
+    params: ArtifactDownloadParams;
+    result: (ArtifactDownloadResult) & Record<string, unknown>;
+  };
+  "session/external_event": {
+    params: SessionExternalEventParams;
+    result: (RuntimeAcceptResult) & Record<string, unknown>;
+  };
+  "session/peer_response_terminal": {
+    params: SessionPeerResponseTerminalParams;
+    result: (RuntimeAcceptResult) & Record<string, unknown>;
+  };
+  "session/inject_context": {
+    params: InjectSystemContextParams;
+    result: (InjectSystemContextResult) & Record<string, unknown>;
+  };
+  "session/input_status": {
+    params: SessionInputStateParams;
+    result: (SessionInputStateResult) & Record<string, unknown>;
+  };
+  "events/latest_cursor": {
+    params: EventsLatestCursorParams;
+    result: (EventsLatestCursorResult) & Record<string, unknown>;
+  };
+  "events/list_since": {
+    params: EventsListSinceParams;
+    result: (EventsListSinceResult) & Record<string, unknown>;
+  };
+  "events/snapshot": {
+    params: EventsSnapshotParams;
+    result: (EventsSnapshotResult) & Record<string, unknown>;
+  };
+  "session/stream_open": {
+    params: SessionStreamOpenParams;
+    result: (SessionStreamOpenResult) & Record<string, unknown>;
+  };
+  "session/stream_close": {
+    params: SessionStreamCloseParams;
+    result: (SessionStreamCloseResult) & Record<string, unknown>;
+  };
+  "schedule/create": {
+    params: CreateScheduleRequest;
+    result: (Schedule) & Record<string, unknown>;
+  };
+  "schedule/get": {
+    params: ScheduleIdParams;
+    result: (Schedule) & Record<string, unknown>;
+  };
+  "schedule/list": {
+    params: ListSchedulesParams;
+    result: (ScheduleListResult) & Record<string, unknown>;
+  };
+  "schedule/update": {
+    params: UpdateScheduleParams;
+    result: (Schedule) & Record<string, unknown>;
+  };
+  "schedule/pause": {
+    params: ScheduleIdParams;
+    result: (Schedule) & Record<string, unknown>;
+  };
+  "schedule/resume": {
+    params: ScheduleIdParams;
+    result: (Schedule) & Record<string, unknown>;
+  };
+  "schedule/delete": {
+    params: ScheduleIdParams;
+    result: (Schedule) & Record<string, unknown>;
+  };
+  "schedule/occurrences": {
+    params: ScheduleOccurrencesParams;
+    result: (ScheduleOccurrencesResult) & Record<string, unknown>;
+  };
+  "schedule/tools": {
+    params: Record<string, never>;
+    result: (ScheduleToolsResult) & Record<string, unknown>;
+  };
+  "schedule/call": {
+    params: ScheduleToolCallParams;
+    result: unknown;
+  };
+  "workgraph/get": {
+    params: WorkGraphIdParams;
+    result: (WorkItem) & Record<string, unknown>;
+  };
+  "workgraph/list": {
+    params: WorkItemFilter;
+    result: (WorkItemsResult) & Record<string, unknown>;
+  };
+  "workgraph/ready": {
+    params: ReadyWorkFilter;
+    result: (WorkItemsResult) & Record<string, unknown>;
+  };
+  "workgraph/snapshot": {
+    params: WorkGraphSnapshotFilter;
+    result: (WorkGraphSnapshot) & Record<string, unknown>;
+  };
+  "workgraph/events": {
+    params: WorkGraphEventFilter;
+    result: (WorkEventsResult) & Record<string, unknown>;
+  };
+  "workgraph/goal/status": {
+    params: GoalStatusRequest;
+    result: (GoalStatusResult) & Record<string, unknown>;
+  };
+  "workgraph/attention/list": {
+    params: AttentionListRequest;
+    result: (AttentionListResult) & Record<string, unknown>;
+  };
+  "skills/list": {
+    params: Record<string, never>;
+    result: (SkillListResponse) & Record<string, unknown>;
+  };
+  "live/open": {
+    params: LiveOpenParams;
+    result: (LiveOpenResult) & Record<string, unknown>;
+  };
+  "live/status": {
+    params: LiveChannelParams;
+    result: (LiveStatusResult) & Record<string, unknown>;
+  };
+  "live/close": {
+    params: LiveChannelParams;
+    result: (LiveCloseResult) & Record<string, unknown>;
+  };
+  "live/send_input": {
+    params: LiveSendInputParams;
+    result: (LiveSendInputResult) & Record<string, unknown>;
+  };
+  "live/commit_input": {
+    params: LiveCommitInputParams;
+    result: (LiveCommitInputResult) & Record<string, unknown>;
+  };
+  "live/interrupt": {
+    params: LiveChannelParams;
+    result: (LiveInterruptResult) & Record<string, unknown>;
+  };
+  "live/truncate": {
+    params: LiveTruncateParams;
+    result: (LiveTruncateResult) & Record<string, unknown>;
+  };
+  "live/refresh": {
+    params: LiveChannelParams;
+    result: (LiveRefreshResult) & Record<string, unknown>;
+  };
+  "live/webrtc/answer": {
+    params: LiveWebrtcAnswerParams;
+    result: (LiveWebrtcAnswerResult) & Record<string, unknown>;
+  };
+  "mob/create": {
+    params: MobCreateParams;
+    result: (MobCreateResult) & Record<string, unknown>;
+  };
+  "mob/list": {
+    params: Record<string, never>;
+    result: (MobListResult) & Record<string, unknown>;
+  };
+  "mob/status": {
+    params: MobIdParams;
+    result: (MobStatusResult) & Record<string, unknown>;
+  };
+  "mob/lifecycle": {
+    params: MobLifecycleParams;
+    result: (MobLifecycleResult) & Record<string, unknown>;
+  };
+  "mob/spawn": {
+    params: MobSpawnParams;
+    result: (MobSpawnResult) & Record<string, unknown>;
+  };
+  "mob/spawn_many": {
+    params: MobSpawnManyParams;
+    result: (MobSpawnManyResult) & Record<string, unknown>;
+  };
+  "mob/ensure_member": {
+    params: MobEnsureMemberParams;
+    result: (MobEnsureMemberResult) & Record<string, unknown>;
+  };
+  "mob/reconcile": {
+    params: MobReconcileParams;
+    result: (MobReconcileResult) & Record<string, unknown>;
+  };
+  "mob/list_members_matching": {
+    params: MobListMembersMatchingParams;
+    result: (MobListMembersMatchingResult) & Record<string, unknown>;
+  };
+  "mob/retire": {
+    params: MobMemberParams;
+    result: (MobRetireResult) & Record<string, unknown>;
+  };
+  "mob/respawn": {
+    params: MobRespawnParams;
+    result: (MobRespawnResult) & Record<string, unknown>;
+  };
+  "mob/wire": {
+    params: MobWireParams;
+    result: (MobWireResult) & Record<string, unknown>;
+  };
+  "mob/wire_members_batch": {
+    params: MobWireMembersBatchParams;
+    result: (MobWireMembersBatchResult) & Record<string, unknown>;
+  };
+  "mob/unwire": {
+    params: MobUnwireParams;
+    result: (MobUnwireResult) & Record<string, unknown>;
+  };
+  "mob/members": {
+    params: MobIdParams;
+    result: (MobMembersResult) & Record<string, unknown>;
+  };
+  "mob/events": {
+    params: MobEventsParams;
+    result: (MobEventsResult) & Record<string, unknown>;
+  };
+  "mob/member_send": {
+    params: MobMemberSendParams;
+    result: (MobMemberSendResult) & Record<string, unknown>;
+  };
+  "mob/ingress_interaction": {
+    params: MobIngressInteractionParams;
+    result: (MobIngressInteractionResult) & Record<string, unknown>;
+  };
+  "mob/append_system_context": {
+    params: MobAppendSystemContextParams;
+    result: (MobAppendSystemContextResult) & Record<string, unknown>;
+  };
+  "mob/flows": {
+    params: MobIdParams;
+    result: (MobFlowsResult) & Record<string, unknown>;
+  };
+  "mob/flow_run": {
+    params: MobFlowRunParams;
+    result: (MobFlowRunResult) & Record<string, unknown>;
+  };
+  "mob/run": {
+    params: MobRunParams;
+    result: (MobFlowRunResult) & Record<string, unknown>;
+  };
+  "mob/flow_status": {
+    params: MobFlowStatusParams;
+    result: (MobFlowStatusResult) & Record<string, unknown>;
+  };
+  "mob/run_result": {
+    params: MobRunResultParams;
+    result: (MobRunResult) & Record<string, unknown>;
+  };
+  "mob/flow_cancel": {
+    params: MobFlowCancelParams;
+    result: (MobFlowCancelResult) & Record<string, unknown>;
+  };
+  "mob/spawn_helper": {
+    params: MobSpawnHelperParams;
+    result: (MobHelperResult) & Record<string, unknown>;
+  };
+  "mob/fork_helper": {
+    params: MobForkHelperParams;
+    result: (MobHelperResult) & Record<string, unknown>;
+  };
+  "mob/force_cancel": {
+    params: MobMemberParams;
+    result: (MobForceCancelResult) & Record<string, unknown>;
+  };
+  "mob/turn_start": {
+    params: MobTurnStartParams;
+    result: (WireRunResult) & Record<string, unknown>;
+  };
+  "mob/member_status": {
+    params: MobMemberParams;
+    result: (MobMemberStatusResult) & Record<string, unknown>;
+  };
+  "mob/snapshot": {
+    params: MobIdParams;
+    result: (MobSnapshotResult) & Record<string, unknown>;
+  };
+  "mob/destroy": {
+    params: MobIdParams;
+    result: (MobDestroyResult) & Record<string, unknown>;
+  };
+  "mob/rotate_supervisor": {
+    params: MobIdParams;
+    result: (MobRotateSupervisorResult) & Record<string, unknown>;
+  };
+  "mob/submit_work": {
+    params: MobSubmitWorkParams;
+    result: (MobSubmitWorkResult) & Record<string, unknown>;
+  };
+  "mob/conclude_objective": {
+    params: MobConcludeObjectiveParams;
+    result: (MobConcludeObjectiveResult) & Record<string, unknown>;
+  };
+  "mob/cancel_work": {
+    params: MobCancelWorkParams;
+    result: (MobCancelWorkResult) & Record<string, unknown>;
+  };
+  "mob/cancel_all_work": {
+    params: MobCancelAllWorkParams;
+    result: (MobCancelAllWorkResult) & Record<string, unknown>;
+  };
+  "mob/wait_kickoff": {
+    params: MobWaitParams;
+    result: (MobWaitMembersResult) & Record<string, unknown>;
+  };
+  "mob/wait_ready": {
+    params: MobWaitParams;
+    result: (MobWaitMembersResult) & Record<string, unknown>;
+  };
+  "mob/profile/create": {
+    params: MobProfileCreateParams;
+    result: (MobProfileLookupResult) & Record<string, unknown>;
+  };
+  "mob/profile/get": {
+    params: MobProfileNameParams;
+    result: (MobProfileLookupResult) & Record<string, unknown>;
+  };
+  "mob/profile/list": {
+    params: Record<string, never>;
+    result: (MobProfileListResult) & Record<string, unknown>;
+  };
+  "mob/profile/update": {
+    params: MobProfileUpdateParams;
+    result: (MobProfileLookupResult) & Record<string, unknown>;
+  };
+  "mob/profile/delete": {
+    params: MobProfileDeleteParams;
+    result: (MobProfileDeleteResult) & Record<string, unknown>;
+  };
+  "mob/stream_open": {
+    params: MobStreamOpenParams;
+    result: (MobStreamOpenResult) & Record<string, unknown>;
+  };
+  "mob/stream_close": {
+    params: MobStreamCloseParams;
+    result: (MobStreamCloseResult) & Record<string, unknown>;
+  };
+  "mob/grant_scopes": {
+    params: MobGrantScopesParams;
+    result: (MobGrantScopesResult) & Record<string, unknown>;
+  };
+  "mob/revoke_scopes": {
+    params: MobRevokeScopesParams;
+    result: (MobRevokeScopesResult) & Record<string, unknown>;
+  };
+  "mob/grants": {
+    params: MobIdParams;
+    result: (MobGrantsResult) & Record<string, unknown>;
+  };
+  "mob/member_history": {
+    params: MobMemberHistoryParams;
+    result: (MobMemberHistoryResult) & Record<string, unknown>;
+  };
+  "mob/hosts": {
+    params: MobIdParams;
+    result: (MobHostsResult) & Record<string, unknown>;
+  };
+  "mob/route_installs": {
+    params: MobIdParams;
+    result: (MobRouteInstallsResult) & Record<string, unknown>;
+  };
+  "mob/bind_host": {
+    params: MobBindHostParams;
+    result: (MobBindHostResult) & Record<string, unknown>;
+  };
+  "mob/revoke_host": {
+    params: MobRevokeHostParams;
+    result: (MobRevokeHostResult) & Record<string, unknown>;
+  };
+  "mob/hard_cancel_member": {
+    params: MobHardCancelParams;
+    result: (MobHardCancelResult) & Record<string, unknown>;
+  };
+  "mob/member_live_open": {
+    params: MobMemberLiveOpenParams;
+    result: (LiveOpenResult) & Record<string, unknown>;
+  };
+  "mob/member_live_close": {
+    params: MobMemberLiveChannelParams;
+    result: (LiveCloseResult) & Record<string, unknown>;
+  };
+  "mob/member_live_status": {
+    params: MobMemberLiveStatusParams;
+    result: (LiveStatusResult) & Record<string, unknown>;
+  };
+  "mob/member_live_control": {
+    params: MobMemberLiveControlParams;
+    result: (BridgeLiveControlOutcome) & Record<string, unknown>;
+  };
+  "mcp/add": {
+    params: McpAddParams;
+    result: (McpLiveOpResponse) & Record<string, unknown>;
+  };
+  "mcp/remove": {
+    params: McpRemoveParams;
+    result: (McpLiveOpResponse) & Record<string, unknown>;
+  };
+  "mcp/reload": {
+    params: McpReloadParams;
+    result: (McpLiveOpResponse) & Record<string, unknown>;
+  };
+  "comms/send": {
+    params: CommsSendParams;
+    result: (CommsSendResult) & Record<string, unknown>;
+  };
+  "comms/peers": {
+    params: CommsPeersParams;
+    result: (CommsPeersResult) & Record<string, unknown>;
+  };
+}
+
+export type RpcMethodName = keyof RpcMethodContracts;
+export type RpcMethodParams<M extends RpcMethodName> =
+  RpcMethodContracts[M]["params"];
+export type RpcMethodResult<M extends RpcMethodName> =
+  RpcMethodContracts[M]["result"];

--- a/sdks/typescript/src/generated/types.ts
+++ b/sdks/typescript/src/generated/types.ts
@@ -397,6 +397,26 @@ export interface SessionExternalEventEnvelopePeerResponseTerminal {
 
 export type SessionExternalEventEnvelope = SessionExternalEventEnvelopeGenericJson | SessionExternalEventEnvelopePeerResponseTerminal;
 
+export interface SessionExternalEventParamsGenericJson {
+  session_id: string;
+  blocks?: WireContentBlock[] | null;
+  event_type: string;
+  kind: "generic_json";
+  payload: unknown;
+}
+
+export interface SessionExternalEventParamsPeerResponseTerminal {
+  session_id: string;
+  display_name?: PeerName | null;
+  kind: "peer_response_terminal";
+  peer_id: PeerId;
+  request_id: string;
+  result: unknown;
+  status: "completed" | "failed" | "cancelled";
+}
+
+export type SessionExternalEventParams = SessionExternalEventParamsGenericJson | SessionExternalEventParamsPeerResponseTerminal;
+
 export interface WireDeviceCompleteResultPending {
   state: "pending";
 }

--- a/sdks/typescript/src/mob.ts
+++ b/sdks/typescript/src/mob.ts
@@ -37,6 +37,8 @@ import type {
   WireHostRef,
   WireMemberLifecycleCapabilities,
   WireMobMemberStatus,
+  WireMobBackendKind,
+  WireMobRuntimeMode,
   WireMemberProgressSnapshot,
   WireNonPortableResourceKind,
   WireReachability,
@@ -206,8 +208,8 @@ export interface MobHelperOptions {
   profileName?: string;
   modelOverride?: string;
   authBinding?: WireAuthBindingRef;
-  runtimeMode?: string;
-  backend?: string;
+  runtimeMode?: WireMobRuntimeMode;
+  backend?: WireMobBackendKind;
 }
 
 export interface MobForkHelperOptions extends MobHelperOptions {

--- a/sdks/typescript/src/types.ts
+++ b/sdks/typescript/src/types.ts
@@ -337,7 +337,7 @@ export interface TranscriptForkOptions extends TranscriptEditOptions {
 /** Canonical message-shaped replacement payload for `session/fork_replace`. */
 export interface TranscriptMessageReplacement {
   readonly type: "message";
-  readonly message: Record<string, unknown>;
+  readonly message: TranscriptRewriteMessage;
 }
 
 /** Replace one content block in a user message. */
@@ -351,7 +351,7 @@ export interface TranscriptUserContentBlockReplacement {
 export interface TranscriptAssistantBlockReplacement {
   readonly type: "assistant_block";
   readonly blockIndex: number;
-  readonly block: Record<string, unknown>;
+  readonly block: Generated.WireAssistantBlock;
 }
 
 /** Replace one content block inside one tool-result payload. */
@@ -384,37 +384,8 @@ export interface TranscriptRewriteReason {
   readonly note?: string;
 }
 
-/** Public transcript message accepted by same-session rewrite APIs. */
-export type TranscriptRewriteMessage =
-  | {
-      readonly role: "system";
-      readonly content: string;
-      readonly created_at?: string;
-    }
-  | {
-      readonly role: "system_notice";
-      readonly kind: string;
-      readonly body?: string;
-      readonly content?: string;
-      readonly blocks?: readonly Record<string, unknown>[];
-      readonly created_at?: string;
-    }
-  | {
-      readonly role: "user";
-      readonly content: ContentInput;
-      readonly created_at?: string;
-    }
-  | {
-      readonly role: "block_assistant";
-      readonly blocks: readonly Record<string, unknown>[];
-      readonly stop_reason?: string;
-      readonly created_at?: string;
-    }
-  | {
-      readonly role: "tool_results";
-      readonly results: readonly Record<string, unknown>[];
-      readonly created_at?: string;
-    };
+/** Generated wire message accepted by same-session rewrite APIs. */
+export type TranscriptRewriteMessage = Generated.TranscriptRewriteMessage;
 
 export type TranscriptRewriteInputMessage = TranscriptRewriteMessage | SessionMessage;
 
@@ -867,7 +838,7 @@ export interface CommsPeerLifecycleCommand {
   kind: "peer_lifecycle";
   to: string;
   lifecycle_kind: "mob.peer_added" | "mob.peer_retired" | "mob.peer_unwired";
-  params?: unknown;
+  params: Generated.CommsPeerLifecycleParams;
 }
 
 // The supervisor bridge is a generated wire contract. The package-root
@@ -1064,7 +1035,7 @@ export interface CommsPeerResponseCommand {
   to: string;
   in_reply_to: string;
   status: CommsResponseStatus;
-  result?: unknown;
+  result?: Generated.CommsPeerResponseResult;
   handling_mode?: CommsHandlingMode;
 }
 
@@ -1193,9 +1164,9 @@ export interface CreateScheduleRequest {
   readonly description?: string;
   readonly trigger: Record<string, unknown>;
   readonly target: Record<string, unknown>;
-  readonly misfirePolicy?: Record<string, unknown> | string;
-  readonly overlapPolicy?: string;
-  readonly missingTargetPolicy?: string;
+  readonly misfirePolicy?: Record<string, unknown>;
+  readonly overlapPolicy?: "allow_concurrent" | "skip_if_running";
+  readonly missingTargetPolicy?: "skip" | "mark_misfired";
   readonly labels?: Readonly<Record<string, string>>;
   readonly planningHorizonDays?: number;
   readonly planningHorizonOccurrences?: number;
@@ -1207,9 +1178,9 @@ export interface UpdateSchedulePatch {
   readonly description?: string;
   readonly trigger?: Record<string, unknown>;
   readonly target?: Record<string, unknown>;
-  readonly misfirePolicy?: Record<string, unknown> | string;
-  readonly overlapPolicy?: string;
-  readonly missingTargetPolicy?: string;
+  readonly misfirePolicy?: Record<string, unknown>;
+  readonly overlapPolicy?: "allow_concurrent" | "skip_if_running";
+  readonly missingTargetPolicy?: "skip" | "mark_misfired";
   readonly planningHorizonDays?: number;
   readonly planningHorizonOccurrences?: number;
   readonly labels?: Readonly<Record<string, string>>;

--- a/sdks/typescript/tests/types.test.js
+++ b/sdks/typescript/tests/types.test.js
@@ -2407,6 +2407,55 @@ describe("Comms methods", () => {
     ]);
   });
 
+  it("does not normalize opaque supervisor bridge JSON", async () => {
+    const client = new MeerkatClient();
+    const calls = [];
+    client.request = async (method, params) => {
+      calls.push({ method, params });
+      return {
+        kind: "peer_request_sent",
+        envelope_id: "env-1",
+        interaction_id: "interaction-1",
+        request_id: "request-1",
+        stream_reserved: false,
+      };
+    };
+    const spec = {
+      output_schema: {
+        default: { type: "image", data: "digest-covered-example" },
+      },
+    };
+
+    await client.send("s1", {
+      kind: "peer_request",
+      to: "agent-a",
+      intent: "supervisor.bridge",
+      params: {
+        command: "materialize_member",
+        binding_generation: 1,
+        epoch: 2,
+        fence_token: 3,
+        generation: 4,
+        launch: { mode: "fresh" },
+        protocol_version: 1,
+        spec,
+        spec_digest: "digest-1",
+        supervisor: {
+          address: "inproc://supervisor",
+          name: "supervisor",
+          peer_id: "pictionary/supervisor/supervisor",
+        },
+      },
+    });
+
+    assert.deepEqual(calls[0].params.params.spec, spec);
+    assert.equal(
+      Object.hasOwn(calls[0].params.params.spec.output_schema.default, "source"),
+      false,
+    );
+    assert.equal(calls[0].params.params.spec_digest, "digest-1");
+  });
+
   it("Session.peers rejects a missing required peers field", async () => {
     const client = new MeerkatClient();
     client.request = async () => ({});

--- a/tools/sdk-codegen/generate.py
+++ b/tools/sdk-codegen/generate.py
@@ -15,7 +15,6 @@ import sys
 from pathlib import Path
 from typing import Any
 
-
 # K20: catalog-named contract types adopted by the totalized RPC method
 # catalog (config/get|set|patch, turn/interrupt, workgraph list/ready/events,
 # initialize, skills/list). Schema-driven; the inventory-coverage ratchet
@@ -396,6 +395,7 @@ PUBLIC_RPC_CATALOG_OBJECT_TYPES = [
 
 PUBLIC_RPC_CATALOG_ALIAS_TYPES = [
     "SessionExternalEventEnvelope",
+    "SessionExternalEventParams",
     "WireDeviceCompleteResult",
 ]
 
@@ -1083,9 +1083,18 @@ def _one_of_typed_dict_variants(
         return None
 
     expanded_variants: list[dict[str, Any]] = []
+    outer_object = {
+        key: value for key, value in schema.items() if key not in {"oneOf", "$defs"}
+    }
+    merge_outer = (
+        outer_object.get("type") == "object"
+        and isinstance(outer_object.get("properties"), dict)
+    )
     for variant in schema["oneOf"]:
         if not isinstance(variant, dict):
             return None
+        if merge_outer:
+            variant = _merge_object_variant_schemas(outer_object, variant)
         expanded_variants.extend(_expand_flattened_object_variants(root, variant))
 
     const_fields_by_variant: list[dict[str, str]] = []
@@ -4511,6 +4520,159 @@ def generate_typescript_types(schemas: dict, output_dir: Path, *, has_comms: boo
     (output_dir / "index.ts").write_text(index_content)
 
 
+def generate_typescript_rpc_contracts(schemas: dict, output_dir: Path) -> None:
+    """Emit the catalog-owned method-to-params/result type map.
+
+    The client transport is generic over this map, so every literal RPC send
+    site is checked against the generated wire contract at the actual request
+    boundary. This is deliberately stronger than requiring a generated type
+    name to appear somewhere inside the enclosing wrapper.
+    """
+    methods = schemas.get("rpc-methods", {}).get("methods")
+    if not isinstance(methods, list):
+        raise KeyError("rpc-methods.json must contain a methods array")
+
+    generated_text = (output_dir / "types.ts").read_text()
+    generated_names = set(
+        re.findall(
+            r"\bexport (?:interface|type|enum|class) ([A-Za-z_$][\w$]*)\b",
+            generated_text,
+        )
+    )
+    referenced: set[str] = set()
+
+    def render_type(type_ref: Any, *, params: bool) -> str:
+        if not type_ref:
+            return "Record<string, never>" if params else "Record<string, unknown>"
+        rendered: list[str] = []
+        for part in str(type_ref).split("|"):
+            name = part.strip()
+            if not name or name == "Value" or name not in generated_names:
+                rendered.append("Record<string, unknown>" if params else "unknown")
+            else:
+                referenced.add(name)
+                rendered.append(name)
+        joined = " | ".join(rendered)
+        if not params and joined != "unknown":
+            return f"({joined}) & Record<string, unknown>"
+        return joined
+
+    entries: list[tuple[str, str, str]] = []
+    for method in methods:
+        if not isinstance(method, dict) or not isinstance(method.get("name"), str):
+            raise KeyError("rpc-methods.json contains an invalid method entry")
+        entries.append(
+            (
+                method["name"],
+                render_type(method.get("params_type"), params=True),
+                render_type(method.get("result_type"), params=False),
+            )
+        )
+
+    lines = [
+        "// Generated RPC method contracts for @rkat/sdk.",
+        "// Source: artifacts/schemas/rpc-methods.json",
+    ]
+    if referenced:
+        lines.append("import type {")
+        lines.extend(f"  {name}," for name in sorted(referenced))
+        lines.extend(["} from \"./types.js\";", ""])
+    lines.append("export interface RpcMethodContracts {")
+    for method, params_type, result_type in entries:
+        lines.append(f"  {json.dumps(method)}: {{")
+        lines.append(f"    params: {params_type};")
+        lines.append(f"    result: {result_type};")
+        lines.append("  };")
+    lines.extend(
+        [
+            "}",
+            "",
+            "export type RpcMethodName = keyof RpcMethodContracts;",
+            "export type RpcMethodParams<M extends RpcMethodName> =",
+            "  RpcMethodContracts[M][\"params\"];",
+            "export type RpcMethodResult<M extends RpcMethodName> =",
+            "  RpcMethodContracts[M][\"result\"];",
+            "",
+        ]
+    )
+    (output_dir / "rpc_contracts.ts").write_text("\n".join(lines))
+
+
+def generate_python_rpc_contracts(schemas: dict, output_dir: Path) -> None:
+    """Emit catalog-owned overloads for the Python transport boundary."""
+    methods = schemas.get("rpc-methods", {}).get("methods")
+    if not isinstance(methods, list):
+        raise KeyError("rpc-methods.json must contain a methods array")
+
+    generated_text = (output_dir / "types.py").read_text()
+    generated_names = set(
+        re.findall(r"^class ([A-Za-z_][A-Za-z0-9_]*)", generated_text, re.MULTILINE)
+    )
+    generated_names.update(
+        re.findall(
+            r"^([A-Za-z_][A-Za-z0-9_]*)\s*(?::\s*[^=\n]+)?=",
+            generated_text,
+            re.MULTILINE,
+        )
+    )
+    referenced: set[str] = set()
+
+    def render_type(type_ref: Any, *, params: bool) -> str:
+        if not type_ref:
+            return "dict[str, Any]"
+        rendered: list[str] = []
+        for part in str(type_ref).split("|"):
+            name = part.strip()
+            if not name or name == "Value" or name not in generated_names:
+                rendered.append("dict[str, Any]" if params else "Any")
+            else:
+                referenced.add(name)
+                rendered.append(name)
+        return " | ".join(rendered)
+
+    entries: list[tuple[str, str, str]] = []
+    for method in methods:
+        if not isinstance(method, dict) or not isinstance(method.get("name"), str):
+            raise KeyError("rpc-methods.json contains an invalid method entry")
+        entries.append(
+            (
+                method["name"],
+                render_type(method.get("params_type"), params=True),
+                render_type(method.get("result_type"), params=False),
+            )
+        )
+
+    lines = [
+        '\"\"\"Generated RPC method contracts for meerkat-sdk.',
+        "",
+        "Source: artifacts/schemas/rpc-methods.json",
+        '\"\"\"',
+        "",
+        "from __future__ import annotations",
+        "",
+        "from collections.abc import Awaitable",
+        "from typing import Any, Literal, Protocol, overload",
+    ]
+    if referenced:
+        lines.extend(["", "from .types import ("])
+        lines.extend(f"    {name}," for name in sorted(referenced))
+        lines.append(")")
+    lines.extend(["", "", "class RpcRequest(Protocol):"])
+    for method, params_type, result_type in entries:
+        lines.extend(
+            [
+                "    @overload",
+                "    def __call__(",
+                "        self,",
+                f"        method: Literal[{json.dumps(method)}],",
+                f"        params: {params_type},",
+                "        /,",
+                f"    ) -> Awaitable[{result_type}]: ...",
+                "",
+            ]
+        )
+    (output_dir / "rpc_contracts.py").write_text("\n".join(lines))
+
 def _web_events_ts_type(root: dict[str, Any], schema: Any) -> str:
     if schema is True:
         return "unknown"
@@ -6493,6 +6655,8 @@ def main():
     py_output = output_root / "sdks" / "python" / "meerkat" / "generated"
     generate_python_types(schemas, py_output, has_comms=has_comms, has_skills=has_skills)
     print(f"Generated Python types in {py_output}")
+    generate_python_rpc_contracts(schemas, py_output)
+    print(f"Generated Python RPC contracts in {py_output}")
     generate_python_event_inventory(schemas, py_output)
     print(f"Generated Python event inventory in {py_output}")
     # Must follow generate_python_types: the event payload module emits only the
@@ -6507,6 +6671,8 @@ def main():
     ts_output = output_root / "sdks" / "typescript" / "src" / "generated"
     generate_typescript_types(schemas, ts_output, has_comms=has_comms, has_skills=has_skills)
     print(f"Generated TypeScript types in {ts_output}")
+    generate_typescript_rpc_contracts(schemas, ts_output)
+    print(f"Generated TypeScript RPC contracts in {ts_output}")
     generate_typescript_event_inventory(schemas, ts_output)
     print(f"Generated TypeScript event inventory in {ts_output}")
     # Must follow generate_typescript_types, for the same reason as the Python


### PR DESCRIPTION
## What changed

- generated complete TypeScript and Python RPC contract maps for all 164 catalog methods
- bound the actual TypeScript and Python request transports to those generated method, params, and result types
- removed the marker-only signature aliases and the expired 239-entry hand-rolled waiver
- fixed the incomplete `session/external_event` catalog contract by adding the required `session_id` alongside its flattened event envelope
- fixed Python codegen so outer object properties are preserved when schemas use root `oneOf` variants
- structurally checks every literal Python request payload against generated required-field alternatives
- migrated remaining untyped Python request parameters and repaired auth login wrappers that omitted required realm and binding selectors
- restricted TypeScript content normalization to known content fields so opaque digest-covered bridge JSON is never rewritten

## Why

The expired waiver hid duplicate hand-authored wire truth. The previous PR shape referenced generated types without constraining the actual request boundary, so it could still drift while the parity gate remained green. This implementation makes the catalog-generated contracts authoritative at the transport seam.

## Impact

Runtime behavior is unchanged except for two correctness fixes:

- `session/external_event` now has a complete generated contract matching the handler's existing wire payload
- Python auth login start requests now include the catalog-required realm and binding selectors instead of sending requests the server must reject

TypeScript and Python wrappers retain dictionary compatibility at runtime while exposing generated request types at their public boundaries.

## Validation

- mandatory full pre-push hook passed on `4b2cd5d2e`, including changed-crate Clippy, machine/TLC verification, generated-header and Bazel gates, workspace library and integration tests, cold restart, and e2e-fast
- RPC parity mutation suite: 6/6 passed, including marker-only, missing-method, unbound-transport, misspelled required-key, and local-annotation bypass cases
- post-review TypeScript build and opaque-bridge normalization regression passed
- post-review Python wrapper focus: 9/9 passed
- RPC surface alignment, schema freshness, SDK codegen freshness, wrapper freshness, SDK event inventory, Ruff, formatting, syntax, and diff checks passed
- exact-SHA GitHub CI run 32215022557 passed: 30 successful jobs, 1 intentionally skipped bounded-TLC job, and 0 failures
- full SDK lane on the exact SHA passed: TypeScript 307/307; Python 531 passed and 9 skipped