### PR TITLE
test: bound the unregister retry so a stranded teardown names itself

### DIFF
--- a/meerkat-mob/src/runtime/tests.rs
+++ b/meerkat-mob/src/runtime/tests.rs
@@ -606,17 +606,137 @@ fn test_trusted_peer_descriptor(name: &str, address: &str) -> TrustedPeerDescrip
     .expect("valid non-zero test trusted peer descriptor")
 }
 
+/// How long the helper below keeps re-asking before it declares the unregister
+/// stranded.
+///
+/// `MeerkatMachine::unregister_session` reports `UnregisterInProgress` only when
+/// its own two-second caller grace elapses, so retrying that report without a
+/// budget is an unbounded wait wearing a timeout's clothes: 120 turns land
+/// exactly on the four-minute CI unit-test bound, and the shard then dies
+/// without naming which wait never finished.
+const UNREGISTER_COMPLETION_BUDGET: Duration = Duration::from_secs(30);
+
+/// Why a bounded unregister retry stopped asking.
+#[derive(Debug)]
+enum UnregisterRetryStop {
+    /// The coordinator reported a genuine driver error.
+    Driver(meerkat_runtime::RuntimeDriverError),
+    /// The coordinator kept reporting `UnregisterInProgress` until the budget
+    /// was spent.
+    StillInProgress { attempts: u32, waited: Duration },
+}
+
+/// Retry `attempt` while the unregister coordinator reports that a teardown is
+/// still in progress, giving up once `budget` is spent.
+///
+/// Separated from its one production caller so the budget itself is testable
+/// without a live `MeerkatMachine`.
+async fn retry_while_unregister_in_progress<F, Fut>(
+    budget: Duration,
+    mut attempt: F,
+) -> Result<(), UnregisterRetryStop>
+where
+    F: FnMut() -> Fut,
+    Fut: std::future::Future<Output = Result<(), meerkat_runtime::RuntimeDriverError>>,
+{
+    let started = Instant::now();
+    let mut attempts = 0_u32;
+    loop {
+        attempts += 1;
+        match attempt().await {
+            Ok(()) => return Ok(()),
+            Err(meerkat_runtime::RuntimeDriverError::UnregisterInProgress { .. }) => {
+                let waited = started.elapsed();
+                if waited >= budget {
+                    return Err(UnregisterRetryStop::StillInProgress { attempts, waited });
+                }
+                tokio::task::yield_now().await;
+            }
+            Err(error) => return Err(UnregisterRetryStop::Driver(error)),
+        }
+    }
+}
+
 async fn unregister_runtime_session_until_complete(
     adapter: &meerkat_runtime::MeerkatMachine,
     session_id: &SessionId,
 ) -> Result<(), meerkat_runtime::RuntimeDriverError> {
-    loop {
-        match adapter.unregister_session(session_id).await {
-            Ok(()) => return Ok(()),
-            Err(meerkat_runtime::RuntimeDriverError::UnregisterInProgress { .. }) => {}
-            Err(error) => return Err(error),
-        }
+    match retry_while_unregister_in_progress(UNREGISTER_COMPLETION_BUDGET, || {
+        adapter.unregister_session(session_id)
+    })
+    .await
+    {
+        Ok(()) => Ok(()),
+        Err(UnregisterRetryStop::Driver(error)) => Err(error),
+        Err(UnregisterRetryStop::StillInProgress { attempts, waited }) => panic!(
+            "unregister for session {session_id} did not complete within {waited:?}: all \
+             {attempts} attempts reported UnregisterInProgress. The exact executor may be \
+             stranded in a non-interruptible turn; take a stack sample of this process to \
+             establish what the coordinator is waiting on"
+        ),
     }
+}
+
+#[tokio::test]
+async fn bounded_unregister_retry_stops_once_the_budget_is_spent() {
+    let session_id = SessionId::new();
+    let attempts = std::cell::Cell::new(0_u32);
+    let budget = Duration::from_millis(20);
+
+    let stop = retry_while_unregister_in_progress(budget, || {
+        attempts.set(attempts.get() + 1);
+        std::future::ready(Err(
+            meerkat_runtime::RuntimeDriverError::UnregisterInProgress {
+                runtime_id: meerkat_runtime::LogicalRuntimeId::for_session(&session_id),
+            },
+        ))
+    })
+    .await
+    .expect_err("a coordinator that never completes must exhaust the budget");
+
+    match stop {
+        UnregisterRetryStop::StillInProgress {
+            attempts: reported,
+            waited,
+        } => {
+            assert_eq!(
+                reported,
+                attempts.get(),
+                "the reported attempt count must be the attempts actually made"
+            );
+            assert!(
+                waited >= budget,
+                "the retry must spend the whole budget before giving up, waited {waited:?}"
+            );
+        }
+        other => panic!("expected an exhausted budget, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn bounded_unregister_retry_still_completes_a_slow_but_finishing_teardown() {
+    let session_id = SessionId::new();
+    let attempts = std::cell::Cell::new(0_u32);
+
+    retry_while_unregister_in_progress(UNREGISTER_COMPLETION_BUDGET, || {
+        let made = attempts.get() + 1;
+        attempts.set(made);
+        std::future::ready(if made < 3 {
+            Err(meerkat_runtime::RuntimeDriverError::UnregisterInProgress {
+                runtime_id: meerkat_runtime::LogicalRuntimeId::for_session(&session_id),
+            })
+        } else {
+            Ok(())
+        })
+    })
+    .await
+    .expect("a teardown that finishes must not be reported as stranded");
+
+    assert_eq!(
+        attempts.get(),
+        3,
+        "the retry must keep asking until the coordinator completes"
+    );
 }
 
 async fn install_machine_peer_request_response_authority(


### PR DESCRIPTION
Follow-up to the unit-shard timeout observed on #992. Mechanism found by reading, reviewed on the bus at exact head `d5b8fce2`.

## What was wrong

`unregister_runtime_session_until_complete` (`meerkat-mob/src/runtime/tests.rs`) retried `MeerkatMachine::unregister_session` for as long as it reported `UnregisterInProgress`, with no deadline and no attempt cap.

That report is produced **only** when the coordinator's own two-second caller grace elapses (`UNREGISTER_CALLER_WAIT_GRACE`, `meerkat-runtime/src/meerkat_machine/session_management.rs`). So the loop was an unbounded wait wearing a timeout's clothes: 120 turns at two seconds land exactly on the four-minute `ci-unit` bound.

That arithmetic is the confirmation. The shard didn't die at 240s by coincidence; 240s *is* 2s times the bound.

## Why it mattered

On CI unit shard 6 during #992 the shard died at the bound naming only the test, not the wait inside it. The `ci-unit` bound added in #988 bought us "which test"; this buys "which wait", one level down.

Three tests share the helper, so all three carried the hazard.

## What changed

- `retry_while_unregister_in_progress(budget, attempt)` stops once the budget is spent and returns a typed `UnregisterRetryStop` (`Driver(..)` or `StillInProgress { attempts, waited }`). Split out from its one caller specifically so the budget is testable without a live `MeerkatMachine`.
- The caller keeps its signature and its panic-on-stranded behaviour, but now reports how many attempts were made, how long they took, and the next diagnostic step.
- The panic states **only what the helper observed**. Whether the exact executor is stranded in a non-interruptible turn remains a hypothesis, so it is offered as a lead rather than asserted.

## The budget is measured, not guessed

The three existing callers complete in **86 milliseconds combined**, so a legitimate teardown finishes on the first ask and never retries. 30 seconds is roughly fifteen attempts of headroom over a path that normally needs one.

This is deliberate: the false kill on #988's first CI run came from a per-test ceiling derived from an aggregate. This number is three orders of magnitude above the measured happy path.

## Validation

- 5 tests, 5 passed: both new tests, the test that timed out on #992, and the two other helper callers
- `clippy -p meerkat-mob --all-targets -- -D warnings` clean
- Mandatory pre-push hook passed in full, including the workspace deterministic unit + integration + e2e gate

Test-only change. No runtime behaviour is touched.