### PR TITLE
fix: await exact CLI runtime teardown

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -548,7 +548,7 @@
           "FILE:@@//meerkat-session/Cargo.toml f16575bfc5f9aebb512da9703dcfb70d9e3563bfe34ecb19fc4d5185e8344e90",
           "FILE:@@//meerkat-mob/Cargo.toml 49d85eaeb7cacb479f5626ed7df84d4339677c58eaa567c8eb1cf2152aef128e",
           "FILE:@@//meerkat-mob-mcp/Cargo.toml 6d06ee6af285a9d922c95fbb397448b0fb45be7f1b94207e9ddfc66bf1207527",
-          "FILE:@@//meerkat-cli/Cargo.toml 8e06fe9a79952a7c43709aebef7f0b7d753937e5f51055824f1224e4a475d443",
+          "FILE:@@//meerkat-cli/Cargo.toml 3c53f23f7c3e952b5e1a8c3d2a611ffc134ead49f155595af4e9fdcd8b44a677",
           "FILE:@@//meerkat-mob-pack/Cargo.toml 9ac2462d05c859e5b4ab523d6bebe65fe1940f619796a2356b6cd7d00ef68965",
           "FILE:@@//meerkat-rpc/Cargo.toml ff71910e9150bd5b7414450b7fa25e9749ce06a39440d4a352107da64d3a1185",
           "FILE:@@//meerkat-rest/Cargo.toml a483eb130ffdc56d04316fa1f4ff68d6ae6a5627f739098821a9e151a257ac19",

--- a/meerkat-cli/BUILD.bazel
+++ b/meerkat-cli/BUILD.bazel
@@ -3210,6 +3210,7 @@ rust_binary(
         proc_macro = True,
     ),
     deps = [
+        "//meerkat-mob:meerkat_mob",
         "//meerkat:meerkat",
         "//meerkat:meerkat_anthropic_agent_factory_build",
         "//meerkat:meerkat_atif_agent_factory_build",
@@ -3264,6 +3265,7 @@ rust_binary(
         proc_macro = True,
     ),
     deps = [
+        "//meerkat-mob:meerkat_mob",
         "//meerkat:meerkat",
         "//meerkat:meerkat_anthropic_agent_factory_build",
         "//meerkat:meerkat_atif_agent_factory_build",
@@ -3321,6 +3323,7 @@ rust_binary(
         proc_macro = True,
     ),
     deps = [
+        "//meerkat-mob:meerkat_mob",
         "//meerkat:meerkat",
         "//meerkat:meerkat_anthropic_agent_factory_build",
         "//meerkat:meerkat_atif_agent_factory_build",

--- a/meerkat-cli/Cargo.toml
+++ b/meerkat-cli/Cargo.toml
@@ -153,6 +153,7 @@ skills = ["meerkat/skills"]
 integration-real-tests = []
 
 [dev-dependencies]
+meerkat-mob = { workspace = true, features = ["test-support"] }
 meerkat-runtime = { workspace = true, features = ["test-support"] }
 parking_lot = { workspace = true }
 rusqlite = { workspace = true }

--- a/meerkat-cli/src/main.rs
+++ b/meerkat-cli/src/main.rs
@@ -626,6 +626,48 @@ where
     }
 }
 
+const CLI_RUNTIME_UNREGISTER_TIMEOUT: Duration = Duration::from_secs(30);
+
+async fn await_cli_runtime_unregister<F>(
+    registration: &meerkat_runtime::RuntimeSessionRegistrationWitness,
+    timeout: Duration,
+    unregister: F,
+) -> anyhow::Result<()>
+where
+    F: std::future::Future<Output = Result<bool, meerkat_runtime::RuntimeDriverError>>,
+{
+    match tokio::time::timeout(timeout, unregister).await {
+        Ok(result) => {
+            let _removed = result?;
+            Ok(())
+        }
+        Err(_elapsed) => Err(anyhow::anyhow!(
+            "CLI shutdown timed out after {timeout:?} waiting for exact unregister of session {} at runtime epoch {}; cleanup remains process-owned",
+            registration.session_id(),
+            registration.epoch_id()
+        )),
+    }
+}
+
+#[cfg(any(feature = "session-store", test))]
+async fn unregister_cli_runtime_session(
+    runtime_adapter: &meerkat_runtime::MeerkatMachine,
+    session_id: &SessionId,
+) -> anyhow::Result<()> {
+    let Some(registration) = runtime_adapter
+        .current_session_registration_witness(session_id)
+        .await
+    else {
+        return Ok(());
+    };
+    await_cli_runtime_unregister(
+        &registration,
+        CLI_RUNTIME_UNREGISTER_TIMEOUT,
+        runtime_adapter.unregister_session_registration_until_terminal_if_current(&registration),
+    )
+    .await
+}
+
 fn validate_stream_render_summary(
     summary: &stream_renderer::StreamRenderSummary,
 ) -> anyhow::Result<()> {
@@ -11256,7 +11298,7 @@ async fn run_agent(
                 // Unregister the runtime-backed executor before awaiting stream tasks.
                 // The adapter owns the boxed executor, and the executor now holds the
                 // caller stream sender for runtime-backed turns.
-                runtime_adapter.unregister_session(&session_id).await?;
+                unregister_cli_runtime_session(&runtime_adapter, &session_id).await?;
                 service.shutdown().await;
                 shutdown_mcp(&mcp_adapter).await;
                 Ok(())
@@ -11947,7 +11989,7 @@ async fn resume_session_with_llm_override(
                 log_stage("service.create_session(done)");
 
                 // Shutdown the session service and MCP connections gracefully.
-                resume_adapter.unregister_session(&session_id).await?;
+                unregister_cli_runtime_session(&resume_adapter, &session_id).await?;
                 log_stage("service.shutdown");
                 service.shutdown().await;
                 log_stage("shutdown_mcp");
@@ -19737,13 +19779,47 @@ default_model = "gemma"
         Box::pin(tokio::time::timeout(
             Duration::from_secs(2),
             pipeline.shutdown_after(async {
-                runtime_adapter.unregister_session(&session_id).await?;
+                unregister_cli_runtime_session(&runtime_adapter, &session_id).await?;
                 Ok(())
             }),
         ))
         .await
         .expect("shutdown should finish once runtime executor is unregistered")
         .expect("shutdown should succeed");
+    }
+
+    #[tokio::test]
+    async fn cli_runtime_unregister_backstop_reports_exact_identity() {
+        let runtime_adapter = meerkat_runtime::MeerkatMachine::ephemeral();
+        let session_id = SessionId::new();
+        runtime_adapter
+            .register_session(session_id.clone())
+            .await
+            .expect("test runtime registration should succeed");
+        let registration = runtime_adapter
+            .current_session_registration_witness(&session_id)
+            .await
+            .expect("test runtime registration must expose exact identity");
+
+        let error = await_cli_runtime_unregister(
+            &registration,
+            Duration::ZERO,
+            std::future::pending::<Result<bool, meerkat_runtime::RuntimeDriverError>>(),
+        )
+        .await
+        .expect_err("pending exact unregister must hit the CLI liveness backstop");
+        let message = error.to_string();
+        assert!(message.contains("timed out after 0ns"), "{message}");
+        assert!(message.contains(&session_id.to_string()), "{message}");
+        assert!(
+            message.contains(&registration.epoch_id().to_string()),
+            "{message}"
+        );
+
+        runtime_adapter
+            .unregister_session(&session_id)
+            .await
+            .expect("test runtime cleanup should succeed");
     }
 
     #[tokio::test]
@@ -19809,7 +19885,7 @@ default_model = "gemma"
                 pipeline,
                 Err::<(), _>(anyhow::anyhow!("turn abandoned: synthetic failure")),
                 async {
-                    runtime_adapter.unregister_session(&session_id).await?;
+                    unregister_cli_runtime_session(&runtime_adapter, &session_id).await?;
                     Ok(())
                 },
             ),

--- a/meerkat-mob/src/runtime/actor.rs
+++ b/meerkat-mob/src/runtime/actor.rs
@@ -22633,9 +22633,11 @@ impl MobActor {
         #[cfg(any(test, feature = "test-support"))]
         let crash_stop_reply_tx = self.crash_stop_reply_tx.take();
         // Process death releases actor-owned runtime adapters and their inproc
-        // routes. Make that destruction happen before a crash-stop caller can
-        // construct a same-process cold replacement.
+        // routes as well as the separately-owned command receiver. Make both
+        // destructions happen before a crash-stop caller can construct a
+        // same-process cold replacement.
         drop(self);
+        drop(command_rx);
         #[cfg(any(test, feature = "test-support"))]
         if let Some(reply_tx) = crash_stop_reply_tx {
             let _ = reply_tx.send(Ok(()));

--- a/meerkat-runtime/src/meerkat_machine/session_management.rs
+++ b/meerkat-runtime/src/meerkat_machine/session_management.rs
@@ -12,6 +12,9 @@ enum UnregisterTeardownCaller {
 
 #[derive(Clone, Copy, PartialEq, Eq)]
 enum UnregisterTeardownAdmission {
+    /// Admits an ordinary current registration. This mode is not itself an
+    /// exactness fence: callers that require incarnation safety must also pass
+    /// the expected epoch and `RuntimeSessionRegistrationWitness` arguments.
     AnyCurrentRegistration,
     ExactTerminalUnattachedRegistration,
 }
@@ -5977,6 +5980,29 @@ impl MeerkatMachine {
             UnregisterTeardownAdmission::AnyCurrentRegistration,
             Some(registration),
             UnregisterTeardownWait::CallerGrace,
+        )
+        .await?
+        .require_completed()
+    }
+
+    /// Unregister one exact current registration and await its owned teardown
+    /// saga to terminal completion. This is for process-lifecycle owners that
+    /// must not exit while cleanup remains in flight. The exact witness keeps
+    /// a later same-SessionId registration outside this teardown authority.
+    pub async fn unregister_session_registration_until_terminal_if_current(
+        &self,
+        registration: &RuntimeSessionRegistrationWitness,
+    ) -> Result<bool, RuntimeDriverError> {
+        if !registration.belongs_to(self) {
+            return Ok(false);
+        }
+        self.join_or_start_unregister_teardown_with_admission(
+            registration.session_id(),
+            Some(registration.epoch_id()),
+            UnregisterTeardownCaller::Explicit,
+            UnregisterTeardownAdmission::AnyCurrentRegistration,
+            Some(registration),
+            UnregisterTeardownWait::UntilTerminal,
         )
         .await?
         .require_completed()

--- a/meerkat-runtime/src/meerkat_machine_tests.rs
+++ b/meerkat-runtime/src/meerkat_machine_tests.rs
@@ -15048,6 +15048,78 @@ mod stop_teardown_coordinator_class {
     }
 
     #[tokio::test]
+    async fn exact_lifecycle_unregister_joins_owned_saga_after_caller_grace_expires() {
+        let machine = Arc::new(MeerkatMachine::ephemeral());
+        let session_id = SessionId::new();
+        let cleanup_started = Arc::new(Notify::new());
+        let release_cleanup = Arc::new(Notify::new());
+        machine
+            .register_session_with_executor(
+                session_id.clone(),
+                Box::new(GatedCleanupExecutor {
+                    machine: Arc::clone(&machine),
+                    session_id: session_id.clone(),
+                    cleanup_started: Arc::clone(&cleanup_started),
+                    release_cleanup: Arc::clone(&release_cleanup),
+                    unregister_during_cleanup: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+                    fail_cleanup_attempts: Arc::new(AtomicUsize::new(0)),
+                    cleanup_calls: Arc::new(AtomicUsize::new(0)),
+                    loop_task_id: Arc::new(std::sync::Mutex::new(None)),
+                    cleanup_task_id: Arc::new(std::sync::Mutex::new(None)),
+                }),
+            )
+            .await
+            .expect("runtime executor registration should succeed");
+        let registration = machine
+            .current_session_registration_witness(&session_id)
+            .await
+            .expect("registered runtime must expose exact lifecycle identity");
+
+        let bounded_caller = {
+            let machine = Arc::clone(&machine);
+            let session_id = session_id.clone();
+            tokio::spawn(async move { machine.unregister_session(&session_id).await })
+        };
+        tokio::time::timeout(Duration::from_secs(1), cleanup_started.notified())
+            .await
+            .expect("owned teardown must reach the deterministic cleanup gate");
+        let bounded_error = tokio::time::timeout(Duration::from_secs(3), bounded_caller)
+            .await
+            .expect("ordinary caller grace must remain bounded")
+            .expect("bounded unregister task should not panic")
+            .expect_err("blocked cleanup must surface typed in-progress truth");
+        assert!(matches!(
+            bounded_error,
+            RuntimeDriverError::UnregisterInProgress { .. }
+        ));
+
+        let terminal_waiter = {
+            let machine = Arc::clone(&machine);
+            let registration = registration.clone();
+            tokio::spawn(async move {
+                machine
+                    .unregister_session_registration_until_terminal_if_current(&registration)
+                    .await
+            })
+        };
+        tokio::task::yield_now().await;
+        assert!(
+            !terminal_waiter.is_finished(),
+            "process-lifecycle owner must join the exact saga past ordinary caller grace"
+        );
+        release_cleanup.notify_one();
+        assert!(
+            tokio::time::timeout(Duration::from_secs(1), terminal_waiter)
+                .await
+                .expect("terminal waiter must finish after cleanup release")
+                .expect("terminal waiter task should not panic")
+                .expect("exact unregister should succeed"),
+            "exact registration must be the one removed"
+        );
+        assert!(!machine.contains_session(&session_id).await);
+    }
+
+    #[tokio::test]
     async fn noncooperative_interrupt_and_executor_return_in_progress_then_converge() {
         let store = Arc::new(crate::store::InMemoryRuntimeStore::new());
         let machine = Arc::new(MeerkatMachine::persistent(


### PR DESCRIPTION
## Summary

- capture the exact runtime registration before CLI shutdown
- wait for that registration's owned unregister saga instead of treating the ordinary 2-second caller grace as teardown failure
- retain ABA safety through epoch plus `RuntimeSessionRegistrationWitness` fencing
- add a 30-second CLI liveness backstop with exact session and epoch diagnostics
- enable `meerkat-mob/test-support` only in the rkat dev graph so its existing bin test compiles in narrow feature scopes

## Why

PR #973's real archived Linux test exposed a load-sensitive shutdown failure after the useful CLI run had already completed. The owned unregister saga was still valid, but the generic bounded caller returned `UnregisterInProgress` after two seconds and the CLI converted that into process failure.

Retrying by SessionId or increasing the generic grace would be unsafe because a retry could target a same-SessionId successor. The lifecycle owner now waits only on the captured registration incarnation. A separate 30-second backstop prevents a genuinely wedged teardown from holding the CLI forever; expiry reports the exact session and runtime epoch while stating that cleanup remains process-owned.

## Validation

- mandatory pre-push hook: green
- exact runtime regression: green
- exact CLI timeout/diagnostic regression: green
- `rkat` default binary check: green
- changed-crate all-target/all-feature Clippy: green
- MobKit second-head review bound to `85554d1ec`: pass
