### PR TITLE
ci: compile Nextest archives once for sharded tests

### DIFF
--- a/.github/actions/build-nextest-archive/action.yml
+++ b/.github/actions/build-nextest-archive/action.yml
@@ -1,0 +1,32 @@
+name: Build Nextest archive
+description: Build one canonical Meerkat test family and publish its portable Nextest archive.
+
+inputs:
+  family:
+    description: Canonical archive family.
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Build portable test archive
+      id: archive
+      shell: bash
+      env:
+        ARCHIVE_FAMILY: ${{ inputs.family }}
+      run: |
+        set -euo pipefail
+        archive_path="${RUNNER_TEMP}/nextest-${ARCHIVE_FAMILY}.tar.zst"
+        scripts/ci-nextest-archive.sh build "${ARCHIVE_FAMILY}" "${archive_path}"
+        ls -lh "${archive_path}"
+        echo "path=${archive_path}" >>"${GITHUB_OUTPUT}"
+
+    - name: Upload portable test archive
+      uses: actions/upload-artifact@v7
+      with:
+        name: nextest-${{ inputs.family }}-${{ github.sha }}
+        path: ${{ steps.archive.outputs.path }}
+        if-no-files-found: error
+        compression-level: 0
+        overwrite: true
+        retention-days: 3

--- a/.github/actions/run-nextest-archive/action.yml
+++ b/.github/actions/run-nextest-archive/action.yml
@@ -1,0 +1,37 @@
+name: Run Nextest archive partition
+description: Download one canonical Meerkat test archive and execute one fail-closed partition.
+
+inputs:
+  family:
+    description: Canonical archive family.
+    required: true
+  partition:
+    description: Nextest partition expression.
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Download portable test archive
+      uses: actions/download-artifact@v7
+      with:
+        name: nextest-${{ inputs.family }}-${{ github.sha }}
+        path: ${{ runner.temp }}/nextest-archives
+
+    - name: Install nextest
+      uses: taiki-e/install-action@nextest
+      env:
+        HOME: ${{ runner.temp }}/install-action-home-${{ github.job }}
+
+    - name: Run archived test partition
+      shell: bash
+      env:
+        ARCHIVE_FAMILY: ${{ inputs.family }}
+        ARCHIVE_PARTITION: ${{ inputs.partition }}
+      run: |
+        set -euo pipefail
+        archive_path="${RUNNER_TEMP}/nextest-archives/nextest-${ARCHIVE_FAMILY}.tar.zst"
+        scripts/ci-nextest-archive.sh run \
+          "${ARCHIVE_FAMILY}" \
+          "${archive_path}" \
+          "${ARCHIVE_PARTITION}"

--- a/.github/actions/run-nextest-archive/action.yml
+++ b/.github/actions/run-nextest-archive/action.yml
@@ -12,6 +12,11 @@ inputs:
 runs:
   using: composite
   steps:
+    - name: Setup pinned Rust test tools
+      uses: ./.github/actions/setup-rust-ci
+      with:
+        components: rustfmt
+
     - name: Download portable test archive
       uses: actions/download-artifact@v7
       with:

--- a/.github/actions/setup-rust-ci/action.yml
+++ b/.github/actions/setup-rust-ci/action.yml
@@ -1,6 +1,12 @@
 name: Setup Rust CI
 description: Install Meerkat's pinned Rust toolchain and force its binaries ahead of runner defaults.
 
+inputs:
+  components:
+    description: Comma-separated Rust components required by this job.
+    required: false
+    default: rustfmt, clippy
+
 runs:
   using: composite
   steps:
@@ -9,7 +15,7 @@ runs:
       with:
         # The CI lanes run fmt/clippy directly; the dtolnay action installs a
         # minimal profile, so name the components explicitly.
-        components: rustfmt, clippy
+        components: ${{ inputs.components }}
 
     - name: Pin Rust toolchain binaries
       shell: bash

--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -15,11 +15,13 @@ name: Cargo CI
 #   clippy          — workspace clippy, all features, lib/bin targets
 #                     (--all-targets multiplies build volume several-fold for
 #                     test-only lint yield; it runs nightly)
-#   unit (x8)       — lib unit tests, nextest hash-partitioned
-#   int-heavy (x3)  — meerkat-integration-tests integration lane
-#   int-rest (x8)   — integration tests in crate-group lanes (heavy groups
-#                     also hash-partitioned); the last
-#                     group is the complement of the named ones
+#   unit-archive    - build lib unit tests once into a portable archive
+#   unit (x8)       - run hash partitions from the shared unit archive
+#   int-archives    - build the three fast-profile integration families on one
+#                     runner so their shared dependency graph is compiled once
+#   int-heavy, int-mob, int-else (x3 each)
+#                   - run hash partitions from the shared family archives
+#   int-rest (x2)   - direct singleton crate-group integration lanes
 #   e2e-fast        — deterministic end-to-end lane (real binaries)
 #   ratchets        — version/schema/SDK/surface generation ratchets
 #   machine-verify  — canonical bounded TLC lane; machine-authority changes
@@ -161,7 +163,11 @@ jobs:
         uses: ./.github/actions/setup-rust-ci
 
       - name: Install governance scan dependencies
-        run: sudo apt-get update && sudo apt-get install -y ripgrep
+        run: |
+          if ! command -v rg >/dev/null 2>&1; then
+            sudo apt-get update
+            sudo apt-get install -y ripgrep
+          fi
 
       - name: Setup sccache
         uses: mozilla-actions/sccache-action@v0.0.11
@@ -178,6 +184,9 @@ jobs:
 
       - name: Format check
         run: make fmt-check
+
+      - name: Nextest archive contract self-test
+        run: scripts/test-ci-nextest-archive.sh
 
       - name: Surface/backend gates
         run: make legacy-surface-gate session-control-gate deprecated-backend-gate bridge-no-responsestatus-gate
@@ -272,15 +281,71 @@ jobs:
       - name: Clippy (lib/bin targets; --all-targets runs nightly)
         run: ./scripts/repo-cargo clippy --workspace --all-features -- -D warnings
 
+  unit-archive:
+    name: Build unit-test archive
+    needs: changes
+    if: ${{ needs.changes.outputs.code_changed == 'true' }}
+    runs-on: ubuntu-latest
+    env:
+      RUSTC_WRAPPER: sccache
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Rust
+        uses: ./.github/actions/setup-rust-ci
+
+      - name: Setup sccache
+        uses: mozilla-actions/sccache-action@v0.0.11
+
+      - name: Setup mold linker
+        uses: rui314/setup-mold@v1
+
+      - name: Cache cargo
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: ci-nextest-unit-archive
+
+      - name: Install nextest
+        uses: taiki-e/install-action@nextest
+        env:
+          HOME: ${{ runner.temp }}/install-action-home-${{ github.job }}
+
+      - name: Build workspace unit archive
+        uses: ./.github/actions/build-nextest-archive
+        with:
+          family: unit
+
   unit:
     name: Unit tests (shard ${{ matrix.partition }}/8)
-    needs: changes
+    needs:
+      - changes
+      - unit-archive
     if: ${{ needs.changes.outputs.code_changed == 'true' }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
         partition: [1, 2, 3, 4, 5, 6, 7, 8]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Unit tests (shard)
+        uses: ./.github/actions/run-nextest-archive
+        with:
+          family: unit
+          partition: hash:${{ matrix.partition }}/8
+
+  # Integration tests split by build scope, not just run partition. One runner
+  # builds the three shared fast-profile archives so matching dependencies are
+  # compiled once; two singleton feature shapes stay direct. The complement
+  # archive keeps coverage complete when new workspace crates are added.
+  int-archives:
+    name: Build integration-test archives
+    needs: changes
+    if: ${{ needs.changes.outputs.code_changed == 'true' }}
+    runs-on: ubuntu-latest
     env:
       RUSTC_WRAPPER: sccache
     steps:
@@ -299,62 +364,93 @@ jobs:
       - name: Cache cargo
         uses: Swatinem/rust-cache@v2
         with:
-          # unit builds only lib-test binaries; int builds only integration
-          # binaries — separate lanes so neither pays the other's link cost.
-          shared-key: ci-unit
+          shared-key: ci-nextest-integration-archives
 
       - name: Install nextest
         uses: taiki-e/install-action@nextest
         env:
           HOME: ${{ runner.temp }}/install-action-home-${{ github.job }}
 
-      - name: Unit tests (shard)
-        run: ./scripts/repo-cargo unit --partition "hash:${{ matrix.partition }}/8"
+      - name: Build integration-crate archive
+        uses: ./.github/actions/build-nextest-archive
+        with:
+          family: int-heavy
 
-  # Integration tests split by BUILD scope, not just run partition: linking
-  # every integration binary in the workspace is the dominant fixed cost, and
-  # meerkat-integration-tests owns the biggest binaries. Coverage is complete
-  # by construction: one crate + workspace-minus-that-crate.
+      - name: Build Mob integration archive
+        uses: ./.github/actions/build-nextest-archive
+        with:
+          family: int-mob
+
+      - name: Build complement integration archive
+        uses: ./.github/actions/build-nextest-archive
+        with:
+          family: int-everything-else
+
   int-heavy:
     name: Integration tests, meerkat-integration-tests (shard ${{ matrix.partition }}/3)
-    needs: changes
+    needs:
+      - changes
+      - int-archives
     if: ${{ needs.changes.outputs.code_changed == 'true' }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
         partition: [1, 2, 3]
-    env:
-      RUSTC_WRAPPER: sccache
     steps:
       - name: Checkout
         uses: actions/checkout@v6
 
-      - name: Setup Rust
-        uses: ./.github/actions/setup-rust-ci
-
-      - name: Setup sccache
-        uses: mozilla-actions/sccache-action@v0.0.11
-
-      - name: Setup mold linker
-        uses: rui314/setup-mold@v1
-
-      - name: Cache cargo
-        uses: Swatinem/rust-cache@v2
-        with:
-          shared-key: ci-int-heavy
-
-      - name: Install nextest
-        uses: taiki-e/install-action@nextest
-        env:
-          HOME: ${{ runner.temp }}/install-action-home-${{ github.job }}
-
       - name: Integration-fast tests (integration crate shard)
-        run: >-
-          ./scripts/repo-cargo nextest run -p meerkat-integration-tests --tests
-          --profile fast --show-progress none --status-level none
-          --final-status-level fail --partition "hash:${{ matrix.partition }}/3"
+        uses: ./.github/actions/run-nextest-archive
+        with:
+          family: int-heavy
+          partition: hash:${{ matrix.partition }}/3
 
+  int-mob:
+    name: Integration tests, mob-${{ matrix.partition }}of3 crates
+    needs:
+      - changes
+      - int-archives
+    if: ${{ needs.changes.outputs.code_changed == 'true' }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        partition: [1, 2, 3]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Integration-fast tests (Mob shard)
+        uses: ./.github/actions/run-nextest-archive
+        with:
+          family: int-mob
+          partition: hash:${{ matrix.partition }}/3
+
+  int-else:
+    name: Integration tests, everything-else-${{ matrix.partition }}of3 crates
+    needs:
+      - changes
+      - int-archives
+    if: ${{ needs.changes.outputs.code_changed == 'true' }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        partition: [1, 2, 3]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Integration-fast tests (complement shard)
+        uses: ./.github/actions/run-nextest-archive
+        with:
+          family: int-everything-else
+          partition: hash:${{ matrix.partition }}/3
+
+  # Singleton crate groups still build and execute directly. Archiving them
+  # would add transfer overhead without eliminating duplicate compilation.
   int-rest:
     name: Integration tests, ${{ matrix.group }} crates
     needs: changes
@@ -362,30 +458,9 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
-      # Crate-group lanes: each job builds and links ONLY its group's
-      # integration binaries (linking all ~44 crates' test bins per shard was
-      # the dominant fixed cost). The `everything-else` group is the
-      # COMPLEMENT of the named groups, so coverage stays complete by
-      # construction — a new crate lands there automatically.
       matrix:
         include:
-          - group: mob-1of3
-            partition: "hash:1/3"
-            scope: >-
-              -p meerkat-mob -p meerkat-mob-adaptive -p meerkat-mob-mcp
-              -p meerkat-mob-pack -p meerkat-schedule -p meerkat-workgraph
-          - group: mob-2of3
-            partition: "hash:2/3"
-            scope: >-
-              -p meerkat-mob -p meerkat-mob-adaptive -p meerkat-mob-mcp
-              -p meerkat-mob-pack -p meerkat-schedule -p meerkat-workgraph
-          - group: mob-3of3
-            partition: "hash:3/3"
-            scope: >-
-              -p meerkat-mob -p meerkat-mob-adaptive -p meerkat-mob-mcp
-              -p meerkat-mob-pack -p meerkat-schedule -p meerkat-workgraph
           - group: core-machine
-            partition: "hash:1/1"
             scope: >-
               -p meerkat-core -p meerkat-models -p meerkat-machine-codegen
               -p meerkat-machine-derive -p meerkat-machine-dsl
@@ -394,12 +469,9 @@ jobs:
               -p meerkat-capabilities -p meerkat-agent-build-authority
               -p meerkat-contracts
           # meerkat-store/sqlite is explicit here: nothing in this crate
-          # group enables it (only mob/facade crates do, in other lanes), and
-          # without it the SQLite storage-conformance tests in
-          # meerkat-store/tests are cfg'd out of the only blocking lane that
-          # builds them.
+          # group enables it, and otherwise the SQLite storage-conformance
+          # tests are cfg'd out of the only blocking lane that builds them.
           - group: client-session
-            partition: "hash:1/1"
             scope: >-
               -p meerkat-anthropic -p meerkat-auth-core -p meerkat-client
               -p meerkat-comms -p meerkat-gemini -p meerkat-hooks
@@ -407,69 +479,6 @@ jobs:
               -p meerkat-openai -p meerkat-providers -p meerkat-session
               -p meerkat-skills -p meerkat-store -p meerkat-tools
               --features meerkat-store/sqlite
-          - group: everything-else-1of3
-            partition: "hash:1/3"
-            scope: >-
-              --workspace --exclude meerkat-integration-tests
-              --exclude meerkat-mob --exclude meerkat-mob-adaptive
-              --exclude meerkat-mob-mcp --exclude meerkat-mob-pack
-              --exclude meerkat-schedule --exclude meerkat-workgraph
-              --exclude meerkat-core --exclude meerkat-models
-              --exclude meerkat-machine-codegen --exclude meerkat-machine-derive
-              --exclude meerkat-machine-dsl --exclude meerkat-machine-dsl-core
-              --exclude meerkat-machine-kernels --exclude meerkat-machine-schema
-              --exclude machine-dsl-tests --exclude meerkat-capabilities
-              --exclude meerkat-agent-build-authority --exclude meerkat-contracts
-              --exclude meerkat-anthropic --exclude meerkat-auth-core
-              --exclude meerkat-client --exclude meerkat-comms
-              --exclude meerkat-gemini --exclude meerkat-hooks
-              --exclude meerkat-llm-core --exclude meerkat-mcp
-              --exclude meerkat-memory --exclude meerkat-openai
-              --exclude meerkat-providers --exclude meerkat-session
-              --exclude meerkat-skills --exclude meerkat-store
-              --exclude meerkat-tools
-          - group: everything-else-2of3
-            partition: "hash:2/3"
-            scope: >-
-              --workspace --exclude meerkat-integration-tests
-              --exclude meerkat-mob --exclude meerkat-mob-adaptive
-              --exclude meerkat-mob-mcp --exclude meerkat-mob-pack
-              --exclude meerkat-schedule --exclude meerkat-workgraph
-              --exclude meerkat-core --exclude meerkat-models
-              --exclude meerkat-machine-codegen --exclude meerkat-machine-derive
-              --exclude meerkat-machine-dsl --exclude meerkat-machine-dsl-core
-              --exclude meerkat-machine-kernels --exclude meerkat-machine-schema
-              --exclude machine-dsl-tests --exclude meerkat-capabilities
-              --exclude meerkat-agent-build-authority --exclude meerkat-contracts
-              --exclude meerkat-anthropic --exclude meerkat-auth-core
-              --exclude meerkat-client --exclude meerkat-comms
-              --exclude meerkat-gemini --exclude meerkat-hooks
-              --exclude meerkat-llm-core --exclude meerkat-mcp
-              --exclude meerkat-memory --exclude meerkat-openai
-              --exclude meerkat-providers --exclude meerkat-session
-              --exclude meerkat-skills --exclude meerkat-store
-              --exclude meerkat-tools
-          - group: everything-else-3of3
-            partition: "hash:3/3"
-            scope: >-
-              --workspace --exclude meerkat-integration-tests
-              --exclude meerkat-mob --exclude meerkat-mob-adaptive
-              --exclude meerkat-mob-mcp --exclude meerkat-mob-pack
-              --exclude meerkat-schedule --exclude meerkat-workgraph
-              --exclude meerkat-core --exclude meerkat-models
-              --exclude meerkat-machine-codegen --exclude meerkat-machine-derive
-              --exclude meerkat-machine-dsl --exclude meerkat-machine-dsl-core
-              --exclude meerkat-machine-kernels --exclude meerkat-machine-schema
-              --exclude machine-dsl-tests --exclude meerkat-capabilities
-              --exclude meerkat-agent-build-authority --exclude meerkat-contracts
-              --exclude meerkat-anthropic --exclude meerkat-auth-core
-              --exclude meerkat-client --exclude meerkat-comms
-              --exclude meerkat-gemini --exclude meerkat-hooks
-              --exclude meerkat-llm-core --exclude meerkat-mcp
-              --exclude meerkat-memory --exclude meerkat-openai
-              --exclude meerkat-providers --exclude meerkat-session
-              --exclude meerkat-skills --exclude meerkat-store
-              --exclude meerkat-tools
     env:
       RUSTC_WRAPPER: sccache
     steps:
@@ -495,11 +504,11 @@ jobs:
         env:
           HOME: ${{ runner.temp }}/install-action-home-${{ github.job }}
 
-      - name: Integration-fast tests (crate group)
+      - name: Integration-fast tests (singleton crate group)
         run: >-
           ./scripts/repo-cargo nextest run ${{ matrix.scope }} --tests
           --profile fast --show-progress none --status-level none
-          --final-status-level fail --partition "${{ matrix.partition }}"
+          --final-status-level fail --partition hash:1/1
 
   e2e-fast:
     name: Deterministic e2e lane
@@ -924,8 +933,12 @@ jobs:
       - fmt-governance
       - locks
       - clippy
+      - unit-archive
       - unit
+      - int-archives
       - int-heavy
+      - int-mob
+      - int-else
       - int-rest
       - e2e-fast
       - ratchets
@@ -945,8 +958,12 @@ jobs:
             ${{ needs.fmt-governance.result }}
             ${{ needs.locks.result }}
             ${{ needs.clippy.result }}
+            ${{ needs.unit-archive.result }}
             ${{ needs.unit.result }}
+            ${{ needs.int-archives.result }}
             ${{ needs.int-heavy.result }}
+            ${{ needs.int-mob.result }}
+            ${{ needs.int-else.result }}
             ${{ needs.int-rest.result }}
             ${{ needs.e2e-fast.result }}
             ${{ needs.ratchets.result }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -100,6 +100,13 @@ repos:
   # On push: formatting check
   - repo: local
     hooks:
+      - id: ci-nextest-archive-contract
+        name: CI nextest archive family and fail-closed contracts
+        entry: scripts/test-ci-nextest-archive.sh
+        language: script
+        pass_filenames: false
+        stages: [pre-push]
+
       - id: cargo-fmt
         name: cargo fmt --check
         entry: scripts/repo-cargo fmt --all -- --check

--- a/examples/035-mdm-tux-rs/tests/kennel_protocol.rs
+++ b/examples/035-mdm-tux-rs/tests/kennel_protocol.rs
@@ -62,6 +62,8 @@ impl KennelSession {
 /// port if the child exits early or never becomes reachable.
 async fn spawn_kennel() -> anyhow::Result<(String, tokio::process::Child, tempfile::TempDir)> {
     let mut last_err = None;
+    let kennel = std::env::var_os("CARGO_BIN_EXE_mdm-kennel")
+        .expect("Cargo or Nextest must provide the runtime kennel binary path");
 
     for attempt in 0..10 {
         let temp = tempfile::tempdir()?;
@@ -70,7 +72,7 @@ async fn spawn_kennel() -> anyhow::Result<(String, tokio::process::Child, tempfi
         let port = listener.local_addr()?.port();
         drop(listener);
 
-        let mut child = tokio::process::Command::new(env!("CARGO_BIN_EXE_mdm-kennel"))
+        let mut child = tokio::process::Command::new(&kennel)
             .arg("--listen")
             .arg(format!("127.0.0.1:{port}"))
             .arg("--data-dir")

--- a/meerkat-cli/tests/help_mobpack_contract.rs
+++ b/meerkat-cli/tests/help_mobpack_contract.rs
@@ -178,11 +178,11 @@ fn embedded_help_mobpack_examples_match_typed_authoring_contracts()
     )?;
     let pack = dist.join("release-triage.mobpack");
     let rkat = std::env::var_os("CARGO_BIN_EXE_rkat")
-        .expect("Cargo or Nextest must provide the runtime rkat binary path");
+        .ok_or("Cargo or Nextest must provide the runtime rkat binary path")?;
 
     let empty_path = temp.path().join("empty-path");
     std::fs::create_dir_all(&empty_path)?;
-    let doctor = Command::new(rkat)
+    let doctor = Command::new(&rkat)
         .current_dir(temp.path())
         .env("HOME", temp.path())
         .env("XDG_CONFIG_HOME", temp.path().join("config"))
@@ -201,7 +201,7 @@ fn embedded_help_mobpack_examples_match_typed_authoring_contracts()
         "doctor restored the false direct dependency claim: {doctor_output}"
     );
 
-    let packed = Command::new(rkat)
+    let packed = Command::new(&rkat)
         .current_dir(temp.path())
         .env("HOME", temp.path())
         .env("XDG_CONFIG_HOME", temp.path().join("config"))
@@ -220,7 +220,7 @@ fn embedded_help_mobpack_examples_match_typed_authoring_contracts()
         output_text(&packed)
     );
 
-    let inspected = Command::new(rkat)
+    let inspected = Command::new(&rkat)
         .current_dir(temp.path())
         .env("HOME", temp.path())
         .env("XDG_CONFIG_HOME", temp.path().join("config"))
@@ -234,7 +234,7 @@ fn embedded_help_mobpack_examples_match_typed_authoring_contracts()
         output_text(&inspected)
     );
 
-    let permissive = Command::new(rkat)
+    let permissive = Command::new(&rkat)
         .current_dir(temp.path())
         .env("HOME", temp.path())
         .env("XDG_CONFIG_HOME", temp.path().join("config"))
@@ -256,7 +256,7 @@ fn embedded_help_mobpack_examples_match_typed_authoring_contracts()
         output_text(&permissive)
     );
 
-    let strict = Command::new(rkat)
+    let strict = Command::new(&rkat)
         .current_dir(temp.path())
         .env("HOME", temp.path())
         .env("XDG_CONFIG_HOME", temp.path().join("config"))
@@ -282,7 +282,7 @@ fn embedded_help_mobpack_examples_match_typed_authoring_contracts()
         "export default function init() {}\n",
     )?;
     let web_out = dist.join("release-triage-web");
-    let web_build = Command::new(rkat)
+    let web_build = Command::new(&rkat)
         .current_dir(temp.path())
         .env("HOME", temp.path())
         .env("XDG_CONFIG_HOME", temp.path().join("config"))

--- a/meerkat-cli/tests/help_mobpack_contract.rs
+++ b/meerkat-cli/tests/help_mobpack_contract.rs
@@ -177,7 +177,8 @@ fn embedded_help_mobpack_examples_match_typed_authoring_contracts()
         "0707070707070707070707070707070707070707070707070707070707070707\n",
     )?;
     let pack = dist.join("release-triage.mobpack");
-    let rkat = env!("CARGO_BIN_EXE_rkat");
+    let rkat = std::env::var_os("CARGO_BIN_EXE_rkat")
+        .expect("Cargo or Nextest must provide the runtime rkat binary path");
 
     let empty_path = temp.path().join("empty-path");
     std::fs::create_dir_all(&empty_path)?;

--- a/meerkat-cli/tests/storage_doctor.rs
+++ b/meerkat-cli/tests/storage_doctor.rs
@@ -78,7 +78,9 @@ fn insert_session(conn: &Connection, session: &Session) {
 }
 
 fn run_doctor(temp: &TempDir, args: &[&str]) -> Output {
-    let binary = PathBuf::from(env!("CARGO_BIN_EXE_rkat"));
+    let binary = std::env::var_os("CARGO_BIN_EXE_rkat")
+        .map(PathBuf::from)
+        .expect("Cargo or Nextest must provide the runtime rkat binary path");
     let project = temp.path().join("project");
     std::fs::create_dir_all(&project).unwrap();
     let mut command = Command::new(binary);

--- a/meerkat-cli/tests/storage_migrate.rs
+++ b/meerkat-cli/tests/storage_migrate.rs
@@ -277,7 +277,7 @@ fn insert_session(conn: &Connection, session: &Session) {
 fn run_rkat(temp: &TempDir, args: &[&str]) -> Output {
     let binary = std::env::var_os("CARGO_BIN_EXE_rkat")
         .map(PathBuf::from)
-        .unwrap_or_else(|| PathBuf::from(env!("CARGO_BIN_EXE_rkat")));
+        .expect("Cargo or Nextest must provide the runtime rkat binary path");
     let project = temp.path().join("project");
     std::fs::create_dir_all(&project).unwrap();
     let mut command = Command::new(binary);

--- a/scripts/ci-nextest-archive.sh
+++ b/scripts/ci-nextest-archive.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="${ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+CARGO="${CARGO:-${ROOT}/scripts/repo-cargo}"
+NEXTEST_BIN="${NEXTEST_BIN:-cargo-nextest}"
+
+usage() {
+  cat >&2 <<'EOF'
+usage:
+  scripts/ci-nextest-archive.sh build <family> <archive-file>
+  scripts/ci-nextest-archive.sh run <family> <archive-file> <partition>
+
+families: unit, int-heavy, int-mob, int-everything-else
+EOF
+  exit 2
+}
+
+family="${2:-}"
+archive_file="${3:-}"
+[[ -n "$family" && -n "$archive_file" ]] || usage
+
+profile=default
+case "$family" in
+  unit)
+    cargo_args=(--workspace --lib)
+    ;;
+  int-heavy)
+    cargo_args=(-p meerkat-integration-tests --tests --profile fast)
+    profile=fast
+    ;;
+  int-mob)
+    cargo_args=(
+      -p meerkat-mob
+      -p meerkat-mob-adaptive
+      -p meerkat-mob-mcp
+      -p meerkat-mob-pack
+      -p meerkat-schedule
+      -p meerkat-workgraph
+      --tests
+      --profile fast
+    )
+    profile=fast
+    ;;
+  int-everything-else)
+    cargo_args=(
+      --workspace
+      --exclude meerkat-integration-tests
+      --exclude meerkat-mob
+      --exclude meerkat-mob-adaptive
+      --exclude meerkat-mob-mcp
+      --exclude meerkat-mob-pack
+      --exclude meerkat-schedule
+      --exclude meerkat-workgraph
+      --exclude meerkat-core
+      --exclude meerkat-models
+      --exclude meerkat-machine-codegen
+      --exclude meerkat-machine-derive
+      --exclude meerkat-machine-dsl
+      --exclude meerkat-machine-dsl-core
+      --exclude meerkat-machine-kernels
+      --exclude meerkat-machine-schema
+      --exclude machine-dsl-tests
+      --exclude meerkat-capabilities
+      --exclude meerkat-agent-build-authority
+      --exclude meerkat-contracts
+      --exclude meerkat-anthropic
+      --exclude meerkat-auth-core
+      --exclude meerkat-client
+      --exclude meerkat-comms
+      --exclude meerkat-gemini
+      --exclude meerkat-hooks
+      --exclude meerkat-llm-core
+      --exclude meerkat-mcp
+      --exclude meerkat-memory
+      --exclude meerkat-openai
+      --exclude meerkat-providers
+      --exclude meerkat-session
+      --exclude meerkat-skills
+      --exclude meerkat-store
+      --exclude meerkat-tools
+      --tests
+      --profile fast
+    )
+    profile=fast
+    ;;
+  *)
+    echo "error: unknown nextest archive family '${family}'" >&2
+    usage
+    ;;
+esac
+
+case "${1:-}" in
+  build)
+    mkdir -p "$(dirname "$archive_file")"
+    "$CARGO" nextest archive "${cargo_args[@]}" --archive-file "$archive_file"
+    [[ -s "$archive_file" ]] || {
+      echo "error: nextest archive was not created at ${archive_file}" >&2
+      exit 1
+    }
+    ;;
+  run)
+    partition="${4:-}"
+    [[ -n "$partition" ]] || usage
+    [[ -s "$archive_file" ]] || {
+      echo "error: nextest archive is missing or empty at ${archive_file}" >&2
+      exit 1
+    }
+    run_args=(
+      nextest run
+      --archive-file "$archive_file"
+      --workspace-remap "$ROOT"
+      --no-tests=fail
+      --show-progress none
+      --status-level none
+      --final-status-level fail
+      --partition "$partition"
+    )
+    if [[ "$profile" == fast ]]; then
+      run_args+=(--profile fast)
+    fi
+    "$NEXTEST_BIN" "${run_args[@]}"
+    ;;
+  *)
+    usage
+    ;;
+esac

--- a/scripts/ci-nextest-archive.sh
+++ b/scripts/ci-nextest-archive.sh
@@ -119,7 +119,7 @@ case "${1:-}" in
     if [[ "$profile" == fast ]]; then
       run_args+=(--profile fast)
     fi
-    "$NEXTEST_BIN" "${run_args[@]}"
+    MEERKAT_WORKSPACE_ROOT="$ROOT" "$NEXTEST_BIN" "${run_args[@]}"
     ;;
   *)
     usage

--- a/scripts/test-ci-nextest-archive.sh
+++ b/scripts/test-ci-nextest-archive.sh
@@ -77,6 +77,10 @@ while IFS= read -r command; do
     echo "archived run omitted --no-tests=fail: ${command}" >&2
     exit 1
   }
+  # This proves that every archived execution passes Nextest's relocation
+  # flag. Compile-time CARGO_MANIFEST_DIR reads can still embed the builder
+  # checkout, so the count ratchet below prevents that known gap from growing
+  # until the dedicated portability cleanup removes it.
   [[ "$command" == *' <--workspace-remap> '* ]] || {
     echo "archived run omitted --workspace-remap: ${command}" >&2
     exit 1
@@ -165,5 +169,22 @@ else_job="$(sed -n '/^  int-else:$/,/^  int-rest:$/p' "$WORKFLOW")"
   echo "int-else execution does not depend on int-archives" >&2
   exit 1
 }
+
+if rg -n 'env!\("CARGO_BIN_EXE_' "$ROOT" --glob '*.rs'; then
+  echo "archived tests must resolve Cargo binary paths from the runtime environment" >&2
+  exit 1
+fi
+
+manifest_dir_env_matches="$(
+  rg -n 'env!\("CARGO_MANIFEST_DIR"\)' "$ROOT" --glob '*.rs' || true
+)"
+manifest_dir_env_count="$(
+  printf '%s\n' "$manifest_dir_env_matches" | sed '/^$/d' | wc -l | tr -d '[:space:]'
+)"
+if ((manifest_dir_env_count > 71)); then
+  printf '%s\n' "$manifest_dir_env_matches" >&2
+  echo "compile-time CARGO_MANIFEST_DIR archive paths grew from the pinned budget of 71" >&2
+  exit 1
+fi
 
 echo "CI nextest archive family and fail-closed contracts hold"

--- a/scripts/test-ci-nextest-archive.sh
+++ b/scripts/test-ci-nextest-archive.sh
@@ -1,0 +1,162 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TEST_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/meerkat-ci-nextest-archive.XXXXXX")"
+trap 'rm -rf -- "$TEST_ROOT"' EXIT
+
+LOG="${TEST_ROOT}/commands.log"
+FAKE_CARGO="${TEST_ROOT}/repo-cargo"
+FAKE_NEXTEST="${TEST_ROOT}/cargo-nextest"
+
+cat >"$FAKE_CARGO" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf 'cargo' >>"$COMMAND_LOG"
+printf ' <%s>' "$@" >>"$COMMAND_LOG"
+printf '\n' >>"$COMMAND_LOG"
+archive_file=""
+while (($#)); do
+  if [[ "$1" == "--archive-file" ]]; then
+    archive_file="$2"
+    break
+  fi
+  shift
+done
+[[ -n "$archive_file" ]] || exit 91
+printf 'archive\n' >"$archive_file"
+EOF
+
+cat >"$FAKE_NEXTEST" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf 'nextest' >>"$COMMAND_LOG"
+printf ' <%s>' "$@" >>"$COMMAND_LOG"
+printf '\n' >>"$COMMAND_LOG"
+EOF
+
+chmod +x "$FAKE_CARGO" "$FAKE_NEXTEST"
+export COMMAND_LOG="$LOG"
+export ROOT
+export CARGO="$FAKE_CARGO"
+export NEXTEST_BIN="$FAKE_NEXTEST"
+
+families=(unit int-heavy int-mob int-everything-else)
+for family in "${families[@]}"; do
+  archive="${TEST_ROOT}/${family}.tar.zst"
+  "$ROOT/scripts/ci-nextest-archive.sh" build "$family" "$archive"
+  "$ROOT/scripts/ci-nextest-archive.sh" run "$family" "$archive" hash:1/1
+done
+
+assert_line_contains() {
+  local pattern="$1"
+  if ! grep -F -- "$pattern" "$LOG" >/dev/null; then
+    echo "missing command fragment: ${pattern}" >&2
+    cat "$LOG" >&2
+    exit 1
+  fi
+}
+
+assert_line_contains 'cargo <nextest> <archive> <--workspace> <--lib>'
+assert_line_contains 'cargo <nextest> <archive> <-p> <meerkat-integration-tests> <--tests> <--profile> <fast>'
+assert_line_contains '<-p> <meerkat-mob> <-p> <meerkat-mob-adaptive>'
+assert_line_contains '<--workspace> <--exclude> <meerkat-integration-tests> <--exclude> <meerkat-mob>'
+
+run_count="$(grep -c '^nextest ' "$LOG")"
+[[ "$run_count" == 4 ]] || {
+  echo "expected four archived runs, got ${run_count}" >&2
+  exit 1
+}
+while IFS= read -r command; do
+  [[ "$command" == *' <--no-tests=fail> '* ]] || {
+    echo "archived run omitted --no-tests=fail: ${command}" >&2
+    exit 1
+  }
+  [[ "$command" == *' <--workspace-remap> '* ]] || {
+    echo "archived run omitted --workspace-remap: ${command}" >&2
+    exit 1
+  }
+  [[ "$command" == *' <--partition> <hash:1/1>'* ]] || {
+    echo "archived run omitted the requested partition: ${command}" >&2
+    exit 1
+  }
+done < <(grep '^nextest ' "$LOG")
+
+unit_run="$(grep '^nextest ' "$LOG" | head -n 1)"
+[[ "$unit_run" != *' <--profile> <fast>'* ]] || {
+  echo "unit archive run unexpectedly selected the fast profile" >&2
+  exit 1
+}
+fast_run_count="$(grep '^nextest ' "$LOG" | grep -c -- '<--profile> <fast>')"
+[[ "$fast_run_count" == 3 ]] || {
+  echo "expected three fast-profile archive runs, got ${fast_run_count}" >&2
+  exit 1
+}
+
+if "$ROOT/scripts/ci-nextest-archive.sh" build unknown "${TEST_ROOT}/unknown.tar.zst" >/dev/null 2>&1; then
+  echo "unknown archive family was accepted" >&2
+  exit 1
+fi
+if "$ROOT/scripts/ci-nextest-archive.sh" run unit "${TEST_ROOT}/unit.tar.zst" >/dev/null 2>&1; then
+  echo "archive run without a partition was accepted" >&2
+  exit 1
+fi
+
+BUILD_ACTION="$ROOT/.github/actions/build-nextest-archive/action.yml"
+RUN_ACTION="$ROOT/.github/actions/run-nextest-archive/action.yml"
+WORKFLOW="$ROOT/.github/workflows/cargo.yml"
+
+assert_file_contains() {
+  local file="$1"
+  local pattern="$2"
+  if ! grep -F -- "$pattern" "$file" >/dev/null; then
+    echo "${file} is missing required contract: ${pattern}" >&2
+    exit 1
+  fi
+}
+
+stable_artifact_name="nextest-\${{ inputs.family }}-\${{ github.sha }}"
+assert_file_contains "$BUILD_ACTION" "name: ${stable_artifact_name}"
+assert_file_contains "$BUILD_ACTION" 'overwrite: true'
+assert_file_contains "$RUN_ACTION" "name: ${stable_artifact_name}"
+assert_file_contains "$RUN_ACTION" 'scripts/ci-nextest-archive.sh run'
+
+for dependency in unit-archive int-archives; do
+  assert_file_contains "$WORKFLOW" "      - ${dependency}"
+  assert_file_contains "$WORKFLOW" "            \${{ needs.${dependency}.result }}"
+done
+for execution_job in unit int-heavy int-mob int-else int-rest; do
+  assert_file_contains "$WORKFLOW" "      - ${execution_job}"
+  assert_file_contains "$WORKFLOW" "            \${{ needs.${execution_job}.result }}"
+done
+
+unit_job="$(sed -n '/^  unit:$/,/^  int-archives:$/p' "$WORKFLOW")"
+[[ "$unit_job" == *'      - unit-archive'* ]] || {
+  echo "unit execution does not depend on unit-archive" >&2
+  exit 1
+}
+archive_job="$(sed -n '/^  int-archives:$/,/^  int-heavy:$/p' "$WORKFLOW")"
+for family in int-heavy int-mob int-everything-else; do
+  [[ "$archive_job" == *"          family: ${family}"* ]] || {
+    echo "integration archive builder omits ${family}" >&2
+    exit 1
+  }
+done
+
+heavy_job="$(sed -n '/^  int-heavy:$/,/^  int-mob:$/p' "$WORKFLOW")"
+[[ "$heavy_job" == *'      - int-archives'* ]] || {
+  echo "int-heavy execution does not depend on int-archives" >&2
+  exit 1
+}
+mob_job="$(sed -n '/^  int-mob:$/,/^  int-else:$/p' "$WORKFLOW")"
+[[ "$mob_job" == *'      - int-archives'* ]] || {
+  echo "int-mob execution does not depend on int-archives" >&2
+  exit 1
+}
+else_job="$(sed -n '/^  int-else:$/,/^  int-rest:$/p' "$WORKFLOW")"
+[[ "$else_job" == *'      - int-archives'* ]] || {
+  echo "int-else execution does not depend on int-archives" >&2
+  exit 1
+}
+
+echo "CI nextest archive family and fail-closed contracts hold"

--- a/scripts/test-ci-nextest-archive.sh
+++ b/scripts/test-ci-nextest-archive.sh
@@ -30,6 +30,10 @@ EOF
 cat >"$FAKE_NEXTEST" <<'EOF'
 #!/usr/bin/env bash
 set -euo pipefail
+[[ "${MEERKAT_WORKSPACE_ROOT:-}" == "${EXPECTED_WORKSPACE_ROOT:?}" ]] || {
+  echo "archived run omitted MEERKAT_WORKSPACE_ROOT" >&2
+  exit 92
+}
 printf 'nextest' >>"$COMMAND_LOG"
 printf ' <%s>' "$@" >>"$COMMAND_LOG"
 printf '\n' >>"$COMMAND_LOG"
@@ -37,6 +41,7 @@ EOF
 
 chmod +x "$FAKE_CARGO" "$FAKE_NEXTEST"
 export COMMAND_LOG="$LOG"
+export EXPECTED_WORKSPACE_ROOT="$ROOT"
 export ROOT
 export CARGO="$FAKE_CARGO"
 export NEXTEST_BIN="$FAKE_NEXTEST"

--- a/scripts/test-ci-nextest-archive.sh
+++ b/scripts/test-ci-nextest-archive.sh
@@ -124,6 +124,8 @@ stable_artifact_name="nextest-\${{ inputs.family }}-\${{ github.sha }}"
 assert_file_contains "$BUILD_ACTION" "name: ${stable_artifact_name}"
 assert_file_contains "$BUILD_ACTION" 'overwrite: true'
 assert_file_contains "$RUN_ACTION" "name: ${stable_artifact_name}"
+assert_file_contains "$RUN_ACTION" 'uses: ./.github/actions/setup-rust-ci'
+assert_file_contains "$RUN_ACTION" 'components: rustfmt'
 assert_file_contains "$RUN_ACTION" 'scripts/ci-nextest-archive.sh run'
 
 for dependency in unit-archive int-archives; do

--- a/xtask/tests/ci_gate_requires_rmat.rs
+++ b/xtask/tests/ci_gate_requires_rmat.rs
@@ -109,7 +109,10 @@ fn cargo_workflow_covers_the_full_per_push_gate_set() {
             "e2e-fast",
             "fmt-governance",
             "gate",
+            "int-archives",
+            "int-else",
             "int-heavy",
+            "int-mob",
             "int-rest",
             "locks",
             "machine-verify",
@@ -117,6 +120,7 @@ fn cargo_workflow_covers_the_full_per_push_gate_set() {
             "sdk-host",
             "sdk-web",
             "unit",
+            "unit-archive",
             "wasm-check",
             "wasm-contract",
         ],
@@ -189,14 +193,19 @@ fn cargo_workflow_covers_the_full_per_push_gate_set() {
 
     // Full-workspace verification (the changed-crates-only gate missed
     // dependent-crate breakage; do not reintroduce it as the only test gate).
-    // Unit/int run as sharded nextest partitions of the same workspace-wide
-    // lanes the `unit`/`int` cargo aliases define; clippy covers the whole
-    // workspace with all features (test-target lints run nightly).
+    // Unit and integration execution jobs consume portable Nextest archives
+    // built once per compatible Cargo profile. The archive contract self-test
+    // pins the complete build scopes and fail-closed partitions; clippy covers
+    // the whole workspace with all features (test-target lints run nightly).
     for lane in [
         "clippy --workspace --all-features",
-        "repo-cargo unit --partition",
-        "-p meerkat-integration-tests --tests",
-        "--workspace --exclude meerkat-integration-tests",
+        "uses: ./.github/actions/build-nextest-archive",
+        "uses: ./.github/actions/run-nextest-archive",
+        "family: unit",
+        "family: int-heavy",
+        "family: int-mob",
+        "family: int-everything-else",
+        "scripts/test-ci-nextest-archive.sh",
         "make e2e-fast",
         "make verify-schema-freshness",
         "make verify-sdk-codegen-freshness",


### PR DESCRIPTION
## Summary

- build workspace unit tests once into a portable Nextest archive, then run all eight partitions from that artifact
- build the three fast-profile integration families on one shared runner, then run their nine partitions without recompiling on fresh VMs
- keep singleton feature shapes direct, preserve complete complement coverage, and bind both archive builders into the aggregate gate
- fail closed on empty partitions, unknown families, missing artifacts, and builder failures
- skip the unreliable apt install when `rg` is already present on the hosted runner

## Validation

- full installed pre-push hook green at `56e2fcdf3`
- real local unit archive: 46 binaries, 84 files, 782 MiB; archive listing succeeded from a remapped checkout path
- mutation proof: removing `--no-tests=fail` makes the archive contract self-test fail
- exact `cargo_workflow_covers_the_full_per_push_gate_set` governance regression green
- `make fmt-check`, ShellCheck, YAML validation, archive contract self-test, and `git diff --check` green
- MobKit second-head review: workflow/test-only change, zero shipping Rust; archive failure/cancellation cascade is fail-closed because both builders are aggregate-gate dependencies

This PR CI run is the destination proof for archive upload/download size, execution-only shard behavior, and wall-clock impact.