### PR TITLE
fix(runtime): prevent post-drain queued run admission

### DIFF
--- a/meerkat-mob/src/runtime/tests.rs
+++ b/meerkat-mob/src/runtime/tests.rs
@@ -1837,6 +1837,17 @@ struct MockSessionService {
     archive_delay_ms: AtomicU64,
     start_turn_delay_ms: AtomicU64,
     start_turn_interrupts: RwLock<HashMap<SessionId, tokio::sync::watch::Sender<u64>>>,
+    /// Exact runtime runs whose executor call has entered this mock service.
+    /// The production session services fence interruption by `RunId`; the mock
+    /// must retain the same fact across the small gap before `start_turn`
+    /// subscribes to its cooperative interrupt channel.
+    runtime_apply_runs: RwLock<HashMap<SessionId, meerkat_core::RunId>>,
+    /// Exact interrupts delivered after machine run admission but before the
+    /// mock turn has subscribed. A watch subscription starts at the sender's
+    /// current version, so the watch channel alone cannot represent this race.
+    /// This remains independent of the machine queue gate: the exact run is
+    /// already admitted when this mock-only delivery gap opens.
+    pending_runtime_interrupts: RwLock<HashSet<(SessionId, meerkat_core::RunId)>>,
     inject_delay_ms: AtomicU64,
     flow_turn_delay_ms: AtomicU64,
     flow_turn_never_terminal: std::sync::atomic::AtomicBool,
@@ -1953,6 +1964,8 @@ impl MockSessionService {
             archive_delay_ms: AtomicU64::new(0),
             start_turn_delay_ms: AtomicU64::new(0),
             start_turn_interrupts: RwLock::new(HashMap::new()),
+            runtime_apply_runs: RwLock::new(HashMap::new()),
+            pending_runtime_interrupts: RwLock::new(HashSet::new()),
             inject_delay_ms: AtomicU64::new(0),
             flow_turn_delay_ms: AtomicU64::new(0),
             flow_turn_never_terminal: std::sync::atomic::AtomicBool::new(false),
@@ -3126,6 +3139,18 @@ impl SessionService for MockSessionService {
             .await
             .get(id)
             .map(tokio::sync::watch::Sender::subscribe);
+        let active_runtime_run = self.runtime_apply_runs.read().await.get(id).cloned();
+        if let Some(run_id) = active_runtime_run
+            && self
+                .pending_runtime_interrupts
+                .write()
+                .await
+                .remove(&(id.clone(), run_id))
+        {
+            return Err(SessionError::Agent(
+                meerkat_core::error::AgentError::Cancelled,
+            ));
+        }
         self.flow_turn_overlays
             .write()
             .await
@@ -4070,7 +4095,7 @@ impl MobSessionService for MockSessionService {
     async fn interrupt_run_with_machine_authority(
         &self,
         session_id: &SessionId,
-        _expected_run_id: &meerkat_core::RunId,
+        expected_run_id: &meerkat_core::RunId,
         _authority: meerkat_runtime::MachineSessionControlAuthority,
     ) -> Result<bool, SessionError> {
         let barrier = { self.runtime_control_barrier.read().await.clone() };
@@ -4078,10 +4103,26 @@ impl MobSessionService for MockSessionService {
             barrier.hard_calls.fetch_add(1, Ordering::Relaxed);
             barrier.wait_for_release().await;
         }
+        self.pending_runtime_interrupts
+            .write()
+            .await
+            .insert((session_id.clone(), expected_run_id.clone()));
         match SessionService::interrupt(self, session_id).await {
             Ok(()) => Ok(true),
-            Err(SessionError::NotRunning { .. }) => Ok(false),
-            Err(error) => Err(error),
+            Err(SessionError::NotRunning { .. }) => {
+                // Machine authority already admitted this exact run. Ambient
+                // live-session `NotRunning` can therefore be the same
+                // pre-entry window the latch closes; retaining the exact tuple
+                // is delivery to that run, not widening to a future successor.
+                Ok(true)
+            }
+            Err(error) => {
+                self.pending_runtime_interrupts
+                    .write()
+                    .await
+                    .remove(&(session_id.clone(), expected_run_id.clone()));
+                Err(error)
+            }
         }
     }
 
@@ -4277,7 +4318,27 @@ impl MobSessionService for MockSessionService {
         contributing_input_ids: Vec<meerkat_core::InputId>,
     ) -> Result<meerkat_core::lifecycle::core_executor::CoreApplyOutput, SessionError> {
         let exact_result_text = req.prompt.text_content();
-        <Self as SessionService>::start_turn(self, session_id, req).await?;
+        let replaced = self
+            .runtime_apply_runs
+            .write()
+            .await
+            .insert(session_id.clone(), run_id.clone());
+        debug_assert!(
+            replaced.is_none(),
+            "mock runtime service admitted overlapping exact runs for session {session_id}"
+        );
+        let turn_result = <Self as SessionService>::start_turn(self, session_id, req).await;
+        {
+            let mut active_runs = self.runtime_apply_runs.write().await;
+            if active_runs.get(session_id) == Some(&run_id) {
+                active_runs.remove(session_id);
+            }
+        }
+        self.pending_runtime_interrupts
+            .write()
+            .await
+            .remove(&(session_id.clone(), run_id.clone()));
+        turn_result?;
         let receipt = meerkat_core::lifecycle::run_receipt::RunBoundaryReceiptDraft {
             run_id,
             boundary,
@@ -4359,6 +4420,11 @@ impl MobSessionService for MockSessionService {
         self.live_session_data.write().await.remove(session_id);
         self.keep_alive_notifiers.write().await.remove(session_id);
         self.start_turn_interrupts.write().await.remove(session_id);
+        self.runtime_apply_runs.write().await.remove(session_id);
+        self.pending_runtime_interrupts
+            .write()
+            .await
+            .retain(|(candidate, _)| candidate != session_id);
         self.session_comms_names.write().await.remove(session_id);
         self.external_tools_by_session
             .write()
@@ -4401,6 +4467,11 @@ impl MobSessionService for MockSessionService {
             notifier.notify_waiters();
         }
         self.start_turn_interrupts.write().await.remove(session_id);
+        self.runtime_apply_runs.write().await.remove(session_id);
+        self.pending_runtime_interrupts
+            .write()
+            .await
+            .retain(|(candidate, _)| candidate != session_id);
         self.session_comms_names.write().await.remove(session_id);
         self.external_tools_by_session
             .write()
@@ -58231,6 +58302,70 @@ async fn test_spawn_member_customizer_spawner_provenance_ignores_roster_state_mi
                     .is_some_and(|id| id.identity.as_str() == lead.as_str())),
         "spawn provenance must be gated by MobMachine lifecycle projection, not the roster compatibility state mirror"
     );
+}
+
+#[tokio::test]
+async fn mock_exact_interrupt_before_turn_subscription_is_not_lost() {
+    let service = Arc::new(MockSessionService::new());
+    let adapter = service.enable_runtime_adapter();
+    let session_id = service
+        .create_session(CreateSessionRequest {
+            injected_context: Vec::new(),
+            model: "pre-subscription-interrupt-model".to_string(),
+            prompt: ContentInput::Text("create pre-subscription interrupt probe".to_string()),
+            system_prompt: meerkat_core::SystemPromptOverride::Inherit,
+            max_tokens: None,
+            event_tx: None,
+            initial_turn: meerkat_core::service::InitialTurnPolicy::Defer,
+            deferred_prompt_policy: meerkat_core::service::DeferredPromptPolicy::Discard,
+            build: None,
+            labels: None,
+        })
+        .await
+        .expect("create interrupt probe session")
+        .session_id;
+    service
+        .keep_alive_notifiers
+        .write()
+        .await
+        .insert(session_id.clone(), Arc::new(tokio::sync::Notify::new()));
+
+    let run_id = meerkat_core::RunId::new();
+    let interrupted =
+        <MockSessionService as MobSessionService>::interrupt_run_with_machine_authority(
+            service.as_ref(),
+            &session_id,
+            &run_id,
+            adapter.session_control_authority(),
+        )
+        .await
+        .expect("deliver exact interrupt before executor entry");
+    assert!(interrupted);
+
+    let error = tokio::time::timeout(
+        Duration::from_secs(1),
+        <MockSessionService as MobSessionService>::apply_runtime_turn(
+            service.as_ref(),
+            &session_id,
+            run_id,
+            StartTurnRequest {
+                injected_context: Vec::new(),
+                prompt: ContentInput::Text("turn must observe the retained interrupt".to_string()),
+                system_prompt: None,
+                event_tx: None,
+                runtime: meerkat_core::service::StartTurnRuntimeSemantics::default(),
+            },
+            meerkat_core::lifecycle::run_primitive::RunApplyBoundary::Immediate,
+            Vec::new(),
+        ),
+    )
+    .await
+    .expect("retained exact interrupt must prevent a stranded keep-alive turn")
+    .expect_err("pre-subscription exact interrupt must cancel the same runtime run");
+    assert!(matches!(
+        error,
+        SessionError::Agent(meerkat_core::error::AgentError::Cancelled)
+    ));
 }
 
 #[tokio::test]

--- a/meerkat-runtime/src/meerkat_machine/mod.rs
+++ b/meerkat-runtime/src/meerkat_machine/mod.rs
@@ -5499,6 +5499,38 @@ impl MeerkatMachine {
         Ok(gate_guard)
     }
 
+    /// Acquire queue-admission authority for a current runtime-loop driver.
+    ///
+    /// Existing run commit and terminalization must remain available while an
+    /// unregister is Draining, but no new queued run may cross that boundary.
+    /// Holding the session mutation gate while checking Active gives queue
+    /// admission and BeginUnregisterSession one total order.
+    pub(crate) async fn lock_current_runtime_loop_queue_driver_authority(
+        &self,
+        session_id: &SessionId,
+        driver: &SharedDriver,
+    ) -> Result<crate::tokio::sync::OwnedMutexGuard<()>, RuntimeDriverError> {
+        let gate_guard = self
+            .lock_current_session_driver_gate(session_id, driver)
+            .await?;
+        {
+            let sessions = self.sessions.read().await;
+            let entry = sessions
+                .get(session_id)
+                .ok_or(RuntimeDriverError::NotReady {
+                    state: RuntimeState::Destroyed,
+                })?;
+            if !entry.generated_executor_registration_active() {
+                return Err(RuntimeDriverError::ValidationFailed {
+                    reason:
+                        "generated MeerkatMachine has no active runtime-loop queue registration"
+                            .to_string(),
+                });
+            }
+        }
+        Ok(gate_guard)
+    }
+
     pub(crate) async fn current_runtime_stop_cleanup_in_progress(
         &self,
         session_id: &SessionId,

--- a/meerkat-runtime/src/meerkat_machine/session_management.rs
+++ b/meerkat-runtime/src/meerkat_machine/session_management.rs
@@ -8218,6 +8218,12 @@ impl MeerkatMachine {
             // (mid `start_turn`) never observes the closed channel. Hard-cancel
             // the in-flight run so a well-behaved executor unwinds `apply` and
             // the loop reaches its clean stop/terminal-handoff exit promptly.
+            // `None` cannot race a later executor entry here. Queue admission
+            // requires Active while holding this registration's mutation gate,
+            // whereas an already-admitted run may retain the broader
+            // Active-or-Draining authority needed to commit and terminalize.
+            // Thus BeginUnregisterSession either follows a published run ID or
+            // makes every later queue-admission attempt fail closed.
             if let (Some(interrupt_handle), Some(expected_run_id)) =
                 (loop_interrupt_handle, loop_interrupt_run_id)
             {

--- a/meerkat-runtime/src/meerkat_machine_tests.rs
+++ b/meerkat-runtime/src/meerkat_machine_tests.rs
@@ -12830,6 +12830,128 @@ async fn cancel_after_boundary_on_idle_attached_runtime_consumes_before_successo
 }
 
 #[tokio::test]
+async fn unregister_draining_fences_queue_admission_before_executor_apply() {
+    struct CountingExecutor {
+        apply_calls: Arc<AtomicUsize>,
+    }
+
+    #[async_trait::async_trait]
+    impl CoreExecutor for CountingExecutor {
+        async fn apply(
+            &mut self,
+            run_id: RunId,
+            primitive: RunPrimitive,
+        ) -> Result<CoreApplyOutput, CoreExecutorError> {
+            self.apply_calls.fetch_add(1, Ordering::SeqCst);
+            Ok(CoreApplyOutput::with_untyped_snapshot(
+                RunBoundaryReceiptDraft {
+                    run_id,
+                    boundary: RunApplyBoundary::RunStart,
+                    contributing_input_ids: primitive.contributing_input_ids().to_vec(),
+                    conversation_digest: None,
+                    message_count: 0,
+                },
+                None,
+                None,
+            ))
+        }
+
+        async fn cancel_after_boundary(
+            &mut self,
+            _reason: String,
+        ) -> Result<(), CoreExecutorError> {
+            Ok(())
+        }
+
+        async fn stop_runtime_executor(
+            &mut self,
+            _reason: String,
+        ) -> Result<(), CoreExecutorError> {
+            Ok(())
+        }
+    }
+
+    let adapter = Arc::new(MeerkatMachine::ephemeral());
+    let session_id = SessionId::new();
+    let apply_calls = Arc::new(AtomicUsize::new(0));
+    adapter
+        .register_session_with_executor(
+            session_id.clone(),
+            Box::new(CountingExecutor {
+                apply_calls: Arc::clone(&apply_calls),
+            }),
+        )
+        .await
+        .expect("idle runtime executor registration should succeed");
+
+    // Pause the accepted input immediately before queue authority. Unregister
+    // must win the mutation-gate order, commit Draining, and observe no run ID
+    // before the loop is released to attempt queue admission.
+    let (queue_gap_entered, queue_gap_release) =
+        adapter.arm_runtime_loop_before_queue_authority_test_hook(session_id.clone());
+    let (outcome, completion) = adapter
+        .accept_input_with_completion(&session_id, make_prompt("must not start"))
+        .await
+        .expect("queued input should be accepted before unregister");
+    assert!(outcome.is_accepted());
+    tokio::time::timeout(Duration::from_secs(1), queue_gap_entered)
+        .await
+        .expect("runtime loop should reach the forced queue-authority gap")
+        .expect("runtime-loop queue-authority hook should remain armed");
+
+    let unregister_adapter = Arc::clone(&adapter);
+    let unregister_session_id = session_id.clone();
+    let unregister = tokio::spawn(async move {
+        unregister_adapter
+            .unregister_session(&unregister_session_id)
+            .await
+    });
+    tokio::time::timeout(Duration::from_secs(1), async {
+        loop {
+            let state = adapter
+                .session_dsl_state(&session_id)
+                .await
+                .expect("session should remain observable during drain");
+            if state.registration_phase == crate::meerkat_machine::dsl::RegistrationPhase::Draining
+            {
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("unregister should commit Draining while the queue is paused");
+
+    queue_gap_release
+        .send(())
+        .expect("runtime loop should still be waiting at the forced gap");
+    tokio::time::timeout(Duration::from_secs(5), unregister)
+        .await
+        .expect("unregister should not wait on a post-Draining run")
+        .expect("unregister task should not panic")
+        .expect("session should unregister cleanly");
+
+    assert_eq!(
+        apply_calls.load(Ordering::SeqCst),
+        0,
+        "Draining must reject new queued executor work"
+    );
+    let completion_outcome = tokio::time::timeout(
+        Duration::from_secs(1),
+        completion
+            .expect("accepted input should retain a completion waiter")
+            .wait_authorized(),
+    )
+    .await
+    .expect("unregister should resolve refused queued work through canonical stop");
+    assert!(matches!(
+        completion_outcome,
+        CompletionOutcome::RuntimeTerminated { .. }
+    ));
+    assert!(!adapter.contains_session(&session_id).await);
+}
+
+#[tokio::test]
 async fn hard_cancel_current_run_uses_prepared_session_interrupt_handle_before_executor_attach() {
     struct CountingInterruptHandle {
         calls: Arc<AtomicUsize>,

--- a/meerkat-runtime/src/runtime_loop.rs
+++ b/meerkat-runtime/src/runtime_loop.rs
@@ -4402,6 +4402,37 @@ impl RuntimeLoopAuthorityBinding {
             })
     }
 
+    async fn lock_current_queue_driver_authority(
+        &self,
+        driver: &crate::meerkat_machine::SharedDriver,
+        context: &'static str,
+    ) -> Result<crate::tokio::sync::OwnedMutexGuard<()>, crate::traits::RuntimeDriverError> {
+        #[cfg(test)]
+        if let Some(gate) = &self.detached_test_gate {
+            let _ = (driver, context);
+            return Ok(std::sync::Arc::clone(gate).lock_owned().await);
+        }
+
+        let machine =
+            self.machine
+                .upgrade()
+                .ok_or(crate::traits::RuntimeDriverError::NotReady {
+                    state: crate::runtime_state::RuntimeState::Destroyed,
+                })?;
+        machine
+            .lock_current_runtime_loop_queue_driver_authority(&self.session_id, driver)
+            .await
+            .map_err(|err| {
+                tracing::warn!(
+                    session_id = %self.session_id,
+                    error = %err,
+                    context,
+                    "runtime loop refused queue admission outside Active registration"
+                );
+                err
+            })
+    }
+
     /// Exact teardown authority for an executor already retained by the
     /// runtime-loop handoff slot. Unlike live loop work, teardown recovery must
     /// also admit `Queuing` after `RuntimeExecutorExited`; exact session/driver
@@ -5716,7 +5747,7 @@ async fn process_queue(
             .await;
 
         let queue_authority_guard = match authority_binding
-            .lock_current_driver_authority(driver, "runtime loop queue processing")
+            .lock_current_queue_driver_authority(driver, "runtime loop queue processing")
             .await
         {
             Ok(guard) => guard,


### PR DESCRIPTION
## Summary

- require an Active executor registration at the runtime-loop queue-dequeue authority point
- retain Active-or-Draining authority for already-admitted run commit and terminalization
- preserve exact mock interrupts delivered after run admission but before the mock turn subscribes
- prove refused queued work is owned by canonical stop and resolves as RuntimeTerminated

## Root cause

Unregister commits Draining and captures the current run ID while holding the session mutation gate. The runtime loop previously reacquired the same gate through an Active-or-Draining authority check for queue processing. If unregister observed no current run first, an already-queued input could then publish a run and enter apply after the gate was released. Unregister had no captured run ID to interrupt and waited indefinitely for the loop handoff.

The Mob test service had a second independent contract defect. Its exact interrupt path delegated to a watch channel, but a receiver subscribed after delivery starts at the current version and cannot observe that earlier interrupt. An admitted run could therefore enter the mock service after exact interrupt acknowledgement and block forever.

## Regression proof

The production regression uses the existing before-queue-authority hook to commit Draining at the exact ordering boundary. With only the new queue-authority call reverted to the old Active-or-Draining call, the test fails because executor apply is reached once. Restoring the Active-only queue gate makes the test pass. The same test requires the refused input's completion to resolve as RuntimeTerminated.

This repairs the exact failure reproduced in exact-main CI:
https://github.com/lukacf/meerkat/actions/runs/32578906891

## Validation

- new queue-admission regression: pass
- new exact mock interrupt regression: pass
- original resume reconciliation failure: pass
- adjacent boundary-cancel and detached-driver authority tests: pass
- focused Clippy for meerkat-runtime and meerkat-mob, all targets: pass
- mandatory pre-push hook, including machine/TLC verification and deterministic unit, integration, cold-restart, and e2e gates: pass
