### PR TITLE
Handle first-publish packages in npm release preflight

### DIFF
--- a/scripts/release-npm-publish-preflight
+++ b/scripts/release-npm-publish-preflight
@@ -42,9 +42,36 @@ if [[ -z "${actor}" ]]; then
 fi
 
 required_packages=('@rkat/sdk' '@rkat/web')
+read_write_packages=()
+first_publish_packages=()
 for package_index in "${!required_packages[@]}"; do
   package_name="${required_packages[package_index]}"
+  package_view="${preflight_dir}/view-${package_index}.json"
+  package_view_error="${preflight_dir}/view-${package_index}.err"
   permissions_json="${preflight_dir}/permissions-${package_index}.json"
+
+  set +e
+  npm view "${package_name}" --json --registry="${registry}" \
+    >"${package_view}" 2>"${package_view_error}"
+  view_status=$?
+  set -e
+  if [[ ${view_status} -ne 0 ]]; then
+    if grep -Eq '(^|[^[:alnum:]_])E404([^[:alnum:]_]|$)' \
+      "${package_view}" "${package_view_error}"; then
+      printf 'npm publication preflight: first publish of %s, no access record to check yet\n' \
+        "${package_name}"
+      first_publish_packages+=("${package_name}")
+      continue
+    fi
+    if grep -Eq '(^|[^[:alnum:]_])E403([^[:alnum:]_]|$)' \
+      "${package_view}" "${package_view_error}"; then
+      echo "npm registry denied access while checking ${package_name}; refusing publication" >&2
+    else
+      echo "npm package lookup failed for ${package_name}; refusing to treat it as a first publish" >&2
+    fi
+    exit "${view_status}"
+  fi
+
   npm access list collaborators "${package_name}" --json --registry="${registry}" >"${permissions_json}"
 
   node - "${permissions_json}" "${actor}" "${package_name}" <<'NODE'
@@ -70,6 +97,19 @@ if (permission !== 'read-write') {
   process.exit(1);
 }
 NODE
+  read_write_packages+=("${package_name}")
 done
 
-printf 'npm publication preflight passed for %s: @rkat/sdk and @rkat/web are read-write\n' "${actor}"
+if [[ ${#read_write_packages[@]} -eq 0 ]]; then
+  echo "all required npm packages appear unpublished; refusing a preflight with no verified access record" >&2
+  exit 1
+fi
+
+printf 'npm publication preflight passed for %s' "${actor}"
+if [[ ${#read_write_packages[@]} -gt 0 ]]; then
+  printf ': existing packages are read-write (%s)' "${read_write_packages[*]}"
+fi
+if [[ ${#first_publish_packages[@]} -gt 0 ]]; then
+  printf ': first-publish packages have no access record yet (%s)' "${first_publish_packages[*]}"
+fi
+printf '\n'

--- a/scripts/test-release-npm-publish-preflight.sh
+++ b/scripts/test-release-npm-publish-preflight.sh
@@ -32,6 +32,33 @@ case "${1:-}" in
     fi
     printf '%s\n' "${FAKE_NPM_ACTOR:-release-owner}"
     ;;
+  view)
+    if [[ -n "${FAKE_NPM_NOT_FOUND_PACKAGE:-}" && "${2:-}" == "${FAKE_NPM_NOT_FOUND_PACKAGE}" ]]; then
+      echo 'npm error code E404' >&2
+      exit 4
+    fi
+    case "${FAKE_NPM_VIEW_MODE:-success}" in
+      success)
+        printf '%s\n' '{"name":"published-package"}'
+        ;;
+      not_found)
+        echo 'npm error code E404' >&2
+        exit 4
+        ;;
+      forbidden)
+        echo 'npm error code E403' >&2
+        exit 5
+        ;;
+      failure)
+        echo 'npm error code EUNKNOWN' >&2
+        exit 6
+        ;;
+      *)
+        echo "unexpected FAKE_NPM_VIEW_MODE: ${FAKE_NPM_VIEW_MODE}" >&2
+        exit 93
+        ;;
+    esac
+    ;;
   access)
     if [[ "${FAKE_NPM_ACCESS_MODE:-success}" == "failure" ]]; then
       echo "access lookup failed" >&2
@@ -113,12 +140,84 @@ fi
 assert_secret_absent
 
 run_case failure FAKE_NPM_WHOAMI_MODE=failure
+run_case failure FAKE_NPM_VIEW_MODE=not_found
+for package_name in @rkat/sdk @rkat/web; do
+  if ! grep -Fxq "view ${package_name} --json --registry=https://registry.npmjs.org/" "${fake_log}"; then
+    echo "npm preflight did not inspect ${package_name} existence" >&2
+    cat "${fake_log}" >&2
+    exit 1
+  fi
+  if ! grep -Fq "first publish of ${package_name}, no access record to check yet" "${run_output}"; then
+    echo "npm preflight did not identify ${package_name} as a first publish" >&2
+    cat "${run_output}" >&2
+    exit 1
+  fi
+done
+if grep -Fq 'access list collaborators' "${fake_log}"; then
+  echo "first-publish preflight unexpectedly requested a nonexistent access record" >&2
+  cat "${fake_log}" >&2
+  exit 1
+fi
+if ! grep -Fq 'refusing a preflight with no verified access record' "${run_output}"; then
+  echo "all-first-publish preflight did not fail as a vacuous registry check" >&2
+  cat "${run_output}" >&2
+  exit 1
+fi
+
+run_case success FAKE_NPM_NOT_FOUND_PACKAGE=@rkat/web
+if ! grep -Fxq 'access list collaborators @rkat/sdk --json --registry=https://registry.npmjs.org/' "${fake_log}"; then
+  echo "mixed first-publish preflight did not verify the existing package" >&2
+  cat "${fake_log}" >&2
+  exit 1
+fi
+if grep -Fq 'access list collaborators @rkat/web' "${fake_log}"; then
+  echo "mixed first-publish preflight requested a nonexistent access record" >&2
+  cat "${fake_log}" >&2
+  exit 1
+fi
+if ! grep -Fq 'existing packages are read-write (@rkat/sdk)' "${run_output}" || \
+  ! grep -Fq 'first-publish packages have no access record yet (@rkat/web)' "${run_output}"; then
+  echo "mixed first-publish preflight did not report its two evidence classes" >&2
+  cat "${run_output}" >&2
+  exit 1
+fi
+
+run_case failure FAKE_NPM_VIEW_MODE=forbidden
+if ! grep -Fq 'npm registry denied access while checking @rkat/sdk; refusing publication' "${run_output}"; then
+  echo "npm preflight did not distinguish forbidden access from a first publish" >&2
+  cat "${run_output}" >&2
+  exit 1
+fi
+
+run_case failure FAKE_NPM_VIEW_MODE=failure
+if ! grep -Fq 'refusing to treat it as a first publish' "${run_output}"; then
+  echo "npm preflight did not fail closed for an unknown package-lookup error" >&2
+  cat "${run_output}" >&2
+  exit 1
+fi
+
 run_case failure FAKE_NPM_ACCESS_MODE=failure
 run_case failure FAKE_NPM_ACCESS_JSON='{"release-owner":"read-only"}'
 run_case failure FAKE_NPM_ACCESS_JSON='{}'
 run_case failure FAKE_NPM_ACCESS_JSON='{not-json'
 run_case success FAKE_NPM_ACCESS_JSON='{"release-owner":"read-write"}'
 
+if ! grep -Fq 'existing packages are read-write (@rkat/sdk @rkat/web)' "${run_output}"; then
+  echo "npm preflight did not report the verified existing-package permissions" >&2
+  cat "${run_output}" >&2
+  exit 1
+fi
+
+if ! grep -Fxq 'view @rkat/sdk --json --registry=https://registry.npmjs.org/' "${fake_log}"; then
+  echo "npm preflight did not inspect @rkat/sdk existence" >&2
+  cat "${fake_log}" >&2
+  exit 1
+fi
+if ! grep -Fxq 'view @rkat/web --json --registry=https://registry.npmjs.org/' "${fake_log}"; then
+  echo "npm preflight did not inspect @rkat/web existence" >&2
+  cat "${fake_log}" >&2
+  exit 1
+fi
 if ! grep -Fxq 'access list collaborators @rkat/sdk --json --registry=https://registry.npmjs.org/' "${fake_log}"; then
   echo "npm preflight did not inspect @rkat/sdk collaborators" >&2
   cat "${fake_log}" >&2


### PR DESCRIPTION
## Summary

- probe each required npm package before requesting its collaborator record
- treat an explicit npm E404 as a first-publish candidate while keeping E403 and unknown lookup failures fail-closed
- continue requiring actor-specific read-write access for every existing package
- reject the all-E404 case so a wrong registry or invisible package set cannot make the preflight vacuous
- report existing read-write packages separately from first-publish candidates

An npm E404 means the package is not visible to the current token, not ontologically nonexistent. Real publication remains authoritative. The mixed case is allowed only when at least one existing package establishes a verified access record.

## Validation

- mandatory exact-tree pre-push gate: passed
- focused npm preflight contract suite: passed
- ShellCheck: passed
- `git diff --check`: passed
- real npm CLI probe confirmed existing-package success and missing scoped-package E404 behavior
