### PR TITLE
Report stalled unregister handoffs without bounding cleanup

### DIFF
--- a/meerkat-runtime/src/meerkat_machine/mod.rs
+++ b/meerkat-runtime/src/meerkat_machine/mod.rs
@@ -1262,6 +1262,13 @@ struct PendingUnregisterFinalization {
 struct UnregisterTeardownMechanicalObservations {
     runtime_loop_forced_abort: std::sync::atomic::AtomicBool,
     comms_drain_forced_abort: std::sync::atomic::AtomicBool,
+    /// Report intervals elapsed while the unregister saga waited for the
+    /// runtime loop to hand off the exact executor.
+    ///
+    /// Non-zero means that handoff stalled. This is an observation and never a
+    /// bound: nothing is aborted or failed on its account, and the wait itself
+    /// stays deliberately unbounded for the reason recorded at its await site.
+    runtime_loop_handoff_wait_reports: std::sync::atomic::AtomicU32,
 }
 
 /// Owned persistence worker for one runtime's ops epoch. The unregister saga
@@ -1282,6 +1289,7 @@ impl UnregisterTeardownMechanicalObservations {
         Self {
             runtime_loop_forced_abort: std::sync::atomic::AtomicBool::new(false),
             comms_drain_forced_abort: std::sync::atomic::AtomicBool::new(false),
+            runtime_loop_handoff_wait_reports: std::sync::atomic::AtomicU32::new(0),
         }
     }
 

--- a/meerkat-runtime/src/meerkat_machine/session_management.rs
+++ b/meerkat-runtime/src/meerkat_machine/session_management.rs
@@ -8258,7 +8258,37 @@ impl MeerkatMachine {
             // would drop the exact executor and make required external cleanup
             // impossible to retry, so machine-owned Draining truth is retained
             // until the loop actually hands the executor off.
-            match loop_handle.await {
+            // Waiting forever is the deliberate choice above; waiting SILENTLY
+            // is not. A stalled handoff previously surfaced only as an
+            // anonymous four-minute CI shard death. Re-arm a report every
+            // interval so the stall is attributable while the wait stays
+            // unbounded. `timeout` drops only the `&mut` borrow of the handle on
+            // elapse, never the task, so this cannot abort the runtime loop.
+            #[cfg(not(test))]
+            const HANDOFF_REPORT_INTERVAL: std::time::Duration = std::time::Duration::from_secs(5);
+            #[cfg(test)]
+            const HANDOFF_REPORT_INTERVAL: std::time::Duration =
+                std::time::Duration::from_millis(50);
+            let handoff_wait_started = std::time::Instant::now();
+            let mut loop_handle = loop_handle;
+            let loop_join_result = loop {
+                match crate::tokio::time::timeout(HANDOFF_REPORT_INTERVAL, &mut loop_handle).await {
+                    Ok(join_result) => break join_result,
+                    Err(_elapsed) => {
+                        let reports = teardown_observations
+                            .runtime_loop_handoff_wait_reports
+                            .fetch_add(1, std::sync::atomic::Ordering::AcqRel)
+                            + 1;
+                        tracing::warn!(
+                            %session_id,
+                            reports,
+                            waited_ms = handoff_wait_started.elapsed().as_millis(),
+                            "unregister is still waiting for the runtime loop to hand off the exact executor"
+                        );
+                    }
+                }
+            };
+            match loop_join_result {
                 Ok(()) => {}
                 Err(join_error) => {
                     teardown_observations
@@ -9250,6 +9280,25 @@ impl MeerkatMachine {
     /// Check whether a runtime driver is already registered for a session.
     pub async fn contains_session(&self, session_id: &SessionId) -> bool {
         self.sessions.read().await.contains_key(session_id)
+    }
+
+    /// Report intervals elapsed so far while an in-flight unregister waits for
+    /// the runtime loop to hand off the exact executor.
+    ///
+    /// `None` once the registration is gone. Observation only: a non-zero count
+    /// never fails or bounds the wait.
+    #[cfg(any(test, feature = "test-support"))]
+    #[doc(hidden)]
+    pub async fn unregister_runtime_loop_handoff_wait_reports(
+        &self,
+        session_id: &SessionId,
+    ) -> Option<u32> {
+        self.sessions.read().await.get(session_id).map(|entry| {
+            entry
+                .unregister_teardown_observations
+                .runtime_loop_handoff_wait_reports
+                .load(std::sync::atomic::Ordering::Acquire)
+        })
     }
 
     /// Observe whether archiving still has runtime retirement work to finish.

--- a/meerkat-runtime/src/meerkat_machine_tests.rs
+++ b/meerkat-runtime/src/meerkat_machine_tests.rs
@@ -12830,6 +12830,129 @@ async fn cancel_after_boundary_on_idle_attached_runtime_consumes_before_successo
 }
 
 #[tokio::test]
+async fn unregister_reports_a_stalled_runtime_loop_handoff_without_aborting_it() {
+    struct StallingStopExecutor {
+        stop_entered: Option<tokio::sync::oneshot::Sender<()>>,
+        stop_release: Option<tokio::sync::oneshot::Receiver<()>>,
+        stop_returned: Arc<AtomicUsize>,
+    }
+
+    #[async_trait::async_trait]
+    impl CoreExecutor for StallingStopExecutor {
+        async fn apply(
+            &mut self,
+            run_id: RunId,
+            primitive: RunPrimitive,
+        ) -> Result<CoreApplyOutput, CoreExecutorError> {
+            Ok(CoreApplyOutput::with_untyped_snapshot(
+                RunBoundaryReceiptDraft {
+                    run_id,
+                    boundary: RunApplyBoundary::RunStart,
+                    contributing_input_ids: primitive.contributing_input_ids().to_vec(),
+                    conversation_digest: None,
+                    message_count: 0,
+                },
+                None,
+                None,
+            ))
+        }
+
+        async fn cancel_after_boundary(
+            &mut self,
+            _reason: String,
+        ) -> Result<(), CoreExecutorError> {
+            Ok(())
+        }
+
+        async fn stop_runtime_executor(
+            &mut self,
+            _reason: String,
+        ) -> Result<(), CoreExecutorError> {
+            if let Some(entered) = self.stop_entered.take() {
+                let _ = entered.send(());
+            }
+            if let Some(release) = self.stop_release.take() {
+                let _ = release.await;
+            }
+            self.stop_returned.store(1, Ordering::SeqCst);
+            Ok(())
+        }
+    }
+
+    let adapter = Arc::new(MeerkatMachine::ephemeral());
+    let session_id = SessionId::new();
+    let (stop_entered_tx, stop_entered_rx) = tokio::sync::oneshot::channel();
+    let (stop_release_tx, stop_release_rx) = tokio::sync::oneshot::channel();
+    let stop_returned = Arc::new(AtomicUsize::new(0));
+    adapter
+        .register_session_with_executor(
+            session_id.clone(),
+            Box::new(StallingStopExecutor {
+                stop_entered: Some(stop_entered_tx),
+                stop_release: Some(stop_release_rx),
+                stop_returned: Arc::clone(&stop_returned),
+            }),
+        )
+        .await
+        .expect("idle runtime executor registration should succeed");
+
+    let unregister_adapter = Arc::clone(&adapter);
+    let unregister_session_id = session_id.clone();
+    let unregister = tokio::spawn(async move {
+        unregister_adapter
+            .unregister_session(&unregister_session_id)
+            .await
+    });
+
+    // Park the runtime loop inside its canonical executor stop so the handoff
+    // wait cannot complete.
+    tokio::time::timeout(Duration::from_secs(2), stop_entered_rx)
+        .await
+        .expect("the runtime loop should reach its canonical executor stop")
+        .expect("stop-entry signal should not be dropped");
+
+    // Visibility: the wait must report while it waits. Test builds use a 50ms
+    // report interval.
+    let reports = tokio::time::timeout(Duration::from_secs(2), async {
+        loop {
+            if let Some(reports) = adapter
+                .unregister_runtime_loop_handoff_wait_reports(&session_id)
+                .await
+                && reports > 0
+            {
+                break reports;
+            }
+            tokio::time::sleep(Duration::from_millis(5)).await;
+        }
+    })
+    .await
+    .expect("a stalled handoff must report at least one elapsed interval");
+    assert!(
+        reports >= 1,
+        "stalled handoff should have reported at least once, got {reports}"
+    );
+
+    // Non-abort: the parked loop is still alive to take its release. Had the
+    // wait aborted the task, the executor future would already be dropped and
+    // this send could not be received.
+    stop_release_tx
+        .send(())
+        .expect("the stalled runtime loop must still be alive to release");
+
+    tokio::time::timeout(Duration::from_secs(5), unregister)
+        .await
+        .expect("unregister should complete once the loop hands off")
+        .expect("unregister task should not panic")
+        .expect("session should unregister cleanly after a reported stall");
+    assert_eq!(
+        stop_returned.load(Ordering::SeqCst),
+        1,
+        "the executor stop must have returned rather than been dropped by an abort"
+    );
+    assert!(!adapter.contains_session(&session_id).await);
+}
+
+#[tokio::test]
 async fn unregister_draining_fences_queue_admission_before_executor_apply() {
     struct CountingExecutor {
         apply_calls: Arc<AtomicUsize>,

--- a/meerkat-runtime/src/meerkat_machine_tests.rs
+++ b/meerkat-runtime/src/meerkat_machine_tests.rs
@@ -4991,7 +4991,7 @@ async fn cold_registration_cannot_publish_an_epoch_retired_by_overlapping_unregi
         contended,
         "overlapping register/unregister must encounter the first cold publisher's exact held transaction slot"
     );
-    release.notify_waiters();
+    release.notify_one();
     first_registration
         .await
         .expect("first registration task")


### PR DESCRIPTION
## Summary

- report each elapsed interval while unregister waits for the runtime loop to hand off the exact executor
- expose a test-support observation count without changing lifecycle authority or bounding the wait
- prove a stalled handoff becomes visible while the executor remains alive and unregister converges after release
- repair the pre-existing registration-race test gate by retaining its single release permit with `notify_one()`

The timeout wraps only a mutable borrow of the join handle. It never aborts the runtime loop, because doing so would discard the exact executor and make required external cleanup impossible to retry.

The CI-only correction fixes a lost-wake race in `cold_registration_cannot_publish_an_epoch_retired_by_overlapping_unregister`. Its store announced entry and then registered `release.notified()`; the test could run `notify_waiters()` in that gap, which stores no permit and left the test parked forever. `notify_one()` preserves the one release permit if the waiter is late. This changes only test synchronization, not runtime behavior.

## Validation

- mandatory exact-tree pre-push gate on amended head: passed
- corrected runtime lib test graph in the hook: passed
- unregister sweep: 72/72 passed
- mutation proof: reverting the report loop makes the new test fail at the expected visibility assertion
- `clippy -p meerkat-runtime --all-targets -- -D warnings`: passed
- `cargo fmt --check`: passed
