### PR TITLE
release: require exact binary provenance and pinned toolchain

### DIFF
--- a/.github/workflows/release-semver-readiness.yml
+++ b/.github/workflows/release-semver-readiness.yml
@@ -80,9 +80,8 @@ jobs:
             echo "needed=true" >> "${GITHUB_OUTPUT}"
           fi
 
-      - name: Install Rust
-        if: ${{ steps.unpublished.outputs.needed == 'true' }}
-        uses: dtolnay/rust-toolchain@stable
+      - if: ${{ steps.unpublished.outputs.needed == 'true' }}
+        uses: ./.github/actions/setup-rust-ci
 
       - name: Cache Cargo
         if: ${{ steps.unpublished.outputs.needed == 'true' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1025,6 +1025,12 @@ jobs:
           print(f"Verified {len(actual)} macOS/Linux release archives")
           PY
 
+      - name: Verify exact-tag macOS/Linux build provenance
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ github.ref_name }}
+        run: scripts/verify-release-asset-provenance release-artifacts "${RELEASE_TAG}"
+
       # Never churn already-published archives on a rerun. Missing archives
       # are still added, while the final publisher handles Windows later.
       - name: Publish macOS/Linux release assets
@@ -1222,6 +1228,12 @@ jobs:
             --source-dir release-artifacts \
             --output-dir prepared-release-artifacts \
             --release-tag "${RELEASE_TAG}"
+
+      - name: Verify exact-tag release build provenance
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.release_tag || github.ref_name }}
+        run: scripts/verify-release-asset-provenance prepared-release-artifacts "${RELEASE_TAG}"
 
       - name: Publish release archives
         uses: softprops/action-gh-release@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -257,8 +257,7 @@ jobs:
           ref: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.release_tag != '' && github.event.inputs.release_tag || github.ref }}
           fetch-depth: 0
 
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+      - uses: ./.github/actions/setup-rust-ci
 
       - name: Cache cargo registry
         uses: Swatinem/rust-cache@v2
@@ -466,9 +465,8 @@ jobs:
           path: .semver-recovery-policy
           persist-credentials: false
 
-      - name: Install Rust
-        if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.semver_evidence_job_id == '' }}
-        uses: dtolnay/rust-toolchain@stable
+      - if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.semver_evidence_job_id == '' }}
+        uses: ./.github/actions/setup-rust-ci
 
       - name: Cache cargo
         if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.semver_evidence_job_id == '' }}
@@ -602,8 +600,7 @@ jobs:
         with:
           ref: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.release_tag != '' && github.event.inputs.release_tag || github.ref }}
 
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+      - uses: ./.github/actions/setup-rust-ci
 
       - name: Add release target
         run: rustup target add ${{ matrix.target }}
@@ -1096,8 +1093,7 @@ jobs:
           # package must always be built from the explicitly selected release.
           ref: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.release_tag != '' && github.event.inputs.release_tag || github.ref }}
 
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+      - uses: ./.github/actions/setup-rust-ci
 
       - name: Cache cargo registry
         uses: Swatinem/rust-cache@v2
@@ -1336,8 +1332,7 @@ jobs:
         with:
           ref: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.release_tag != '' && github.event.inputs.release_tag || github.ref }}
 
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+      - uses: ./.github/actions/setup-rust-ci
 
       - name: Cache cargo registry
         uses: Swatinem/rust-cache@v2

--- a/scripts/verify-release-asset-provenance
+++ b/scripts/verify-release-asset-provenance
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat >&2 <<'EOF'
+Usage: verify-release-asset-provenance <artifact-dir> <release-tag> [signer-workflow]
+
+Verify every release archive in artifact-dir against GitHub's signed build
+provenance. The certificate-bound source repository digest must equal the
+commit named by release-tag. signer-workflow defaults to the release workflow.
+EOF
+  exit 2
+}
+
+[[ "$#" -ge 2 && "$#" -le 3 ]] || usage
+
+artifact_dir="$1"
+release_tag="$2"
+signer_workflow="${3:-github.com/${GITHUB_REPOSITORY:-lukacf/meerkat}/.github/workflows/release.yml}"
+repository="${GITHUB_REPOSITORY:-lukacf/meerkat}"
+
+[[ -d "${artifact_dir}" ]] || {
+  echo "release artifact directory does not exist: ${artifact_dir}" >&2
+  exit 1
+}
+[[ "${release_tag}" == v* ]] || {
+  echo "release tag must start with v: ${release_tag}" >&2
+  exit 1
+}
+command -v gh >/dev/null 2>&1 || {
+  echo "gh is required to verify release attestations" >&2
+  exit 1
+}
+
+release_sha="$(git rev-parse "${release_tag}^{commit}")"
+[[ "${release_sha}" =~ ^[0-9a-f]{40}$ ]] || {
+  echo "release tag did not resolve to a commit: ${release_tag}" >&2
+  exit 1
+}
+
+archives=()
+while IFS= read -r -d '' archive; do
+  archives+=("${archive}")
+done < <(find "${artifact_dir}" -type f \( -name '*.tar.gz' -o -name '*.zip' \) -print0)
+
+if [[ "${#archives[@]}" -eq 0 ]]; then
+  echo "no release archives found under ${artifact_dir}" >&2
+  exit 1
+fi
+
+for archive in "${archives[@]}"; do
+  gh attestation verify "${archive}" \
+    --repo "${repository}" \
+    --source-digest "${release_sha}" \
+    --signer-workflow "${signer_workflow}" \
+    >/dev/null
+  echo "verified release provenance: $(basename "${archive}") <- ${release_sha}"
+done
+
+echo "Verified ${#archives[@]} release archive attestations for ${release_tag} at ${release_sha}"

--- a/xtask/BUILD.bazel
+++ b/xtask/BUILD.bazel
@@ -674,6 +674,8 @@ rust_test(
         ":package_runfiles",
         "//:github_workflows",
         "//:repo_governance_files",
+        "//:workspace_cargo_manifests",
+        "//:workspace_metadata",
         "tests/rustfmt_host.sh",
         "@@rules_rust++rust+rustfmt_nightly-2026-04-16__aarch64-apple-darwin_tools//:rustfmt_bin",
         "@@rules_rust++rust+rustfmt_nightly-2026-04-16__aarch64-apple-darwin_tools//:rustc_lib",
@@ -685,6 +687,7 @@ rust_test(
         "RUSTFMT": "$(rootpath tests/rustfmt_host.sh)",
         "RUSTFMT_DARWIN": "$(rootpath @@rules_rust++rust+rustfmt_nightly-2026-04-16__aarch64-apple-darwin_tools//:rustfmt_bin)",
         "RUSTFMT_LINUX": "$(rootpath @@rules_rust++rust+rustfmt_nightly-2026-04-16__x86_64-unknown-linux-gnu_tools//:rustfmt_bin)",
+        "WORKSPACE_ROOT": ".",
     },
     proc_macro_deps = all_crate_deps(
         package_name = "xtask",

--- a/xtask/tests/release_workflow_asset_manifest.rs
+++ b/xtask/tests/release_workflow_asset_manifest.rs
@@ -41,6 +41,39 @@ fn read_workflow(path: &Path) -> serde_yaml::Value {
         .unwrap_or_else(|error| panic!("cannot parse {} as YAML: {error}", path.display()))
 }
 
+#[test]
+fn release_workflows_use_the_repository_pinned_rust_toolchain() {
+    let release_path = workflow_yml_path();
+    let release = std::fs::read_to_string(&release_path)
+        .unwrap_or_else(|error| panic!("cannot read {}: {error}", release_path.display()));
+    assert!(
+        !release.contains("dtolnay/rust-toolchain@stable"),
+        "release jobs must not resolve a moving stable compiler"
+    );
+    assert_eq!(
+        release
+            .matches("uses: ./.github/actions/setup-rust-ci")
+            .count(),
+        5,
+        "all five Rust-using release jobs must use the pinned setup action"
+    );
+
+    let semver_path = release_path.with_file_name("release-semver-readiness.yml");
+    let semver = std::fs::read_to_string(&semver_path)
+        .unwrap_or_else(|error| panic!("cannot read {}: {error}", semver_path.display()));
+    assert!(
+        !semver.contains("dtolnay/rust-toolchain@stable"),
+        "semver readiness must not resolve a moving stable compiler"
+    );
+    assert_eq!(
+        semver
+            .matches("uses: ./.github/actions/setup-rust-ci")
+            .count(),
+        1,
+        "semver readiness must use the pinned setup action"
+    );
+}
+
 fn workflow_step<'a>(
     workflow: &'a serde_yaml::Value,
     path: &Path,

--- a/xtask/tests/release_workflow_asset_manifest.rs
+++ b/xtask/tests/release_workflow_asset_manifest.rs
@@ -28,6 +28,12 @@ fn asset_verifier_path() -> PathBuf {
     path
 }
 
+fn provenance_verifier_path() -> PathBuf {
+    let mut path = manifest_script_path();
+    path.set_file_name("verify-release-asset-provenance");
+    path
+}
+
 fn read_workflow(path: &Path) -> serde_yaml::Value {
     let text = std::fs::read_to_string(path)
         .unwrap_or_else(|error| panic!("cannot read {}: {error}", path.display()));
@@ -211,6 +217,49 @@ fn release_asset_manifest_contract_stays_flat_and_collision_checked() {
         !manifest.contains("xargs sha256sum"),
         "checksums.sha256 must be rendered from public basenames, not staged paths"
     );
+}
+
+#[test]
+fn release_archives_require_exact_tag_build_provenance_before_publication() {
+    let path = workflow_yml_path();
+    let workflow = read_workflow(&path);
+
+    for (job, step, directory) in [
+        (
+            "publish_unix_release_and_homebrew",
+            "Verify exact-tag macOS/Linux build provenance",
+            "release-artifacts",
+        ),
+        (
+            "publish_github_release",
+            "Verify exact-tag release build provenance",
+            "prepared-release-artifacts",
+        ),
+    ] {
+        let script = step_script(&workflow, &path, job, step);
+        assert!(
+            script.contains(&format!(
+                "scripts/verify-release-asset-provenance {directory}"
+            )),
+            "{job} must verify provenance for {directory}; script:\n{script}"
+        );
+    }
+
+    let verifier_path = provenance_verifier_path();
+    let verifier = std::fs::read_to_string(&verifier_path)
+        .unwrap_or_else(|error| panic!("cannot read {}: {error}", verifier_path.display()));
+    for contract in [
+        "git rev-parse \"${release_tag}^{commit}\"",
+        "gh attestation verify",
+        "--repo \"${repository}\"",
+        "--source-digest \"${release_sha}\"",
+        "--signer-workflow \"${signer_workflow}\"",
+    ] {
+        assert!(
+            verifier.contains(contract),
+            "release provenance verifier must preserve `{contract}`; script:\n{verifier}"
+        );
+    }
 }
 
 fn expected_complete_archive_names(version: &str) -> Vec<String> {


### PR DESCRIPTION
## Outcome

- Refuses to publish any release archive unless GitHub build provenance exists and binds the archive to the exact commit named by the release tag.
- Applies the same provenance gate to the early BuildBuddy macOS/Linux publisher and the final complete-asset publisher.
- Replaces moving Rust stable in release and semver-readiness workflows with the repository-pinned Rust 1.94.1 setup action.
- Refreshes generated Bazel runfiles for the strengthened release workflow contract test.

## Evidence

- Functional verification passed against a public v0.8.30 Windows archive, including exact source digest and signer workflow.
- Release workflow asset-manifest contract tests: 8/8 green.
- actionlint, bash syntax, cargo fmt, and diff hygiene are green.
- Mandatory pre-push hook passed on exact head 8baa54b1ceaab202ae791cc4bfd49cf9c879dbd5.

## Boundary

This PR establishes the mandatory trust gate before moving binary construction ahead of the tag. It does not yet move the binary matrix or alter registry publication ordering.
