### PR TITLE
fix(mob): converge absent shutdown interrupts

### DIFF
--- a/meerkat-mob/src/runtime/actor.rs
+++ b/meerkat-mob/src/runtime/actor.rs
@@ -14830,12 +14830,7 @@ impl MobActor {
                 let result = provisioner
                     .interrupt_member(&member_ref, expected_member.as_ref())
                     .await;
-                let result = match result {
-                    Err(MobError::SessionError(
-                        meerkat_core::service::SessionError::NotFound { .. },
-                    )) => Ok(()),
-                    result => result,
-                };
+                let result = converge_autonomous_stop_interrupt_result(result);
                 let _ = result_tx.send(result);
             });
             self.autonomous_stop_interrupts.insert(
@@ -52481,6 +52476,20 @@ fn routed_effect_session_scope(effect: &mob_dsl::MobMachineEffect) -> Option<Ses
     routed_effect_session_scope_dsl(effect).and_then(|id| SessionId::parse(&id.0).ok())
 }
 
+/// A shutdown interrupt is level-triggered: if the exact runtime registration
+/// disappeared before dispatch, its terminal objective already holds. Keep
+/// this convergence local to shutdown so ordinary force-cancel callers still
+/// observe the typed absence instead of receiving a false global success.
+fn converge_autonomous_stop_interrupt_result(result: Result<(), MobError>) -> Result<(), MobError> {
+    match result {
+        Err(MobError::SessionError(
+            meerkat_core::service::SessionError::NotFound { .. }
+            | meerkat_core::service::SessionError::NotRunning { .. },
+        )) => Ok(()),
+        result => result,
+    }
+}
+
 fn revival_error_means_session_already_live(
     error: &MobError,
     bridge_session_id: &SessionId,
@@ -52512,9 +52521,12 @@ fn recovered_single_target_failure(
 mod autonomous_stop_planning_tests {
     use super::{
         AutonomousStopPhase, MAX_CONCURRENT_AUTONOMOUS_STOP_INTERRUPTS, advance_rotating_cursor,
-        autonomous_stop_phase, disposal_uses_host_release_authority, lifecycle_origin_fenced,
-        mob_dsl,
+        autonomous_stop_phase, converge_autonomous_stop_interrupt_result,
+        disposal_uses_host_release_authority, lifecycle_origin_fenced, mob_dsl,
     };
+    use crate::MobError;
+    use meerkat_core::service::SessionError;
+    use meerkat_core::types::SessionId;
 
     #[test]
     fn bounded_rotation_advances_past_each_full_window() {
@@ -52549,6 +52561,30 @@ mod autonomous_stop_planning_tests {
             autonomous_stop_phase(0, 0),
             AutonomousStopPhase::DriveInterrupts
         );
+    }
+
+    #[test]
+    fn shutdown_interrupt_converges_typed_runtime_absence_only() {
+        for error in [
+            SessionError::NotFound {
+                id: SessionId::new(),
+            },
+            SessionError::NotRunning {
+                id: SessionId::new(),
+            },
+        ] {
+            assert!(
+                converge_autonomous_stop_interrupt_result(Err(MobError::SessionError(error)))
+                    .is_ok(),
+                "shutdown should converge an already-absent runtime"
+            );
+        }
+
+        let error = MobError::Internal("runtime authority is unknown".to_string());
+        assert!(matches!(
+            converge_autonomous_stop_interrupt_result(Err(error)),
+            Err(MobError::Internal(message)) if message == "runtime authority is unknown"
+        ));
     }
 
     #[test]

--- a/meerkat-mob/src/runtime/provisioner.rs
+++ b/meerkat-mob/src/runtime/provisioner.rs
@@ -8895,9 +8895,13 @@ impl MobProvisioner for SessionBackend {
             // adapter registration truth, not direct session-service fallback.
             self.remove_runtime_session_state(&session_id, expected_state.as_ref())
                 .await;
-            return Err(MobError::Internal(format!(
-                "runtime-backed interrupt requested for unregistered runtime session '{session_id}'"
-            )));
+            // The registration's absence proves that no runtime turn remains
+            // to cancel. Preserve that as typed `NotRunning`: shutdown may
+            // converge the level-triggered request, while ordinary callers
+            // still observe that their previously-live target disappeared.
+            return Err(MobError::SessionError(SessionError::NotRunning {
+                id: session_id,
+            }));
         }
         self.session_service
             .cancel_after_boundary(&session_id)

--- a/meerkat-mob/src/runtime/tests.rs
+++ b/meerkat-mob/src/runtime/tests.rs
@@ -38302,6 +38302,26 @@ async fn test_interrupt_member_without_adapter_rejects_unsupported_boundary_canc
 
 #[cfg(feature = "runtime-adapter")]
 #[tokio::test]
+async fn test_runtime_backed_interrupt_reports_unregistered_session_as_typed_not_running() {
+    let service = Arc::new(MockSessionService::new());
+    let adapter = Arc::new(meerkat_runtime::MeerkatMachine::ephemeral());
+    let provisioner = super::provisioner::SessionBackend::new(service, Some(adapter), None);
+    let session_id = SessionId::new();
+    let member_ref = MemberRef::from_bridge_session_id(session_id.clone());
+
+    let error = provisioner
+        .interrupt_member(&member_ref, None)
+        .await
+        .expect_err("an ordinary interrupt caller must observe runtime absence");
+
+    assert!(matches!(
+        error,
+        MobError::SessionError(SessionError::NotRunning { id }) if id == session_id
+    ));
+}
+
+#[cfg(feature = "runtime-adapter")]
+#[tokio::test]
 async fn test_explicit_hard_cancel_member_without_adapter_is_rejected() {
     let service = Arc::new(MockSessionService::new());
     let session = service


### PR DESCRIPTION
## Summary

- report a disappeared runtime registration as typed `SessionError::NotRunning` after exact stale-sidecar cleanup
- converge only autonomous shutdown interrupts when the target is already absent
- preserve typed absence for ordinary force-cancel callers instead of adding a MobKit string classifier or global success mapping

This closes the teardown race surfaced by MobKit workgraph CI without weakening the normal runtime control boundary.

## Validation

- `shutdown_interrupt_converges_typed_runtime_absence_only`
- `test_runtime_backed_interrupt_reports_unregistered_session_as_typed_not_running`
- `make fmt`
- `git diff --check`
- mandatory pre-push hook, including changed-crate Clippy, machine verification, workspace unit/integration/cold-restart/e2e gate
