### PR TITLE
fix(mob): preserve durable state across adoption and respawn

### DIFF
--- a/meerkat-mob/src/identity.rs
+++ b/meerkat-mob/src/identity.rs
@@ -291,7 +291,11 @@ pub struct DesiredMemberOverlay {
     pub labels: Option<BTreeMap<String, String>>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub additional_instructions: Option<Vec<String>>,
-    pub system_prompt: PortableSystemPrompt,
+    /// Build-time prompt replacement for materializing a fresh member.
+    /// `None` is reserved for adoption of an existing exact session: its
+    /// durable transcript remains the sole prompt authority on resume.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub system_prompt: Option<PortableSystemPrompt>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub tool_access_policy: Option<WireResolvedToolAccessPolicy>,
     #[serde(default)]
@@ -3827,7 +3831,7 @@ pub(crate) fn identity_adoption_fixture(
             context: None,
             labels: None,
             additional_instructions: None,
-            system_prompt: PortableSystemPrompt::Disable,
+            system_prompt: Some(PortableSystemPrompt::Disable),
             tool_access_policy: None,
             tool_category_overrides: ToolCategoryOverrides::default(),
             application_tool_policy: ApplicationToolPolicyBinding::Unmanaged,

--- a/meerkat-mob/src/runtime/actor.rs
+++ b/meerkat-mob/src/runtime/actor.rs
@@ -17818,6 +17818,24 @@ impl MobActor {
             .await
             .map_err(MobError::from)?;
 
+        // Adoption records the baseline of an already-materialized member.
+        // Its ordered System messages are durable transcript state, including
+        // legacy histories with multiple unkeyed rows. A resolved one-message
+        // replacement cannot faithfully restate that sequence, and resume
+        // must not append, collapse, or reconstruct it.
+        if request.member.system_prompt_override.is_some() {
+            return Err(MobError::WiringError(
+                "identity adoption cannot restate an existing session's durable system prompt; omit system_prompt_override so the transcript remains authoritative"
+                    .to_string(),
+            ));
+        }
+        let mut compiled_declaration = request.member.clone();
+        // Satisfy the fresh-material compiler without consulting a mutable
+        // host prompt source, then replace the placeholder with the explicit
+        // exact-session preservation state below.
+        compiled_declaration.system_prompt_override =
+            Some(meerkat_contracts::wire::PortableSystemPrompt::Disable);
+
         let resolved_profile = if request.member.profile_override.is_none() {
             Some(
                 self.definition
@@ -17830,17 +17848,18 @@ impl MobActor {
         } else {
             None
         };
-        let material = super::spec_compiler::compile_desired_member_material(
+        let mut material = super::spec_compiler::compile_desired_member_material(
             super::spec_compiler::CompileDesiredMemberMaterialParams {
                 agent_identity: &request.agent_identity,
-                declaration: &request.member,
+                declaration: &compiled_declaration,
                 resolved_profile: resolved_profile.as_ref(),
                 definition: &self.definition,
-                base_prompt: self.spawn_base_prompt_source.as_deref(),
+                base_prompt: None,
                 non_portable_disabled: Vec::new(),
             },
         )
         .await?;
+        material.overlay.system_prompt = None;
         let material_runtime_mode = match material.overlay.runtime_mode {
             meerkat_contracts::wire::WireMobRuntimeMode::AutonomousHost => {
                 crate::MobRuntimeMode::AutonomousHost
@@ -38169,7 +38188,16 @@ impl MobActor {
                 "respawn successor for '{original_identity}' cannot auto-wire a parent; Meerkat restores machine-owned topology"
             ))));
         }
-        if placed_host.is_none() && replacement_spec.binding.as_ref() != Some(&snapshot.binding) {
+        // A successor-spec caller does not own the predecessor's runtime
+        // binding and the roster intentionally does not expose it. Omission
+        // therefore means preserve; only an explicit unequal binding is a
+        // forbidden change request.
+        if placed_host.is_none()
+            && replacement_spec
+                .binding
+                .as_ref()
+                .is_some_and(|binding| binding != &snapshot.binding)
+        {
             return Err(MobRespawnError::from(MobError::Internal(format!(
                 "spawn customizer cannot change respawn runtime binding for '{original_identity}'"
             ))));

--- a/meerkat-mob/src/runtime/spec_compiler.rs
+++ b/meerkat-mob/src/runtime/spec_compiler.rs
@@ -295,7 +295,7 @@ pub(crate) async fn compile_desired_member_material(
             context: declaration.context.clone(),
             labels: declaration.labels.clone(),
             additional_instructions: declaration.additional_instructions.clone(),
-            system_prompt,
+            system_prompt: Some(system_prompt),
             tool_access_policy: declaration.tool_access_policy.clone(),
             tool_category_overrides: meerkat_core::ToolCategoryOverrides::default(),
             application_tool_policy: meerkat_core::ApplicationToolPolicyBinding::Unmanaged,
@@ -385,12 +385,17 @@ pub(crate) fn spawn_spec_from_desired_member(
     spec.application_tool_policy = material.overlay.application_tool_policy.clone();
     spec.auth_binding = material.overlay.auth_binding.clone().map(Into::into);
     spec.budget_limits = material.overlay.budget_limits.clone();
-    spec.system_prompt_override = Some(match &material.overlay.system_prompt {
-        PortableSystemPrompt::Set { text } => {
-            super::handle::SpawnSystemPromptOverride::Replace(text.clone())
-        }
-        PortableSystemPrompt::Disable => super::handle::SpawnSystemPromptOverride::Disable,
-    });
+    spec.system_prompt_override =
+        material
+            .overlay
+            .system_prompt
+            .as_ref()
+            .map(|prompt| match prompt {
+                PortableSystemPrompt::Set { text } => {
+                    super::handle::SpawnSystemPromptOverride::Replace(text.clone())
+                }
+                PortableSystemPrompt::Disable => super::handle::SpawnSystemPromptOverride::Disable,
+            });
     spec.override_profile = Some(profile);
     spec.continuity_intent = super::handle::SpawnContinuityIntent::DurableIdentity {
         continuity_key: identity.as_str().to_string(),
@@ -702,6 +707,11 @@ pub(crate) async fn compile_portable_member_spec(
         runtime_mode,
     } = overlay;
 
+    let system_prompt = system_prompt.ok_or_else(|| {
+        MobError::Internal(format!(
+            "fresh portable member spec for '{agent_identity}' cannot inherit an existing session transcript"
+        ))
+    })?;
     let spec = PortableMemberSpec {
         mob_id: mob_id.as_str().to_string(),
         profile_name: profile_name.as_str().to_string(),

--- a/meerkat-mob/src/runtime/tests.rs
+++ b/meerkat-mob/src/runtime/tests.rs
@@ -12400,6 +12400,190 @@ async fn test_existing_member_adoption_tool_update_and_resume_keep_identity_and_
 }
 
 #[tokio::test]
+async fn test_existing_member_adoption_preserves_prompt_sequence_without_spawn_prompt_source() {
+    let definition = with_unique_mob_id(sample_definition(), "persisted-prompt-adoption");
+    let mob_id = definition.id.clone();
+    let member = AgentIdentity::from("worker-persisted-prompt");
+    let stale_prompt = "stale prompt with retired private context";
+    let intermediate_prompt = "intermediate unkeyed prompt";
+    let persisted_prompt = "HomeCore current agent-specific persisted prompt";
+    let service = Arc::new(MockSessionService::new());
+    let _ = service.enable_runtime_adapter();
+    let initial = service
+        .create_session(CreateSessionRequest {
+            injected_context: Vec::new(),
+            model: "claude-sonnet-4-5".to_string(),
+            prompt: "seed".to_string().into(),
+            system_prompt: meerkat_core::SystemPromptOverride::Set(stale_prompt.to_string()),
+            max_tokens: Some(4096),
+            event_tx: None,
+            build: Some(meerkat_core::service::SessionBuildOptions {
+                comms_name: Some(format!("{mob_id}/worker/{member}")),
+                ..Default::default()
+            }),
+            initial_turn: meerkat_core::service::InitialTurnPolicy::Defer,
+            deferred_prompt_policy: meerkat_core::service::DeferredPromptPolicy::Discard,
+            labels: None,
+        })
+        .await
+        .expect("seed existing session");
+    let session_id = initial.session_id;
+    let mut evolved = service
+        .live_session_clone(&session_id)
+        .await
+        .expect("live session before prompt evolution");
+    evolved.append_system_message(intermediate_prompt);
+    evolved.append_system_message(persisted_prompt);
+    service.replace_live_session(evolved).await;
+    MobSessionService::discard_live_session(service.as_ref(), &session_id)
+        .await
+        .expect("discard live session while retaining the durable snapshot");
+
+    let event_store = InMemoryMobEventStore::new();
+    let runs = Arc::new(InMemoryMobRunStore::new());
+    let specs = Arc::new(InMemoryMobSpecStore::new());
+    let runtime_metadata = Arc::new(InMemoryMobRuntimeMetadataStore::new());
+    let identity_store = Arc::new(InMemoryMobIdentityStore::paired_with_event_store(
+        &event_store,
+        Arc::new(crate::store::SystemMobIdentityStoreClock),
+    ));
+    let storage = MobStorage {
+        events: Arc::new(event_store),
+        runs,
+        specs,
+        runtime_metadata,
+        identity: identity_store.clone(),
+        identity_member: Some(identity_store.clone()),
+        identity_status: Arc::new(InMemoryMobIdentityStatusStore::new()),
+        realm_profiles: None,
+    };
+    let handle = MobBuilder::new(definition, storage)
+        .with_session_service(service.clone())
+        .create()
+        .await
+        .expect("create adoption mob without SpawnBasePromptSource");
+    handle
+        .attach_existing_session_as_member(
+            ProfileName::from("worker"),
+            member.clone(),
+            session_id.clone(),
+        )
+        .await
+        .expect("attach existing persisted session");
+
+    let adoption = crate::identity::AdoptMemberIdentityDeclaration {
+        mob_id: mob_id.clone(),
+        agent_identity: member.clone(),
+        request_id: crate::identity::IdentityAdoptionId::new("adopt-persisted-prompt")
+            .expect("valid adoption id"),
+        precondition: crate::identity::IdentityAdoptionPrecondition::ExpectedAbsent,
+        declaration_scope: crate::identity::IdentityDeclarationScopeId::new("homecore")
+            .expect("valid declaration scope"),
+        declaration_revision: 1,
+        session: crate::identity::DesiredSessionTarget {
+            session_id: session_id.clone(),
+            lineage_id: meerkat_core::SessionLineageId::for_session(&session_id),
+            lineage_generation: meerkat_core::SessionGeneration::INITIAL,
+            authority_policy: crate::identity::DesiredSessionAuthorityPolicy::RequireExisting,
+        },
+        member: crate::identity::IdentityProfileMemberDeclaration {
+            profile_name: ProfileName::from("worker"),
+            profile_override: None,
+            model_override: None,
+            external_addressable_override: None,
+            context: None,
+            labels: None,
+            additional_instructions: None,
+            system_prompt_override: None,
+            tool_access_policy: None,
+            auth_binding: None,
+            budget_limits: None,
+            runtime_mode: Some(meerkat_contracts::wire::WireMobRuntimeMode::AutonomousHost),
+            required_env_keys: Vec::new(),
+            required_local_callback_tools: Vec::new(),
+            execution: crate::identity::DesiredExecution::ControllingSession,
+        },
+        wiring_custody: crate::identity::IdentityWiringCustody::ExternalManaged,
+        owned_wiring: BTreeSet::new(),
+        convergence: crate::identity::IdentityConvergenceMode::Drain { max_wait_ms: 5_000 },
+    };
+    let mut clobbering_adoption = adoption.clone();
+    clobbering_adoption.member.system_prompt_override =
+        Some(meerkat_contracts::wire::PortableSystemPrompt::Set {
+            text: "reconstructed host base prompt".to_string(),
+        });
+    let error = handle
+        .adopt_member_identity_declaration(clobbering_adoption)
+        .await
+        .expect_err("adoption must reject a prompt that would clobber persisted state");
+    assert!(
+        error
+            .to_string()
+            .contains("cannot restate an existing session's durable system prompt"),
+        "prompt restatement rejection should be explicit: {error}"
+    );
+
+    handle
+        .adopt_member_identity_declaration(adoption.clone())
+        .await
+        .expect("adopt existing member while preserving transcript authority");
+
+    let record = match identity_store
+        .observe_identity_intent(&mob_id, &member)
+        .await
+        .expect("read adopted identity intent")
+    {
+        crate::identity::IdentityStoredObservation::Valid(record) => record,
+        other => panic!("expected valid adopted identity intent, got {other:?}"),
+    };
+    let crate::identity::IdentityIntent::Present {
+        member: desired_member,
+        ..
+    } = record.intent
+    else {
+        panic!("adoption must persist present intent");
+    };
+    assert!(
+        desired_member.material.overlay.system_prompt.is_none(),
+        "adoption must preserve the existing transcript instead of sealing one selected prompt row"
+    );
+    let rematerialization = super::spec_compiler::spawn_spec_from_desired_member(
+        &member,
+        &adoption.session,
+        &desired_member,
+    )
+    .expect("lower adopted desired member");
+    assert!(
+        rematerialization.system_prompt_override.is_none(),
+        "exact-session resume must not replace or collapse the persisted System sequence"
+    );
+    let history = service
+        .read_history(
+            &session_id,
+            meerkat_core::service::SessionHistoryQuery {
+                offset: 0,
+                limit: None,
+            },
+        )
+        .await
+        .expect("read preserved adopted history");
+    let system_prompts = history
+        .messages
+        .iter()
+        .filter_map(|message| match message {
+            meerkat_core::Message::System(system) => Some(system.content.as_str()),
+            _ => None,
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(
+        system_prompts,
+        vec![stale_prompt, intermediate_prompt, persisted_prompt],
+        "adoption must leave every legacy unkeyed System row intact and ordered"
+    );
+    handle.shutdown().await.expect("shutdown adoption mob");
+}
+
+#[tokio::test]
 async fn test_mob_shutdown() {
     let (handle, _service) = create_test_mob(sample_definition()).await;
     handle.shutdown().await.expect("shutdown");
@@ -20555,7 +20739,7 @@ async fn test_respawn_contract_aligns_receipt_with_canonical_member_state() {
 }
 
 #[tokio::test]
-async fn test_respawn_with_successor_spec_commits_reprofiled_successor_atomically() {
+async fn test_respawn_with_successor_spec_preserves_omitted_binding_and_reprofiles_atomically() {
     let mut definition = sample_definition();
     definition.id = MobId::from("successor-spec-commit-mob");
     let (handle, _service) = create_test_mob(definition).await;
@@ -20577,7 +20761,6 @@ async fn test_respawn_with_successor_spec_commits_reprofiled_successor_atomicall
         .expect("predecessor exists");
 
     let mut successor = SpawnMemberSpec::new("lead", member_id.clone());
-    successor.binding = Some(crate::RuntimeBinding::Session);
     successor.runtime_mode = Some(crate::MobRuntimeMode::TurnDriven);
     successor.labels = Some(BTreeMap::from([(
         "successor-policy".to_string(),


### PR DESCRIPTION
## Summary

- preserve the complete durable system-prompt sequence when `require_existing` adopts an exact session
- reject lossy explicit prompt restatements during adoption instead of replacing an N-row transcript with one message
- treat an omitted successor binding as preserve-current during atomic respawn reprofiling

## Ownership

The durable session transcript remains the sole prompt authority for an adopted existing session. Fresh and remote portable material still carries a fully resolved prompt. A successor spec may omit binding to preserve the current placement contract; only an explicitly different binding is rejected.

## Validation

- focused adoption regression: green
- focused successor respawn regression: green
- `make fmt-check`: green
- `git diff --check`: green
- mandatory pre-push hook: green, including workspace unit, integration, cold-restart, and e2e-fast gates
