### PR TITLE
Fix immutable v0.8.30 release recovery

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -643,20 +643,28 @@ jobs:
           if [[ "${{ runner.os }}" == "Windows" ]]; then
             export CARGO_BUILD_JOBS=2
           fi
+          cargo_cmd=(./scripts/repo-cargo)
+          if [[ "${{ runner.os }}" == "Linux" ]]; then
+            # The immutable v0.8.30 wrapper asks Git for
+            # `rev-parse --path-format=absolute`, which predates the
+            # Bullseye container's Git 2.30. The release job already owns an
+            # isolated target directory, so use the rustup-proxied Cargo
+            # directly only on this legacy container. Fail closed unless
+            # rustup selected the exact repository pin first.
+            expected_rust="$(awk -F '"' '/^[[:space:]]*channel[[:space:]]*=/ { print $2; exit }' rust-toolchain.toml)"
+            active_rust="$(rustc --version | awk '{ print $2 }')"
+            if [[ -z "${expected_rust}" || "${active_rust}" != "${expected_rust}" ]]; then
+              echo "Linux release toolchain mismatch: expected ${expected_rust:-missing}, active ${active_rust:-missing}" >&2
+              exit 1
+            fi
+            echo "Linux release toolchain: rustc ${active_rust}"
+            cargo_cmd=(cargo)
+          fi
+
           # Package names (for cargo build -p) — binary names differ via [[bin]]
           PACKAGES=("rkat" "meerkat-rpc" "meerkat-rest" "meerkat-mcp-server")
           for pkg in "${PACKAGES[@]}"; do
-            if [[ "${{ runner.os }}" == "Linux" ]]; then
-              # The immutable v0.8.30 wrapper asks Git for
-              # `rev-parse --path-format=absolute`, which predates the
-              # Bullseye container's Git 2.30. The release job already owns an
-              # isolated target directory and installs the stable toolchain,
-              # so use that exact toolchain directly only on this legacy
-              # container. Non-Linux release builds retain repo-cargo.
-              rustup run stable cargo build --locked -p "$pkg" --release --target "${{ matrix.target }}"
-            else
-              ./scripts/repo-cargo build --locked -p "$pkg" --release --target "${{ matrix.target }}"
-            fi
+            "${cargo_cmd[@]}" build --locked -p "$pkg" --release --target "${{ matrix.target }}"
           done
 
       - name: Ad-hoc codesign macOS binaries

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -646,7 +646,17 @@ jobs:
           # Package names (for cargo build -p) — binary names differ via [[bin]]
           PACKAGES=("rkat" "meerkat-rpc" "meerkat-rest" "meerkat-mcp-server")
           for pkg in "${PACKAGES[@]}"; do
-            ./scripts/repo-cargo build -p "$pkg" --release --target "${{ matrix.target }}"
+            if [[ "${{ runner.os }}" == "Linux" ]]; then
+              # The immutable v0.8.30 wrapper asks Git for
+              # `rev-parse --path-format=absolute`, which predates the
+              # Bullseye container's Git 2.30. The release job already owns an
+              # isolated target directory and installs the stable toolchain,
+              # so use that exact toolchain directly only on this legacy
+              # container. Non-Linux release builds retain repo-cargo.
+              rustup run stable cargo build --locked -p "$pkg" --release --target "${{ matrix.target }}"
+            else
+              ./scripts/repo-cargo build --locked -p "$pkg" --release --target "${{ matrix.target }}"
+            fi
           done
 
       - name: Ad-hoc codesign macOS binaries

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,6 +41,16 @@ on:
         required: false
         default: ""
         type: string
+      semver_evidence_run_id:
+        description: "Package recovery: exact failed tag-run id whose completed semver measurement needs only amended declarations"
+        required: false
+        default: ""
+        type: string
+      semver_evidence_job_id:
+        description: "Package recovery: exact failed semver job id from semver_evidence_run_id"
+        required: false
+        default: ""
+        type: string
       release_backend:
         description: "Release backend for validation and binary builds"
         required: false
@@ -444,21 +454,66 @@ jobs:
           ref: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.release_tag != '' && github.event.inputs.release_tag || github.ref }}
           fetch-depth: 0
 
+      # A tag is immutable once any artifact is public. If its full semver
+      # measurement completed and failed only because declarations were
+      # missing, a package-recovery dispatch may reuse that exact measurement.
+      # The verifier itself and the amended changelog come from the workflow
+      # ref, while every published source checkout remains the release tag.
+      - name: Checkout semver recovery policy
+        if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.semver_evidence_job_id != '' }}
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.sha }}
+          path: .semver-recovery-policy
+          persist-credentials: false
+
       - name: Install Rust
+        if: ${{ github.event_name != 'workflow_dispatch' || github.event.inputs.semver_evidence_job_id == '' }}
         uses: dtolnay/rust-toolchain@stable
 
       - name: Cache cargo
+        if: ${{ github.event_name != 'workflow_dispatch' || github.event.inputs.semver_evidence_job_id == '' }}
         uses: Swatinem/rust-cache@v2
         with:
           shared-key: release-semver-breaks
 
       - name: Install cargo-semver-checks
+        if: ${{ github.event_name != 'workflow_dispatch' || github.event.inputs.semver_evidence_job_id == '' }}
         uses: taiki-e/install-action@cargo-semver-checks
         env:
           HOME: ${{ runner.temp }}/install-action-home-${{ github.job }}
 
       - name: Verify every reported break is named and the notes are stamped
+        if: ${{ github.event_name != 'workflow_dispatch' || github.event.inputs.semver_evidence_job_id == '' }}
         run: make semver-breaks
+
+      - name: Verify exact completed semver measurement and amended declarations
+        if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.semver_evidence_job_id != '' }}
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          EVIDENCE_RUN_ID: ${{ github.event.inputs.semver_evidence_run_id }}
+          EVIDENCE_JOB_ID: ${{ github.event.inputs.semver_evidence_job_id }}
+          RELEASE_TAG: ${{ github.event.inputs.release_tag }}
+        run: |
+          set -euo pipefail
+          if [[ -z "${EVIDENCE_RUN_ID}" || -z "${EVIDENCE_JOB_ID}" || -z "${RELEASE_TAG}" ]]; then
+            echo "semver evidence recovery requires release_tag, semver_evidence_run_id, and semver_evidence_job_id" >&2
+            exit 1
+          fi
+          release_sha="$(git rev-parse HEAD)"
+          gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${EVIDENCE_RUN_ID}" > "${RUNNER_TEMP}/semver-run.json"
+          gh api "repos/${GITHUB_REPOSITORY}/actions/jobs/${EVIDENCE_JOB_ID}" > "${RUNNER_TEMP}/semver-job.json"
+          gh api "repos/${GITHUB_REPOSITORY}/actions/jobs/${EVIDENCE_JOB_ID}/logs" > "${RUNNER_TEMP}/semver-job.log"
+          python3 .semver-recovery-policy/scripts/verify_semver_recovery_evidence.py \
+            --run-json "${RUNNER_TEMP}/semver-run.json" \
+            --job-json "${RUNNER_TEMP}/semver-job.json" \
+            --job-log "${RUNNER_TEMP}/semver-job.log" \
+            --evidence-run-id "${EVIDENCE_RUN_ID}" \
+            --evidence-job-id "${EVIDENCE_JOB_ID}" \
+            --release-tag "${RELEASE_TAG}" \
+            --release-sha "${release_sha}" \
+            --changelog .semver-recovery-policy/CHANGELOG.md
 
   build_binaries:
     name: Build and package surface binaries with GitHub-hosted runners

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -108,6 +108,23 @@ them.
                         `FactoryError`, `interaction_id`, `RealtimeSessionEvent`.
   - `meerkat-mob`: `LifecycleOperationProgressStalled`, `MobError`, `MobSessionService`,
                    `enqueue_committed_parent_session_boundary_after_runtime_turn`.
+
+    This ledger entry was appended after `v0.8.30` was tagged. The immutable
+    tag's changelog therefore omits it; the GitHub Release body links to this
+    corrected declaration. Published package source remains the original,
+    qualified tag.
+
+    `MobSessionService::enqueue_committed_parent_session_boundary_after_runtime_turn`
+    is now required; its `Ok(0)`/`Unsupported` default is removed. A wrapper
+    around a persistent inner service must forward to that inner service, or
+    answer for itself while guarded by `supports_persistent_sessions()` - never
+    return a bare `Ok(0)`. Cargo reports the method through both public trait
+    paths, but they are one required implementation change.
+
+    `MobError::LifecycleOperationProgressStalled { intent, member_id, stage }`
+    is a new variant. Exhaustive matches on `MobError` must add an arm. It
+    replaces fixed explicit-resume expiry with a typed stall naming the member
+    and lifecycle stage that stopped making progress.
   - `meerkat-machine-kernels`: `AbandonLiveInteraction`, `AbandonLiveInteractionAttached`,
                                `AbandonLiveInteractionIdle`,
                                `AbandonLiveInteractionPreservingEarlierDelegationAttached`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,6 +106,8 @@ them.
                     `UnwindSafe`.
   - `meerkat-llm-core`: `AssistantTranscriptTruncated`, `ExperimentalModelRequiresLiveChannel`,
                         `FactoryError`, `interaction_id`, `RealtimeSessionEvent`.
+  - `meerkat-mob`: `LifecycleOperationProgressStalled`, `MobError`, `MobSessionService`,
+                   `enqueue_committed_parent_session_boundary_after_runtime_turn`.
   - `meerkat-machine-kernels`: `AbandonLiveInteraction`, `AbandonLiveInteractionAttached`,
                                `AbandonLiveInteractionIdle`,
                                `AbandonLiveInteractionPreservingEarlierDelegationAttached`,

--- a/Makefile
+++ b/Makefile
@@ -688,13 +688,14 @@ semver-breaks:
 	@echo "$(GREEN)Checking public-API breaks vs published baselines...$(NC)"
 	@scripts/check-semver-breaks.sh
 
-# The analyser half of the semver-breaks gate, unit-tested against committed
-# real cargo-semver-checks reports. Runs without the tool installed, so it can
-# run on every PR: a parser that has drifted from the report grammar reports
-# "no breaks" for the same reason a clean release does.
+# The analyser and immutable-tag recovery verifier, unit-tested without the
+# cargo-semver-checks tool so they can run on every PR. A parser that has
+# drifted from the report grammar reports "no breaks" for the same reason a
+# clean release does.
 semver-breaks-selftest:
-	@echo "$(GREEN)Self-testing the semver-breaks analyser...$(NC)"
+	@echo "$(GREEN)Self-testing the semver-breaks gates...$(NC)"
 	@$(PYTHON) scripts/test_check_semver_breaks.py
+	@$(PYTHON) scripts/test_verify_semver_recovery_evidence.py
 
 # Full pre-release checklist
 release-preflight: release-doctor verify-lock-consistency verify-bazel-locks-strict ci verify-schema-freshness check-rust-release-packaging semver-breaks

--- a/scripts/release-workflow-dispatch
+++ b/scripts/release-workflow-dispatch
@@ -3,7 +3,7 @@ set -euo pipefail
 
 usage() {
   cat <<'EOF'
-usage: release-workflow-dispatch [--mode full|assets|packages|web-sdk|web-sdk-publish] [--version vX.Y.Z] [--backend auto|github-hosted|buildbuddy] [--ref REF] [--web-sdk-artifact-run-id RUN_ID] [--dry-run]
+usage: release-workflow-dispatch [--mode full|assets|packages|web-sdk|web-sdk-publish] [--version vX.Y.Z] [--backend auto|github-hosted|buildbuddy] [--ref REF] [--web-sdk-artifact-run-id RUN_ID] [--semver-evidence-run-id RUN_ID --semver-evidence-job-id JOB_ID] [--dry-run]
 
 Dispatches the release workflow through the same public/default vs owner-only
 BuildBuddy backend split used by CI.
@@ -21,6 +21,8 @@ Environment equivalents:
   RELEASE_REF                Workflow ref. Defaults to the tag for full and main for recovery modes.
   REGISTRY_DRY_RUN           true/false for package publish dry-runs.
   WEB_SDK_ARTIFACT_RUN_ID    Existing workflow run id containing rkat-web-package.
+  SEMVER_EVIDENCE_RUN_ID     Exact failed tag-run id with a completed semver measurement.
+  SEMVER_EVIDENCE_JOB_ID     Exact failed semver job id from that run.
   RELEASE_WORKFLOW_DRY_RUN   true/false to print the gh command without dispatching.
   MEERKAT_BUILDBUDDY         When RELEASE_BACKEND=auto, true selects buildbuddy
                               and false/0 selects github-hosted. If unset, auto
@@ -34,6 +36,8 @@ version="${VERSION:-${RELEASE_TAG:-}}"
 backend="${RELEASE_BACKEND:-auto}"
 workflow_ref="${RELEASE_REF:-}"
 web_sdk_artifact_run_id="${WEB_SDK_ARTIFACT_RUN_ID:-}"
+semver_evidence_run_id="${SEMVER_EVIDENCE_RUN_ID:-}"
+semver_evidence_job_id="${SEMVER_EVIDENCE_JOB_ID:-}"
 case "${RELEASE_WORKFLOW_DRY_RUN:-false}" in
   1|true|TRUE|yes|YES|on|ON) dry_run=1 ;;
   *) dry_run=0 ;;
@@ -63,6 +67,14 @@ while [[ $# -gt 0 ]]; do
       ;;
     --web-sdk-artifact-run-id)
       web_sdk_artifact_run_id="${2:?--web-sdk-artifact-run-id requires a value}"
+      shift 2
+      ;;
+    --semver-evidence-run-id)
+      semver_evidence_run_id="${2:?--semver-evidence-run-id requires a value}"
+      shift 2
+      ;;
+    --semver-evidence-job-id)
+      semver_evidence_job_id="${2:?--semver-evidence-job-id requires a value}"
       shift 2
       ;;
     -h|--help)
@@ -156,12 +168,30 @@ if [[ -z "${workflow_ref}" ]]; then
   esac
 fi
 
+if [[ -n "${semver_evidence_run_id}" || -n "${semver_evidence_job_id}" ]]; then
+  if [[ -z "${semver_evidence_run_id}" || -z "${semver_evidence_job_id}" ]]; then
+    echo "semver recovery requires both --semver-evidence-run-id and --semver-evidence-job-id" >&2
+    exit 2
+  fi
+  if [[ "${mode}" != "packages" ]]; then
+    echo "semver evidence recovery is supported only for --mode packages" >&2
+    exit 2
+  fi
+fi
+
 args=(
   gh workflow run release.yml
   --ref "${workflow_ref}"
   -f "release_tag=${version}"
   -f "release_backend=${backend}"
 )
+
+if [[ -n "${semver_evidence_run_id}" ]]; then
+  args+=(
+    -f "semver_evidence_run_id=${semver_evidence_run_id}"
+    -f "semver_evidence_job_id=${semver_evidence_job_id}"
+  )
+fi
 
 case "${mode}" in
   full)
@@ -206,6 +236,9 @@ printf 'release workflow backend: %s\n' "${backend}"
 printf 'release workflow mode: %s\n' "${mode}"
 printf 'release workflow ref: %s\n' "${workflow_ref}"
 printf 'release workflow tag: %s\n' "${version}"
+if [[ -n "${semver_evidence_run_id}" ]]; then
+  printf 'release workflow semver evidence: run %s, job %s\n' "${semver_evidence_run_id}" "${semver_evidence_job_id}"
+fi
 if [[ "${backend}" == "buildbuddy" ]]; then
   printf 'release workflow acceleration: BuildBuddy validation + early Linux/macOS assets and Homebrew; Windows remains GitHub-hosted\n'
 else

--- a/scripts/test_verify_semver_recovery_evidence.py
+++ b/scripts/test_verify_semver_recovery_evidence.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+"""Unit tests for exact semver measurement recovery evidence."""
+
+from __future__ import annotations
+
+import copy
+import importlib.util
+import sys
+import unittest
+from pathlib import Path
+
+
+SCRIPT = Path(__file__).with_name("verify_semver_recovery_evidence.py")
+SPEC = importlib.util.spec_from_file_location("verify_semver_recovery_evidence", SCRIPT)
+assert SPEC and SPEC.loader
+gate = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = gate
+SPEC.loader.exec_module(gate)
+
+RUN_ID = 33123992541
+JOB_ID = 98697718256
+TAG = "v0.8.30"
+SHA = "5e229e0b8379ac162a6b3c69187d186b570535e9"
+RUN = {
+    "id": RUN_ID,
+    "event": "push",
+    "head_branch": TAG,
+    "head_sha": SHA,
+    "path": ".github/workflows/release.yml",
+}
+JOB = {
+    "id": JOB_ID,
+    "run_id": RUN_ID,
+    "workflow_name": "Release",
+    "name": "Breaks declared and notes stamped",
+    "head_branch": TAG,
+    "head_sha": SHA,
+    "status": "completed",
+    "conclusion": "failure",
+    "steps": [
+        {"name": "Set up job", "conclusion": "success"},
+        {"name": "Checkout", "conclusion": "success"},
+        {"name": "Install Rust", "conclusion": "success"},
+        {"name": "Cache cargo", "conclusion": "success"},
+        {"name": "Install cargo-semver-checks", "conclusion": "success"},
+        {
+            "name": "Verify every reported break is named and the notes are stamped",
+            "conclusion": "failure",
+        },
+    ],
+}
+LOG = """\
+2026-08-27T22:51:01.0000000Z semver-breaks: analyser self-test passed
+2026-08-28T00:25:42.0000000Z semver-breaks: FAILED
+2026-08-28T00:25:42.0000000Z   - [meerkat-mob] enum_variant_added: `variant MobError:LifecycleOperationProgressStalled` is not named under `### Breaking` (missing: `MobError`, `LifecycleOperationProgressStalled`)
+2026-08-28T00:25:42.0000000Z   - [meerkat-mob] trait_method_added: `trait method meerkat_mob::MobSessionService::enqueue_committed_parent_session_boundary_after_runtime_turn` is not named under `### Breaking` (missing: `MobSessionService`, `enqueue_committed_parent_session_boundary_after_runtime_turn`)
+2026-08-28T00:25:42.0000000Z
+2026-08-28T00:25:42.0000000Z Policy (M3): 0.x patch releases may break public API, but every break must be
+2026-08-28T00:25:42.0000000Z declared under `### Breaking` in the pending release section, naming the changed
+2026-08-28T00:25:42.0000000Z signatures, so exact-pinned downstreams can plan the bump.
+2026-08-28T00:25:42.0000000Z
+2026-08-28T00:25:42.0000000Z cargo-semver-checks exited 100; last 40 report lines:
+"""
+CHANGELOG = """\
+# Changelog
+
+## [Unreleased]
+
+## [0.8.30] - 2026-08-26
+
+### Breaking
+
+- `MobError::LifecycleOperationProgressStalled` was added and
+  `MobSessionService::enqueue_committed_parent_session_boundary_after_runtime_turn` is required.
+"""
+
+
+class EvidenceTests(unittest.TestCase):
+    def test_accepts_exact_completed_measurement_with_amended_declarations(self) -> None:
+        gate.verify_metadata(
+            RUN,
+            JOB,
+            evidence_run_id=RUN_ID,
+            evidence_job_id=JOB_ID,
+            release_tag=TAG,
+            release_sha=SHA,
+        )
+        findings = gate.parse_missing_declarations(LOG)
+        self.assertEqual(len(findings), 2)
+        self.assertEqual(
+            findings[0].symbols,
+            ("MobError", "LifecycleOperationProgressStalled"),
+        )
+
+    def test_rejects_non_tag_dispatch_evidence(self) -> None:
+        run = copy.deepcopy(RUN)
+        run["event"] = "workflow_dispatch"
+        with self.assertRaisesRegex(gate.EvidenceError, "run event"):
+            gate.verify_metadata(
+                run,
+                JOB,
+                evidence_run_id=RUN_ID,
+                evidence_job_id=JOB_ID,
+                release_tag=TAG,
+                release_sha=SHA,
+            )
+
+    def test_rejects_wrong_release_sha(self) -> None:
+        with self.assertRaisesRegex(gate.EvidenceError, "run SHA"):
+            gate.verify_metadata(
+                RUN,
+                JOB,
+                evidence_run_id=RUN_ID,
+                evidence_job_id=JOB_ID,
+                release_tag=TAG,
+                release_sha="0" * 40,
+            )
+
+    def test_rejects_measurement_setup_failure(self) -> None:
+        job = copy.deepcopy(JOB)
+        job["steps"][4]["conclusion"] = "failure"
+        with self.assertRaisesRegex(gate.EvidenceError, "Install cargo-semver-checks"):
+            gate.verify_metadata(
+                RUN,
+                job,
+                evidence_run_id=RUN_ID,
+                evidence_job_id=JOB_ID,
+                release_tag=TAG,
+                release_sha=SHA,
+            )
+
+    def test_rejects_any_analyzer_failure_beyond_missing_declarations(self) -> None:
+        bad = LOG.replace(
+            "2026-08-28T00:25:42.0000000Z Policy (M3):",
+            "2026-08-28T00:25:42.0000000Z   - the report never reached these publishable crates: meerkat-runtime\n"
+            "2026-08-28T00:25:42.0000000Z Policy (M3):",
+        )
+        with self.assertRaisesRegex(gate.EvidenceError, "unexpected analyzer failure line"):
+            gate.parse_missing_declarations(bad)
+
+    def test_rejects_missing_exit_attestation(self) -> None:
+        with self.assertRaisesRegex(gate.EvidenceError, "exit line"):
+            gate.parse_missing_declarations(
+                LOG.replace("cargo-semver-checks exited 100", "cargo-semver-checks completed")
+            )
+
+    def test_changelog_must_name_every_missing_symbol(self) -> None:
+        import tempfile
+
+        findings = gate.parse_missing_declarations(LOG)
+        with tempfile.TemporaryDirectory() as directory:
+            changelog = Path(directory) / "CHANGELOG.md"
+            changelog.write_text(CHANGELOG, encoding="utf-8")
+            gate.verify_changelog(changelog, TAG, findings)
+            changelog.write_text(
+                CHANGELOG.replace("LifecycleOperationProgressStalled", "LifecycleStalled"),
+                encoding="utf-8",
+            )
+            with self.assertRaisesRegex(gate.EvidenceError, "LifecycleOperationProgressStalled"):
+                gate.verify_changelog(changelog, TAG, findings)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/verify_semver_recovery_evidence.py
+++ b/scripts/verify_semver_recovery_evidence.py
@@ -1,0 +1,217 @@
+#!/usr/bin/env python3
+"""Verify that a failed tag semver job needs declaration repair only.
+
+This is not a semver bypass. It accepts a prior measurement only when GitHub
+metadata binds the completed job to the exact immutable release tag and SHA,
+all measurement setup steps succeeded, and the analyzer's complete failure
+set contains only missing changelog declarations. The amended changelog must
+then name every symbol from that exact failure set under the stamped release.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import pathlib
+import re
+import sys
+from dataclasses import dataclass
+
+import check_semver_breaks as semver_gate
+
+
+ANSI_RE = re.compile(r"\x1b\[[0-9;]*[A-Za-z]")
+TIMESTAMP_RE = re.compile(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z(?:\s|$)")
+FINDING_RE = re.compile(
+    r"^\s*- \[(?P<crate>[^]]+)] (?P<lint>[a-z0-9_]+): "
+    r"`(?P<item>.+)` is not named under `### Breaking` "
+    r"\(missing: (?P<missing>.+)\)$"
+)
+
+
+class EvidenceError(ValueError):
+    pass
+
+
+@dataclass(frozen=True)
+class MissingDeclaration:
+    crate: str
+    lint: str
+    item: str
+    symbols: tuple[str, ...]
+
+
+def normalized_lines(text: str) -> list[str]:
+    lines: list[str] = []
+    for raw in ANSI_RE.sub("", text).splitlines():
+        lines.append(TIMESTAMP_RE.sub("", raw, count=1))
+    return lines
+
+
+def exactly_one_index(lines: list[str], value: str) -> int:
+    matches = [index for index, line in enumerate(lines) if line == value]
+    if len(matches) != 1:
+        raise EvidenceError(f"expected exactly one `{value}` line, found {len(matches)}")
+    return matches[0]
+
+
+def parse_missing_declarations(log_text: str) -> tuple[MissingDeclaration, ...]:
+    lines = normalized_lines(log_text)
+    selftest = exactly_one_index(lines, "semver-breaks: analyser self-test passed")
+    failed = exactly_one_index(lines, "semver-breaks: FAILED")
+    policy = exactly_one_index(lines, "Policy (M3): 0.x patch releases may break public API, but every break must be")
+    exit_lines = [
+        (index, line)
+        for index, line in enumerate(lines)
+        if line.startswith("cargo-semver-checks exited ")
+        and line.endswith("; last 40 report lines:")
+    ]
+    if len(exit_lines) != 1:
+        raise EvidenceError(
+            f"expected exactly one cargo-semver-checks exit line, found {len(exit_lines)}"
+        )
+    exit_index, exit_line = exit_lines[0]
+    if not selftest < failed < policy < exit_index:
+        raise EvidenceError("semver evidence markers are incomplete or out of order")
+    exit_match = re.fullmatch(
+        r"cargo-semver-checks exited (?P<code>[1-9][0-9]*); last 40 report lines:",
+        exit_line,
+    )
+    if exit_match is None:
+        raise EvidenceError("semver evidence does not contain a nonzero tool exit")
+
+    findings: list[MissingDeclaration] = []
+    for line in lines[failed + 1 : policy]:
+        if not line.strip():
+            continue
+        match = FINDING_RE.fullmatch(line)
+        if match is None:
+            raise EvidenceError(f"unexpected analyzer failure line: {line}")
+        symbols = tuple(re.findall(r"`([^`]+)`", match.group("missing")))
+        if not symbols:
+            raise EvidenceError(f"missing declaration line has no symbols: {line}")
+        findings.append(
+            MissingDeclaration(
+                crate=match.group("crate"),
+                lint=match.group("lint"),
+                item=match.group("item"),
+                symbols=symbols,
+            )
+        )
+    if not findings:
+        raise EvidenceError("semver analyzer failure contains no missing declarations")
+    return tuple(findings)
+
+
+def require_equal(actual: object, expected: object, label: str) -> None:
+    if actual != expected:
+        raise EvidenceError(f"{label} is {actual!r}, expected {expected!r}")
+
+
+def verify_metadata(
+    run: dict[str, object],
+    job: dict[str, object],
+    *,
+    evidence_run_id: int,
+    evidence_job_id: int,
+    release_tag: str,
+    release_sha: str,
+) -> None:
+    require_equal(run.get("id"), evidence_run_id, "run id")
+    require_equal(run.get("event"), "push", "run event")
+    require_equal(run.get("head_branch"), release_tag, "run tag")
+    require_equal(run.get("head_sha"), release_sha, "run SHA")
+    require_equal(run.get("path"), ".github/workflows/release.yml", "run workflow path")
+    require_equal(job.get("id"), evidence_job_id, "job id")
+    require_equal(job.get("run_id"), evidence_run_id, "job run id")
+    require_equal(job.get("workflow_name"), "Release", "job workflow")
+    require_equal(job.get("name"), "Breaks declared and notes stamped", "job name")
+    require_equal(job.get("head_branch"), release_tag, "job tag")
+    require_equal(job.get("head_sha"), release_sha, "job SHA")
+    require_equal(job.get("status"), "completed", "job status")
+    require_equal(job.get("conclusion"), "failure", "job conclusion")
+
+    steps = {
+        step.get("name"): step.get("conclusion")
+        for step in job.get("steps", [])
+        if isinstance(step, dict)
+    }
+    for name in ("Set up job", "Checkout", "Install Rust", "Cache cargo", "Install cargo-semver-checks"):
+        require_equal(steps.get(name), "success", f"step {name}")
+    require_equal(
+        steps.get("Verify every reported break is named and the notes are stamped"),
+        "failure",
+        "semver measurement step",
+    )
+
+
+def verify_changelog(
+    changelog_path: pathlib.Path,
+    release_tag: str,
+    findings: tuple[MissingDeclaration, ...],
+) -> None:
+    if not release_tag.startswith("v") or len(release_tag) == 1:
+        raise EvidenceError(f"release tag must have v prefix: {release_tag!r}")
+    version = release_tag[1:]
+    sections = semver_gate.parse_changelog(changelog_path.read_text(encoding="utf-8"))
+    stamped_errors = semver_gate.check_stamped(sections, version)
+    if stamped_errors:
+        raise EvidenceError("; ".join(stamped_errors))
+    section = semver_gate.pending_section(sections)
+    if section is None:
+        raise EvidenceError("changelog has no pending release section")
+    body = semver_gate.breaking_body(section)
+    if body is None:
+        raise EvidenceError(f"{section.heading.strip()} has no `### Breaking` section")
+    undeclared: list[str] = []
+    for finding in findings:
+        for symbol in finding.symbols:
+            if not semver_gate.names_symbol(body, symbol):
+                undeclared.append(f"[{finding.crate}] {finding.lint}: {symbol}")
+    if undeclared:
+        raise EvidenceError("amended changelog is still missing: " + ", ".join(undeclared))
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--run-json", required=True, type=pathlib.Path)
+    parser.add_argument("--job-json", required=True, type=pathlib.Path)
+    parser.add_argument("--job-log", required=True, type=pathlib.Path)
+    parser.add_argument("--evidence-run-id", required=True, type=int)
+    parser.add_argument("--evidence-job-id", required=True, type=int)
+    parser.add_argument("--release-tag", required=True)
+    parser.add_argument("--release-sha", required=True)
+    parser.add_argument("--changelog", required=True, type=pathlib.Path)
+    args = parser.parse_args()
+    try:
+        run = json.loads(args.run_json.read_text(encoding="utf-8"))
+        job = json.loads(args.job_json.read_text(encoding="utf-8"))
+        verify_metadata(
+            run,
+            job,
+            evidence_run_id=args.evidence_run_id,
+            evidence_job_id=args.evidence_job_id,
+            release_tag=args.release_tag,
+            release_sha=args.release_sha,
+        )
+        findings = parse_missing_declarations(
+            args.job_log.read_text(encoding="utf-8", errors="replace")
+        )
+        verify_changelog(args.changelog, args.release_tag, findings)
+    except (EvidenceError, OSError, json.JSONDecodeError) as error:
+        print(f"semver recovery evidence rejected: {error}", file=sys.stderr)
+        return 1
+
+    print(
+        "semver recovery evidence accepted: "
+        f"run {args.evidence_run_id}, job {args.evidence_job_id}, "
+        f"tag {args.release_tag}, SHA {args.release_sha}, "
+        f"{len(findings)} missing-declaration finding(s) now declared"
+    )
+    for finding in findings:
+        print(f"  [{finding.crate}] {finding.lint}: {', '.join(finding.symbols)}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

- amend the stamped 0.8.30 breaking ledger with the two missing `meerkat-mob` API changes and implementor guidance
- add a fail-closed package recovery path that reuses the completed 95-minute semver measurement only when GitHub run/job metadata binds it to the exact immutable tag and SHA, every setup step passed, and the complete analyzer failure set contains only missing declarations
- keep ordinary tag semver validation unchanged
- let Linux release assets use the installed stable Cargo directly with `--locked` inside their isolated Bullseye container because the immutable tag's `repo-cargo` requires a Git option unavailable in Bullseye Git 2.30; macOS and Windows retain `repo-cargo`

## Why

`@rkat/web@0.8.30` is already public from `v0.8.30` at `5e229e0b8379ac162a6b3c69187d186b570535e9`, so the tag cannot move. The completed semver job measured that exact source and failed only because three rows naming two API changes were absent from the stamped changelog. Registry publication must still build from the immutable tag.

The first Linux asset recovery fixed CMake and Git ownership, then exposed a second deterministic compatibility boundary: Bullseye Git 2.30 does not support `git rev-parse --path-format=absolute`, so the tagged wrapper failed before Cargo on both architectures.

## Evidence

- mandatory pre-push hook passed on both pushed commits, with no bypass
- `make semver-breaks-selftest`: 58/58 green
- real recovery evidence accepted only for release run `33123992541`, job `98697718256`, tag `v0.8.30`, SHA `5e229e0b8379ac162a6b3c69187d186b570535e9`
- the original tagged changelog is a proven negative and is rejected for all four missing symbols
- `actionlint .github/workflows/release.yml`: green
- `git diff --check`: green
- asset recovery run `33131328434` independently proved checkout of the exact tag; both Linux jobs installed CMake 3.18 and then failed only at the unsupported Git option before Cargo

After merge and exact-main CI, release authority will dispatch package recovery with the exact evidence IDs and asset recovery with `release_tag=v0.8.30` explicitly.
