### PR TITLE
fix: avoid duplicate optional Bazel deps

### DIFF
--- a/meerkat-openai/BUILD.bazel
+++ b/meerkat-openai/BUILD.bazel
@@ -60,7 +60,6 @@ rust_library(
         "//meerkat-core:meerkat_core",
         "//meerkat-llm-core:meerkat_llm_core",
         "//meerkat-models:meerkat_models",
-        "@crates//:oai-rt-rs-0.4.1",
     ] + all_crate_deps(
         package_name = "meerkat-openai",
         normal = True,
@@ -101,7 +100,6 @@ rust_library(
         "//meerkat:meerkat_core_agent_factory_build",
         "//meerkat:meerkat_llm_core_agent_factory_build",
         "//meerkat:meerkat_models_agent_factory_build",
-        "@crates//:oai-rt-rs-0.4.1",
     ] + all_crate_deps(
         package_name = "meerkat-openai",
         normal = True,
@@ -159,7 +157,6 @@ rust_test(
         "//meerkat-llm-core:meerkat_llm_core",
         "//meerkat-models:meerkat_models",
         "//meerkat-runtime:meerkat_runtime_test_support",
-        "@crates//:oai-rt-rs-0.4.1",
     ] + all_crate_deps(
         package_name = "meerkat-openai",
         normal = True,
@@ -221,7 +218,6 @@ rust_test(
         "//meerkat-models:meerkat_models",
         "//meerkat-openai:meerkat_openai",
         "//meerkat-runtime:meerkat_runtime_test_support",
-        "@crates//:oai-rt-rs-0.4.1",
     ] + all_crate_deps(
         package_name = "meerkat-openai",
         normal = True,
@@ -281,7 +277,6 @@ rust_test(
         "//meerkat-models:meerkat_models",
         "//meerkat-openai:meerkat_openai",
         "//meerkat-runtime:meerkat_runtime_test_support",
-        "@crates//:oai-rt-rs-0.4.1",
     ] + all_crate_deps(
         package_name = "meerkat-openai",
         normal = True,

--- a/scripts/generate-bazel-rust-builds.mjs
+++ b/scripts/generate-bazel-rust-builds.mjs
@@ -85,6 +85,12 @@ const requiredTargetFeatures = new Map(
 const resolvedFeatures = new Map(
   (metadata.resolve?.nodes ?? []).map((node) => [node.id, new Set(node.features ?? [])]),
 );
+const resolvedDependencyPackageIds = new Map(
+  (metadata.resolve?.nodes ?? []).map((node) => [
+    node.id,
+    new Set((node.deps ?? []).map((dep) => dep.pkg)),
+  ]),
+);
 
 function addFeature(pkg, feature) {
   if (!feature || feature.startsWith("dep:")) return false;
@@ -302,7 +308,7 @@ function rewriteRuntimeTestSupportDeps(deps, useAgentFactoryDeps) {
   });
 }
 
-function externalCrateLabel(dep) {
+function externalCratePackage(dep) {
   const candidates = externalByName.get(dep.name) ?? [];
   let pkg = candidates.length === 1 ? candidates[0] : null;
   if (!pkg && dep.req?.startsWith("^")) {
@@ -315,6 +321,11 @@ function externalCrateLabel(dep) {
       return version[0] === requested[0];
     }) ?? null;
   }
+  return pkg;
+}
+
+function externalCrateLabel(dep) {
+  const pkg = externalCratePackage(dep);
   if (!pkg) return null;
   const repository = bazelOnlyExternalRepositoryByPackage.get(pkg.name) ?? "crates";
   return `@${repository}//:${pkg.name}-${pkg.version}`;
@@ -326,13 +337,20 @@ function optionalExternalDeps(
 ) {
   const labels = new Set();
   const alreadyResolved = resolvedFeatures.get(pkg.id) ?? new Set();
+  const alreadyResolvedDependencyIds = resolvedDependencyPackageIds.get(pkg.id) ?? new Set();
   for (const feature of features) {
     if (alreadyResolved.has(feature)) continue;
     for (const expansion of pkg.features?.[feature] ?? []) {
       const depName = expansion.startsWith("dep:") ? expansion.slice(4) : null;
       if (!depName) continue;
       const dep = pkg.dependencies.find((candidate) => candidate.name === depName && candidate.source !== null);
-      const label = dep ? externalCrateLabel(dep) : null;
+      const externalPkg = dep ? externalCratePackage(dep) : null;
+      // `all_crate_deps` already owns every dependency in Cargo's default
+      // resolved graph, even when a second feature also expands to it. Add an
+      // explicit label only for a package absent from that graph; otherwise
+      // the same label appears twice once the second feature is selected.
+      if (!dep || !externalPkg || alreadyResolvedDependencyIds.has(externalPkg.id)) continue;
+      const label = externalCrateLabel(dep);
       if (label) labels.add(label);
     }
   }


### PR DESCRIPTION
## Summary

- distinguish Cargo-default resolved dependencies from dependencies introduced only by generated target feature unions
- keep `all_crate_deps` authoritative when Cargo already resolves the dependency
- emit explicit labels only for otherwise-unresolved optional dependencies
- regenerate `meerkat-openai/BUILD.bazel` without duplicate `oai-rt-rs` labels

## Release blocker

The mandatory exact-main Turbo S gate failed during Bazel analysis at invocation `006332c1-24e3-48d2-8aad-b102b07914b9`. `meerkat-openai` already resolves `oai-rt-rs` through its default `realtime` feature, so `all_crate_deps` emitted it. The generator also emitted it explicitly when selecting `experimental-gpt-live`, producing a duplicate deps label.

The corrected predicate uses Cargo's default resolved dependency package IDs. This preserves necessary explicit optional labels such as `xtask/which`, which is absent from the default graph, and the WebRTC dependencies isolated in `@meerkat_live_crates`.

## Evidence

- exact previously failing target is green at BuildBuddy invocation `3b36d7af-b055-46b8-aa40-5e2771b18fb2`
- generated Bazel drift check is green
- Cargo lock consistency and strict Bazel module-lock gates are green
- formatting and diff hygiene are green
- final combined tree passed the mandatory pre-push hook

The final exact-main Turbo S remains mandatory after merge. No package or tag will be published before it is green.
