### PR TITLE
Document WorkGraphStore atomic lock contract

### DIFF
--- a/meerkat-workgraph/src/store.rs
+++ b/meerkat-workgraph/src/store.rs
@@ -129,6 +129,17 @@ pub trait WorkGraphStore: Send + Sync {
         Err(unsupported(self.kind()))
     }
 
+    /// Atomically update one item and its attention bindings under one store
+    /// mutation boundary.
+    ///
+    /// This is a primitive, not a composition hook. Implementations that use
+    /// per-key locks must acquire the complete item-plus-attention key set in
+    /// one deterministic order, validate every expected revision, and apply
+    /// every mutation inline while those guards are held. They must not call
+    /// [`WorkGraphStore::update_item_cas`] (or another public method that
+    /// reacquires any key in that set) from inside the boundary. Async mutexes
+    /// are not reentrant, so the otherwise natural acquire-then-delegate shape
+    /// silently self-deadlocks instead of returning a store error.
     async fn update_item_and_attention_cas(
         &self,
         item: WorkItem,


### PR DESCRIPTION
## Summary

- document `update_item_and_attention_cas` as an atomic store primitive, not a composition hook
- require implementations using per-key locks to acquire the full item-plus-attention key set in deterministic order
- explicitly forbid delegating to public methods that reacquire those keys, because Tokio mutexes are not reentrant and the shape self-deadlocks

## Context

This follows an OB3 production bridge failure where an external `WorkGraphStore` implementation held the combined lock set and then called `update_item_cas`, silently deadlocking. Built-in Meerkat stores were not affected, but the trait contract made the unsafe implementation shape too easy to infer.

## Validation

- mandatory pre-push hook passed in full
- `git diff --check` passed
- docs-only source change; no additional duplicate Cargo lane was run
