### PR TITLE
perf: reuse prebuilt Nextest binaries in pre-push

### DIFF
--- a/scripts/pre-push-unit.sh
+++ b/scripts/pre-push-unit.sh
@@ -10,7 +10,7 @@ ROOT="${ROOT:-$(cd "$(dirname "$0")/.." && pwd)}"
 CARGO="${CARGO:-$ROOT/scripts/repo-cargo}"
 GIT_BIN="${GIT_BIN:-git}"
 
-CACHE_VERSION="v9"
+CACHE_VERSION="v10"
 NEXTEST_TIMEOUT_SECS="${MEERKAT_PRE_PUSH_NEXTEST_TIMEOUT_SECS:-300}"
 BUILD_TIMEOUT_SECS="${MEERKAT_PRE_PUSH_BUILD_TIMEOUT_SECS:-${MEERKAT_PRE_PUSH_NARROW_BUILD_TIMEOUT_SECS:-900}}"
 # The unit lane includes a dense-topology stress test with its own 300-second
@@ -190,7 +190,17 @@ retry_lane() {
 }
 
 acquire_lock
-trap release_lock EXIT
+NEXTEST_REUSE_DIR=""
+
+release_resources() {
+  if [[ -n "$NEXTEST_REUSE_DIR" && -d "$NEXTEST_REUSE_DIR" ]]; then
+    rm -rf -- "$NEXTEST_REUSE_DIR"
+  fi
+  release_lock
+}
+
+trap release_resources EXIT
+NEXTEST_REUSE_DIR="$(mktemp -d "${TMPDIR:-/tmp}/meerkat-pre-push-nextest.XXXXXX")"
 
 require_exact_clean_head
 tree="$(tree_key)"
@@ -204,47 +214,68 @@ if [[ "${MEERKAT_SKIP_PRE_PUSH_UNIT_CACHE:-0}" != "1" && -f "$stamp_path" ]]; th
   exit 0
 fi
 
+workspace_cargo_metadata="${NEXTEST_REUSE_DIR}/workspace-cargo-metadata.json"
+workspace_binaries_metadata="${NEXTEST_REUSE_DIR}/workspace-binaries-metadata.json"
+headcanonical_binaries_metadata="${NEXTEST_REUSE_DIR}/headcanonical-binaries-metadata.json"
+
+write_cargo_metadata() {
+  "$CARGO" metadata --format-version 1 >"$workspace_cargo_metadata"
+}
+
+build_workspace_inventory() {
+  "$CARGO" nextest list --workspace \
+    --list-type binaries-only --message-format json \
+    -E 'kind(lib) or kind(test)' >"$workspace_binaries_metadata"
+}
+
+build_headcanonical_inventory() {
+  "$CARGO" nextest list -p meerkat-mob --test cold_restart_mob_resume \
+    --features test-support --profile fast \
+    --list-type binaries-only --message-format json \
+    >"$headcanonical_binaries_metadata"
+}
+
+write_cargo_metadata
 retry_lane \
-  "workspace unit build" \
+  "workspace default-feature test build" \
   "$BUILD_TIMEOUT_SECS" \
-  "$CARGO" nextest run --workspace --lib --no-run
+  build_workspace_inventory
 retry_lane \
   "workspace unit lane" \
   "$UNIT_NEXTEST_TIMEOUT_SECS" \
-  "$CARGO" nextest run --workspace --lib --no-fail-fast \
+  "$CARGO" nextest run \
+    --cargo-metadata "$workspace_cargo_metadata" \
+    --binaries-metadata "$workspace_binaries_metadata" \
+    -E 'kind(lib)' --no-tests=fail --no-fail-fast \
     --show-progress none --status-level none --final-status-level fail
-retry_lane \
-  "workspace integration build" \
-  "$BUILD_TIMEOUT_SECS" \
-  "$CARGO" nextest run --workspace --tests --profile fast \
-    --no-run -E 'kind(test)'
 retry_lane \
   "workspace integration lane" \
   "$INTEGRATION_NEXTEST_TIMEOUT_SECS" \
-  "$CARGO" nextest run --workspace --tests --profile fast --no-fail-fast \
-    -E 'kind(test)' \
+  "$CARGO" nextest run \
+    --cargo-metadata "$workspace_cargo_metadata" \
+    --binaries-metadata "$workspace_binaries_metadata" \
+    --profile fast -E 'kind(test)' --no-tests=fail --no-fail-fast \
     --show-progress none --status-level none --final-status-level fail
 retry_lane \
   "HeadCanonical cold-restart build" \
   "$BUILD_TIMEOUT_SECS" \
-  "$CARGO" nextest run -p meerkat-mob --test cold_restart_mob_resume \
-    --features test-support --profile fast --no-tests=fail --no-run
+  build_headcanonical_inventory
 retry_lane \
   "HeadCanonical cold-restart lane" \
   "$NEXTEST_TIMEOUT_SECS" \
-  "$CARGO" nextest run -p meerkat-mob --test cold_restart_mob_resume \
-    --features test-support --profile fast --no-tests=fail \
+  "$CARGO" nextest run \
+    --cargo-metadata "$workspace_cargo_metadata" \
+    --binaries-metadata "$headcanonical_binaries_metadata" \
+    --profile fast -E 'binary(cold_restart_mob_resume)' --no-tests=fail \
     --show-progress none --status-level none --final-status-level fail
-retry_lane \
-  "e2e-fast build" \
-  "$BUILD_TIMEOUT_SECS" \
-  "$CARGO" nextest run -p meerkat-integration-tests --test e2e_fast_lane \
-    --no-run
 retry_lane \
   "e2e-fast lane" \
   "$NEXTEST_TIMEOUT_SECS" \
-  "$CARGO" nextest run -p meerkat-integration-tests --test e2e_fast_lane \
-    --no-fail-fast --show-progress none --status-level none --final-status-level fail
+  "$CARGO" nextest run \
+    --cargo-metadata "$workspace_cargo_metadata" \
+    --binaries-metadata "$workspace_binaries_metadata" \
+    -E 'binary(e2e_fast_lane)' --no-tests=fail --no-fail-fast \
+    --show-progress none --status-level none --final-status-level fail
 
 require_exact_clean_head
 final_tree="$(tree_key)"

--- a/scripts/test-pre-push-unit-status.sh
+++ b/scripts/test-pre-push-unit-status.sh
@@ -22,33 +22,28 @@ cat > "$FAKE_CARGO" <<'EOF'
 set -euo pipefail
 
 args=" $* "
-if [[ "$args" == *" --test cold_restart_mob_resume "* ]]; then
-  if [[ "$args" == *" --no-run "* ]]; then
-    lane="headcanonical-build"
-  else
-    lane="headcanonical-process-death"
-  fi
-elif [[ "$args" == *" --lib "* ]]; then
-  if [[ "$args" == *" --no-run "* ]]; then
-    lane="unit-build"
-  else
-    lane="unit"
-  fi
-elif [[ "$args" == *" --tests "* ]]; then
-  [[ "$args" == *" -E kind(test) "* ]] || exit 98
-  if [[ "$args" == *" --no-run "* ]]; then
-    lane="integration-build"
-  else
-    lane="integration"
-  fi
-elif [[ "$args" == *" --test e2e_fast_lane "* ]]; then
-  if [[ "$args" == *" --no-run "* ]]; then
-    lane="e2e-fast-build"
-  else
-    lane="e2e-fast"
-  fi
+if [[ "${1:-}" == "metadata" ]]; then
+  printf '{}\n'
+  exit 0
+elif [[ "$args" == *" nextest list "* && "$args" == *" --test cold_restart_mob_resume "* ]]; then
+  lane="headcanonical-build"
+elif [[ "$args" == *" nextest list "* && "$args" == *" --workspace "* ]]; then
+  [[ "$args" == *" -E kind(lib) or kind(test) "* ]] || exit 98
+  lane="workspace-build"
+elif [[ "$args" == *" --binaries-metadata "* && "$args" == *" -E kind(lib) "* ]]; then
+  lane="unit"
+elif [[ "$args" == *" --binaries-metadata "* && "$args" == *" -E kind(test) "* ]]; then
+  lane="integration"
+elif [[ "$args" == *" --binaries-metadata "* && "$args" == *" -E binary(cold_restart_mob_resume) "* ]]; then
+  lane="headcanonical-process-death"
+elif [[ "$args" == *" --binaries-metadata "* && "$args" == *" -E binary(e2e_fast_lane) "* ]]; then
+  lane="e2e-fast"
 else
   exit 99
+fi
+
+if [[ "$args" == *" --binaries-metadata "* && "$args" != *" --no-tests=fail "* ]]; then
+  exit 97
 fi
 printf '%s\n' "$lane" >> "$MEERKAT_PRE_PUSH_TEST_LANE_LOG"
 timeout_lane="${MEERKAT_PRE_PUSH_TEST_TIMEOUT_LANE:-}"
@@ -64,6 +59,9 @@ if [[ "$lane" == "$timeout_lane" && "$timeout_attempts" -gt 0 ]]; then
 fi
 if [[ "$lane" == "$MEERKAT_PRE_PUSH_TEST_FAIL_LANE" ]]; then
   exit "$MEERKAT_PRE_PUSH_TEST_FAIL_STATUS"
+fi
+if [[ "$lane" == "workspace-build" || "$lane" == "headcanonical-build" ]]; then
+  printf '{}\n'
 fi
 EOF
 chmod +x "$FAKE_CARGO"
@@ -117,12 +115,12 @@ assert_failure_case() {
   fi
 }
 
-assert_failure_case unit 37 "unit-build unit"
-assert_failure_case integration 38 "unit-build unit integration-build integration"
+assert_failure_case unit 37 "workspace-build unit"
+assert_failure_case integration 38 "workspace-build unit integration"
 assert_failure_case headcanonical-process-death 39 \
-  "unit-build unit integration-build integration headcanonical-build headcanonical-process-death"
+  "workspace-build unit integration headcanonical-build headcanonical-process-death"
 assert_failure_case e2e-fast 40 \
-  "unit-build unit integration-build integration headcanonical-build headcanonical-process-death e2e-fast-build e2e-fast"
+  "workspace-build unit integration headcanonical-build headcanonical-process-death e2e-fast"
 
 assert_timeout_case() {
   local timeout_lane="$1"
@@ -180,23 +178,19 @@ assert_timeout_case() {
 }
 
 assert_timeout_case unit 1 0 \
-  "unit-build unit unit integration-build integration headcanonical-build headcanonical-process-death e2e-fast-build e2e-fast" 1
-assert_timeout_case unit 2 124 "unit-build unit unit" 0
-assert_timeout_case unit-build 1 0 \
-  "unit-build unit-build unit integration-build integration headcanonical-build headcanonical-process-death e2e-fast-build e2e-fast" 1
-assert_timeout_case unit-build 2 124 "unit-build unit-build" 0
-assert_timeout_case integration-build 1 0 \
-  "unit-build unit integration-build integration-build integration headcanonical-build headcanonical-process-death e2e-fast-build e2e-fast" 1
-assert_timeout_case integration-build 2 124 \
-  "unit-build unit integration-build integration-build" 0
+  "workspace-build unit unit integration headcanonical-build headcanonical-process-death e2e-fast" 1
+assert_timeout_case unit 2 124 "workspace-build unit unit" 0
+assert_timeout_case workspace-build 1 0 \
+  "workspace-build workspace-build unit integration headcanonical-build headcanonical-process-death e2e-fast" 1
+assert_timeout_case workspace-build 2 124 "workspace-build workspace-build" 0
 assert_timeout_case headcanonical-process-death 1 0 \
-  "unit-build unit integration-build integration headcanonical-build headcanonical-process-death headcanonical-process-death e2e-fast-build e2e-fast" 1
+  "workspace-build unit integration headcanonical-build headcanonical-process-death headcanonical-process-death e2e-fast" 1
 assert_timeout_case headcanonical-process-death 2 124 \
-  "unit-build unit integration-build integration headcanonical-build headcanonical-process-death headcanonical-process-death" 0
+  "workspace-build unit integration headcanonical-build headcanonical-process-death headcanonical-process-death" 0
 assert_timeout_case headcanonical-build 1 0 \
-  "unit-build unit integration-build integration headcanonical-build headcanonical-build headcanonical-process-death e2e-fast-build e2e-fast" 1
+  "workspace-build unit integration headcanonical-build headcanonical-build headcanonical-process-death e2e-fast" 1
 assert_timeout_case headcanonical-build 2 124 \
-  "unit-build unit integration-build integration headcanonical-build headcanonical-build" 0
+  "workspace-build unit integration headcanonical-build headcanonical-build" 0
 
 assert_preflight_rejection() {
   local label="$1"
@@ -257,7 +251,7 @@ rm -rf "$TEST_ROOT/.git/meerkat-hook-cache"
     "$REPO_ROOT/scripts/pre-push-unit.sh"
 )
 if [[ "$(paste -sd ' ' "$LANE_LOG")" != \
-  "unit-build unit integration-build integration headcanonical-build headcanonical-process-death e2e-fast-build e2e-fast" ]]; then
+  "workspace-build unit integration headcanonical-build headcanonical-process-death e2e-fast" ]]; then
   echo "successful pre-push lane order was '$(paste -sd ' ' "$LANE_LOG")'" >&2
   exit 1
 fi
@@ -314,7 +308,7 @@ test_head="$(git -C "$TEST_ROOT" rev-parse HEAD)"
     PRE_COMMIT_TO_REF="$test_head" \
     "$REPO_ROOT/scripts/pre-push-unit.sh"
 )
-expected_source_lanes="unit-build unit integration-build integration headcanonical-build headcanonical-process-death e2e-fast-build e2e-fast"
+expected_source_lanes="workspace-build unit integration headcanonical-build headcanonical-process-death e2e-fast"
 if [[ "$(paste -sd ' ' "$LANE_LOG")" != "$expected_source_lanes" ]]; then
   echo "source change lane order was '$(paste -sd ' ' "$LANE_LOG")'; expected '${expected_source_lanes}'" >&2
   exit 1


### PR DESCRIPTION
## What changed

- Build one default-feature Nextest binary inventory for the workspace pre-push lanes.
- Reuse that inventory for unit, integration, and e2e-fast execution.
- Keep HeadCanonical on a separate `test-support` inventory.
- Fail closed if any metadata filter selects zero tests.
- Bump the deterministic source-test evidence version for the new gate semantics.

## Why

The previous hook invoked separate Cargo build and run commands for each lane. Even with a large warm target directory, those feature-graph traversals and link steps repeated expensive work on every pushed tree. The default-feature lanes share one build graph and can safely reuse the same Nextest metadata, while HeadCanonical must remain isolated because it enables `test-support`.

## Impact

The pre-push sequence drops from eight Cargo/Nextest graph commands to six. Runtime filters, profiles, timeouts, retry behavior, and fail-fast policy remain lane-specific.

## Validation

- Full pre-push script contract selftest
- Mutation proof for inventory coverage and zero-test rejection
- Real Nextest cargo/binary metadata reuse probe
- Bash syntax, ShellCheck, formatting, and diff checks
- Installed authoritative pre-push hook on the exact pushed SHA
- Independent scripts-only MobKit diff review
