### PR TITLE
test: ratchet exact session control refusal

### DIFF
--- a/meerkat-core/src/service/mod.rs
+++ b/meerkat-core/src/service/mod.rs
@@ -3110,6 +3110,31 @@ mod tests {
         assert!(matches!(err, SessionError::Unsupported(name) if name == "has_live_session"));
     }
 
+    #[tokio::test]
+    async fn exact_run_controls_default_to_typed_unsupported() {
+        let service = UnsupportedSessionService;
+        let session_id = SessionId::new();
+        let run_id = RunId::new();
+
+        let interrupt = service
+            .interrupt_run_if_current(&session_id, &run_id)
+            .await
+            .expect_err("an implementation without exact-run authority must fail closed");
+        assert!(
+            matches!(interrupt, SessionError::Unsupported(ref name) if name == "interrupt_run_if_current"),
+            "default exact interrupt must name its unsupported capability: {interrupt:?}"
+        );
+
+        let boundary_cancel = service
+            .cancel_after_boundary_for_run(&session_id, &run_id)
+            .await
+            .expect_err("an implementation without exact-run authority must fail closed");
+        assert!(
+            matches!(boundary_cancel, SessionError::Unsupported(ref name) if name == "cancel_after_boundary_for_run"),
+            "default exact boundary cancel must name its unsupported capability: {boundary_cancel:?}"
+        );
+    }
+
     #[test]
     fn spawn_profile_scope_allows_only_granted_profile_without_manage_scope() {
         let ctx = MobToolAuthorityContext::generated_for_test(

--- a/meerkat-session/src/persistent.rs
+++ b/meerkat-session/src/persistent.rs
@@ -11557,6 +11557,32 @@ mod tests {
         }
     }
 
+    #[tokio::test]
+    async fn runtime_backed_exact_boundary_cancel_requires_machine_authority() {
+        let service = PersistentSessionService::new(
+            DummyBuilder,
+            4,
+            Arc::new(MemoryStore::new()),
+            Arc::new(InMemoryRuntimeStore::new()),
+            memory_blob_store(),
+        );
+        let session_id = SessionId::new();
+        let run_id = RunId::new();
+
+        let error = SessionService::cancel_after_boundary_for_run(&service, &session_id, &run_id)
+            .await
+            .expect_err("public exact boundary cancel must not bypass machine authority");
+
+        match error {
+            SessionError::Unsupported(message) => {
+                assert!(message.contains("cancel_after_boundary_for_run"));
+                assert!(message.contains("machine-owned"));
+                assert!(message.contains("machine-authority seam"));
+            }
+            other => panic!("expected machine-owned exact-boundary refusal, got {other:?}"),
+        }
+    }
+
     /// The three WholeBlob checkpoint refusals below all say "live actor reload
     /// required", and the runtime can only honour that by tearing the live
     /// executor down. Reported as `InternalError` they were indistinguishable


### PR DESCRIPTION
## Summary

- ratchet the `SessionService` defaults for exact interrupt and exact boundary cancel as typed `Unsupported`
- prove `PersistentSessionService` refuses public exact boundary cancellation with machine-authority guidance
- keep the machine-owned exact-control seam as the only runtime-backed authority

## Scope

This is a test-only contract PR. It does not claim full exact-control conformance across every test double. In particular, Mob runtime fixture faithfulness is a separate follow-up because some fixtures do not retain active RunId state and currently lower machine-authority boundary cancellation to ambient cancellation.

## Validation

- `./scripts/repo-cargo test -p meerkat-core --lib exact_run_controls_default_to_typed_unsupported`
- `./scripts/repo-cargo test -p meerkat-session --features session-store --lib runtime_backed_exact_` - 2 passed
- `./scripts/repo-cargo fmt --all -- --check`
- `git diff --check`
- mandatory pre-push hook green, including changed-crate Clippy, machine verification, workspace unit and integration coverage, cold restart, and e2e-fast
