### PR TITLE
release: require complete binary asset set

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1209,7 +1209,7 @@ jobs:
         with:
           path: release-artifacts
 
-      - name: Build checksum manifest
+      - name: Prepare and verify complete release asset set
         env:
           RELEASE_TAG: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.release_tag || github.ref_name }}
         run: |
@@ -1218,14 +1218,17 @@ jobs:
             echo "release_tag is required for release asset recovery" >&2
             exit 1
           fi
-          scripts/release-build-asset-manifest release-artifacts "${RELEASE_TAG}"
+          scripts/verify-release-assets.py prepare \
+            --source-dir release-artifacts \
+            --output-dir prepared-release-artifacts \
+            --release-tag "${RELEASE_TAG}"
 
       - name: Publish release archives
         uses: softprops/action-gh-release@v2
         with:
           files: |
-            release-artifacts/**/*.tar.gz
-            release-artifacts/**/*.zip
+            prepared-release-artifacts/*.tar.gz
+            prepared-release-artifacts/*.zip
           draft: false
           fail_on_unmatched_files: true
           generate_release_notes: true
@@ -1241,14 +1244,16 @@ jobs:
           RELEASE_TAG: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.release_tag || github.ref_name }}
         run: |
           set -euo pipefail
-          rm -rf published-release-artifacts
-          mkdir -p published-release-artifacts
+          mkdir -p published-release-downloads
           gh release download "${RELEASE_TAG}" \
             --repo "${GITHUB_REPOSITORY}" \
             --pattern '*.tar.gz' \
             --pattern '*.zip' \
-            --dir published-release-artifacts
-          scripts/release-build-asset-manifest published-release-artifacts "${RELEASE_TAG}"
+            --dir published-release-downloads
+          scripts/verify-release-assets.py prepare \
+            --source-dir published-release-downloads \
+            --output-dir published-release-artifacts \
+            --release-tag "${RELEASE_TAG}"
 
       # Publish checksums and index.json only after every platform archive is
       # present, keeping the public manifest a complete release authority.

--- a/scripts/verify-release-assets.py
+++ b/scripts/verify-release-assets.py
@@ -1,0 +1,257 @@
+#!/usr/bin/env python3
+"""Prepare and verify the complete, flat Meerkat binary release asset set."""
+
+import argparse
+import hashlib
+import json
+import shutil
+import sys
+from pathlib import Path
+
+
+ARCHIVE_PREFIXES = ("rkat", "rkat-mcp", "rkat-rest", "rkat-rpc")
+TARGET_ARCHIVES = (
+    ("x86_64-unknown-linux-gnu", "tar.gz"),
+    ("aarch64-unknown-linux-gnu", "tar.gz"),
+    ("aarch64-apple-darwin", "tar.gz"),
+    ("x86_64-apple-darwin", "tar.gz"),
+    ("x86_64-pc-windows-msvc", "zip"),
+)
+MANIFEST_NAME = "index.json"
+CHECKSUMS_NAME = "checksums.sha256"
+
+
+class ReleaseAssetError(RuntimeError):
+    pass
+
+
+def normalized_version(release_tag):
+    tag = release_tag.strip()
+    if not tag:
+        raise ReleaseAssetError("release tag must not be empty")
+    version = tag[1:] if tag.startswith("v") else tag
+    version = version.replace("/", "-")
+    if not version:
+        raise ReleaseAssetError("release tag does not contain a version")
+    return tag, version
+
+
+def expected_archive_names(version):
+    return sorted(
+        f"{prefix}-{version}-{target}.{extension}"
+        for prefix in ARCHIVE_PREFIXES
+        for target, extension in TARGET_ARCHIVES
+    )
+
+
+def is_archive(path):
+    return path.name.endswith(".tar.gz") or path.name.endswith(".zip")
+
+
+def sha256(path):
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def describe_set_mismatch(label, expected, actual):
+    missing = sorted(expected - actual)
+    unexpected = sorted(actual - expected)
+    details = []
+    if missing:
+        details.append("missing: " + ", ".join(missing))
+    if unexpected:
+        details.append("unexpected: " + ", ".join(unexpected))
+    return f"{label} mismatch ({'; '.join(details)})"
+
+
+def verify_assets(assets_dir, release_tag):
+    tag, version = normalized_version(release_tag)
+    assets_dir = assets_dir.resolve()
+    if not assets_dir.is_dir():
+        raise ReleaseAssetError(f"asset directory does not exist: {assets_dir}")
+
+    all_files = sorted(path for path in assets_dir.rglob("*") if path.is_file())
+    nested = [
+        path.relative_to(assets_dir).as_posix()
+        for path in all_files
+        if path.parent != assets_dir
+    ]
+    if nested:
+        raise ReleaseAssetError(
+            "release assets must be flat; nested files: " + ", ".join(nested)
+        )
+
+    expected_archives = set(expected_archive_names(version))
+    actual_archives = {path.name for path in all_files if is_archive(path)}
+    if actual_archives != expected_archives:
+        raise ReleaseAssetError(
+            describe_set_mismatch("archive set", expected_archives, actual_archives)
+        )
+
+    allowed_files = expected_archives | {MANIFEST_NAME, CHECKSUMS_NAME}
+    actual_files = {path.name for path in all_files}
+    if actual_files != allowed_files:
+        raise ReleaseAssetError(
+            describe_set_mismatch("release file set", allowed_files, actual_files)
+        )
+
+    manifest_path = assets_dir / MANIFEST_NAME
+    try:
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as error:
+        raise ReleaseAssetError(f"cannot read {MANIFEST_NAME}: {error}") from error
+
+    expected_manifest = {
+        "version": version,
+        "tag": tag,
+        "artifacts": sorted(expected_archives),
+        "checksums": CHECKSUMS_NAME,
+    }
+    if manifest != expected_manifest:
+        raise ReleaseAssetError(
+            f"{MANIFEST_NAME} does not match the flat release asset set"
+        )
+
+    checksum_path = assets_dir / CHECKSUMS_NAME
+    checksums = {}
+    try:
+        checksum_lines = checksum_path.read_text(encoding="utf-8").splitlines()
+    except OSError as error:
+        raise ReleaseAssetError(f"cannot read {CHECKSUMS_NAME}: {error}") from error
+
+    for line_number, line in enumerate(checksum_lines, start=1):
+        try:
+            digest, name = line.split("  ", 1)
+        except ValueError as error:
+            raise ReleaseAssetError(
+                f"invalid {CHECKSUMS_NAME} line {line_number}: {line!r}"
+            ) from error
+        if len(digest) != 64 or any(
+            character not in "0123456789abcdef" for character in digest
+        ):
+            raise ReleaseAssetError(
+                f"invalid SHA-256 on {CHECKSUMS_NAME} line {line_number}"
+            )
+        if "/" in name or "\\" in name:
+            raise ReleaseAssetError(
+                f"checksum entry must use a flat basename, found {name!r}"
+            )
+        if name in checksums:
+            raise ReleaseAssetError(f"duplicate checksum entry for {name}")
+        checksums[name] = digest
+
+    if set(checksums) != expected_archives:
+        raise ReleaseAssetError(
+            describe_set_mismatch(
+                "checksum entries", expected_archives, set(checksums)
+            )
+        )
+    for name in sorted(expected_archives):
+        actual_digest = sha256(assets_dir / name)
+        if checksums[name] != actual_digest:
+            raise ReleaseAssetError(f"checksum mismatch for {name}")
+
+    print(f"verified {len(expected_archives)} flat release archives for {tag}")
+
+
+def prepare_assets(source_dir, output_dir, release_tag):
+    tag, version = normalized_version(release_tag)
+    source_dir = source_dir.resolve()
+    output_dir = output_dir.resolve()
+    if not source_dir.is_dir():
+        raise ReleaseAssetError(f"artifact directory does not exist: {source_dir}")
+    if output_dir.exists():
+        raise ReleaseAssetError(f"output directory already exists: {output_dir}")
+
+    archives = sorted(
+        path for path in source_dir.rglob("*") if path.is_file() and is_archive(path)
+    )
+    archives_by_name = {}
+    duplicates = {}
+    for path in archives:
+        if path.name in archives_by_name:
+            duplicates.setdefault(path.name, [archives_by_name[path.name]]).append(path)
+        else:
+            archives_by_name[path.name] = path
+    if duplicates:
+        duplicate_details = []
+        for name, paths in sorted(duplicates.items()):
+            locations = ", ".join(
+                path.relative_to(source_dir).as_posix() for path in paths
+            )
+            duplicate_details.append(f"{name}: {locations}")
+        raise ReleaseAssetError(
+            "duplicate archive basenames detected; refusing to flatten: "
+            + "; ".join(duplicate_details)
+        )
+
+    expected_archives = set(expected_archive_names(version))
+    actual_archives = set(archives_by_name)
+    if actual_archives != expected_archives:
+        raise ReleaseAssetError(
+            describe_set_mismatch(
+                "downloaded archive set", expected_archives, actual_archives
+            )
+        )
+
+    output_dir.mkdir(parents=True)
+    for name in sorted(expected_archives):
+        shutil.copy2(archives_by_name[name], output_dir / name)
+
+    checksum_lines = [
+        f"{sha256(output_dir / name)}  {name}\n" for name in sorted(expected_archives)
+    ]
+    (output_dir / CHECKSUMS_NAME).write_text(
+        "".join(checksum_lines), encoding="utf-8"
+    )
+
+    manifest = {
+        "version": version,
+        "tag": tag,
+        "artifacts": sorted(expected_archives),
+        "checksums": CHECKSUMS_NAME,
+    }
+    (output_dir / MANIFEST_NAME).write_text(
+        json.dumps(manifest, indent=2) + "\n", encoding="utf-8"
+    )
+    verify_assets(output_dir, tag)
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    prepare = subparsers.add_parser(
+        "prepare", help="flatten and prepare downloaded artifacts"
+    )
+    prepare.add_argument("--source-dir", type=Path, required=True)
+    prepare.add_argument("--output-dir", type=Path, required=True)
+    prepare.add_argument("--release-tag", required=True)
+
+    verify = subparsers.add_parser(
+        "verify", help="verify a prepared flat release asset set"
+    )
+    verify.add_argument("--assets-dir", type=Path, required=True)
+    verify.add_argument("--release-tag", required=True)
+
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+    try:
+        if args.command == "prepare":
+            prepare_assets(args.source_dir, args.output_dir, args.release_tag)
+        else:
+            verify_assets(args.assets_dir, args.release_tag)
+    except ReleaseAssetError as error:
+        print(f"release asset error: {error}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/xtask/tests/release_workflow_asset_manifest.rs
+++ b/xtask/tests/release_workflow_asset_manifest.rs
@@ -22,6 +22,12 @@ fn manifest_script_path() -> PathBuf {
     path
 }
 
+fn asset_verifier_path() -> PathBuf {
+    let mut path = manifest_script_path();
+    path.set_file_name("verify-release-assets.py");
+    path
+}
+
 fn read_workflow(path: &Path) -> serde_yaml::Value {
     let text = std::fs::read_to_string(path)
         .unwrap_or_else(|error| panic!("cannot read {}: {error}", path.display()));
@@ -117,7 +123,9 @@ fn published_assets_are_manifest_authority_on_reruns() {
         "gh release download",
         "--pattern '*.tar.gz'",
         "--pattern '*.zip'",
-        "scripts/release-build-asset-manifest published-release-artifacts",
+        "scripts/verify-release-assets.py prepare",
+        "--source-dir published-release-downloads",
+        "--output-dir published-release-artifacts",
     ] {
         assert!(
             final_download.contains(contract),
@@ -163,13 +171,19 @@ fn release_asset_manifest_contract_stays_flat_and_collision_checked() {
         &workflow,
         &path,
         "publish_github_release",
-        "Build checksum manifest",
+        "Prepare and verify complete release asset set",
     );
-    assert!(
-        script
-            .contains("scripts/release-build-asset-manifest release-artifacts \"${RELEASE_TAG}\""),
-        "release workflow must delegate to the manifest authority; script:\n{script}"
-    );
+    for contract in [
+        "scripts/verify-release-assets.py prepare",
+        "--source-dir release-artifacts",
+        "--output-dir prepared-release-artifacts",
+        "--release-tag \"${RELEASE_TAG}\"",
+    ] {
+        assert!(
+            script.contains(contract),
+            "release workflow must preserve `{contract}`; script:\n{script}"
+        );
+    }
 
     let manifest_path = manifest_script_path();
     let manifest = std::fs::read_to_string(&manifest_path)
@@ -196,6 +210,95 @@ fn release_asset_manifest_contract_stays_flat_and_collision_checked() {
     assert!(
         !manifest.contains("xargs sha256sum"),
         "checksums.sha256 must be rendered from public basenames, not staged paths"
+    );
+}
+
+fn expected_complete_archive_names(version: &str) -> Vec<String> {
+    let binaries = ["rkat", "rkat-mcp", "rkat-rest", "rkat-rpc"];
+    let targets = [
+        ("x86_64-unknown-linux-gnu", "tar.gz"),
+        ("aarch64-unknown-linux-gnu", "tar.gz"),
+        ("aarch64-apple-darwin", "tar.gz"),
+        ("x86_64-apple-darwin", "tar.gz"),
+        ("x86_64-pc-windows-msvc", "zip"),
+    ];
+    let mut names = Vec::new();
+    for binary in binaries {
+        for (target, extension) in targets {
+            names.push(format!("{binary}-{version}-{target}.{extension}"));
+        }
+    }
+    names.sort_unstable();
+    names
+}
+
+fn run_asset_verifier(source: &Path, output: &Path) -> Output {
+    let interpreter = std::env::var_os("PYTHON").unwrap_or_else(|| OsString::from("python3"));
+    Command::new(interpreter)
+        .arg(asset_verifier_path())
+        .arg("prepare")
+        .arg("--source-dir")
+        .arg(source)
+        .arg("--output-dir")
+        .arg(output)
+        .arg("--release-tag")
+        .arg("v0.8.31")
+        .output()
+        .expect("run complete release asset verifier")
+}
+
+#[test]
+fn complete_release_asset_inventory_is_four_binaries_by_five_targets() {
+    let temp = tempdir().expect("tempdir");
+    let source = temp.path().join("downloaded");
+    let output = temp.path().join("prepared");
+    std::fs::create_dir(&source).expect("create source");
+    let names = expected_complete_archive_names("0.8.31");
+    assert_eq!(names.len(), 20, "release contract must name 20 archives");
+    for (index, name) in names.iter().enumerate() {
+        let lane = source.join(format!("lane-{index}"));
+        std::fs::create_dir(&lane).expect("create staged lane");
+        std::fs::write(lane.join(name), format!("artifact-{index}")).expect("write archive");
+    }
+
+    let result = run_asset_verifier(&source, &output);
+    assert!(
+        result.status.success(),
+        "complete inventory must verify: {}",
+        String::from_utf8_lossy(&result.stderr)
+    );
+    assert_eq!(
+        std::fs::read_dir(&output).expect("read output").count(),
+        22,
+        "20 archives plus two manifests must be prepared"
+    );
+}
+
+#[test]
+fn complete_release_asset_inventory_rejects_one_missing_archive() {
+    let temp = tempdir().expect("tempdir");
+    let source = temp.path().join("downloaded");
+    let output = temp.path().join("prepared");
+    std::fs::create_dir(&source).expect("create source");
+    let mut names = expected_complete_archive_names("0.8.31");
+    let missing = names.pop().expect("nonempty release inventory");
+    for (index, name) in names.iter().enumerate() {
+        std::fs::write(source.join(name), format!("artifact-{index}")).expect("write archive");
+    }
+
+    let result = run_asset_verifier(&source, &output);
+    assert!(
+        !result.status.success(),
+        "a partial release must fail closed"
+    );
+    let stderr = String::from_utf8_lossy(&result.stderr);
+    assert!(
+        stderr.contains("downloaded archive set mismatch") && stderr.contains(&missing),
+        "missing archive must be named: {stderr}"
+    );
+    assert!(
+        !output.exists(),
+        "a rejected inventory must not leave a successful-looking output directory"
     );
 }
 


### PR DESCRIPTION
## Summary

- require exactly 4 Meerkat binaries across all 5 release targets before final asset publication
- flatten and verify all 20 archives, checksums, and index rather than describing whatever subset happened to build
- retain the separate macOS/Linux Homebrew producer path

## Regression evidence

- focused release workflow contract: 6/6 green
- missing-one-archive fixture fails closed and names the missing asset
- actionlint, Python compile, fmt, and diff hygiene green
- normal pre-push hook passed

This closes the release-set defect that allowed v0.8.30 to publish only 12 of 20 archives with no manifests.