### PR TITLE
Reuse stable detached pre-push caches

### DIFF
--- a/scripts/pre-push-bazel-locks.sh
+++ b/scripts/pre-push-bazel-locks.sh
@@ -121,7 +121,15 @@ elif [[ -z "${bb_bin}" ]]; then
     "${YELLOW}" "${NC}"
 else
   lock_log="${TMPDIR:-/tmp}/meerkat-pre-push-bazel-lock.$$"
-  if "${bb_bin}" mod deps --lockfile_mode=error >"${lock_log}" 2>&1; then
+  bb_startup_args=()
+  if [[ -n "${MEERKAT_PRE_PUSH_BAZEL_OUTPUT_BASE:-}" ]]; then
+    mkdir -p "$(dirname "${MEERKAT_PRE_PUSH_BAZEL_OUTPUT_BASE}")"
+    bb_startup_args+=(
+      "--output_base=${MEERKAT_PRE_PUSH_BAZEL_OUTPUT_BASE}"
+      "--max_idle_secs=${MEERKAT_PRE_PUSH_BAZEL_MAX_IDLE_SECS:-600}"
+    )
+  fi
+  if "${bb_bin}" "${bb_startup_args[@]}" mod deps --lockfile_mode=error >"${lock_log}" 2>&1; then
     printf '%bBazel module lockfile is up to date%b\n' "${GREEN}" "${NC}"
   else
     printf '%bMODULE.bazel.lock is stale.%b\n' "${RED}" "${NC}"

--- a/scripts/pre-push-dispatch.sh
+++ b/scripts/pre-push-dispatch.sh
@@ -102,6 +102,8 @@ pushed_tree="$(git -C "$SOURCE_ROOT" rev-parse "${pushed_commit}^{tree}")"
 git_common_dir="$(git -C "$SOURCE_ROOT" rev-parse --path-format=absolute --git-common-dir)"
 hook_cache_root="${git_common_dir}/meerkat-hook-cache"
 hook_cache_dir="${hook_cache_root}/exact-tree"
+# This accelerates identical tracked trees only. CI remains authoritative for
+# toolchain, environment, credential, and other inputs outside the Git tree.
 hook_stamp="${hook_cache_dir}/${CACHE_VERSION}-${pushed_tree}.ok"
 dispatcher_lock_dir="${hook_cache_root}/dispatcher.lock"
 dispatcher_lock_pid="${dispatcher_lock_dir}/pid"

--- a/scripts/pre-push-dispatch.sh
+++ b/scripts/pre-push-dispatch.sh
@@ -32,6 +32,24 @@ REMOTE_URL="$2"
 SOURCE_ROOT="$(git rev-parse --show-toplevel)"
 ZERO_SHA="0000000000000000000000000000000000000000"
 CACHE_VERSION="v1"
+LOCK_WAIT_SECS="${MEERKAT_PRE_PUSH_DISPATCH_LOCK_WAIT_SECS:-3600}"
+
+hash_path() {
+  if command -v shasum >/dev/null 2>&1; then
+    printf '%s' "$1" | shasum -a 256 | cut -c1-16
+  elif command -v sha256sum >/dev/null 2>&1; then
+    printf '%s' "$1" | sha256sum | cut -c1-16
+  else
+    printf '%s' "$1" | cksum | cut -d' ' -f1
+  fi
+}
+
+sanitize_cache_key() {
+  local raw="${1:-}"
+  local key
+  key="$(printf '%s' "${raw}" | LC_ALL=C tr -c 'A-Za-z0-9._-' '-')"
+  printf '%s' "${key:-default}"
+}
 
 # Git exports repository-local variables to hooks. They must not cross into the
 # detached validation worktree: nested git commands would otherwise continue
@@ -81,33 +99,40 @@ fi
 
 dispatch_step="resolving the exact-tree evidence cache"
 pushed_tree="$(git -C "$SOURCE_ROOT" rev-parse "${pushed_commit}^{tree}")"
-git_common_dir="$(git -C "$SOURCE_ROOT" rev-parse --git-common-dir)"
-if [[ "$git_common_dir" != /* ]]; then
-  git_common_dir="${SOURCE_ROOT}/${git_common_dir}"
-fi
-hook_cache_dir="${git_common_dir}/meerkat-hook-cache/exact-tree"
+git_common_dir="$(git -C "$SOURCE_ROOT" rev-parse --path-format=absolute --git-common-dir)"
+hook_cache_root="${git_common_dir}/meerkat-hook-cache"
+hook_cache_dir="${hook_cache_root}/exact-tree"
 hook_stamp="${hook_cache_dir}/${CACHE_VERSION}-${pushed_tree}.ok"
-mkdir -p "$hook_cache_dir"
+dispatcher_lock_dir="${hook_cache_root}/dispatcher.lock"
+dispatcher_lock_pid="${dispatcher_lock_dir}/pid"
+validation_lane="$(sanitize_cache_key "${RUST_LANE_ID:-pre-push}")"
+validation_tree="${hook_cache_root}/worktrees/${validation_lane}"
+validation_run_root=""
+validation_tree_owned=0
+dispatcher_lock_held=0
+export RUST_LANE_ID="${RUST_LANE_ID:-pre-push}"
 
-if [[ "${MEERKAT_SKIP_PRE_PUSH_TREE_CACHE:-0}" != "1" && -f "$hook_stamp" ]]; then
-  echo "complete pre-push gate already validated for tree ${pushed_tree}; reusing exact-tree evidence."
-  exit 0
-fi
+release_dispatcher_lock() {
+  if [[ "${dispatcher_lock_held}" -eq 1 ]]; then
+    rm -rf -- "${dispatcher_lock_dir}"
+    dispatcher_lock_held=0
+  fi
+}
 
-dispatch_step="creating the detached validation worktree"
-validation_root="$(mktemp -d "${TMPDIR:-/tmp}/meerkat-pre-push-exact.XXXXXX")"
-validation_tree="${validation_root}/tree"
 cleanup() {
   local pending_status=$?
-  if [[ -d "$validation_tree" ]]; then
+  if [[ "${validation_tree_owned}" -eq 1 && -n "${validation_tree}" && -d "${validation_tree}" ]]; then
     if ! git -C "$SOURCE_ROOT" worktree remove --force "$validation_tree" >/dev/null 2>&1; then
       echo "note: validation worktree left behind: ${validation_tree}" >&2
       echo "      prune it with: git -C ${SOURCE_ROOT} worktree prune" >&2
     fi
   fi
-  if ! rm -rf "$validation_root" 2>/dev/null; then
-    echo "note: validation scratch directory left behind: ${validation_root}" >&2
+  if [[ -n "${validation_run_root}" && -d "${validation_run_root}" ]]; then
+    if ! rm -rf -- "${validation_run_root}" 2>/dev/null; then
+      echo "note: validation scratch directory left behind: ${validation_run_root}" >&2
+    fi
   fi
+  release_dispatcher_lock
   # Residue must never decide the push. A failing command inside an EXIT trap
   # under `set -e` otherwise rewrites a fully passing gate into a bare exit 1
   # with nothing but hook successes on screen, which is exactly the
@@ -116,6 +141,80 @@ cleanup() {
 }
 trap cleanup EXIT
 
+acquire_dispatcher_lock() {
+  local start_ts now_ts owner_pid last_notice_ts stale_lock_dir lock_mtime
+  start_ts="$(date +%s)"
+  last_notice_ts="${start_ts}"
+  while ! mkdir "${dispatcher_lock_dir}" 2>/dev/null; do
+    owner_pid=""
+    if [[ -f "${dispatcher_lock_pid}" ]]; then
+      owner_pid="$(cat "${dispatcher_lock_pid}" 2>/dev/null || true)"
+    fi
+    if [[ ! "${owner_pid}" =~ ^[0-9]+$ ]]; then
+      owner_pid=""
+    fi
+    lock_mtime=""
+    if stat -f %m "${dispatcher_lock_dir}" >/dev/null 2>&1; then
+      lock_mtime="$(stat -f %m "${dispatcher_lock_dir}")"
+    elif stat -c %Y "${dispatcher_lock_dir}" >/dev/null 2>&1; then
+      lock_mtime="$(stat -c %Y "${dispatcher_lock_dir}")"
+    fi
+    now_ts="$(date +%s)"
+    if { [[ -n "${owner_pid}" ]] && ! kill -0 "${owner_pid}" 2>/dev/null; } ||
+      { [[ -z "${owner_pid}" ]] && [[ "${lock_mtime:-0}" =~ ^[0-9]+$ ]] &&
+        (( now_ts - lock_mtime >= 5 )); }; then
+      stale_lock_dir="${dispatcher_lock_dir}.stale.$$"
+      if mv "${dispatcher_lock_dir}" "${stale_lock_dir}" 2>/dev/null; then
+        rm -rf -- "${stale_lock_dir}"
+      fi
+      continue
+    fi
+    if (( now_ts - start_ts >= LOCK_WAIT_SECS )); then
+      echo "Timed out waiting ${LOCK_WAIT_SECS}s for the repository pre-push dispatcher lock." >&2
+      return 1
+    fi
+    if (( now_ts - last_notice_ts >= 30 )); then
+      echo "Waiting for repository pre-push validation already owned by pid ${owner_pid:-unknown}..." >&2
+      last_notice_ts="${now_ts}"
+    fi
+    sleep 1
+  done
+  dispatcher_lock_held=1
+  printf '%s\n' "$$" >"${dispatcher_lock_pid}"
+}
+
+mkdir -p "$hook_cache_dir" "$(dirname "${validation_tree}")"
+
+if [[ "${MEERKAT_SKIP_PRE_PUSH_TREE_CACHE:-0}" != "1" && -f "$hook_stamp" ]]; then
+  echo "complete pre-push gate already validated for tree ${pushed_tree}; reusing exact-tree evidence."
+  exit 0
+fi
+
+dispatch_step="waiting for the repository pre-push validation lane"
+acquire_dispatcher_lock
+
+# Another push may have validated this exact tree while this process waited.
+if [[ "${MEERKAT_SKIP_PRE_PUSH_TREE_CACHE:-0}" != "1" && -f "$hook_stamp" ]]; then
+  echo "complete pre-push gate already validated for tree ${pushed_tree}; reusing exact-tree evidence."
+  exit 0
+fi
+
+dispatch_step="creating the stable detached validation worktree"
+git -C "$SOURCE_ROOT" worktree remove --force "$validation_tree" >/dev/null 2>&1 || true
+if [[ -e "${validation_tree}" || -L "${validation_tree}" ]]; then
+  case "${validation_tree}" in
+    "${hook_cache_root}"/worktrees/*)
+      rm -rf -- "${validation_tree}"
+      ;;
+    *)
+      echo "Refusing to remove unexpected validation path: ${validation_tree}" >&2
+      exit 1
+      ;;
+  esac
+fi
+validation_run_root="$(mktemp -d "${TMPDIR:-/tmp}/meerkat-pre-push-exact.XXXXXX")"
+
+validation_tree_owned=1
 git -C "$SOURCE_ROOT" worktree add --detach --quiet "$validation_tree" "$pushed_commit"
 
 export PRE_COMMIT_REMOTE_NAME="$REMOTE_NAME"
@@ -127,16 +226,21 @@ else
   PRE_COMMIT_FROM_REF="$remote_sha"
 fi
 export PRE_COMMIT_FROM_REF
-# repo-cargo already includes the common Git directory in its cache key. A
-# stable lane keeps the detached validation worktree hot across pushes.
-export RUST_LANE_ID="${RUST_LANE_ID:-pre-push}"
+# Keep Bazel's disk state stable across the same detached validation lane. The
+# workspace path above is stable too, so Bazel can retain both the output base
+# and its server instead of starting a new pair for every pushed tree.
+if [[ -z "${MEERKAT_PRE_PUSH_BAZEL_OUTPUT_BASE:-}" ]]; then
+  bazel_output_root="${MEERKAT_PRE_PUSH_BAZEL_OUTPUT_ROOT:-${XDG_CACHE_HOME:-${HOME}/.cache}/meerkat/pre-push-bazel}"
+  common_dir_hash="$(hash_path "${git_common_dir}")"
+  export MEERKAT_PRE_PUSH_BAZEL_OUTPUT_BASE="${bazel_output_root}/repo-${common_dir_hash}-${validation_lane}"
+fi
 
 cd "$validation_tree"
 
 # The hook transcript is captured so a failure can name the hook that caused
 # it. Python buffers block-wise when its stdout is a pipe; unbuffering keeps
 # the operator's terminal live through the long deterministic lanes.
-gate_log="${validation_root}/push-stage-hooks.log"
+gate_log="${validation_run_root}/push-stage-hooks.log"
 dispatch_step="running push-stage validation hooks"
 # Hook failure is a reported outcome, not a dispatcher fault: the ERR trap fires
 # even with errexit disabled, so it is lifted for exactly this pipeline. Capture

--- a/scripts/repo-cargo
+++ b/scripts/repo-cargo
@@ -24,7 +24,13 @@ sanitize_cache_key() {
   printf '%s' "${key:-default}"
 }
 
-repo_slug="$(basename "${repo_root}")"
+git_common_name="$(basename "${git_common_dir}")"
+if [[ "${git_common_name}" == ".git" ]]; then
+  repo_slug="$(basename "$(dirname "${git_common_dir}")")"
+else
+  repo_slug="${git_common_name}"
+fi
+repo_slug="$(sanitize_cache_key "${repo_slug}")"
 repo_key="${repo_slug}-$(hash_path "${git_common_dir}")"
 target_cache_schema="v4"
 toolchain_spec=""

--- a/scripts/rust-lane-doctor
+++ b/scripts/rust-lane-doctor
@@ -98,6 +98,14 @@ else
   bad "Cargo home changes across same-repo lanes"
 fi
 
+repo_cache_identity_probe="$(./scripts/test-repo-cargo-cache-identity.sh 2>&1 || true)"
+if contains_line "repo-cargo linked-worktree cache identity selftest passed" "${repo_cache_identity_probe}"; then
+  pass "linked worktrees share repository cache identity while default lanes stay isolated"
+else
+  bad "linked worktrees split repository caches or collapse default lanes"
+  printf '%s\n' "${repo_cache_identity_probe}" >&2
+fi
+
 fast_profile_output="$(./scripts/repo-cargo nextest show-config version --profile fast --color never --no-pager 2>&1 || true)"
 if grep -q '\[profile.fast\]' .config/nextest.toml &&
   grep -q 'default-filter' .config/nextest.toml &&

--- a/scripts/test-pre-push-dispatch.sh
+++ b/scripts/test-pre-push-dispatch.sh
@@ -6,12 +6,25 @@ TEST_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/meerkat-pre-push-dispatch.XXXXXX")"
 HARNESS_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/meerkat-pre-push-dispatch-harness.XXXXXX")"
 CACHE_REPO="${TEST_ROOT}-cache"
 ATTRIBUTION_ROOT="${TEST_ROOT}-attribution"
+LOCK_ROOT="${TEST_ROOT}-lock"
+LOCK_FIRST_PID=""
+LOCK_SECOND_PID=""
 cleanup_harness() {
   local residue_status=$?
+  if [[ -n "${LOCK_FIRST_PID}" ]]; then
+    kill "${LOCK_FIRST_PID}" 2>/dev/null || true
+    wait "${LOCK_FIRST_PID}" 2>/dev/null || true
+  fi
+  if [[ -n "${LOCK_SECOND_PID}" ]]; then
+    kill "${LOCK_SECOND_PID}" 2>/dev/null || true
+    wait "${LOCK_SECOND_PID}" 2>/dev/null || true
+  fi
   # Attribution scenarios deliberately create paths the dispatcher cannot
   # remove; make them removable again before tearing the harness down.
-  chmod -R u+rwx "$TEST_ROOT" "$HARNESS_ROOT" "$CACHE_REPO" "$ATTRIBUTION_ROOT" 2>/dev/null || true
-  rm -rf "$TEST_ROOT" "$HARNESS_ROOT" "$CACHE_REPO" "$ATTRIBUTION_ROOT" 2>/dev/null || true
+  chmod -R u+rwx "$TEST_ROOT" "$HARNESS_ROOT" "$CACHE_REPO" "$ATTRIBUTION_ROOT" \
+    "$LOCK_ROOT" 2>/dev/null || true
+  rm -rf "$TEST_ROOT" "$HARNESS_ROOT" "$CACHE_REPO" "$ATTRIBUTION_ROOT" \
+    "$LOCK_ROOT" 2>/dev/null || true
   exit "$residue_status"
 }
 trap cleanup_harness EXIT
@@ -43,6 +56,7 @@ git -C "$MEERKAT_DISPATCH_NESTED_INIT_ROOT" init -q
   printf 'remote_name=%s\n' "${PRE_COMMIT_REMOTE_NAME:-}"
   printf 'remote_url=%s\n' "${PRE_COMMIT_REMOTE_URL:-}"
   printf 'lane=%s\n' "${RUST_LANE_ID:-}"
+  printf 'bazel_output_base=%s\n' "${MEERKAT_PRE_PUSH_BAZEL_OUTPUT_BASE:-}"
   if [[ -e dirty-source-only ]]; then
     printf 'dirty_source_visible=yes\n'
   fi
@@ -60,6 +74,7 @@ run_dispatch() {
       MEERKAT_DISPATCH_INVOCATION_LOG="$INVOCATION_LOG" \
       MEERKAT_DISPATCH_NESTED_INIT_ROOT="$NESTED_INIT_ROOT" \
       MEERKAT_SKIP_PRE_PUSH_TREE_CACHE=1 \
+      MEERKAT_PRE_PUSH_BAZEL_OUTPUT_ROOT="${HARNESS_ROOT}/bazel-output" \
       RUST_LANE_ID="" \
       "$REPO_ROOT/scripts/pre-push-dispatch.sh" origin example.invalid \
       <<<"$stdin_payload"
@@ -92,6 +107,11 @@ if grep -Fq "dirty_source_visible=yes" "$INVOCATION_LOG"; then
   exit 1
 fi
 validated_cwd="$(sed -n 's/^cwd=//p' "$INVOCATION_LOG")"
+validated_bazel_output_base="$(sed -n 's/^bazel_output_base=//p' "$INVOCATION_LOG")"
+if [[ -z "${validated_bazel_output_base}" ]]; then
+  echo "dispatcher did not export a stable Bazel output base" >&2
+  exit 1
+fi
 if [[ -e "$validated_cwd" ]]; then
   echo "dispatcher leaked its detached validation worktree: ${validated_cwd}" >&2
   exit 1
@@ -105,6 +125,19 @@ fi
 run_dispatch "refs/heads/new ${head_sha} refs/heads/new ${ZERO_SHA:-0000000000000000000000000000000000000000}"
 assert_log_line "args=run --config .pre-commit-config.yaml --hook-stage pre-push --all-files"
 assert_log_line "from=4b825dc642cb6eb9a060e54bf8d69288fbee4904"
+second_validated_cwd="$(sed -n 's/^cwd=//p' "$INVOCATION_LOG")"
+second_bazel_output_base="$(sed -n 's/^bazel_output_base=//p' "$INVOCATION_LOG")"
+if [[ "${second_validated_cwd}" != "${validated_cwd}" ]]; then
+  echo "dispatcher changed detached validation paths across pushed trees" >&2
+  printf 'first: %s\nsecond: %s\n' "${validated_cwd}" "${second_validated_cwd}" >&2
+  exit 1
+fi
+if [[ "${second_bazel_output_base}" != "${validated_bazel_output_base}" ]]; then
+  echo "dispatcher changed Bazel output bases across pushed trees" >&2
+  printf 'first: %s\nsecond: %s\n' \
+    "${validated_bazel_output_base}" "${second_bazel_output_base}" >&2
+  exit 1
+fi
 
 tag_object="$(git -C "$TEST_ROOT" -c user.name=Meerkat -c user.email=meerkat@example.invalid \
   tag -a dispatch-test -m dispatch-test && git -C "$TEST_ROOT" rev-parse dispatch-test)"
@@ -150,6 +183,118 @@ run_cached_dispatch \
   "refs/tags/dispatch-cache-test ${cache_tag_object} refs/tags/dispatch-cache-test 0000000000000000000000000000000000000000"
 if [[ -s "$INVOCATION_LOG" ]]; then
   echo "dispatcher recomputed a previously validated exact tree for a tag push" >&2
+  exit 1
+fi
+
+# A cache-hit process does not own the stable validation worktree. It must not
+# remove a path that an in-flight dispatcher may be using for another tree.
+cache_common_dir="$(git -C "$CACHE_REPO" rev-parse --path-format=absolute --git-common-dir)"
+active_validation_tree="${cache_common_dir}/meerkat-hook-cache/worktrees/pre-push"
+git -C "$CACHE_REPO" worktree add --detach --quiet "$active_validation_tree" "$cache_head_sha"
+run_cached_dispatch \
+  "refs/tags/dispatch-cache-test ${cache_tag_object} refs/tags/dispatch-cache-test 0000000000000000000000000000000000000000"
+if [[ ! -d "$active_validation_tree" ]]; then
+  echo "cached dispatcher removed a stable validation worktree it did not own" >&2
+  exit 1
+fi
+git -C "$CACHE_REPO" worktree remove --force "$active_validation_tree"
+
+# Concurrent pushes share one stable worktree. The later process waits for the
+# repository dispatcher lock, then reuses the exact-tree stamp written by the
+# first process instead of invoking the broad gate twice.
+LOCK_REPO="${LOCK_ROOT}/repo"
+LOCK_BIN="${LOCK_ROOT}/bin"
+LOCK_ENTERED="${LOCK_ROOT}/entered"
+LOCK_RELEASE="${LOCK_ROOT}/release"
+LOCK_INVOCATIONS="${LOCK_ROOT}/invocations"
+mkdir -p "$LOCK_REPO" "$LOCK_BIN"
+git -C "$LOCK_REPO" init -q
+git -C "$LOCK_REPO" -c user.name=Meerkat -c user.email=meerkat@example.invalid \
+  commit --allow-empty -qm "lock base"
+lock_base_sha="$(git -C "$LOCK_REPO" rev-parse HEAD)"
+git -C "$LOCK_REPO" -c user.name=Meerkat -c user.email=meerkat@example.invalid \
+  commit --allow-empty -qm "lock candidate"
+lock_head_sha="$(git -C "$LOCK_REPO" rev-parse HEAD)"
+cat > "${LOCK_BIN}/pre-commit" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$$" >> "$MEERKAT_DISPATCH_LOCK_INVOCATIONS"
+: > "$MEERKAT_DISPATCH_LOCK_ENTERED"
+while [[ ! -f "$MEERKAT_DISPATCH_LOCK_RELEASE" ]]; do
+  sleep 0.05
+done
+EOF
+chmod +x "${LOCK_BIN}/pre-commit"
+
+run_lock_dispatch() {
+  local local_ref="$1"
+  (
+    cd "$LOCK_REPO"
+    PATH="${LOCK_BIN}:$PATH" \
+      GIT_DIR="${LOCK_REPO}/.git" \
+      GIT_WORK_TREE="$LOCK_REPO" \
+      MEERKAT_DISPATCH_LOCK_INVOCATIONS="$LOCK_INVOCATIONS" \
+      MEERKAT_DISPATCH_LOCK_ENTERED="$LOCK_ENTERED" \
+      MEERKAT_DISPATCH_LOCK_RELEASE="$LOCK_RELEASE" \
+      RUST_LANE_ID="" \
+      "$REPO_ROOT/scripts/pre-push-dispatch.sh" origin example.invalid \
+      <<<"${local_ref} ${lock_head_sha} ${local_ref} ${lock_base_sha}"
+  )
+}
+
+run_lock_dispatch refs/heads/first >"${LOCK_ROOT}/first.log" 2>&1 &
+LOCK_FIRST_PID=$!
+for _ in $(seq 1 100); do
+  [[ -f "$LOCK_ENTERED" ]] && break
+  sleep 0.05
+done
+if [[ ! -f "$LOCK_ENTERED" ]]; then
+  echo "first dispatcher did not enter the validation gate" >&2
+  exit 1
+fi
+run_lock_dispatch refs/heads/second >"${LOCK_ROOT}/second.log" 2>&1 &
+LOCK_SECOND_PID=$!
+sleep 0.3
+if [[ "$(wc -l < "$LOCK_INVOCATIONS" | tr -d ' ')" != "1" ]]; then
+  echo "repository dispatcher lock allowed overlapping validation gates" >&2
+  exit 1
+fi
+: > "$LOCK_RELEASE"
+wait "$LOCK_FIRST_PID"
+LOCK_FIRST_PID=""
+wait "$LOCK_SECOND_PID"
+LOCK_SECOND_PID=""
+if [[ "$(wc -l < "$LOCK_INVOCATIONS" | tr -d ' ')" != "1" ]]; then
+  echo "waiting dispatcher ignored exact-tree evidence from the lock owner" >&2
+  exit 1
+fi
+
+# The dispatcher-exported output base is useful only if the authoritative
+# Bazel lock gate passes it to bb as a startup option.
+FAKE_BB="${HARNESS_ROOT}/bb"
+BB_ARG_LOG="${HARNESS_ROOT}/bb-args"
+cat > "$FAKE_BB" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$@" > "$MEERKAT_DISPATCH_BB_ARG_LOG"
+EOF
+chmod +x "$FAKE_BB"
+expected_bazel_output_base="${HARNESS_ROOT}/bazel-output/consumption-proof"
+BUILDBUDDY_BB="$FAKE_BB" \
+  MEERKAT_DISPATCH_BB_ARG_LOG="$BB_ARG_LOG" \
+  MEERKAT_PRE_PUSH_BAZEL_OUTPUT_BASE="$expected_bazel_output_base" \
+  "$REPO_ROOT/scripts/pre-push-bazel-locks.sh" --require-bb >/dev/null
+expected_bb_args="${HARNESS_ROOT}/expected-bb-args"
+cat > "$expected_bb_args" <<EOF
+--output_base=${expected_bazel_output_base}
+--max_idle_secs=600
+mod
+deps
+--lockfile_mode=error
+EOF
+if ! cmp -s "$expected_bb_args" "$BB_ARG_LOG"; then
+  echo "Bazel lock gate did not consume the dispatcher output-base contract" >&2
+  diff -u "$expected_bb_args" "$BB_ARG_LOG" >&2 || true
   exit 1
 fi
 
@@ -234,6 +379,7 @@ attribution_status=0
 run_attribution_dispatch() {
   local mode="$1"
   local output_path="$2"
+  local attribution_common_dir attribution_validation_tree
   install_scripted_pre_commit "$mode"
   set +e
   (
@@ -250,6 +396,12 @@ run_attribution_dispatch() {
   )
   attribution_status=$?
   set -e
+  attribution_common_dir="$(git -C "$ATTRIBUTION_REPO" rev-parse --path-format=absolute --git-common-dir)"
+  attribution_validation_tree="${attribution_common_dir}/meerkat-hook-cache/worktrees/pre-push"
+  chmod -R u+rwx "$attribution_validation_tree" 2>/dev/null || true
+  git -C "$ATTRIBUTION_REPO" worktree remove --force "$attribution_validation_tree" \
+    >/dev/null 2>&1 || true
+  rm -rf -- "$attribution_validation_tree" 2>/dev/null || true
   chmod -R u+rwx "$ATTRIBUTION_TMP" 2>/dev/null || true
   rm -rf "${ATTRIBUTION_TMP:?}"/* 2>/dev/null || true
   git -C "$ATTRIBUTION_REPO" worktree prune 2>/dev/null || true

--- a/scripts/test-repo-cargo-cache-identity.sh
+++ b/scripts/test-repo-cargo-cache-identity.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+TEST_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/meerkat-repo-cargo-identity.XXXXXX")"
+TEST_REPO="${TEST_ROOT}/source-repo"
+WORKTREE_A="${TEST_ROOT}/detached-a"
+WORKTREE_B="${TEST_ROOT}/detached-b"
+
+cleanup() {
+  local pending_status=$?
+  git -C "${TEST_REPO}" worktree remove --force "${WORKTREE_A}" >/dev/null 2>&1 || true
+  git -C "${TEST_REPO}" worktree remove --force "${WORKTREE_B}" >/dev/null 2>&1 || true
+  chmod -R u+rwx "${TEST_ROOT}" 2>/dev/null || true
+  rm -rf -- "${TEST_ROOT}"
+  exit "${pending_status}"
+}
+trap cleanup EXIT
+
+value_from_env() {
+  local key="$1"
+  local text="$2"
+  printf '%s\n' "${text}" | awk -F= -v key="${key}" '$1 == key { print substr($0, length(key) + 2) }'
+}
+
+mkdir -p "${TEST_REPO}/scripts"
+cp "${ROOT}/scripts/repo-cargo" "${TEST_REPO}/scripts/repo-cargo"
+git -C "${TEST_REPO}" init -q
+git -C "${TEST_REPO}" add scripts/repo-cargo
+git -C "${TEST_REPO}" -c user.name=Meerkat -c user.email=meerkat@example.invalid \
+  commit -qm "cache identity fixture"
+git -C "${TEST_REPO}" worktree add --detach --quiet "${WORKTREE_A}" HEAD
+git -C "${TEST_REPO}" worktree add --detach --quiet "${WORKTREE_B}" HEAD
+
+shared_a="$(cd "${WORKTREE_A}" && RUST_LANE_ID=shared-cache ./scripts/repo-cargo --print-env)"
+shared_b="$(cd "${WORKTREE_B}" && RUST_LANE_ID=shared-cache ./scripts/repo-cargo --print-env)"
+shared_source="$(cd "${TEST_REPO}" && RUST_LANE_ID=shared-cache ./scripts/repo-cargo --print-env)"
+repo_key_a="$(value_from_env repo_key "${shared_a}")"
+repo_key_b="$(value_from_env repo_key "${shared_b}")"
+repo_key_source="$(value_from_env repo_key "${shared_source}")"
+cargo_home_a="$(value_from_env CARGO_HOME "${shared_a}")"
+cargo_home_b="$(value_from_env CARGO_HOME "${shared_b}")"
+cargo_home_source="$(value_from_env CARGO_HOME "${shared_source}")"
+target_a="$(value_from_env CARGO_TARGET_DIR "${shared_a}")"
+target_b="$(value_from_env CARGO_TARGET_DIR "${shared_b}")"
+target_source="$(value_from_env CARGO_TARGET_DIR "${shared_source}")"
+
+if ! [[ "${repo_key_a}" == "${repo_key_b}" && "${repo_key_a}" == "${repo_key_source}" ]]; then
+  echo "repo-cargo split one repository by detached worktree basename" >&2
+  printf 'source repo key: %s\nworktree A repo key: %s\nworktree B repo key: %s\n' \
+    "${repo_key_source}" "${repo_key_a}" "${repo_key_b}" >&2
+  exit 1
+fi
+if ! [[ "${cargo_home_a}" == "${cargo_home_b}" &&
+  "${cargo_home_a}" == "${cargo_home_source}" &&
+  "${target_a}" == "${target_b}" && "${target_a}" == "${target_source}" ]]; then
+  echo "repo-cargo did not reuse one explicitly named lane across linked worktrees" >&2
+  exit 1
+fi
+
+default_a="$(cd "${WORKTREE_A}" && env -u RUST_LANE_ID ./scripts/repo-cargo --print-env)"
+default_b="$(cd "${WORKTREE_B}" && env -u RUST_LANE_ID ./scripts/repo-cargo --print-env)"
+default_target_a="$(value_from_env CARGO_TARGET_DIR "${default_a}")"
+default_target_b="$(value_from_env CARGO_TARGET_DIR "${default_b}")"
+if [[ "${default_target_a}" == "${default_target_b}" ]]; then
+  echo "repo-cargo collapsed distinct default worktree lanes" >&2
+  exit 1
+fi
+
+echo "repo-cargo linked-worktree cache identity selftest passed"


### PR DESCRIPTION
## Summary

- derive `repo-cargo` repository identity from the common Git directory so linked worktrees share one repository cache namespace
- serialize detached pre-push validation on one stable repository-scoped worktree and reuse exact-tree evidence after waiting
- give the Bazel lock gate a stable output base so both disk state and the Bazel server survive pushed-tree recreation
- retain distinct default worktree lanes and document that CI remains authoritative for inputs outside the tracked Git tree

## Validation

- mandatory pre-push hook passed on exact SHA `46dae9356cad4abacb80aa674237595666c5286a`
- `scripts/test-repo-cargo-cache-identity.sh`
- `scripts/test-pre-push-dispatch.sh`
- `RUST_LANE_ID=codex0825-stable-cache ./scripts/rust-lane-doctor` - 23 pass, 0 fail
- shell syntax and `git diff --check`
- four mutation proofs: linked-worktree slug split, random validation path, missing Bazel startup args, and missing post-lock exact-tree recheck
- real Bazel probe retained the same server PID across removal and recreation of the stable detached worktree

## Review

MobKit second-head diff-only review passed. The candidate changes scripts only, with no Rust, Cargo manifest, SDK, or adopter surface changes.
