### PR TITLE
fix(mob): harden persistent resume authority

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,19 @@ them.
 
 ## [Unreleased]
 
+### Added
+
+- `MobStorage::created_definition` reads the latest durable `MobCreated`
+  definition without building or actuating a mob, allowing hosts to compare an
+  edited composition against the event-log authority before resume.
+
+### Fixed
+
+- Mob resume now recognizes a structurally valid legacy runtime alias at any
+  generation when its embedded durable identity matches the requested member.
+  Exact mob and role checks remain required, and malformed generations or
+  different identities continue to fail closed.
+
 ## [0.8.28] - 2026-08-24
 
 ### Added

--- a/meerkat-mob/src/build.rs
+++ b/meerkat-mob/src/build.rs
@@ -765,45 +765,66 @@ fn resumed_member_segment_matches_current_or_legacy(current: &str, stored: &str)
     if current == stored {
         return true;
     }
-    let current_identity = if let Some(encoded) = current.strip_prefix("mk--") {
-        let Some(decoded) = decode_legacy_member_alias_segment(encoded) else {
-            return false;
-        };
-        if stored == decoded {
-            return true;
-        }
-        decoded
-    } else {
-        current.to_string()
+    let Some((current_identity, current_is_runtime_alias)) =
+        durable_identity_from_member_segment(current)
+    else {
+        return false;
     };
-    mobkit_generation_zero_identity_runtime_alias(&current_identity)
-        .is_some_and(|alias| stored == alias)
+    let Some((stored_identity, stored_is_runtime_alias)) =
+        durable_identity_from_member_segment(stored)
+    else {
+        return false;
+    };
+    match (current_is_runtime_alias, stored_is_runtime_alias) {
+        (false, false) => current_identity == stored_identity,
+        // A stable identity may adopt a legacy alias at any generation, but
+        // two persisted runtime observations must name the same exact alias.
+        // Otherwise a typed binding from one run could incorrectly certify a
+        // comms name from another run merely because both embed the same
+        // durable identity.
+        (true, true) => decoded_member_segment(current) == decoded_member_segment(stored),
+        (true, false) => runtime_alias_identity_matches_stable(&current_identity, &stored_identity),
+        (false, true) => runtime_alias_identity_matches_stable(&stored_identity, &current_identity),
+    }
 }
 
-fn mobkit_generation_zero_identity_runtime_alias(current: &str) -> Option<String> {
-    let mut encoded = String::with_capacity(current.len() + 26);
-    encoded.push_str("mk--rt_c");
-    let canonical_identity = if current.contains(':') {
-        current.to_string()
-    } else {
-        format!("identity:{current}")
-    };
-    for character in canonical_identity.chars() {
-        match character {
-            '_' => encoded.push_str("__"),
-            ':' => encoded.push_str("_c"),
-            character if character.is_ascii_alphanumeric() || character == '-' => {
-                encoded.push(character);
-            }
-            character => {
-                encoded.push_str("_x");
-                encoded.push_str(&format!("{:x}", character as u32));
-                encoded.push('_');
-            }
+/// Recover the durable identity proved by one raw or comms-safe member segment.
+///
+/// MobKit previously persisted runtime aliases in typed member bindings. Those
+/// aliases carry one exact durable identity plus an incidental generation. The
+/// generation is not part of the durable member identity, but it must still be
+/// a canonical `u64` before the alias can authorize resume compatibility.
+fn durable_identity_from_member_segment(member: &str) -> Option<(String, bool)> {
+    let decoded = decoded_member_segment(member)?;
+
+    let durable_identity = if let Some(runtime_alias) = decoded.strip_prefix("rt:") {
+        let (identity, generation) = runtime_alias.rsplit_once(':')?;
+        if identity.is_empty() || generation.parse::<u64>().is_err() {
+            return None;
         }
+        return Some((identity.to_string(), true));
+    } else {
+        decoded.as_str()
+    };
+    if durable_identity.is_empty() {
+        return None;
     }
-    encoded.push_str("_c0");
-    Some(encoded)
+
+    Some((durable_identity.to_string(), false))
+}
+
+fn decoded_member_segment(member: &str) -> Option<String> {
+    if let Some(encoded) = member.strip_prefix("mk--") {
+        decode_legacy_member_alias_segment(encoded)
+    } else {
+        Some(member.to_string())
+    }
+}
+
+fn runtime_alias_identity_matches_stable(runtime_identity: &str, stable_identity: &str) -> bool {
+    runtime_identity == stable_identity
+        || (!stable_identity.contains(':')
+            && runtime_identity.strip_prefix("identity:") == Some(stable_identity))
 }
 
 fn split_member_comms_name(value: &str) -> Option<(&str, &str, &str)> {
@@ -3614,6 +3635,68 @@ mod tests {
     }
 
     #[test]
+    fn test_resumed_metadata_accepts_ob3_generation_two_runtime_binding() {
+        let stable_member = "mk--person_cfederico_x2e_gomez_x40_king_x2e_com";
+        let legacy_runtime_member = "mk--rt_cperson_cfederico_x2e_gomez_x40_king_x2e_com_c2";
+        let canonical_binding = meerkat_core::MobMemberBinding {
+            mob_id: "ob3".to_string(),
+            role: "personal".to_string(),
+            member: stable_member.to_string(),
+        };
+        let mut config = AgentBuildConfig::new("gpt-5.5");
+        config.comms_name = Some(format!("ob3/personal/{stable_member}"));
+        config.mob_member_binding = Some(canonical_binding.clone());
+        config.peer_meta = Some(PeerMeta::default().with_label("fixture", "current"));
+
+        let metadata = SessionMetadata {
+            schema_version: meerkat_core::SESSION_METADATA_SCHEMA_VERSION,
+            model: "gpt-5.5".to_string(),
+            max_tokens: 16_384,
+            structured_output_retries: 2,
+            provider: meerkat_core::Provider::OpenAI,
+            self_hosted_server_id: None,
+            provider_params: None,
+            tooling: Default::default(),
+            keep_alive: false,
+            comms_name: Some(format!("ob3/personal/{legacy_runtime_member}")),
+            peer_meta: Some(
+                PeerMeta::default()
+                    .with_label("fixture", "stale")
+                    .with_label("agent_identity", legacy_runtime_member)
+                    .with_label("meerkat_id", legacy_runtime_member),
+            ),
+            realm_id: None,
+            instance_id: None,
+            backend: None,
+            config_generation: None,
+            auth_binding: None,
+            mob_member_binding: Some(meerkat_core::MobMemberBinding {
+                mob_id: "ob3".to_string(),
+                role: "personal".to_string(),
+                member: legacy_runtime_member.to_string(),
+            }),
+        };
+
+        apply_resumed_session_metadata(&mut config, &metadata)
+            .expect("generation-two runtime binding proves the same durable identity");
+        assert_eq!(
+            config.comms_name.as_deref(),
+            Some("ob3/personal/mk--person_cfederico_x2e_gomez_x40_king_x2e_com")
+        );
+        assert_eq!(config.mob_member_binding, Some(canonical_binding));
+        let labels = &config.peer_meta.expect("canonical peer metadata").labels;
+        assert_eq!(labels.get("fixture").map(String::as_str), Some("current"));
+        assert_eq!(
+            labels.get("agent_identity").map(String::as_str),
+            Some(stable_member)
+        );
+        assert_eq!(
+            labels.get("meerkat_id").map(String::as_str),
+            Some(stable_member)
+        );
+    }
+
+    #[test]
     fn encoded_stable_identity_accepts_legacy_generation_zero_runtime_binding() {
         for (stable_member, legacy_member) in [
             ("mk--agent_calice", "mk--rt_cagent_calice_c0"),
@@ -3633,11 +3716,29 @@ mod tests {
     }
 
     #[test]
+    fn encoded_stable_identity_accepts_legacy_runtime_binding_at_any_generation() {
+        let stable_member = "mk--person_cfederico_x2e_gomez_x40_king_x2e_com";
+        for generation in [1_u64, 2, u64::MAX] {
+            let legacy_member =
+                format!("mk--rt_cperson_cfederico_x2e_gomez_x40_king_x2e_com_c{generation}");
+            assert!(
+                resumed_comms_name_matches_current_or_legacy(
+                    &format!("ob3/personal/{stable_member}"),
+                    &format!("ob3/personal/{legacy_member}"),
+                ),
+                "stable encoded member must prove its legacy generation-{generation} runtime binding"
+            );
+        }
+    }
+
+    #[test]
     fn encoded_stable_identity_rejects_unproven_legacy_runtime_binding() {
         let current = "homecore/identity/mk--agent_calice";
         for stored in [
             "homecore/identity/mk--rt_cagent_cbob_c0",
-            "homecore/identity/mk--rt_cagent_calice_c1",
+            "homecore/identity/mk--rt_cagent_cbob_c2",
+            "homecore/identity/mk--rt_cagent_calice_cnot-a-generation",
+            "homecore/identity/mk--rt_cagent_calice_c18446744073709551616",
             "other/identity/mk--rt_cagent_calice_c0",
             "homecore/worker/mk--rt_cagent_calice_c0",
             "homecore/identity/mk--agent_calice_x",
@@ -3650,14 +3751,17 @@ mod tests {
     }
 
     #[test]
-    fn test_identity_runtime_alias_rejects_wrong_mob_role_member_or_generation() {
+    fn test_identity_runtime_alias_rejects_wrong_mob_role_member_or_malformed_generation() {
         let current = "homecore/identity/parent-1";
         for stored in [
+            "homecore/identity/identity:parent-1",
             "other/identity/mk--rt_cidentity_cparent-1_c0",
             "homecore/worker/mk--rt_cidentity_cparent-1_c0",
             "homecore/identity/mk--rt_cidentity_cparent-2_c0",
             "homecore/identity/mk--rt_cworker_cparent-1_c0",
-            "homecore/identity/mk--rt_cidentity_cparent-1_c1",
+            "homecore/identity/mk--rt_cidentity_cparent-1_c-1",
+            "homecore/identity/mk--rt_cidentity_cparent-1_c18446744073709551616",
+            "homecore/identity/mk--rt_cidentity_cparent-1_c",
         ] {
             assert!(
                 !resumed_comms_name_matches_current_or_legacy(current, stored),
@@ -3667,22 +3771,27 @@ mod tests {
     }
 
     #[test]
-    fn generation_zero_runtime_alias_encodes_typed_colon_identity_once() {
+    fn member_segment_normalization_recovers_only_proven_durable_identity() {
         assert_eq!(
-            mobkit_generation_zero_identity_runtime_alias("domain:home-automation").as_deref(),
-            Some("mk--rt_cdomain_chome-automation_c0")
+            durable_identity_from_member_segment("mk--rt_cdomain_chome-automation_c10"),
+            Some(("domain:home-automation".to_string(), true))
         );
         assert_eq!(
-            mobkit_generation_zero_identity_runtime_alias("parent-1").as_deref(),
-            Some("mk--rt_cidentity_cparent-1_c0")
+            durable_identity_from_member_segment("rt:identity:parent-1:1"),
+            Some(("identity:parent-1".to_string(), true))
         );
         assert_eq!(
-            mobkit_generation_zero_identity_runtime_alias("agent:alice_smith").as_deref(),
-            Some("mk--rt_cagent_calice__smith_c0")
+            durable_identity_from_member_segment("parent-1"),
+            Some(("parent-1".to_string(), false))
         );
         assert_eq!(
-            mobkit_generation_zero_identity_runtime_alias("agent:alice.smith").as_deref(),
-            Some("mk--rt_cagent_calice_x2e_smith_c0")
+            durable_identity_from_member_segment("mk--agent_calice_x2e_smith"),
+            Some(("agent:alice.smith".to_string(), false))
+        );
+        assert!(durable_identity_from_member_segment("mk--rt_cagent_calice_c-1").is_none());
+        assert!(
+            durable_identity_from_member_segment("mk--rt_cagent_calice_c18446744073709551616")
+                .is_none()
         );
     }
 

--- a/meerkat-mob/src/runtime/builder.rs
+++ b/meerkat-mob/src/runtime/builder.rs
@@ -7725,22 +7725,12 @@ impl MobBuilder {
             canonical_runtime_adapter_for_session_service(&session_service, runtime_adapter)?;
         // §8 check deferred until after definition recovery — the definition
         // comes from the event log, so we can't check profiles before replay.
-        let all_events = storage.events.replay_all().await?;
-
-        // Use the last MobCreated event — reset appends a fresh MobCreated
-        // to start a new epoch, so the latest one reflects the current definition.
-        let definition = all_events
-            .iter()
-            .rev()
-            .find_map(|event| match &event.kind {
-                MobEventKind::MobCreated { definition } => Some(*definition.clone()),
-                _ => None,
-            })
-            .ok_or_else(|| {
-                MobError::Internal(
-                    "cannot resume mob: no MobCreated event found in storage".to_string(),
-                )
-            })?;
+        let (all_events, definition) = storage.replay_with_created_definition().await?;
+        let definition = definition.ok_or_else(|| {
+            MobError::Internal(
+                "cannot resume mob: no MobCreated event found in storage".to_string(),
+            )
+        })?;
         MobSupervisorBridge::preflight_ingress_ownership(
             definition
                 .backend

--- a/meerkat-mob/src/storage.rs
+++ b/meerkat-mob/src/storage.rs
@@ -11,6 +11,10 @@ use crate::store::{
     MobIdentityStore, MobRunStore, MobRuntimeMetadataStore, MobSpecStore, RealmProfileStore,
     authority_validating_mob_run_store,
 };
+use crate::{
+    MobDefinition,
+    event::{MobEvent, MobEventKind},
+};
 #[cfg(not(target_arch = "wasm32"))]
 use std::path::Path;
 use std::sync::Arc;
@@ -156,6 +160,33 @@ impl MobStorage {
     /// Return whether the structural event log is empty.
     pub async fn is_event_log_empty(&self) -> Result<bool, crate::store::MobStoreError> {
         Ok(self.events.latest_cursor().await? == 0)
+    }
+
+    /// Read the definition that the persistent mob storage was created for.
+    ///
+    /// This is a pre-actuation read: it does not build a runtime, resume
+    /// members, or emit events. Reset starts a new structural epoch by
+    /// appending another `MobCreated`, so the last such event is authoritative.
+    pub async fn created_definition(
+        &self,
+    ) -> Result<Option<MobDefinition>, crate::store::MobStoreError> {
+        let (_, definition) = self.replay_with_created_definition().await?;
+        Ok(definition)
+    }
+
+    /// Replay structural events together with their authoritative definition.
+    ///
+    /// Runtime resume and the public pre-actuation read share this exact
+    /// selection path so neither can reinterpret the event log independently.
+    pub(crate) async fn replay_with_created_definition(
+        &self,
+    ) -> Result<(Vec<MobEvent>, Option<MobDefinition>), crate::store::MobStoreError> {
+        let events = self.events.replay_all().await?;
+        let definition = events.iter().rev().find_map(|event| match &event.kind {
+            MobEventKind::MobCreated { definition } => Some(*definition.clone()),
+            _ => None,
+        });
+        Ok((events, definition))
     }
 
     /// Create a storage bundle backed by a single SQLite database file.
@@ -539,6 +570,51 @@ mod tests {
                 .unwrap(),
             crate::IdentityStoredObservation::Valid(status)
         );
+    }
+
+    #[tokio::test]
+    async fn created_definition_reads_latest_epoch_without_mutating_storage() {
+        let storage = MobStorage::in_memory();
+        assert_eq!(storage.created_definition().await.unwrap(), None);
+
+        let first = MobDefinition::explicit("created-definition-test");
+        storage
+            .events
+            .append(NewMobEvent {
+                mob_id: first.id.clone(),
+                timestamp: None,
+                kind: MobEventKind::MobCreated {
+                    definition: Box::new(first),
+                },
+            })
+            .await
+            .unwrap();
+        storage
+            .events
+            .append(NewMobEvent {
+                mob_id: MobId::from("created-definition-test"),
+                timestamp: None,
+                kind: MobEventKind::MobCompleted,
+            })
+            .await
+            .unwrap();
+        let mut latest = MobDefinition::explicit("created-definition-test");
+        latest.image_generation_provider = Some(meerkat_core::Provider::OpenAI);
+        storage
+            .events
+            .append(NewMobEvent {
+                mob_id: latest.id.clone(),
+                timestamp: None,
+                kind: MobEventKind::MobCreated {
+                    definition: Box::new(latest.clone()),
+                },
+            })
+            .await
+            .unwrap();
+
+        let cursor_before = storage.events.latest_cursor().await.unwrap();
+        assert_eq!(storage.created_definition().await.unwrap(), Some(latest));
+        assert_eq!(storage.events.latest_cursor().await.unwrap(), cursor_before);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- accept legacy MobKit runtime aliases at any valid `u64` generation when they structurally prove the requested stable member identity
- keep resume fail-closed across mob, role, identity, malformed generation, and conflicting persisted runtime observations
- expose a non-actuating `MobStorage::created_definition()` read seam that selects the latest `MobCreated` epoch without advancing the cursor
- route `MobBuilder::for_resume` through the same replay helper so definition selection has one owner

## Production failure reproduced

The regression fixture mirrors the OB3 store shape:

- requested member: `mk--person_cfederico_x2e_gomez_x40_king_x2e_com`
- persisted binding member: `mk--rt_cperson_cfederico_x2e_gomez_x40_king_x2e_com_c2`
- persisted comms name: `ob3/personal/mk--rt_cperson_cfederico_x2e_gomez_x40_king_x2e_com_c2`

The previous compatibility rule covered only generation zero. The durable identity is now recovered structurally from a well-formed runtime alias, while the runtime generation remains incidental to stable identity matching.

Two persisted runtime observations still have to name the same exact decoded alias. The mandatory pre-push suite caught and prevented an over-broad first version that would have allowed a generation-0 comms alias to certify a generation-1 typed binding.

## Validation

- red before fix: exact OB3 generation-2 resume fixture
- green: generations 0, 1, 2, and `u64::MAX`
- green: exact OB3 persisted comms-name plus typed-binding fixture
- green: malformed, negative, overflow, wrong-mob, wrong-role, wrong-identity, and conflicting-generation rejection
- green: latest-epoch `created_definition()` read with unchanged cursor
- green: `make fmt`
- green: `git diff --check`
- green: mandatory pre-push hook, including changed-crate Clippy, machine/TLC verification, 10,407 workspace tests, integration, cold-restart, and e2e gates

## Downstream release validation

- Run A: published Meerkat 0.8.29 plus published MobKit 0.8.23, assert the affected OB3 member resumes and no resume-rejected event is emitted
- Run B: published Meerkat 0.8.29 plus published MobKit 0.8.24, run the full joint OB3 gate
