### PR TITLE
fix(cli): flush HTML artifacts before publishing

### DIFF
--- a/meerkat-cli/src/main.rs
+++ b/meerkat-cli/src/main.rs
@@ -491,6 +491,9 @@ async fn write_html_output_artifact(
     file.write_all(html.as_bytes())
         .await
         .map_err(|e| anyhow::anyhow!("Failed to write HTML artifact {}: {e}", path.display()))?;
+    file.flush()
+        .await
+        .map_err(|e| anyhow::anyhow!("Failed to flush HTML artifact {}: {e}", path.display()))?;
     Ok(path)
 }
 


### PR DESCRIPTION
## Summary

- flush generated HTML artifacts before returning their path
- prevent immediate readers and browser launch from observing an empty or partial Tokio file buffer

## Failure and root cause

Exact-main CI run 32743220945 failed in `rkat::tests::test_write_html_output_artifact_uses_realm_presentation_dir` because the helper returned after `write_all` without flushing. The test immediately reopened the file and observed content without `artifact`; production browser launch has the same publication race.

## Validation

- exact previously failing test: passed
- pre-push hook: passed
  - 10,403 workspace unit tests
  - 2,128 workspace integration tests
  - HeadCanonical cold-restart lane
  - e2e-fast lane
