### PR TITLE
Correct CI suite recovery guidance

### DIFF
--- a/docs/reference/build-and-ci.mdx
+++ b/docs/reference/build-and-ci.mdx
@@ -130,18 +130,32 @@ Treat check-context precedence as part of retry recovery:
 2. Compare the active step and elapsed time with a successful exact-head run
    before classifying a slow job as hung.
 3. When a new PR-associated attempt is necessary, expect the automatic
-   cancellation residue. The replacement attempt must reach both aggregate
-   gates in the newest check suite before its results can clear the failures.
-4. Verify the PR's latest `GHA Cargo / Cargo lane gate` and `CI gate` contexts
-   directly. A green shard or successful manual workflow is useful evidence,
-   but it does not by itself prove that the required PR contexts were replaced.
+   cancellation residue. The recovery attempt must reach both aggregate gates
+   in the check suite it is repairing.
+4. Inspect every check suite on the reviewed head that publishes the required
+   `GHA Cargo / Cargo lane gate` or `CI gate` context. A green shard or
+   successful manual workflow is useful evidence, but it does not clear a
+   failed required context in another suite on the same head.
 
 Do not infer mergeability from a workflow's overall conclusion alone, and do not
-assume that any later successful result supersedes an earlier failure. A newer
-failed check suite can keep merge policy blocked even when an older suite's later
-attempt reports success for the same required context, so recovery must succeed
-in the newest suite. Treat an attempted merge that stays blocked as stronger
-evidence than a required-check CLI that reports pass.
+apply a creation-time or completion-time recency rule to suites on the same
+head. In the observed recovery, auto-merge remained blocked after the newest of
+three suites reported a successful `CI gate`; it fired only after the last
+remaining suite reported that context successful. Treat each suite that
+publishes a required context as independent recovery evidence, because neither
+the newest nor the latest-completed result was observed to supersede the
+others. In this recovery, `gh pr checks` reported pass while guarded merge
+remained blocked, so an attempted merge that stays blocked is stronger evidence
+than that flattened view.
+
+Inspect the suite records directly when the rollup and merge policy disagree:
+
+```bash
+gh api "repos/OWNER/REPO/commits/HEAD_SHA/check-suites?per_page=100" \
+  --jq '.check_suites[] | {id, app: .app.slug, conclusion, updated_at}'
+gh api "repos/OWNER/REPO/check-suites/SUITE_ID/check-runs?per_page=100" \
+  --jq '[.check_runs[] | select(.name == "CI gate") | {conclusion, completed_at}]'
+```
 
 ## Nightly Lanes
 


### PR DESCRIPTION
## Summary

- remove the disproved newest-suite precedence rule
- require recovery of every suite on the reviewed head that publishes required gate contexts
- document direct suite and check-run inspection when flattened PR checks disagree with guarded merge

## Validation

- make docs-check
- git diff --check
- mandatory pre-push gate

## Review

- Lead full-diff agreement on exact head 72d13f13ad5e5bcf9c0aeca6b376c968af4dd86a