### PR TITLE
feat(mob): add atomic successor-spec respawn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,14 @@ them.
 
 ## [Unreleased]
 
+### Added
+
+- `MobHandle::respawn_with_successor_spec` atomically replaces a member from a
+  fully lowered `SpawnMemberSpec` while Meerkat retains authority over
+  predecessor retirement, successor generation and fence minting, fresh
+  session creation, and topology restoration. `MemberRespawnReceipt::runtime_id`
+  exposes the exact committed successor runtime identity to bridge surfaces.
+
 ## [0.8.27] - 2026-08-24
 
 ### Fixed

--- a/meerkat-mob/src/mob_machine.rs
+++ b/meerkat-mob/src/mob_machine.rs
@@ -78,6 +78,7 @@ pub(crate) enum MobMachineCommand {
     Respawn {
         agent_identity: AgentIdentity,
         initial_message: Option<meerkat_core::types::ContentInput>,
+        successor_spec: Option<Box<crate::runtime::SpawnMemberSpec>>,
     },
     RetireAll,
     /// Submit a unit of work to a mob member. Fence-token freshness,

--- a/meerkat-mob/src/runtime/actor.rs
+++ b/meerkat-mob/src/runtime/actor.rs
@@ -20856,11 +20856,12 @@ impl MobActor {
                 MobCommand::Respawn {
                     agent_identity,
                     initial_message,
+                    successor_spec,
                     reply_tx,
                 } => {
                     let respawn_identity = agent_identity.clone();
                     match boxed_arm_future(|| {
-                        self.handle_respawn(agent_identity, initial_message)
+                        self.handle_respawn(agent_identity, initial_message, successor_spec)
                     })
                     .await
                     {
@@ -38025,9 +38026,11 @@ impl MobActor {
         &mut self,
         agent_identity: AgentIdentity,
         initial_message: Option<ContentInput>,
+        successor_spec: Option<Box<super::handle::SpawnMemberSpec>>,
     ) -> Result<RespawnProgress, super::handle::MobRespawnError> {
         use super::handle::{MemberRespawnReceipt, MobRespawnError};
 
+        let explicit_successor = successor_spec.is_some();
         let (placed_host, snapshot, replacement_spec, original_identity) =
             boxed_arm_future(|| async {
                 tracing::debug!(
@@ -38114,22 +38117,27 @@ impl MobActor {
         );
 
                 let original_identity = AgentIdentity::from(agent_identity.as_str());
-                let mut replacement_spec = super::handle::SpawnMemberSpec::new(
-                    snapshot.profile_name.clone(),
-                    original_identity.clone(),
-                );
-        replacement_spec.initial_message = initial_message;
-        replacement_spec.runtime_mode = Some(snapshot.runtime_mode);
-        // ADJ-24: a placed member's replacement carries the machine placement
-        // fact and NO explicit binding (placement and binding are mutually
-        // exclusive on the remote lane — one transport story per member).
-        match placed_host.as_ref() {
-            Some(host) => replacement_spec.placement = Some(host.clone()),
-            None => replacement_spec.binding = Some(snapshot.binding.clone()),
-        }
-        replacement_spec.labels = Some(snapshot.labels.clone());
-        replacement_spec.override_profile = snapshot.effective_profile_override.clone();
-        replacement_spec.model_override = snapshot.effective_model_override.clone();
+                let mut replacement_spec = match successor_spec {
+                    Some(spec) => *spec,
+                    None => {
+                        let mut spec = super::handle::SpawnMemberSpec::new(
+                            snapshot.profile_name.clone(),
+                            original_identity.clone(),
+                        );
+                        spec.initial_message = initial_message;
+                        spec.runtime_mode = Some(snapshot.runtime_mode);
+                        // ADJ-24: a placed member's replacement carries the
+                        // machine placement fact and NO explicit binding.
+                        match placed_host.as_ref() {
+                            Some(host) => spec.placement = Some(host.clone()),
+                            None => spec.binding = Some(snapshot.binding.clone()),
+                        }
+                        spec.labels = Some(snapshot.labels.clone());
+                        spec.override_profile = snapshot.effective_profile_override.clone();
+                        spec.model_override = snapshot.effective_model_override.clone();
+                        spec
+                    }
+                };
         self.customize_spawn_spec(
             super::handle::SpawnSource::Respawn,
             None,
@@ -38142,10 +38150,23 @@ impl MobActor {
                 replacement_spec.identity
             ))));
         }
-        if replacement_spec.role_name != snapshot.profile_name {
+        if !explicit_successor && replacement_spec.role_name != snapshot.profile_name {
             return Err(MobRespawnError::from(MobError::Internal(format!(
                 "spawn customizer cannot change respawn profile for '{original_identity}' from '{}' to '{}'",
                 snapshot.profile_name, replacement_spec.role_name
+            ))));
+        }
+        if !matches!(
+            replacement_spec.launch_mode,
+            crate::launch::MemberLaunchMode::Fresh
+        ) {
+            return Err(MobRespawnError::from(MobError::Internal(format!(
+                "respawn successor for '{original_identity}' must use fresh launch mode; Meerkat mints the successor session"
+            ))));
+        }
+        if replacement_spec.auto_wire_parent {
+            return Err(MobRespawnError::from(MobError::Internal(format!(
+                "respawn successor for '{original_identity}' cannot auto-wire a parent; Meerkat restores machine-owned topology"
             ))));
         }
         if placed_host.is_none() && replacement_spec.binding.as_ref() != Some(&snapshot.binding) {
@@ -38201,10 +38222,10 @@ impl MobActor {
         }
 
         let super::handle::SpawnMemberSpec {
-            role_name: _,
+            role_name: replacement_profile_name,
             identity: _,
             initial_message: replacement_initial_message,
-            runtime_mode: _,
+            runtime_mode: replacement_runtime_mode,
             backend: _,
             binding: _,
             context: replacement_context,
@@ -38220,7 +38241,7 @@ impl MobActor {
             inherited_tool_filter: replacement_inherited_tool_filter,
             override_profile: replacement_profile_override,
             model_override: replacement_model_override,
-            objective_id: _,
+            objective_id: replacement_objective_id,
             auth_binding: replacement_auth_binding,
             external_tools: replacement_external_tools,
             compaction_curator_override: replacement_compaction_curator_override,
@@ -38377,7 +38398,7 @@ impl MobActor {
             }
             None => (
                 ContentInput::from(
-                    self.fallback_spawn_prompt(&snapshot.profile_name, &agent_identity),
+                    self.fallback_spawn_prompt(&replacement_profile_name, &agent_identity),
                 ),
                 None,
             ),
@@ -38387,7 +38408,7 @@ impl MobActor {
             p
         } else {
             self.definition
-                .resolve_profile(&snapshot.profile_name, self.realm_profile_store.as_ref())
+                .resolve_profile(&replacement_profile_name, self.realm_profile_store.as_ref())
                 .await?
         };
         if let Some(model) = replacement_model_override.as_ref() {
@@ -38397,13 +38418,14 @@ impl MobActor {
             &mut profile,
             replacement_tool_category_overrides,
         );
+        let replacement_runtime_mode = replacement_runtime_mode.unwrap_or(profile.runtime_mode);
         if replacement_inherited_tool_filter.is_some() && replacement_profile_override.is_none() {
             build::open_profile_tool_categories_for_inherited_filter(&mut profile);
         }
         let replacement_authorized_profile_material = self
             .authorize_spawn_profile_material(
                 &agent_identity,
-                &snapshot.profile_name,
+                &replacement_profile_name,
                 &profile,
                 "respawn_profile_authority",
             )
@@ -38416,7 +38438,7 @@ impl MobActor {
             self.external_tools_for_profile(&profile, replacement_external_tools.clone())?;
         let mut config = build::build_agent_config(build::BuildAgentConfigParams {
             mob_id: &self.definition.id,
-            profile_name: &snapshot.profile_name,
+            profile_name: &replacement_profile_name,
             agent_identity: &agent_identity,
             profile: &profile,
             definition: &self.definition,
@@ -38432,7 +38454,7 @@ impl MobActor {
             system_prompt_override: replacement_system_prompt_override,
         })
         .await?;
-        config.keep_alive = snapshot.runtime_mode == crate::MobRuntimeMode::AutonomousHost;
+        config.keep_alive = replacement_runtime_mode == crate::MobRuntimeMode::AutonomousHost;
         config.override_web_search = replacement_tool_category_overrides.web_search;
         config.application_tool_policy = replacement_application_tool_policy;
         config.tool_consequence_policy_registry = self.tool_consequence_policy_registry.clone();
@@ -38446,7 +38468,7 @@ impl MobActor {
         let req = with_spawn_budget_limits(req, replacement_budget_limits);
         let peer_name = render_member_comms_name(
             self.definition.id.as_str(),
-            snapshot.profile_name.as_str(),
+            replacement_profile_name.as_str(),
             agent_identity.as_str(),
         )?;
         let mut provision_request = ProvisionMemberRequest {
@@ -38547,14 +38569,14 @@ impl MobActor {
 
         let (respawn_inline_reply_tx, _respawn_inline_reply_rx) = oneshot::channel();
         let respawn_pending = PendingSpawn {
-            profile_name: snapshot.profile_name.clone(),
+            profile_name: replacement_profile_name.clone(),
             agent_identity: agent_identity.clone(),
             admitted_bridge_session_id,
             prompt: prompt.clone(),
             initial_turn_prompt: initial_turn_prompt.clone(),
             suppress_autonomous_initial_prompt: false,
             identity_member_permit: None,
-            runtime_mode: snapshot.runtime_mode,
+            runtime_mode: replacement_runtime_mode,
             labels: replacement_labels.clone(),
             owner_bridge_session_id: None,
             auto_wire_parent: false,
@@ -38567,7 +38589,7 @@ impl MobActor {
             }),
             effective_profile_override: replacement_profile_override.clone(),
             effective_model_override: replacement_model_override.clone(),
-            objective_id: None,
+            objective_id: replacement_objective_id,
             per_spawn_external_tools: replacement_external_tools.clone(),
             authorized_profile_material: replacement_authorized_profile_material.clone(),
             continuity_intent: replacement_continuity_intent.clone(),
@@ -38691,7 +38713,7 @@ impl MobActor {
                 member_ref = ?spawn_receipt.member_ref,
                 "MobActor::handle_respawn provisioned replacement member"
             );
-            if snapshot.runtime_mode == crate::MobRuntimeMode::AutonomousHost
+            if replacement_runtime_mode == crate::MobRuntimeMode::AutonomousHost
                 && let Err(capability_error) =
                     Self::ensure_autonomous_dispatch_capability_for_provisioner(
                         &self.provisioner,
@@ -38774,11 +38796,11 @@ impl MobActor {
                 "MobActor::handle_respawn finalizing replacement spawn"
             );
             let finalized = boxed_arm_future(|| self.finalize_spawn_from_pending(
-                    &snapshot.profile_name,
+                    &replacement_profile_name,
                     &agent_identity,
                     replacement_generation,
                     respawn_fence,
-                    snapshot.runtime_mode,
+                    replacement_runtime_mode,
                     prompt,
                     initial_turn_prompt,
                     false,
@@ -38793,7 +38815,7 @@ impl MobActor {
                     .then_some(snapshot.restore_wiring.clone()),
                     replacement_profile_override,
                     replacement_model_override,
-                    None,
+                    replacement_objective_id,
                     replacement_external_tools,
                     replacement_authorized_profile_material,
                     replacement_continuity_intent,

--- a/meerkat-mob/src/runtime/handle.rs
+++ b/meerkat-mob/src/runtime/handle.rs
@@ -1506,6 +1506,12 @@ impl MemberRespawnReceipt {
             fence_token,
         }
     }
+
+    /// Exact runtime identity minted for the committed successor generation.
+    #[must_use]
+    pub fn runtime_id(&self) -> &AgentRuntimeId {
+        &self.agent_runtime_id
+    }
 }
 
 /// Report returned after rotating a mob-owned supervisor authority.
@@ -5442,11 +5448,13 @@ impl MobHandle {
             MobMachineCommand::Respawn {
                 agent_identity,
                 initial_message,
+                successor_spec,
             } => {
                 let receipt = self
                     .send_actor_command(|reply_tx| MobCommand::Respawn {
                         agent_identity,
                         initial_message,
+                        successor_spec,
                         reply_tx,
                     })
                     .await?;
@@ -8591,23 +8599,48 @@ impl MobHandle {
         identity: AgentIdentity,
         initial_message: Option<ContentInput>,
     ) -> Result<MemberRespawnReceipt, MobRespawnError> {
-        let reply = match self
+        match self
             .execute_machine_command(MobMachineCommand::Respawn {
                 agent_identity: identity,
                 initial_message,
+                successor_spec: None,
             })
             .await?
         {
             MobMachineCommandResult::Respawn(reply) => reply,
-            _ => {
-                return Err(MobRespawnError::from(MobError::Internal(
-                    "unexpected command result variant".into(),
-                )));
-            }
-        };
-        match reply {
-            Ok(receipt) => Ok(receipt),
-            Err(err) => Err(err),
+            _ => Err(MobRespawnError::from(MobError::Internal(
+                "unexpected command result variant".into(),
+            ))),
+        }
+    }
+
+    /// Atomically retire a member and replace it from a fully lowered spawn spec.
+    ///
+    /// The successor spec's exact identity names the existing roster member and
+    /// remains unchanged. Callers that encode public identities at the Mob
+    /// boundary must pass the already-encoded roster key here exactly once;
+    /// Meerkat does not decode or re-encode application-owned identity formats.
+    /// Meerkat owns predecessor retirement, successor
+    /// generation and fence minting, fresh session creation, and topology
+    /// restoration. Resume and fork launch modes are rejected because a
+    /// successor always receives a newly minted session.
+    pub async fn respawn_with_successor_spec(
+        &self,
+        successor_spec: SpawnMemberSpec,
+    ) -> Result<MemberRespawnReceipt, MobRespawnError> {
+        let identity = successor_spec.identity.clone();
+        match self
+            .execute_machine_command(MobMachineCommand::Respawn {
+                agent_identity: identity,
+                initial_message: None,
+                successor_spec: Some(Box::new(successor_spec)),
+            })
+            .await?
+        {
+            MobMachineCommandResult::Respawn(reply) => reply,
+            _ => Err(MobRespawnError::from(MobError::Internal(
+                "unexpected command result variant".into(),
+            ))),
         }
     }
 

--- a/meerkat-mob/src/runtime/scope_gate.rs
+++ b/meerkat-mob/src/runtime/scope_gate.rs
@@ -491,6 +491,7 @@ mod tests {
             MobCommand::Respawn {
                 agent_identity: crate::ids::AgentIdentity::from("m"),
                 initial_message: None,
+                successor_spec: None,
                 reply_tx: tx,
             }
             .required_control_scope(),

--- a/meerkat-mob/src/runtime/state.rs
+++ b/meerkat-mob/src/runtime/state.rs
@@ -555,6 +555,7 @@ pub(super) enum MobCommand {
     Respawn {
         agent_identity: AgentIdentity,
         initial_message: Option<ContentInput>,
+        successor_spec: Option<Box<super::handle::SpawnMemberSpec>>,
         reply_tx: oneshot::Sender<
             Result<super::handle::MemberRespawnReceipt, super::handle::MobRespawnError>,
         >,

--- a/meerkat-mob/src/runtime/tests.rs
+++ b/meerkat-mob/src/runtime/tests.rs
@@ -20555,6 +20555,114 @@ async fn test_respawn_contract_aligns_receipt_with_canonical_member_state() {
 }
 
 #[tokio::test]
+async fn test_respawn_with_successor_spec_commits_reprofiled_successor_atomically() {
+    let mut definition = sample_definition();
+    definition.id = MobId::from("successor-spec-commit-mob");
+    let (handle, _service) = create_test_mob(definition).await;
+    let member_id = AgentIdentity::from("successor-spec-target");
+    handle
+        .spawn_with_options(
+            ProfileName::from("worker"),
+            member_id.clone(),
+            None,
+            Some(crate::MobRuntimeMode::TurnDriven),
+            None,
+        )
+        .await
+        .expect("spawn predecessor");
+    let predecessor = handle
+        .get_member(&member_id)
+        .await
+        .expect("predecessor lookup")
+        .expect("predecessor exists");
+
+    let mut successor = SpawnMemberSpec::new("lead", member_id.clone());
+    successor.binding = Some(crate::RuntimeBinding::Session);
+    successor.runtime_mode = Some(crate::MobRuntimeMode::TurnDriven);
+    successor.labels = Some(BTreeMap::from([(
+        "successor-policy".to_string(),
+        "applied".to_string(),
+    )]));
+    successor.initial_message = Some("start the successor".into());
+
+    let receipt = handle
+        .respawn_with_successor_spec(successor)
+        .await
+        .expect("successor respawn succeeds");
+    let committed = handle
+        .get_member(&member_id)
+        .await
+        .expect("successor lookup")
+        .expect("successor exists");
+
+    assert_eq!(receipt.identity, member_id);
+    assert_eq!(receipt.runtime_id(), &committed.agent_runtime_id);
+    assert_eq!(committed.role, ProfileName::from("lead"));
+    assert_eq!(committed.runtime_mode, crate::MobRuntimeMode::TurnDriven);
+    assert_eq!(
+        committed.labels.get("successor-policy").map(String::as_str),
+        Some("applied")
+    );
+    assert_eq!(
+        committed.agent_runtime_id.generation,
+        predecessor
+            .agent_runtime_id
+            .generation
+            .next()
+            .expect("test generation has a successor")
+    );
+}
+
+#[tokio::test]
+async fn test_respawn_with_successor_spec_rejects_session_adoption_before_retire() {
+    let mut definition = sample_definition();
+    definition.id = MobId::from("successor-spec-refusal-mob");
+    let (handle, _service) = create_test_mob(definition).await;
+    let member_id = AgentIdentity::from("successor-resume-refused");
+    let predecessor_ref = handle
+        .spawn_with_options(
+            ProfileName::from("worker"),
+            member_id.clone(),
+            None,
+            Some(crate::MobRuntimeMode::TurnDriven),
+            None,
+        )
+        .await
+        .expect("spawn predecessor");
+    let predecessor = handle
+        .get_member(&member_id)
+        .await
+        .expect("predecessor lookup")
+        .expect("predecessor exists");
+
+    let mut successor = SpawnMemberSpec::new("lead", member_id.clone())
+        .with_resume_bridge_session_id(
+            predecessor_ref
+                .bridge_session_id()
+                .cloned()
+                .expect("predecessor session"),
+        );
+    successor.binding = Some(crate::RuntimeBinding::Session);
+    let error = handle
+        .respawn_with_successor_spec(successor)
+        .await
+        .expect_err("successor cannot adopt a caller-selected session");
+    assert!(
+        error.to_string().contains("must use fresh launch mode"),
+        "unexpected refusal: {error}"
+    );
+
+    let still_live = handle
+        .get_member(&member_id)
+        .await
+        .expect("post-refusal lookup")
+        .expect("predecessor remains live");
+    assert_eq!(still_live.agent_runtime_id, predecessor.agent_runtime_id);
+    assert_eq!(still_live.fence_token, predecessor.fence_token);
+    assert_eq!(still_live.role, ProfileName::from("worker"));
+}
+
+#[tokio::test]
 async fn test_respawn_abandonment_append_failure_closes_reply_and_actor_channels() {
     let events = Arc::new(FaultInjectedMobEventStore::new());
     let (handle, _service) = create_test_mob_with_events(sample_definition(), events.clone()).await;


### PR DESCRIPTION
## Summary

Add a first-class successor-spec respawn operation for paired runtimes that must retire an existing member and atomically recreate the same roster identity with a new fully lowered profile.

- adds `MobHandle::respawn_with_successor_spec(SpawnMemberSpec)`
- keeps the existing same-profile `respawn` contract unchanged
- treats `successor_spec.identity` as the exact roster key, with no second identity argument or re-encoding
- preserves the existing runtime binding, placement, and machine-owned topology
- requires a fresh successor session and rejects resume/fork launch modes before predecessor retirement
- exposes the machine-minted successor runtime ID on `MemberRespawnReceipt`

## Authority contract

Meerkat remains the single owner of predecessor retirement, generation/fence/session minting, and topology restoration. Callers supply the already-lowered successor role/profile/policy/context material exactly once.

## Validation

- targeted atomic successor reprofile test
- fresh-session rejection-before-retire test
- existing same-profile receipt regression
- existing wiring restoration regression
- authoritative pre-push gate, including all-features Clippy, machine verification, deterministic unit/integration/cold-restart/e2e-fast

## Downstream

Unblocks the held MobKit reset/reprofile capability proofs and the next paired release.

