### PR TITLE
ci: enforce release latency objectives

### DIFF
--- a/.github/workflows/buildbuddy.yml
+++ b/.github/workflows/buildbuddy.yml
@@ -1,12 +1,8 @@
 name: GCP BuildBuddy CI
 
-# RETIRED FROM CI ROUTING (2026-07-03): ci.yml no longer calls this workflow;
-# CI runs on free GitHub-hosted runners via cargo.yml + nightly.yml. This file
-# is `workflow_call`-only, so with no caller it is inert. It is kept as a
-# manual fallback during the transition (restore by re-adding the ci.yml job
-# or `git revert`). DELETE this file — together with the GCP control-plane /
-# executor-pool scripts it drives — once a few releases have shipped cleanly
-# on the GHA-only lane.
+# Authoritative full CI. The top-level workflow calls this reusable lane so
+# compilation and test execution can share BuildBuddy's remote cache and RBE
+# fleet instead of rebuilding overlapping Cargo graphs on fresh runners.
 
 on:
   workflow_call:
@@ -62,9 +58,8 @@ permissions:
 
 concurrency:
   group: buildbuddy-gcp-executors
-  # Keep all pending BuildBuddy runs queued behind the shared GCP executor pool.
-  # GitHub's default single pending slot cancels older PR CI before any steps run.
-  queue: max
+  # One run owns scale-up/scale-down of the shared GCP executor pool at a time.
+  # Renovate is grouped and concurrency-limited so it cannot flood this lane.
   cancel-in-progress: false
 
 env:
@@ -89,8 +84,8 @@ env:
   MEERKAT_GCP_BUILDBUDDY_CACHE_DISK_GB: ${{ vars.MEERKAT_GCP_BUILDBUDDY_CACHE_DISK_GB || '1000' }}
   MEERKAT_GCP_BUILDBUDDY_CACHE_DISK_TYPE: ${{ vars.MEERKAT_GCP_BUILDBUDDY_CACHE_DISK_TYPE || 'pd-ssd' }}
   MEERKAT_GCP_BUILDBUDDY_DOWN_MODE: ${{ vars.MEERKAT_GCP_BUILDBUDDY_DOWN_MODE || 'stopped' }}
-  MEERKAT_GCP_BUILDBUDDY_CI_MAX_SECONDS: ${{ vars.MEERKAT_GCP_BUILDBUDDY_CI_MAX_SECONDS || '1500' }}
-  MEERKAT_GCP_BUILDBUDDY_SDK_CI_MAX_SECONDS: ${{ vars.MEERKAT_GCP_BUILDBUDDY_SDK_CI_MAX_SECONDS || '2400' }}
+  MEERKAT_GCP_BUILDBUDDY_CI_MAX_SECONDS: "1200"
+  MEERKAT_GCP_BUILDBUDDY_SDK_CI_MAX_SECONDS: "1200"
   MEERKAT_BUILDBUDDY_EXECUTOR_POOL: ${{ vars.MEERKAT_BUILDBUDDY_EXECUTOR_POOL || 'meerkat-ci' }}
   MEERKAT_BUILDBUDDY_CI_IMAGE: ${{ vars.MEERKAT_BUILDBUDDY_CI_IMAGE || 'europe-west1-docker.pkg.dev/king-dnn-training-dev/meerkat-ci/meerkat-ci-rust:1.94.0' }}
   MEERKAT_HOST_CARGO_HOME: /usr/local/cargo
@@ -431,7 +426,7 @@ jobs:
       BUILDBUDDY_HTTP_URL: ${{ needs.control-plane-up.outputs.http_url }}
       BUILDBUDDY_ENDPOINT: ${{ needs.control-plane-up.outputs.grpc_url }}
       CI_STARTED_AT_EPOCH: ${{ needs.control-plane-up.outputs.started_at_epoch }}
-      MEERKAT_GCP_BUILDBUDDY_CI_MAX_SECONDS: ${{ vars.MEERKAT_GCP_BUILDBUDDY_SDK_CI_MAX_SECONDS || '2400' }}
+      MEERKAT_GCP_BUILDBUDDY_CI_MAX_SECONDS: "1200"
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -635,7 +630,7 @@ jobs:
         shell: bash
         env:
           CI_STARTED_AT_EPOCH: ${{ needs.control-plane-up.outputs.started_at_epoch }}
-          MAX_SECONDS: ${{ needs.wasm-feature-changes.outputs.sdk_changed == 'true' && (vars.MEERKAT_GCP_BUILDBUDDY_SDK_CI_MAX_SECONDS || '2400') || (vars.MEERKAT_GCP_BUILDBUDDY_CI_MAX_SECONDS || '1500') }}
+          MAX_SECONDS: "1200"
         run: |
           if ! [[ "${CI_STARTED_AT_EPOCH}" =~ ^[0-9]+$ ]]; then
             echo "::error::Missing or invalid GCP BuildBuddy CI start timestamp: '${CI_STARTED_AT_EPOCH}'"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,15 +1,8 @@
 name: CI
 
-# Single-lane CI on GitHub-hosted runners (free for this public repo).
-#
-# The former GCP BuildBuddy lane (control-plane + 12-executor RBE fleet spun
-# up per run) was retired on 2026-07-03 for cost: every push routed ~360
-# vCPUs of STANDARD-provisioned c3d compute plus a 24/7 control plane. The
-# cargo lane below covers the same gate set; the expensive low-yield lanes
-# (feature matrices, e2e-system, per-package no-unification clippy) moved to
-# the nightly workflow. `buildbuddy.yml` is kept unreferenced as a manual
-# fallback during the transition and should be deleted once a few releases
-# have gone through cleanly.
+# BuildBuddy RBE is the authoritative full CI lane. The GitHub-hosted Cargo
+# workflow remains available for manual diagnostics and nightly coverage, but
+# fresh-runner compilation cannot satisfy the 20-minute push-to-terminal SLO.
 
 on:
   push:
@@ -31,35 +24,62 @@ concurrency:
   cancel-in-progress: true
 
 permissions:
+  actions: read
   contents: read
 
 jobs:
-  cargo:
-    name: GHA Cargo
-    uses: ./.github/workflows/cargo.yml
+  gcp-buildbuddy:
+    name: GCP BuildBuddy
+    uses: ./.github/workflows/buildbuddy.yml
     with:
-      base_sha: >-
+      mode: changed-paths
+      machine_authority_base_sha: >-
         ${{
           github.event_name == 'pull_request' && github.event.pull_request.base.sha ||
           github.event_name == 'push' && github.event.before ||
           ''
         }}
+      machine_authority_head_sha: ${{ github.sha }}
+    secrets: inherit
 
   gate:
     name: CI gate
     if: ${{ always() }}
     needs:
-      - cargo
+      - gcp-buildbuddy
     runs-on: ubuntu-latest
     steps:
       - name: Check CI result
         shell: bash
         env:
-          CARGO_RESULT: ${{ needs.cargo.result }}
+          BUILDBUDDY_RESULT: ${{ needs.gcp-buildbuddy.result }}
         run: |
-          echo "GHA Cargo result: ${CARGO_RESULT}"
-          if [[ "${CARGO_RESULT}" != "success" ]]; then
+          echo "GCP BuildBuddy result: ${BUILDBUDDY_RESULT}"
+          if [[ "${BUILDBUDDY_RESULT}" != "success" ]]; then
             echo "::error::CI did not complete successfully."
+            exit 1
+          fi
+
+      - name: Enforce push-to-terminal budget
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          MAX_SECONDS: "1200"
+        run: |
+          set -euo pipefail
+          created_at="$(gh api "/repos/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}" --jq .created_at)"
+          elapsed="$(python3 - "${created_at}" <<'PY'
+          import datetime
+          import sys
+
+          started = datetime.datetime.fromisoformat(sys.argv[1].replace("Z", "+00:00"))
+          now = datetime.datetime.now(datetime.timezone.utc)
+          print(int((now - started).total_seconds()))
+          PY
+          )"
+          echo "Push-to-full-CI terminal budget: ${elapsed}/${MAX_SECONDS} seconds"
+          if ((elapsed > MAX_SECONDS)); then
+            echo "::error::Full CI exceeded the 20-minute push-to-terminal SLO (${elapsed}s)."
             exit 1
           fi
 
@@ -71,7 +91,7 @@ jobs:
         id: attestation
         shell: bash
         env:
-          CARGO_RESULT: ${{ needs.cargo.result }}
+          BUILDBUDDY_RESULT: ${{ needs.gcp-buildbuddy.result }}
         run: |
           set -euo pipefail
           destination="${RUNNER_TEMP}/meerkat-ci-attestation"
@@ -86,9 +106,9 @@ jobs:
             --arg workflow_run_attempt "${GITHUB_RUN_ATTEMPT}" \
             --arg event "${GITHUB_EVENT_NAME}" \
             --arg ref "${GITHUB_REF}" \
-            --arg cargo_result "${CARGO_RESULT}" \
+            --arg validation_result "${BUILDBUDDY_RESULT}" \
             '{
-              schema_version: 1,
+              schema_version: 2,
               repository: $repository,
               commit_sha: $commit_sha,
               tree_sha: $tree_sha,
@@ -97,7 +117,8 @@ jobs:
               workflow_run_attempt: $workflow_run_attempt,
               event: $event,
               ref: $ref,
-              cargo_result: $cargo_result
+              validation_backend: "gcp-buildbuddy",
+              validation_result: $validation_result
             }' > "${destination}/attestation.json"
           echo "tree_sha=${tree_sha}"
           echo "path=${destination}" >> "${GITHUB_OUTPUT}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,7 @@ concurrency:
 permissions:
   actions: read
   contents: read
+  id-token: write
 
 jobs:
   gcp-buildbuddy:

--- a/.github/workflows/release-semver-readiness.yml
+++ b/.github/workflows/release-semver-readiness.yml
@@ -1,0 +1,148 @@
+name: Release semver readiness
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - Cargo.toml
+      - CHANGELOG.md
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
+    paths:
+      - Cargo.toml
+      - CHANGELOG.md
+  workflow_dispatch:
+    inputs:
+      release_ref:
+        description: Commit or branch to measure before tagging.
+        required: true
+        type: string
+
+concurrency:
+  group: release-semver-${{ github.event.pull_request.number || github.event.inputs.release_ref || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  semver:
+    name: Measure and attest release semver
+    runs-on: ubuntu-latest
+    timeout-minutes: 330
+    steps:
+      - name: Checkout candidate
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.release_ref || github.sha }}
+          fetch-depth: 0
+
+      - name: Resolve candidate identity
+        id: candidate
+        shell: bash
+        run: |
+          set -euo pipefail
+          version="$(python3 - <<'PY'
+          import pathlib
+          import tomllib
+
+          workspace = tomllib.loads(pathlib.Path("Cargo.toml").read_text())
+          print(workspace["workspace"]["package"]["version"])
+          PY
+          )"
+          tree_sha="$(git rev-parse 'HEAD^{tree}')"
+          commit_sha="$(git rev-parse HEAD)"
+          {
+            echo "version=${version}"
+            echo "tree_sha=${tree_sha}"
+            echo "commit_sha=${commit_sha}"
+          } >> "${GITHUB_OUTPUT}"
+
+      - name: Check whether candidate is unpublished
+        id: unpublished
+        shell: bash
+        env:
+          VERSION: ${{ steps.candidate.outputs.version }}
+        run: |
+          set -euo pipefail
+          endpoint="https://crates.io/api/v1/crates/meerkat-core/${VERSION}"
+          if curl -fsSL \
+            -H 'User-Agent: meerkat-release-readiness (https://github.com/lukacf/meerkat)' \
+            "${endpoint}" >/dev/null 2>&1; then
+            echo "needed=false" >> "${GITHUB_OUTPUT}"
+            echo "meerkat-core ${VERSION} is already public; no pre-tag evidence is needed."
+          else
+            echo "needed=true" >> "${GITHUB_OUTPUT}"
+          fi
+
+      - name: Install Rust
+        if: ${{ steps.unpublished.outputs.needed == 'true' }}
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Cargo
+        if: ${{ steps.unpublished.outputs.needed == 'true' }}
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: release-semver-breaks
+
+      - name: Install cargo-semver-checks
+        if: ${{ steps.unpublished.outputs.needed == 'true' }}
+        uses: taiki-e/install-action@cargo-semver-checks
+        env:
+          HOME: ${{ runner.temp }}/install-action-home-${{ github.job }}
+
+      - name: Measure and verify declared breaks
+        if: ${{ steps.unpublished.outputs.needed == 'true' }}
+        env:
+          MEERKAT_SEMVER_REPORT_OUT: ${{ runner.temp }}/semver-evidence/report.txt
+        run: make semver-breaks
+
+      - name: Build exact-tree semver attestation
+        if: ${{ steps.unpublished.outputs.needed == 'true' }}
+        shell: bash
+        env:
+          TREE_SHA: ${{ steps.candidate.outputs.tree_sha }}
+          VERSION: ${{ steps.candidate.outputs.version }}
+        run: |
+          set -euo pipefail
+          evidence="${RUNNER_TEMP}/semver-evidence"
+          report_sha="$(sha256sum "${evidence}/report.txt" | awk '{print $1}')"
+          jq -n \
+            --arg repository "${GITHUB_REPOSITORY}" \
+            --arg tree_sha "${TREE_SHA}" \
+            --arg commit_sha "${{ steps.candidate.outputs.commit_sha }}" \
+            --arg version "${VERSION}" \
+            --arg workflow "${GITHUB_WORKFLOW}" \
+            --arg workflow_run_id "${GITHUB_RUN_ID}" \
+            --arg workflow_run_attempt "${GITHUB_RUN_ATTEMPT}" \
+            --arg event "${GITHUB_EVENT_NAME}" \
+            --arg ref "${GITHUB_REF}" \
+            --arg report_sha256 "${report_sha}" \
+            '{
+              schema_version: 1,
+              repository: $repository,
+              tree_sha: $tree_sha,
+              commit_sha: $commit_sha,
+              version: $version,
+              workflow: $workflow,
+              workflow_run_id: $workflow_run_id,
+              workflow_run_attempt: $workflow_run_attempt,
+              event: $event,
+              ref: $ref,
+              result: "success",
+              report_sha256: $report_sha256
+            }' > "${evidence}/attestation.json"
+
+      - name: Upload exact-tree semver evidence
+        if: ${{ steps.unpublished.outputs.needed == 'true' }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: ${{ github.event_name == 'push' && format('meerkat-semver-attestation-main-{0}', steps.candidate.outputs.tree_sha) || format('meerkat-semver-attestation-preview-{0}', steps.candidate.outputs.tree_sha) }}
+          path: ${{ runner.temp }}/semver-evidence
+          if-no-files-found: error
+          retention-days: 30

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -225,8 +225,7 @@ jobs:
             --arg tree_sha "${RELEASE_TREE}" \
             --arg workflow_run_id "${CI_RUN_ID}" \
             --arg workflow_run_attempt "${CI_RUN_ATTEMPT}" \
-            '.schema_version == 1 and
-             .repository == $repository and
+            '.repository == $repository and
              .commit_sha == $commit_sha and
              .tree_sha == $tree_sha and
              .workflow == "CI" and
@@ -234,7 +233,10 @@ jobs:
              .workflow_run_attempt == $workflow_run_attempt and
              .event == "push" and
              .ref == "refs/heads/main" and
-             .cargo_result == "success"' \
+             ((.schema_version == 1 and .cargo_result == "success") or
+              (.schema_version == 2 and
+               .validation_backend == "gcp-buildbuddy" and
+               .validation_result == "success"))' \
             "${attestation}"
           echo "Verified exact-tree CI attestation for ${RELEASE_SHA} (${RELEASE_TREE})"
 
@@ -440,12 +442,9 @@ jobs:
       github.event.inputs.publish_web_sdk_only != 'true' &&
       github.event.inputs.publish_release_assets_only != 'true'
     runs-on: ubuntu-latest
-    # cargo-semver-checks builds rustdoc JSON for the current and the published
-    # baseline of all 39 publishable library crates. Measured cold on an M-series
-    # laptop with a warm cargo cache: 83 minutes. This is the slowest gate in the
-    # release, and it runs in parallel with the binary builds. The generous
-    # ceiling is deliberate: a timeout kill fails the release for a reason that
-    # has nothing to do with semver.
+    # The 83-minute measurement belongs before the tag. Tag-triggered releases
+    # consume exact-tree evidence from Release semver readiness. Manual recovery
+    # may still run or verify an explicit historical measurement.
     timeout-minutes: 330
     steps:
       - name: Checkout
@@ -468,24 +467,82 @@ jobs:
           persist-credentials: false
 
       - name: Install Rust
-        if: ${{ github.event_name != 'workflow_dispatch' || github.event.inputs.semver_evidence_job_id == '' }}
+        if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.semver_evidence_job_id == '' }}
         uses: dtolnay/rust-toolchain@stable
 
       - name: Cache cargo
-        if: ${{ github.event_name != 'workflow_dispatch' || github.event.inputs.semver_evidence_job_id == '' }}
+        if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.semver_evidence_job_id == '' }}
         uses: Swatinem/rust-cache@v2
         with:
           shared-key: release-semver-breaks
 
       - name: Install cargo-semver-checks
-        if: ${{ github.event_name != 'workflow_dispatch' || github.event.inputs.semver_evidence_job_id == '' }}
+        if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.semver_evidence_job_id == '' }}
         uses: taiki-e/install-action@cargo-semver-checks
         env:
           HOME: ${{ runner.temp }}/install-action-home-${{ github.job }}
 
       - name: Verify every reported break is named and the notes are stamped
-        if: ${{ github.event_name != 'workflow_dispatch' || github.event.inputs.semver_evidence_job_id == '' }}
+        if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.semver_evidence_job_id == '' }}
         run: make semver-breaks
+
+      - name: Verify exact-tree pre-tag semver evidence
+        if: ${{ github.event_name != 'workflow_dispatch' }}
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          tree_sha="$(git rev-parse 'HEAD^{tree}')"
+          version="$(python3 - <<'PY'
+          import pathlib
+          import tomllib
+
+          workspace = tomllib.loads(pathlib.Path("Cargo.toml").read_text())
+          print(workspace["workspace"]["package"]["version"])
+          PY
+          )"
+          artifact_name="meerkat-semver-attestation-main-${tree_sha}"
+          artifact_json="$(gh api "repos/${GITHUB_REPOSITORY}/actions/artifacts?name=${artifact_name}&per_page=100")"
+          artifact_id="$(jq -r '[.artifacts[] | select(.expired == false)] | sort_by(.created_at) | last | .id // empty' <<<"${artifact_json}")"
+          if [[ -z "${artifact_id}" ]]; then
+            echo "::error::No unexpired exact-tree semver evidence exists for ${tree_sha}."
+            echo "Run Release semver readiness before creating the tag."
+            exit 1
+          fi
+          evidence="${RUNNER_TEMP}/semver-evidence"
+          mkdir -p "${evidence}"
+          gh api "repos/${GITHUB_REPOSITORY}/actions/artifacts/${artifact_id}/zip" > "${RUNNER_TEMP}/semver-evidence.zip"
+          unzip -q "${RUNNER_TEMP}/semver-evidence.zip" -d "${evidence}"
+          workflow_run_id="$(jq -r --argjson artifact_id "${artifact_id}" \
+            '[.artifacts[] | select(.id == $artifact_id)] | first | .workflow_run.id' \
+            <<<"${artifact_json}")"
+          run_json="$(gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${workflow_run_id}")"
+          jq -e \
+            --arg repository "${GITHUB_REPOSITORY}" \
+            --arg tree_sha "${tree_sha}" \
+            --arg version "${version}" \
+            --arg workflow_run_id "${workflow_run_id}" \
+            '.schema_version == 1 and
+             .repository == $repository and
+             .tree_sha == $tree_sha and
+             .version == $version and
+             .workflow == "Release semver readiness" and
+             .workflow_run_id == $workflow_run_id and
+             .event == "push" and
+             .ref == "refs/heads/main" and
+             .result == "success"' \
+            "${evidence}/attestation.json"
+          jq -e \
+            '.name == "Release semver readiness" and
+             .event == "push" and
+             .head_branch == "main" and
+             .conclusion == "success"' \
+            <<<"${run_json}" >/dev/null
+          expected_report_sha="$(jq -r .report_sha256 "${evidence}/attestation.json")"
+          actual_report_sha="$(sha256sum "${evidence}/report.txt" | awk '{print $1}')"
+          [[ "${actual_report_sha}" == "${expected_report_sha}" ]]
+          echo "Verified exact-tree semver evidence for ${tree_sha} (${version})"
 
       - name: Verify exact completed semver measurement and amended declarations
         if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.semver_evidence_job_id != '' }}
@@ -1288,6 +1345,42 @@ jobs:
         run: |
           MEERKAT_REGISTRY_DRY_RUN="${{ github.event_name == 'workflow_dispatch' && github.event.inputs.registry_dry_run == 'true' }}" \
             scripts/release-publish-rust-crates.sh
+
+      - name: Verify all Rust crates are public within 30 minutes
+        if: >-
+          ${{
+            (github.event_name != 'workflow_dispatch' ||
+             github.event.inputs.registry_dry_run != 'true') &&
+            (github.event_name != 'workflow_dispatch' ||
+             github.event.inputs.publish_web_sdk_only != 'true')
+          }}
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          release_tag="${{ github.event_name == 'workflow_dispatch' && github.event.inputs.release_tag || github.ref_name }}"
+          release_sha="$(git rev-parse HEAD)"
+          tag_run_json="$(gh api \
+            "repos/${GITHUB_REPOSITORY}/actions/workflows/release.yml/runs?event=push&head_sha=${release_sha}&per_page=100")"
+          tag_pushed_at="$(jq -r \
+            --arg release_tag "${release_tag}" \
+            --arg release_sha "${release_sha}" \
+            '[.workflow_runs[] |
+              select(.event == "push" and
+                     .head_sha == $release_sha and
+                     .head_branch == $release_tag)] |
+             sort_by(.created_at) | first | .created_at // empty' \
+            <<<"${tag_run_json}")"
+          if [[ -z "${tag_pushed_at}" ]]; then
+            echo "::error::No tag-triggered release run found for ${release_tag} at ${release_sha}."
+            exit 1
+          fi
+          python3 scripts/verify-rust-release-public.py \
+            --repo-root "${GITHUB_WORKSPACE}" \
+            --tag-pushed-at "${tag_pushed_at}" \
+            --deadline-seconds 900 \
+            --slo-seconds 1800
 
       - name: Publish Python SDK
         if: >-

--- a/.github/workflows/renovate-bazel-lock.yml
+++ b/.github/workflows/renovate-bazel-lock.yml
@@ -1,0 +1,90 @@
+name: Renovate Bazel lock sync
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - synchronize
+      - reopened
+
+concurrency:
+  group: renovate-bazel-lock-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: write
+  pull-requests: read
+
+jobs:
+  sync:
+    name: Refresh MODULE.bazel.lock
+    if: >-
+      github.actor == 'renovate[bot]' &&
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      startsWith(github.event.pull_request.head.ref, 'renovate/')
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    env:
+      BASE_SHA: ${{ github.event.pull_request.base.sha }}
+      HEAD_REF: ${{ github.event.pull_request.head.ref }}
+      HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+    steps:
+      - name: Checkout exact Renovate head
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ env.HEAD_SHA }}
+          fetch-depth: 0
+
+      - name: Admit only dependency-owned changes
+        shell: bash
+        run: |
+          set -euo pipefail
+          git diff --name-only "${BASE_SHA}...${HEAD_SHA}" > "${RUNNER_TEMP}/changed-files"
+          if grep -qEv '(^|/)Cargo\.toml$|^Cargo\.lock$|^MODULE\.bazel\.lock$' \
+            "${RUNNER_TEMP}/changed-files"; then
+            echo "::error::Refusing privileged lock refresh because the Renovate diff is not Cargo metadata only."
+            grep -Ev '(^|/)Cargo\.toml$|^Cargo\.lock$|^MODULE\.bazel\.lock$' \
+              "${RUNNER_TEMP}/changed-files"
+            exit 1
+          fi
+          if ! grep -qx 'Cargo.lock' "${RUNNER_TEMP}/changed-files"; then
+            echo "Cargo.lock is unchanged; no Bazel module lock refresh is needed."
+            echo "needs_refresh=false" >> "${GITHUB_ENV}"
+            exit 0
+          fi
+          echo "needs_refresh=true" >> "${GITHUB_ENV}"
+
+      - name: Install pinned BuildBuddy CLI from the trusted base
+        if: ${{ env.needs_refresh == 'true' }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          trusted_installer="${RUNNER_TEMP}/install-buildbuddy-cli"
+          git show "${BASE_SHA}:scripts/install-buildbuddy-cli" > "${trusted_installer}"
+          chmod 700 "${trusted_installer}"
+          echo "BB_BIN=$(${trusted_installer})" >> "${GITHUB_ENV}"
+
+      - name: Refresh Bazel module lock
+        if: ${{ env.needs_refresh == 'true' }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          trusted_checker="${RUNNER_TEMP}/check-bazel-module-lock-inputs.py"
+          git show "${BASE_SHA}:scripts/check_bazel_module_lock_inputs.py" > "${trusted_checker}"
+          "${BB_BIN}" mod deps --lockfile_mode=update
+          python3 "${trusted_checker}" "${GITHUB_WORKSPACE}"
+
+      - name: Commit refreshed lock to Renovate branch
+        if: ${{ env.needs_refresh == 'true' }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          if git diff --quiet -- MODULE.bazel.lock; then
+            echo "MODULE.bazel.lock is already current."
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add MODULE.bazel.lock
+          git commit -m "chore: refresh Bazel module lock"
+          git push origin "HEAD:refs/heads/${HEAD_REF}"

--- a/renovate.json
+++ b/renovate.json
@@ -2,7 +2,16 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:recommended"],
   "schedule": ["before 9am on Monday"],
+  "branchConcurrentLimit": 1,
+  "prConcurrentLimit": 1,
+  "prHourlyLimit": 1,
   "packageRules": [
+    {
+      "description": "Keep routine dependency updates in one validation train",
+      "matchUpdateTypes": ["minor", "patch", "pin", "digest", "lockFileMaintenance"],
+      "groupName": "routine dependencies",
+      "groupSlug": "routine-dependencies"
+    },
     {
       "matchUpdateTypes": ["patch"],
       "automerge": true

--- a/scripts/buildbuddy-doctor
+++ b/scripts/buildbuddy-doctor
@@ -358,14 +358,16 @@ fi
 rm -rf "${dispatch_log_root}"
 
 if grep -Fq 'name: CI' .github/workflows/ci.yml &&
-  grep -Fq 'name: GHA Cargo' .github/workflows/ci.yml &&
+  grep -Fq 'name: GCP BuildBuddy' .github/workflows/ci.yml &&
   job_has_line .github/workflows/ci.yml gate 'name: CI gate' &&
   job_has_line .github/workflows/ci.yml gate 'name: Check CI result' &&
-  job_has_line .github/workflows/ci.yml gate 'CARGO_RESULT:' &&
+  job_has_line .github/workflows/ci.yml gate 'BUILDBUDDY_RESULT:' &&
   job_has_line .github/workflows/ci.yml gate 'CI did not complete successfully.' &&
-  grep -Fq 'uses: ./.github/workflows/cargo.yml' .github/workflows/ci.yml &&
-  ! grep -Fq 'uses: ./.github/workflows/buildbuddy.yml' .github/workflows/ci.yml &&
-  ! job_has_line .github/workflows/ci.yml gcp-buildbuddy 'name: GCP BuildBuddy' &&
+  job_has_line .github/workflows/ci.yml gate 'Enforce push-to-terminal budget' &&
+  job_has_line .github/workflows/ci.yml gate 'MAX_SECONDS: "1200"' &&
+  ! grep -Fq 'uses: ./.github/workflows/cargo.yml' .github/workflows/ci.yml &&
+  grep -Fq 'uses: ./.github/workflows/buildbuddy.yml' .github/workflows/ci.yml &&
+  job_has_line .github/workflows/ci.yml gcp-buildbuddy 'name: GCP BuildBuddy' &&
   grep -Fq 'name: Cargo CI' .github/workflows/cargo.yml &&
   grep -Fq 'workflow_call:' .github/workflows/cargo.yml &&
   grep -Fq 'name: GCP BuildBuddy CI' .github/workflows/buildbuddy.yml &&
@@ -377,15 +379,16 @@ if grep -Fq 'name: CI' .github/workflows/ci.yml &&
   ! grep -Fq 'buildbuddy-hosted' .github/workflows/ci.yml &&
   ! grep -Fq 'buildbuddy-hosted' .github/workflows/buildbuddy.yml &&
   grep -Fq 'GCP BuildBuddy gate' .github/workflows/buildbuddy.yml; then
-  pass "Top-level CI uses GHA Cargo while GCP BuildBuddy remains an inert reusable fallback"
+  pass "Top-level CI uses the reusable GCP BuildBuddy lane"
 else
-  bad "Top-level GHA-only CI or inert GCP BuildBuddy fallback is not wired correctly"
+  bad "Top-level GCP BuildBuddy CI is not wired correctly"
 fi
 
 if grep -Fq 'MEERKAT_GCP_BUILDBUDDY_CI_MAX_SECONDS' .github/workflows/buildbuddy.yml &&
   grep -Fq 'MEERKAT_GCP_BUILDBUDDY_SDK_CI_MAX_SECONDS' .github/workflows/buildbuddy.yml &&
   grep -Fq 'buildbuddy-gcp-executors' .github/workflows/buildbuddy.yml &&
-  grep -Fq 'queue: max' .github/workflows/buildbuddy.yml &&
+  grep -Fq 'cancel-in-progress: false' .github/workflows/buildbuddy.yml &&
+  ! grep -Fq 'queue: max' .github/workflows/buildbuddy.yml &&
   grep -Fq 'MEERKAT_GCP_BUILDBUDDY_WAIT_ON_DOWN' .github/workflows/buildbuddy.yml &&
   grep -Fq 'scripts/gcp-buildbuddy-executor-pool down' .github/workflows/buildbuddy.yml &&
   grep -Fq 'MEERKAT_GCP_BUILDBUDDY_DOWN_MODE' .github/workflows/buildbuddy.yml &&
@@ -411,8 +414,8 @@ else
   bad "CI or BuildBuddy opt-in switch is not wired consistently"
 fi
 
-if job_has_line .github/workflows/ci.yml cargo 'name: GHA Cargo' &&
-  ! job_has_line .github/workflows/ci.yml gcp-buildbuddy 'name: GCP BuildBuddy' &&
+if job_has_line .github/workflows/ci.yml gcp-buildbuddy 'name: GCP BuildBuddy' &&
+  ! job_has_line .github/workflows/ci.yml cargo 'name: GHA Cargo' &&
   job_has_line .github/workflows/ci.yml gate 'name: CI gate' &&
   job_has_line .github/workflows/buildbuddy.yml prebuild-submit 'name: Prebuild submitter' &&
   job_has_line .github/workflows/buildbuddy.yml prebuild-submit 'group: gcp-prebuild' &&
@@ -426,7 +429,7 @@ if job_has_line .github/workflows/ci.yml cargo 'name: GHA Cargo' &&
   job_has_line .github/workflows/buildbuddy.yml wasm-feature-changes 'name: WASM, SDK, and feature change detection' &&
   job_has_line .github/workflows/buildbuddy.yml wasm-sdk-submit 'name: SDK suites submitter' &&
   job_has_line .github/workflows/buildbuddy.yml wasm-sdk-submit 'timeout-minutes: 45' &&
-  job_has_line .github/workflows/buildbuddy.yml wasm-sdk-submit "MEERKAT_GCP_BUILDBUDDY_CI_MAX_SECONDS: \${{ vars.MEERKAT_GCP_BUILDBUDDY_SDK_CI_MAX_SECONDS || '2400' }}" &&
+  job_has_line .github/workflows/buildbuddy.yml wasm-sdk-submit 'MEERKAT_GCP_BUILDBUDDY_CI_MAX_SECONDS: "1200"' &&
   job_has_line .github/workflows/buildbuddy.yml wasm-check-submit 'name: WASM check submitter' &&
   job_has_line .github/workflows/buildbuddy.yml minimal-feature-submit 'name: Minimal feature submitter' &&
   job_has_line .github/workflows/buildbuddy.yml feature-submit 'name: Feature matrix submitter' &&
@@ -481,7 +484,7 @@ if job_has_line .github/workflows/ci.yml cargo 'name: GHA Cargo' &&
   ! job_has_line .github/workflows/buildbuddy.yml feature-submit 'rmat-audit' &&
   ! job_has_line .github/workflows/buildbuddy.yml feature-submit 'machine-authority' &&
   grep -Fq 'MEERKAT_BUILDBUDDY_BATCH_JOBS' .github/workflows/buildbuddy.yml &&
-  grep -Fq "MAX_SECONDS: \${{ needs.wasm-feature-changes.outputs.sdk_changed == 'true' && (vars.MEERKAT_GCP_BUILDBUDDY_SDK_CI_MAX_SECONDS || '2400') || (vars.MEERKAT_GCP_BUILDBUDDY_CI_MAX_SECONDS || '1500') }}" .github/workflows/buildbuddy.yml &&
+  grep -Fq 'MAX_SECONDS: "1200"' .github/workflows/buildbuddy.yml &&
   grep -Fq 'MEERKAT_BUILDBUDDY_BATCH_JOBS: ${{ inputs.batch_jobs || env.MEERKAT_BUILDBUDDY_BATCH_JOBS }}' .github/actions/run-buildbuddy-ci-lane-batch/action.yml &&
   grep -Fq 'Check GCP CI duration SLO' .github/workflows/buildbuddy.yml &&
   grep -Fq 'Active BuildBuddy lane heartbeat' scripts/buildbuddy-ci-lane-batch &&
@@ -679,14 +682,14 @@ fi
 if ! grep -Fq 'rust-release-packaging:' .github/workflows/cargo.yml &&
   grep -Fq 'Verify Rust release config' .github/workflows/release.yml &&
   job_has_line .github/workflows/nightly.yml feature-matrix 'make test-feature-matrix' &&
-  grep -Fq 'name: GHA Cargo' .github/workflows/ci.yml &&
-  ! grep -Fq 'name: GCP BuildBuddy' .github/workflows/ci.yml &&
-  ! grep -Fq 'uses: ./.github/workflows/buildbuddy.yml' .github/workflows/ci.yml &&
+  ! grep -Fq 'name: GHA Cargo' .github/workflows/ci.yml &&
+  grep -Fq 'name: GCP BuildBuddy' .github/workflows/ci.yml &&
+  grep -Fq 'uses: ./.github/workflows/buildbuddy.yml' .github/workflows/ci.yml &&
   ! grep -Fq 'BuildBuddy hosted' .github/workflows/ci.yml &&
   ! grep -Fq 'buildbuddy-hosted' .github/workflows/ci.yml; then
-  pass "CI uses one GHA Cargo lane and defers low-churn feature checks to nightly"
+  pass "CI uses one GCP BuildBuddy lane and defers low-churn feature checks to nightly"
 else
-  bad "CI does not match the GHA-only per-push plus nightly shape"
+  bad "CI does not match the BuildBuddy per-push plus nightly shape"
 fi
 
 if grep -Fq 'name = "e2e_system_tests"' BUILD.bazel &&

--- a/scripts/check-semver-breaks.sh
+++ b/scripts/check-semver-breaks.sh
@@ -66,6 +66,14 @@ analyser_exit=0
     --tool-exit-code "$tool_exit" \
     "${release_args[@]}" || analyser_exit=$?
 
+# Release-readiness CI preserves the complete measurement as exact-tree
+# evidence. This output path is observational only and cannot relax the
+# analyser verdict.
+if [[ -n "${MEERKAT_SEMVER_REPORT_OUT:-}" ]]; then
+    mkdir -p "$(dirname "$MEERKAT_SEMVER_REPORT_OUT")"
+    cp "$report_file" "$MEERKAT_SEMVER_REPORT_OUT"
+fi
+
 if [[ "$analyser_exit" -ne 0 ]]; then
     echo >&2
     echo "cargo-semver-checks exited ${tool_exit}; last 40 report lines:" >&2

--- a/scripts/pre-push-dispatch.sh
+++ b/scripts/pre-push-dispatch.sh
@@ -222,8 +222,32 @@ git -C "$SOURCE_ROOT" worktree add --detach --quiet "$validation_tree" "$pushed_
 export PRE_COMMIT_REMOTE_NAME="$REMOTE_NAME"
 export PRE_COMMIT_REMOTE_URL="$REMOTE_URL"
 export PRE_COMMIT_TO_REF="$pushed_commit"
+empty_tree="$(git -C "$SOURCE_ROOT" hash-object -t tree /dev/null)"
 if [[ "$remote_sha" == "$ZERO_SHA" ]]; then
-  PRE_COMMIT_FROM_REF="$(git -C "$SOURCE_ROOT" hash-object -t tree /dev/null)"
+  PRE_COMMIT_FROM_REF="$empty_tree"
+  # A newly created branch still has a proven diff base. Use the fetched
+  # remote default branch when available so pre-commit does not reinterpret
+  # branch creation as "every repository file changed" and launch unrelated
+  # machine/TLC lanes. Tags remain fail-closed on the empty tree unless their
+  # exact tree already has reusable evidence from the branch push.
+  if [[ "$local_ref" == refs/heads/* ]]; then
+    remote_default_ref="$(
+      git -C "$SOURCE_ROOT" symbolic-ref --quiet \
+        "refs/remotes/${REMOTE_NAME}/HEAD" 2>/dev/null || true
+    )"
+    if [[ -z "$remote_default_ref" ]] &&
+      git -C "$SOURCE_ROOT" rev-parse --verify \
+        "refs/remotes/${REMOTE_NAME}/main^{commit}" >/dev/null 2>&1; then
+      remote_default_ref="refs/remotes/${REMOTE_NAME}/main"
+    fi
+    if [[ -n "$remote_default_ref" ]] &&
+      git -C "$SOURCE_ROOT" rev-parse --verify \
+        "${remote_default_ref}^{commit}" >/dev/null 2>&1; then
+      PRE_COMMIT_FROM_REF="$(
+        git -C "$SOURCE_ROOT" merge-base "$pushed_commit" "$remote_default_ref"
+      )"
+    fi
+  fi
 else
   PRE_COMMIT_FROM_REF="$remote_sha"
 fi
@@ -249,12 +273,13 @@ dispatch_step="running push-stage validation hooks"
 # the whole PIPESTATUS array at once; any later command resets it.
 trap - ERR
 set +e
-if [[ "$remote_sha" == "$ZERO_SHA" ]]; then
+if [[ "$PRE_COMMIT_FROM_REF" == "$empty_tree" ]]; then
   PYTHONUNBUFFERED=1 pre-commit run --config .pre-commit-config.yaml \
     --hook-stage pre-push --all-files 2>&1 | tee "$gate_log"
 else
   PYTHONUNBUFFERED=1 pre-commit run --config .pre-commit-config.yaml \
-    --hook-stage pre-push --from-ref "$remote_sha" --to-ref "$pushed_commit" \
+    --hook-stage pre-push --from-ref "$PRE_COMMIT_FROM_REF" \
+    --to-ref "$pushed_commit" \
     2>&1 | tee "$gate_log"
 fi
 gate_pipeline_status=("${PIPESTATUS[@]}")

--- a/scripts/test-pre-push-dispatch.sh
+++ b/scripts/test-pre-push-dispatch.sh
@@ -36,6 +36,9 @@ base_sha="$(git -C "$TEST_ROOT" rev-parse HEAD)"
 git -C "$TEST_ROOT" -c user.name=Meerkat -c user.email=meerkat@example.invalid \
   commit --allow-empty -qm "candidate"
 head_sha="$(git -C "$TEST_ROOT" rev-parse HEAD)"
+git -C "$TEST_ROOT" update-ref refs/remotes/origin/main "$base_sha"
+git -C "$TEST_ROOT" symbolic-ref \
+  refs/remotes/origin/HEAD refs/remotes/origin/main
 
 FAKE_PRE_COMMIT="${HARNESS_ROOT}/pre-commit"
 INVOCATION_LOG="${HARNESS_ROOT}/invocation"
@@ -123,8 +126,8 @@ fi
 
 : > "$INVOCATION_LOG"
 run_dispatch "refs/heads/new ${head_sha} refs/heads/new ${ZERO_SHA:-0000000000000000000000000000000000000000}"
-assert_log_line "args=run --config .pre-commit-config.yaml --hook-stage pre-push --all-files"
-assert_log_line "from=4b825dc642cb6eb9a060e54bf8d69288fbee4904"
+assert_log_line "args=run --config .pre-commit-config.yaml --hook-stage pre-push --from-ref ${base_sha} --to-ref ${head_sha}"
+assert_log_line "from=${base_sha}"
 second_validated_cwd="$(sed -n 's/^cwd=//p' "$INVOCATION_LOG")"
 second_bazel_output_base="$(sed -n 's/^bazel_output_base=//p' "$INVOCATION_LOG")"
 if [[ "${second_validated_cwd}" != "${validated_cwd}" ]]; then
@@ -138,6 +141,15 @@ if [[ "${second_bazel_output_base}" != "${validated_bazel_output_base}" ]]; then
     "${validated_bazel_output_base}" "${second_bazel_output_base}" >&2
   exit 1
 fi
+
+# If the remote default branch is unavailable, branch creation stays
+# fail-closed on the empty tree rather than guessing a comparison base.
+git -C "$TEST_ROOT" symbolic-ref --delete refs/remotes/origin/HEAD
+git -C "$TEST_ROOT" update-ref -d refs/remotes/origin/main
+: > "$INVOCATION_LOG"
+run_dispatch "refs/heads/fallback ${head_sha} refs/heads/fallback 0000000000000000000000000000000000000000"
+assert_log_line "args=run --config .pre-commit-config.yaml --hook-stage pre-push --all-files"
+assert_log_line "from=4b825dc642cb6eb9a060e54bf8d69288fbee4904"
 
 tag_object="$(git -C "$TEST_ROOT" -c user.name=Meerkat -c user.email=meerkat@example.invalid \
   tag -a dispatch-test -m dispatch-test && git -C "$TEST_ROOT" rev-parse dispatch-test)"

--- a/scripts/verify-rust-release-public.py
+++ b/scripts/verify-rust-release-public.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+"""Wait until every canonical Meerkat release crate is public and non-yanked."""
+
+from __future__ import annotations
+
+import argparse
+import datetime
+import json
+import pathlib
+import subprocess
+import time
+import urllib.error
+import urllib.request
+
+try:
+    import tomllib
+except ModuleNotFoundError:  # pragma: no cover - Python < 3.11 local fallback
+    import tomli as tomllib
+
+
+USER_AGENT = "meerkat-release-verifier (https://github.com/lukacf/meerkat)"
+
+
+def release_crates(root: pathlib.Path) -> list[str]:
+    output = subprocess.check_output(
+        [str(root / "scripts" / "release-rust-crates.sh")], text=True
+    )
+    return [line.strip() for line in output.splitlines() if line.strip()]
+
+
+def fetch_version(crate: str, version: str) -> dict | None:
+    url = f"https://crates.io/api/v1/crates/{crate}/{version}"
+    request = urllib.request.Request(url, headers={"User-Agent": USER_AGENT})
+    try:
+        with urllib.request.urlopen(request, timeout=20) as response:
+            return json.load(response)["version"]
+    except urllib.error.HTTPError as error:
+        if error.code in (404, 429, 500, 502, 503, 504):
+            return None
+        raise
+    except (TimeoutError, urllib.error.URLError):
+        return None
+
+
+def parse_instant(value: str) -> datetime.datetime:
+    return datetime.datetime.fromisoformat(value.replace("Z", "+00:00"))
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--repo-root", type=pathlib.Path, default=pathlib.Path.cwd())
+    parser.add_argument("--deadline-seconds", type=int, default=900)
+    parser.add_argument("--tag-pushed-at", required=True)
+    parser.add_argument("--slo-seconds", type=int, default=1800)
+    args = parser.parse_args()
+
+    root = args.repo_root.resolve()
+    workspace = tomllib.loads((root / "Cargo.toml").read_text())
+    version = workspace["workspace"]["package"]["version"]
+    crates = release_crates(root)
+    deadline = time.monotonic() + args.deadline_seconds
+    pending = set(crates)
+    published_at: dict[str, datetime.datetime] = {}
+    observed_at: dict[str, datetime.datetime] = {}
+
+    while pending:
+        for crate in sorted(pending):
+            published = fetch_version(crate, version)
+            if not published:
+                continue
+            if published.get("yanked"):
+                raise SystemExit(f"{crate} {version} is public but yanked")
+            if not published.get("checksum"):
+                raise SystemExit(f"{crate} {version} has no registry checksum")
+            created_at = published.get("created_at")
+            if not created_at:
+                raise SystemExit(f"{crate} {version} has no registry creation timestamp")
+            published_at[crate] = parse_instant(created_at)
+            observed_at[crate] = datetime.datetime.now(datetime.timezone.utc)
+            pending.remove(crate)
+            print(f"public {crate} {version} {published['checksum']}", flush=True)
+        if not pending:
+            break
+        if time.monotonic() >= deadline:
+            raise SystemExit(
+                f"timed out waiting for {len(pending)} crate(s): {', '.join(sorted(pending))}"
+            )
+        print(f"waiting for {len(pending)} crate(s)", flush=True)
+        time.sleep(10)
+
+    tag_pushed_at = parse_instant(args.tag_pushed_at)
+    final_publication = max(published_at.values())
+    final_observation = max(observed_at.values())
+    registry_elapsed = max(
+        0, int((final_publication - tag_pushed_at).total_seconds())
+    )
+    observed_elapsed = max(
+        0,
+        int((final_observation - tag_pushed_at).total_seconds()),
+    )
+    print(
+        f"all {len(crates)} crates observed public {observed_elapsed}/{args.slo_seconds} "
+        f"seconds after tag push (registry-created component: {registry_elapsed}s)"
+    )
+    if observed_elapsed > args.slo_seconds:
+        raise SystemExit(
+            f"tag-to-crates.io SLO exceeded: {observed_elapsed}s > "
+            f"{args.slo_seconds}s"
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/xtask/tests/ci_gate_requires_rmat.rs
+++ b/xtask/tests/ci_gate_requires_rmat.rs
@@ -2,11 +2,11 @@
 
 //! Pinning tests for the CI workflow contract.
 //!
-//! CI runs a single Cargo lane on free GitHub-hosted runners (the GCP
-//! BuildBuddy lane was retired 2026-07-03). These tests ratchet the load-
-//! bearing invariants: the typed governance gates (rmat-audit set) bind every
-//! run, the per-push lane plus the nightly workflow cover the full `make ci`
-//! target set, and the retired BuildBuddy workflow stays inert until deleted.
+//! CI runs one authoritative GCP BuildBuddy/RBE lane. The GitHub-hosted Cargo
+//! workflow remains a diagnostic fallback, while nightly owns low-churn heavy
+//! coverage. These tests ratchet the load-bearing invariants: the typed
+//! governance gates (rmat-audit set) bind every run, BuildBuddy stays on the
+//! hot path, and the aggregate gate enforces the 20-minute terminal budget.
 
 use std::path::{Path, PathBuf};
 
@@ -47,7 +47,7 @@ fn job_names(doc: &serde_yaml::Value, path: &Path) -> Vec<String> {
 }
 
 #[test]
-fn ci_runs_a_single_free_cargo_lane() {
+fn ci_runs_one_authoritative_buildbuddy_lane() {
     let ci_yml = workflow_yml_path("ci.yml");
     let ci = std::fs::read_to_string(&ci_yml)
         .unwrap_or_else(|e| panic!("read {}: {e}", ci_yml.display()));
@@ -55,19 +55,24 @@ fn ci_runs_a_single_free_cargo_lane() {
 
     assert_eq!(
         job_names(&doc, &ci_yml),
-        vec!["cargo", "gate"],
-        "{} should expose only the Cargo lane and the aggregating gate",
+        vec!["gate", "gcp-buildbuddy"],
+        "{} should expose only BuildBuddy and the aggregating gate",
         ci_yml.display(),
     );
-    assert!(ci.contains("uses: ./.github/workflows/cargo.yml"));
     assert!(
-        !ci.contains("uses: ./.github/workflows/buildbuddy.yml"),
-        "the retired GCP BuildBuddy lane must not be routed from CI"
+        ci.contains("uses: ./.github/workflows/buildbuddy.yml"),
+        "CI must route through the authoritative GCP BuildBuddy lane"
+    );
+    assert!(
+        !ci.contains("uses: ./.github/workflows/cargo.yml"),
+        "the diagnostic Cargo workflow must not duplicate authoritative CI"
     );
     assert!(
         !ci.contains("github.actor"),
         "CI must not route by actor — one lane for everyone"
     );
+    assert!(ci.contains("name: Enforce push-to-terminal budget"));
+    assert!(ci.contains("MAX_SECONDS: \"1200\""));
 }
 
 #[test]
@@ -94,7 +99,7 @@ fn machine_authority_classifier_protects_required_gate_owners() {
 }
 
 #[test]
-fn cargo_workflow_covers_the_full_per_push_gate_set() {
+fn cargo_diagnostic_workflow_preserves_the_full_gate_set() {
     let cargo_yml = workflow_yml_path("cargo.yml");
     let cargo = std::fs::read_to_string(&cargo_yml)
         .unwrap_or_else(|e| panic!("read {}: {e}", cargo_yml.display()));
@@ -255,17 +260,13 @@ fn nightly_covers_the_deferred_heavy_lanes() {
 }
 
 #[test]
-fn buildbuddy_workflow_is_retired_and_inert() {
+fn buildbuddy_workflow_is_authoritative_and_single_caller() {
     let ci_yml = workflow_yml_path("ci.yml");
     let cargo_yml = workflow_yml_path("cargo.yml");
     let nightly_yml = workflow_yml_path("nightly.yml");
     let buildbuddy_yml = workflow_yml_path("buildbuddy.yml");
-    if !buildbuddy_yml.exists() {
-        // Fully deleted — the retirement completed; nothing to pin.
-        return;
-    }
-
-    // workflow_call-only: without a caller the workflow can never run.
+    // The implementation stays workflow_call-only so ci.yml remains the one
+    // top-level policy owner and attestation boundary.
     // (YAML 1.1 parses the bare `on` key as boolean true.)
     let doc = read_workflow(&buildbuddy_yml);
     let triggers = doc
@@ -278,19 +279,30 @@ fn buildbuddy_workflow_is_retired_and_inert() {
     assert_eq!(
         names,
         vec!["workflow_call"],
-        "retired buildbuddy.yml must stay workflow_call-only (inert without a caller)"
+        "buildbuddy.yml must stay workflow_call-only behind the CI policy owner"
     );
-    for caller in [&ci_yml, &cargo_yml, &nightly_yml] {
+    let ci = std::fs::read_to_string(&ci_yml)
+        .unwrap_or_else(|e| panic!("read {}: {e}", ci_yml.display()));
+    assert!(
+        ci.lines().any(|line| {
+            line.trim_start().starts_with("uses:") && line.contains("buildbuddy.yml")
+        }),
+        "{} must call the authoritative BuildBuddy workflow",
+        ci_yml.display()
+    );
+    for caller in [&cargo_yml, &nightly_yml] {
         let text = std::fs::read_to_string(caller)
             .unwrap_or_else(|e| panic!("read {}: {e}", caller.display()));
-        // Prose may mention the file (retirement notes); a `uses:` reference
-        // is what would revive it.
         assert!(
             !text.lines().any(|line| {
                 line.trim_start().starts_with("uses:") && line.contains("buildbuddy.yml")
             }),
-            "{} must not call the retired BuildBuddy workflow",
+            "{} must not duplicate the authoritative BuildBuddy caller",
             caller.display()
         );
     }
+    let buildbuddy = std::fs::read_to_string(&buildbuddy_yml)
+        .unwrap_or_else(|e| panic!("read {}: {e}", buildbuddy_yml.display()));
+    assert!(buildbuddy.contains("MAX_SECONDS: \"1200\""));
+    assert!(!buildbuddy.contains("queue: max"));
 }

--- a/xtask/tests/ci_gate_requires_rmat.rs
+++ b/xtask/tests/ci_gate_requires_rmat.rs
@@ -73,6 +73,10 @@ fn ci_runs_one_authoritative_buildbuddy_lane() {
     );
     assert!(ci.contains("name: Enforce push-to-terminal budget"));
     assert!(ci.contains("MAX_SECONDS: \"1200\""));
+    assert!(
+        ci.contains("id-token: write"),
+        "the caller must grant the OIDC permission requested by the reusable BuildBuddy workflow"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Outcome

Make the 0.8.31 release train enforce two explicit service objectives:

- git push to full CI terminal in at most 20 minutes
- release tag to all Rust crates publicly observable on crates.io in at most 30 minutes

Binary completion remains tracked separately and may exceed 30 minutes.

## 0.8.30 retrospective

The actual tag-to-public endpoint was approximately 6h07m, not the earlier 759-second successful-attempt measurement. The earlier figure excluded failed and superseded attempts. This change measures from the earliest exact tag-triggered release workflow across all attempts to the first successful public observation of every expected non-yanked crate.

## Changes

- make the GCP BuildBuddy workflow the single authoritative broad CI lane
- enforce a 1200-second push-to-terminal CI budget
- move expensive semver readiness to PR/main before tagging and consume exact-main evidence during release
- verify all 42 Rust crates and their checksums after publication
- enforce the 30-minute tag-to-public objective against the earliest tag workflow attempt
- serialize and group routine Renovate dependency changes
- safely regenerate the Bazel module lock for narrowly allowlisted Renovate PRs
- make first pushes diff against a proven remote default branch instead of treating every file as changed
- update workflow, dispatcher, release, and RMAT contracts to cover the new authority shape

## Evidence

- normal pre-push hook passed without bypass
- actionlint green for changed workflows
- pre-push dispatcher contract tests green
- CI/RMAT workflow contract test 5/5 green
- semver script tests 51/51 green
- release doctor 21 pass, one benign warning
- BuildBuddy doctor 43 pass, one dirty-tree warning during development
- Renovate config validator green
- `git diff --check` green

## Known latency result

The local normal push hook itself exceeded 20 minutes. Profiling showed the remaining cost is dominated by deterministic workspace unit/integration execution, the independent cold-restart feature graph, e2e-fast, and machine-authority checks. This PR makes the hosted objective authoritative and measurable; lane-specific evidence fingerprints and compilation reuse are the next 0.8.31 optimization, not hidden as a green claim here.
