### PR TITLE
fix: wire session authority bridge env

### DIFF
--- a/meerkat-session/BUILD.bazel
+++ b/meerkat-session/BUILD.bazel
@@ -48,6 +48,7 @@ rust_library(
     rustc_env = {
         "CARGO_PKG_VERSION": "0.8.30",
         "CARGO_MANIFEST_DIR": "./meerkat-session",
+        "MEERKAT_GENERATED_AUTHORITY_BRIDGE_SYMBOL_SUFFIX": "bazel_private_generated_authority_bridge",
     },
     proc_macro_deps = all_crate_deps(
         package_name = "meerkat-session",
@@ -97,6 +98,7 @@ rust_library(
     rustc_env = {
         "CARGO_PKG_VERSION": "0.8.30",
         "CARGO_MANIFEST_DIR": "./meerkat-session",
+        "MEERKAT_GENERATED_AUTHORITY_BRIDGE_SYMBOL_SUFFIX": "bazel_private_generated_authority_bridge",
     },
     proc_macro_deps = all_crate_deps(
         package_name = "meerkat-session",
@@ -138,6 +140,7 @@ rust_library(
     rustc_env = {
         "CARGO_PKG_VERSION": "0.8.30",
         "CARGO_MANIFEST_DIR": "./meerkat-session",
+        "MEERKAT_GENERATED_AUTHORITY_BRIDGE_SYMBOL_SUFFIX": "bazel_private_generated_authority_bridge",
     },
     proc_macro_deps = all_crate_deps(
         package_name = "meerkat-session",
@@ -179,6 +182,7 @@ rust_library(
     rustc_env = {
         "CARGO_PKG_VERSION": "0.8.30",
         "CARGO_MANIFEST_DIR": "./meerkat-session",
+        "MEERKAT_GENERATED_AUTHORITY_BRIDGE_SYMBOL_SUFFIX": "bazel_private_generated_authority_bridge",
     },
     proc_macro_deps = all_crate_deps(
         package_name = "meerkat-session",
@@ -224,6 +228,7 @@ rust_test(
     rustc_env = {
         "CARGO_PKG_VERSION": "0.8.30",
         "CARGO_MANIFEST_DIR": "./meerkat-session",
+        "MEERKAT_GENERATED_AUTHORITY_BRIDGE_SYMBOL_SUFFIX": "bazel_private_generated_authority_bridge",
     },
     tags = [
         "fast",
@@ -285,6 +290,7 @@ rust_test(
         "CARGO_PKG_VERSION": "0.8.30",
         "CARGO_BIN_NAME": "ephemeral_contract",
         "CARGO_MANIFEST_DIR": "./meerkat-session",
+        "MEERKAT_GENERATED_AUTHORITY_BRIDGE_SYMBOL_SUFFIX": "bazel_private_generated_authority_bridge",
     },
     tags = [
         "fast",
@@ -344,6 +350,7 @@ rust_test(
         "CARGO_PKG_VERSION": "0.8.30",
         "CARGO_BIN_NAME": "persistence_compat",
         "CARGO_MANIFEST_DIR": "./meerkat-session",
+        "MEERKAT_GENERATED_AUTHORITY_BRIDGE_SYMBOL_SUFFIX": "bazel_private_generated_authority_bridge",
     },
     tags = [
         "fast",
@@ -403,6 +410,7 @@ rust_test(
         "CARGO_PKG_VERSION": "0.8.30",
         "CARGO_BIN_NAME": "regression_lifecycle",
         "CARGO_MANIFEST_DIR": "./meerkat-session",
+        "MEERKAT_GENERATED_AUTHORITY_BRIDGE_SYMBOL_SUFFIX": "bazel_private_generated_authority_bridge",
     },
     tags = [
         "fast",
@@ -462,6 +470,7 @@ rust_test(
         "CARGO_PKG_VERSION": "0.8.30",
         "CARGO_BIN_NAME": "session_store_append_only_trybuild",
         "CARGO_MANIFEST_DIR": "./meerkat-session",
+        "MEERKAT_GENERATED_AUTHORITY_BRIDGE_SYMBOL_SUFFIX": "bazel_private_generated_authority_bridge",
     },
     tags = [
         "trybuild",

--- a/scripts/generate-bazel-rust-builds.mjs
+++ b/scripts/generate-bazel-rust-builds.mjs
@@ -61,6 +61,7 @@ const generatedAuthorityBridgeSymbolSuffix = "bazel_private_generated_authority_
 const generatedAuthorityBridgePackageKeys = new Set([
   "meerkat-core",
   "meerkat-live",
+  "meerkat-session",
   "meerkat-runtime",
   "meerkat-mob",
 ]);


### PR DESCRIPTION
## Summary

- add `meerkat-session` to the generated-authority bridge owning-package set
- regenerate all Meerkat Session Bazel variants with the required compile-time symbol suffix

## Release blocker

The mandatory exact-main Turbo S gate reached remote execution and failed compiling `//meerkat-session:meerkat_session_agent_factory_build` at invocation `205c5675-f0a3-485d-ae85-25829058f87a`. `meerkat-session/src/live_transcript_authority.rs` uses `MEERKAT_GENERATED_AUTHORITY_BRIDGE_SYMBOL_SUFFIX` at compile time, but the Bazel generator's owning-package set omitted `meerkat-session`.

A workspace audit of every Rust use of the env key found the existing owners plus exactly this missing package. The regenerated diff adds the env to the nine Meerkat Session library/test variants and changes nothing else.

## Evidence

- exact previously failing target is green at BuildBuddy invocation `3c470e64-9bda-4155-b706-e297154dd51b`
- generated Bazel drift check is green
- Cargo lock consistency and strict Bazel module-lock gates are green
- formatting and diff hygiene are green
- final combined tree passed the mandatory pre-push hook

The final exact-main Turbo S remains mandatory after merge. No package or tag will be published before it is green.
