### PR TITLE
Reuse source-test evidence for lock-only pushes

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -117,6 +117,9 @@ repos:
         language: script
         types: [rust]
         pass_filenames: false
+        # Cargo.lock has no Rust file type, but lock-only pushes must still
+        # compile the resolved dependency graph before source tests are reused.
+        always_run: true
         stages: [pre-push]
 
   # On push: machine file codegen + verify

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -118,7 +118,8 @@ repos:
         types: [rust]
         pass_filenames: false
         # Cargo.lock has no Rust file type, but lock-only pushes must still
-        # compile the resolved dependency graph before source tests are reused.
+        # compile the resolved dependency graph before prior-graph source-test
+        # evidence is reused. CI re-tests the current lock graph.
         always_run: true
         stages: [pre-push]
 

--- a/scripts/pre-push-unit.sh
+++ b/scripts/pre-push-unit.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Pre-push deterministic test gate:
 # - validates the exact detached pushed tree selected by pre-push-dispatch.sh
-# - skips reruns for the same committed tree
+# - reuses source-test evidence across root lockfile-only commits
 # - serializes runs so repeated pushes don't fight each other
 # - retries nextest once if discovery hangs
 set -euo pipefail
@@ -10,7 +10,7 @@ ROOT="${ROOT:-$(cd "$(dirname "$0")/.." && pwd)}"
 CARGO="${CARGO:-$ROOT/scripts/repo-cargo}"
 GIT_BIN="${GIT_BIN:-git}"
 
-CACHE_VERSION="v8"
+CACHE_VERSION="v9"
 NEXTEST_TIMEOUT_SECS="${MEERKAT_PRE_PUSH_NEXTEST_TIMEOUT_SECS:-300}"
 BUILD_TIMEOUT_SECS="${MEERKAT_PRE_PUSH_BUILD_TIMEOUT_SECS:-${MEERKAT_PRE_PUSH_NARROW_BUILD_TIMEOUT_SECS:-900}}"
 # The unit lane includes a dense-topology stress test with its own 300-second
@@ -35,6 +35,28 @@ tree_key() {
   else
     "$GIT_BIN" write-tree
   fi
+}
+
+source_test_fingerprint() {
+  local tree_record tree_path
+  # Root dependency locks are validated by the preceding Cargo and Bazel lock
+  # gates, while CI remains authoritative for advisories. The always-run
+  # changed-crate Clippy gate also compiles their resolved workspace graph.
+  # Excluding only these two generated lock artifacts lets that narrow
+  # dependency evidence reuse source-test results; every other tracked byte
+  # remains fail-closed because tests may read fixtures or configuration with
+  # arbitrary extensions.
+  "$GIT_BIN" ls-tree -rz --full-tree HEAD |
+    while IFS= read -r -d '' tree_record; do
+      tree_path="${tree_record#*$'\t'}"
+      case "$tree_path" in
+        Cargo.lock | MODULE.bazel.lock)
+          continue
+          ;;
+      esac
+      printf '%s\0' "$tree_record"
+    done |
+    "$GIT_BIN" hash-object --stdin
 }
 
 require_exact_clean_head() {
@@ -171,11 +193,12 @@ trap release_lock EXIT
 
 require_exact_clean_head
 tree="$(tree_key)"
-stamp_key="${CACHE_VERSION}-cargo-${tree}"
+source_fingerprint="$(source_test_fingerprint)"
+stamp_key="${CACHE_VERSION}-cargo-source-${source_fingerprint}"
 stamp_path="${HOOK_CACHE_DIR}/${stamp_key}.ok"
 
 if [[ "${MEERKAT_SKIP_PRE_PUSH_UNIT_CACHE:-0}" != "1" && -f "$stamp_path" ]]; then
-  echo "deterministic pre-push gate already validated for tree ${tree}; skipping."
+  echo "deterministic pre-push source tests already validated for fingerprint ${source_fingerprint}; skipping."
   exit 0
 fi
 
@@ -227,7 +250,12 @@ if [[ "$final_tree" != "$tree" ]]; then
   echo "Checked-out HEAD changed during pre-push validation; refusing a stale success stamp." >&2
   exit 1
 fi
+final_source_fingerprint="$(source_test_fingerprint)"
+if [[ "$final_source_fingerprint" != "$source_fingerprint" ]]; then
+  echo "Source-test inputs changed during pre-push validation; refusing a stale success stamp." >&2
+  exit 1
+fi
 stamp_tmp="${stamp_path}.tmp.$$"
-printf 'tree=%s\nbackend=cargo\nrunners=unit,integration-fast,headcanonical-process-death,e2e-fast\n' \
-  "$tree" > "$stamp_tmp"
+printf 'tree=%s\nsource_fingerprint=%s\nexcluded=Cargo.lock,MODULE.bazel.lock\nbackend=cargo\nrunners=unit,integration-fast,headcanonical-process-death,e2e-fast\n' \
+  "$tree" "$source_fingerprint" > "$stamp_tmp"
 mv "$stamp_tmp" "$stamp_path"

--- a/scripts/pre-push-unit.sh
+++ b/scripts/pre-push-unit.sh
@@ -45,7 +45,8 @@ source_test_fingerprint() {
   # Excluding only these two generated lock artifacts lets that narrow
   # dependency evidence reuse source-test results; every other tracked byte
   # remains fail-closed because tests may read fixtures or configuration with
-  # arbitrary extensions.
+  # arbitrary extensions. The current lock graph is compiled, not re-tested:
+  # reused test evidence was executed against the prior root lock graph.
   "$GIT_BIN" ls-tree -rz --full-tree HEAD |
     while IFS= read -r -d '' tree_record; do
       tree_path="${tree_record#*$'\t'}"
@@ -198,7 +199,8 @@ stamp_key="${CACHE_VERSION}-cargo-source-${source_fingerprint}"
 stamp_path="${HOOK_CACHE_DIR}/${stamp_key}.ok"
 
 if [[ "${MEERKAT_SKIP_PRE_PUSH_UNIT_CACHE:-0}" != "1" && -f "$stamp_path" ]]; then
-  echo "deterministic pre-push source tests already validated for fingerprint ${source_fingerprint}; skipping."
+  echo "reusing deterministic source-test evidence for fingerprint ${source_fingerprint}."
+  echo "Current root lock graph was compiled by pre-push Clippy but is not re-tested locally; CI is authoritative."
   exit 0
 fi
 
@@ -256,6 +258,6 @@ if [[ "$final_source_fingerprint" != "$source_fingerprint" ]]; then
   exit 1
 fi
 stamp_tmp="${stamp_path}.tmp.$$"
-printf 'tree=%s\nsource_fingerprint=%s\nexcluded=Cargo.lock,MODULE.bazel.lock\nbackend=cargo\nrunners=unit,integration-fast,headcanonical-process-death,e2e-fast\n' \
+printf 'tree=%s\nsource_fingerprint=%s\nexcluded=Cargo.lock,MODULE.bazel.lock\nreuse_boundary=current-lock-graph-compiled-not-retested\nbackend=cargo\nrunners=unit,integration-fast,headcanonical-process-death,e2e-fast\n' \
   "$tree" "$source_fingerprint" > "$stamp_tmp"
 mv "$stamp_tmp" "$stamp_path"

--- a/scripts/rust-lane-doctor
+++ b/scripts/rust-lane-doctor
@@ -224,6 +224,17 @@ else
   printf '%s\n' "${agent_gate_probe}" >&2
 fi
 
+lock_clippy_probe="$(./scripts/agent-gate --dry-run --working-tree --clippy-only Cargo.lock 2>&1 || true)"
+clippy_hook_contract="$(grep -A 10 -F -- '- id: cargo-clippy' .pre-commit-config.yaml || true)"
+if [[ "${lock_clippy_probe}" == *"Global Rust build/test configuration changed"* ]] &&
+  [[ "${lock_clippy_probe}" == *"clippy --workspace --all-targets --all-features"* ]] &&
+  [[ "${clippy_hook_contract}" == *"always_run: true"* ]]; then
+  pass "lock-only pushes compile the resolved workspace graph before source-test reuse"
+else
+  bad "lock-only pushes can reuse source tests without compiling resolved dependencies"
+  printf '%s\n%s\n' "${lock_clippy_probe}" "${clippy_hook_contract}" >&2
+fi
+
 package_clippy_probe_dir="$(mktemp -d "${TMPDIR:-/tmp}/meerkat-clippy-scope.XXXXXX")"
 trap 'rm -rf -- "${package_clippy_probe_dir}"' EXIT
 package_clippy_probe_metadata="${package_clippy_probe_dir}/metadata.json"

--- a/scripts/test-pre-push-unit-status.sh
+++ b/scripts/test-pre-push-unit-status.sh
@@ -7,8 +7,11 @@ HARNESS_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/meerkat-pre-push-harness.XXXXXX")"
 trap 'rm -rf "$TEST_ROOT" "$HARNESS_ROOT"' EXIT
 
 git -C "$TEST_ROOT" init -q
+printf 'lock revision 0\n' > "$TEST_ROOT/Cargo.lock"
+printf 'module lock revision 0\n' > "$TEST_ROOT/MODULE.bazel.lock"
+git -C "$TEST_ROOT" add Cargo.lock MODULE.bazel.lock
 git -C "$TEST_ROOT" -c user.name=Meerkat -c user.email=meerkat@example.invalid \
-  commit --allow-empty -qm "test fixture"
+  commit -qm "test fixture"
 test_head="$(git -C "$TEST_ROOT" rev-parse HEAD)"
 
 FAKE_CARGO="$HARNESS_ROOT/fake-cargo"
@@ -262,3 +265,64 @@ if ! find "$TEST_ROOT/.git/meerkat-hook-cache" -name '*.ok' -print -quit | grep 
   echo "successful pre-push run did not create a cache stamp" >&2
   exit 1
 fi
+
+initial_stamp_count="$(find "$TEST_ROOT/.git/meerkat-hook-cache" -name '*.ok' | wc -l | tr -d ' ')"
+printf 'lock revision 1\n' > "$TEST_ROOT/Cargo.lock"
+printf 'module lock revision 1\n' > "$TEST_ROOT/MODULE.bazel.lock"
+git -C "$TEST_ROOT" add Cargo.lock MODULE.bazel.lock
+git -C "$TEST_ROOT" -c user.name=Meerkat -c user.email=meerkat@example.invalid \
+  commit -qm "lock-only repair"
+test_head="$(git -C "$TEST_ROOT" rev-parse HEAD)"
+: > "$LANE_LOG"
+(
+  cd "$TEST_ROOT"
+  ROOT="$REPO_ROOT" \
+    CARGO="$FAKE_CARGO" \
+    MEERKAT_PRE_PUSH_TEST_LANE_LOG="$LANE_LOG" \
+    MEERKAT_PRE_PUSH_TEST_FAIL_LANE="" \
+    MEERKAT_PRE_PUSH_TEST_FAIL_STATUS=99 \
+    PRE_COMMIT_TO_REF="$test_head" \
+    "$REPO_ROOT/scripts/pre-push-unit.sh"
+)
+if [[ -s "$LANE_LOG" ]]; then
+  echo "root lockfile-only repair reran source-test lanes: $(paste -sd ' ' "$LANE_LOG")" >&2
+  exit 1
+fi
+lock_stamp_count="$(find "$TEST_ROOT/.git/meerkat-hook-cache" -name '*.ok' | wc -l | tr -d ' ')"
+if [[ "$lock_stamp_count" != "$initial_stamp_count" ]]; then
+  echo "root lockfile-only repair created a different source-test fingerprint" >&2
+  exit 1
+fi
+
+printf 'pub fn changed_source() {}\n' > "$TEST_ROOT/source.rs"
+git -C "$TEST_ROOT" add source.rs
+git -C "$TEST_ROOT" -c user.name=Meerkat -c user.email=meerkat@example.invalid \
+  commit -qm "source repair"
+test_head="$(git -C "$TEST_ROOT" rev-parse HEAD)"
+: > "$LANE_LOG"
+(
+  cd "$TEST_ROOT"
+  ROOT="$REPO_ROOT" \
+    CARGO="$FAKE_CARGO" \
+    MEERKAT_PRE_PUSH_NEXTEST_TIMEOUT_SECS=10 \
+    MEERKAT_PRE_PUSH_UNIT_NEXTEST_TIMEOUT_SECS=10 \
+    MEERKAT_PRE_PUSH_INTEGRATION_NEXTEST_TIMEOUT_SECS=10 \
+    MEERKAT_PRE_PUSH_BUILD_TIMEOUT_SECS=10 \
+    MEERKAT_PRE_PUSH_TEST_LANE_LOG="$LANE_LOG" \
+    MEERKAT_PRE_PUSH_TEST_FAIL_LANE="" \
+    MEERKAT_PRE_PUSH_TEST_FAIL_STATUS=99 \
+    PRE_COMMIT_TO_REF="$test_head" \
+    "$REPO_ROOT/scripts/pre-push-unit.sh"
+)
+expected_source_lanes="unit-build unit integration-build integration headcanonical-build headcanonical-process-death e2e-fast-build e2e-fast"
+if [[ "$(paste -sd ' ' "$LANE_LOG")" != "$expected_source_lanes" ]]; then
+  echo "source change lane order was '$(paste -sd ' ' "$LANE_LOG")'; expected '${expected_source_lanes}'" >&2
+  exit 1
+fi
+source_stamp_count="$(find "$TEST_ROOT/.git/meerkat-hook-cache" -name '*.ok' | wc -l | tr -d ' ')"
+if [[ "$source_stamp_count" -ne $((initial_stamp_count + 1)) ]]; then
+  echo "source change did not create a distinct source-test evidence stamp" >&2
+  exit 1
+fi
+
+echo "pre-push deterministic gate status and source-fingerprint contracts hold"


### PR DESCRIPTION
## Summary

- key the broad deterministic source-test stamp on every tracked byte except the root `Cargo.lock` and `MODULE.bazel.lock`
- keep pre-push Clippy always-running so lock-only pushes compile the newly resolved workspace dependency graph
- reuse prior source-test execution only for root lockfile-only changes, while leaving every fixture, config, script, source, and other tracked byte fail-closed
- record and print the exact boundary: the current lock graph is compiled locally but not re-tested locally; exact-main CI remains authoritative

## Validation

- mandatory pre-push hook passed on exact SHA `bf75f5bb05faf03cb461e71bf6f9ad7fe7781f06`
- deterministic gate status/fingerprint contract suite passed
- Rust lane doctor: 24 pass, 0 fail
- actual 0.8.24 h2 repair pair `f3f528ba5^1..f3f528ba5` produces an identical source-test fingerprint
- mutation: re-including `Cargo.lock` reran all eight source-test phases and failed the lock-only reuse assertion
- mutation: removing `always_run` caused the doctor to fail the dependency-compilation contract
- shell syntax, pre-commit config validation, and `git diff --check`

## Safety boundary

The reused tests ran against the prior root dependency lock graph. The current lock graph is compiled by the preceding workspace Clippy gate and is fully re-tested in CI. This optimization intentionally does not claim local runtime-test evidence for changed dependency bytes.

MobKit second-head diff-only review passed for the mechanism and requested the explicit compiled-not-retested wording now present in the script, output, stamp, hook comment, and this PR.
