### PR TITLE
ci: run tiny integration archive on builder

### DIFF
--- a/.github/actions/build-nextest-archive/action.yml
+++ b/.github/actions/build-nextest-archive/action.yml
@@ -1,10 +1,19 @@
 name: Build Nextest archive
-description: Build one canonical Meerkat test family and publish its portable Nextest archive.
+description: Build one canonical Meerkat test family and optionally publish its portable archive.
 
 inputs:
   family:
     description: Canonical archive family.
     required: true
+  publish:
+    description: Upload the archive for execution on another runner.
+    required: false
+    default: "true"
+
+outputs:
+  path:
+    description: Absolute path to the built archive on this runner.
+    value: ${{ steps.archive.outputs.path }}
 
 runs:
   using: composite
@@ -22,6 +31,7 @@ runs:
         echo "path=${archive_path}" >>"${GITHUB_OUTPUT}"
 
     - name: Upload portable test archive
+      if: ${{ inputs.publish == 'true' }}
       uses: actions/upload-artifact@v7
       with:
         name: nextest-${{ inputs.family }}-${{ github.sha }}

--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -18,8 +18,9 @@ name: Cargo CI
 #   unit-archive    - build lib unit tests once into a portable archive
 #   unit (x8)       - run hash partitions from the shared unit archive
 #   int-archives    - build the three fast-profile integration families on one
-#                     runner so their shared dependency graph is compiled once
-#   int-heavy, int-mob, int-else (x3 each)
+#                     runner so their shared dependency graph is compiled once;
+#                     run the sub-second integration-crate family in place
+#   int-mob, int-else (x3 each)
 #                   - run hash partitions from the shared family archives
 #   int-rest (x2)   - direct singleton crate-group integration lanes
 #   e2e-fast        — deterministic end-to-end lane (real binaries)
@@ -338,11 +339,14 @@ jobs:
           partition: hash:${{ matrix.partition }}/8
 
   # Integration tests split by build scope, not just run partition. One runner
-  # builds the three shared fast-profile archives so matching dependencies are
-  # compiled once; two singleton feature shapes stay direct. The complement
-  # archive keeps coverage complete when new workspace crates are added.
+  # builds the three fast-profile families so matching dependencies are
+  # compiled once; two singleton feature shapes stay direct. The tiny
+  # integration-crate family runs beside its freshly built archive instead of
+  # uploading 367 MB to three runners for less than one second of total tests.
+  # The complement archive keeps coverage complete when new workspace crates
+  # are added.
   int-archives:
-    name: Build integration-test archives
+    name: Build integration archives + run integration-crate tests
     needs: changes
     if: ${{ needs.changes.outputs.code_changed == 'true' }}
     runs-on: ubuntu-latest
@@ -372,9 +376,18 @@ jobs:
           HOME: ${{ runner.temp }}/install-action-home-${{ github.job }}
 
       - name: Build integration-crate archive
+        id: int-heavy-archive
         uses: ./.github/actions/build-nextest-archive
         with:
           family: int-heavy
+          publish: "false"
+
+      - name: Run integration-crate tests from the local archive
+        run: >-
+          scripts/ci-nextest-archive.sh run
+          int-heavy
+          "${{ steps.int-heavy-archive.outputs.path }}"
+          hash:1/1
 
       - name: Build Mob integration archive
         uses: ./.github/actions/build-nextest-archive
@@ -385,27 +398,6 @@ jobs:
         uses: ./.github/actions/build-nextest-archive
         with:
           family: int-everything-else
-
-  int-heavy:
-    name: Integration tests, meerkat-integration-tests (shard ${{ matrix.partition }}/3)
-    needs:
-      - changes
-      - int-archives
-    if: ${{ needs.changes.outputs.code_changed == 'true' }}
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        partition: [1, 2, 3]
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-
-      - name: Integration-fast tests (integration crate shard)
-        uses: ./.github/actions/run-nextest-archive
-        with:
-          family: int-heavy
-          partition: hash:${{ matrix.partition }}/3
 
   int-mob:
     name: Integration tests, mob-${{ matrix.partition }}of3 crates
@@ -936,7 +928,6 @@ jobs:
       - unit-archive
       - unit
       - int-archives
-      - int-heavy
       - int-mob
       - int-else
       - int-rest
@@ -961,7 +952,6 @@ jobs:
             ${{ needs.unit-archive.result }}
             ${{ needs.unit.result }}
             ${{ needs.int-archives.result }}
-            ${{ needs.int-heavy.result }}
             ${{ needs.int-mob.result }}
             ${{ needs.int-else.result }}
             ${{ needs.int-rest.result }}

--- a/scripts/test-ci-nextest-archive.sh
+++ b/scripts/test-ci-nextest-archive.sh
@@ -127,6 +127,8 @@ assert_file_contains() {
 stable_artifact_name="nextest-\${{ inputs.family }}-\${{ github.sha }}"
 assert_file_contains "$BUILD_ACTION" "name: ${stable_artifact_name}"
 assert_file_contains "$BUILD_ACTION" 'overwrite: true'
+assert_file_contains "$BUILD_ACTION" "if: \${{ inputs.publish == 'true' }}"
+assert_file_contains "$BUILD_ACTION" 'value: ${{ steps.archive.outputs.path }}'
 assert_file_contains "$RUN_ACTION" "name: ${stable_artifact_name}"
 assert_file_contains "$RUN_ACTION" 'uses: ./.github/actions/setup-rust-ci'
 assert_file_contains "$RUN_ACTION" 'components: rustfmt'
@@ -136,7 +138,7 @@ for dependency in unit-archive int-archives; do
   assert_file_contains "$WORKFLOW" "      - ${dependency}"
   assert_file_contains "$WORKFLOW" "            \${{ needs.${dependency}.result }}"
 done
-for execution_job in unit int-heavy int-mob int-else int-rest; do
+for execution_job in unit int-mob int-else int-rest; do
   assert_file_contains "$WORKFLOW" "      - ${execution_job}"
   assert_file_contains "$WORKFLOW" "            \${{ needs.${execution_job}.result }}"
 done
@@ -146,17 +148,23 @@ unit_job="$(sed -n '/^  unit:$/,/^  int-archives:$/p' "$WORKFLOW")"
   echo "unit execution does not depend on unit-archive" >&2
   exit 1
 }
-archive_job="$(sed -n '/^  int-archives:$/,/^  int-heavy:$/p' "$WORKFLOW")"
+archive_job="$(sed -n '/^  int-archives:$/,/^  int-mob:$/p' "$WORKFLOW")"
 for family in int-heavy int-mob int-everything-else; do
   [[ "$archive_job" == *"          family: ${family}"* ]] || {
     echo "integration archive builder omits ${family}" >&2
     exit 1
   }
 done
-
-heavy_job="$(sed -n '/^  int-heavy:$/,/^  int-mob:$/p' "$WORKFLOW")"
-[[ "$heavy_job" == *'      - int-archives'* ]] || {
-  echo "int-heavy execution does not depend on int-archives" >&2
+[[ "$archive_job" == *'          publish: "false"'* ]] || {
+  echo "int-heavy archive must not be published to redundant execution runners" >&2
+  exit 1
+}
+[[ "$archive_job" == *'scripts/ci-nextest-archive.sh run'* ]] || {
+  echo "int-heavy archive is not executed on its build runner" >&2
+  exit 1
+}
+[[ "$archive_job" == *'          hash:1/1'* ]] || {
+  echo "int-heavy local archive execution is not fail-closed over the whole family" >&2
   exit 1
 }
 mob_job="$(sed -n '/^  int-mob:$/,/^  int-else:$/p' "$WORKFLOW")"

--- a/xtask/tests/ci_gate_requires_rmat.rs
+++ b/xtask/tests/ci_gate_requires_rmat.rs
@@ -111,7 +111,6 @@ fn cargo_workflow_covers_the_full_per_push_gate_set() {
             "gate",
             "int-archives",
             "int-else",
-            "int-heavy",
             "int-mob",
             "int-rest",
             "locks",


### PR DESCRIPTION
## Outcome

Keep `meerkat-integration-tests` in the shared integration archive builder for compile reuse, but execute its complete archive on that same runner and do not publish it to three redundant executor jobs.

## Evidence

CI run 32324557843 measured:

- 53 integration-crate tests across three shards: 0.827 seconds total test time
- archive size: 367 MB
- one artifact download: 1,058.361 seconds before 0.259 seconds of tests

Unit, Mob, complement, singleton, and all non-archive CI topology remains unchanged. The aggregate gate now relies on `int-archives`, whose success includes the fail-closed `hash:1/1` integration-crate run.

## Verification

- `scripts/test-ci-nextest-archive.sh`
- focused `cargo_workflow_covers_the_full_per_push_gate_set` xtask regression
- `actionlint -ignore SC2129 .github/workflows/cargo.yml` (SC2129 is identical on `origin/main`)
- YAML parse of the workflow and composite action
- `git diff --check`
- mandatory pre-push hook, fully green
