### PR TITLE
Bound hung CI unit tests by name

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -5,6 +5,22 @@
 # Turbo-S live-smoke cohort is a Bazel sh_test suite, so its serialization and
 # retry policy belongs to scripts/buildbuddy-bazel-poc rather than here.
 
+[profile.ci-unit]
+# CI unit shards normally finish in a few minutes total. Bound any single test
+# that stops making progress so nextest reports its name instead of leaving an
+# anonymous shard running until a human cancels the workflow. Integration and
+# e2e lanes intentionally do not select this profile.
+inherits = "default"
+slow-timeout = { period = "60s", terminate-after = 4 }
+
+[[profile.ci-unit.overrides]]
+# This workflow-style xtask test performs nested machine-authority compilation.
+# Its measured healthy runtime is about 4.5 minutes on GitHub-hosted runners,
+# so give only this exact case additional headroom without weakening the unit
+# lane's general four-minute attribution bound.
+filter = 'test(=machines::tests::machine_workflow_red_ok_detects_missing_and_stale_generated_artifacts)'
+slow-timeout = { period = "60s", terminate-after = 8 }
+
 [profile.fast]
 # Cargo's default fast lane: unit + integration-fast, with dedicated e2e lane
 # wrappers left behind explicit `cargo e2e-*` aliases.

--- a/scripts/ci-nextest-archive.sh
+++ b/scripts/ci-nextest-archive.sh
@@ -24,6 +24,7 @@ profile=default
 case "$family" in
   unit)
     cargo_args=(--workspace --lib)
+    profile=ci-unit
     ;;
   int-heavy)
     cargo_args=(-p meerkat-integration-tests --tests --profile fast)
@@ -116,8 +117,8 @@ case "${1:-}" in
       --final-status-level fail
       --partition "$partition"
     )
-    if [[ "$profile" == fast ]]; then
-      run_args+=(--profile fast)
+    if [[ "$profile" != default ]]; then
+      run_args+=(--profile "$profile")
     fi
     MEERKAT_WORKSPACE_ROOT="$ROOT" "$NEXTEST_BIN" "${run_args[@]}"
     ;;

--- a/scripts/test-ci-nextest-archive.sh
+++ b/scripts/test-ci-nextest-archive.sh
@@ -92,8 +92,13 @@ while IFS= read -r command; do
 done < <(grep '^nextest ' "$LOG")
 
 unit_run="$(grep '^nextest ' "$LOG" | head -n 1)"
-[[ "$unit_run" != *' <--profile> <fast>'* ]] || {
-  echo "unit archive run unexpectedly selected the fast profile" >&2
+[[ "$unit_run" == *' <--profile> <ci-unit>'* ]] || {
+  echo "unit archive run omitted the bounded ci-unit profile" >&2
+  exit 1
+}
+ci_unit_run_count="$(grep '^nextest ' "$LOG" | grep -c -- '<--profile> <ci-unit>')"
+[[ "$ci_unit_run_count" == 1 ]] || {
+  echo "expected one ci-unit archive run, got ${ci_unit_run_count}" >&2
   exit 1
 }
 fast_run_count="$(grep '^nextest ' "$LOG" | grep -c -- '<--profile> <fast>')"
@@ -114,6 +119,7 @@ fi
 BUILD_ACTION="$ROOT/.github/actions/build-nextest-archive/action.yml"
 RUN_ACTION="$ROOT/.github/actions/run-nextest-archive/action.yml"
 WORKFLOW="$ROOT/.github/workflows/cargo.yml"
+NEXTEST_CONFIG="$ROOT/.config/nextest.toml"
 
 assert_file_contains() {
   local file="$1"
@@ -133,6 +139,11 @@ assert_file_contains "$RUN_ACTION" "name: ${stable_artifact_name}"
 assert_file_contains "$RUN_ACTION" 'uses: ./.github/actions/setup-rust-ci'
 assert_file_contains "$RUN_ACTION" 'components: rustfmt'
 assert_file_contains "$RUN_ACTION" 'scripts/ci-nextest-archive.sh run'
+assert_file_contains "$NEXTEST_CONFIG" '[profile.ci-unit]'
+assert_file_contains "$NEXTEST_CONFIG" 'inherits = "default"'
+assert_file_contains "$NEXTEST_CONFIG" 'slow-timeout = { period = "60s", terminate-after = 4 }'
+assert_file_contains "$NEXTEST_CONFIG" 'filter = '\''test(=machines::tests::machine_workflow_red_ok_detects_missing_and_stale_generated_artifacts)'\'''
+assert_file_contains "$NEXTEST_CONFIG" 'slow-timeout = { period = "60s", terminate-after = 8 }'
 
 for dependency in unit-archive int-archives; do
   assert_file_contains "$WORKFLOW" "      - ${dependency}"


### PR DESCRIPTION
## Summary

- add a dedicated `ci-unit` nextest profile for CI unit shards
- report and terminate an ordinary unit test after four 60-second slow periods
- give one exact workflow-style xtask case an eight-minute ceiling because it performs nested feature compilation and has a measured healthy runtime around 4.5 minutes
- leave integration and e2e profiles unchanged
- extend the archive contract self-test to pin profile selection and both timeout bounds

## Why

Repeated unit-shard stalls currently remain anonymous until a human cancels the workflow. The first CI run proved the policy works by naming `machine_workflow_red_ok_detects_missing_and_stale_generated_artifacts` at 240 seconds. The preceding exact-main run showed the same healthy shard taking 270.384 seconds, so the revision preserves the four-minute default and scopes additional headroom only to that known workflow-style test.

## Validation

- mandatory pre-push hook passed on the initial head; revised-head hook is running
- `scripts/test-ci-nextest-archive.sh`
- `./scripts/repo-cargo nextest show-config --profile ci-unit version`
- `git diff --check`
