### PR TITLE
fix(docs): sync MobKit release navigation

### DIFF
--- a/.github/workflows/publish-mobkit-docs.yml
+++ b/.github/workflows/publish-mobkit-docs.yml
@@ -95,13 +95,13 @@ jobs:
       - name: Publish generated snapshot to main
         run: |
           set -euo pipefail
-          git add docs/mobkit
+          git add docs/mobkit docs/docs.json
           if git diff --cached --quiet; then
             echo "docs.rkat.ai already contains $MOBKIT_TAG"
             exit 0
           fi
 
-          unexpected=$(git diff --cached --name-only | grep -Ev '^docs/mobkit/' || true)
+          unexpected=$(git diff --cached --name-only | grep -Ev '^docs/(mobkit/|docs\.json$)' || true)
           if [[ -n "$unexpected" ]]; then
             echo "::error::MobKit docs publication staged unexpected paths:" >&2
             echo "$unexpected" >&2

--- a/scripts/sync-mobkit-docs.py
+++ b/scripts/sync-mobkit-docs.py
@@ -13,6 +13,7 @@ Usage:
 from __future__ import annotations
 
 import argparse
+import copy
 import hashlib
 import json
 import re
@@ -24,6 +25,7 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 DESTINATION = ROOT / "docs" / "mobkit"
+SITE_CONFIG = ROOT / "docs" / "docs.json"
 ASSET_PATHS = ("images", "logo.png")
 ROOT_LINK_RE = re.compile(r'(?P<prefix>\]\(|(?:href|src)=["\'])/(?P<path>[^/])')
 REQUIRED_PAGE_ICONS = {
@@ -69,6 +71,54 @@ def flatten_pages(value: object) -> list[str]:
             for page in flatten_pages(value[key])
         ]
     return []
+
+
+def namespace_navigation(value: object, prefix: str) -> object:
+    """Prefix page references while preserving navigation labels and metadata."""
+    if isinstance(value, str):
+        return f"{prefix}/{value}"
+    if isinstance(value, list):
+        return [namespace_navigation(item, prefix) for item in value]
+    if isinstance(value, dict):
+        return {
+            key: (
+                namespace_navigation(item, prefix)
+                if key in {"pages", "groups", "tabs", "products"}
+                else copy.deepcopy(item)
+            )
+            for key, item in value.items()
+        }
+    return copy.deepcopy(value)
+
+
+def site_config_for_source(
+    source_config: dict[str, object],
+    site_config: dict[str, object],
+) -> dict[str, object]:
+    """Replace the MobKit product tabs from the release-owned navigation."""
+    source_navigation = source_config.get("navigation")
+    if not isinstance(source_navigation, dict):
+        raise SystemExit("MobKit docs config has no navigation object")
+    source_tabs = source_navigation.get("tabs")
+    if not isinstance(source_tabs, list) or not source_tabs:
+        raise SystemExit("MobKit docs navigation contains no tabs")
+
+    rendered = copy.deepcopy(site_config)
+    site_navigation = rendered.get("navigation")
+    if not isinstance(site_navigation, dict):
+        raise SystemExit("docs/docs.json has no navigation object")
+    products = site_navigation.get("products")
+    if not isinstance(products, list):
+        raise SystemExit("docs/docs.json navigation has no products")
+    mobkit_products = [
+        product
+        for product in products
+        if isinstance(product, dict) and product.get("product") == "MobKit"
+    ]
+    if len(mobkit_products) != 1:
+        raise SystemExit("docs/docs.json must contain exactly one MobKit product")
+    mobkit_products[0]["tabs"] = namespace_navigation(source_tabs, "mobkit")
+    return rendered
 
 
 def git_output(source: Path, *args: str) -> str:
@@ -197,6 +247,12 @@ def build_snapshot(
 def main() -> int:
     args = parse_args()
     source = args.source.resolve()
+    source_config_path = source / "docs" / "docs.json"
+    if not source_config_path.is_file():
+        raise SystemExit(f"MobKit docs config not found: {source_config_path}")
+    source_config = json.loads(source_config_path.read_text(encoding="utf-8"))
+    site_config = json.loads(SITE_CONFIG.read_text(encoding="utf-8"))
+    expected_site_config = site_config_for_source(source_config, site_config)
 
     if args.check:
         if not DESTINATION.is_dir():
@@ -218,6 +274,11 @@ def main() -> int:
                     "MobKit docs snapshot is stale; run "
                     f"python3 scripts/sync-mobkit-docs.py {source}"
                 )
+        if site_config != expected_site_config:
+            raise SystemExit(
+                "MobKit docs navigation is stale; run "
+                f"python3 scripts/sync-mobkit-docs.py {source}"
+            )
         print("mobkit-docs-sync: ok")
         return 0
 
@@ -228,6 +289,10 @@ def main() -> int:
         DESTINATION,
         source_ref=args.source_ref,
         require_clean=args.require_clean,
+    )
+    SITE_CONFIG.write_text(
+        json.dumps(expected_site_config, indent=2) + "\n",
+        encoding="utf-8",
     )
     manifest = json.loads((DESTINATION / "_source.json").read_text())
     print(

--- a/scripts/test_publish_mobkit_docs.py
+++ b/scripts/test_publish_mobkit_docs.py
@@ -37,11 +37,11 @@ class PublishMobKitDocsWorkflowTests(unittest.TestCase):
     def test_validates_then_publishes_only_generated_paths(self) -> None:
         docs_check = self.workflow.index("run: make docs-check")
         mint_check = self.workflow.index("mint@4.2.728 broken-links")
-        publish = self.workflow.index("git add docs/mobkit")
+        publish = self.workflow.index("git add docs/mobkit docs/docs.json")
 
         self.assertLess(docs_check, publish)
         self.assertLess(mint_check, publish)
-        self.assertIn("grep -Ev '^docs/mobkit/'", self.workflow[publish:])
+        self.assertIn("grep -Ev '^docs/(mobkit/|docs\\.json$)'", self.workflow[publish:])
         self.assertIn("git push origin HEAD:main", self.workflow[publish:])
 
 

--- a/scripts/test_sync_mobkit_docs.py
+++ b/scripts/test_sync_mobkit_docs.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import importlib.util
+import json
 import tempfile
 import unittest
 from pathlib import Path
@@ -37,6 +38,66 @@ class SyncMobKitDocsTests(unittest.TestCase):
                 encoding="utf-8",
             )
             self.assertEqual(sync.workspace_version(cargo_toml), "1.2.3")
+
+    def test_release_navigation_replaces_retired_pages_at_the_product_boundary(self) -> None:
+        source_config = {
+            "navigation": {
+                "tabs": [
+                    {
+                        "tab": "Documentation",
+                        "groups": [
+                            {
+                                "group": "Getting started",
+                                "pages": ["introduction", "quickstart"],
+                            }
+                        ],
+                    }
+                ]
+            }
+        }
+        site_config = {
+            "navigation": {
+                "products": [
+                    {"product": "Meerkat", "tabs": []},
+                    {
+                        "product": "MobKit",
+                        "description": "preserved",
+                        "tabs": [
+                            {
+                                "tab": "Plans",
+                                "groups": [
+                                    {
+                                        "group": "Plans",
+                                        "pages": [
+                                            "mobkit/plans/storage-unification-plan"
+                                        ],
+                                    }
+                                ],
+                            }
+                        ],
+                    },
+                ]
+            }
+        }
+
+        rendered = sync.site_config_for_source(source_config, site_config)
+
+        mobkit = rendered["navigation"]["products"][1]
+        self.assertEqual(mobkit["description"], "preserved")
+        self.assertEqual(
+            mobkit["tabs"][0]["groups"][0]["pages"],
+            ["mobkit/introduction", "mobkit/quickstart"],
+        )
+        self.assertNotIn("storage-unification-plan", json.dumps(rendered))
+        self.assertEqual(site_config["navigation"]["products"][1]["tabs"][0]["tab"], "Plans")
+
+    def test_release_navigation_requires_one_mobkit_product(self) -> None:
+        source_config = {"navigation": {"tabs": [{"tab": "Docs", "groups": []}]}}
+        with self.assertRaisesRegex(SystemExit, "exactly one MobKit product"):
+            sync.site_config_for_source(
+                source_config,
+                {"navigation": {"products": []}},
+            )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- make the released MobKit navigation authoritative for Meerkat's MobKit product tabs
- prefix imported page references under mobkit/ and remove retired pages from the host navigation
- stage both docs/mobkit and docs/docs.json in the publication workflow
- add regression coverage for navigation drift and retired-page removal

## Root cause

The Publish MobKit docs run for MobKit v0.8.22 failed because the page sync refreshed docs/mobkit, while Meerkat retained a duplicated static MobKit navigation entry for mobkit/plans/storage-unification-plan. MobKit had archived that plan and removed it from its public navigation, leaving Meerkat with a broken link to a page that correctly no longer shipped.

## Validation

- python3 scripts/test_sync_mobkit_docs.py - 5 passed
- python3 scripts/test_publish_mobkit_docs.py - 4 passed
- make docs-check - 113 current pages
- exact MobKit v0.8.22 sync from commit 3d8a7ed658da7fa8188edbcc353cf28031cb2dc8 - 26 pages written, 112 pages checked
- mint broken-links under supported Node 22 - passed
- git diff --check
- mandatory pre-push hook - passed
