### PR TITLE
ci: expose slow integration tests without killing them

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -23,8 +23,12 @@ slow-timeout = { period = "60s", terminate-after = 8 }
 
 [profile.fast]
 # Cargo's default fast lane: unit + integration-fast, with dedicated e2e lane
-# wrappers left behind explicit `cargo e2e-*` aliases.
+# wrappers left behind explicit `cargo e2e-*` aliases. Report every test still
+# running at one-minute intervals without killing it. CI integration shards
+# surface those observations by raising their status levels; local fast aliases
+# deliberately keep status output quiet.
 default-filter = 'not binary(e2e_auth_lane) and not binary(e2e_build_lane) and not binary(e2e_fast_lane) and not binary(e2e_system_lane) and not binary(e2e_live_lane) and not binary(e2e_smoke_lane) and not binary(e2e_models_lane)'
+slow-timeout = { period = "60s" }
 
 # Real-loopback mob integration tests previously shared a process-local mutex,
 # but Nextest runs each test in its own process. On macOS, concurrent binaries

--- a/scripts/ci-nextest-archive.sh
+++ b/scripts/ci-nextest-archive.sh
@@ -21,6 +21,8 @@ archive_file="${3:-}"
 [[ -n "$family" && -n "$archive_file" ]] || usage
 
 profile=default
+status_level=none
+final_status_level=fail
 case "$family" in
   unit)
     cargo_args=(--workspace --lib)
@@ -29,6 +31,8 @@ case "$family" in
   int-heavy)
     cargo_args=(-p meerkat-integration-tests --tests --profile fast)
     profile=fast
+    status_level=slow
+    final_status_level=slow
     ;;
   int-mob)
     cargo_args=(
@@ -42,6 +46,8 @@ case "$family" in
       --profile fast
     )
     profile=fast
+    status_level=slow
+    final_status_level=slow
     ;;
   int-everything-else)
     cargo_args=(
@@ -84,6 +90,8 @@ case "$family" in
       --profile fast
     )
     profile=fast
+    status_level=slow
+    final_status_level=slow
     ;;
   *)
     echo "error: unknown nextest archive family '${family}'" >&2
@@ -113,8 +121,8 @@ case "${1:-}" in
       --workspace-remap "$ROOT"
       --no-tests=fail
       --show-progress none
-      --status-level none
-      --final-status-level fail
+      --status-level "$status_level"
+      --final-status-level "$final_status_level"
       --partition "$partition"
     )
     if [[ "$profile" != default ]]; then

--- a/scripts/test-ci-nextest-archive.sh
+++ b/scripts/test-ci-nextest-archive.sh
@@ -96,16 +96,39 @@ unit_run="$(grep '^nextest ' "$LOG" | head -n 1)"
   echo "unit archive run omitted the bounded ci-unit profile" >&2
   exit 1
 }
+[[ "$unit_run" == *' <--final-status-level> <fail>'* ]] || {
+  echo "unit archive run changed its failure-only final status" >&2
+  exit 1
+}
+[[ "$unit_run" == *' <--status-level> <none>'* ]] || {
+  echo "unit archive run changed its quiet streaming status" >&2
+  exit 1
+}
 ci_unit_run_count="$(grep '^nextest ' "$LOG" | grep -c -- '<--profile> <ci-unit>')"
 [[ "$ci_unit_run_count" == 1 ]] || {
   echo "expected one ci-unit archive run, got ${ci_unit_run_count}" >&2
   exit 1
 }
-fast_run_count="$(grep '^nextest ' "$LOG" | grep -c -- '<--profile> <fast>')"
-[[ "$fast_run_count" == 3 ]] || {
-  echo "expected three fast-profile archive runs, got ${fast_run_count}" >&2
+fast_build_count="$(grep '^cargo ' "$LOG" | grep -c -- '<--profile> <fast>')"
+[[ "$fast_build_count" == 3 ]] || {
+  echo "expected three fast-profile integration archive builds, got ${fast_build_count}" >&2
   exit 1
 }
+fast_run_count="$(grep '^nextest ' "$LOG" | grep -c -- '<--profile> <fast>')"
+[[ "$fast_run_count" == 3 ]] || {
+  echo "expected three fast-profile integration archive runs, got ${fast_run_count}" >&2
+  exit 1
+}
+while IFS= read -r command; do
+  [[ "$command" == *' <--status-level> <slow>'* ]] || {
+    echo "integration archive run suppressed streaming slow-test markers: ${command}" >&2
+    exit 1
+  }
+  [[ "$command" == *' <--final-status-level> <slow>'* ]] || {
+    echo "integration archive run suppressed its slow-test summary: ${command}" >&2
+    exit 1
+  }
+done < <(grep '^nextest ' "$LOG" | grep -- '<--profile> <fast>')
 
 if "$ROOT/scripts/ci-nextest-archive.sh" build unknown "${TEST_ROOT}/unknown.tar.zst" >/dev/null 2>&1; then
   echo "unknown archive family was accepted" >&2
@@ -144,6 +167,15 @@ assert_file_contains "$NEXTEST_CONFIG" 'inherits = "default"'
 assert_file_contains "$NEXTEST_CONFIG" 'slow-timeout = { period = "60s", terminate-after = 4 }'
 assert_file_contains "$NEXTEST_CONFIG" 'filter = '\''test(=machines::tests::machine_workflow_red_ok_detects_missing_and_stale_generated_artifacts)'\'''
 assert_file_contains "$NEXTEST_CONFIG" 'slow-timeout = { period = "60s", terminate-after = 8 }'
+fast_profile="$(sed -n '/^\[profile.fast\]$/,/^\[/p' "$NEXTEST_CONFIG")"
+[[ "$fast_profile" == *'slow-timeout = { period = "60s" }'* ]] || {
+  echo "fast profile must report slow tests every 60 seconds" >&2
+  exit 1
+}
+[[ "$fast_profile" != *'terminate-after'* ]] || {
+  echo "fast observation profile must not terminate tests" >&2
+  exit 1
+}
 
 for dependency in unit-archive int-archives; do
   assert_file_contains "$WORKFLOW" "      - ${dependency}"


### PR DESCRIPTION
## Summary

- report integration tests that remain running after 60 seconds
- stream slow-test names during a hang and retain them in the final summary
- keep the existing fast-profile overrides and add no termination bound
- add fail-closed coverage for all three integration archive families and the unchanged unit lane

## Validation

- scripts/test-ci-nextest-archive.sh
- git diff --check
- mandatory pre-push hook
