### PR TITLE
Retry unknown provider failures before terminalizing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,10 @@ them.
   backoff waits totaling about 3.5 seconds plus up to four provider round trips
   before terminalizing. These attempts consume the aggregate turn budget, so
   operators should check turn deadlines, stall alerts, and console read
-  timeouts against their provider latency.
+  timeouts against their provider latency. As an intentional REST wire-contract
+  consequence, such exhausted unknown failures now report error kind
+  `retry_exhausted` rather than `llm_failure`; clients branching on that code
+  must handle the new value.
 
 ## [0.8.24] - 2026-08-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,21 @@ them.
 
 ## [Unreleased]
 
+### Corrected
+
+- Provider failures whose class is genuinely unknown now enter the existing
+  machine-authorized, bounded retry path instead of terminalizing the agent on
+  the first attempt. The retry budget and exponential backoff are unchanged;
+  explicit terminal classes such as invalid request, authentication failure,
+  missing model, content filtering, context overflow, and oversized requests
+  remain non-retryable. OpenAI Responses streaming now also recognizes the
+  observed `server_is_overloaded` code as the typed retryable overload class.
+  With the default policy, a persistently unknown failure can now add three
+  backoff waits totaling about 3.5 seconds plus up to four provider round trips
+  before terminalizing. These attempts consume the aggregate turn budget, so
+  operators should check turn deadlines, stall alerts, and console read
+  timeouts against their provider latency.
+
 ## [0.8.24] - 2026-08-18
 
 ### Breaking

--- a/meerkat-core/src/agent/state.rs
+++ b/meerkat-core/src/agent/state.rs
@@ -17149,6 +17149,66 @@ mod tests {
         }
     }
 
+    struct UnknownThenSucceedClient {
+        calls: std::sync::atomic::AtomicUsize,
+    }
+
+    impl UnknownThenSucceedClient {
+        fn new() -> Self {
+            Self {
+                calls: std::sync::atomic::AtomicUsize::new(0),
+            }
+        }
+
+        fn calls(&self) -> usize {
+            self.calls.load(std::sync::atomic::Ordering::SeqCst)
+        }
+    }
+
+    #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+    #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+    impl AgentLlmClient for UnknownThenSucceedClient {
+        async fn stream_response(
+            &self,
+            _messages: &[Message],
+            _tools: &[Arc<ToolDef>],
+            _max_tokens: u32,
+            _temperature: Option<f32>,
+            _provider_params: Option<&crate::lifecycle::run_primitive::ProviderParamsOverride>,
+        ) -> Result<super::LlmStreamResult, AgentError> {
+            let attempt = self.calls.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            if attempt == 0 {
+                return Err(AgentError::llm(
+                    "mock",
+                    crate::error::LlmFailureReason::ProviderError(
+                        crate::error::LlmProviderError::retryable(
+                            crate::error::LlmProviderErrorKind::Unknown,
+                            serde_json::json!({"message": "unrecognized provider failure"}),
+                        ),
+                    ),
+                    "unrecognized provider failure",
+                ));
+            }
+
+            Ok(super::LlmStreamResult::new(
+                vec![AssistantBlock::Text {
+                    text: "ok after unknown retry".to_string(),
+                    meta: None,
+                }],
+                StopReason::EndTurn,
+                normalized_test_usage(self, Usage::default()),
+            ))
+        }
+
+        fn provider(&self) -> crate::provider::Provider {
+            crate::provider::Provider::Other
+        }
+
+        fn model(&self) -> &'static str {
+            "mock-model"
+        }
+    }
+
     /// First call reports one stream event then hangs forever; second call
     /// succeeds. Exercises the stream-inactivity watchdog retry path.
     struct StallThenSucceedClient {
@@ -18461,6 +18521,38 @@ mod tests {
         assert!(
             actual_delay >= hint,
             "retry delay ({actual_delay:?}) must be at least the server hint ({hint:?})",
+        );
+    }
+
+    #[tokio::test]
+    async fn unknown_provider_failure_retries_instead_of_killing_agent() {
+        use crate::retry::RetryPolicy;
+
+        let client = Arc::new(UnknownThenSucceedClient::new());
+        let mut agent = with_test_turn_state_handle(AgentBuilder::new())
+            .retry_policy(RetryPolicy {
+                max_retries: 1,
+                initial_delay: Duration::from_millis(1),
+                max_delay: Duration::from_millis(1),
+                multiplier: 1.0,
+                call_timeout: None,
+                stream_inactivity_timeout: None,
+            })
+            .build_standalone(client.clone(), Arc::new(NoTools), Arc::new(NoopStore))
+            .await;
+
+        let result = agent
+            .run("retry unknown once".to_string().into())
+            .await
+            .expect(
+                "an unknown provider failure must consume retry authority before terminalizing",
+            );
+
+        assert_eq!(result.text, "ok after unknown retry");
+        assert_eq!(
+            client.calls(),
+            2,
+            "one unknown failure, one successful retry"
         );
     }
 

--- a/meerkat-core/src/retry.rs
+++ b/meerkat-core/src/retry.rs
@@ -481,6 +481,26 @@ mod tests {
     }
 
     #[test]
+    fn retry_schedule_bounds_unknown_provider_failures() {
+        let policy = RetryPolicy::default().with_max_retries(2);
+        let error = AgentError::Llm {
+            provider: "test",
+            reason: LlmFailureReason::ProviderError(LlmProviderError::retryable(
+                LlmProviderErrorKind::Unknown,
+                serde_json::json!({"message": "unrecognized provider failure"}),
+            )),
+            message: "unrecognized provider failure".to_string(),
+        };
+
+        assert!(policy.schedule_retry(&error, 0, None).is_some());
+        assert!(policy.schedule_retry(&error, 1, None).is_some());
+        assert!(
+            policy.schedule_retry(&error, 2, None).is_none(),
+            "unknown failures must exhaust the configured retry budget"
+        );
+    }
+
+    #[test]
     fn retry_schedule_ignores_json_only_provider_retryability() {
         let policy = RetryPolicy::default().with_max_retries(3);
         let error = AgentError::Llm {

--- a/meerkat-llm-core/src/error.rs
+++ b/meerkat-llm-core/src/error.rs
@@ -78,6 +78,11 @@ pub enum LlmError {
     InvalidApiKey,
 
     // === Unknown ===
+    /// The provider returned a failure class this client does not yet know.
+    /// This is deliberately retryable: absence of a known terminal class is
+    /// not evidence that the turn should terminalize.
+    /// [`RetryPolicy`](meerkat_core::retry::RetryPolicy) still bounds attempts
+    /// and backoff.
     #[error("Unknown error: {message}")]
     Unknown { message: String },
 
@@ -186,7 +191,8 @@ impl LlmError {
             Self::RateLimited { .. }
             | Self::ServerOverloaded
             | Self::NetworkTimeout { .. }
-            | Self::ConnectionReset => true,
+            | Self::ConnectionReset
+            | Self::Unknown { .. } => true,
             Self::ServerError { status, .. } => *status >= 500,
             _ => false,
         }
@@ -329,7 +335,7 @@ impl LlmError {
                 }),
             )),
             Self::Unknown { message } => {
-                LlmFailureReason::ProviderError(LlmProviderError::non_retryable(
+                LlmFailureReason::ProviderError(LlmProviderError::retryable(
                     LlmProviderErrorKind::Unknown,
                     json!({
                         "message": message,
@@ -414,6 +420,23 @@ mod tests {
                 model: "gpt-5".to_string()
             }
             .is_retryable()
+        );
+    }
+
+    #[test]
+    fn unknown_provider_errors_default_to_retryable() {
+        let err = LlmError::Unknown {
+            message: "provider returned an unrecognized transient class".to_string(),
+        };
+
+        assert!(err.is_retryable());
+        let LlmFailureReason::ProviderError(provider_error) = err.failure_reason() else {
+            panic!("unknown provider failures must retain the provider-error carrier");
+        };
+        assert_eq!(provider_error.kind, LlmProviderErrorKind::Unknown);
+        assert_eq!(
+            provider_error.retryability,
+            meerkat_core::error::LlmProviderErrorRetryability::Retryable
         );
     }
 

--- a/meerkat-openai/src/client.rs
+++ b/meerkat-openai/src/client.rs
@@ -2779,27 +2779,7 @@ impl LlmClient for OpenAiClient {
                                 "OpenAI response failed"
                             );
 
-                            let error = match error_code {
-                                "rate_limit_exceeded" => LlmError::RateLimited { retry_after_ms: None },
-                                "server_error" => LlmError::ServerError {
-                                    status: 500,
-                                    message: error_msg.to_string(),
-                                },
-                                "context_length_exceeded" | "context_window_exceeded" => {
-                                    LlmError::ContextLengthExceeded {
-                                        max: 0,
-                                        requested: 1,
-                                    }
-                                }
-                                "invalid_request_error" => LlmError::from_http_status(
-                                    400,
-                                    error_msg.to_string(),
-                                    None,
-                                ),
-                                _ => LlmError::Unknown {
-                                    message: format!("{error_code}: {error_msg}"),
-                                },
-                            };
+                            let error = map_responses_stream_error(error_code, error_msg);
 
                             done_emitted = true;
                             chunk_yielded.set(true);
@@ -2826,27 +2806,7 @@ impl LlmClient for OpenAiClient {
                                 "OpenAI streaming error"
                             );
 
-                            let error = match error_code {
-                                "rate_limit_exceeded" => LlmError::RateLimited { retry_after_ms: None },
-                                "server_error" => LlmError::ServerError {
-                                    status: 500,
-                                    message: error_msg.to_string(),
-                                },
-                                "context_length_exceeded" | "context_window_exceeded" => {
-                                    LlmError::ContextLengthExceeded {
-                                        max: 0,
-                                        requested: 1,
-                                    }
-                                }
-                                "invalid_request_error" => LlmError::from_http_status(
-                                    400,
-                                    error_msg.to_string(),
-                                    None,
-                                ),
-                                _ => LlmError::Unknown {
-                                    message: format!("{error_code}: {error_msg}"),
-                                },
-                            };
+                            let error = map_responses_stream_error(error_code, error_msg);
 
                             done_emitted = true;
                             chunk_yielded.set(true);
@@ -2919,6 +2879,27 @@ struct ResponsesStreamEvent {
     output_index: Option<u64>,
     /// Sequence number for built-in tool streaming events.
     sequence_number: Option<u64>,
+}
+
+fn map_responses_stream_error(error_code: &str, error_message: &str) -> LlmError {
+    match error_code {
+        "rate_limit_exceeded" => LlmError::RateLimited {
+            retry_after_ms: None,
+        },
+        "server_error" => LlmError::ServerError {
+            status: 500,
+            message: error_message.to_string(),
+        },
+        "server_is_overloaded" => LlmError::ServerOverloaded,
+        "context_length_exceeded" | "context_window_exceeded" => LlmError::ContextLengthExceeded {
+            max: 0,
+            requested: 1,
+        },
+        "invalid_request_error" => LlmError::from_http_status(400, error_message.to_string(), None),
+        _ => LlmError::Unknown {
+            message: format!("{error_code}: {error_message}"),
+        },
+    }
 }
 
 fn validate_responses_terminal_status(event_type: &str, response: &Value) -> Result<(), LlmError> {
@@ -7455,6 +7436,68 @@ mod tests {
             saw_error_done,
             "Expected Done with error outcome from response.failed"
         );
+    }
+
+    #[tokio::test]
+    async fn response_failed_server_is_overloaded_is_typed_retryable() {
+        let payload = [
+            r#"data: {"type":"response.failed","response":{"id":"resp_overloaded","status":"failed","error":{"code":"server_is_overloaded","message":"The server is overloaded. Please retry later."}}}"#,
+            "",
+        ]
+        .join("\n");
+        let (base_url, server) = spawn_openai_stub_server(payload).await;
+        let client = OpenAiClient::new_with_base_url("test-key".to_string(), base_url);
+        let request = LlmRequest::new(
+            "gpt-5-mini",
+            vec![Message::User(UserMessage::text("hello".to_string()))],
+        );
+
+        let mut stream = client.stream(&request);
+        let mut observed = None;
+        while let Some(event) = stream.next().await {
+            if let LlmEvent::Done {
+                outcome: LlmDoneOutcome::Error { error },
+            } = event.expect("stream event")
+            {
+                observed = Some(error);
+                break;
+            }
+        }
+        server.abort();
+
+        let error = observed.expect("response.failed must yield a terminal error event");
+        assert!(matches!(&error, LlmError::ServerOverloaded));
+        let meerkat_core::error::LlmFailureReason::ProviderError(provider_error) =
+            error.failure_reason()
+        else {
+            panic!("overload must retain a typed provider failure");
+        };
+        assert_eq!(
+            provider_error.kind,
+            meerkat_core::error::LlmProviderErrorKind::ServerOverloaded
+        );
+        assert!(provider_error.is_retryable());
+    }
+
+    #[test]
+    fn unrecognized_stream_error_code_defaults_to_retryable_unknown() {
+        let error = map_responses_stream_error(
+            "future_transient_provider_error",
+            "provider asks the caller to try again later",
+        );
+
+        assert!(matches!(&error, LlmError::Unknown { .. }));
+        assert!(error.is_retryable());
+        let meerkat_core::error::LlmFailureReason::ProviderError(provider_error) =
+            error.failure_reason()
+        else {
+            panic!("unknown provider failure must retain a typed provider carrier");
+        };
+        assert_eq!(
+            provider_error.kind,
+            meerkat_core::error::LlmProviderErrorKind::Unknown
+        );
+        assert!(provider_error.is_retryable());
     }
 
     // =========================================================================

--- a/meerkat-rest/src/lib.rs
+++ b/meerkat-rest/src/lib.rs
@@ -14252,7 +14252,9 @@ mod tests {
         assert!(payload["details"]["session_id"].is_string());
         assert!(payload["details"]["session_ref"].is_string());
         assert_eq!(payload["details"]["turn_error_code"], "TURN_ABANDONED");
-        assert_eq!(payload["details"]["error"]["kind"], "llm_failure");
+        // ErrorLlmClient returns an unclassified provider failure. Unknown
+        // failures now exhaust the bounded retry policy before terminalizing.
+        assert_eq!(payload["details"]["error"]["kind"], "retry_exhausted");
         assert_eq!(payload["details"]["error"]["terminal"], true);
     }
 

--- a/meerkat-runtime/src/meerkat_machine_tests.rs
+++ b/meerkat-runtime/src/meerkat_machine_tests.rs
@@ -18016,7 +18016,9 @@ async fn apply_input_intermediate_peer_input_during_running_turn_wakes_without_b
         );
     }
 
-    allow_first_finish.notify_waiters();
+    // Store a permit if the executor has signalled start but has not yet
+    // polled its release future. notify_waiters would lose that release.
+    allow_first_finish.notify_one();
 
     let settled = tokio::time::timeout(Duration::from_secs(1), async {
         loop {

--- a/meerkat-runtime/tests/meerkat_machine.rs
+++ b/meerkat-runtime/tests/meerkat_machine.rs
@@ -4372,11 +4372,14 @@ async fn degraded_registration_cold_reloads_through_the_ordinary_registration_pa
     // fail roughly one run in three, always with `left: None`, which reads as
     // "the successor cannot execute" when it actually means "nobody looked".
     //
-    // Await a real reading, then assert on it. A genuine nonzero still fails.
+    // Await real readings from both nonblocking accessors, then assert on them.
+    // A genuine nonzero still fails.
     let mut reload_required = None;
+    let mut dead_runtime_loops = None;
     for _ in 0..200 {
-        if let Some(count) = adapter.reload_required_session_count() {
-            reload_required = Some(count);
+        reload_required = adapter.reload_required_session_count();
+        dead_runtime_loops = adapter.dead_runtime_loop_session_count();
+        if reload_required.is_some() && dead_runtime_loops.is_some() {
             break;
         }
         tokio::time::sleep(Duration::from_millis(5)).await;
@@ -4387,7 +4390,7 @@ async fn degraded_registration_cold_reloads_through_the_ordinary_registration_pa
         "the successor must be able to execute against durable state"
     );
     assert_eq!(
-        adapter.dead_runtime_loop_session_count(),
+        dead_runtime_loops,
         Some(0),
         "and it must carry a live runtime loop rather than inherit the corpse"
     );


### PR DESCRIPTION
## What changed

- Make genuinely unknown provider failures retryable through the existing machine-authorized RetryPolicy instead of terminalizing on the first attempt.
- Recognize the observed OpenAI Responses streaming code server_is_overloaded as the typed ServerOverloaded class.
- Use one shared structured streaming-error mapper for both response.failed and error SSE events.
- Declare the REST terminal wire consequence: exhausted unknown failures now report retry_exhausted instead of llm_failure.
- Stabilize two existing runtime lifecycle regressions exposed by the release/main gates without changing production behavior.

## Why

OB3 observed OpenAI server_is_overloaded arrive as Unknown on Meerkat 0.8.23. The first failure terminalized 20 of 36 workers, produced zero retries, and stranded 19 claimed initiatives even though the provider explicitly asked the caller to retry later.

The policy is deliberately survival-biased: explicit terminal classes remain terminal, but absence of a known terminal classification is not evidence that the agent should die. Unknown failures reuse the existing bounded retry state machine and exponential backoff, so there is no hot loop or new retry authority.

With defaults, a persistent unknown failure can add three backoff waits totaling about 3.5 seconds plus up to four provider round trips. Those attempts consume the aggregate turn budget. Operators should re-check turn deadlines, stall alerts, and console read timeouts against provider latency.

## Mainline test-race repairs

- The cold-reload integration regression now waits for real readings from both nonblocking try_read health accessors. None means no measurement, not zero.
- The peer-wake unit regression now releases its blocked executor with Notify::notify_one, which retains a permit if the executor has signalled start but has not yet polled its release future. notify_waiters could lose that release under CI scheduling.

These are test-only corrections. The second race was independently observed on exact-main CI run 32216431941; the first was independently observed by the mandatory pre-push workspace lane.

## Validation

- Mandatory pre-push hook passed end to end on aa91749cd: hygiene, format, scoped Clippy, machine verification, generated-header and bridge gates, Bazel/lock gates, gate self-tests, 10,360 workspace unit tests, 2,121 workspace integration tests, Mob cold restart, and e2e-fast.
- Exact workspace-shape cold-reload regression passed under --workspace --tests.
- Exact peer-wake unit regression passed.
- Exact REST retry-exhaustion regression passed.
- Focused retry policy, OpenAI mapping, and agent survival regressions passed.
- MobKit second-head review passed the production retry/fallback semantics and confirmed no tool replay exposure; it also reviewed the REST wire declaration. Final tip adds test-only race repairs.

## Adopter impact

Clients branching on the REST error kind llm_failure for persistently unknown provider failures must also handle retry_exhausted. Explicit authentication, invalid request, missing model, content filtering, context overflow, and oversized request failures remain non-retryable.
