### PR TITLE
Keep changed-crate Clippy scoped to changed packages

### DIFF
--- a/scripts/cargo-agent-gate
+++ b/scripts/cargo-agent-gate
@@ -403,6 +403,7 @@ else
 fi
 
 clippy_flags=("${pkg_flags[@]}")
+clippy_scope_args=("--no-deps")
 clippy_target_args=("--all-targets" "--all-features")
 if [[ "${#sorted_exact_tests[@]}" -gt 0 ]]; then
   clippy_flags=("${test_flags[@]}")
@@ -424,6 +425,7 @@ if [[ "${dry_run}" -eq 1 ]]; then
   if [[ "${run_clippy}" -eq 1 ]]; then
     printf 'DRY-RUN %s clippy' "$CARGO"
     printf ' %q' "${clippy_flags[@]}"
+    printf ' %q' "${clippy_scope_args[@]}"
     if [[ "${#clippy_target_args[@]}" -gt 0 ]]; then
       printf ' %q' "${clippy_target_args[@]}"
     fi
@@ -438,7 +440,7 @@ if [[ "${dry_run}" -eq 1 ]]; then
 fi
 
 if [[ "${run_clippy}" -eq 1 ]]; then
-  "$CARGO" clippy "${clippy_flags[@]}" ${clippy_target_args[@]+"${clippy_target_args[@]}"} -- -D warnings
+  "$CARGO" clippy "${clippy_flags[@]}" "${clippy_scope_args[@]}" ${clippy_target_args[@]+"${clippy_target_args[@]}"} -- -D warnings
 fi
 if [[ "${run_tests}" -eq 1 ]]; then
   "$CARGO" nextest run "${test_flags[@]}" --profile fast --no-tests=pass \

--- a/scripts/rust-lane-doctor
+++ b/scripts/rust-lane-doctor
@@ -216,6 +216,47 @@ else
   printf '%s\n' "${agent_gate_probe}" >&2
 fi
 
+package_clippy_probe_dir="$(mktemp -d "${TMPDIR:-/tmp}/meerkat-clippy-scope.XXXXXX")"
+trap 'rm -rf -- "${package_clippy_probe_dir}"' EXIT
+package_clippy_probe_metadata="${package_clippy_probe_dir}/metadata.json"
+package_clippy_probe_args="${package_clippy_probe_dir}/args"
+package_clippy_probe_cargo="${package_clippy_probe_dir}/cargo"
+./scripts/repo-cargo metadata --format-version=1 --no-deps >"${package_clippy_probe_metadata}"
+cat >"${package_clippy_probe_cargo}" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+case "${1:-}" in
+  metadata)
+    cat "${CARGO_AGENT_GATE_TEST_METADATA}"
+    ;;
+  clippy)
+    shift
+    printf '%s\n' "$@" >"${CARGO_AGENT_GATE_TEST_ARGS}"
+    ;;
+  *)
+    printf 'unexpected cargo-agent-gate command: %s\n' "${1:-<none>}" >&2
+    exit 64
+    ;;
+esac
+EOF
+chmod +x "${package_clippy_probe_cargo}"
+package_clippy_probe="$({
+  CARGO="${package_clippy_probe_cargo}" \
+    CARGO_AGENT_GATE_TEST_METADATA="${package_clippy_probe_metadata}" \
+    CARGO_AGENT_GATE_TEST_ARGS="${package_clippy_probe_args}" \
+    ./scripts/cargo-agent-gate --clippy-only --working-tree meerkat-openai/src/client.rs
+} 2>&1 || true)"
+expected_package_clippy_args=$'-p\nmeerkat-openai\n--no-deps\n--all-targets\n--all-features\n--\n-D\nwarnings'
+actual_package_clippy_args="$(cat "${package_clippy_probe_args}" 2>/dev/null || true)"
+if [[ "${actual_package_clippy_args}" == "${expected_package_clippy_args}" ]]; then
+  pass "cargo-agent-gate executes changed-crate Clippy with package-only dependencies"
+else
+  bad "cargo-agent-gate package Clippy can lint unrelated path dependencies"
+  printf '%s\n' "${package_clippy_probe}" >&2
+  printf 'actual Clippy args:\n%s\n' "${actual_package_clippy_args}" >&2
+fi
+
 buildbuddy_agent_gate_probe="$(MEERKAT_BUILDBUDDY=1 ./scripts/agent-gate --dry-run --working-tree meerkat-runtime/src/input_ledger.rs 2>&1 || true)"
 if [[ "${buildbuddy_agent_gate_probe}" == *"BuildBuddy agent gate paths:"* &&
   "${buildbuddy_agent_gate_probe}" == *"BuildBuddy changed gate dry-run"* ]]; then


### PR DESCRIPTION
## Summary

- pass `--no-deps` to package-scoped `cargo-agent-gate` Clippy runs
- retain `--all-targets --all-features` and `-D warnings` for the changed package
- execute the real gate path in `rust-lane-doctor` against a recording Cargo stub and exact-match its argument vector

## Why

Changed-crate Clippy currently lints path dependencies too, rebuilding and linting large unrelated workspace crates. The changed package should remain strict, while workspace-wide Clippy remains the final broad verification lane.

## Validation

- `rust-lane-doctor`: 22 pass, 1 expected dirty-tree warning, 0 fail
- mutation proof: removing `--no-deps` makes the doctor fail 1/1; restoring it passes
- real `meerkat-openai` all-target/all-feature package Clippy path passed
- mandatory pre-push hook passed: workspace Clippy, machine verification, 10,360 unit tests, workspace integration tests, cold restart, and e2e-fast
- first local all-at-once unit attempt had seven lifecycle observation failures; all seven passed serialized in 3.07s, exact-main sharded CI was green, and the authoritative hook rerun passed all 10,360 tests

No Rust source or runtime behavior changes.
