### PR TITLE
Document CI rerun context precedence

### DIFF
--- a/docs/reference/build-and-ci.mdx
+++ b/docs/reference/build-and-ci.mdx
@@ -114,6 +114,31 @@ The final top-level gate emits a small attestation that binds a successful
 `main` push to the exact commit SHA, Git tree SHA, workflow run, and workflow
 attempt. Attestations are not emitted for pull requests or failed runs.
 
+## CI Retry And Concurrency
+
+Pull request CI uses one concurrency group per PR with
+`cancel-in-progress: true`. Starting another PR-associated attempt in that
+group automatically cancels the older in-progress attempt, even when nobody
+issues an explicit cancel command. Because the aggregate Cargo and top-level
+CI gates run with `always()`, the cancelled attempt can then publish fresh
+failed gate contexts during teardown.
+
+Treat check-context precedence as part of retry recovery:
+
+1. Preserve the reviewed head commit when approvals or downstream evidence are
+   bound to its exact bytes.
+2. Compare the active step and elapsed time with a successful exact-head run
+   before classifying a slow job as hung.
+3. When a new PR-associated attempt is necessary, expect the automatic
+   cancellation residue. The replacement attempt must reach both aggregate
+   gates so its later results supersede the failures.
+4. Verify the PR's latest `GHA Cargo / Cargo lane gate` and `CI gate` contexts
+   directly. A green shard or successful manual workflow is useful evidence,
+   but it does not by itself prove that the required PR contexts were replaced.
+
+Do not infer mergeability from a workflow's overall conclusion alone. The PR
+rollup's latest result for each required context name is authoritative.
+
 ## Nightly Lanes
 
 Expensive or low-churn coverage runs daily and on demand on GitHub-hosted


### PR DESCRIPTION
## Summary

- document that same-PR CI reruns share a concurrency group with automatic cancellation enabled
- explain that an implicit cancellation can publish fresh failed aggregate contexts
- define exact-head, elapsed-time, and latest-context checks for bounded retry recovery

## Context

This records the failure mode observed while recovering PR #984: starting a replacement PR-associated attempt automatically cancelled the stuck attempt, whose `always()` aggregate gates then emitted new failures. The replacement attempt must reach later successful `GHA Cargo / Cargo lane gate` and `CI gate` contexts before mergeability is restored.

## Validation

- mandatory pre-push hook passed in full
- `git diff --check` passed
- docs-only change; no additional manual Cargo lane was run
