### PR TITLE
Fix semver evidence log download

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -504,7 +504,7 @@ jobs:
           release_sha="$(git rev-parse HEAD)"
           gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${EVIDENCE_RUN_ID}" > "${RUNNER_TEMP}/semver-run.json"
           gh api "repos/${GITHUB_REPOSITORY}/actions/jobs/${EVIDENCE_JOB_ID}" > "${RUNNER_TEMP}/semver-job.json"
-          gh api "repos/${GITHUB_REPOSITORY}/actions/jobs/${EVIDENCE_JOB_ID}/logs" > "${RUNNER_TEMP}/semver-job.log"
+          gh api --allow-escape-sequences "repos/${GITHUB_REPOSITORY}/actions/jobs/${EVIDENCE_JOB_ID}/logs" > "${RUNNER_TEMP}/semver-job.log"
           python3 .semver-recovery-policy/scripts/verify_semver_recovery_evidence.py \
             --run-json "${RUNNER_TEMP}/semver-run.json" \
             --job-json "${RUNNER_TEMP}/semver-job.json" \


### PR DESCRIPTION
## Summary

- opt into raw terminal escape sequences for the exact semver job-log download
- keep the existing ANSI stripping and evidence verification unchanged

## Why

GitHub CLI 2.97+ now refuses non-JSON responses containing terminal escape sequences unless `--allow-escape-sequences` is explicit. The completed Cargo semver log legitimately contains ANSI color codes and is written to a file before the verifier strips ANSI and validates the exact run, job, tag, SHA, setup steps, complete finding set, and amended changelog.

Observed recovery failure: https://github.com/lukacf/meerkat/actions/runs/33140103360/job/98748930527

## Validation

- `git diff --check`
- mandatory pre-push hook passed in full, without bypass
