### PR TITLE
ci: isolate concurrent pre-push validation

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,6 +3,10 @@
 # Setup: make install-hooks
 
 default_stages: [pre-commit]
+# Once any hook has rejected the exact pushed tree, later expensive hooks
+# cannot make that push acceptable. Stop immediately so the operator can fix
+# the named defect without spending another broad validation cycle first.
+fail_fast: true
 
 repos:
   # On commit: auto-format Rust code

--- a/scripts/pre-push-dispatch.sh
+++ b/scripts/pre-push-dispatch.sh
@@ -105,14 +105,20 @@ hook_cache_dir="${hook_cache_root}/exact-tree"
 # This accelerates identical tracked trees only. CI remains authoritative for
 # toolchain, environment, credential, and other inputs outside the Git tree.
 hook_stamp="${hook_cache_dir}/${CACHE_VERSION}-${pushed_tree}.ok"
-dispatcher_lock_dir="${hook_cache_root}/dispatcher.lock"
+# Each source worktree gets a stable validation lane unless the caller names
+# one explicitly. The detached worktree, Cargo target, Bazel output base, and
+# dispatcher lock are all lane-owned, so unrelated worktrees can validate in
+# parallel without sharing mutable build state. Concurrent pushes from the
+# same source worktree still serialize on the same lane.
+default_validation_lane="pre-push-$(hash_path "${SOURCE_ROOT}")"
+validation_lane="$(sanitize_cache_key "${RUST_LANE_ID:-${default_validation_lane}}")"
+dispatcher_lock_dir="${hook_cache_root}/dispatcher-${validation_lane}.lock"
 dispatcher_lock_pid="${dispatcher_lock_dir}/pid"
-validation_lane="$(sanitize_cache_key "${RUST_LANE_ID:-pre-push}")"
 validation_tree="${hook_cache_root}/worktrees/${validation_lane}"
 validation_run_root=""
 validation_tree_owned=0
 dispatcher_lock_held=0
-export RUST_LANE_ID="${RUST_LANE_ID:-pre-push}"
+export RUST_LANE_ID="${validation_lane}"
 
 release_dispatcher_lock() {
   if [[ "${dispatcher_lock_held}" -eq 1 ]]; then

--- a/scripts/pre-push-unit.sh
+++ b/scripts/pre-push-unit.sh
@@ -2,7 +2,7 @@
 # Pre-push deterministic test gate:
 # - validates the exact detached pushed tree selected by pre-push-dispatch.sh
 # - reuses source-test evidence across root lockfile-only commits
-# - serializes runs so repeated pushes don't fight each other
+# - serializes identical source evidence while isolated worktree lanes run in parallel
 # - retries nextest once if discovery hangs
 set -euo pipefail
 
@@ -28,8 +28,9 @@ LOCK_WAIT_SECS="${MEERKAT_PRE_PUSH_UNIT_LOCK_WAIT_SECS:-180}"
 GIT_DIR_PATH="$("$GIT_BIN" rev-parse --git-common-dir)"
 HOOK_CACHE_ROOT="${GIT_DIR_PATH}/meerkat-hook-cache"
 HOOK_CACHE_DIR="${HOOK_CACHE_ROOT}/deterministic"
-LOCK_DIR="${HOOK_CACHE_ROOT}/deterministic.lock"
-PID_FILE="${LOCK_DIR}/pid"
+LOCK_DIR=""
+PID_FILE=""
+lock_held=0
 
 mkdir -p "$HOOK_CACHE_DIR"
 
@@ -141,10 +142,14 @@ acquire_lock() {
   done
 
   echo "$$" > "$PID_FILE"
+  lock_held=1
 }
 
 release_lock() {
-  rm -rf "$LOCK_DIR"
+  if [[ "$lock_held" -eq 1 ]]; then
+    rm -rf "$LOCK_DIR"
+    lock_held=0
+  fi
 }
 
 run_with_timeout() {
@@ -193,7 +198,6 @@ retry_lane() {
   run_with_timeout "$timeout_secs" "${lane_cmd[@]}"
 }
 
-acquire_lock
 NEXTEST_REUSE_DIR=""
 
 release_resources() {
@@ -211,7 +215,20 @@ tree="$(tree_key)"
 source_fingerprint="$(source_test_fingerprint)"
 stamp_key="${CACHE_VERSION}-cargo-source-${source_fingerprint}"
 stamp_path="${HOOK_CACHE_DIR}/${stamp_key}.ok"
+LOCK_DIR="${HOOK_CACHE_ROOT}/deterministic-locks/${stamp_key}.lock"
+PID_FILE="${LOCK_DIR}/pid"
 
+if [[ "${MEERKAT_SKIP_PRE_PUSH_UNIT_CACHE:-0}" != "1" && -f "$stamp_path" ]]; then
+  echo "reusing deterministic source-test evidence for fingerprint ${source_fingerprint}."
+  echo "Current root lock graph was compiled by pre-push Clippy but is not re-tested locally; CI is authoritative."
+  exit 0
+fi
+
+mkdir -p "$(dirname "$LOCK_DIR")"
+acquire_lock
+
+# A peer validating the same source fingerprint may have completed while this
+# process waited. Reuse its evidence instead of rebuilding the same graph.
 if [[ "${MEERKAT_SKIP_PRE_PUSH_UNIT_CACHE:-0}" != "1" && -f "$stamp_path" ]]; then
   echo "reusing deterministic source-test evidence for fingerprint ${source_fingerprint}."
   echo "Current root lock graph was compiled by pre-push Clippy but is not re-tested locally; CI is authoritative."

--- a/scripts/test-pre-push-dispatch.sh
+++ b/scripts/test-pre-push-dispatch.sh
@@ -29,6 +29,27 @@ cleanup_harness() {
 }
 trap cleanup_harness EXIT
 
+hash_path() {
+  if command -v shasum >/dev/null 2>&1; then
+    printf '%s' "$1" | shasum -a 256 | cut -c1-16
+  elif command -v sha256sum >/dev/null 2>&1; then
+    printf '%s' "$1" | sha256sum | cut -c1-16
+  else
+    printf '%s' "$1" | cksum | cut -d' ' -f1
+  fi
+}
+
+default_lane_for_root() {
+  local canonical_root
+  canonical_root="$(git -C "$1" rev-parse --show-toplevel)"
+  printf 'pre-push-%s' "$(hash_path "$canonical_root")"
+}
+
+if ! grep -Fxq 'fail_fast: true' "$REPO_ROOT/.pre-commit-config.yaml"; then
+  echo "pre-push configuration must stop after the first rejecting hook" >&2
+  exit 1
+fi
+
 git -C "$TEST_ROOT" init -q
 git -C "$TEST_ROOT" -c user.name=Meerkat -c user.email=meerkat@example.invalid \
   commit --allow-empty -qm "base"
@@ -104,7 +125,7 @@ assert_log_line "to=${head_sha}"
 assert_log_line "from=${base_sha}"
 assert_log_line "remote_name=origin"
 assert_log_line "remote_url=example.invalid"
-assert_log_line "lane=pre-push"
+assert_log_line "lane=$(default_lane_for_root "$TEST_ROOT")"
 if grep -Fq "dirty_source_visible=yes" "$INVOCATION_LOG"; then
   echo "dispatcher exposed dirty source-worktree bytes to validation" >&2
   exit 1
@@ -201,7 +222,8 @@ fi
 # A cache-hit process does not own the stable validation worktree. It must not
 # remove a path that an in-flight dispatcher may be using for another tree.
 cache_common_dir="$(git -C "$CACHE_REPO" rev-parse --path-format=absolute --git-common-dir)"
-active_validation_tree="${cache_common_dir}/meerkat-hook-cache/worktrees/pre-push"
+cache_validation_lane="$(default_lane_for_root "$CACHE_REPO")"
+active_validation_tree="${cache_common_dir}/meerkat-hook-cache/worktrees/${cache_validation_lane}"
 git -C "$CACHE_REPO" worktree add --detach --quiet "$active_validation_tree" "$cache_head_sha"
 run_cached_dispatch \
   "refs/tags/dispatch-cache-test ${cache_tag_object} refs/tags/dispatch-cache-test 0000000000000000000000000000000000000000"
@@ -280,6 +302,66 @@ if [[ "$(wc -l < "$LOCK_INVOCATIONS" | tr -d ' ')" != "1" ]]; then
   echo "waiting dispatcher ignored exact-tree evidence from the lock owner" >&2
   exit 1
 fi
+
+# Different source worktrees derive different validation lanes. Their detached
+# worktrees, Cargo targets, Bazel output bases, and dispatcher locks are
+# isolated, so they must be able to enter validation concurrently even though
+# they share one Git common directory.
+printf 'parallel lane proof\n' > "${LOCK_REPO}/parallel.txt"
+git -C "$LOCK_REPO" add parallel.txt
+git -C "$LOCK_REPO" -c user.name=Meerkat -c user.email=meerkat@example.invalid \
+  commit -qm "parallel candidate"
+lock_parallel_sha="$(git -C "$LOCK_REPO" rev-parse HEAD)"
+LOCK_PEER_REPO="${LOCK_ROOT}/peer"
+git -C "$LOCK_REPO" worktree add --detach --quiet "$LOCK_PEER_REPO" "$lock_parallel_sha"
+rm -f "$LOCK_ENTERED" "$LOCK_RELEASE" "$LOCK_INVOCATIONS"
+
+run_parallel_dispatch() {
+  local source_repo="$1"
+  local local_ref="$2"
+  (
+    cd "$source_repo"
+    PATH="${LOCK_BIN}:$PATH" \
+      GIT_DIR="$(git -C "$source_repo" rev-parse --absolute-git-dir)" \
+      GIT_WORK_TREE="$source_repo" \
+      MEERKAT_DISPATCH_LOCK_INVOCATIONS="$LOCK_INVOCATIONS" \
+      MEERKAT_DISPATCH_LOCK_ENTERED="$LOCK_ENTERED" \
+      MEERKAT_DISPATCH_LOCK_RELEASE="$LOCK_RELEASE" \
+      RUST_LANE_ID="" \
+      "$REPO_ROOT/scripts/pre-push-dispatch.sh" origin example.invalid \
+      <<<"${local_ref} ${lock_parallel_sha} ${local_ref} ${lock_head_sha}"
+  )
+}
+
+run_parallel_dispatch "$LOCK_REPO" refs/heads/parallel-first \
+  >"${LOCK_ROOT}/parallel-first.log" 2>&1 &
+LOCK_FIRST_PID=$!
+for _ in $(seq 1 100); do
+  [[ -f "$LOCK_ENTERED" ]] && break
+  sleep 0.05
+done
+if [[ ! -f "$LOCK_ENTERED" ]]; then
+  echo "first worktree dispatcher did not enter the validation gate" >&2
+  exit 1
+fi
+run_parallel_dispatch "$LOCK_PEER_REPO" refs/heads/parallel-second \
+  >"${LOCK_ROOT}/parallel-second.log" 2>&1 &
+LOCK_SECOND_PID=$!
+for _ in $(seq 1 100); do
+  [[ -f "$LOCK_INVOCATIONS" ]] &&
+    [[ "$(wc -l < "$LOCK_INVOCATIONS" | tr -d ' ')" == "2" ]] && break
+  sleep 0.05
+done
+if [[ "$(wc -l < "$LOCK_INVOCATIONS" | tr -d ' ')" != "2" ]]; then
+  echo "independent source worktrees were serialized by one repository dispatcher lock" >&2
+  exit 1
+fi
+: > "$LOCK_RELEASE"
+wait "$LOCK_FIRST_PID"
+LOCK_FIRST_PID=""
+wait "$LOCK_SECOND_PID"
+LOCK_SECOND_PID=""
+git -C "$LOCK_REPO" worktree remove --force "$LOCK_PEER_REPO"
 
 # The dispatcher-exported output base is useful only if the authoritative
 # Bazel lock gate passes it to bb as a startup option.
@@ -428,7 +510,7 @@ run_attribution_dispatch() {
   attribution_status=$?
   set -e
   attribution_common_dir="$(git -C "$ATTRIBUTION_REPO" rev-parse --path-format=absolute --git-common-dir)"
-  attribution_validation_tree="${attribution_common_dir}/meerkat-hook-cache/worktrees/pre-push"
+  attribution_validation_tree="${attribution_common_dir}/meerkat-hook-cache/worktrees/$(default_lane_for_root "$ATTRIBUTION_REPO")"
   chmod -R u+rwx "$attribution_validation_tree" 2>/dev/null || true
   git -C "$ATTRIBUTION_REPO" worktree remove --force "$attribution_validation_tree" \
     >/dev/null 2>&1 || true

--- a/scripts/test-pre-push-unit-status.sh
+++ b/scripts/test-pre-push-unit-status.sh
@@ -6,6 +6,15 @@ TEST_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/meerkat-pre-push-status.XXXXXX")"
 HARNESS_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/meerkat-pre-push-harness.XXXXXX")"
 trap 'rm -rf "$TEST_ROOT" "$HARNESS_ROOT"' EXIT
 
+if ! grep -Fq "deterministic-locks/\${stamp_key}.lock" "$REPO_ROOT/scripts/pre-push-unit.sh"; then
+  echo "pre-push deterministic gate must lock only an identical source fingerprint" >&2
+  exit 1
+fi
+if grep -Fq 'HOOK_CACHE_ROOT}/deterministic.lock' "$REPO_ROOT/scripts/pre-push-unit.sh"; then
+  echo "pre-push deterministic gate must not serialize unrelated source fingerprints" >&2
+  exit 1
+fi
+
 git -C "$TEST_ROOT" init -q
 printf 'lock revision 0\n' > "$TEST_ROOT/Cargo.lock"
 printf 'module lock revision 0\n' > "$TEST_ROOT/MODULE.bazel.lock"


### PR DESCRIPTION
## Outcome

- Derives the default pre-push Cargo lane from the source worktree path, so linked worktrees no longer serialize behind one global release lane.
- Serializes identical source fingerprints and reuses their evidence, while unrelated fingerprints can validate concurrently.
- Enables pre-commit fail-fast so cheap deterministic failures stop before the expensive workspace gate.

## Evidence

- Focused dispatcher and deterministic-gate contract tests pass.
- Same-worktree serialization/reuse and cross-worktree concurrency tests pass.
- Bash syntax, pre-commit configuration, formatting, and diff hygiene are green.
- Mandatory pre-push hook passed on exact commit 72d1162632630f94a2096f897f0d070e3fbc93a5.

## Scope

This removes avoidable cross-worktree queueing and fail-late behavior. It does not claim that a cold source-changing local gate is itself below 20 minutes; that remains a separate optimization boundary.
