### PR TITLE
feat(mob): authorize one-shot durable member-role migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,8 +28,31 @@ them.
 
 ## [Unreleased]
 
+### Breaking
+
+- **`meerkat_mob::MemberLaunchMode::Resume` gains
+  `resume_from_role: Option<ProfileName>`**, and the trusted remote-host
+  **`meerkat_contracts::MaterializeLaunchMode::Resume` gains
+  `resume_from_role: Option<String>`**. Direct struct-variant constructors must
+  provide the new field. Omitted JSON remains backward compatible and means a
+  strict same-role resume. `meerkat_mob::MobError` gains
+  `MemberRoleMigrationRequired` and `MemberRoleMigrationRejected`; exhaustive
+  matches must add both arms.
+
 ### Corrected
 
+- Durable mob members can now perform an explicitly declared, one-shot role
+  migration on an exact Resume request. The declaration must name the one
+  durable predecessor role; mob id and member identity never migrate, wrong or
+  absent declarations fail closed, and an exact live session is refused. A
+  successful cold build preserves the session and transcript while restamping
+  the current comms name, typed member binding, role/profile labels, callback
+  context, and explicitly configured tooling. The declaration is available on
+  trusted host `SpawnMemberSpec` and remote-host materialization paths, not on
+  agent-callable spawn wire commands or standing profiles. The restamp is
+  forward-only against a shared durable store: rollback requires another
+  declared forward migration (or separately versioned durable state), not an
+  old binary silently reclaiming the predecessor role.
 - Provider failures whose class is genuinely unknown now enter the existing
   machine-authorized, bounded retry path instead of terminalizing the agent on
   the first attempt. The retry budget and exponential backoff are unchanged;

--- a/artifacts/schemas/params.json
+++ b/artifacts/schemas/params.json
@@ -7533,6 +7533,13 @@
                 "const": "resume",
                 "type": "string"
               },
+              "resume_from_role": {
+                "description": "One-request predecessor role declaration for an exact durable\nmember identity. Absence preserves strict same-role resume.",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
               "session_id": {
                 "type": "string"
               }

--- a/artifacts/schemas/rest-openapi.json
+++ b/artifacts/schemas/rest-openapi.json
@@ -9184,6 +9184,13 @@
                 "const": "resume",
                 "type": "string"
               },
+              "resume_from_role": {
+                "description": "One-request predecessor role declaration for an exact durable\nmember identity. Absence preserves strict same-role resume.",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
               "session_id": {
                 "type": "string"
               }

--- a/artifacts/schemas/wire-types.json
+++ b/artifacts/schemas/wire-types.json
@@ -9136,6 +9136,13 @@
                 "const": "resume",
                 "type": "string"
               },
+              "resume_from_role": {
+                "description": "One-request predecessor role declaration for an exact durable\nmember identity. Absence preserves strict same-role resume.",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
               "session_id": {
                 "type": "string"
               }
@@ -16736,6 +16743,13 @@
               "mode": {
                 "const": "resume",
                 "type": "string"
+              },
+              "resume_from_role": {
+                "description": "One-request predecessor role declaration for an exact durable\nmember identity. Absence preserves strict same-role resume.",
+                "type": [
+                  "string",
+                  "null"
+                ]
               },
               "session_id": {
                 "type": "string"
@@ -45581,6 +45595,13 @@
                 "const": "resume",
                 "type": "string"
               },
+              "resume_from_role": {
+                "description": "One-request predecessor role declaration for an exact durable\nmember identity. Absence preserves strict same-role resume.",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
               "session_id": {
                 "type": "string"
               }
@@ -53705,6 +53726,13 @@
               "mode": {
                 "const": "resume",
                 "type": "string"
+              },
+              "resume_from_role": {
+                "description": "One-request predecessor role declaration for an exact durable\nmember identity. Absence preserves strict same-role resume.",
+                "type": [
+                  "string",
+                  "null"
+                ]
               },
               "session_id": {
                 "type": "string"
@@ -78632,6 +78660,13 @@
           "mode": {
             "const": "resume",
             "type": "string"
+          },
+          "resume_from_role": {
+            "description": "One-request predecessor role declaration for an exact durable\nmember identity. Absence preserves strict same-role resume.",
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "session_id": {
             "type": "string"

--- a/meerkat-contracts/src/wire/supervisor_bridge.rs
+++ b/meerkat-contracts/src/wire/supervisor_bridge.rs
@@ -989,7 +989,13 @@ pub enum MaterializeLaunchMode {
     // would silently accept smuggled sibling fields. Wire bytes are identical
     // ({"mode":"fresh"}).
     Fresh {},
-    Resume { session_id: String },
+    Resume {
+        session_id: String,
+        /// One-request predecessor role declaration for an exact durable
+        /// member identity. Absence preserves strict same-role resume.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        resume_from_role: Option<String>,
+    },
 }
 
 /// Which launch path actually ran on the member host (§19.L1).
@@ -5543,6 +5549,7 @@ mod tests {
                 spec_digest: "d".repeat(64),
                 launch: MaterializeLaunchMode::Resume {
                     session_id: "sess-9".to_string(),
+                    resume_from_role: None,
                 },
             })),
             BridgeCommand::ReleaseMember(BridgeReleasePayload {
@@ -6111,7 +6118,21 @@ mod tests {
         assert_eq!(
             resume,
             MaterializeLaunchMode::Resume {
-                session_id: "sess-1".to_string()
+                session_id: "sess-1".to_string(),
+                resume_from_role: None,
+            }
+        );
+        let migrating: MaterializeLaunchMode = serde_json::from_value(json!({
+            "mode": "resume",
+            "session_id": "sess-1",
+            "resume_from_role": "domain",
+        }))
+        .expect("trusted host materialization carries the one-request predecessor role");
+        assert_eq!(
+            migrating,
+            MaterializeLaunchMode::Resume {
+                session_id: "sess-1".to_string(),
+                resume_from_role: Some("domain".to_string()),
             }
         );
 

--- a/meerkat-mob/src/build.rs
+++ b/meerkat-mob/src/build.rs
@@ -68,6 +68,7 @@ fn stamp_standard_mob_member_labels(
     peer_meta
         .with_label("mob_id", binding.mob_id.as_str())
         .with_label("role", binding.role.as_str())
+        .with_label("profile_name", binding.role.as_str())
         .with_label("meerkat_id", binding.member.as_str())
         .with_label("agent_identity", binding.member.as_str())
 }
@@ -137,6 +138,9 @@ pub struct BuildAgentConfigParams<'a> {
 pub struct BuildResumedAgentConfigParams<'a> {
     pub base: BuildAgentConfigParams<'a>,
     pub(crate) expected_session_id: &'a SessionId,
+    /// One-request predecessor-role declaration carried by the exact Resume
+    /// launch. `None` preserves strict same-role durable identity.
+    pub resume_from_role: Option<&'a ProfileName>,
     pub resumed_session: Session,
 }
 
@@ -377,6 +381,7 @@ pub async fn build_resumed_agent_config(
     let BuildResumedAgentConfigParams {
         base,
         expected_session_id,
+        resume_from_role,
         resumed_session,
     } = params;
     let inherited_tool_filter = base.inherited_tool_filter.clone();
@@ -398,7 +403,7 @@ pub async fn build_resumed_agent_config(
     let metadata = resumed_session
         .session_metadata()
         .ok_or_else(|| MobError::Internal("missing durable session metadata".to_string()))?;
-    apply_resumed_session_metadata(&mut config, &metadata)?;
+    apply_resumed_session_metadata_with_role_migration(&mut config, &metadata, resume_from_role)?;
     // Rematerialization authors nothing. Prompt configuration can be needed
     // to rebuild the disposable executor, but it is never new durable input.
     // New ordered System content enters through the typed admission API after
@@ -416,6 +421,14 @@ fn apply_resumed_session_metadata(
     config: &mut AgentBuildConfig,
     metadata: &SessionMetadata,
 ) -> Result<(), MobError> {
+    apply_resumed_session_metadata_with_role_migration(config, metadata, None)
+}
+
+fn apply_resumed_session_metadata_with_role_migration(
+    config: &mut AgentBuildConfig,
+    metadata: &SessionMetadata,
+    resume_from_role: Option<&ProfileName>,
+) -> Result<(), MobError> {
     let Some(current_comms_name) = config.comms_name.clone() else {
         return Err(MobError::Internal(
             "missing current comms_name for resumed mob member".to_string(),
@@ -426,39 +439,27 @@ fn apply_resumed_session_metadata(
             "missing durable comms_name for resumed mob member".to_string(),
         ));
     };
-    if !resumed_comms_name_matches_current_or_legacy(&current_comms_name, &stored_comms_name) {
-        return Err(MobError::Internal(format!(
-            "persisted comms_name '{stored_comms_name}' does not match current mob identity '{current_comms_name}'"
-        )));
-    }
     if let Some(current_binding) = config.mob_member_binding.as_ref() {
-        let current_binding_comms = current_binding.comms_name().map_err(|error| {
-            MobError::Internal(format!(
-                "current mob member binding cannot render a comms_name: {error}"
-            ))
-        })?;
-        if current_binding_comms.to_string() != current_comms_name {
+        if !member_binding_proves_comms_name(current_binding, &current_comms_name) {
             return Err(MobError::Internal(format!(
-                "current mob member binding '{current_binding_comms}' does not match current comms_name '{current_comms_name}'"
+                "current mob member binding '{current_binding:?}' does not match current comms_name '{current_comms_name}'"
             )));
         }
     }
-    if let Some(stored_binding) = metadata.mob_member_binding.as_ref() {
-        let Some(current_binding) = config.mob_member_binding.as_ref() else {
-            return Err(MobError::Internal(
-                "persisted mob member binding has no current binding to resume into".to_string(),
-            ));
-        };
-        let stored_binding_comms = stored_binding.comms_name().map_err(|error| {
-            MobError::Internal(format!(
-                "persisted mob member binding cannot render a comms_name: {error}"
-            ))
-        })?;
-        if !resumed_member_binding_matches_current_or_legacy(current_binding, stored_binding) {
-            return Err(MobError::Internal(format!(
-                "persisted mob member binding '{stored_binding_comms}' does not match current mob identity '{current_comms_name}'"
-            )));
-        }
+    let role_migrated = admit_resumed_member_identity(
+        &current_comms_name,
+        &stored_comms_name,
+        config.mob_member_binding.as_ref(),
+        metadata.mob_member_binding.as_ref(),
+        resume_from_role,
+    )?;
+    if role_migrated {
+        // AgentFactory performs its own generic resume projection after this
+        // mob-specific admission. Fence the two identity projections that
+        // must stay current so durable metadata cannot overwrite the admitted
+        // target role before the factory restamps SessionMetadata.
+        config.resume_override_mask.comms_name = true;
+        config.resume_override_mask.peer_meta = true;
     }
 
     // Durable metadata restores only the fields the profile did not claim via
@@ -562,13 +563,159 @@ pub(crate) fn resumed_comms_name_matches_current_or_legacy(current: &str, stored
         && resumed_member_segment_matches_current_or_legacy(current_member, stored_member)
 }
 
-fn resumed_member_binding_matches_current_or_legacy(
-    current: &meerkat_core::MobMemberBinding,
-    stored: &meerkat_core::MobMemberBinding,
+/// Admit one durable member identity into a resumed build.
+///
+/// Mob id and member identity never migrate. Role may change only when the
+/// exact Resume launch declares the durable predecessor role. The declaration
+/// is consumed here and is not copied into session metadata; successful build
+/// materialization restamps the current binding through the ordinary factory
+/// path.
+fn admit_resumed_member_identity(
+    current_comms_name: &str,
+    stored_comms_name: &str,
+    current_binding: Option<&meerkat_core::MobMemberBinding>,
+    stored_binding: Option<&meerkat_core::MobMemberBinding>,
+    resume_from_role: Option<&ProfileName>,
+) -> Result<bool, MobError> {
+    let Some((current_mob, current_role, current_member)) =
+        split_member_comms_name(current_comms_name)
+    else {
+        return Err(MobError::Internal(format!(
+            "current mob comms_name '{current_comms_name}' is malformed"
+        )));
+    };
+    let Some((stored_mob, stored_role_from_name, stored_member_from_name)) =
+        split_member_comms_name(stored_comms_name)
+    else {
+        return Err(MobError::Internal(format!(
+            "persisted comms_name '{stored_comms_name}' is malformed"
+        )));
+    };
+    let canonical_member = current_binding
+        .map(|binding| binding.member.as_str())
+        .unwrap_or(current_member);
+
+    if current_mob != stored_mob {
+        return Err(role_migration_identity_rejection(
+            canonical_member,
+            current_role,
+            resume_from_role,
+            format!(
+                "persisted comms_name '{stored_comms_name}' does not prove the current mob/member identity '{current_comms_name}'"
+            ),
+        ));
+    }
+
+    if let Some(binding) = current_binding {
+        if !member_binding_proves_comms_components(
+            binding,
+            current_mob,
+            current_role,
+            current_member,
+        ) {
+            return Err(MobError::Internal(format!(
+                "current mob member binding '{binding:?}' contradicts current comms_name '{current_comms_name}'"
+            )));
+        }
+    }
+
+    let stored_role = if let Some(binding) = stored_binding {
+        if !member_binding_proves_comms_components(
+            binding,
+            stored_mob,
+            stored_role_from_name,
+            stored_member_from_name,
+        ) || binding.mob_id != current_mob
+            || !member_segments_prove_same_identity(canonical_member, &binding.member)
+        {
+            return Err(role_migration_identity_rejection(
+                canonical_member,
+                current_role,
+                resume_from_role,
+                format!(
+                    "persisted mob member binding '{binding:?}' contradicts persisted comms_name '{stored_comms_name}' or the requested mob/member identity"
+                ),
+            ));
+        }
+        binding.role.as_str()
+    } else {
+        if !member_segments_prove_same_identity(canonical_member, stored_member_from_name) {
+            return Err(role_migration_identity_rejection(
+                canonical_member,
+                current_role,
+                resume_from_role,
+                format!(
+                    "persisted comms_name '{stored_comms_name}' does not prove the current mob/member identity '{current_comms_name}'"
+                ),
+            ));
+        }
+        stored_role_from_name
+    };
+
+    if stored_role == current_role {
+        return Ok(false);
+    }
+
+    let member_id = AgentIdentity::from(canonical_member);
+    let requested_role = ProfileName::from(current_role);
+    let Some(declared_predecessor_role) = resume_from_role else {
+        return Err(MobError::MemberRoleMigrationRequired {
+            member_id,
+            stored_role: ProfileName::from(stored_role),
+            requested_role,
+        });
+    };
+    if declared_predecessor_role.as_str() != stored_role {
+        return Err(MobError::MemberRoleMigrationRejected {
+            member_id,
+            declared_predecessor_role: declared_predecessor_role.clone(),
+            requested_role,
+            reason: format!("durable predecessor role is '{stored_role}', not the declared role"),
+        });
+    }
+    Ok(true)
+}
+
+fn role_migration_identity_rejection(
+    current_member: &str,
+    current_role: &str,
+    resume_from_role: Option<&ProfileName>,
+    reason: String,
+) -> MobError {
+    match resume_from_role {
+        Some(declared_predecessor_role) => MobError::MemberRoleMigrationRejected {
+            member_id: AgentIdentity::from(current_member),
+            declared_predecessor_role: declared_predecessor_role.clone(),
+            requested_role: ProfileName::from(current_role),
+            reason,
+        },
+        None => MobError::Internal(reason),
+    }
+}
+
+fn member_segments_prove_same_identity(left: &str, right: &str) -> bool {
+    resumed_member_segment_matches_current_or_legacy(left, right)
+        || resumed_member_segment_matches_current_or_legacy(right, left)
+}
+
+fn member_binding_proves_comms_name(
+    binding: &meerkat_core::MobMemberBinding,
+    comms_name: &str,
 ) -> bool {
-    current.mob_id == stored.mob_id
-        && current.role == stored.role
-        && resumed_member_segment_matches_current_or_legacy(&current.member, &stored.member)
+    split_member_comms_name(comms_name).is_some_and(|(mob_id, role, member)| {
+        member_binding_proves_comms_components(binding, mob_id, role, member)
+    })
+}
+
+fn member_binding_proves_comms_components(
+    binding: &meerkat_core::MobMemberBinding,
+    mob_id: &str,
+    role: &str,
+    member: &str,
+) -> bool {
+    binding.mob_id == mob_id
+        && binding.role == role
+        && member_segments_prove_same_identity(&binding.member, member)
 }
 
 fn resumed_member_segment_matches_current_or_legacy(current: &str, stored: &str) -> bool {
@@ -587,8 +734,13 @@ fn resumed_member_segment_matches_current_or_legacy(current: &str, stored: &str)
 
 fn mobkit_generation_zero_identity_runtime_alias(current: &str) -> Option<String> {
     let mut encoded = String::with_capacity(current.len() + 26);
-    encoded.push_str("mk--rt_cidentity_c");
-    for character in current.chars() {
+    encoded.push_str("mk--rt_c");
+    let canonical_identity = if current.contains(':') {
+        current.to_string()
+    } else {
+        format!("identity:{current}")
+    };
+    for character in canonical_identity.chars() {
         match character {
             '_' => encoded.push_str("__"),
             ':' => encoded.push_str("_c"),
@@ -1154,6 +1306,7 @@ mod tests {
                 system_prompt_override: None,
             },
             expected_session_id: &session_id,
+            resume_from_role: None,
             resumed_session: resumed_session_with_metadata(session_id.clone()),
         })
         .await
@@ -1874,6 +2027,7 @@ mod tests {
                 system_prompt_override: None,
             },
             expected_session_id: &session_id,
+            resume_from_role: None,
             resumed_session,
         })
         .await
@@ -1939,6 +2093,7 @@ mod tests {
                 )),
             },
             expected_session_id: &session_id,
+            resume_from_role: None,
             resumed_session,
         })
         .await
@@ -2000,6 +2155,7 @@ mod tests {
                 )),
             },
             expected_session_id: &session_id,
+            resume_from_role: None,
             resumed_session,
         })
         .await
@@ -2059,6 +2215,7 @@ mod tests {
                 system_prompt_override: None,
             },
             expected_session_id: &session_id,
+            resume_from_role: None,
             resumed_session,
         })
         .await
@@ -2150,6 +2307,7 @@ mod tests {
                 system_prompt_override: None,
             },
             expected_session_id: &session_id,
+            resume_from_role: None,
             resumed_session,
         })
         .await
@@ -2250,6 +2408,7 @@ mod tests {
                 system_prompt_override: None,
             },
             expected_session_id: &session_id,
+            resume_from_role: None,
             resumed_session,
         })
         .await
@@ -2717,6 +2876,7 @@ mod tests {
                 system_prompt_override: None,
             },
             expected_session_id: &session_id,
+            resume_from_role: None,
             resumed_session,
         })
         .await
@@ -3388,6 +3548,18 @@ mod tests {
     }
 
     #[test]
+    fn generation_zero_runtime_alias_encodes_typed_colon_identity_once() {
+        assert_eq!(
+            mobkit_generation_zero_identity_runtime_alias("domain:home-automation").as_deref(),
+            Some("mk--rt_cdomain_chome-automation_c0")
+        );
+        assert_eq!(
+            mobkit_generation_zero_identity_runtime_alias("parent-1").as_deref(),
+            Some("mk--rt_cidentity_cparent-1_c0")
+        );
+    }
+
+    #[test]
     fn test_resumed_metadata_rejects_tampered_binding_even_with_valid_comms_alias() {
         let mut config = AgentBuildConfig::new("gpt-5.5");
         config.comms_name = Some("homecore/identity/parent-1".to_string());
@@ -3425,6 +3597,127 @@ mod tests {
         assert!(
             error.to_string().contains("persisted mob member binding"),
             "unexpected refusal: {error}"
+        );
+    }
+
+    fn role_migration_fixture() -> (AgentBuildConfig, SessionMetadata) {
+        let mut config = AgentBuildConfig::new("gpt-5.5");
+        config.comms_name =
+            Some("homecore/home-automation/mk--rt_cdomain_chome-automation_c0".to_string());
+        config.mob_member_binding = Some(meerkat_core::MobMemberBinding {
+            mob_id: "homecore".to_string(),
+            role: "home-automation".to_string(),
+            member: "domain:home-automation".to_string(),
+        });
+        config.override_shell = meerkat_core::ToolCategoryOverride::Enable;
+
+        let tooling = meerkat_core::SessionTooling {
+            shell: meerkat_core::ToolCategoryOverride::Disable,
+            ..Default::default()
+        };
+        let metadata = SessionMetadata {
+            schema_version: meerkat_core::SESSION_METADATA_SCHEMA_VERSION,
+            model: "gpt-5.5".to_string(),
+            max_tokens: 16_384,
+            structured_output_retries: 2,
+            provider: meerkat_core::Provider::OpenAI,
+            self_hosted_server_id: None,
+            provider_params: None,
+            tooling,
+            keep_alive: false,
+            comms_name: Some("homecore/domain/mk--rt_cdomain_chome-automation_c0".to_string()),
+            peer_meta: Some(PeerMeta::default().with_label("role", "domain")),
+            realm_id: None,
+            instance_id: None,
+            backend: None,
+            config_generation: None,
+            auth_binding: None,
+            mob_member_binding: Some(meerkat_core::MobMemberBinding {
+                mob_id: "homecore".to_string(),
+                role: "domain".to_string(),
+                member: "domain:home-automation".to_string(),
+            }),
+        };
+        (config, metadata)
+    }
+
+    #[test]
+    fn resumed_role_drift_requires_an_explicit_one_request_declaration() {
+        let (mut config, metadata) = role_migration_fixture();
+        let error =
+            apply_resumed_session_metadata_with_role_migration(&mut config, &metadata, None)
+                .expect_err("role drift without authority must fail closed");
+
+        assert!(matches!(
+            error,
+            MobError::MemberRoleMigrationRequired {
+                member_id,
+                stored_role,
+                requested_role,
+            } if member_id.as_str() == "domain:home-automation"
+                && stored_role.as_str() == "domain"
+                && requested_role.as_str() == "home-automation"
+        ));
+    }
+
+    #[test]
+    fn resumed_role_migration_rejects_the_wrong_predecessor() {
+        let (mut config, metadata) = role_migration_fixture();
+        let declared = ProfileName::from("assistant");
+        let error = apply_resumed_session_metadata_with_role_migration(
+            &mut config,
+            &metadata,
+            Some(&declared),
+        )
+        .expect_err("a declaration cannot authorize a different predecessor");
+
+        assert!(matches!(
+            error,
+            MobError::MemberRoleMigrationRejected {
+                declared_predecessor_role,
+                requested_role,
+                ..
+            } if declared_predecessor_role.as_str() == "assistant"
+                && requested_role.as_str() == "home-automation"
+        ));
+    }
+
+    #[test]
+    fn exact_role_migration_keeps_current_tooling_and_restamps_current_identity() {
+        let (mut config, metadata) = role_migration_fixture();
+        let declared = ProfileName::from("domain");
+        apply_resumed_session_metadata_with_role_migration(&mut config, &metadata, Some(&declared))
+            .expect("exact predecessor declaration should authorize the restamp");
+
+        assert!(
+            config.resume_override_mask.comms_name && config.resume_override_mask.peer_meta,
+            "the generic AgentFactory resume pass must not restore the predecessor role over an admitted restamp"
+        );
+        assert_eq!(
+            config.comms_name.as_deref(),
+            Some("homecore/home-automation/mk--rt_cdomain_chome-automation_c0")
+        );
+        assert_eq!(
+            config.mob_member_binding,
+            Some(meerkat_core::MobMemberBinding {
+                mob_id: "homecore".to_string(),
+                role: "home-automation".to_string(),
+                member: "domain:home-automation".to_string(),
+            })
+        );
+        assert_eq!(
+            config.override_shell,
+            meerkat_core::ToolCategoryOverride::Enable,
+            "the current profile's explicit shell enablement must survive resume"
+        );
+        assert_eq!(
+            config
+                .peer_meta
+                .as_ref()
+                .and_then(|meta| meta.labels.get("role"))
+                .map(String::as_str),
+            Some("home-automation"),
+            "peer metadata must be restamped to the current durable role"
         );
     }
 

--- a/meerkat-mob/src/error.rs
+++ b/meerkat-mob/src/error.rs
@@ -738,6 +738,31 @@ pub enum MobError {
         participant_name: String,
         holder_pubkey: meerkat_comms::PubKey,
     },
+
+    /// A durable session belongs to the same mob member but carries a
+    /// different role, and this exact resume request supplied no migration
+    /// declaration. Role remains part of durable comms identity; callers must
+    /// opt into the one-way restamp explicitly.
+    #[error(
+        "durable member '{member_id}' has predecessor role '{stored_role}', but resume targets role '{requested_role}'; supply resume_from_role='{stored_role}' on this exact resume request"
+    )]
+    MemberRoleMigrationRequired {
+        member_id: AgentIdentity,
+        stored_role: ProfileName,
+        requested_role: ProfileName,
+    },
+
+    /// A resume request supplied a role-migration declaration, but the
+    /// durable identity facts did not prove the exact declared predecessor.
+    #[error(
+        "role migration for durable member '{member_id}' from '{declared_predecessor_role}' to '{requested_role}' was rejected: {reason}"
+    )]
+    MemberRoleMigrationRejected {
+        member_id: AgentIdentity,
+        declared_predecessor_role: ProfileName,
+        requested_role: ProfileName,
+        reason: String,
+    },
 }
 
 /// THE single owner of the operator-facing name-occupancy remedy text, shared

--- a/meerkat-mob/src/launch.rs
+++ b/meerkat-mob/src/launch.rs
@@ -6,7 +6,7 @@
 //! `ForkContext` is a mob-native type defined here (not in `meerkat-core`)
 //! because forking is a mob-level orchestration concept.
 
-use crate::ids::AgentIdentity;
+use crate::ids::{AgentIdentity, ProfileName};
 use meerkat_core::types::SessionId;
 use serde::{Deserialize, Serialize};
 
@@ -24,7 +24,17 @@ pub enum MemberLaunchMode {
     #[default]
     Fresh,
     /// Resume an existing bridge session binding by ID.
-    Resume { bridge_session_id: SessionId },
+    ///
+    /// `resume_from_role` is a one-request migration declaration for a
+    /// durable member whose role changed while its mob id and agent identity
+    /// stayed the same. Absence preserves the strict same-role resume
+    /// invariant. A populated declaration authorizes only the named
+    /// predecessor role; it is never a standing profile permission.
+    Resume {
+        bridge_session_id: SessionId,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        resume_from_role: Option<ProfileName>,
+    },
     /// Fork from another member's conversation history.
     Fork {
         source_member_id: AgentIdentity,
@@ -38,7 +48,19 @@ impl MemberLaunchMode {
     /// the session id. Returns `None` for `Fresh` and `Fork` modes.
     pub fn resume_bridge_session_id(&self) -> Option<&SessionId> {
         match self {
-            Self::Resume { bridge_session_id } => Some(bridge_session_id),
+            Self::Resume {
+                bridge_session_id, ..
+            } => Some(bridge_session_id),
+            _ => None,
+        }
+    }
+
+    /// Declared predecessor role for this exact resume request.
+    pub fn resume_from_role(&self) -> Option<&ProfileName> {
+        match self {
+            Self::Resume {
+                resume_from_role, ..
+            } => resume_from_role.as_ref(),
             _ => None,
         }
     }
@@ -68,6 +90,7 @@ mod tests {
         let sid = SessionId::new();
         let mode = MemberLaunchMode::Resume {
             bridge_session_id: sid.clone(),
+            resume_from_role: None,
         };
 
         assert_eq!(mode.resume_bridge_session_id(), Some(&sid));
@@ -85,6 +108,26 @@ mod tests {
             serde_json::from_value(payload).expect("resume launch mode should deserialize");
 
         assert_eq!(mode.resume_bridge_session_id(), Some(&sid));
+        assert!(mode.resume_from_role().is_none());
+    }
+
+    #[test]
+    fn resume_launch_mode_round_trips_one_request_predecessor_role() {
+        let sid = SessionId::new();
+        let mode = MemberLaunchMode::Resume {
+            bridge_session_id: sid.clone(),
+            resume_from_role: Some(ProfileName::from("domain")),
+        };
+
+        let encoded = serde_json::to_value(&mode).expect("migration resume serializes");
+        assert_eq!(encoded["resume_from_role"], "domain");
+        let decoded: MemberLaunchMode =
+            serde_json::from_value(encoded).expect("migration resume deserializes");
+        assert_eq!(decoded.resume_bridge_session_id(), Some(&sid));
+        assert_eq!(
+            decoded.resume_from_role(),
+            Some(&ProfileName::from("domain"))
+        );
     }
 
     /// DELETE_ME A3 + C1 regression: `MemberLaunchMode` and its variants
@@ -106,6 +149,7 @@ mod tests {
         let sid = SessionId::new();
         let resume = MemberLaunchMode::Resume {
             bridge_session_id: sid.clone(),
+            resume_from_role: None,
         };
         assert_eq!(resume.resume_bridge_session_id(), Some(&sid));
 

--- a/meerkat-mob/src/runtime/actor.rs
+++ b/meerkat-mob/src/runtime/actor.rs
@@ -67,6 +67,12 @@ enum ActorLoopWakeSelection {
     BreakActor,
 }
 
+struct RevivedMemberMaterializationOptions<'a> {
+    resume_from_role: Option<&'a ProfileName>,
+    recovered_binding_without_endpoint: bool,
+    restore_topology_immediately: bool,
+}
+
 // Expand the command match synchronously so each arm constructs and erases
 // its own async future. A single async block around the whole match recreates
 // the aggregate command-loop poll frame this boundary exists to avoid.
@@ -3618,6 +3624,7 @@ struct DeferredResumeProvision {
     inherited_tool_filter: Option<meerkat_core::InheritedToolVisibilityAuthority>,
     tool_access_policy: Option<meerkat_core::ops::ToolAccessPolicy>,
     system_prompt_override: Option<super::handle::SpawnSystemPromptOverride>,
+    resume_from_role: Option<ProfileName>,
     resume_id: SessionId,
     prompt: ContentInput,
     budget_limits: Option<meerkat_core::BudgetLimits>,
@@ -3709,6 +3716,7 @@ impl DeferredResumeProvision {
             inherited_tool_filter,
             tool_access_policy,
             system_prompt_override,
+            resume_from_role,
             resume_id,
             prompt,
             budget_limits,
@@ -3749,6 +3757,7 @@ impl DeferredResumeProvision {
                 system_prompt_override,
             },
             expected_session_id: &resume_id,
+            resume_from_role: resume_from_role.as_ref(),
             resumed_session: stored_session,
         })
         .await?;
@@ -4967,6 +4976,7 @@ mod placed_route_session_tests {
 /// All mutations go through here; reads bypass via shared `Arc` state.
 struct ExplicitResumeMemberRebuild {
     entry: RosterEntry,
+    restore_spec: super::handle::SpawnMemberSpec,
     member_ref: MemberRef,
     bridge_session_id: SessionId,
     requires_materialization: bool,
@@ -10822,6 +10832,7 @@ impl MobActor {
         entry: &RosterEntry,
         member_ref: &MemberRef,
         bridge_session_id: &SessionId,
+        resume_from_role: Option<&ProfileName>,
         recovered_binding_without_endpoint: bool,
         restore_topology_immediately: bool,
     ) -> Result<(), MobError> {
@@ -10959,8 +10970,11 @@ impl MobActor {
                             member_ref,
                             bridge_session_id,
                             authorized,
-                            recovered_binding_without_endpoint,
-                            restore_topology_immediately,
+                            RevivedMemberMaterializationOptions {
+                                resume_from_role,
+                                recovered_binding_without_endpoint,
+                                restore_topology_immediately,
+                            },
                         )
                         .await
                     }
@@ -11594,6 +11608,7 @@ impl MobActor {
             spec_digest: record.spec_digest.clone(),
             launch: super::bridge_protocol::MaterializeLaunchMode::Resume {
                 session_id: binding.0.clone(),
+                resume_from_role: None,
             },
         });
 
@@ -11709,8 +11724,7 @@ impl MobActor {
         member_ref: &MemberRef,
         bridge_session_id: &SessionId,
         authorized_resume: super::session_service::AuthorizedSessionResume,
-        recovered_binding_without_endpoint: bool,
-        restore_topology_immediately: bool,
+        options: RevivedMemberMaterializationOptions<'_>,
     ) -> Result<(), MobError> {
         let agent_identity = entry.agent_identity.clone();
         let domain_identity = AgentIdentity::from(agent_identity.as_str());
@@ -11765,6 +11779,7 @@ impl MobActor {
                 system_prompt_override: None,
             },
             expected_session_id: bridge_session_id,
+            resume_from_role: options.resume_from_role,
             resumed_session: stored_session,
         })
         .await?;
@@ -11888,7 +11903,7 @@ impl MobActor {
         // materialized comms incarnation before any topology is restored.
         // An already-live replacement supplied its endpoint to the first
         // carrier and therefore remains the ordinary one-event path.
-        if recovered_binding_without_endpoint {
+        if options.recovered_binding_without_endpoint {
             let runtime = self
                 .provisioner
                 .comms_runtime(member_ref)
@@ -11927,7 +11942,7 @@ impl MobActor {
         self.ensure_mob_comms_drain(&agent_identity, member_ref)
             .await?;
 
-        if restore_topology_immediately {
+        if options.restore_topology_immediately {
             // Dispatch-triggered one-member revival restores its topology
             // immediately. Explicit mob Resume passes `false`: its shared
             // all-member reconciliation must preflight the complete trust
@@ -15208,6 +15223,53 @@ impl MobActor {
                 continue;
             }
 
+            // The cold explicit-resume request is customized before either
+            // exact-session admission or successor search. This makes a
+            // one-shot resume_from_role declaration part of the actual
+            // recovery request instead of an after-the-fact build tweak.
+            let mut restore_spec = super::handle::SpawnMemberSpec::new(
+                entry.role.clone(),
+                entry.agent_identity.clone(),
+            );
+            restore_spec.launch_mode = crate::launch::MemberLaunchMode::Resume {
+                bridge_session_id: session_id.clone(),
+                resume_from_role: None,
+            };
+            restore_spec.runtime_mode = Some(entry.runtime_mode);
+            restore_spec.labels = Some(entry.labels.clone());
+            restore_spec.override_profile = entry.effective_profile_override.clone();
+            restore_spec.model_override = entry.effective_model_override.clone();
+            self.customize_spawn_spec(super::handle::SpawnSource::Resume, None, &mut restore_spec)?;
+            if restore_spec.identity != entry.agent_identity {
+                return Err(MobError::Internal(format!(
+                    "spawn customizer cannot change explicit-resume identity from '{}' to '{}'",
+                    entry.agent_identity, restore_spec.identity
+                )));
+            }
+            if restore_spec.role_name != entry.role {
+                return Err(MobError::Internal(format!(
+                    "spawn customizer cannot change explicit-resume profile for '{}' from '{}' to '{}'",
+                    entry.agent_identity, entry.role, restore_spec.role_name
+                )));
+            }
+            let crate::launch::MemberLaunchMode::Resume {
+                bridge_session_id: customized_session_id,
+                resume_from_role,
+            } = &restore_spec.launch_mode
+            else {
+                return Err(MobError::Internal(format!(
+                    "spawn customizer removed the explicit-resume launch for '{}'",
+                    entry.agent_identity
+                )));
+            };
+            if customized_session_id != &session_id {
+                return Err(MobError::Internal(format!(
+                    "spawn customizer cannot change explicit-resume session for '{}' from '{}' to '{}'",
+                    entry.agent_identity, session_id, customized_session_id
+                )));
+            }
+            let resume_from_role = resume_from_role.clone();
+
             let current_snapshot_present = self.session_service.supports_persistent_sessions()
                 && self
                     .session_service
@@ -15218,6 +15280,7 @@ impl MobActor {
             if current_snapshot_present || !self.session_service.supports_persistent_sessions() {
                 rebuild.push(ExplicitResumeMemberRebuild {
                     entry,
+                    restore_spec,
                     member_ref,
                     bridge_session_id: session_id,
                     requires_materialization,
@@ -15242,6 +15305,7 @@ impl MobActor {
                 &self.definition.id,
                 &entry.role,
                 &entry.agent_identity,
+                resume_from_role.as_ref(),
             )
             .await?;
             let Some((replacement_session_id, _replacement_session)) = replacement else {
@@ -15250,6 +15314,7 @@ impl MobActor {
                 // terminal Broken after Resume commits.
                 rebuild.push(ExplicitResumeMemberRebuild {
                     entry,
+                    restore_spec,
                     member_ref,
                     bridge_session_id: session_id,
                     requires_materialization,
@@ -15277,6 +15342,12 @@ impl MobActor {
                     Some(admission.clone()),
                 )
                 .await?;
+            if let crate::launch::MemberLaunchMode::Resume {
+                bridge_session_id, ..
+            } = &mut restore_spec.launch_mode
+            {
+                *bridge_session_id = replacement_session_id.clone();
+            }
             // Publish an endpoint from a live successor only when this exact
             // provisioner is allowed to reuse that attachment. If preparation
             // retires foreign attachment A, its descriptor is stale by
@@ -15304,6 +15375,7 @@ impl MobActor {
             };
             rebuild.push(ExplicitResumeMemberRebuild {
                 entry,
+                restore_spec,
                 member_ref: replacement_member_ref,
                 bridge_session_id: replacement_session_id,
                 requires_materialization: replacement_requires_materialization,
@@ -15328,6 +15400,7 @@ impl MobActor {
         for rebuild in rebuild {
             let ExplicitResumeMemberRebuild {
                 mut entry,
+                restore_spec,
                 member_ref,
                 bridge_session_id,
                 requires_materialization,
@@ -15370,33 +15443,27 @@ impl MobActor {
                 continue;
             }
 
-            // A cold actor has no persisted copy of per-spawn external tools.
-            // The public SpawnMemberCustomizer contract explicitly re-supplies
-            // those process-local mechanics at SpawnSource::Resume. Startup
-            // reconciliation already seeds this map for a Running mob; the
-            // explicit Stopped -> Running seam must do the same before its
-            // machine-authorized revival build.
-            let mut restore_spec = super::handle::SpawnMemberSpec::new(
-                entry.role.clone(),
-                entry.agent_identity.clone(),
-            );
-            restore_spec.runtime_mode = Some(entry.runtime_mode);
-            restore_spec.labels = Some(entry.labels.clone());
-            restore_spec.override_profile = entry.effective_profile_override.clone();
-            restore_spec.model_override = entry.effective_model_override.clone();
-            self.customize_spawn_spec(super::handle::SpawnSource::Resume, None, &mut restore_spec)?;
-            if restore_spec.identity != entry.agent_identity {
+            // The public SpawnMemberCustomizer already ran before exact
+            // session/successor selection in prepare_explicit_resume. Keep the
+            // resulting process-local overlay and one-shot migration
+            // declaration on this exact rebuild request.
+            let crate::launch::MemberLaunchMode::Resume {
+                bridge_session_id: customized_session_id,
+                resume_from_role,
+            } = &restore_spec.launch_mode
+            else {
                 return Err(MobError::Internal(format!(
-                    "spawn customizer cannot change explicit-resume identity from '{}' to '{}'",
-                    entry.agent_identity, restore_spec.identity
+                    "explicit-resume rebuild lost its Resume launch for '{}'",
+                    entry.agent_identity
+                )));
+            };
+            if customized_session_id != &bridge_session_id {
+                return Err(MobError::Internal(format!(
+                    "explicit-resume rebuild session drifted for '{}': request='{}' selected='{}'",
+                    entry.agent_identity, customized_session_id, bridge_session_id
                 )));
             }
-            if restore_spec.role_name != entry.role {
-                return Err(MobError::Internal(format!(
-                    "spawn customizer cannot change explicit-resume profile for '{}' from '{}' to '{}'",
-                    entry.agent_identity, entry.role, restore_spec.role_name
-                )));
-            }
+            let resume_from_role = resume_from_role.clone();
             entry.effective_profile_override = restore_spec.override_profile.clone();
             entry.effective_model_override = restore_spec.model_override.clone();
             entry.labels = restore_spec
@@ -15426,6 +15493,7 @@ impl MobActor {
                     &entry,
                     &member_ref,
                     &bridge_session_id,
+                    resume_from_role.as_ref(),
                     repoints_session_binding && recovered_peer_endpoint.is_none(),
                     false,
                 )
@@ -23785,6 +23853,7 @@ impl MobActor {
         }
         // Normalize launch-mode resume/fork details for the provisioning path.
         let resume_bridge_session_id = launch_mode.resume_bridge_session_id().cloned();
+        let resume_from_role = launch_mode.resume_from_role().cloned();
         let fork_spec = match launch_mode {
             crate::launch::MemberLaunchMode::Fork {
                 source_member_id,
@@ -23895,6 +23964,23 @@ impl MobActor {
             if let Some(resume_id) = resume_bridge_session_id {
                 let member_ref = MemberRef::from_bridge_session_id(resume_id.clone());
 
+                // A role migration is a cold, one-shot restamp of durable
+                // identity. Never let it reuse or race an exact live actor,
+                // even when that actor is idle and `SessionInfo::is_active`
+                // is false. Ordinary same-role resume keeps its established
+                // live-session fast path below.
+                if let Some(declared_predecessor_role) = resume_from_role.as_ref()
+                    && self.session_service.has_live_session(&resume_id).await?
+                {
+                    return Err(MobError::MemberRoleMigrationRejected {
+                        member_id: agent_identity.clone(),
+                        declared_predecessor_role: declared_predecessor_role.clone(),
+                        requested_role: profile_name.clone(),
+                        reason: "the exact session is still live; stop or retire its current runtime before restamping durable comms identity"
+                            .to_string(),
+                    });
+                }
+
                 // Validate the session exists and is active.
                 let is_active = self
                     .provisioner
@@ -23906,6 +23992,15 @@ impl MobActor {
                         ))
                     })?;
                 if is_active.unwrap_or(false) {
+                    if let Some(declared_predecessor_role) = resume_from_role.as_ref() {
+                        return Err(MobError::MemberRoleMigrationRejected {
+                            member_id: agent_identity.clone(),
+                            declared_predecessor_role: declared_predecessor_role.clone(),
+                            requested_role: profile_name.clone(),
+                            reason: "the exact session is still live; stop or retire its current runtime before restamping durable comms identity"
+                                .to_string(),
+                        });
+                    }
                     // Validate interaction-scoped injection for autonomous mode.
                     if selected_runtime_mode == crate::MobRuntimeMode::AutonomousHost
                         && self.provisioner.interaction_event_injector(&resume_id).await.is_none()
@@ -24000,6 +24095,7 @@ impl MobActor {
                             inherited_tool_filter: inherited_tool_filter.clone(),
                             tool_access_policy: tool_access_policy.clone(),
                             system_prompt_override: system_prompt_override.clone(),
+                            resume_from_role: resume_from_role.clone(),
                             resume_id,
                             prompt: prompt.clone(),
                             budget_limits: budget_limits.clone(),
@@ -24072,6 +24168,7 @@ impl MobActor {
                                 system_prompt_override: system_prompt_override.clone(),
                             },
                             expected_session_id: &resume_id,
+                            resume_from_role: resume_from_role.as_ref(),
                             resumed_session: stored_session,
                         },
                     )
@@ -25545,6 +25642,9 @@ impl MobActor {
         // with a local source renders context text controlling-side; the
         // wire launch is Fresh (Fork unrepresentable, A6).
         let resume_session_id = launch_mode.resume_bridge_session_id().cloned();
+        let resume_from_role = launch_mode
+            .resume_from_role()
+            .map(|role| role.as_str().to_string());
         let fork_spec = match launch_mode {
             crate::launch::MemberLaunchMode::Fork {
                 source_member_id,
@@ -26047,6 +26147,7 @@ impl MobActor {
         let launch = match resume_session_id.as_ref() {
             Some(session_id) => super::bridge_protocol::MaterializeLaunchMode::Resume {
                 session_id: session_id.to_string(),
+                resume_from_role,
             },
             None => super::bridge_protocol::MaterializeLaunchMode::Fresh {},
         };
@@ -47952,6 +48053,7 @@ impl MobActor {
                         entry,
                         &machine_member_ref,
                         bridge_session_id,
+                        None,
                         false,
                         true,
                     )

--- a/meerkat-mob/src/runtime/builder.rs
+++ b/meerkat-mob/src/runtime/builder.rs
@@ -2785,6 +2785,7 @@ pub(super) async fn latest_persisted_session_for_member(
     mob_id: &crate::ids::MobId,
     role: &crate::ids::ProfileName,
     agent_identity: &crate::ids::AgentIdentity,
+    resume_from_role: Option<&crate::ids::ProfileName>,
 ) -> Result<
     Option<(
         meerkat_core::types::SessionId,
@@ -2797,11 +2798,21 @@ pub(super) async fn latest_persisted_session_for_member(
         role.as_str(),
         agent_identity.as_str(),
     )?;
+    let predecessor_comms_name = resume_from_role
+        .map(|predecessor_role| {
+            super::actor::render_member_comms_name(
+                mob_id.as_str(),
+                predecessor_role.as_str(),
+                agent_identity.as_str(),
+            )
+        })
+        .transpose()?;
 
     // Candidate matching runs over the metadata-only read seam: the member
     // identity facts (typed binding, comms name) live on session metadata, so
     // scanning the realm never materializes full transcripts.
     let mut best: Option<(
+        u8,
         meerkat_core::time_compat::SystemTime,
         meerkat_core::types::SessionId,
     )> = None;
@@ -2816,24 +2827,27 @@ pub(super) async fn latest_persisted_session_for_member(
         else {
             continue;
         };
-        if !persisted_session_matches_member(
+        let Some(match_rank) = persisted_session_member_match_rank(
             view.session_metadata.as_ref(),
             mob_id,
             role,
             agent_identity,
             &canonical_comms_name,
-        ) {
+            resume_from_role,
+            predecessor_comms_name.as_deref(),
+        ) else {
             continue;
-        }
-        let replace = best
-            .as_ref()
-            .is_none_or(|(updated_at, _)| summary.updated_at > *updated_at);
+        };
+        let replace = best.as_ref().is_none_or(|(best_rank, updated_at, _)| {
+            match_rank > *best_rank
+                || (match_rank == *best_rank && summary.updated_at > *updated_at)
+        });
         if replace {
-            best = Some((summary.updated_at, summary.session_id.clone()));
+            best = Some((match_rank, summary.updated_at, summary.session_id.clone()));
         }
     }
 
-    let Some((_, winner_session_id)) = best else {
+    let Some((_, _, winner_session_id)) = best else {
         return Ok(None);
     };
     // Operationally prepare and full-load ONLY the winner. A winner that
@@ -2859,27 +2873,42 @@ pub(super) async fn latest_persisted_session_for_member(
     Ok(Some((winner_session_id, authorized)))
 }
 
-fn persisted_session_matches_member(
+fn persisted_session_member_match_rank(
     metadata: Option<&meerkat_core::SessionMetadata>,
     mob_id: &crate::ids::MobId,
     role: &crate::ids::ProfileName,
     agent_identity: &crate::ids::AgentIdentity,
     canonical_comms_name: &str,
-) -> bool {
+    resume_from_role: Option<&crate::ids::ProfileName>,
+    predecessor_comms_name: Option<&str>,
+) -> Option<u8> {
     let Some(metadata) = metadata else {
-        return false;
+        return None;
     };
     if let Some(binding) = metadata.mob_member_binding.as_ref() {
         // Typed durable ownership is authoritative. The comms-name fallback
         // exists only for journals written before MobMemberBinding; it must
         // never override a present but contradictory typed identity.
-        return binding.mob_id == mob_id.as_str()
-            && binding.role == role.as_str()
-            && binding.member == agent_identity.as_str();
+        if binding.mob_id != mob_id.as_str() || binding.member != agent_identity.as_str() {
+            return None;
+        }
+        if binding.role == role.as_str() {
+            return Some(2);
+        }
+        return resume_from_role
+            .is_some_and(|predecessor| binding.role == predecessor.as_str())
+            .then_some(1);
     }
-    metadata.comms_name.as_deref().is_some_and(|comms_name| {
-        crate::build::resumed_comms_name_matches_current_or_legacy(canonical_comms_name, comms_name)
-    })
+    let comms_name = metadata.comms_name.as_deref()?;
+    if crate::build::resumed_comms_name_matches_current_or_legacy(canonical_comms_name, comms_name)
+    {
+        return Some(2);
+    }
+    predecessor_comms_name
+        .is_some_and(|predecessor| {
+            crate::build::resumed_comms_name_matches_current_or_legacy(predecessor, comms_name)
+        })
+        .then_some(1)
 }
 
 fn authorize_seeded_session_provision_operation_owner(
@@ -8937,6 +8966,10 @@ impl MobBuilder {
 
             let mut restore_spec =
                 super::SpawnMemberSpec::new(entry.role.clone(), entry.agent_identity.clone());
+            restore_spec.launch_mode = crate::launch::MemberLaunchMode::Resume {
+                bridge_session_id: bridge_session_id.clone(),
+                resume_from_role: None,
+            };
             restore_spec.runtime_mode = Some(entry.runtime_mode);
             restore_spec.labels = Some(entry.labels.clone());
             restore_spec.override_profile = entry.effective_profile_override.clone();
@@ -8963,6 +8996,23 @@ impl MobBuilder {
                     entry.agent_identity, entry.role, restore_spec.role_name
                 )));
             }
+            let crate::launch::MemberLaunchMode::Resume {
+                bridge_session_id: customized_session_id,
+                resume_from_role: restore_resume_from_role,
+            } = &restore_spec.launch_mode
+            else {
+                return Err(MobError::Internal(format!(
+                    "spawn customizer removed the resume launch for '{}'",
+                    entry.agent_identity
+                )));
+            };
+            if customized_session_id != &bridge_session_id {
+                return Err(MobError::Internal(format!(
+                    "spawn customizer cannot change resume session for '{}' from '{}' to '{}'",
+                    entry.agent_identity, bridge_session_id, customized_session_id
+                )));
+            }
+            let restore_resume_from_role = restore_resume_from_role.clone();
             // Seed the actor's retention map so a later machine-authorized
             // revival recomposes the customizer-supplied per-spawn overlay.
             if let Some(tools) = restore_spec.external_tools.clone() {
@@ -9011,6 +9061,7 @@ impl MobBuilder {
                                 &definition.id,
                                 &entry.role,
                                 &entry.agent_identity,
+                                restore_resume_from_role.as_ref(),
                             )
                             .await?
                         {
@@ -9138,6 +9189,7 @@ impl MobBuilder {
                             system_prompt_override: restore_spec.system_prompt_override.clone(),
                         },
                         expected_session_id: &bridge_session_id,
+                        resume_from_role: restore_resume_from_role.as_ref(),
                         resumed_session: stored_session,
                     })
                     .await;
@@ -10381,6 +10433,103 @@ mod tests {
     };
     use chrono::Utc;
     use meerkat_core::time_compat::UNIX_EPOCH;
+
+    fn member_session_metadata(
+        mob_id: &str,
+        role: &str,
+        member: &str,
+    ) -> meerkat_core::SessionMetadata {
+        meerkat_core::SessionMetadata {
+            schema_version: meerkat_core::SESSION_METADATA_SCHEMA_VERSION,
+            model: "test-model".to_string(),
+            max_tokens: 1024,
+            structured_output_retries: 0,
+            provider: meerkat_core::Provider::Anthropic,
+            self_hosted_server_id: None,
+            provider_params: None,
+            tooling: Default::default(),
+            keep_alive: false,
+            comms_name: Some(format!("{mob_id}/{role}/{member}")),
+            peer_meta: None,
+            realm_id: None,
+            instance_id: None,
+            backend: None,
+            config_generation: None,
+            auth_binding: None,
+            mob_member_binding: Some(meerkat_core::MobMemberBinding {
+                mob_id: mob_id.to_string(),
+                role: role.to_string(),
+                member: member.to_string(),
+            }),
+        }
+    }
+
+    #[test]
+    fn persisted_member_selector_ranks_current_role_before_declared_predecessor() {
+        let mob_id = MobId::from("homecore");
+        let current_role = ProfileName::from("home-automation");
+        let predecessor_role = ProfileName::from("domain");
+        let member = AgentIdentity::from("mk--rt_cdomain_chome-automation_c0");
+        let current_comms = "homecore/home-automation/mk--rt_cdomain_chome-automation_c0";
+        let predecessor_comms = "homecore/domain/mk--rt_cdomain_chome-automation_c0";
+        let current =
+            member_session_metadata(mob_id.as_str(), current_role.as_str(), member.as_str());
+        let predecessor =
+            member_session_metadata(mob_id.as_str(), predecessor_role.as_str(), member.as_str());
+        let unrelated = member_session_metadata("other-mob", "domain", member.as_str());
+
+        assert_eq!(
+            persisted_session_member_match_rank(
+                Some(&current),
+                &mob_id,
+                &current_role,
+                &member,
+                current_comms,
+                Some(&predecessor_role),
+                Some(predecessor_comms),
+            ),
+            Some(2),
+            "a current-role row must outrank even a newer predecessor row"
+        );
+        assert_eq!(
+            persisted_session_member_match_rank(
+                Some(&predecessor),
+                &mob_id,
+                &current_role,
+                &member,
+                current_comms,
+                Some(&predecessor_role),
+                Some(predecessor_comms),
+            ),
+            Some(1)
+        );
+        assert_eq!(
+            persisted_session_member_match_rank(
+                Some(&predecessor),
+                &mob_id,
+                &current_role,
+                &member,
+                current_comms,
+                None,
+                None,
+            ),
+            None,
+            "a predecessor row is invisible without the exact one-shot declaration"
+        );
+        assert_eq!(
+            persisted_session_member_match_rank(
+                Some(&unrelated),
+                &mob_id,
+                &current_role,
+                &member,
+                current_comms,
+                Some(&predecessor_role),
+                Some(predecessor_comms),
+            ),
+            None,
+            "mob and member identity never migrate"
+        );
+    }
 
     #[cfg(not(target_arch = "wasm32"))]
     struct NoAcceptorMaterial;

--- a/meerkat-mob/src/runtime/handle.rs
+++ b/meerkat-mob/src/runtime/handle.rs
@@ -1840,6 +1840,10 @@ fn spawn_many_failure_observation(error: &MobError) -> mob_dsl::MobSpawnManyFail
         MobError::InvalidTransition { .. } => {
             mob_dsl::MobSpawnManyFailureObservationKind::InvalidTransition
         }
+        MobError::MemberRoleMigrationRequired { .. }
+        | MobError::MemberRoleMigrationRejected { .. } => {
+            mob_dsl::MobSpawnManyFailureObservationKind::InvalidTransition
+        }
         MobError::MobMachineRejected { .. } => {
             mob_dsl::MobSpawnManyFailureObservationKind::InvalidTransition
         }
@@ -4528,8 +4532,47 @@ impl SpawnMemberSpec {
     pub fn with_resume_bridge_session_id(mut self, id: meerkat_core::types::SessionId) -> Self {
         self.launch_mode = crate::launch::MemberLaunchMode::Resume {
             bridge_session_id: id,
+            resume_from_role: None,
         };
         self
+    }
+
+    /// Resume one exact durable session while authorizing a role migration
+    /// from one exact predecessor role.
+    ///
+    /// The enclosing spec binds the mob member identity and target role. This
+    /// declaration therefore authorizes only `(mob, identity, from_role) ->
+    /// target_role` for this request. It is not persisted as standing
+    /// permission; callers restoring after a process restart must re-supply it
+    /// through [`SpawnMemberCustomizer`] at [`SpawnSource::Resume`].
+    pub fn with_resume_bridge_session_id_from_role(
+        mut self,
+        id: meerkat_core::types::SessionId,
+        predecessor_role: impl Into<ProfileName>,
+    ) -> Self {
+        self.launch_mode = crate::launch::MemberLaunchMode::Resume {
+            bridge_session_id: id,
+            resume_from_role: Some(predecessor_role.into()),
+        };
+        self
+    }
+
+    /// Attach a predecessor-role declaration to an already configured Resume
+    /// launch. Customizers use this on the pre-populated cold-resume spec.
+    pub fn declare_resume_from_role(
+        &mut self,
+        predecessor_role: impl Into<ProfileName>,
+    ) -> Result<(), MobError> {
+        let crate::launch::MemberLaunchMode::Resume {
+            resume_from_role, ..
+        } = &mut self.launch_mode
+        else {
+            return Err(MobError::WiringError(
+                "resume_from_role requires launch_mode=resume".to_string(),
+            ));
+        };
+        *resume_from_role = Some(predecessor_role.into());
+        Ok(())
     }
 
     /// Set an explicit [`crate::launch::MemberLaunchMode`].
@@ -8046,6 +8089,7 @@ impl MobHandle {
         let mut spec = SpawnMemberSpec::new(profile_name, agent_identity);
         spec.launch_mode = crate::launch::MemberLaunchMode::Resume {
             bridge_session_id: session_id,
+            resume_from_role: None,
         };
         spec.runtime_mode = runtime_mode;
         spec.backend = backend;
@@ -10859,6 +10903,7 @@ impl MobHandle {
         let fork_session_id = fork.session_id.clone();
         member.launch_mode = crate::launch::MemberLaunchMode::Resume {
             bridge_session_id: fork_session_id.clone(),
+            resume_from_role: None,
         };
         if let Err(error) = self
             .spawn_spec_internal_with_source(member, SpawnSource::PersistedForkResume)
@@ -13292,7 +13337,25 @@ mod tests {
             SpawnMemberSpec::new("worker", "worker-1").with_resume_bridge_session_id(sid.clone());
 
         assert_eq!(spec.launch_mode.resume_bridge_session_id(), Some(&sid));
+        assert!(spec.launch_mode.resume_from_role().is_none());
+    }
+
+    #[test]
+    fn spawn_member_spec_role_migration_requires_and_preserves_resume() {
+        let sid = SessionId::new();
+        let spec = SpawnMemberSpec::new("home-automation", "member-1")
+            .with_resume_bridge_session_id_from_role(sid.clone(), "domain");
         assert_eq!(spec.launch_mode.resume_bridge_session_id(), Some(&sid));
+        assert_eq!(
+            spec.launch_mode.resume_from_role(),
+            Some(&ProfileName::from("domain"))
+        );
+
+        let mut fresh = SpawnMemberSpec::new("home-automation", "member-1");
+        assert!(matches!(
+            fresh.declare_resume_from_role("domain"),
+            Err(MobError::WiringError(_))
+        ));
     }
 
     #[test]
@@ -13300,6 +13363,7 @@ mod tests {
         let sid = SessionId::new();
         let resume = crate::launch::MemberLaunchMode::Resume {
             bridge_session_id: sid,
+            resume_from_role: None,
         };
         let fork = crate::launch::MemberLaunchMode::Fork {
             source_member_id: AgentIdentity::from("lead-1"),

--- a/meerkat-mob/src/runtime/host_actor.rs
+++ b/meerkat-mob/src/runtime/host_actor.rs
@@ -6547,7 +6547,7 @@ impl MobHostActor {
         // one member key across every mob served by this daemon. Check before
         // preflight/build/rebind side effects; the machine's injectivity
         // invariant independently fail-closes the eventual record commit.
-        if let MaterializeLaunchMode::Resume { session_id } = &payload.launch
+        if let MaterializeLaunchMode::Resume { session_id, .. } = &payload.launch
             && let Some((owner, _)) = self
                 .binding_authority
                 .state()
@@ -6647,7 +6647,7 @@ impl MobHostActor {
         let superseded_session_id = superseded_session_id.filter(|old_session_id| {
             !matches!(
                 &payload.launch,
-                MaterializeLaunchMode::Resume { session_id } if session_id == old_session_id
+                MaterializeLaunchMode::Resume { session_id, .. } if session_id == old_session_id
             )
         });
         let mut superseded_residency_update = None;

--- a/meerkat-mob/src/runtime/host_materialize.rs
+++ b/meerkat-mob/src/runtime/host_materialize.rs
@@ -38,6 +38,7 @@ use meerkat_runtime::SessionServiceRuntimeExt as _;
 use crate::MobRuntimeMode;
 use crate::build::{BuildAgentConfigParams, BuildResumedAgentConfigParams};
 use crate::definition::{MobDefinition, SkillSource};
+use crate::ids::ProfileName;
 use crate::profile::{Profile, ProfileBinding, ResumeOverrideField, ToolConfig};
 use crate::runtime::SpawnSystemPromptOverride;
 use crate::runtime::host_actor::{
@@ -767,7 +768,7 @@ pub async fn assemble_preflight_observations(
     };
     let identity = match launch {
         MaterializeLaunchMode::Fresh {} => Some(candidate_identity),
-        MaterializeLaunchMode::Resume { session_id } => match SessionId::parse(session_id) {
+        MaterializeLaunchMode::Resume { session_id, .. } => match SessionId::parse(session_id) {
             Err(_) => {
                 // The materializer owns the stable typed invalid-id reply.
                 // No identity can be authoritatively derived before that.
@@ -1645,6 +1646,7 @@ impl HostMemberMaterializer {
             resume_materialization,
             resume_authority,
             resume_preparation,
+            resume_from_role,
             launch_outcome,
             generation_start_seq,
             residency_update,
@@ -1664,13 +1666,17 @@ impl HostMemberMaterializer {
                     None,
                     None,
                     None,
+                    None,
                     MaterializeLaunchOutcome::Fresh,
                     1,
                     residency_update,
                     Some(boundary),
                 )
             }
-            MaterializeLaunchMode::Resume { session_id } => {
+            MaterializeLaunchMode::Resume {
+                session_id,
+                resume_from_role,
+            } => {
                 let id = SessionId::parse(session_id).map_err(|err| {
                     MaterializeServeError::ResumeSessionIdInvalid {
                         session_id: session_id.clone(),
@@ -1744,6 +1750,7 @@ impl HostMemberMaterializer {
                             Some(materialization),
                             Some(authority),
                             Some(preparation),
+                            resume_from_role.as_deref().map(ProfileName::from),
                             MaterializeLaunchOutcome::ResumedFromSnapshot,
                             generation_start_seq,
                             residency_update,
@@ -1758,7 +1765,12 @@ impl HostMemberMaterializer {
         };
 
         let mut config = self
-            .compile_member_config(&decompiled, &session_id, resumed_session)
+            .compile_member_config(
+                &decompiled,
+                &session_id,
+                resumed_session,
+                resume_from_role.as_ref(),
+            )
             .await?;
 
         // Step 2 tail — runtime bindings for the (possibly pre-created) id.
@@ -2301,7 +2313,7 @@ impl HostMemberMaterializer {
         };
 
         let mut config = self
-            .compile_member_config(&decompiled, &session_id, Some(session))
+            .compile_member_config(&decompiled, &session_id, Some(session), None)
             .await?;
         let mut prepared = match self
             .substrate
@@ -2655,6 +2667,7 @@ impl HostMemberMaterializer {
         decompiled: &DecompiledMemberBuild,
         session_id: &SessionId,
         resumed_session: Option<meerkat_core::Session>,
+        resume_from_role: Option<&ProfileName>,
     ) -> Result<meerkat::AgentBuildConfig, MaterializeServeError> {
         let base = BuildAgentConfigParams {
             mob_id: &decompiled.mob_id,
@@ -2692,6 +2705,7 @@ impl HostMemberMaterializer {
                 crate::build::build_resumed_agent_config(BuildResumedAgentConfigParams {
                     base,
                     expected_session_id: session_id,
+                    resume_from_role,
                     resumed_session: session,
                 })
                 .await?

--- a/meerkat-mob/src/runtime/member_upcall.rs
+++ b/meerkat-mob/src/runtime/member_upcall.rs
@@ -922,11 +922,11 @@ fn wire_runtime_mode(mode: crate::MobRuntimeMode) -> WireMobRuntimeMode {
 fn wire_launch_mode(mode: crate::launch::MemberLaunchMode) -> WireMemberLaunchMode {
     match mode {
         crate::launch::MemberLaunchMode::Fresh => WireMemberLaunchMode::Fresh,
-        crate::launch::MemberLaunchMode::Resume { bridge_session_id } => {
-            WireMemberLaunchMode::Resume {
-                bridge_session_id: bridge_session_id.to_string(),
-            }
-        }
+        crate::launch::MemberLaunchMode::Resume {
+            bridge_session_id, ..
+        } => WireMemberLaunchMode::Resume {
+            bridge_session_id: bridge_session_id.to_string(),
+        },
         crate::launch::MemberLaunchMode::Fork {
             source_member_id,
             fork_context,

--- a/meerkat-mob/src/runtime/spec_compiler.rs
+++ b/meerkat-mob/src/runtime/spec_compiler.rs
@@ -324,6 +324,7 @@ pub(crate) fn spawn_spec_from_desired_member(
     spec.initial_message = None;
     spec.launch_mode = crate::launch::MemberLaunchMode::Resume {
         bridge_session_id: session.session_id.clone(),
+        resume_from_role: None,
     };
     spec.runtime_mode = Some(domain_runtime_mode(material.overlay.runtime_mode));
     spec.context = material

--- a/meerkat-mob/src/runtime/tests.rs
+++ b/meerkat-mob/src/runtime/tests.rs
@@ -1428,6 +1428,9 @@ struct CreateSessionRecord {
     runtime_build_mode_session_owned: bool,
     budget_limits: Option<meerkat_core::BudgetLimits>,
     model: String,
+    override_shell: ToolCategoryOverride,
+    mob_member_binding: Option<meerkat_core::MobMemberBinding>,
+    app_context: Option<serde_json::Value>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -2886,6 +2889,19 @@ impl MockSessionService {
                     .as_ref()
                     .and_then(|build| build.budget_limits.clone()),
                 model: req.model.clone(),
+                override_shell: req
+                    .build
+                    .as_ref()
+                    .map(|build| build.override_shell)
+                    .unwrap_or(ToolCategoryOverride::Inherit),
+                mob_member_binding: req
+                    .build
+                    .as_ref()
+                    .and_then(|build| build.mob_member_binding.clone()),
+                app_context: req
+                    .build
+                    .as_ref()
+                    .and_then(|build| build.app_context.clone()),
             });
 
         let mcp_server_names: Vec<String> = req
@@ -24666,6 +24682,7 @@ async fn test_build_resumed_agent_config_rejects_mismatched_session_identity() {
                 system_prompt_override: None,
             },
             expected_session_id: &wrong_session_id,
+            resume_from_role: None,
             resumed_session: resumed,
         })
         .await
@@ -56974,6 +56991,248 @@ impl SpawnMemberCustomizer for ResumeOverlayCustomizer {
     }
 }
 
+#[derive(Clone)]
+struct ResumeRoleMigrationCustomizer {
+    called: Arc<AtomicBool>,
+}
+
+impl SpawnMemberCustomizer for ResumeRoleMigrationCustomizer {
+    fn customize_spawn(
+        &self,
+        ctx: &SpawnCustomizationContext,
+        spec: &mut SpawnMemberSpec,
+    ) -> Result<(), MobError> {
+        if ctx.spawn_source == SpawnSource::Resume
+            && spec.identity.as_str() == "mk--rt_cdomain_chome-automation_c0"
+        {
+            if ctx.requested_profile.as_str() != "home-automation" {
+                return Err(MobError::Internal(format!(
+                    "unexpected migration target profile '{}'",
+                    ctx.requested_profile
+                )));
+            }
+            spec.declare_resume_from_role("domain")?;
+            spec.context = Some(serde_json::json!({
+                "homecore_profile": "home-automation",
+                "identity": "domain:home-automation",
+            }));
+            self.called.store(true, Ordering::SeqCst);
+        }
+        Ok(())
+    }
+}
+
+fn role_migration_definition(mob_id: &str) -> MobDefinition {
+    let mut definition = sample_definition_with_turn_driven_worker();
+    definition.id = MobId::from(mob_id);
+    let mut predecessor = definition
+        .profiles
+        .get(&ProfileName::from("worker"))
+        .expect("worker profile")
+        .clone();
+    predecessor
+        .as_inline_mut()
+        .expect("inline predecessor")
+        .tools
+        .shell = false;
+    let mut target = predecessor.clone();
+    target.as_inline_mut().expect("inline target").tools.shell = true;
+    definition
+        .profiles
+        .insert(ProfileName::from("domain"), predecessor);
+    definition
+        .profiles
+        .insert(ProfileName::from("home-automation"), target);
+    definition
+}
+
+#[tokio::test]
+async fn role_migration_refuses_an_exact_live_session_even_when_idle() {
+    let service = Arc::new(MockSessionService::new());
+    let _ = service.enable_runtime_adapter();
+    let definition = role_migration_definition("role-migration-live");
+
+    let predecessor = MobBuilder::new(definition.clone(), MobStorage::in_memory())
+        .with_session_service(service.clone())
+        .create()
+        .await
+        .expect("create predecessor mob");
+    predecessor
+        .spawn_spec(SpawnMemberSpec::new(
+            "domain",
+            "mk--rt_cdomain_chome-automation_c0",
+        ))
+        .await
+        .expect("spawn predecessor member");
+    let session_id = predecessor
+        .resolve_bridge_session_id(&AgentIdentity::from("mk--rt_cdomain_chome-automation_c0"))
+        .await
+        .expect("predecessor session");
+    crash_stop_and_release_routes(predecessor).await;
+    assert!(
+        service
+            .has_live_session(&session_id)
+            .await
+            .expect("observe exact live session"),
+        "the fixture must retain an idle live actor so the migration cannot be mistaken for cold resume"
+    );
+
+    let successor = MobBuilder::new(definition, MobStorage::in_memory())
+        .with_session_service(service)
+        .with_spawn_member_customizer(Arc::new(ResumeRoleMigrationCustomizer {
+            called: Arc::new(AtomicBool::new(false)),
+        }))
+        .create()
+        .await
+        .expect("create successor mob");
+    let error = successor
+        .spawn_spec(
+            SpawnMemberSpec::new("home-automation", "mk--rt_cdomain_chome-automation_c0")
+                .with_resume_bridge_session_id(session_id),
+        )
+        .await
+        .expect_err("a one-shot role migration must never restamp a live actor");
+    assert!(
+        matches!(
+            error,
+            MobError::MemberRoleMigrationRejected { ref reason, .. }
+                if reason.contains("exact session is still live")
+        ),
+        "live role migration must fail with the typed migration refusal, got {error:?}"
+    );
+    successor.shutdown().await.expect("shutdown successor mob");
+}
+
+/// The adopter-shaped regression: an existing durable member was created as
+/// `domain` with shell disabled, then a new activation resumes the same exact
+/// mob/member/session as `home-automation` with shell enabled. The one-shot
+/// declaration must survive the public Resume customizer round trip, reach the
+/// real resumed build, and keep the target role/tooling at the AgentFactory
+/// boundary.
+#[tokio::test]
+async fn resume_customizer_carries_exact_role_migration_into_cold_build() {
+    let service = Arc::new(MockSessionService::new());
+    let _ = service.enable_runtime_adapter();
+    let definition = role_migration_definition("role-migration-cold");
+
+    let predecessor = MobBuilder::new(definition.clone(), MobStorage::in_memory())
+        .with_session_service(service.clone())
+        .create()
+        .await
+        .expect("create predecessor mob");
+    let mut predecessor_spec = SpawnMemberSpec::new("domain", "mk--rt_cdomain_chome-automation_c0");
+    predecessor_spec.labels = Some(BTreeMap::from([(
+        "identity".to_string(),
+        "domain:home-automation".to_string(),
+    )]));
+    predecessor_spec.context = Some(serde_json::json!({
+        "homecore_profile": "domain",
+        "identity": "domain:home-automation",
+    }));
+    predecessor
+        .spawn_spec(predecessor_spec)
+        .await
+        .expect("spawn predecessor member");
+    let session_id = predecessor
+        .resolve_bridge_session_id(&AgentIdentity::from("mk--rt_cdomain_chome-automation_c0"))
+        .await
+        .expect("predecessor session");
+    // Model an actual process restart: copy only durable session state into a
+    // fresh service/runtime adapter. Reusing the predecessor adapter would
+    // retain its exact attachment authority and would test a concurrent warm
+    // takeover, which this one-shot cold migration deliberately does not
+    // authorize.
+    let restarted_service = Arc::new(service.cold_restart_preserving_durable_state().await);
+    let _ = restarted_service.enable_runtime_adapter();
+    crash_stop_and_release_routes(predecessor).await;
+    drop(service);
+
+    let called = Arc::new(AtomicBool::new(false));
+    let successor = MobBuilder::new(definition, MobStorage::in_memory())
+        .with_session_service(restarted_service.clone())
+        .with_spawn_member_customizer(Arc::new(ResumeRoleMigrationCustomizer {
+            called: Arc::clone(&called),
+        }))
+        .create()
+        .await
+        .expect("create successor mob");
+    successor
+        .spawn_spec(
+            SpawnMemberSpec::new("home-automation", "mk--rt_cdomain_chome-automation_c0")
+                .with_resume_bridge_session_id(session_id.clone()),
+        )
+        .await
+        .expect("one-shot role migration should resume the exact session");
+
+    assert!(
+        called.load(Ordering::SeqCst),
+        "the declaration must travel through SpawnMemberCustomizer at SpawnSource::Resume"
+    );
+    assert_eq!(
+        successor
+            .resolve_bridge_session_id(&AgentIdentity::from("mk--rt_cdomain_chome-automation_c0",))
+            .await
+            .expect("successor session"),
+        session_id,
+        "role migration must preserve the exact durable session"
+    );
+    let request = restarted_service
+        .create_requests
+        .read()
+        .await
+        .last()
+        .cloned()
+        .expect("resumed build request");
+    assert_eq!(
+        request.comms_name.as_deref(),
+        Some("role-migration-cold/home-automation/mk--rt_cdomain_chome-automation_c0")
+    );
+    assert_eq!(
+        request.mob_member_binding,
+        Some(meerkat_core::MobMemberBinding {
+            mob_id: "role-migration-cold".to_string(),
+            role: "home-automation".to_string(),
+            member: "mk--rt_cdomain_chome-automation_c0".to_string(),
+        })
+    );
+    assert_eq!(
+        request.peer_meta_labels.get("role").map(String::as_str),
+        Some("home-automation")
+    );
+    assert_eq!(
+        request
+            .peer_meta_labels
+            .get("profile_name")
+            .map(String::as_str),
+        Some("home-automation")
+    );
+    assert_eq!(
+        request.peer_meta_labels.get("identity").map(String::as_str),
+        Some("domain:home-automation"),
+        "the adopter-owned raw identity label must survive beside the encoded transport identity"
+    );
+    assert_eq!(
+        request
+            .peer_meta_labels
+            .get("agent_identity")
+            .map(String::as_str),
+        Some("mk--rt_cdomain_chome-automation_c0")
+    );
+    assert_eq!(
+        request.app_context,
+        Some(serde_json::json!({
+            "homecore_profile": "home-automation",
+            "identity": "domain:home-automation",
+        })),
+        "Meerkat must persist the current callback-owned context, never rewrite or restore the opaque predecessor profile"
+    );
+    assert_eq!(
+        request.override_shell,
+        ToolCategoryOverride::Enable,
+        "the target profile's explicit shell capability must survive durable resume"
+    );
+}
+
 /// Restore-seeded retention: tools attached by a `SpawnMemberCustomizer` at
 /// `SpawnSource::Resume` seed the actor's retention map, so a later
 /// machine-authorized revival in the restored incarnation recomposes them
@@ -63073,6 +63332,12 @@ fn summarize_mob_runtime_error(error: &MobError) -> String {
             format!("session_unavailable_for_resume:{reason:?}")
         }
         MobError::MemberAlreadyExists(_) => "meerkat_already_exists".to_string(),
+        MobError::MemberRoleMigrationRequired { .. } => {
+            "member_role_migration_required".to_string()
+        }
+        MobError::MemberRoleMigrationRejected { .. } => {
+            "member_role_migration_rejected".to_string()
+        }
         MobError::NotExternallyAddressable(_) => "not_externally_addressable".to_string(),
         MobError::InvalidTransition { from, to } => {
             format!("invalid_transition:{}->{}", from.as_str(), to.as_str())

--- a/meerkat-mob/src/runtime/upcall_responder.rs
+++ b/meerkat-mob/src/runtime/upcall_responder.rs
@@ -1035,6 +1035,7 @@ fn domain_launch_mode(
                 })?;
             crate::launch::MemberLaunchMode::Resume {
                 bridge_session_id: session_id,
+                resume_from_role: None,
             }
         }
         WireMemberLaunchMode::Fork {

--- a/meerkat-mob/tests/host_materialize_serving.rs
+++ b/meerkat-mob/tests/host_materialize_serving.rs
@@ -895,6 +895,7 @@ async fn resume_launch_on_ephemeral_substrate_rejects_realm_backend_unavailable(
         1,
         MaterializeLaunchMode::Resume {
             session_id: meerkat_core::SessionId::new().to_string(),
+            resume_from_role: None,
         },
     );
     let reply = probe
@@ -987,6 +988,7 @@ async fn materialize_resume_launch_outcomes() {
         2,
         MaterializeLaunchMode::Resume {
             session_id: fresh_ack.session_id.clone(),
+            resume_from_role: None,
         },
     );
     let reply = probe
@@ -1017,6 +1019,7 @@ async fn materialize_resume_launch_outcomes() {
         1,
         MaterializeLaunchMode::Resume {
             session_id: meerkat_core::SessionId::new().to_string(),
+            resume_from_role: None,
         },
     );
     let reply = probe
@@ -1028,6 +1031,69 @@ async fn materialize_resume_launch_outcomes() {
         .await
         .expect("typed reply");
     assert_rejected(&reply, &BridgeRejectionCause::ResumeSessionNotFound);
+
+    fixture.shutdown().await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn materialize_resume_carries_exact_predecessor_role_into_host_build() {
+    let _guard = REAL_COMMS_TEST_LOCK.lock().await;
+    let fixture = member_build_fixture("mat-role-migration-host").await;
+    let probe = spawn_peer_comms_endpoint("mat-role-migration-supervisor", true, None).await;
+    probe.trust(fixture.host_peer_descriptor()).await;
+    raw_bind(&probe, &fixture, "mob-role-migration", 1).await;
+
+    let fresh = sample_materialize_payload(
+        &probe,
+        1,
+        sample_portable_member_spec("mob-role-migration", "member-1", "domain"),
+        1,
+        1,
+        MaterializeLaunchMode::Fresh {},
+    );
+    let fresh_reply = probe
+        .send_bridge_command_raw(
+            &fixture.host_peer_descriptor(),
+            &BridgeCommand::MaterializeMember(fresh),
+            REPLY_TIMEOUT,
+        )
+        .await
+        .expect("fresh predecessor materialization");
+    let BridgeReply::MemberMaterialized(fresh_ack) = fresh_reply else {
+        panic!("expected predecessor materialization, got {fresh_reply:?}");
+    };
+
+    let mut target =
+        sample_portable_member_spec("mob-role-migration", "member-1", "home-automation");
+    target.profile.tools.shell = true;
+    let migrating = sample_materialize_payload(
+        &probe,
+        1,
+        target,
+        2,
+        2,
+        MaterializeLaunchMode::Resume {
+            session_id: fresh_ack.session_id.clone(),
+            resume_from_role: Some("domain".to_string()),
+        },
+    );
+    let migrating_reply = probe
+        .send_bridge_command_raw(
+            &fixture.host_peer_descriptor(),
+            &BridgeCommand::MaterializeMember(migrating),
+            REPLY_TIMEOUT,
+        )
+        .await
+        .expect("role-migrating materialization");
+    let BridgeReply::MemberMaterialized(migrated) = migrating_reply else {
+        panic!("expected migrated materialization, got {migrating_reply:?}");
+    };
+    assert_eq!(migrated.session_id, fresh_ack.session_id);
+    assert_eq!(
+        migrated.launch_outcome,
+        MaterializeLaunchOutcome::ResumedFromSnapshot,
+        "the trusted host must carry the exact predecessor declaration into the resumed build"
+    );
 
     fixture.shutdown().await;
 }
@@ -1114,6 +1180,7 @@ async fn same_session_generation_cutover_drains_old_events_before_floor_capture(
         2,
         MaterializeLaunchMode::Resume {
             session_id: fresh.session_id.clone(),
+            resume_from_role: None,
         },
     );
     let reply = probe
@@ -1204,6 +1271,7 @@ async fn generation_cutover_projection_failure_preserves_replayable_old_owner() 
         2,
         MaterializeLaunchMode::Resume {
             session_id: fresh.session_id.clone(),
+            resume_from_role: None,
         },
     );
     let reply = probe
@@ -1301,6 +1369,7 @@ async fn one_session_id_cannot_alias_two_host_member_owners() {
         1,
         MaterializeLaunchMode::Resume {
             session_id: owned.session_id.clone(),
+            resume_from_role: None,
         },
     );
     let reply = intruder
@@ -1850,6 +1919,7 @@ async fn executor_stop_between_ensure_and_attach_return_cleans_preinstalled_side
         1,
         MaterializeLaunchMode::Resume {
             session_id: preserved_session.to_string(),
+            resume_from_role: None,
         },
     ));
 
@@ -1934,6 +2004,7 @@ async fn materialize_persist_failure_preserves_resumable_session_and_quiesces_ex
         1,
         MaterializeLaunchMode::Resume {
             session_id: preserved_session.to_string(),
+            resume_from_role: None,
         },
     ));
     let reply = probe
@@ -1999,6 +2070,7 @@ async fn same_session_resume_definite_cas_failure_preserves_snapshot_for_retry()
         2,
         MaterializeLaunchMode::Resume {
             session_id: fresh.session_id.clone(),
+            resume_from_role: None,
         },
     ));
     let reply = probe

--- a/meerkat-mob/tests/member_upcall_lane.rs
+++ b/meerkat-mob/tests/member_upcall_lane.rs
@@ -352,6 +352,7 @@ async fn held_envelope_is_fenced_after_same_session_resume_generation_bump() {
     let mut replacement = support::placed_spawn_spec("worker", "b2", &harness.host_id);
     replacement.launch_mode = meerkat_mob::launch::MemberLaunchMode::Resume {
         bridge_session_id: old_session.clone(),
+        resume_from_role: None,
     };
     harness
         .controlling
@@ -377,7 +378,7 @@ async fn held_envelope_is_fenced_after_same_session_resume_generation_bump() {
     assert!(
         matches!(
             &replacement_payload.launch,
-            meerkat_mob::runtime::bridge_protocol::MaterializeLaunchMode::Resume { session_id }
+            meerkat_mob::runtime::bridge_protocol::MaterializeLaunchMode::Resume { session_id, .. }
                 if session_id == &old_session.to_string()
         ),
         "the generation bump resumes the same session"

--- a/meerkat-mob/tests/remote_spawn_materialization.rs
+++ b/meerkat-mob/tests/remote_spawn_materialization.rs
@@ -671,6 +671,7 @@ async fn launch_modes_map_to_wire_launch_without_local_probes() {
     let mut spec = support::placed_spawn_spec("worker", "resumer", &report.host_id);
     spec.launch_mode = meerkat_mob::launch::MemberLaunchMode::Resume {
         bridge_session_id: remote_session.clone(),
+        resume_from_role: None,
     };
     controlling
         .handle
@@ -685,7 +686,7 @@ async fn launch_modes_map_to_wire_launch_without_local_probes() {
     assert!(
         matches!(
             &resume_payload.launch,
-            MaterializeLaunchMode::Resume { session_id } if *session_id == remote_session.to_string()
+            MaterializeLaunchMode::Resume { session_id, .. } if *session_id == remote_session.to_string()
         ),
         "Resume launch rides the payload verbatim, got {:?}",
         resume_payload.launch

--- a/meerkat-mob/tests/support/mod.rs
+++ b/meerkat-mob/tests/support/mod.rs
@@ -2366,7 +2366,7 @@ fn scripted_materialize_reply(
                 meerkat_core::SessionId::new().to_string(),
                 MaterializeLaunchOutcome::Fresh,
             ),
-            MaterializeLaunchMode::Resume { session_id } => (
+            MaterializeLaunchMode::Resume { session_id, .. } => (
                 session_id.clone(),
                 MaterializeLaunchOutcome::ResumedFromSnapshot,
             ),

--- a/meerkat-rpc/src/session_runtime.rs
+++ b/meerkat-rpc/src/session_runtime.rs
@@ -13528,17 +13528,7 @@ mod tests {
                 .await
         });
 
-        let deadline = tokio::time::Instant::now() + tokio::time::Duration::from_secs(1);
-        loop {
-            if calls.load(AtomicOrdering::SeqCst) >= 1 {
-                break;
-            }
-            assert!(
-                tokio::time::Instant::now() < deadline,
-                "blocking turn did not enter the LLM stream before deadline"
-            );
-            tokio::time::sleep(tokio::time::Duration::from_millis(10)).await;
-        }
+        wait_for_llm_calls(&calls, 1, "blocking turn").await;
 
         (session_id, turn, release)
     }
@@ -16610,17 +16600,7 @@ mod tests {
                 .await
         });
 
-        let deadline = tokio::time::Instant::now() + tokio::time::Duration::from_secs(1);
-        loop {
-            if calls.load(AtomicOrdering::SeqCst) > 0 {
-                break;
-            }
-            assert!(
-                tokio::time::Instant::now() < deadline,
-                "session did not start the service-side turn before deadline"
-            );
-            tokio::time::sleep(tokio::time::Duration::from_millis(10)).await;
-        }
+        wait_for_llm_calls(&calls, 1, "service-side session turn").await;
 
         let append_req = AppendSystemContextRequest {
             content: meerkat_core::lifecycle::run_primitive::CoreRenderable::text(
@@ -16975,17 +16955,7 @@ mod tests {
         });
 
         // Wait until the first turn is definitely running.
-        let deadline = tokio::time::Instant::now() + tokio::time::Duration::from_secs(1);
-        loop {
-            if calls.load(AtomicOrdering::SeqCst) > 0 {
-                break;
-            }
-            assert!(
-                tokio::time::Instant::now() < deadline,
-                "session did not start the service-side turn before deadline"
-            );
-            tokio::time::sleep(tokio::time::Duration::from_millis(10)).await;
-        }
+        wait_for_llm_calls(&calls, 1, "service-side session turn").await;
 
         // Try to start a second turn
         let (event_tx2, _rx2) = mpsc::channel(100);
@@ -17010,7 +16980,7 @@ mod tests {
             err.code
         );
 
-        release.notify_waiters();
+        release.notify_one();
         turn_handle
             .await
             .unwrap()
@@ -18381,8 +18351,8 @@ mod tests {
             "new-runtime cleanup must not unregister a session with active runtime input"
         );
 
-        release.notify_waiters();
-        let result = tokio::time::timeout(tokio::time::Duration::from_secs(1), active_turn)
+        release.notify_one();
+        let result = tokio::time::timeout(TEST_ASYNC_WITNESS_TIMEOUT, active_turn)
             .await
             .expect("active input should complete after release");
         result
@@ -20004,18 +19974,8 @@ mod tests {
                 .await
         });
 
-        let deadline = tokio::time::Instant::now() + tokio::time::Duration::from_secs(1);
-        loop {
-            if calls.load(AtomicOrdering::SeqCst) >= 1 {
-                break;
-            }
-            assert!(
-                tokio::time::Instant::now() < deadline,
-                "initial turn did not enter the LLM stream before deadline"
-            );
-            tokio::time::sleep(tokio::time::Duration::from_millis(10)).await;
-        }
-        release.notify_waiters();
+        wait_for_llm_calls(&calls, 1, "initial turn").await;
+        release.notify_one();
         initial_turn
             .await
             .expect("initial turn task")
@@ -20023,7 +19983,7 @@ mod tests {
 
         let service = runtime.session_service();
         let session_for_turn = session_id.clone();
-        let direct_turn = tokio::spawn(async move {
+        let mut direct_turn = tokio::spawn(async move {
             service
                 .start_turn(
                     &session_for_turn,
@@ -20032,20 +19992,12 @@ mod tests {
                 .await
         });
 
-        let deadline = tokio::time::Instant::now() + tokio::time::Duration::from_secs(1);
-        loop {
-            if calls.load(AtomicOrdering::SeqCst) >= 2 {
-                break;
-            }
-            if direct_turn.is_finished() {
-                let result = direct_turn.await.expect("direct turn task");
+        tokio::select! {
+            () = calls.wait_for(2, "direct service turn") => {}
+            result = &mut direct_turn => {
+                let result = result.expect("direct turn task");
                 panic!("direct service turn finished before reaching LLM stream: {result:?}");
             }
-            assert!(
-                tokio::time::Instant::now() < deadline,
-                "direct service turn did not enter the LLM stream before deadline"
-            );
-            tokio::time::sleep(tokio::time::Duration::from_millis(10)).await;
         }
 
         let blocked = runtime
@@ -20059,7 +20011,7 @@ mod tests {
             "rpc create should be blocked by mob/direct running turn: {blocked:?}"
         );
 
-        release.notify_waiters();
+        release.notify_one();
         direct_turn
             .await
             .expect("direct turn task")
@@ -20124,7 +20076,7 @@ mod tests {
             "RPC create should remain blocked while first turn is running: {blocked:?}"
         );
 
-        release.notify_waiters();
+        release.notify_one();
         pending_first_turn
             .await
             .expect("pending first turn task")
@@ -20468,7 +20420,7 @@ mod tests {
             .interrupt(&session_id)
             .await
             .expect("interrupt should reach promoting live turn");
-        let interrupted = tokio::time::timeout(tokio::time::Duration::from_secs(1), running_turn)
+        let interrupted = tokio::time::timeout(TEST_ASYNC_WITNESS_TIMEOUT, running_turn)
             .await
             .expect("promoting first turn should finish after interrupt")
             .expect("turn task should not panic")
@@ -20817,7 +20769,7 @@ mod tests {
         assert_eq!(err.code, error::SESSION_BUSY);
         hook.release.notify_waiters();
 
-        tokio::time::timeout(tokio::time::Duration::from_secs(1), running_turn)
+        tokio::time::timeout(TEST_ASYNC_WITNESS_TIMEOUT, running_turn)
             .await
             .expect("pending apply should finish")
             .expect("apply task should not panic")
@@ -22760,7 +22712,7 @@ mod tests {
             "cancelled caller must not release capacity while service turn is still running: {blocked:?}"
         );
 
-        release.notify_waiters();
+        release.notify_one();
         let deadline = tokio::time::Instant::now() + tokio::time::Duration::from_secs(2);
         loop {
             match runtime
@@ -22851,7 +22803,7 @@ mod tests {
             .expect("stored candidate metadata after rejected start");
         assert_eq!(meta.model, "claude-sonnet-4-5");
         assert_eq!(meta.provider, meerkat_core::Provider::Anthropic);
-        release.notify_waiters();
+        release.notify_one();
         blocking_turn
             .await
             .expect("blocking turn task")
@@ -22893,7 +22845,7 @@ mod tests {
             .expect("stored candidate metadata after rejected apply");
         assert_eq!(meta.model, "claude-sonnet-4-5");
         assert_eq!(meta.provider, meerkat_core::Provider::Anthropic);
-        release.notify_waiters();
+        release.notify_one();
         blocking_turn
             .await
             .expect("blocking turn task")

--- a/meerkat-rpc/src/session_runtime.rs
+++ b/meerkat-rpc/src/session_runtime.rs
@@ -11999,8 +11999,43 @@ mod tests {
         }
     }
 
+    const TEST_ASYNC_WITNESS_TIMEOUT: tokio::time::Duration = tokio::time::Duration::from_secs(10);
+
+    #[derive(Default)]
+    struct BlockingLlmCallWitness {
+        calls: AtomicUsize,
+        entered: Notify,
+    }
+
+    impl BlockingLlmCallWitness {
+        fn load(&self, ordering: AtomicOrdering) -> usize {
+            self.calls.load(ordering)
+        }
+
+        fn record(&self) -> usize {
+            let previous = self.calls.fetch_add(1, AtomicOrdering::SeqCst);
+            // `notify_one` retains a permit when the observer has not reached
+            // `notified()` yet, so the test cannot lose the exact stream-entry
+            // witness between its count check and await.
+            self.entered.notify_one();
+            previous
+        }
+
+        async fn wait_for(&self, expected: usize, description: &str) {
+            tokio::time::timeout(TEST_ASYNC_WITNESS_TIMEOUT, async {
+                while self.load(AtomicOrdering::SeqCst) < expected {
+                    self.entered.notified().await;
+                }
+            })
+            .await
+            .unwrap_or_else(|_| {
+                panic!("{description} did not enter the LLM stream before deadline")
+            });
+        }
+    }
+
     struct BlockingMockLlmClient {
-        calls: Arc<AtomicUsize>,
+        calls: Arc<BlockingLlmCallWitness>,
         release: Arc<Notify>,
     }
 
@@ -12977,7 +13012,7 @@ mod tests {
             let calls = Arc::clone(&self.calls);
             let release = Arc::clone(&self.release);
             Box::pin(async_stream::stream! {
-                calls.fetch_add(1, AtomicOrdering::SeqCst);
+                calls.record();
                 release.notified().await;
                 yield Ok(meerkat_client::LlmEvent::TextDelta {
                     delta: "Blocked response".to_string(),
@@ -13008,7 +13043,7 @@ mod tests {
     }
 
     struct BlockAfterFirstMockLlmClient {
-        calls: Arc<AtomicUsize>,
+        calls: Arc<BlockingLlmCallWitness>,
         release: Arc<Notify>,
     }
 
@@ -13027,7 +13062,7 @@ mod tests {
         ) -> Pin<
             Box<dyn futures::Stream<Item = Result<meerkat_client::LlmEvent, LlmError>> + Send + 'a>,
         > {
-            let call = self.calls.fetch_add(1, AtomicOrdering::SeqCst);
+            let call = self.calls.record();
             let release = Arc::clone(&self.release);
             Box::pin(async_stream::stream! {
                 if call > 0 {
@@ -13298,8 +13333,8 @@ mod tests {
         }
     }
 
-    fn blocking_build_config() -> (AgentBuildConfig, Arc<AtomicUsize>, Arc<Notify>) {
-        let calls = Arc::new(AtomicUsize::new(0));
+    fn blocking_build_config() -> (AgentBuildConfig, Arc<BlockingLlmCallWitness>, Arc<Notify>) {
+        let calls = Arc::new(BlockingLlmCallWitness::default());
         let release = Arc::new(Notify::new());
         let client = BlockingMockLlmClient {
             calls: Arc::clone(&calls),
@@ -13315,8 +13350,9 @@ mod tests {
         )
     }
 
-    fn block_after_first_build_config() -> (AgentBuildConfig, Arc<AtomicUsize>, Arc<Notify>) {
-        let calls = Arc::new(AtomicUsize::new(0));
+    fn block_after_first_build_config()
+    -> (AgentBuildConfig, Arc<BlockingLlmCallWitness>, Arc<Notify>) {
+        let calls = Arc::new(BlockingLlmCallWitness::default());
         let release = Arc::new(Notify::new());
         let client = BlockAfterFirstMockLlmClient {
             calls: Arc::clone(&calls),
@@ -13437,18 +13473,12 @@ mod tests {
         })
     }
 
-    async fn wait_for_llm_calls(calls: &AtomicUsize, expected: usize, description: &str) {
-        let deadline = tokio::time::Instant::now() + tokio::time::Duration::from_secs(1);
-        loop {
-            if calls.load(AtomicOrdering::SeqCst) >= expected {
-                break;
-            }
-            assert!(
-                tokio::time::Instant::now() < deadline,
-                "{description} did not enter the LLM stream before deadline"
-            );
-            tokio::time::sleep(tokio::time::Duration::from_millis(10)).await;
-        }
+    async fn wait_for_llm_calls(
+        calls: &BlockingLlmCallWitness,
+        expected: usize,
+        description: &str,
+    ) {
+        calls.wait_for(expected, description).await;
     }
 
     async fn wait_for_runtime_unregistered(
@@ -18266,7 +18296,7 @@ mod tests {
     #[tokio::test]
     async fn new_runtime_cleanup_preserves_active_input() {
         let temp = tempfile::tempdir().unwrap();
-        let calls = Arc::new(AtomicUsize::new(0));
+        let calls = Arc::new(BlockingLlmCallWitness::default());
         let release = Arc::new(Notify::new());
         let runtime = make_runtime(temp_factory(&temp), 2);
         runtime.set_default_llm_client(Some(Arc::new(BlockingMockLlmClient {
@@ -20501,7 +20531,7 @@ mod tests {
         assert_eq!(err.code, error::SESSION_BUSY);
         hook.release.notify_waiters();
 
-        tokio::time::timeout(tokio::time::Duration::from_secs(1), running_turn)
+        tokio::time::timeout(TEST_ASYNC_WITNESS_TIMEOUT, running_turn)
             .await
             .expect("pending first turn should finish")
             .expect("turn task should not panic")
@@ -20574,7 +20604,7 @@ mod tests {
         assert_eq!(err.code, error::SESSION_BUSY);
         hook.release.notify_waiters();
 
-        tokio::time::timeout(tokio::time::Duration::from_secs(1), running_turn)
+        tokio::time::timeout(TEST_ASYNC_WITNESS_TIMEOUT, running_turn)
             .await
             .expect("pending first turn should finish")
             .expect("turn task should not panic")
@@ -20662,7 +20692,7 @@ mod tests {
         assert_eq!(err.code, error::SESSION_BUSY);
         hook.release.notify_waiters();
 
-        tokio::time::timeout(tokio::time::Duration::from_secs(1), running_turn)
+        tokio::time::timeout(TEST_ASYNC_WITNESS_TIMEOUT, running_turn)
             .await
             .expect("runtime-routed first turn should finish")
             .expect("turn task should not panic")
@@ -20728,7 +20758,7 @@ mod tests {
         assert_eq!(err.code, error::SESSION_BUSY);
         hook.release.notify_waiters();
 
-        tokio::time::timeout(tokio::time::Duration::from_secs(1), running_turn)
+        tokio::time::timeout(TEST_ASYNC_WITNESS_TIMEOUT, running_turn)
             .await
             .expect("runtime-routed first turn should finish")
             .expect("turn task should not panic")


### PR DESCRIPTION
## Summary

- authorize an exact one-shot predecessor-role declaration on a trusted durable Resume request
- keep mob id, member identity, session id, transcript, and durable state fixed while restamping the target role, comms name, binding, profile labels, callback context, and explicit tooling
- carry the declaration through trusted local and remote-host materialization paths without exposing it on the agent-callable wire
- replace contention-sensitive RPC test polling with retained async witnesses and retained release permits after the mandatory hook and CI reproduced lost-wake timing failures under full workspace concurrency

## Safety contract

- role remains part of durable comms identity
- absent or wrong predecessor declarations fail closed
- any exact live session, including an idle one, is refused
- mob and member identity never migrate
- the declaration applies to one exact Resume request and is not persisted as ambient authority
- forward-only against shared durable state; rollback requires another authorized forward migration or versioned durable state

## Validation

Exact branch head: `3c9637ea2c9fd1a1386036b140bdd29bd39a3198`

- installed mandatory pre-push hook passed in full, including changed-crate Clippy, machine codegen and formal verification, schema/lock/dispatcher gates, 10,370-test unit lane, fast integration lane, explicit cold-restart resume, and e2e-fast
- GitHub CI run `32356131214`: 32/32 jobs green, including all 8 unit shards, Mob 3/3, complement 3/3, TLC, deterministic e2e, Clippy, SDK, WASM, governance, security, and aggregate CI gate
- focused role-migration tests: 5/5
- persisted-member selector ranking: 1/1
- remote-host materialization carrier: 1/1
- closed materialize wire contract: 1/1
- schema, SDK, protocol drift gates: green
- `meerkat-mob` all-target Clippy with warnings denied: green
- focused RPC witness/release tests: 11/11
- `meerkat-rpc` all-target, all-feature Clippy with warnings denied: green

## External merge gates

- MobKit must carry the exact predecessor role into the trusted Resume request against this exact Meerkat SHA
- HomeCore must cold-resume the captured durable member and prove:
  - callback profile resolves as `home-automation`
  - shell and builtins are enabled by the target profile
  - the full post-migration tool-name set is not a strict subset of the captured pre-migration set
  - raw `identity` and encoded `agent_identity` remain distinct and correct
  - role, profile, binding, and comms metadata are restamped while the exact session and transcript are preserved

Do not mark ready or merge until those exact-SHA adopter proofs are recorded.
