### PR TITLE
refactor(mob): centralize member tool apply lowering

### DIFF
--- a/meerkat-mob/src/identity.rs
+++ b/meerkat-mob/src/identity.rs
@@ -1710,6 +1710,27 @@ pub struct ApplyMemberToolDeclaration {
     pub convergence: IdentityConvergenceMode,
 }
 
+impl TryFrom<meerkat_contracts::wire::MobApplyMemberToolDeclarationParams>
+    for ApplyMemberToolDeclaration
+{
+    type Error = IdentityIntentError;
+
+    fn try_from(
+        value: meerkat_contracts::wire::MobApplyMemberToolDeclarationParams,
+    ) -> Result<Self, Self::Error> {
+        let request = Self {
+            mob_id: MobId::from(value.mob_id),
+            agent_identity: AgentIdentity::from(value.agent_identity),
+            request_id: MemberToolMutationId::new(value.request_id)?,
+            expected_intent_revision: value.expected_intent_revision,
+            declaration: value.declaration.try_into()?,
+            convergence: value.convergence.into(),
+        };
+        request.validate()?;
+        Ok(request)
+    }
+}
+
 impl ApplyMemberToolDeclaration {
     pub fn validate(&self) -> Result<(), IdentityIntentError> {
         validate_text("mob_id", self.mob_id.as_str())?;
@@ -3826,6 +3847,48 @@ pub(crate) fn identity_adoption_fixture(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn member_tool_apply_wire_lowers_through_one_validated_domain_boundary() {
+        let declaration = MemberToolDeclaration {
+            category_overrides: ToolCategoryOverrides::default(),
+            callback_tools: CallbackToolSetDeclaration::Inherit,
+            execution: MemberToolAccessDeclaration::Unrestricted,
+            application_policy: ApplicationToolPolicyBinding::Unmanaged,
+        };
+        let params = meerkat_contracts::wire::MobApplyMemberToolDeclarationParams {
+            mob_id: "tool-policy-mob".to_string(),
+            agent_identity: "worker-1".to_string(),
+            request_id: "apply-tool-policy-1".to_string(),
+            expected_intent_revision: 7,
+            declaration: declaration.to_wire(),
+            convergence: meerkat_contracts::wire::WireIdentityConvergenceMode::CancelActive,
+        };
+
+        let request = ApplyMemberToolDeclaration::try_from(params.clone())
+            .expect("lower valid wire request through the domain boundary");
+        assert_eq!(request.mob_id.as_str(), params.mob_id);
+        assert_eq!(
+            request.agent_identity,
+            AgentIdentity::from(params.agent_identity.as_str())
+        );
+        assert_eq!(request.request_id.as_str(), params.request_id.as_str());
+        assert_eq!(
+            request.expected_intent_revision,
+            params.expected_intent_revision
+        );
+        assert_eq!(request.declaration, declaration);
+        assert_eq!(request.convergence, IdentityConvergenceMode::CancelActive);
+
+        let invalid = meerkat_contracts::wire::MobApplyMemberToolDeclarationParams {
+            expected_intent_revision: 0,
+            ..params
+        };
+        assert!(matches!(
+            ApplyMemberToolDeclaration::try_from(invalid),
+            Err(IdentityIntentError::ZeroIntentRevision)
+        ));
+    }
 
     #[test]
     fn identity_adoption_wire_is_strict_and_round_trips_full_declaration() {

--- a/meerkat-rpc/src/handlers/mob.rs
+++ b/meerkat-rpc/src/handlers/mob.rs
@@ -35,9 +35,8 @@ use meerkat_core::types::ContentInput;
 use meerkat_mob::{
     AgentIdentity, ApplyMemberToolDeclaration, FlowId, IdentityConvergenceResolutionId,
     IdentityConvergenceStatus, IdentityIntent, IdentityStoredObservation, MemberRespawnReceipt,
-    MemberToolMutationId, MobBackendKind, MobError, MobId, MobMemberStatus, MobRespawnError,
-    MobRuntimeMode, Profile, ResolveIdentityConvergenceBlock, RunId, SpawnMemberSpec, SpawnResult,
-    ToolConfig,
+    MobBackendKind, MobError, MobId, MobMemberStatus, MobRespawnError, MobRuntimeMode, Profile,
+    ResolveIdentityConvergenceBlock, RunId, SpawnMemberSpec, SpawnResult, ToolConfig,
 };
 use meerkat_mob_mcp::{MobAppendSystemContextError, MobMcpDestroyError, MobMcpState};
 use std::collections::BTreeMap;
@@ -583,27 +582,11 @@ pub async fn handle_apply_member_tool_declaration(
         Ok(params) => params,
         Err(error) => return error.with_id(id),
     };
-    let mob_id = match parse_mob_id(id.clone(), &params.mob_id) {
-        Ok(mob_id) => mob_id,
-        Err(response) => return response,
-    };
-    let declaration: Result<meerkat_mob::MemberToolDeclaration, _> = params.declaration.try_into();
-    let declaration = match declaration {
-        Ok(declaration) => declaration,
+    let request = match ApplyMemberToolDeclaration::try_from(params) {
+        Ok(request) => request,
         Err(error) => return invalid_params(id, error.to_string()),
     };
-    let request_id = match MemberToolMutationId::new(params.request_id) {
-        Ok(request_id) => request_id,
-        Err(error) => return invalid_params(id, error.to_string()),
-    };
-    let request = ApplyMemberToolDeclaration {
-        mob_id: mob_id.clone(),
-        agent_identity: AgentIdentity::from(params.agent_identity.as_str()),
-        request_id,
-        expected_intent_revision: params.expected_intent_revision,
-        declaration,
-        convergence: params.convergence.into(),
-    };
+    let mob_id = request.mob_id.clone();
     match state
         .mob_apply_member_tool_declaration(&mob_id, request)
         .await


### PR DESCRIPTION
## Summary

- add the shared `TryFrom<MobApplyMemberToolDeclarationParams>` boundary in `meerkat-mob`
- validate the complete domain request once at that wire-to-domain boundary
- make the Meerkat RPC handler consume the shared conversion instead of reproducing field assembly

This is the paired follow-up discovered while reviewing the MobKit member-tool gateway. MobKit currently pins published Meerkat 0.8.26 and therefore mirrors the 0.8.26 assembly mechanically; its next Meerkat pin can consume this shared conversion and remove that drift surface.

## Evidence

- focused `member_tool_apply_wire_lowers_through_one_validated_domain_boundary` unit test passed
- `./scripts/repo-cargo check -p meerkat-rpc` passed
- mandatory full pre-push hook passed, including changed-crate Clippy, machine/TLC gates, workspace unit and integration archives, cold restart, and e2e
- `git diff --check` passed
