### PR TITLE
fix(mob): expose applied role migration witness

### DIFF
--- a/meerkat-mob/src/build.rs
+++ b/meerkat-mob/src/build.rs
@@ -454,6 +454,22 @@ fn apply_resumed_session_metadata_with_role_migration(
         resume_from_role,
     )?;
     if role_migrated {
+        if let (Some(declared_predecessor_role), Some((_, requested_role, current_member))) = (
+            resume_from_role,
+            split_member_comms_name(&current_comms_name),
+        ) {
+            let member = config
+                .mob_member_binding
+                .as_ref()
+                .map(|binding| binding.member.as_str())
+                .unwrap_or(current_member);
+            tracing::info!(
+                member,
+                from_role = declared_predecessor_role.as_str(),
+                to_role = requested_role,
+                "applied declared member role migration"
+            );
+        }
         // AgentFactory performs its own generic resume projection after this
         // mob-specific admission. Fence the two identity projections that
         // must stay current so durable metadata cannot overwrite the admitted
@@ -3718,6 +3734,27 @@ mod tests {
                 .map(String::as_str),
             Some("home-automation"),
             "peer metadata must be restamped to the current durable role"
+        );
+    }
+
+    #[test]
+    fn consumed_role_migration_declaration_is_inert_after_the_restamp() {
+        let (mut config, mut metadata) = role_migration_fixture();
+        metadata.comms_name = config.comms_name.clone();
+        metadata.mob_member_binding = config.mob_member_binding.clone();
+        metadata.peer_meta = Some(PeerMeta::default().with_label("role", "home-automation"));
+
+        let expected_comms_name = config.comms_name.clone();
+        let expected_binding = config.mob_member_binding.clone();
+        let declared = ProfileName::from("domain");
+        apply_resumed_session_metadata_with_role_migration(&mut config, &metadata, Some(&declared))
+            .expect("an already-consumed predecessor declaration must be inert");
+
+        assert_eq!(config.comms_name, expected_comms_name);
+        assert_eq!(config.mob_member_binding, expected_binding);
+        assert!(
+            !config.resume_override_mask.comms_name && !config.resume_override_mask.peer_meta,
+            "a declaration must not authorize another restamp once durable and current roles match"
         );
     }
 


### PR DESCRIPTION
## Summary

- emit a direct INFO witness only when a declared durable member-role migration is actually applied
- include the exact member identity, predecessor role, and current role in that witness
- pin that a stale repeated declaration is inert after the durable restamp and does not rearm comms metadata overrides

## Why

MobKit exposes a separate per-boot ARMED witness when a trusted host supplies a declaration. HomeCore acceptance needs to distinguish that declaration being present from Meerkat actually applying the one-shot restamp. On activation N the APPLIED witness must appear; on N+1 the same declaration remains inert because the stored role already matches the current role.

## Validation

- six focused role-migration tests passed before the rebase
- targeted `meerkat-mob` Clippy with warnings denied passed
- mandatory full pre-push hook passed on exact SHA `e74ce13386a0240f518b5c6d6b913fa15a04d233`, including machine/TLC verification, workspace libraries and integration tests, cold restart, and e2e-fast
