### PR TITLE
fix: verify npm package publish access

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -396,10 +396,11 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - name: Checkout release helpers
+      # A recovery dispatch must run the fixed generic preflight from the
+      # workflow commit. Package build and publish jobs below still check out
+      # the immutable release tag selected by release_tag.
+      - name: Checkout workflow helpers
         uses: actions/checkout@v6
-        with:
-          ref: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.release_tag != '' && github.event.inputs.release_tag || github.ref }}
 
       - name: Setup Node
         uses: actions/setup-node@v6

--- a/scripts/release-npm-publish-preflight
+++ b/scripts/release-npm-publish-preflight
@@ -29,7 +29,6 @@ preflight_dir="$(mktemp -d "${TMPDIR:-/tmp}/meerkat-npm-preflight.XXXXXX")"
 trap 'rm -rf "${preflight_dir}"' EXIT
 
 npm_config="${preflight_dir}/npmrc"
-permissions_json="${preflight_dir}/permissions.json"
 printf 'registry=%s\n%s:_authToken=%s\n' \
   "${registry}" \
   "${auth_config_key}" \
@@ -42,12 +41,16 @@ if [[ -z "${actor}" ]]; then
   exit 1
 fi
 
-npm access list packages "${actor}" --json --registry="${registry}" >"${permissions_json}"
+required_packages=('@rkat/sdk' '@rkat/web')
+for package_index in "${!required_packages[@]}"; do
+  package_name="${required_packages[package_index]}"
+  permissions_json="${preflight_dir}/permissions-${package_index}.json"
+  npm access list collaborators "${package_name}" --json --registry="${registry}" >"${permissions_json}"
 
-node - "${permissions_json}" '@rkat/sdk' '@rkat/web' <<'NODE'
+  node - "${permissions_json}" "${actor}" "${package_name}" <<'NODE'
 const fs = require('node:fs');
 
-const [permissionsPath, ...requiredPackages] = process.argv.slice(2);
+const [permissionsPath, actor, packageName] = process.argv.slice(2);
 let permissions;
 try {
   permissions = JSON.parse(fs.readFileSync(permissionsPath, 'utf8'));
@@ -61,18 +64,12 @@ if (permissions === null || Array.isArray(permissions) || typeof permissions !==
   process.exit(1);
 }
 
-let failed = false;
-for (const packageName of requiredPackages) {
-  const permission = permissions[packageName];
-  if (permission !== 'read-write') {
-    console.error(`${packageName} npm permission is ${permission ?? 'missing'}; read-write is required`);
-    failed = true;
-  }
-}
-
-if (failed) {
+const permission = permissions[actor];
+if (permission !== 'read-write') {
+  console.error(`${actor} npm permission on ${packageName} is ${permission ?? 'missing'}; read-write is required`);
   process.exit(1);
 }
 NODE
+done
 
 printf 'npm publication preflight passed for %s: @rkat/sdk and @rkat/web are read-write\n' "${actor}"

--- a/scripts/test-release-npm-publish-preflight.sh
+++ b/scripts/test-release-npm-publish-preflight.sh
@@ -40,7 +40,7 @@ case "${1:-}" in
     if [[ -n "${FAKE_NPM_ACCESS_JSON+x}" ]]; then
       printf '%s\n' "${FAKE_NPM_ACCESS_JSON}"
     else
-      printf '%s\n' '{"@rkat/sdk":"read-write","@rkat/web":"read-write"}'
+      printf '%s\n' '{"release-owner":"read-write"}'
     fi
     ;;
   *)
@@ -114,10 +114,26 @@ assert_secret_absent
 
 run_case failure FAKE_NPM_WHOAMI_MODE=failure
 run_case failure FAKE_NPM_ACCESS_MODE=failure
-run_case failure FAKE_NPM_ACCESS_JSON='{"@rkat/sdk":"read-only","@rkat/web":"read-write"}'
-run_case failure FAKE_NPM_ACCESS_JSON='{"@rkat/sdk":"read-write"}'
+run_case failure FAKE_NPM_ACCESS_JSON='{"release-owner":"read-only"}'
+run_case failure FAKE_NPM_ACCESS_JSON='{}'
 run_case failure FAKE_NPM_ACCESS_JSON='{not-json'
-run_case success FAKE_NPM_ACCESS_JSON='{"@rkat/sdk":"read-write","@rkat/web":"read-write"}'
+run_case success FAKE_NPM_ACCESS_JSON='{"release-owner":"read-write"}'
+
+if ! grep -Fxq 'access list collaborators @rkat/sdk --json --registry=https://registry.npmjs.org/' "${fake_log}"; then
+  echo "npm preflight did not inspect @rkat/sdk collaborators" >&2
+  cat "${fake_log}" >&2
+  exit 1
+fi
+if ! grep -Fxq 'access list collaborators @rkat/web --json --registry=https://registry.npmjs.org/' "${fake_log}"; then
+  echo "npm preflight did not inspect @rkat/web collaborators" >&2
+  cat "${fake_log}" >&2
+  exit 1
+fi
+if grep -Fq 'access list packages' "${fake_log}"; then
+  echo "npm preflight used the organization package-list endpoint" >&2
+  cat "${fake_log}" >&2
+  exit 1
+fi
 
 python3 - "${root}/.github/workflows/release.yml" <<'PY'
 import pathlib
@@ -141,6 +157,8 @@ web = job("publish_web_sdk")
 
 assert "scripts/release-npm-publish-preflight" in preflight
 assert "alpha_crates_only" in preflight
+assert "Checkout workflow helpers" in preflight
+assert "github.event.inputs.release_tag" not in preflight
 assert re.search(r"(?m)^    needs: \[require_ci_green\]$", preflight)
 assert "needs.require_ci_green.result == 'success'" in preflight
 for name, body in (("publish_registries", registries), ("publish_web_sdk", web)):


### PR DESCRIPTION
## Summary

- replace the invalid account-wide npm package lookup with collaborator checks on @rkat/sdk and @rkat/web
- require the authenticated actor to report read-write on each target package
- make workflow-dispatch recovery load this generic preflight helper from the workflow commit while package payload jobs remain pinned to the immutable release tag

## Release evidence

- npm whoami succeeds as lucrf
- npm access list packages lucrf is interpreted as /-/org/lucrf/package and returns 403
- npm access list collaborators @rkat/sdk and @rkat/web each report lucrf as read-write
- this proves the registry permission bit, not npm OTP or final publish policy; real publication remains authoritative

## Validation

- scripts/test-release-npm-publish-preflight.sh
- shellcheck on the helper and its contract test
- git diff --check
- mandatory pre-push hook, including machine verification and workspace unit/integration/e2e gate

This unblocks package recovery for v0.8.26. The successful Web package artifact from release run 32604877235 can be reused instead of rebuilt.
