### PR TITLE
Guard release registry SLO critical path

### DIFF
--- a/scripts/pre-push-harness-only.sh
+++ b/scripts/pre-push-harness-only.sh
@@ -45,6 +45,7 @@ while IFS=$'\t' read -r status path remainder; do
   case "$path" in
     scripts/pre-push-*.sh | \
     scripts/test-pre-push-*.sh | \
+    scripts/release-doctor | \
     scripts/release-projection-only.mjs | \
     scripts/test-release-projection-*.sh)
       ;;

--- a/scripts/release-doctor
+++ b/scripts/release-doctor
@@ -237,6 +237,34 @@ else
   bad "Rust crate publish script is missing crates.io rate-limit retry handling"
 fi
 
+semver_job="$(workflow_job release_semver_gate)"
+if grep -Fq 'Verify exact-tree pre-tag semver evidence' <<<"${semver_job}" &&
+  grep -Fq "github.event_name != 'workflow_dispatch'" <<<"${semver_job}" &&
+  grep -Fq "github.event_name == 'workflow_dispatch' && github.event.inputs.semver_evidence_job_id == ''" <<<"${semver_job}"; then
+  pass "Tag releases reuse exact-tree pre-tag semver evidence"
+else
+  bad "Tag releases must reuse exact-tree pre-tag semver evidence instead of rerunning the long semver measurement"
+fi
+
+registry_job="$(workflow_job publish_registries)"
+registry_needs="$(grep -m1 '^[[:space:]]*needs:' <<<"${registry_job}" || true)"
+if grep -Fq 'require_ci_green' <<<"${registry_needs}" &&
+  grep -Fq 'release_validate_gate' <<<"${registry_needs}" &&
+  grep -Fq 'release_semver_gate' <<<"${registry_needs}" &&
+  grep -Fq 'registry_credentials_preflight' <<<"${registry_needs}" &&
+  ! grep -Eq 'build_binaries|publish_github_release|publish_web_sdk' <<<"${registry_needs}"; then
+  pass "Rust registry publication is independent of binary and SDK completion"
+else
+  bad "Rust registry publication has an invalid critical-path dependency: ${registry_needs:-missing needs}"
+fi
+
+if grep -Fq 'scripts/verify-rust-release-public.py' <<<"${registry_job}" &&
+  grep -Fq -- '--slo-seconds 1800' <<<"${registry_job}"; then
+  pass "Rust registry publication enforces the 30 minute tag-to-public SLO"
+else
+  bad "Rust registry publication does not enforce the 30 minute tag-to-public SLO"
+fi
+
 if [[ -n "${VERSION:-${RELEASE_TAG:-}}" ]]; then
   tag="${VERSION:-${RELEASE_TAG:-}}"
   case "${tag}" in

--- a/scripts/test-pre-push-harness-only.sh
+++ b/scripts/test-pre-push-harness-only.sh
@@ -10,11 +10,13 @@ git -C "$TEST_ROOT" config user.name Meerkat
 git -C "$TEST_ROOT" config user.email meerkat@example.invalid
 mkdir -p "$TEST_ROOT/scripts"
 printf '#!/usr/bin/env bash\n' > "$TEST_ROOT/scripts/pre-push-unit.sh"
+printf '#!/usr/bin/env bash\n' > "$TEST_ROOT/scripts/release-doctor"
 git -C "$TEST_ROOT" add .
 git -C "$TEST_ROOT" commit -qm base
 base="$(git -C "$TEST_ROOT" rev-parse HEAD)"
 
 printf '# contract update\n' >> "$TEST_ROOT/scripts/pre-push-unit.sh"
+printf '# release SLO contract update\n' >> "$TEST_ROOT/scripts/release-doctor"
 printf '#!/usr/bin/env bash\n' > "$TEST_ROOT/scripts/test-release-projection-new.sh"
 git -C "$TEST_ROOT" add .
 git -C "$TEST_ROOT" commit -qm harness-only


### PR DESCRIPTION
## Summary
- fail release doctor if tag publication reruns long semver work
- fail if Rust registry publication becomes dependent on binary or SDK completion
- enforce presence of the 30-minute tag-to-public verifier
- classify release-doctor-only changes as pre-push harness changes with focused regression coverage

## Evidence
- mandatory pre-push hook passed in 3m07s
- scripts/test-pre-push-harness-only.sh
- scripts/release-doctor --dry-run: 24 pass, 1 expected unset-version warning, 0 fail
- shell syntax and git diff --check green

Pipeline-only. No version, tag, publication, or release.