### PR TITLE
Fix hosted Turbo S environment

### DIFF
--- a/.github/workflows/release-turbo-s.yml
+++ b/.github/workflows/release-turbo-s.yml
@@ -32,12 +32,14 @@ jobs:
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
           MEERKAT_E2E_AUTH_OPENAI_OAUTH_TOKENS_JSON: ${{ secrets.MEERKAT_E2E_AUTH_OPENAI_OAUTH_TOKENS_JSON }}
         run: |
           for key in \
             BUILDBUDDY_API_KEY \
             ANTHROPIC_API_KEY \
             OPENAI_API_KEY \
+            GEMINI_API_KEY \
             MEERKAT_E2E_AUTH_OPENAI_OAUTH_TOKENS_JSON; do
             if [[ -z "${!key}" ]]; then
               echo "::error::Required repository secret ${key} is not configured."
@@ -58,16 +60,17 @@ jobs:
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
           MEERKAT_E2E_AUTH_OPENAI_OAUTH_TOKENS_JSON: ${{ secrets.MEERKAT_E2E_AUTH_OPENAI_OAUTH_TOKENS_JSON }}
         run: |
-          provider_overrides="ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY},OPENAI_API_KEY=${OPENAI_API_KEY}"
+          provider_overrides="ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY},OPENAI_API_KEY=${OPENAI_API_KEY},GEMINI_API_KEY=${GEMINI_API_KEY}"
           oauth_override_base64="$(
             printf 'MEERKAT_E2E_AUTH_OPENAI_OAUTH_TOKENS_JSON=%s' \
               "${MEERKAT_E2E_AUTH_OPENAI_OAUTH_TOKENS_JSON}" | base64 | tr -d '\n'
           )"
           echo "::add-mask::${provider_overrides}"
           echo "::add-mask::${oauth_override_base64}"
-          unset ANTHROPIC_API_KEY OPENAI_API_KEY MEERKAT_E2E_AUTH_OPENAI_OAUTH_TOKENS_JSON
+          unset ANTHROPIC_API_KEY OPENAI_API_KEY GEMINI_API_KEY MEERKAT_E2E_AUTH_OPENAI_OAUTH_TOKENS_JSON
           MEERKAT_BUILDBUDDY_SECRET_ENV_OVERRIDES="${provider_overrides}" \
             MEERKAT_BUILDBUDDY_SECRET_ENV_OVERRIDES_BASE64="${oauth_override_base64}" \
             scripts/buildbuddy-dev e2e-smoke-turbo-s

--- a/scripts/buildbuddy-e2e-smoke-remote-test
+++ b/scripts/buildbuddy-e2e-smoke-remote-test
@@ -226,6 +226,20 @@ prepend_python_runtime() {
   fi
 }
 
+configure_executor_cargo_home() {
+  local test_tmpdir="${TEST_TMPDIR:-}"
+  if [[ -z "${test_tmpdir}" ]]; then
+    echo "error: TEST_TMPDIR is required to derive executor-owned CARGO_HOME" >&2
+    exit 1
+  fi
+
+  export CARGO_HOME="${test_tmpdir}/cargo-home"
+  if ! mkdir -p "${CARGO_HOME}" || [[ ! -d "${CARGO_HOME}" || ! -w "${CARGO_HOME}" ]]; then
+    echo "error: executor-owned CARGO_HOME is not writable: ${CARGO_HOME}" >&2
+    exit 1
+  fi
+}
+
 install_wasm_rust_sysroot_overlay() {
   if ! command -v rustc >/dev/null 2>&1; then
     return 0
@@ -354,6 +368,7 @@ if [[ "${MEERKAT_E2E_SMOKE_TURBO_DEFAULTS:-}" == "1" ]]; then
 fi
 
 workspace_root="$(workspace_root_from_runfiles)"
+configure_executor_cargo_home
 prepend_runfile_tool_dir npm
 prepend_runfile_tool_dir node
 prepend_runfile_tool_dir cargo


### PR DESCRIPTION
## Summary

- require and forward the Gemini API credential used by media scenarios
- derive nested Cargo state from Bazel's per-action `TEST_TMPDIR`
- fail closed when the executor-owned Cargo home cannot be created or written

## Release evidence

Hosted exact-main Turbo S run 33074558952 reached 54/63 green after the Anthropic credential repair. The remaining terminal failures were harness-only:

- six media shards lacked a Gemini credential
- three browser shards inherited Linux `/home/runner/.cargo` into macOS RBE

The owner-controlled Gemini credential was authenticated successfully before it was installed as the repository secret. The remote wrapper now overrides any client-inherited Cargo home with an executor-owned per-action location instead of guessing an executor path.

## Validation

- mandatory pre-push hook: green
- `actionlint .github/workflows/release-turbo-s.yml`: green
- `bash -n scripts/buildbuddy-e2e-smoke-remote-test`: green
- `git diff --check`: green
