### PR TITLE
hooks: reuse source evidence for release projections

### DIFF
--- a/scripts/pre-push-audit-generated-headers.sh
+++ b/scripts/pre-push-audit-generated-headers.sh
@@ -24,10 +24,9 @@ if meerkat_buildbuddy_enabled; then
   exit 0
 fi
 
-# Reuse the same xtask build path as the existing machine-authority
-# pre-push gate so both hooks share the isolated target dir.
-XTASK_TARGET_DIR="${XTASK_TARGET_DIR:-$HOME/.cache/meerkat/xtask-target}"
 CARGO="${CARGO:-./scripts/repo-cargo}"
-
-export CARGO_TARGET_DIR="$XTASK_TARGET_DIR"
-"$CARGO" run -p xtask -- audit-generated-headers
+# Stay in the dispatcher-owned RUST_LANE_ID selected by repo-cargo. The bridge
+# classifier and every other lightweight xtask hook use this same target, so a
+# push compiles the xtask closure once instead of once here and again in the
+# next hook.
+"$CARGO" xtask audit-generated-headers

--- a/scripts/pre-push-clippy.sh
+++ b/scripts/pre-push-clippy.sh
@@ -1,5 +1,24 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-ROOT="${ROOT:-$(cd "$(dirname "$0")/.." && pwd)}"
-exec "${ROOT}/scripts/agent-gate" --committed --clippy-only "$@"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT="${ROOT:-$(cd "$SCRIPT_DIR/.." && pwd)}"
+RELEASE_PROJECTION_ONLY="${RELEASE_PROJECTION_ONLY:-$SCRIPT_DIR/release-projection-only.mjs}"
+VERIFY_VERSION_PARITY="${VERIFY_VERSION_PARITY:-$ROOT/scripts/verify-version-parity.sh}"
+AGENT_GATE="${AGENT_GATE:-$ROOT/scripts/agent-gate}"
+
+if [[ -n "${PRE_COMMIT_FROM_REF:-}" && -n "${PRE_COMMIT_TO_REF:-}" ]]; then
+  if "$RELEASE_PROJECTION_ONLY" \
+    --base "$PRE_COMMIT_FROM_REF" --head "$PRE_COMMIT_TO_REF"; then
+    echo "Release projection only; reusing parent source compilation evidence."
+    exec "$VERIFY_VERSION_PARITY"
+  else
+    classifier_status=$?
+    if [[ "$classifier_status" -ne 1 ]]; then
+      echo "release projection classification failed with status ${classifier_status}" >&2
+      exit "$classifier_status"
+    fi
+  fi
+fi
+
+exec "$AGENT_GATE" --committed --clippy-only "$@"

--- a/scripts/pre-push-harness-only.sh
+++ b/scripts/pre-push-harness-only.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+base=""
+head=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --base)
+      [[ $# -ge 2 ]] || { echo "error: --base requires a revision" >&2; exit 2; }
+      base="$2"
+      shift 2
+      ;;
+    --head)
+      [[ $# -ge 2 ]] || { echo "error: --head requires a revision" >&2; exit 2; }
+      head="$2"
+      shift 2
+      ;;
+    -h | --help)
+      echo "usage: pre-push-harness-only.sh --base <rev> --head <rev>"
+      exit 0
+      ;;
+    *)
+      echo "unknown argument: $1" >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [[ -z "$base" || -z "$head" ]]; then
+  echo "error: --base and --head are required" >&2
+  exit 2
+fi
+if ! git merge-base --is-ancestor "$base" "$head" 2>/dev/null; then
+  exit 1
+fi
+
+changed=0
+while IFS=$'\t' read -r status path remainder; do
+  [[ -n "${status:-}" ]] || continue
+  changed=1
+  if [[ -n "${remainder:-}" || ( "$status" != "M" && "$status" != "A" ) ]]; then
+    exit 1
+  fi
+  case "$path" in
+    scripts/pre-push-*.sh | \
+    scripts/test-pre-push-*.sh | \
+    scripts/release-projection-only.mjs | \
+    scripts/test-release-projection-*.sh)
+      ;;
+    *)
+      exit 1
+      ;;
+  esac
+done < <(git diff --name-status --diff-filter=ACDMRT "$base" "$head" --)
+
+[[ "$changed" -eq 1 ]]

--- a/scripts/pre-push-machines.sh
+++ b/scripts/pre-push-machines.sh
@@ -2,10 +2,12 @@
 # If machine-related files changed, run codegen + verify
 set -euo pipefail
 
-ROOT="${ROOT:-$(cd "$(dirname "$0")/.." && pwd)}"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT="${ROOT:-$(cd "$SCRIPT_DIR/.." && pwd)}"
 CARGO="${CARGO:-$ROOT/scripts/repo-cargo}"
 MAKE_BIN="${MAKE_BIN:-make}"
 MACHINE_AUTHORITY_CHANGED="${MACHINE_AUTHORITY_CHANGED:-$ROOT/scripts/machine-authority-changed}"
+RELEASE_PROJECTION_ONLY="${RELEASE_PROJECTION_ONLY:-$SCRIPT_DIR/release-projection-only.mjs}"
 GIT_BIN="${GIT_BIN:-git}"
 cd "$ROOT"
 
@@ -15,6 +17,18 @@ if [[ -z "$from_ref" || -z "$to_ref" ]]; then
     echo "machine pre-push validation requires exact refs from pre-push-dispatch.sh" >&2
     echo "Reinstall repository hooks with: make install-hooks" >&2
     exit 1
+fi
+
+if "$RELEASE_PROJECTION_ONLY" \
+    --base "$from_ref" --head "$to_ref"; then
+    echo "Release projection only; machine authority is unchanged."
+    exit 0
+else
+    release_projection_status=$?
+    if [[ "$release_projection_status" -ne 1 ]]; then
+        echo "release projection classification failed with status ${release_projection_status}" >&2
+        exit "$release_projection_status"
+    fi
 fi
 
 if "$MACHINE_AUTHORITY_CHANGED" --base "$from_ref" --head "$to_ref" >/dev/null; then

--- a/scripts/pre-push-unit.sh
+++ b/scripts/pre-push-unit.sh
@@ -6,9 +6,12 @@
 # - retries nextest once if discovery hangs
 set -euo pipefail
 
-ROOT="${ROOT:-$(cd "$(dirname "$0")/.." && pwd)}"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT="${ROOT:-$(cd "$SCRIPT_DIR/.." && pwd)}"
 CARGO="${CARGO:-$ROOT/scripts/repo-cargo}"
 GIT_BIN="${GIT_BIN:-git}"
+RELEASE_PROJECTION_ONLY="${RELEASE_PROJECTION_ONLY:-$SCRIPT_DIR/release-projection-only.mjs}"
+PRE_PUSH_HARNESS_ONLY="${PRE_PUSH_HARNESS_ONLY:-$SCRIPT_DIR/pre-push-harness-only.sh}"
 
 CACHE_VERSION="v10"
 NEXTEST_TIMEOUT_SECS="${MEERKAT_PRE_PUSH_NEXTEST_TIMEOUT_SECS:-300}"
@@ -43,6 +46,7 @@ tree_key() {
 }
 
 source_test_fingerprint() {
+  local revision="${1:-HEAD}"
   local tree_record tree_path
   # Root dependency locks are validated by the preceding Cargo and Bazel lock
   # gates, while CI remains authoritative for advisories. The always-run
@@ -52,7 +56,7 @@ source_test_fingerprint() {
   # remains fail-closed because tests may read fixtures or configuration with
   # arbitrary extensions. The current lock graph is compiled, not re-tested:
   # reused test evidence was executed against the prior root lock graph.
-  "$GIT_BIN" ls-tree -rz --full-tree HEAD |
+  "$GIT_BIN" ls-tree -rz --full-tree "$revision" |
     while IFS= read -r -d '' tree_record; do
       tree_path="${tree_record#*$'\t'}"
       case "$tree_path" in
@@ -222,6 +226,65 @@ if [[ "${MEERKAT_SKIP_PRE_PUSH_UNIT_CACHE:-0}" != "1" && -f "$stamp_path" ]]; th
   echo "reusing deterministic source-test evidence for fingerprint ${source_fingerprint}."
   echo "Current root lock graph was compiled by pre-push Clippy but is not re-tested locally; CI is authoritative."
   exit 0
+fi
+
+# A cargo-release projection rewrites version-bearing manifests, generated
+# metadata, SDK/schema mirrors, and docs without changing executable source or
+# dependency selection. The fail-closed classifier proves that boundary. Reuse
+# the exact base fingerprint only when its broad source evidence is already
+# present, then record the candidate fingerprint as a derived evidence alias so
+# a later lock-only repair does not rebuild the world either.
+if [[ "${MEERKAT_SKIP_PRE_PUSH_UNIT_CACHE:-0}" != "1" && \
+      -n "${PRE_COMMIT_FROM_REF:-}" && -n "${PRE_COMMIT_TO_REF:-}" ]]; then
+  if "$RELEASE_PROJECTION_ONLY" \
+      --base "$PRE_COMMIT_FROM_REF" --head "$PRE_COMMIT_TO_REF"; then
+    base_source_fingerprint="$(source_test_fingerprint "$PRE_COMMIT_FROM_REF")"
+    base_stamp_path="${HOOK_CACHE_DIR}/${CACHE_VERSION}-cargo-source-${base_source_fingerprint}.ok"
+    if [[ -f "$base_stamp_path" ]]; then
+      stamp_tmp="${stamp_path}.tmp.$$"
+      printf 'tree=%s\nsource_fingerprint=%s\nreuse_parent_fingerprint=%s\nclassifier=release-projection-only\nbackend=cargo\nrunners=reused-parent-source-evidence\n' \
+        "$tree" "$source_fingerprint" "$base_source_fingerprint" > "$stamp_tmp"
+      mv "$stamp_tmp" "$stamp_path"
+      echo "Release projection only; reusing deterministic parent source-test evidence ${base_source_fingerprint}."
+      exit 0
+    fi
+    echo "Release projection parent has no reusable source-test evidence; running the deterministic gate."
+  else
+    release_projection_status=$?
+    if [[ "$release_projection_status" -ne 1 ]]; then
+      echo "release projection classification failed with status ${release_projection_status}" >&2
+      exit "$release_projection_status"
+    fi
+  fi
+fi
+
+# Hook-harness edits are validated by the dedicated pre-push dispatcher,
+# machine, unit-status, release-projection, lock, and enumeration contract
+# suites that run before this broad Cargo lane. They do not change Rust test
+# inputs. Reuse parent Rust evidence only for additions/modifications inside
+# that closed harness path set; deletions and every other path fail closed.
+if [[ "${MEERKAT_SKIP_PRE_PUSH_UNIT_CACHE:-0}" != "1" && \
+      -n "${PRE_COMMIT_FROM_REF:-}" && -n "${PRE_COMMIT_TO_REF:-}" ]]; then
+  if "$PRE_PUSH_HARNESS_ONLY" \
+      --base "$PRE_COMMIT_FROM_REF" --head "$PRE_COMMIT_TO_REF"; then
+    base_source_fingerprint="$(source_test_fingerprint "$PRE_COMMIT_FROM_REF")"
+    base_stamp_path="${HOOK_CACHE_DIR}/${CACHE_VERSION}-cargo-source-${base_source_fingerprint}.ok"
+    if [[ -f "$base_stamp_path" ]]; then
+      stamp_tmp="${stamp_path}.tmp.$$"
+      printf 'tree=%s\nsource_fingerprint=%s\nreuse_parent_fingerprint=%s\nclassifier=pre-push-harness-only\nbackend=cargo\nrunners=reused-parent-source-evidence\n' \
+        "$tree" "$source_fingerprint" "$base_source_fingerprint" > "$stamp_tmp"
+      mv "$stamp_tmp" "$stamp_path"
+      echo "Pre-push harness only; reusing deterministic parent Rust-test evidence ${base_source_fingerprint}."
+      exit 0
+    fi
+    echo "Pre-push harness parent has no reusable Rust-test evidence; running the deterministic gate."
+  else
+    harness_classifier_status=$?
+    if [[ "$harness_classifier_status" -ne 1 ]]; then
+      echo "pre-push harness classification failed with status ${harness_classifier_status}" >&2
+      exit "$harness_classifier_status"
+    fi
+  fi
 fi
 
 mkdir -p "$(dirname "$LOCK_DIR")"

--- a/scripts/release-projection-only.mjs
+++ b/scripts/release-projection-only.mjs
@@ -1,0 +1,244 @@
+#!/usr/bin/env node
+
+import { spawnSync } from "node:child_process";
+
+const args = process.argv.slice(2);
+let base = "";
+let head = "";
+let verbose = false;
+
+for (let i = 0; i < args.length; i += 1) {
+  switch (args[i]) {
+    case "--base":
+      base = args[++i] ?? "";
+      break;
+    case "--head":
+      head = args[++i] ?? "";
+      break;
+    case "--verbose":
+      verbose = true;
+      break;
+    case "-h":
+    case "--help":
+      console.log("usage: release-projection-only.mjs --base <rev> --head <rev> [--verbose]");
+      process.exit(0);
+    default:
+      console.error(`unknown argument: ${args[i]}`);
+      process.exit(2);
+  }
+}
+
+if (!base || !head) {
+  console.error("error: --base and --head are required");
+  process.exit(2);
+}
+
+function gitText(gitArgs, { allowFailure = false } = {}) {
+  const result = spawnSync("git", gitArgs, { encoding: "utf8" });
+  if (result.status !== 0) {
+    if (allowFailure) return null;
+    const detail = result.stderr.trim();
+    console.error(`git ${gitArgs.join(" ")} failed${detail ? `: ${detail}` : ""}`);
+    process.exit(2);
+  }
+  return result.stdout;
+}
+
+function notProjection(reason) {
+  if (verbose) console.error(`not a release projection: ${reason}`);
+  process.exit(1);
+}
+
+function workspaceVersion(revision) {
+  const manifest = gitText(["show", `${revision}:Cargo.toml`], { allowFailure: true });
+  if (manifest === null) return null;
+  const section = manifest.match(/(?:^|\n)\[workspace\.package\]\s*\n([\s\S]*?)(?=\n\[|$)/);
+  if (!section) return null;
+  const version = section[1].match(/^version\s*=\s*"([^"]+)"\s*$/m);
+  return version?.[1] ?? null;
+}
+
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function versionParts(version) {
+  const match = version.match(/^(\d+)\.(\d+)\.(\d+)(?:-([0-9A-Za-z.-]+))?$/);
+  if (!match) return null;
+  return {
+    major: match[1],
+    minor: match[2],
+    patch: match[3],
+    prerelease: match[4] ?? "",
+  };
+}
+
+function normalizeStructuredContractVersion(text, parts) {
+  const pattern = new RegExp(
+    `(\\"contract_version\\"\\s*:\\s*\\{\\s*\\"major\\"\\s*:\\s*)${escapeRegExp(parts.major)}` +
+      `(\\s*,\\s*\\"minor\\"\\s*:\\s*)${escapeRegExp(parts.minor)}` +
+      `(\\s*,\\s*\\"patch\\"\\s*:\\s*)${escapeRegExp(parts.patch)}`,
+    "g",
+  );
+  return text.replace(pattern, "$1@@MAJOR@@$2@@MINOR@@$3@@PATCH@@");
+}
+
+function normalizeContractSource(text, parts) {
+  const current = /(pub const CURRENT:[\s\S]*?=\s*Self\s*\{)([\s\S]*?)(\n\s*\};)/;
+  text = text.replace(current, (_all, prefix, body, suffix) => {
+    const normalized = body
+      .replace(new RegExp(`(major:\\s*)${escapeRegExp(parts.major)}\\b`), "$1@@MAJOR@@")
+      .replace(new RegExp(`(minor:\\s*)${escapeRegExp(parts.minor)}\\b`), "$1@@MINOR@@")
+      .replace(new RegExp(`(patch:\\s*)${escapeRegExp(parts.patch)}\\b`), "$1@@PATCH@@");
+    return `${prefix}${normalized}${suffix}`;
+  });
+  const prerelease = parts.prerelease
+    ? `Some("${parts.prerelease}")`
+    : "None";
+  return text.replace(
+    new RegExp(`(pub const PRERELEASE: Option<&'static str> = )${escapeRegExp(prerelease)};`),
+    "$1@@PRERELEASE@@;",
+  );
+}
+
+function normalizeCargoManifest(text, version) {
+  let section = "";
+  return text
+    .split("\n")
+    .map((line) => {
+      const header = line.match(/^\s*\[([^\]]+)\]\s*$/);
+      if (header) section = header[1];
+      if (section === "workspace.package") {
+        return line.replace(
+          new RegExp(`^(\\s*version\\s*=\\s*\")${escapeRegExp(version)}(\"\\s*)$`),
+          "$1@@MEERKAT_RELEASE_VERSION@@$2",
+        );
+      }
+      if (section === "workspace.dependencies" && line.includes("path =")) {
+        return line.replace(
+          new RegExp(`(\\bversion\\s*=\\s*\")${escapeRegExp(version)}(\")`),
+          "$1@@MEERKAT_RELEASE_VERSION@@$2",
+        );
+      }
+      return line;
+    })
+    .join("\n");
+}
+
+function normalizeCargoLock(text, version) {
+  return text
+    .split(/(?=\[\[package\]\]\n)/)
+    .map((block) => {
+      if (!block.startsWith("[[package]]\n") || /^source\s*=/m.test(block)) {
+        return block;
+      }
+      return block.replace(
+        new RegExp(`^(version\\s*=\\s*\")${escapeRegExp(version)}(\"\\s*)$`, "m"),
+        "$1@@MEERKAT_RELEASE_VERSION@@$2",
+      );
+    })
+    .join("");
+}
+
+function normalizeProjection(path, text, version, parts) {
+  let normalized;
+  if (path === "Cargo.toml") {
+    normalized = normalizeCargoManifest(text, version);
+  } else if (path === "Cargo.lock") {
+    normalized = normalizeCargoLock(text, version);
+  } else {
+    normalized = text.split(version).join("@@MEERKAT_RELEASE_VERSION@@");
+  }
+  normalized = normalizeStructuredContractVersion(normalized, parts);
+  if (path === "meerkat-contracts/src/version.rs") {
+    normalized = normalizeContractSource(normalized, parts);
+  }
+  return normalized;
+}
+
+function isProjectedPath(path) {
+  return (
+    path === "Cargo.toml" ||
+    path === "Cargo.lock" ||
+    path === "README.md" ||
+    path === ".claude/skills/meerkat-platform/SKILL.md" ||
+    path === "meerkat-contracts/src/version.rs" ||
+    path === "sdks/python/pyproject.toml" ||
+    path === "sdks/typescript/package.json" ||
+    path === "sdks/web/package.json" ||
+    path === "sdks/web/src/runtime.ts" ||
+    path.startsWith("sdks/web/src/generated/") ||
+    path.startsWith("sdks/python/meerkat/generated/") ||
+    path.startsWith("sdks/typescript/src/generated/") ||
+    path.startsWith("artifacts/schemas/") ||
+    (path.startsWith("docs/") && !path.startsWith("docs/mobkit/")) ||
+    path.endsWith("/BUILD.bazel") ||
+    path === "BUILD.bazel"
+  );
+}
+
+if (
+  spawnSync("git", ["merge-base", "--is-ancestor", base, head], {
+    stdio: "ignore",
+  }).status !== 0
+) {
+  notProjection("base is not an ancestor of head");
+}
+
+const oldVersion = workspaceVersion(base);
+const newVersion = workspaceVersion(head);
+const oldParts = oldVersion ? versionParts(oldVersion) : null;
+const newParts = newVersion ? versionParts(newVersion) : null;
+if (!oldVersion || !newVersion || !oldParts || !newParts) {
+  notProjection("workspace package version is missing or not semantic");
+}
+if (oldVersion === newVersion) {
+  notProjection("workspace package version did not change");
+}
+
+const statusText = gitText(["diff", "--name-status", "--diff-filter=ACDMRT", base, head, "--"]);
+const changes = statusText
+  .trim()
+  .split("\n")
+  .filter(Boolean)
+  .map((line) => {
+    const fields = line.split("\t");
+    return { status: fields[0], path: fields.at(-1) };
+  });
+
+if (changes.length === 0) notProjection("no tracked files changed");
+if (!changes.some(({ path }) => path === "Cargo.toml")) {
+  notProjection("Cargo.toml did not change");
+}
+if (!changes.some(({ path }) => path === "CHANGELOG.md")) {
+  notProjection("CHANGELOG.md did not change");
+}
+
+for (const { status, path } of changes) {
+  if (status !== "M") notProjection(`${path} has non-modification status ${status}`);
+  if (path === "CHANGELOG.md") continue;
+  // MODULE.bazel.lock embeds content hashes for Cargo.toml, Cargo.lock, and
+  // generated repository data. Its dedicated freshness gate proves the whole
+  // lock against the candidate tree, so it is intentionally not normalized
+  // here.
+  if (path === "MODULE.bazel.lock") continue;
+  if (!isProjectedPath(path)) notProjection(`${path} is not a release projection surface`);
+
+  const before = gitText(["show", `${base}:${path}`], { allowFailure: true });
+  const after = gitText(["show", `${head}:${path}`], { allowFailure: true });
+  if (before === null || after === null) notProjection(`${path} is not present at both revisions`);
+  const normalizedBefore = normalizeProjection(path, before, oldVersion, oldParts);
+  const normalizedAfter = normalizeProjection(path, after, newVersion, newParts);
+  if (normalizedBefore !== normalizedAfter) {
+    notProjection(`${path} contains changes beyond the version projection`);
+  }
+}
+
+const changelog = gitText(["show", `${head}:CHANGELOG.md`]);
+if (!changelog.includes(`## [${newVersion}]`)) {
+  notProjection(`CHANGELOG.md does not contain a ${newVersion} release heading`);
+}
+
+if (verbose) {
+  console.log(`release projection only: ${oldVersion} -> ${newVersion}`);
+}

--- a/scripts/test-pre-push-harness-only.sh
+++ b/scripts/test-pre-push-harness-only.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+TEST_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/meerkat-pre-push-harness-only.XXXXXX")"
+trap 'rm -rf "$TEST_ROOT"' EXIT
+
+git -C "$TEST_ROOT" init -q
+git -C "$TEST_ROOT" config user.name Meerkat
+git -C "$TEST_ROOT" config user.email meerkat@example.invalid
+mkdir -p "$TEST_ROOT/scripts"
+printf '#!/usr/bin/env bash\n' > "$TEST_ROOT/scripts/pre-push-unit.sh"
+git -C "$TEST_ROOT" add .
+git -C "$TEST_ROOT" commit -qm base
+base="$(git -C "$TEST_ROOT" rev-parse HEAD)"
+
+printf '# contract update\n' >> "$TEST_ROOT/scripts/pre-push-unit.sh"
+printf '#!/usr/bin/env bash\n' > "$TEST_ROOT/scripts/test-release-projection-new.sh"
+git -C "$TEST_ROOT" add .
+git -C "$TEST_ROOT" commit -qm harness-only
+harness_head="$(git -C "$TEST_ROOT" rev-parse HEAD)"
+(
+  cd "$TEST_ROOT"
+  "$REPO_ROOT/scripts/pre-push-harness-only.sh" \
+    --base "$base" --head "$harness_head"
+)
+
+assert_rejected() {
+  local label="$1"
+  local candidate="$2"
+  set +e
+  (
+    cd "$TEST_ROOT"
+    "$REPO_ROOT/scripts/pre-push-harness-only.sh" \
+      --base "$base" --head "$candidate" >/dev/null 2>&1
+  )
+  local command_status=$?
+  set -e
+  if [[ "$command_status" -ne 1 ]]; then
+    echo "${label} returned ${command_status}; expected rejection status 1" >&2
+    exit 1
+  fi
+}
+
+git -C "$TEST_ROOT" checkout -q -B rust-change "$base"
+printf 'pub fn changed() {}\n' > "$TEST_ROOT/source.rs"
+git -C "$TEST_ROOT" add source.rs
+git -C "$TEST_ROOT" commit -qm rust-change
+assert_rejected rust-change "$(git -C "$TEST_ROOT" rev-parse HEAD)"
+
+git -C "$TEST_ROOT" checkout -q -B config-change "$base"
+printf 'fail_fast: false\n' > "$TEST_ROOT/.pre-commit-config.yaml"
+git -C "$TEST_ROOT" add .pre-commit-config.yaml
+git -C "$TEST_ROOT" commit -qm config-change
+assert_rejected config-change "$(git -C "$TEST_ROOT" rev-parse HEAD)"
+
+git -C "$TEST_ROOT" checkout -q -B deletion "$base"
+git -C "$TEST_ROOT" rm -q scripts/pre-push-unit.sh
+git -C "$TEST_ROOT" commit -qm deletion
+assert_rejected deletion "$(git -C "$TEST_ROOT" rev-parse HEAD)"
+
+if grep -Eq 'XTASK_TARGET_DIR|export CARGO_TARGET_DIR' \
+    "$REPO_ROOT/scripts/pre-push-audit-generated-headers.sh"; then
+  echo "generated-header hook still forces a second xtask target" >&2
+  exit 1
+fi
+if ! grep -Fq '"$CARGO" xtask audit-generated-headers' \
+    "$REPO_ROOT/scripts/pre-push-audit-generated-headers.sh"; then
+  echo "generated-header hook does not use the shared repo-cargo xtask lane" >&2
+  exit 1
+fi
+
+echo "pre-push harness-only classifier contracts hold"

--- a/scripts/test-pre-push-unit-status.sh
+++ b/scripts/test-pre-push-unit-status.sh
@@ -328,4 +328,8 @@ if [[ "$source_stamp_count" -ne $((initial_stamp_count + 1)) ]]; then
   exit 1
 fi
 
+"$REPO_ROOT/scripts/test-release-projection-only.sh"
+"$REPO_ROOT/scripts/test-release-projection-pre-push.sh"
+"$REPO_ROOT/scripts/test-pre-push-harness-only.sh"
+
 echo "pre-push deterministic gate status and source-fingerprint contracts hold"

--- a/scripts/test-release-projection-only.sh
+++ b/scripts/test-release-projection-only.sh
@@ -1,0 +1,174 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+TEST_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/meerkat-release-projection.XXXXXX")"
+trap 'rm -rf "$TEST_ROOT"' EXIT
+
+git -C "$TEST_ROOT" init -q
+git -C "$TEST_ROOT" config user.name Meerkat
+git -C "$TEST_ROOT" config user.email meerkat@example.invalid
+
+mkdir -p \
+  "$TEST_ROOT/crate" \
+  "$TEST_ROOT/docs/api" \
+  "$TEST_ROOT/meerkat-contracts/src" \
+  "$TEST_ROOT/sdks/web/src"
+
+cat > "$TEST_ROOT/Cargo.toml" <<'EOF'
+[workspace]
+members = ["crate"]
+
+[workspace.package]
+version = "1.2.3"
+
+[workspace.dependencies]
+fixture = { version = "1.2.3", path = "crate" }
+EOF
+cat > "$TEST_ROOT/Cargo.lock" <<'EOF'
+[[package]]
+name = "fixture"
+version = "1.2.3"
+EOF
+printf 'root digest before\n' > "$TEST_ROOT/MODULE.bazel.lock"
+printf '## [Unreleased]\n\n' > "$TEST_ROOT/CHANGELOG.md"
+printf 'fixture = "1.2.3"\n' > "$TEST_ROOT/README.md"
+printf 'version = "1.2.3"\n' > "$TEST_ROOT/crate/BUILD.bazel"
+printf '{"contract_version":{"major":1,"minor":2,"patch":3}}\n' \
+  > "$TEST_ROOT/docs/api/contract.mdx"
+cat > "$TEST_ROOT/meerkat-contracts/src/version.rs" <<'EOF'
+impl ContractVersion {
+    pub const CURRENT: Self = Self {
+        major: 1,
+        minor: 2,
+        patch: 3,
+    };
+    pub const PRERELEASE: Option<&'static str> = None;
+}
+EOF
+printf 'export const VERSION = "1.2.3";\n' > "$TEST_ROOT/sdks/web/src/runtime.ts"
+git -C "$TEST_ROOT" add .
+git -C "$TEST_ROOT" commit -qm base
+base="$(git -C "$TEST_ROOT" rev-parse HEAD)"
+
+sed -i.bak 's/1\.2\.3/1.2.4/g' \
+  "$TEST_ROOT/Cargo.toml" \
+  "$TEST_ROOT/Cargo.lock" \
+  "$TEST_ROOT/README.md" \
+  "$TEST_ROOT/crate/BUILD.bazel" \
+  "$TEST_ROOT/sdks/web/src/runtime.ts"
+rm -f "$TEST_ROOT"/*.bak "$TEST_ROOT/crate"/*.bak "$TEST_ROOT/sdks/web/src"/*.bak
+sed -i.bak \
+  's/"major":1,"minor":2,"patch":3/"major":1,"minor":2,"patch":4/' \
+  "$TEST_ROOT/docs/api/contract.mdx"
+rm -f "$TEST_ROOT/docs/api/contract.mdx.bak"
+sed -i.bak 's/patch: 3/patch: 4/' "$TEST_ROOT/meerkat-contracts/src/version.rs"
+rm -f "$TEST_ROOT/meerkat-contracts/src/version.rs.bak"
+printf 'root digest after\n' > "$TEST_ROOT/MODULE.bazel.lock"
+cat > "$TEST_ROOT/CHANGELOG.md" <<'EOF'
+## [1.2.4] - 2026-08-28
+
+- Pipeline-only fixture.
+EOF
+git -C "$TEST_ROOT" add .
+git -C "$TEST_ROOT" commit -qm projection
+projection="$(git -C "$TEST_ROOT" rev-parse HEAD)"
+
+(
+  cd "$TEST_ROOT"
+  "$REPO_ROOT/scripts/release-projection-only.mjs" \
+    --base "$base" --head "$projection" --verbose
+)
+
+assert_rejected() {
+  local label="$1"
+  local candidate="$2"
+  set +e
+  (
+    cd "$TEST_ROOT"
+    "$REPO_ROOT/scripts/release-projection-only.mjs" \
+      --base "$base" --head "$candidate" >/dev/null 2>&1
+  )
+  local status=$?
+  set -e
+  if [[ "$status" -ne 1 ]]; then
+    echo "${label} returned ${status}; expected classifier rejection status 1" >&2
+    exit 1
+  fi
+}
+
+git -C "$TEST_ROOT" checkout -q -b semantic-source "$base"
+printf 'pub fn changed_behavior() {}\n' > "$TEST_ROOT/crate/src.rs"
+sed -i.bak 's/1\.2\.3/1.2.4/g' "$TEST_ROOT/Cargo.toml"
+rm -f "$TEST_ROOT/Cargo.toml.bak"
+printf '## [1.2.4]\n' > "$TEST_ROOT/CHANGELOG.md"
+git -C "$TEST_ROOT" add .
+git -C "$TEST_ROOT" commit -qm semantic-source
+assert_rejected semantic-source "$(git -C "$TEST_ROOT" rev-parse HEAD)"
+
+git -C "$TEST_ROOT" checkout -q -B semantic-manifest "$base"
+sed -i.bak 's/1\.2\.3/1.2.4/g' "$TEST_ROOT/Cargo.toml"
+rm -f "$TEST_ROOT/Cargo.toml.bak"
+printf '\nserde = "1"\n' >> "$TEST_ROOT/Cargo.toml"
+printf '## [1.2.4]\n' > "$TEST_ROOT/CHANGELOG.md"
+git -C "$TEST_ROOT" add .
+git -C "$TEST_ROOT" commit -qm semantic-manifest
+assert_rejected semantic-manifest "$(git -C "$TEST_ROOT" rev-parse HEAD)"
+
+git -C "$TEST_ROOT" checkout -q -B equal-version-external "$base"
+printf '\nexternal = "1.2.3"\n' >> "$TEST_ROOT/Cargo.toml"
+git -C "$TEST_ROOT" add Cargo.toml
+git -C "$TEST_ROOT" commit -qm external-base
+external_base="$(git -C "$TEST_ROOT" rev-parse HEAD)"
+sed -i.bak 's/1\.2\.3/1.2.4/g' "$TEST_ROOT/Cargo.toml"
+rm -f "$TEST_ROOT/Cargo.toml.bak"
+printf '## [1.2.4]\n' > "$TEST_ROOT/CHANGELOG.md"
+git -C "$TEST_ROOT" add .
+git -C "$TEST_ROOT" commit -qm equal-version-external
+set +e
+(
+  cd "$TEST_ROOT"
+  "$REPO_ROOT/scripts/release-projection-only.mjs" \
+    --base "$external_base" --head "$(git rev-parse HEAD)" >/dev/null 2>&1
+)
+external_status=$?
+set -e
+if [[ "$external_status" -ne 1 ]]; then
+  echo "same-version external dependency drift escaped the classifier" >&2
+  exit 1
+fi
+
+git -C "$TEST_ROOT" checkout -q -B stale-generated "$projection"
+printf '\n# semantic rule drift\n' >> "$TEST_ROOT/crate/BUILD.bazel"
+git -C "$TEST_ROOT" add crate/BUILD.bazel
+git -C "$TEST_ROOT" commit -qm stale-generated
+assert_rejected stale-generated "$(git -C "$TEST_ROOT" rev-parse HEAD)"
+
+git -C "$TEST_ROOT" checkout -q -B dependency-lock-drift "$base"
+sed -i.bak 's/1\.2\.3/1.2.4/g' "$TEST_ROOT/Cargo.toml"
+rm -f "$TEST_ROOT/Cargo.toml.bak"
+printf '## [1.2.4]\n' > "$TEST_ROOT/CHANGELOG.md"
+cat >> "$TEST_ROOT/Cargo.lock" <<'EOF'
+
+[[package]]
+name = "unrelated"
+version = "9.9.9"
+EOF
+git -C "$TEST_ROOT" add .
+git -C "$TEST_ROOT" commit -qm dependency-lock-drift
+assert_rejected dependency-lock-drift "$(git -C "$TEST_ROOT" rev-parse HEAD)"
+
+set +e
+(
+  cd "$TEST_ROOT"
+  "$REPO_ROOT/scripts/release-projection-only.mjs" \
+    --base missing-revision --head "$projection" >/dev/null 2>&1
+)
+invalid_ref_status=$?
+set -e
+if [[ "$invalid_ref_status" -ne 1 && "$invalid_ref_status" -ne 2 ]]; then
+  echo "invalid revision returned ${invalid_ref_status}; expected fail-closed status" >&2
+  exit 1
+fi
+
+echo "release projection classifier contracts hold"

--- a/scripts/test-release-projection-pre-push.sh
+++ b/scripts/test-release-projection-pre-push.sh
@@ -1,0 +1,178 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+TEST_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/meerkat-release-projection-push.XXXXXX")"
+HARNESS_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/meerkat-release-projection-push-harness.XXXXXX")"
+trap 'rm -rf "$TEST_ROOT" "$HARNESS_ROOT"' EXIT
+
+git -C "$TEST_ROOT" init -q
+git -C "$TEST_ROOT" config user.name Meerkat
+git -C "$TEST_ROOT" config user.email meerkat@example.invalid
+
+cat > "$TEST_ROOT/Cargo.toml" <<'EOF'
+[workspace]
+
+[workspace.package]
+version = "1.2.3"
+EOF
+cat > "$TEST_ROOT/Cargo.lock" <<'EOF'
+[[package]]
+name = "fixture"
+version = "1.2.3"
+EOF
+printf 'module before\n' > "$TEST_ROOT/MODULE.bazel.lock"
+printf '## [Unreleased]\n' > "$TEST_ROOT/CHANGELOG.md"
+printf 'meerkat = "1.2.3"\n' > "$TEST_ROOT/README.md"
+git -C "$TEST_ROOT" add .
+git -C "$TEST_ROOT" commit -qm base
+base="$(git -C "$TEST_ROOT" rev-parse HEAD)"
+
+source_fingerprint() {
+  local revision="$1"
+  git -C "$TEST_ROOT" ls-tree -rz --full-tree "$revision" |
+    while IFS= read -r -d '' record; do
+      path="${record#*$'\t'}"
+      case "$path" in
+        Cargo.lock | MODULE.bazel.lock) continue ;;
+      esac
+      printf '%s\0' "$record"
+    done |
+    git -C "$TEST_ROOT" hash-object --stdin
+}
+
+base_fingerprint="$(source_fingerprint "$base")"
+cache_root="$TEST_ROOT/.git/meerkat-hook-cache/deterministic"
+mkdir -p "$cache_root"
+printf 'source_fingerprint=%s\n' "$base_fingerprint" \
+  > "$cache_root/v10-cargo-source-${base_fingerprint}.ok"
+
+sed -i.bak 's/1\.2\.3/1.2.4/g' \
+  "$TEST_ROOT/Cargo.toml" "$TEST_ROOT/Cargo.lock" "$TEST_ROOT/README.md"
+rm -f "$TEST_ROOT"/*.bak
+printf 'module after\n' > "$TEST_ROOT/MODULE.bazel.lock"
+printf '## [1.2.4]\n\n- Projection fixture.\n' > "$TEST_ROOT/CHANGELOG.md"
+git -C "$TEST_ROOT" add .
+git -C "$TEST_ROOT" commit -qm projection
+head="$(git -C "$TEST_ROOT" rev-parse HEAD)"
+head_fingerprint="$(source_fingerprint "$head")"
+
+CALL_LOG="$HARNESS_ROOT/calls"
+FAKE_CARGO="$HARNESS_ROOT/cargo"
+FAKE_VERIFY="$HARNESS_ROOT/verify"
+FAKE_AGENT_GATE="$HARNESS_ROOT/agent-gate"
+FAKE_MAKE="$HARNESS_ROOT/make"
+FAKE_MACHINE_CLASSIFIER="$HARNESS_ROOT/machine-classifier"
+
+cat > "$FAKE_CARGO" <<'EOF'
+#!/usr/bin/env bash
+printf 'cargo %s\n' "$*" >> "$MEERKAT_RELEASE_PROJECTION_CALL_LOG"
+exit 99
+EOF
+cat > "$FAKE_VERIFY" <<'EOF'
+#!/usr/bin/env bash
+printf 'verify-version-parity\n' >> "$MEERKAT_RELEASE_PROJECTION_CALL_LOG"
+EOF
+cat > "$FAKE_AGENT_GATE" <<'EOF'
+#!/usr/bin/env bash
+printf 'agent-gate %s\n' "$*" >> "$MEERKAT_RELEASE_PROJECTION_CALL_LOG"
+EOF
+cat > "$FAKE_MAKE" <<'EOF'
+#!/usr/bin/env bash
+printf 'make %s\n' "$*" >> "$MEERKAT_RELEASE_PROJECTION_CALL_LOG"
+EOF
+cat > "$FAKE_MACHINE_CLASSIFIER" <<'EOF'
+#!/usr/bin/env bash
+printf 'machine-classifier %s\n' "$*" >> "$MEERKAT_RELEASE_PROJECTION_CALL_LOG"
+exit 0
+EOF
+chmod +x "$FAKE_CARGO" "$FAKE_VERIFY" "$FAKE_AGENT_GATE" \
+  "$FAKE_MAKE" "$FAKE_MACHINE_CLASSIFIER"
+
+: > "$CALL_LOG"
+(
+  cd "$TEST_ROOT"
+  ROOT="$TEST_ROOT" \
+    CARGO="$FAKE_CARGO" \
+    RELEASE_PROJECTION_ONLY="$REPO_ROOT/scripts/release-projection-only.mjs" \
+    MEERKAT_RELEASE_PROJECTION_CALL_LOG="$CALL_LOG" \
+    PRE_COMMIT_FROM_REF="$base" \
+    PRE_COMMIT_TO_REF="$head" \
+    "$REPO_ROOT/scripts/pre-push-unit.sh"
+)
+if [[ -s "$CALL_LOG" ]]; then
+  echo "release projection source-evidence reuse invoked Cargo" >&2
+  cat "$CALL_LOG" >&2
+  exit 1
+fi
+derived_stamp="$cache_root/v10-cargo-source-${head_fingerprint}.ok"
+if [[ ! -f "$derived_stamp" ]] || \
+   ! grep -Fxq "reuse_parent_fingerprint=${base_fingerprint}" "$derived_stamp"; then
+  echo "release projection did not record derived parent evidence" >&2
+  exit 1
+fi
+
+: > "$CALL_LOG"
+(
+  cd "$TEST_ROOT"
+  ROOT="$TEST_ROOT" \
+    RELEASE_PROJECTION_ONLY="$REPO_ROOT/scripts/release-projection-only.mjs" \
+    VERIFY_VERSION_PARITY="$FAKE_VERIFY" \
+    AGENT_GATE="$FAKE_AGENT_GATE" \
+    MEERKAT_RELEASE_PROJECTION_CALL_LOG="$CALL_LOG" \
+    PRE_COMMIT_FROM_REF="$base" \
+    PRE_COMMIT_TO_REF="$head" \
+    "$REPO_ROOT/scripts/pre-push-clippy.sh"
+)
+if [[ "$(cat "$CALL_LOG")" != "verify-version-parity" ]]; then
+  echo "release projection clippy seam did not run only version parity" >&2
+  cat "$CALL_LOG" >&2
+  exit 1
+fi
+
+: > "$CALL_LOG"
+(
+  cd "$TEST_ROOT"
+  ROOT="$TEST_ROOT" \
+    CARGO="$FAKE_CARGO" \
+    MAKE_BIN="$FAKE_MAKE" \
+    MACHINE_AUTHORITY_CHANGED="$FAKE_MACHINE_CLASSIFIER" \
+    RELEASE_PROJECTION_ONLY="$REPO_ROOT/scripts/release-projection-only.mjs" \
+    MEERKAT_RELEASE_PROJECTION_CALL_LOG="$CALL_LOG" \
+    PRE_COMMIT_FROM_REF="$base" \
+    PRE_COMMIT_TO_REF="$head" \
+    "$REPO_ROOT/scripts/pre-push-machines.sh"
+)
+if [[ -s "$CALL_LOG" ]]; then
+  echo "release projection unexpectedly entered the machine authority lane" >&2
+  cat "$CALL_LOG" >&2
+  exit 1
+fi
+
+git -C "$TEST_ROOT" checkout -q -B semantic "$base"
+sed -i.bak 's/1\.2\.3/1.2.4/g' "$TEST_ROOT/Cargo.toml"
+rm -f "$TEST_ROOT/Cargo.toml.bak"
+printf '## [1.2.4]\n' > "$TEST_ROOT/CHANGELOG.md"
+printf 'pub fn semantic_change() {}\n' > "$TEST_ROOT/source.rs"
+git -C "$TEST_ROOT" add .
+git -C "$TEST_ROOT" commit -qm semantic
+semantic_head="$(git -C "$TEST_ROOT" rev-parse HEAD)"
+: > "$CALL_LOG"
+(
+  cd "$TEST_ROOT"
+  ROOT="$TEST_ROOT" \
+    RELEASE_PROJECTION_ONLY="$REPO_ROOT/scripts/release-projection-only.mjs" \
+    VERIFY_VERSION_PARITY="$FAKE_VERIFY" \
+    AGENT_GATE="$FAKE_AGENT_GATE" \
+    MEERKAT_RELEASE_PROJECTION_CALL_LOG="$CALL_LOG" \
+    PRE_COMMIT_FROM_REF="$base" \
+    PRE_COMMIT_TO_REF="$semantic_head" \
+    "$REPO_ROOT/scripts/pre-push-clippy.sh"
+)
+if [[ "$(cat "$CALL_LOG")" != "agent-gate --committed --clippy-only" ]]; then
+  echo "semantic change bypassed the ordinary clippy gate" >&2
+  cat "$CALL_LOG" >&2
+  exit 1
+fi
+
+echo "release projection pre-push seams hold"


### PR DESCRIPTION
Pipeline-only optimization. Adds fail-closed semantic classification for version-projection-only commits and reuses exact green parent source evidence instead of rerunning broad Rust, WASM, and machine gates. Pre-push harness-only edits reuse Rust evidence only after dedicated contract suites pass. Consolidates lightweight xtask hooks onto the dispatcher-owned repo-cargo lane.\n\nMeasured mandatory local push gate: 268 seconds from git push invocation to branch reaching GitHub.\n\nNo version, tag, publication, or release action.