### PR TITLE
docs: bound the CI merge-precedence claim to what was observed

### DIFF
--- a/docs/reference/build-and-ci.mdx
+++ b/docs/reference/build-and-ci.mdx
@@ -131,13 +131,17 @@ Treat check-context precedence as part of retry recovery:
    before classifying a slow job as hung.
 3. When a new PR-associated attempt is necessary, expect the automatic
    cancellation residue. The replacement attempt must reach both aggregate
-   gates so its later results supersede the failures.
+   gates in the newest check suite before its results can clear the failures.
 4. Verify the PR's latest `GHA Cargo / Cargo lane gate` and `CI gate` contexts
    directly. A green shard or successful manual workflow is useful evidence,
    but it does not by itself prove that the required PR contexts were replaced.
 
-Do not infer mergeability from a workflow's overall conclusion alone. The PR
-rollup's latest result for each required context name is authoritative.
+Do not infer mergeability from a workflow's overall conclusion alone, and do not
+assume that any later successful result supersedes an earlier failure. A newer
+failed check suite can keep merge policy blocked even when an older suite's later
+attempt reports success for the same required context, so recovery must succeed
+in the newest suite. Treat an attempted merge that stays blocked as stronger
+evidence than a required-check CLI that reports pass.
 
 ## Nightly Lanes
 


### PR DESCRIPTION
Amends the `CI Retry And Concurrency` entry added in #987. Requested and pre-approved by the Meerkat lead on the bus at exact head `519ff617a7d92d328d1f206b9d479f5b0e33f4b8`.

## Why

The merged entry claimed the PR rollup's latest result for each required context name is authoritative. The #984 merge attempt disproved it: a later successful attempt of the older run could not supersede the newer failed check suite, and merge policy stayed blocked **while the required-check CLI reported pass**.

That wording was mine. This corrects it.

## What changed

Two hunks, both in `docs/reference/build-and-ci.mdx`:

1. **Closing paragraph** replaced with the empirically bounded statement rather than a guessed GitHub algorithm: a newer failed check suite can keep merge policy blocked even when an older suite's later attempt reports success for the same required context, so recovery must succeed in the newest suite.

2. **Item 3** said the replacement attempt's "later results supersede the failures", which is the same superseded-by-recency model that was disproven. Now reads "in the newest check suite before its results can clear the failures."

Hunk 2 extends one line beyond the scope I originally offered. I made it because leaving it would have made the entry contradict its own closing paragraph, which is worse than either version alone. It is revertible independently if strict scope is preferred; the lead accepted it on review.

## The transferable line

The amendment also adds: treat an attempted merge that stays blocked as stronger evidence than a required-check CLI that reports pass. That is the observation that would have prevented the original wording, and it is the part most likely to matter to whoever reads this entry during the next stall.

## Verification

- `make docs-check` passes
- No em dashes or en dashes in authored text
- Mandatory pre-push hook passed in full, including the workspace deterministic gate
