### PR TITLE
perf(mob): avoid full session loads during shutdown

### DIFF
--- a/meerkat-mob/src/runtime/actor.rs
+++ b/meerkat-mob/src/runtime/actor.rs
@@ -14931,7 +14931,7 @@ impl MobActor {
                     .await?;
                 let session_projection_visible = self
                     .session_service
-                    .load_persisted_session(session_id)
+                    .load_persisted_session_metadata(session_id)
                     .await?
                     .is_some();
                 #[cfg(feature = "runtime-adapter")]

--- a/meerkat-mob/src/runtime/tests.rs
+++ b/meerkat-mob/src/runtime/tests.rs
@@ -1830,6 +1830,7 @@ struct MockSessionService {
     load_persisted_session_delay_ms: AtomicU64,
     load_persisted_session_started: tokio::sync::Notify,
     load_persisted_session_calls: AtomicU64,
+    load_persisted_session_metadata_calls: AtomicU64,
     load_persisted_session_in_flight: AtomicU64,
     load_persisted_session_max_in_flight: AtomicU64,
     create_session_in_flight: AtomicU64,
@@ -1957,6 +1958,7 @@ impl MockSessionService {
             load_persisted_session_delay_ms: AtomicU64::new(0),
             load_persisted_session_started: tokio::sync::Notify::new(),
             load_persisted_session_calls: AtomicU64::new(0),
+            load_persisted_session_metadata_calls: AtomicU64::new(0),
             load_persisted_session_in_flight: AtomicU64::new(0),
             load_persisted_session_max_in_flight: AtomicU64::new(0),
             create_session_in_flight: AtomicU64::new(0),
@@ -2534,6 +2536,15 @@ impl MockSessionService {
 
     fn max_concurrent_load_persisted_session_calls(&self) -> u64 {
         self.load_persisted_session_max_in_flight
+            .load(Ordering::Relaxed)
+    }
+
+    fn persisted_session_load_call_count(&self) -> u64 {
+        self.load_persisted_session_calls.load(Ordering::Relaxed)
+    }
+
+    fn persisted_session_metadata_load_call_count(&self) -> u64 {
+        self.load_persisted_session_metadata_calls
             .load(Ordering::Relaxed)
     }
 
@@ -4283,6 +4294,29 @@ impl MobSessionService for MockSessionService {
             self.persisted_session_clone(session_id).await
         };
         Ok(persisted)
+    }
+
+    async fn load_persisted_session_metadata(
+        &self,
+        session_id: &SessionId,
+    ) -> Result<Option<meerkat_core::PersistedSessionMetadataView>, SessionError> {
+        self.load_persisted_session_metadata_calls
+            .fetch_add(1, Ordering::Relaxed);
+        let _authority_guard = self.resume_authority_gate.lock().await;
+        let persisted = if self.archived_session_ids.read().await.contains(session_id) {
+            None
+        } else {
+            self.persisted_session_clone(session_id).await
+        };
+        persisted
+            .as_ref()
+            .map(meerkat_core::PersistedSessionMetadataView::try_from_session)
+            .transpose()
+            .map_err(|error| {
+                SessionError::Agent(meerkat_core::error::AgentError::InternalError(format!(
+                    "session {session_id} durable metadata failed typed restore: {error}"
+                )))
+            })
     }
 
     async fn session_known_to_archive_authority(
@@ -12386,6 +12420,8 @@ async fn test_mob_shutdown_interrupts_active_autonomous_member() {
     )
     .await;
     let baseline_target_interrupts = service.interrupt_call_count_for(&session_id);
+    let baseline_full_loads = service.persisted_session_load_call_count();
+    let baseline_metadata_loads = service.persisted_session_metadata_load_call_count();
 
     handle
         .shutdown()
@@ -12397,6 +12433,15 @@ async fn test_mob_shutdown_interrupts_active_autonomous_member() {
         service.interrupt_call_count_for(&session_id),
         baseline_target_interrupts + 1,
         "active autonomous shutdown must realize exactly one machine-authorized target interrupt"
+    );
+    assert_eq!(
+        service.persisted_session_load_call_count(),
+        baseline_full_loads,
+        "shutdown presence probes must not materialize the full persisted session"
+    );
+    assert!(
+        service.persisted_session_metadata_load_call_count() > baseline_metadata_loads,
+        "shutdown must use the metadata visibility seam for its presence probe"
     );
     assert!(
         !adapter.contains_session(&session_id).await,


### PR DESCRIPTION
## Summary

- use the persisted-session metadata presence seam when autonomous shutdown needs only visibility
- preserve the session service contract that absent and archived sessions are invisible through both full and metadata reads
- ratchet the shutdown path so it cannot regress to full transcript materialization

## Why

The autonomous shutdown planner discarded the full persisted session as a boolean after paying to decode and digest the entire session. MobKit's `workgraph_e2e` uses `runtime_mode = "autonomous_host"` and exercises this cleanup shape. This PR keeps the behavior unchanged while using the ownership-correct metadata presence contract.

This does not claim to fix OB3's host-side `TaskTracker::wait()` wedge, which occurs after MobKit shutdown has returned and is separately owned.

## Verification

- `./scripts/repo-cargo test -p meerkat-mob --lib test_mob_shutdown_interrupts_active_autonomous_member`
- `./scripts/repo-cargo fmt --all -- --check`
- `git diff --check`
- mandatory pre-push hook, including changed-crate Clippy and the workspace deterministic unit, integration, cold-restart, and e2e gate
