### PR TITLE
release: preflight npm package write access

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -381,6 +381,41 @@ jobs:
           echo "BuildBuddy release validation skipped: ${buildbuddy_result}"
           [[ "${cargo_result}" == "success" && "${buildbuddy_result}" == "skipped" ]]
 
+  # Authenticate before any registry job can make an irreversible write. The
+  # same token publishes both npm SDKs, so require live write access to both
+  # package names before Rust crates or the Python SDK begin publishing.
+  registry_credentials_preflight:
+    name: Verify registry publication credentials
+    needs: [require_ci_green]
+    if: >-
+      always() &&
+      needs.require_ci_green.result == 'success' &&
+      (startsWith(github.ref, 'refs/tags/v') ||
+       (github.event_name == 'workflow_dispatch' &&
+        github.event.inputs.publish_release_packages == 'true'))
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout release helpers
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.release_tag != '' && github.event.inputs.release_tag || github.ref }}
+
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: "22"
+
+      - name: Skip npm credentials for the Rust-only alpha lane
+        if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.alpha_crates_only == 'true' }}
+        run: echo "Rust-only alpha publication does not use npm"
+
+      - name: Verify npm identity and package write access
+        if: ${{ github.event_name != 'workflow_dispatch' || github.event.inputs.alpha_crates_only != 'true' }}
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: scripts/release-npm-publish-preflight
+
   # Public-API breaks are allowed in 0.x patch releases and must be DECLARED.
   # This is its own job rather than a step in release_validate_cargo because
   # that job only runs on workflow_dispatch: on a tag push (the primary release
@@ -1111,6 +1146,7 @@ jobs:
       always() &&
       needs.require_ci_green.result == 'success' &&
       needs.release_validate_gate.result == 'success' &&
+      needs.registry_credentials_preflight.result == 'success' &&
       (needs.release_semver_gate.result == 'success' ||
        (github.event_name == 'workflow_dispatch' &&
         github.event.inputs.publish_release_assets_only == 'true' &&
@@ -1119,7 +1155,7 @@ jobs:
       (github.event_name == 'workflow_dispatch' &&
        github.event.inputs.publish_release_packages == 'true' &&
        github.event.inputs.publish_web_sdk_only != 'true'))
-    needs: [require_ci_green, release_validate_gate, release_semver_gate]
+    needs: [require_ci_green, release_validate_gate, release_semver_gate, registry_credentials_preflight]
     runs-on: ubuntu-latest
     timeout-minutes: 180
     steps:
@@ -1204,7 +1240,7 @@ jobs:
             exit 0
           fi
           npm install --ignore-scripts
-          npm config set //registry.npmjs.org/:_authToken ${NODE_AUTH_TOKEN}
+          npm config set //registry.npmjs.org/:_authToken "${NODE_AUTH_TOKEN}"
           npm run build
           PACKFILE="$(npm pack | tail -n 1)"
           SMOKE_DIR="$(mktemp -d)"
@@ -1225,6 +1261,7 @@ jobs:
     if: >-
       always() &&
       needs.require_ci_green.result == 'success' &&
+      needs.registry_credentials_preflight.result == 'success' &&
       (needs.build_web_sdk_package.result == 'success' ||
        (github.event_name == 'workflow_dispatch' &&
         github.event.inputs.web_sdk_artifact_run_id != '')) &&
@@ -1232,7 +1269,7 @@ jobs:
        (github.event_name == 'workflow_dispatch' &&
         github.event.inputs.publish_release_packages == 'true' &&
         github.event.inputs.alpha_crates_only != 'true'))
-    needs: [require_ci_green, build_web_sdk_package]
+    needs: [require_ci_green, build_web_sdk_package, registry_credentials_preflight]
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:

--- a/Makefile
+++ b/Makefile
@@ -665,6 +665,7 @@ regen-schemas:
 
 release-doctor:
 	@echo "$(GREEN)Checking release environment...$(NC)"
+	@scripts/test-release-npm-publish-preflight.sh
 	@scripts/release-doctor
 
 # Semver-break detection (M3 policy: exact-pin + break detection). 0.x patch

--- a/meerkat-rpc/src/session_runtime.rs
+++ b/meerkat-rpc/src/session_runtime.rs
@@ -13528,17 +13528,7 @@ mod tests {
                 .await
         });
 
-        let deadline = tokio::time::Instant::now() + tokio::time::Duration::from_secs(1);
-        loop {
-            if calls.load(AtomicOrdering::SeqCst) >= 1 {
-                break;
-            }
-            assert!(
-                tokio::time::Instant::now() < deadline,
-                "blocking turn did not enter the LLM stream before deadline"
-            );
-            tokio::time::sleep(tokio::time::Duration::from_millis(10)).await;
-        }
+        wait_for_llm_calls(&calls, 1, "blocking turn").await;
 
         (session_id, turn, release)
     }
@@ -16610,17 +16600,7 @@ mod tests {
                 .await
         });
 
-        let deadline = tokio::time::Instant::now() + tokio::time::Duration::from_secs(1);
-        loop {
-            if calls.load(AtomicOrdering::SeqCst) > 0 {
-                break;
-            }
-            assert!(
-                tokio::time::Instant::now() < deadline,
-                "session did not start the service-side turn before deadline"
-            );
-            tokio::time::sleep(tokio::time::Duration::from_millis(10)).await;
-        }
+        wait_for_llm_calls(&calls, 1, "service-side session turn").await;
 
         let append_req = AppendSystemContextRequest {
             content: meerkat_core::lifecycle::run_primitive::CoreRenderable::text(
@@ -16975,17 +16955,7 @@ mod tests {
         });
 
         // Wait until the first turn is definitely running.
-        let deadline = tokio::time::Instant::now() + tokio::time::Duration::from_secs(1);
-        loop {
-            if calls.load(AtomicOrdering::SeqCst) > 0 {
-                break;
-            }
-            assert!(
-                tokio::time::Instant::now() < deadline,
-                "session did not start the service-side turn before deadline"
-            );
-            tokio::time::sleep(tokio::time::Duration::from_millis(10)).await;
-        }
+        wait_for_llm_calls(&calls, 1, "service-side session turn").await;
 
         // Try to start a second turn
         let (event_tx2, _rx2) = mpsc::channel(100);
@@ -17010,7 +16980,7 @@ mod tests {
             err.code
         );
 
-        release.notify_waiters();
+        release.notify_one();
         turn_handle
             .await
             .unwrap()
@@ -18381,8 +18351,8 @@ mod tests {
             "new-runtime cleanup must not unregister a session with active runtime input"
         );
 
-        release.notify_waiters();
-        let result = tokio::time::timeout(tokio::time::Duration::from_secs(1), active_turn)
+        release.notify_one();
+        let result = tokio::time::timeout(TEST_ASYNC_WITNESS_TIMEOUT, active_turn)
             .await
             .expect("active input should complete after release");
         result
@@ -20004,18 +19974,8 @@ mod tests {
                 .await
         });
 
-        let deadline = tokio::time::Instant::now() + tokio::time::Duration::from_secs(1);
-        loop {
-            if calls.load(AtomicOrdering::SeqCst) >= 1 {
-                break;
-            }
-            assert!(
-                tokio::time::Instant::now() < deadline,
-                "initial turn did not enter the LLM stream before deadline"
-            );
-            tokio::time::sleep(tokio::time::Duration::from_millis(10)).await;
-        }
-        release.notify_waiters();
+        wait_for_llm_calls(&calls, 1, "initial turn").await;
+        release.notify_one();
         initial_turn
             .await
             .expect("initial turn task")
@@ -20023,7 +19983,7 @@ mod tests {
 
         let service = runtime.session_service();
         let session_for_turn = session_id.clone();
-        let direct_turn = tokio::spawn(async move {
+        let mut direct_turn = tokio::spawn(async move {
             service
                 .start_turn(
                     &session_for_turn,
@@ -20032,20 +19992,12 @@ mod tests {
                 .await
         });
 
-        let deadline = tokio::time::Instant::now() + tokio::time::Duration::from_secs(1);
-        loop {
-            if calls.load(AtomicOrdering::SeqCst) >= 2 {
-                break;
-            }
-            if direct_turn.is_finished() {
-                let result = direct_turn.await.expect("direct turn task");
+        tokio::select! {
+            () = calls.wait_for(2, "direct service turn") => {}
+            result = &mut direct_turn => {
+                let result = result.expect("direct turn task");
                 panic!("direct service turn finished before reaching LLM stream: {result:?}");
             }
-            assert!(
-                tokio::time::Instant::now() < deadline,
-                "direct service turn did not enter the LLM stream before deadline"
-            );
-            tokio::time::sleep(tokio::time::Duration::from_millis(10)).await;
         }
 
         let blocked = runtime
@@ -20059,7 +20011,7 @@ mod tests {
             "rpc create should be blocked by mob/direct running turn: {blocked:?}"
         );
 
-        release.notify_waiters();
+        release.notify_one();
         direct_turn
             .await
             .expect("direct turn task")
@@ -20124,7 +20076,7 @@ mod tests {
             "RPC create should remain blocked while first turn is running: {blocked:?}"
         );
 
-        release.notify_waiters();
+        release.notify_one();
         pending_first_turn
             .await
             .expect("pending first turn task")
@@ -20468,7 +20420,7 @@ mod tests {
             .interrupt(&session_id)
             .await
             .expect("interrupt should reach promoting live turn");
-        let interrupted = tokio::time::timeout(tokio::time::Duration::from_secs(1), running_turn)
+        let interrupted = tokio::time::timeout(TEST_ASYNC_WITNESS_TIMEOUT, running_turn)
             .await
             .expect("promoting first turn should finish after interrupt")
             .expect("turn task should not panic")
@@ -20817,7 +20769,7 @@ mod tests {
         assert_eq!(err.code, error::SESSION_BUSY);
         hook.release.notify_waiters();
 
-        tokio::time::timeout(tokio::time::Duration::from_secs(1), running_turn)
+        tokio::time::timeout(TEST_ASYNC_WITNESS_TIMEOUT, running_turn)
             .await
             .expect("pending apply should finish")
             .expect("apply task should not panic")
@@ -22760,7 +22712,7 @@ mod tests {
             "cancelled caller must not release capacity while service turn is still running: {blocked:?}"
         );
 
-        release.notify_waiters();
+        release.notify_one();
         let deadline = tokio::time::Instant::now() + tokio::time::Duration::from_secs(2);
         loop {
             match runtime
@@ -22851,7 +22803,7 @@ mod tests {
             .expect("stored candidate metadata after rejected start");
         assert_eq!(meta.model, "claude-sonnet-4-5");
         assert_eq!(meta.provider, meerkat_core::Provider::Anthropic);
-        release.notify_waiters();
+        release.notify_one();
         blocking_turn
             .await
             .expect("blocking turn task")
@@ -22893,7 +22845,7 @@ mod tests {
             .expect("stored candidate metadata after rejected apply");
         assert_eq!(meta.model, "claude-sonnet-4-5");
         assert_eq!(meta.provider, meerkat_core::Provider::Anthropic);
-        release.notify_waiters();
+        release.notify_one();
         blocking_turn
             .await
             .expect("blocking turn task")

--- a/meerkat-rpc/src/session_runtime.rs
+++ b/meerkat-rpc/src/session_runtime.rs
@@ -11999,8 +11999,43 @@ mod tests {
         }
     }
 
+    const TEST_ASYNC_WITNESS_TIMEOUT: tokio::time::Duration = tokio::time::Duration::from_secs(10);
+
+    #[derive(Default)]
+    struct BlockingLlmCallWitness {
+        calls: AtomicUsize,
+        entered: Notify,
+    }
+
+    impl BlockingLlmCallWitness {
+        fn load(&self, ordering: AtomicOrdering) -> usize {
+            self.calls.load(ordering)
+        }
+
+        fn record(&self) -> usize {
+            let previous = self.calls.fetch_add(1, AtomicOrdering::SeqCst);
+            // `notify_one` retains a permit when the observer has not reached
+            // `notified()` yet, so the test cannot lose the exact stream-entry
+            // witness between its count check and await.
+            self.entered.notify_one();
+            previous
+        }
+
+        async fn wait_for(&self, expected: usize, description: &str) {
+            tokio::time::timeout(TEST_ASYNC_WITNESS_TIMEOUT, async {
+                while self.load(AtomicOrdering::SeqCst) < expected {
+                    self.entered.notified().await;
+                }
+            })
+            .await
+            .unwrap_or_else(|_| {
+                panic!("{description} did not enter the LLM stream before deadline")
+            });
+        }
+    }
+
     struct BlockingMockLlmClient {
-        calls: Arc<AtomicUsize>,
+        calls: Arc<BlockingLlmCallWitness>,
         release: Arc<Notify>,
     }
 
@@ -12977,7 +13012,7 @@ mod tests {
             let calls = Arc::clone(&self.calls);
             let release = Arc::clone(&self.release);
             Box::pin(async_stream::stream! {
-                calls.fetch_add(1, AtomicOrdering::SeqCst);
+                calls.record();
                 release.notified().await;
                 yield Ok(meerkat_client::LlmEvent::TextDelta {
                     delta: "Blocked response".to_string(),
@@ -13008,7 +13043,7 @@ mod tests {
     }
 
     struct BlockAfterFirstMockLlmClient {
-        calls: Arc<AtomicUsize>,
+        calls: Arc<BlockingLlmCallWitness>,
         release: Arc<Notify>,
     }
 
@@ -13027,7 +13062,7 @@ mod tests {
         ) -> Pin<
             Box<dyn futures::Stream<Item = Result<meerkat_client::LlmEvent, LlmError>> + Send + 'a>,
         > {
-            let call = self.calls.fetch_add(1, AtomicOrdering::SeqCst);
+            let call = self.calls.record();
             let release = Arc::clone(&self.release);
             Box::pin(async_stream::stream! {
                 if call > 0 {
@@ -13298,8 +13333,8 @@ mod tests {
         }
     }
 
-    fn blocking_build_config() -> (AgentBuildConfig, Arc<AtomicUsize>, Arc<Notify>) {
-        let calls = Arc::new(AtomicUsize::new(0));
+    fn blocking_build_config() -> (AgentBuildConfig, Arc<BlockingLlmCallWitness>, Arc<Notify>) {
+        let calls = Arc::new(BlockingLlmCallWitness::default());
         let release = Arc::new(Notify::new());
         let client = BlockingMockLlmClient {
             calls: Arc::clone(&calls),
@@ -13315,8 +13350,9 @@ mod tests {
         )
     }
 
-    fn block_after_first_build_config() -> (AgentBuildConfig, Arc<AtomicUsize>, Arc<Notify>) {
-        let calls = Arc::new(AtomicUsize::new(0));
+    fn block_after_first_build_config()
+    -> (AgentBuildConfig, Arc<BlockingLlmCallWitness>, Arc<Notify>) {
+        let calls = Arc::new(BlockingLlmCallWitness::default());
         let release = Arc::new(Notify::new());
         let client = BlockAfterFirstMockLlmClient {
             calls: Arc::clone(&calls),
@@ -13437,18 +13473,12 @@ mod tests {
         })
     }
 
-    async fn wait_for_llm_calls(calls: &AtomicUsize, expected: usize, description: &str) {
-        let deadline = tokio::time::Instant::now() + tokio::time::Duration::from_secs(1);
-        loop {
-            if calls.load(AtomicOrdering::SeqCst) >= expected {
-                break;
-            }
-            assert!(
-                tokio::time::Instant::now() < deadline,
-                "{description} did not enter the LLM stream before deadline"
-            );
-            tokio::time::sleep(tokio::time::Duration::from_millis(10)).await;
-        }
+    async fn wait_for_llm_calls(
+        calls: &BlockingLlmCallWitness,
+        expected: usize,
+        description: &str,
+    ) {
+        calls.wait_for(expected, description).await;
     }
 
     async fn wait_for_runtime_unregistered(
@@ -18266,7 +18296,7 @@ mod tests {
     #[tokio::test]
     async fn new_runtime_cleanup_preserves_active_input() {
         let temp = tempfile::tempdir().unwrap();
-        let calls = Arc::new(AtomicUsize::new(0));
+        let calls = Arc::new(BlockingLlmCallWitness::default());
         let release = Arc::new(Notify::new());
         let runtime = make_runtime(temp_factory(&temp), 2);
         runtime.set_default_llm_client(Some(Arc::new(BlockingMockLlmClient {
@@ -20501,7 +20531,7 @@ mod tests {
         assert_eq!(err.code, error::SESSION_BUSY);
         hook.release.notify_waiters();
 
-        tokio::time::timeout(tokio::time::Duration::from_secs(1), running_turn)
+        tokio::time::timeout(TEST_ASYNC_WITNESS_TIMEOUT, running_turn)
             .await
             .expect("pending first turn should finish")
             .expect("turn task should not panic")
@@ -20574,7 +20604,7 @@ mod tests {
         assert_eq!(err.code, error::SESSION_BUSY);
         hook.release.notify_waiters();
 
-        tokio::time::timeout(tokio::time::Duration::from_secs(1), running_turn)
+        tokio::time::timeout(TEST_ASYNC_WITNESS_TIMEOUT, running_turn)
             .await
             .expect("pending first turn should finish")
             .expect("turn task should not panic")
@@ -20662,7 +20692,7 @@ mod tests {
         assert_eq!(err.code, error::SESSION_BUSY);
         hook.release.notify_waiters();
 
-        tokio::time::timeout(tokio::time::Duration::from_secs(1), running_turn)
+        tokio::time::timeout(TEST_ASYNC_WITNESS_TIMEOUT, running_turn)
             .await
             .expect("runtime-routed first turn should finish")
             .expect("turn task should not panic")
@@ -20728,7 +20758,7 @@ mod tests {
         assert_eq!(err.code, error::SESSION_BUSY);
         hook.release.notify_waiters();
 
-        tokio::time::timeout(tokio::time::Duration::from_secs(1), running_turn)
+        tokio::time::timeout(TEST_ASYNC_WITNESS_TIMEOUT, running_turn)
             .await
             .expect("runtime-routed first turn should finish")
             .expect("turn task should not panic")

--- a/meerkat-runtime/src/meerkat_machine_tests.rs
+++ b/meerkat-runtime/src/meerkat_machine_tests.rs
@@ -44386,6 +44386,48 @@ impl CoreExecutor for HealthProbeNoopExecutor {
     }
 }
 
+/// Executor whose first apply stays live until the test releases it.
+///
+/// Health-census tests that inspect an accepted input's ledger row need a
+/// witnessed in-flight turn. A noop executor can finish and remove the row
+/// before the test reacquires the driver, making scheduler speed decide
+/// whether the fixture ever represented the claimed state.
+struct HealthProbeBlockingExecutor {
+    apply_started: Arc<Notify>,
+    apply_release: Arc<Notify>,
+}
+
+#[async_trait::async_trait]
+impl CoreExecutor for HealthProbeBlockingExecutor {
+    async fn apply(
+        &mut self,
+        run_id: RunId,
+        primitive: RunPrimitive,
+    ) -> Result<CoreApplyOutput, CoreExecutorError> {
+        self.apply_started.notify_one();
+        self.apply_release.notified().await;
+        Ok(CoreApplyOutput::with_untyped_snapshot(
+            RunBoundaryReceiptDraft {
+                run_id,
+                boundary: RunApplyBoundary::RunStart,
+                contributing_input_ids: primitive.contributing_input_ids().to_vec(),
+                conversation_digest: None,
+                message_count: 0,
+            },
+            None,
+            None,
+        ))
+    }
+
+    async fn cancel_after_boundary(&mut self, _reason: String) -> Result<(), CoreExecutorError> {
+        Ok(())
+    }
+
+    async fn stop_runtime_executor(&mut self, _reason: String) -> Result<(), CoreExecutorError> {
+        Ok(())
+    }
+}
+
 fn persistent_health_probe_machine() -> Arc<MeerkatMachine> {
     let store: Arc<dyn crate::store::RuntimeStore> =
         Arc::new(crate::store::InMemoryRuntimeStore::new());
@@ -44998,12 +45040,20 @@ async fn parked_queued_input_session_count_sees_the_five_day_wedge_shape() {
     }
     let machine = persistent_health_probe_machine();
     let session_id = SessionId::new();
+    let apply_started = Arc::new(Notify::new());
+    let apply_release = Arc::new(Notify::new());
     machine
         .prepare_bindings(session_id.clone())
         .await
         .expect("bindings should prepare");
     machine
-        .ensure_session_with_executor(session_id.clone(), Box::new(HealthProbeNoopExecutor))
+        .ensure_session_with_executor(
+            session_id.clone(),
+            Box::new(HealthProbeBlockingExecutor {
+                apply_started: Arc::clone(&apply_started),
+                apply_release: Arc::clone(&apply_release),
+            }),
+        )
         .await
         .expect("runtime executor registration should succeed");
 
@@ -45021,6 +45071,9 @@ async fn parked_queued_input_session_count_sees_the_five_day_wedge_shape() {
         .await
         .expect("input should be accepted");
     assert!(matches!(accept_outcome, AcceptOutcome::Accepted { .. }));
+    tokio::time::timeout(Duration::from_secs(5), apply_started.notified())
+        .await
+        .expect("the accepted input should reach executor apply");
     {
         let sessions = machine.sessions.read().await;
         let entry = sessions.get(&session_id).expect("registered session entry");
@@ -45049,6 +45102,7 @@ async fn parked_queued_input_session_count_sees_the_five_day_wedge_shape() {
             );
         }
     }
+    apply_release.notify_one();
     tokio::time::timeout(
         Duration::from_secs(5),
         completion_handle

--- a/scripts/release-doctor
+++ b/scripts/release-doctor
@@ -34,6 +34,15 @@ bool_enabled() {
   esac
 }
 
+workflow_job() {
+  local job_name="$1"
+  awk -v header="  ${job_name}:" '
+    $0 == header { in_job = 1 }
+    in_job && $0 != header && /^  [[:alnum:]_-]+:/ { exit }
+    in_job { print }
+  ' .github/workflows/release.yml
+}
+
 if command -v gh >/dev/null 2>&1; then
   pass "GitHub CLI is installed"
   if gh auth status --hostname github.com >/dev/null 2>&1; then
@@ -128,6 +137,20 @@ if grep -Fq 'build_web_sdk_package:' .github/workflows/release.yml &&
   pass "Release workflow builds @rkat/web once as an artifact before npm publishing"
 else
   bad "Release workflow does not publish @rkat/web from a prebuilt package artifact"
+fi
+
+npm_preflight_job="$(workflow_job registry_credentials_preflight)"
+npm_registry_publish_job="$(workflow_job publish_registries)"
+npm_web_publish_job="$(workflow_job publish_web_sdk)"
+if grep -Fq 'scripts/release-npm-publish-preflight' <<<"${npm_preflight_job}" &&
+  grep -Fq 'alpha_crates_only' <<<"${npm_preflight_job}" &&
+  grep -Eq '^    needs: \[.*registry_credentials_preflight.*\]$' <<<"${npm_registry_publish_job}" &&
+  grep -Fq "needs.registry_credentials_preflight.result == 'success'" <<<"${npm_registry_publish_job}" &&
+  grep -Eq '^    needs: \[.*registry_credentials_preflight.*\]$' <<<"${npm_web_publish_job}" &&
+  grep -Fq "needs.registry_credentials_preflight.result == 'success'" <<<"${npm_web_publish_job}"; then
+  pass "Release workflow verifies npm authentication and package write access before registry publication"
+else
+  bad "Release workflow must gate both npm publication jobs on the live npm credential preflight"
 fi
 
 web_release_ref_jobs="$(

--- a/scripts/release-npm-publish-preflight
+++ b/scripts/release-npm-publish-preflight
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ -z "${NODE_AUTH_TOKEN:-}" ]]; then
+  echo "NODE_AUTH_TOKEN is required for npm publication preflight" >&2
+  exit 1
+fi
+
+for command_name in npm node; do
+  if ! command -v "${command_name}" >/dev/null 2>&1; then
+    echo "${command_name} is required for npm publication preflight" >&2
+    exit 1
+  fi
+done
+
+registry="${NPM_REGISTRY_URL:-https://registry.npmjs.org/}"
+auth_config_key="$(
+  # The JavaScript template literals are intentionally protected from Bash.
+  # shellcheck disable=SC2016
+  node -e '
+    const registry = new URL(process.argv[1]);
+    const path = registry.pathname.replace(/^\/+|\/+$/g, "");
+    process.stdout.write(`//${registry.host}/${path ? `${path}/` : ""}`);
+  ' "${registry}"
+)"
+
+umask 077
+preflight_dir="$(mktemp -d "${TMPDIR:-/tmp}/meerkat-npm-preflight.XXXXXX")"
+trap 'rm -rf "${preflight_dir}"' EXIT
+
+npm_config="${preflight_dir}/npmrc"
+permissions_json="${preflight_dir}/permissions.json"
+printf 'registry=%s\n%s:_authToken=%s\n' \
+  "${registry}" \
+  "${auth_config_key}" \
+  "${NODE_AUTH_TOKEN}" >"${npm_config}"
+export NPM_CONFIG_USERCONFIG="${npm_config}"
+
+actor="$(npm whoami --registry="${registry}")"
+if [[ -z "${actor}" ]]; then
+  echo "npm authentication succeeded without returning an account identity" >&2
+  exit 1
+fi
+
+npm access list packages "${actor}" --json --registry="${registry}" >"${permissions_json}"
+
+node - "${permissions_json}" '@rkat/sdk' '@rkat/web' <<'NODE'
+const fs = require('node:fs');
+
+const [permissionsPath, ...requiredPackages] = process.argv.slice(2);
+let permissions;
+try {
+  permissions = JSON.parse(fs.readFileSync(permissionsPath, 'utf8'));
+} catch (error) {
+  console.error(`npm package-access response was not valid JSON: ${error.message}`);
+  process.exit(1);
+}
+
+if (permissions === null || Array.isArray(permissions) || typeof permissions !== 'object') {
+  console.error('npm package-access response must be a package-to-permission object');
+  process.exit(1);
+}
+
+let failed = false;
+for (const packageName of requiredPackages) {
+  const permission = permissions[packageName];
+  if (permission !== 'read-write') {
+    console.error(`${packageName} npm permission is ${permission ?? 'missing'}; read-write is required`);
+    failed = true;
+  }
+}
+
+if (failed) {
+  process.exit(1);
+}
+NODE
+
+printf 'npm publication preflight passed for %s: @rkat/sdk and @rkat/web are read-write\n' "${actor}"

--- a/scripts/test-release-npm-publish-preflight.sh
+++ b/scripts/test-release-npm-publish-preflight.sh
@@ -1,0 +1,158 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+root="$(git rev-parse --show-toplevel)"
+helper="${root}/scripts/release-npm-publish-preflight"
+test_dir="$(mktemp -d "${TMPDIR:-/tmp}/meerkat-npm-preflight-test.XXXXXX")"
+trap 'rm -rf "${test_dir}"' EXIT
+
+fake_bin="${test_dir}/bin"
+mkdir -p "${fake_bin}"
+
+cat >"${fake_bin}/npm" <<'FAKE_NPM'
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ -z "${NPM_CONFIG_USERCONFIG:-}" || ! -f "${NPM_CONFIG_USERCONFIG}" ]]; then
+  echo "fake npm did not receive a temporary user config" >&2
+  exit 90
+fi
+if ! grep -Fq "${EXPECTED_NODE_AUTH_TOKEN}" "${NPM_CONFIG_USERCONFIG}"; then
+  echo "temporary user config does not contain the expected token" >&2
+  exit 91
+fi
+
+printf '%s\n' "$*" >>"${FAKE_NPM_LOG}"
+
+case "${1:-}" in
+  whoami)
+    if [[ "${FAKE_NPM_WHOAMI_MODE:-success}" == "failure" ]]; then
+      echo "authentication failed" >&2
+      exit 2
+    fi
+    printf '%s\n' "${FAKE_NPM_ACTOR:-release-owner}"
+    ;;
+  access)
+    if [[ "${FAKE_NPM_ACCESS_MODE:-success}" == "failure" ]]; then
+      echo "access lookup failed" >&2
+      exit 3
+    fi
+    if [[ -n "${FAKE_NPM_ACCESS_JSON+x}" ]]; then
+      printf '%s\n' "${FAKE_NPM_ACCESS_JSON}"
+    else
+      printf '%s\n' '{"@rkat/sdk":"read-write","@rkat/web":"read-write"}'
+    fi
+    ;;
+  *)
+    echo "unexpected fake npm command: $*" >&2
+    exit 92
+    ;;
+esac
+FAKE_NPM
+chmod +x "${fake_bin}/npm"
+
+secret='npm_test_secret_must_not_leak'
+run_output="${test_dir}/output"
+fake_log="${test_dir}/npm.log"
+
+assert_secret_absent() {
+  if grep -Fq "${secret}" "${run_output}" "${fake_log}" 2>/dev/null; then
+    echo "npm token leaked into command output or the npm argument log" >&2
+    exit 1
+  fi
+}
+
+run_case() {
+  expected="$1"
+  shift
+  : >"${run_output}"
+  : >"${fake_log}"
+
+  set +e
+  env \
+    PATH="${fake_bin}:${PATH}" \
+    NODE_AUTH_TOKEN="${secret}" \
+    EXPECTED_NODE_AUTH_TOKEN="${secret}" \
+    FAKE_NPM_LOG="${fake_log}" \
+    "$@" \
+    "${helper}" >"${run_output}" 2>&1
+  status=$?
+  set -e
+
+  if [[ "${expected}" == "success" && ${status} -ne 0 ]]; then
+    echo "expected npm preflight success, got exit ${status}" >&2
+    cat "${run_output}" >&2
+    exit 1
+  fi
+  if [[ "${expected}" == "failure" && ${status} -eq 0 ]]; then
+    echo "expected npm preflight failure" >&2
+    cat "${run_output}" >&2
+    exit 1
+  fi
+  assert_secret_absent
+}
+
+: >"${run_output}"
+: >"${fake_log}"
+set +e
+env -u NODE_AUTH_TOKEN \
+  PATH="${fake_bin}:${PATH}" \
+  EXPECTED_NODE_AUTH_TOKEN="${secret}" \
+  FAKE_NPM_LOG="${fake_log}" \
+  "${helper}" >"${run_output}" 2>&1
+missing_token_status=$?
+set -e
+if [[ ${missing_token_status} -eq 0 ]]; then
+  echo "missing NODE_AUTH_TOKEN unexpectedly passed" >&2
+  exit 1
+fi
+if [[ -s "${fake_log}" ]]; then
+  echo "missing-token case invoked npm before failing" >&2
+  exit 1
+fi
+assert_secret_absent
+
+run_case failure FAKE_NPM_WHOAMI_MODE=failure
+run_case failure FAKE_NPM_ACCESS_MODE=failure
+run_case failure FAKE_NPM_ACCESS_JSON='{"@rkat/sdk":"read-only","@rkat/web":"read-write"}'
+run_case failure FAKE_NPM_ACCESS_JSON='{"@rkat/sdk":"read-write"}'
+run_case failure FAKE_NPM_ACCESS_JSON='{not-json'
+run_case success FAKE_NPM_ACCESS_JSON='{"@rkat/sdk":"read-write","@rkat/web":"read-write"}'
+
+python3 - "${root}/.github/workflows/release.yml" <<'PY'
+import pathlib
+import re
+import sys
+
+workflow = pathlib.Path(sys.argv[1]).read_text()
+
+def job(name: str) -> str:
+    match = re.search(
+        rf"(?ms)^  {re.escape(name)}:\n(.*?)(?=^  [A-Za-z0-9_-]+:\n|\Z)",
+        workflow,
+    )
+    if match is None:
+        raise SystemExit(f"release workflow is missing job {name}")
+    return match.group(0)
+
+preflight = job("registry_credentials_preflight")
+registries = job("publish_registries")
+web = job("publish_web_sdk")
+
+assert "scripts/release-npm-publish-preflight" in preflight
+assert "alpha_crates_only" in preflight
+assert re.search(r"(?m)^    needs: \[require_ci_green\]$", preflight)
+assert "needs.require_ci_green.result == 'success'" in preflight
+for name, body in (("publish_registries", registries), ("publish_web_sdk", web)):
+    needs = re.search(r"(?m)^    needs: \[(.*?)\]$", body)
+    assert needs is not None, f"{name} does not have an inline needs list"
+    dependencies = {dependency.strip() for dependency in needs.group(1).split(",")}
+    assert "registry_credentials_preflight" in dependencies, (
+        f"{name} does not need the credential preflight"
+    )
+    assert "needs.registry_credentials_preflight.result == 'success'" in body, (
+        f"{name} does not require a successful credential preflight"
+    )
+PY
+
+printf 'npm publication preflight tests passed\n'


### PR DESCRIPTION
## Summary

- add a live npm publication preflight immediately after exact-main CI
- require the release token to authenticate and hold `read-write` access to both `@rkat/sdk` and `@rkat/web`
- gate both registry-publishing jobs on the successful preflight so crates.io and PyPI cannot publish before npm failure is known
- preserve the Rust-only alpha lane without requiring npm credentials
- keep the token in a mode-restricted temporary npm config rather than command arguments or logs
- add failure-path/selftests and a release-doctor ratchet for the workflow dependency

## Why

Meerkat 0.8.24 published all 42 Rust crates and the Python SDK before the shared npm token failed at the final package steps. The release therefore became partially published. This change makes npm identity and both package-write permissions an early read-only gate before any registry write begins.

## Follow-up test hardening

- make the queued-input census test hold the accepted input at a deterministic executor barrier before asserting the live ledger row and DSL phase-key correspondence
- replace one-second RPC scheduling guesses with signal-driven witnesses already validated on PR 976
- production runtime behavior is unchanged by these test-only follow-ups

## Validation

- `scripts/test-release-npm-publish-preflight.sh`
- `make release-doctor` - 20 pass, 2 expected local warnings, 0 fail
- `actionlint .github/workflows/release.yml`
- `shellcheck scripts/release-npm-publish-preflight scripts/test-release-npm-publish-preflight.sh`
- exact queued-input census test - 1/1 and 50/50 green
- mandatory detached pre-push hook at `626c2bd8c` - full pass, including changed-crate Clippy, workspace unit and integration tests, cold restart, and e2e-fast
- `git diff --check`
