### PR TITLE
feat: add observe-only post-commit hooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,10 @@ them.
 
 ### Breaking
 
+- **Rust hook contracts gained committed-observation variants and payloads.**
+  Exact-pinned downstreams must update exhaustive matches over `HookPoint` and
+  struct literals for `HookInvocation`; `SessionRuntimeBindings::__from_runtime_authority`
+  also gains the runtime-owned `PostCommitHookDispatcher` argument.
 - **Rust auth/provider construction surfaces gained account-aware fields and
   variants.** Exact-pinned downstreams must update exhaustive matches and
   struct literals for `AuthCredentialIdentity`, `CredentialAccountId`,
@@ -56,6 +60,10 @@ them.
 
 ### Added
 
+- Added typed, observe-only post-commit hooks for runtime input acceptance,
+  rejection, and deduplication; peer ingress and egress; and enriched
+  interaction completion. Event streams remain the ordered/replay-aware
+  transport, while session-owned hook tasks are reaped and aborted on teardown.
 - Added native GitHub Copilot device authentication and account-scoped CAPI
   routing for OpenAI Responses/Chat Completions, Anthropic Messages, and
   Gemini Chat Completions, without a Copilot SDK or CLI dependency.

--- a/artifacts/schemas/events.json
+++ b/artifacts/schemas/events.json
@@ -1255,7 +1255,13 @@
           "post_llm_response",
           "pre_tool_execution",
           "post_tool_execution",
-          "turn_boundary"
+          "turn_boundary",
+          "runtime_input_accepted",
+          "runtime_input_rejected",
+          "runtime_input_deduplicated",
+          "peer_ingress_committed",
+          "peer_egress_committed",
+          "interaction_completed"
         ],
         "type": "string"
       },
@@ -6322,7 +6328,13 @@
           "post_llm_response",
           "pre_tool_execution",
           "post_tool_execution",
-          "turn_boundary"
+          "turn_boundary",
+          "runtime_input_accepted",
+          "runtime_input_rejected",
+          "runtime_input_deduplicated",
+          "peer_ingress_committed",
+          "peer_egress_committed",
+          "interaction_completed"
         ],
         "type": "string"
       },

--- a/artifacts/schemas/params.json
+++ b/artifacts/schemas/params.json
@@ -7777,7 +7777,13 @@
           "post_llm_response",
           "pre_tool_execution",
           "post_tool_execution",
-          "turn_boundary"
+          "turn_boundary",
+          "runtime_input_accepted",
+          "runtime_input_rejected",
+          "runtime_input_deduplicated",
+          "peer_ingress_committed",
+          "peer_egress_committed",
+          "interaction_completed"
         ],
         "type": "string"
       },

--- a/artifacts/schemas/rest-openapi.json
+++ b/artifacts/schemas/rest-openapi.json
@@ -9090,7 +9090,13 @@
           "post_llm_response",
           "pre_tool_execution",
           "post_tool_execution",
-          "turn_boundary"
+          "turn_boundary",
+          "runtime_input_accepted",
+          "runtime_input_rejected",
+          "runtime_input_deduplicated",
+          "peer_ingress_committed",
+          "peer_egress_committed",
+          "interaction_completed"
         ],
         "type": "string"
       },

--- a/artifacts/schemas/wire-types.json
+++ b/artifacts/schemas/wire-types.json
@@ -2401,7 +2401,13 @@
           "post_llm_response",
           "pre_tool_execution",
           "post_tool_execution",
-          "turn_boundary"
+          "turn_boundary",
+          "runtime_input_accepted",
+          "runtime_input_rejected",
+          "runtime_input_deduplicated",
+          "peer_ingress_committed",
+          "peer_egress_committed",
+          "interaction_completed"
         ],
         "type": "string"
       },
@@ -21916,7 +21922,13 @@
           "post_llm_response",
           "pre_tool_execution",
           "post_tool_execution",
-          "turn_boundary"
+          "turn_boundary",
+          "runtime_input_accepted",
+          "runtime_input_rejected",
+          "runtime_input_deduplicated",
+          "peer_ingress_committed",
+          "peer_egress_committed",
+          "interaction_completed"
         ],
         "type": "string"
       },
@@ -32899,7 +32911,13 @@
           "post_llm_response",
           "pre_tool_execution",
           "post_tool_execution",
-          "turn_boundary"
+          "turn_boundary",
+          "runtime_input_accepted",
+          "runtime_input_rejected",
+          "runtime_input_deduplicated",
+          "peer_ingress_committed",
+          "peer_egress_committed",
+          "interaction_completed"
         ],
         "type": "string"
       },
@@ -47332,7 +47350,13 @@
           "post_llm_response",
           "pre_tool_execution",
           "post_tool_execution",
-          "turn_boundary"
+          "turn_boundary",
+          "runtime_input_accepted",
+          "runtime_input_rejected",
+          "runtime_input_deduplicated",
+          "peer_ingress_committed",
+          "peer_egress_committed",
+          "interaction_completed"
         ],
         "type": "string"
       },
@@ -63803,7 +63827,13 @@
           "post_llm_response",
           "pre_tool_execution",
           "post_tool_execution",
-          "turn_boundary"
+          "turn_boundary",
+          "runtime_input_accepted",
+          "runtime_input_rejected",
+          "runtime_input_deduplicated",
+          "peer_ingress_committed",
+          "peer_egress_committed",
+          "interaction_completed"
         ],
         "type": "string"
       },
@@ -71574,7 +71604,13 @@
           "post_llm_response",
           "pre_tool_execution",
           "post_tool_execution",
-          "turn_boundary"
+          "turn_boundary",
+          "runtime_input_accepted",
+          "runtime_input_rejected",
+          "runtime_input_deduplicated",
+          "peer_ingress_committed",
+          "peer_egress_committed",
+          "interaction_completed"
         ],
         "type": "string"
       },
@@ -122993,7 +123029,13 @@
           "post_llm_response",
           "pre_tool_execution",
           "post_tool_execution",
-          "turn_boundary"
+          "turn_boundary",
+          "runtime_input_accepted",
+          "runtime_input_rejected",
+          "runtime_input_deduplicated",
+          "peer_ingress_committed",
+          "peer_egress_committed",
+          "interaction_completed"
         ],
         "type": "string"
       },

--- a/docs/examples/hooks.mdx
+++ b/docs/examples/hooks.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Hooks examples"
-description: "Lifecycle hooks for audit and guardrails at 8 hook points."
+description: "Lifecycle and committed-fact hooks for reactions, audit, and guardrails."
 icon: "anchor"
 ---
 
@@ -9,6 +9,28 @@ For the full guide, see [Hooks](/guides/hooks).
 <Note>
 Start here after you understand the normal session/tool flow. If you are new to Meerkat overall, read [Examples: Sessions](/examples/sessions) first.
 </Note>
+
+## Post-commit application reaction
+
+Use a committed-fact point when the handler updates UI or telemetry but must
+never affect the operation it observes:
+
+```toml
+[[hooks.entries]]
+id = "runtime-input-ui"
+point = "runtime_input_accepted"
+mode = "background"
+capability = "observe"
+
+[hooks.entries.runtime]
+type = "http"
+url = "http://127.0.0.1:4100/hooks/runtime-input"
+```
+
+The request carries `HookInvocation.observation` with
+`observation_type = "runtime_input_accepted"` and typed input id, kind, and
+handling mode. The operation has already committed. A denial-shaped response,
+hook failure, or timeout cannot change it.
 
 ## Observer hook (background)
 
@@ -464,7 +486,7 @@ A hook that POSTs the invocation payload to a remote URL. Useful for centralized
   </Tab>
 </Tabs>
 
-## All 8 hook points
+## All 14 hook points
 
 | Hook point | Classification | When it fires |
 |---|---|---|
@@ -476,10 +498,18 @@ A hook that POSTs the invocation payload to a remote URL. Useful for centralized
 | `post_tool_execution` | post | After each tool execution completes |
 | `run_completed` | post | After a successful run completes |
 | `run_failed` | post | After a run fails with an error |
+| `runtime_input_accepted` | post-commit, observe-only | After runtime and session authority commit an accepted input |
+| `runtime_input_rejected` | terminal, observe-only | After runtime terminally rejects an input |
+| `runtime_input_deduplicated` | post-commit, observe-only | After idempotency resolves to an existing committed input |
+| `peer_ingress_committed` | post-commit, observe-only | After runtime commits an accepted peer input |
+| `peer_egress_committed` | post-commit, observe-only | After a successful typed peer delivery receipt |
+| `interaction_completed` | post-commit, observe-only | After durable interaction-terminal publication |
 
 <Note>
 Foreground hooks halt loop progression until they return. Every hook in
 `background` mode is limited to `observe` capability, including post points.
+The six post-commit points are always dispatched asynchronously and require
+`observe`, regardless of their configured execution mode.
 </Note>
 
 ## Disable a hook

--- a/docs/guides/hooks.mdx
+++ b/docs/guides/hooks.mdx
@@ -4,7 +4,9 @@ description: "Typed extension points within the agent loop for observation and g
 icon: "anchor"
 ---
 
-Hooks let you run custom logic at defined points in the agent lifecycle -- before/after tool execution, LLM calls, or at turn boundaries. Use them for approval workflows, audit logging, content filtering, or typed denials.
+Hooks let you run custom logic at defined points in the agent lifecycle and react
+to committed runtime, session, and comms facts. Use them for approval workflows,
+responsive UI, audit logging, telemetry, content filtering, or typed denials.
 
 <Note>
 This page is the task-first guide. For the low-level type and payload inventory, see [Hooks reference](/reference/hooks-reference).
@@ -15,13 +17,15 @@ This page is the task-first guide. For the low-level type and payload inventory,
 Use this guide when you want to:
 
 - add approval gates
+- react to committed input and peer-delivery outcomes
+- update application UI from typed interaction completions
 - log or audit agent behavior
 - block unsafe tool inputs or outputs
 - choose between in-process, command, and HTTP hook runtimes
 
 ## Hook points
 
-Eight extension points are available:
+Fourteen extension points are available:
 
 | HookPoint | Classification | When it fires |
 |-----------|---------------|---------------|
@@ -33,8 +37,19 @@ Eight extension points are available:
 | `PostToolExecution` | post | After each tool execution completes |
 | `RunCompleted` | post | After a successful run completes |
 | `RunFailed` | post | After a run fails with an error |
+| `RuntimeInputAccepted` | post-commit, observe-only | After runtime and session authority commit an accepted input |
+| `RuntimeInputRejected` | terminal, observe-only | After runtime terminally rejects an input without committing admission |
+| `RuntimeInputDeduplicated` | post-commit, observe-only | After an idempotent submission resolves to an existing committed input |
+| `PeerIngressCommitted` | post-commit, observe-only | After runtime commits an accepted typed peer input |
+| `PeerEgressCommitted` | post-commit, observe-only | After a peer send returns a successful typed delivery receipt |
+| `InteractionCompleted` | post-commit, observe-only | After an interaction terminal is durably published |
 
 Classification is determined by the `is_pre()` and `is_post()` methods on `HookPoint`. Foreground hooks block loop progression; background hooks run asynchronously for observation.
+
+The six post-commit points are intrinsically observe-only. Their session-scoped
+dispatcher owns spawned tasks, reaps completed work, and aborts remaining work
+when the dispatcher is dropped. A returned denial, timeout, or hook runtime
+failure cannot change or delay the committed fact.
 
 ## Capabilities
 
@@ -56,6 +71,11 @@ The former `Rewrite` capability is deleted entirely; semantic patch authority is
 **All background hooks must be observe-only.** A background hook with any
 capability other than `Observe` is rejected with
 `HookEngineError::InvalidConfiguration`, regardless of hook point.
+
+The six post-commit points also require `Observe` capability in either execution
+mode. They are always dispatched outside the outcome path; configuring one as
+`Foreground` only orders matching hook handlers within its owned observation
+task.
 </Warning>
 
 Semantic patch publication is retired. `RuntimeHookResponse` rejects unknown fields, so a runtime response carrying any legacy `patches` field fails closed during deserialization.
@@ -199,6 +219,7 @@ Hooks receive a `HookInvocation` struct containing contextual data. Fields are p
 | `llm_response` | `Option<HookLlmResponse>` | `PostLlmResponse` |
 | `tool_call` | `Option<HookToolCall>` | `PreToolExecution` |
 | `tool_result` | `Option<HookToolResult>` | `PostToolExecution` |
+| `observation` | `Option<HookObservation>` | The six post-commit points |
 
 For command and HTTP hooks, the serialized wire payload additionally carries `prompt` and `error` strings. These are serialize-only projections of `prompt_input` and `error_report`; they are never stored fields and are never deserialized back as authority.
 
@@ -207,9 +228,29 @@ For command and HTTP hooks, the serialized wire payload additionally carries `pr
 - **`HookLlmResponse`**: `assistant_text`, `tool_call_names`, `stop_reason`, `usage`, `server_tool_content` (typed `ServerToolKind` projection of provider-native server-tool blocks in the response, e.g. web search — empty when none; lets a foreground hook classify provider-native content ingestion synchronously)
 - **`HookToolCall`**: `tool_use_id`, `name`, `args`, `provenance` (typed `ToolProvenance` of the called tool — kind + source id, e.g. an MCP server name — projected from the tool's `ToolDef`; absent for tools without declared provenance)
 - **`HookToolResult`**: `tool_use_id`, `name`, `content_blocks`, `is_error`, `provenance` (as on `HookToolCall`; the wire payload adds a serialize-only `content` text projection)
+- **`HookObservation`**: a tagged typed union for accepted, rejected, or deduplicated runtime input; committed peer ingress or egress; and completed interaction facts
 </Accordion>
 
 `HookToolResult.content_blocks` carries the typed tool-result blocks, including image blocks, in original order. The wire payload also serializes a `content` string -- a text projection derived from `content_blocks` for external command/HTTP hooks; in Rust, use `HookToolResult::text_projection()`. Both are observational projections and cannot be returned as a rewrite.
+
+## Hooks versus event streams
+
+Use hooks as the default in-process application reaction API. Event streams
+remain the canonical ordered transport for remote observers, replay-aware
+pipelines, transcript/audit projection, and resynchronization after stream
+truncation. Command receipts remain the direct result for the caller that
+initiated an action; the matching committed outcome is also projected through
+the hook surface.
+
+Post-commit hooks are process-local best-effort reactions, not durable delivery.
+A crash after the canonical event is published may lose a hook invocation, and
+recovery of a finalized outbox may replay one. Use event streams for durable or
+replay-aware consumption; hook handlers with external side effects should
+deduplicate by canonical ids such as `interaction_id`.
+
+Post-commit hooks are not synchronous policy seams. They cannot close an
+in-turn race or gate a same-turn write. Keep using synchronous points such as
+`PostToolExecution` when policy must join the agent loop before it advances.
 
 ## Priority ordering and deny short-circuiting
 

--- a/docs/reference/hooks-reference.mdx
+++ b/docs/reference/hooks-reference.mdx
@@ -10,7 +10,7 @@ Use this page when you need exact hook vocabulary and structure rather than a pr
 
 | Type | Values |
 |------|--------|
-| `HookPoint` | `RunStarted`, `PreLlmRequest`, `PreToolExecution`, `TurnBoundary`, `PostLlmResponse`, `PostToolExecution`, `RunCompleted`, `RunFailed` |
+| `HookPoint` | `RunStarted`, `PreLlmRequest`, `PreToolExecution`, `TurnBoundary`, `PostLlmResponse`, `PostToolExecution`, `RunCompleted`, `RunFailed`, `RuntimeInputAccepted`, `RuntimeInputRejected`, `RuntimeInputDeduplicated`, `PeerIngressCommitted`, `PeerEgressCommitted`, `InteractionCompleted` |
 | `HookCapability` | `Observe`, `Guardrail` |
 | `HookExecutionMode` | `Foreground`, `Background` |
 
@@ -63,6 +63,35 @@ remaining foreground and background hooks.
 
 Background hooks are observational. Every background hook must have `Observe`
 capability or configuration validation rejects it, regardless of hook point.
+
+The six committed-fact points are always observe-only and reject `Guardrail`
+capability in either execution mode. Their session-scoped dispatcher does not
+join hook execution to the observed outcome, owns all spawned tasks, reaps
+completed task handles, and aborts in-flight work on drop. Hook decisions and
+runtime failures therefore cannot alter or delay committed facts.
+
+## Committed observation payloads
+
+`HookInvocation.observation` is a tagged `HookObservation` union:
+
+| Variant | Typed payload highlights |
+|---------|--------------------------|
+| `runtime_input_accepted` | input id, runtime input kind, resolved handling mode |
+| `runtime_input_rejected` | attempted input id, runtime input kind, typed rejection reason |
+| `runtime_input_deduplicated` | attempted input id, runtime input kind, existing committed input id |
+| `peer_ingress_committed` | accepted comms kind, canonical peer, request id, sender taint declaration |
+| `peer_egress_committed` | egress kind, canonical peer id, envelope id, strongest typed delivery outcome, interaction correlation |
+| `interaction_completed` | interaction id, result text, optional structured output |
+
+These payloads project exact committed receipts/events. Implementations never
+re-read idempotency rows or reconstruct peer identity from display strings.
+Event streams remain the ordered and replay-aware transport beneath this
+reaction API.
+
+Post-commit hooks are process-local best-effort reactions. Recovery may lose or
+replay an invocation around a crash boundary; use event streams for durable
+delivery and `interaction_id` as the idempotency key for completion side
+effects.
 
 ## Failure reasons
 

--- a/meerkat-comms/src/mcp/tools.rs
+++ b/meerkat-comms/src/mcp/tools.rs
@@ -225,15 +225,37 @@ pub struct ToolContext {
 #[derive(Clone)]
 pub struct RuntimeCommsCommandHandle {
     runtime: Arc<dyn CoreCommsRuntime>,
+    post_commit_hooks: Option<Arc<meerkat_core::PostCommitHookDispatcher>>,
 }
 
 impl RuntimeCommsCommandHandle {
     pub fn new(runtime: Arc<dyn CoreCommsRuntime>) -> Self {
-        Self { runtime }
+        Self {
+            runtime,
+            post_commit_hooks: None,
+        }
+    }
+
+    pub fn with_post_commit_hooks(
+        mut self,
+        post_commit_hooks: Arc<meerkat_core::PostCommitHookDispatcher>,
+    ) -> Self {
+        self.post_commit_hooks = Some(post_commit_hooks);
+        self
     }
 
     pub async fn send(&self, command: CommsCommand) -> Result<SendReceipt, SendError> {
-        self.runtime.send(command).await
+        let observation_command = command.clone();
+        let receipt = self.runtime.send(command).await?;
+        if let Some(dispatcher) = &self.post_commit_hooks
+            && let Some(observation) = meerkat_core::HookObservation::from_committed_peer_send(
+                &observation_command,
+                &receipt,
+            )
+        {
+            dispatcher.dispatch(observation);
+        }
+        Ok(receipt)
     }
 
     pub async fn peers(&self) -> Vec<PeerDirectoryEntry> {
@@ -1077,6 +1099,22 @@ mod tests {
         sent: Mutex<Vec<CommsCommand>>,
         peers: Vec<PeerDirectoryEntry>,
         notify: Arc<Notify>,
+    }
+
+    struct RecordingPostCommitHook {
+        sender: tokio::sync::mpsc::UnboundedSender<meerkat_core::HookInvocation>,
+    }
+
+    #[async_trait::async_trait]
+    impl meerkat_core::HookEngine for RecordingPostCommitHook {
+        async fn execute(
+            &self,
+            invocation: meerkat_core::HookInvocation,
+            _overrides: Option<&meerkat_core::HookRunOverrides>,
+        ) -> Result<meerkat_core::HookExecutionReport, meerkat_core::HookEngineError> {
+            let _ = self.sender.send(invocation);
+            Ok(meerkat_core::HookExecutionReport::empty())
+        }
     }
 
     impl RecordingRuntime {
@@ -2619,7 +2657,15 @@ mod tests {
         let peer_keypair = Keypair::generate();
         let (mut ctx, peer_id) = make_trusted_runtime_less_context(&peer_keypair).await;
         let runtime = Arc::new(RecordingRuntime::new());
-        ctx.runtime = Some(RuntimeCommsCommandHandle::new(runtime));
+        let (hook_tx, mut hook_rx) = tokio::sync::mpsc::unbounded_channel();
+        let hooks = Arc::new(meerkat_core::PostCommitHookDispatcher::new(
+            meerkat_core::SessionId::new(),
+        ));
+        hooks.configure(
+            Some(Arc::new(RecordingPostCommitHook { sender: hook_tx })),
+            meerkat_core::HookRunOverrides::default(),
+        );
+        ctx.runtime = Some(RuntimeCommsCommandHandle::new(runtime).with_post_commit_hooks(hooks));
 
         let result = handle_tools_call(
             &ctx,
@@ -2632,6 +2678,21 @@ mod tests {
         assert_eq!(result["receipt"]["kind"], "peer_message_sent");
         assert_eq!(result["receipt"]["delivery"], "volatile_handed_off");
         assert!(result["receipt"].get("acked").is_none());
+        let hook = tokio::time::timeout(std::time::Duration::from_secs(1), hook_rx.recv())
+            .await
+            .expect("peer-egress hook should be dispatched")
+            .expect("hook dispatcher remains connected");
+        assert_eq!(hook.point, meerkat_core::HookPoint::PeerEgressCommitted);
+        assert!(matches!(
+            hook.observation,
+            Some(meerkat_core::HookObservation::PeerEgressCommitted(
+                meerkat_core::HookPeerEgressCommitted {
+                    kind: meerkat_core::HookPeerEgressKind::Message,
+                    peer_id: observed_peer,
+                    ..
+                }
+            )) if observed_peer == peer_id
+        ));
     }
 
     #[tokio::test]

--- a/meerkat-core/src/agent.rs
+++ b/meerkat-core/src/agent.rs
@@ -2435,6 +2435,39 @@ pub trait CommsRuntime: Send + Sync {
     }
 }
 
+/// Session-scoped comms command surface that projects successful peer sends
+/// onto the observe-only post-commit hook dispatcher.
+pub struct ObservedCommsSender {
+    runtime: Arc<dyn CommsRuntime>,
+    post_commit_hooks: Arc<crate::hooks::PostCommitHookDispatcher>,
+}
+
+impl ObservedCommsSender {
+    pub fn new(
+        runtime: Arc<dyn CommsRuntime>,
+        post_commit_hooks: Arc<crate::hooks::PostCommitHookDispatcher>,
+    ) -> Self {
+        Self {
+            runtime,
+            post_commit_hooks,
+        }
+    }
+
+    pub async fn send(
+        &self,
+        command: CommsCommand,
+    ) -> Result<crate::comms::SendReceipt, crate::comms::SendError> {
+        let observation_command = command.clone();
+        let receipt = self.runtime.send(command).await?;
+        if let Some(observation) =
+            crate::hooks::HookObservation::from_committed_peer_send(&observation_command, &receipt)
+        {
+            self.post_commit_hooks.dispatch(observation);
+        }
+        Ok(receipt)
+    }
+}
+
 /// The main Agent struct
 pub struct Agent<C, T, S>
 where
@@ -2454,6 +2487,7 @@ where
     pub(super) comms_runtime: Option<Arc<dyn CommsRuntime>>,
     pub(super) hook_engine: Option<Arc<dyn HookEngine>>,
     pub(super) hook_run_overrides: HookRunOverrides,
+    pub(super) post_commit_hooks: Arc<crate::hooks::PostCommitHookDispatcher>,
     /// Optional context compaction strategy.
     pub(crate) compactor: Option<Arc<dyn crate::compact::Compactor>>,
     /// Optional host-supplied compaction summary curator. When present it

--- a/meerkat-core/src/agent/builder.rs
+++ b/meerkat-core/src/agent/builder.rs
@@ -71,6 +71,7 @@ pub struct AgentBuilder {
     pub(super) comms_runtime: Option<Arc<dyn CommsRuntime>>,
     pub(super) hook_engine: Option<Arc<dyn HookEngine>>,
     pub(super) hook_run_overrides: HookRunOverrides,
+    pub(super) post_commit_hooks: Option<Arc<crate::hooks::PostCommitHookDispatcher>>,
     pub(super) compactor: Option<Arc<dyn crate::compact::Compactor>>,
     pub(super) compaction_curator: Option<Arc<dyn crate::compact::CompactionCurator>>,
     pub(super) memory_store: Option<Arc<dyn crate::memory::MemoryStore>>,
@@ -239,6 +240,7 @@ impl AgentBuilder {
             comms_runtime: None,
             hook_engine: None,
             hook_run_overrides: HookRunOverrides::default(),
+            post_commit_hooks: None,
             compactor: None,
             compaction_curator: None,
             memory_store: None,
@@ -406,6 +408,15 @@ impl AgentBuilder {
     /// Set run-scoped hook overrides.
     pub fn with_hook_run_overrides(mut self, overrides: HookRunOverrides) -> Self {
         self.hook_run_overrides = overrides;
+        self
+    }
+
+    /// Use the runtime-owned dispatcher for observe-only committed facts.
+    pub fn with_post_commit_hooks(
+        mut self,
+        dispatcher: Arc<crate::hooks::PostCommitHookDispatcher>,
+    ) -> Self {
+        self.post_commit_hooks = Some(dispatcher);
         self
     }
 
@@ -671,7 +682,11 @@ impl AgentBuilder {
         // ends: the receiver is drained at turn boundaries, the sender is
         // cloned for the requesting surface via `cancel_after_boundary_handle`.
         let (cancel_after_boundary_tx, cancel_after_boundary_rx) = mpsc::unbounded_channel();
-
+        let post_commit_hooks = self.post_commit_hooks.unwrap_or_else(|| {
+            Arc::new(crate::hooks::PostCommitHookDispatcher::new(
+                session.id().clone(),
+            ))
+        });
         let mut agent = Agent {
             config: resolved_config,
             client,
@@ -685,6 +700,7 @@ impl AgentBuilder {
             comms_runtime: self.comms_runtime,
             hook_engine: self.hook_engine,
             hook_run_overrides: self.hook_run_overrides,
+            post_commit_hooks,
             compactor: self.compactor,
             compaction_curator: self.compaction_curator,
             last_input_tokens: 0,
@@ -891,6 +907,9 @@ impl AgentBuilder {
                 .remove_metadata(INHERITED_TOOL_FILTER_METADATA_KEY);
         }
 
+        agent
+            .post_commit_hooks
+            .configure(agent.hook_engine.clone(), agent.hook_run_overrides.clone());
         Ok(agent)
     }
 

--- a/meerkat-core/src/agent/comms_impl.rs
+++ b/meerkat-core/src/agent/comms_impl.rs
@@ -17,4 +17,23 @@ where
     pub fn comms_arc(&self) -> Option<std::sync::Arc<dyn CommsRuntime>> {
         self.comms_runtime.clone()
     }
+
+    pub fn observed_comms_sender(&self) -> Option<std::sync::Arc<super::ObservedCommsSender>> {
+        Some(std::sync::Arc::new(super::ObservedCommsSender::new(
+            self.comms_runtime.clone()?,
+            std::sync::Arc::clone(&self.post_commit_hooks),
+        )))
+    }
+
+    /// Send through the configured comms runtime and project a successful peer
+    /// delivery onto the observe-only post-commit hook surface.
+    pub async fn send_comms(
+        &self,
+        command: crate::comms::CommsCommand,
+    ) -> Result<crate::comms::SendReceipt, crate::comms::SendError> {
+        let sender = self.observed_comms_sender().ok_or_else(|| {
+            crate::comms::SendError::Unsupported("comms runtime is not configured".to_string())
+        })?;
+        sender.send(command).await
+    }
 }

--- a/meerkat-core/src/agent/runner.rs
+++ b/meerkat-core/src/agent/runner.rs
@@ -2595,6 +2595,9 @@ impl Agent<dyn AgentLlmClient, dyn AgentToolDispatcher, dyn AgentSessionStore> {
 
         let (cancel_after_boundary_tx, cancel_after_boundary_rx) =
             tokio::sync::mpsc::unbounded_channel();
+        let post_commit_hooks = Arc::new(crate::hooks::PostCommitHookDispatcher::new(
+            snapshot.id().clone(),
+        ));
         let mut operation_agent = Agent {
             config: self.config.clone(),
             client: isolated_client,
@@ -2608,6 +2611,7 @@ impl Agent<dyn AgentLlmClient, dyn AgentToolDispatcher, dyn AgentSessionStore> {
             comms_runtime: None,
             hook_engine: None,
             hook_run_overrides: self.hook_run_overrides.clone(),
+            post_commit_hooks,
             compactor: None,
             compaction_curator: None,
             last_input_tokens: self.last_input_tokens,

--- a/meerkat-core/src/agent/state.rs
+++ b/meerkat-core/src/agent/state.rs
@@ -2025,6 +2025,7 @@ where
                     llm_response: None,
                     tool_call: None,
                     tool_result: None,
+                    observation: None,
                 },
                 event_tx,
             )
@@ -4569,6 +4570,7 @@ where
             llm_response: None,
             tool_call: None,
             tool_result: None,
+            observation: None,
         };
         // Pre-LLM hooks may observe or deny the turn.
         let pre_llm_report = if in_extraction {
@@ -5461,6 +5463,7 @@ where
             }),
             tool_call: None,
             tool_result: None,
+            observation: None,
         };
         let post_llm_report = if in_extraction {
             match self
@@ -5679,6 +5682,7 @@ where
                         provenance: provenance_for_tool(tc.name.as_str()),
                     }),
                     tool_result: None,
+                    observation: None,
                 },
                 ctx.event_tx.as_ref(),
             )
@@ -5829,6 +5833,7 @@ where
                             )
                             .with_provenance(provenance_for_tool(tc.name.as_str())),
                         ),
+                        observation: None,
                     },
                     ctx.run_id,
                     ctx.turn_count,

--- a/meerkat-core/src/hooks.rs
+++ b/meerkat-core/src/hooks.rs
@@ -2,14 +2,17 @@
 
 use crate::error::AgentError;
 use crate::event::{AgentErrorClass, AgentErrorReport, ToolCallArguments};
+#[cfg(target_arch = "wasm32")]
+use crate::tokio;
 use crate::types::{
-    ContentBlock, RunInput, ServerToolKind, SessionId, StopReason, ToolProvenance, ToolResult,
-    Usage,
+    CommsNoticeKind, ContentBlock, HandlingMode, RunInput, ServerToolKind, SessionId, StopReason,
+    SystemNoticePeer, ToolProvenance, ToolResult, Usage,
 };
 use async_trait::async_trait;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
+use std::sync::{Arc, RwLock};
 
 /// Stable identifier for a configured hook.
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq, Hash)]
@@ -52,6 +55,12 @@ pub enum HookPoint {
     PreToolExecution,
     PostToolExecution,
     TurnBoundary,
+    RuntimeInputAccepted,
+    RuntimeInputRejected,
+    RuntimeInputDeduplicated,
+    PeerIngressCommitted,
+    PeerEgressCommitted,
+    InteractionCompleted,
 }
 
 impl HookPoint {
@@ -65,7 +74,30 @@ impl HookPoint {
     pub fn is_post(self) -> bool {
         matches!(
             self,
-            Self::PostLlmResponse | Self::PostToolExecution | Self::RunCompleted | Self::RunFailed
+            Self::PostLlmResponse
+                | Self::PostToolExecution
+                | Self::RunCompleted
+                | Self::RunFailed
+                | Self::RuntimeInputAccepted
+                | Self::RuntimeInputRejected
+                | Self::RuntimeInputDeduplicated
+                | Self::PeerIngressCommitted
+                | Self::PeerEgressCommitted
+                | Self::InteractionCompleted
+        )
+    }
+
+    /// Whether this point observes an already-committed or terminally-resolved
+    /// fact and therefore cannot carry policy authority.
+    pub fn is_observe_only(self) -> bool {
+        matches!(
+            self,
+            Self::RuntimeInputAccepted
+                | Self::RuntimeInputRejected
+                | Self::RuntimeInputDeduplicated
+                | Self::PeerIngressCommitted
+                | Self::PeerEgressCommitted
+                | Self::InteractionCompleted
         )
     }
 }
@@ -84,6 +116,417 @@ pub enum HookExecutionMode {
 pub enum HookCapability {
     Observe,
     Guardrail,
+}
+
+/// Runtime input kind projected onto the public hook surface.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum HookRuntimeInputKind {
+    Prompt,
+    PeerMessage,
+    PeerRequest,
+    PeerResponseProgress,
+    PeerResponseTerminal,
+    FlowStep,
+    ExternalEvent,
+    Continuation,
+    Operation,
+}
+
+/// Runtime lifecycle state carried by a typed input rejection.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum HookRuntimeState {
+    Initializing,
+    Idle,
+    Attached,
+    Running,
+    Retired,
+    Stopped,
+    Destroyed,
+}
+
+/// Typed terminal reason for a runtime input rejection observation.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(tag = "reason_type", rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum HookRuntimeInputRejection {
+    NotReady { state: HookRuntimeState },
+    ValidationFailed { detail: String },
+    DurabilityViolation { detail: String },
+    PeerHandlingModeInvalid { detail: String },
+    PeerResponseTerminalInvalid { detail: String },
+}
+
+/// An input was durably admitted by runtime authority.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct HookRuntimeInputAccepted {
+    pub input_id: crate::lifecycle::InputId,
+    pub input_kind: HookRuntimeInputKind,
+    pub handling_mode: HandlingMode,
+}
+
+/// An input was terminally rejected without an admission commit.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct HookRuntimeInputRejected {
+    pub input_id: crate::lifecycle::InputId,
+    pub input_kind: HookRuntimeInputKind,
+    pub reason: HookRuntimeInputRejection,
+}
+
+/// An idempotent input submission resolved to an existing admitted input.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct HookRuntimeInputDeduplicated {
+    pub input_id: crate::lifecycle::InputId,
+    pub input_kind: HookRuntimeInputKind,
+    pub existing_input_id: crate::lifecycle::InputId,
+}
+
+/// A typed peer input was committed by runtime admission.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct HookPeerIngressCommitted {
+    pub kind: CommsNoticeKind,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub peer: Option<SystemNoticePeer>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub request_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub sender_taint: Option<crate::comms::SenderContentTaint>,
+}
+
+/// Typed class of a committed peer egress operation.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum HookPeerEgressKind {
+    Message,
+    IncarnationFencedMessage,
+    Lifecycle,
+    Request,
+    Response,
+}
+
+/// A peer send reached the strongest successful outcome proved by its
+/// transport and local lifecycle authority.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct HookPeerEgressCommitted {
+    pub kind: HookPeerEgressKind,
+    pub peer_id: crate::comms::PeerId,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub display_name: Option<crate::comms::PeerName>,
+    pub envelope_id: uuid::Uuid,
+    pub delivery: crate::comms::PeerDeliveryOutcome,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub interaction_id: Option<crate::interaction::InteractionId>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub in_reply_to: Option<crate::interaction::InteractionId>,
+}
+
+/// A correlated interaction completion was durably published.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct HookInteractionCompleted {
+    pub interaction_id: crate::interaction::InteractionId,
+    pub result: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub structured_output: Option<Value>,
+}
+
+/// Typed committed fact carried by an observe-only hook invocation.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(
+    tag = "observation_type",
+    content = "observation",
+    rename_all = "snake_case"
+)]
+#[non_exhaustive]
+pub enum HookObservation {
+    RuntimeInputAccepted(HookRuntimeInputAccepted),
+    RuntimeInputRejected(HookRuntimeInputRejected),
+    RuntimeInputDeduplicated(HookRuntimeInputDeduplicated),
+    PeerIngressCommitted(HookPeerIngressCommitted),
+    PeerEgressCommitted(HookPeerEgressCommitted),
+    InteractionCompleted(HookInteractionCompleted),
+}
+
+impl HookObservation {
+    #[must_use]
+    pub fn point(&self) -> HookPoint {
+        match self {
+            Self::RuntimeInputAccepted(_) => HookPoint::RuntimeInputAccepted,
+            Self::RuntimeInputRejected(_) => HookPoint::RuntimeInputRejected,
+            Self::RuntimeInputDeduplicated(_) => HookPoint::RuntimeInputDeduplicated,
+            Self::PeerIngressCommitted(_) => HookPoint::PeerIngressCommitted,
+            Self::PeerEgressCommitted(_) => HookPoint::PeerEgressCommitted,
+            Self::InteractionCompleted(_) => HookPoint::InteractionCompleted,
+        }
+    }
+
+    /// Project a canonical committed agent event onto the hook surface.
+    #[must_use]
+    pub fn from_committed_agent_event(event: &crate::event::AgentEvent) -> Option<Self> {
+        match event {
+            crate::event::AgentEvent::PeerContentIngested {
+                kind,
+                peer,
+                request_id,
+                sender_taint,
+            } => Some(Self::PeerIngressCommitted(HookPeerIngressCommitted {
+                kind: kind.clone(),
+                peer: peer.clone(),
+                request_id: request_id.clone(),
+                sender_taint: *sender_taint,
+            })),
+            crate::event::AgentEvent::InteractionComplete {
+                interaction_id,
+                result,
+                structured_output,
+            } => Some(Self::InteractionCompleted(HookInteractionCompleted {
+                interaction_id: *interaction_id,
+                result: result.clone(),
+                structured_output: structured_output.clone(),
+            })),
+            _ => None,
+        }
+    }
+
+    /// Project a successful peer command receipt onto the hook surface.
+    #[must_use]
+    pub fn from_committed_peer_send(
+        command: &crate::comms::CommsCommand,
+        receipt: &crate::comms::SendReceipt,
+    ) -> Option<Self> {
+        use crate::comms::{CommsCommand, SendReceipt};
+
+        let (kind, route, envelope_id, delivery, interaction_id, in_reply_to) =
+            match (command, receipt) {
+                (
+                    CommsCommand::PeerMessage { to, .. },
+                    SendReceipt::PeerMessageSent {
+                        envelope_id,
+                        delivery,
+                    },
+                ) => (
+                    HookPeerEgressKind::Message,
+                    to,
+                    *envelope_id,
+                    *delivery,
+                    None,
+                    None,
+                ),
+                (
+                    CommsCommand::IncarnationFencedPeerMessage { to, .. },
+                    SendReceipt::PeerMessageSent {
+                        envelope_id,
+                        delivery,
+                    },
+                ) => (
+                    HookPeerEgressKind::IncarnationFencedMessage,
+                    to,
+                    *envelope_id,
+                    *delivery,
+                    None,
+                    None,
+                ),
+                (
+                    CommsCommand::PeerLifecycle { to, .. },
+                    SendReceipt::PeerLifecycleSent {
+                        envelope_id,
+                        delivery,
+                    },
+                ) => (
+                    HookPeerEgressKind::Lifecycle,
+                    to,
+                    *envelope_id,
+                    *delivery,
+                    None,
+                    None,
+                ),
+                (
+                    CommsCommand::PeerRequest { to, .. },
+                    SendReceipt::PeerRequestSent {
+                        envelope_id,
+                        interaction_id,
+                        delivery,
+                        ..
+                    },
+                ) => (
+                    HookPeerEgressKind::Request,
+                    to,
+                    *envelope_id,
+                    *delivery,
+                    Some(*interaction_id),
+                    None,
+                ),
+                (
+                    CommsCommand::PeerResponse { to, .. },
+                    SendReceipt::PeerResponseSent {
+                        envelope_id,
+                        in_reply_to,
+                        delivery,
+                    },
+                ) => (
+                    HookPeerEgressKind::Response,
+                    to,
+                    *envelope_id,
+                    *delivery,
+                    None,
+                    Some(*in_reply_to),
+                ),
+                _ => return None,
+            };
+
+        Some(Self::PeerEgressCommitted(HookPeerEgressCommitted {
+            kind,
+            peer_id: route.peer_id,
+            display_name: route.display_name.clone(),
+            envelope_id,
+            delivery,
+            interaction_id,
+            in_reply_to,
+        }))
+    }
+}
+
+#[derive(Clone)]
+struct PostCommitHookRegistration {
+    engine: Arc<dyn HookEngine>,
+    overrides: crate::config::HookRunOverrides,
+}
+
+struct TrackedPostCommitHookTask {
+    abort: tokio::task::AbortHandle,
+    finished: Arc<std::sync::atomic::AtomicBool>,
+}
+
+struct PostCommitHookTaskCompletion(Arc<std::sync::atomic::AtomicBool>);
+
+impl Drop for PostCommitHookTaskCompletion {
+    fn drop(&mut self) {
+        self.0.store(true, std::sync::atomic::Ordering::Release);
+    }
+}
+
+/// Session-scoped mechanical dispatcher for observe-only committed facts.
+///
+/// Producers call [`Self::dispatch`] only after their owning commit or terminal
+/// resolution. Dispatch never awaits hook execution and cannot change the fact
+/// being observed.
+pub struct PostCommitHookDispatcher {
+    session_id: SessionId,
+    registration: RwLock<Option<PostCommitHookRegistration>>,
+    inflight: std::sync::Mutex<Vec<TrackedPostCommitHookTask>>,
+}
+
+impl PostCommitHookDispatcher {
+    #[must_use]
+    pub fn new(session_id: SessionId) -> Self {
+        Self {
+            session_id,
+            registration: RwLock::new(None),
+            inflight: std::sync::Mutex::new(Vec::new()),
+        }
+    }
+
+    pub fn configure(
+        &self,
+        engine: Option<Arc<dyn HookEngine>>,
+        overrides: crate::config::HookRunOverrides,
+    ) {
+        let mut registration = self
+            .registration
+            .write()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        *registration = engine.map(|engine| PostCommitHookRegistration { engine, overrides });
+    }
+
+    pub fn dispatch(&self, observation: HookObservation) {
+        let registration = self
+            .registration
+            .read()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .clone();
+        let Some(registration) = registration else {
+            return;
+        };
+        let invocation = HookInvocation::committed(self.session_id.clone(), observation);
+        let finished = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let task_finished = Arc::clone(&finished);
+        let task = async move {
+            let _completion = PostCommitHookTaskCompletion(task_finished);
+            match registration
+                .engine
+                .execute_post_commit(invocation.clone(), Some(&registration.overrides))
+                .await
+            {
+                Ok(report) => {
+                    if matches!(report.decision, Some(HookDecision::Deny { .. })) {
+                        tracing::warn!(
+                            point = ?invocation.point,
+                            "observe-only post-commit hook returned a denial; the committed fact is unchanged"
+                        );
+                    }
+                }
+                Err(error) => {
+                    tracing::warn!(
+                        point = ?invocation.point,
+                        error = %error,
+                        "observe-only post-commit hook execution failed; the committed fact is unchanged"
+                    );
+                }
+            }
+        };
+        let handle = tokio::spawn(task);
+        let mut inflight = self
+            .inflight
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        inflight.retain(|task| !task.finished.load(std::sync::atomic::Ordering::Acquire));
+        inflight.push(TrackedPostCommitHookTask {
+            abort: handle.abort_handle(),
+            finished,
+        });
+    }
+
+    /// Stop accepting configured work and abort every owned observation task.
+    ///
+    /// Runtime session teardown calls this explicitly; `Drop` is the fallback.
+    pub fn shutdown(&self) {
+        self.registration
+            .write()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .take();
+        let mut inflight = self
+            .inflight
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        for task in inflight.drain(..) {
+            task.abort.abort();
+        }
+    }
+
+    #[cfg(test)]
+    fn inflight_count(&self) -> usize {
+        self.inflight
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .len()
+    }
+}
+
+impl std::fmt::Debug for PostCommitHookDispatcher {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("PostCommitHookDispatcher")
+            .field("session_id", &self.session_id)
+            .finish_non_exhaustive()
+    }
+}
+
+impl Drop for PostCommitHookDispatcher {
+    fn drop(&mut self) {
+        self.shutdown();
+    }
 }
 
 /// Typed reason codes for guardrail denials.
@@ -373,6 +816,8 @@ pub struct HookInvocation {
     pub tool_call: Option<HookToolCall>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub tool_result: Option<HookToolResult>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub observation: Option<HookObservation>,
 }
 
 impl Serialize for HookInvocation {
@@ -399,7 +844,8 @@ impl Serialize for HookInvocation {
             + usize::from(self.llm_request.is_some())
             + usize::from(self.llm_response.is_some())
             + usize::from(self.tool_call.is_some())
-            + usize::from(self.tool_result.is_some());
+            + usize::from(self.tool_result.is_some())
+            + usize::from(self.observation.is_some());
         let mut state = serializer.serialize_struct("HookInvocation", len)?;
         state.serialize_field("point", &self.point)?;
         state.serialize_field("session_id", &self.session_id)?;
@@ -433,6 +879,9 @@ impl Serialize for HookInvocation {
         if let Some(tool_result) = &self.tool_result {
             state.serialize_field("tool_result", tool_result)?;
         }
+        if let Some(observation) = &self.observation {
+            state.serialize_field("observation", observation)?;
+        }
         state.end()
     }
 }
@@ -450,7 +899,14 @@ impl HookInvocation {
             llm_response: None,
             tool_call: None,
             tool_result: None,
+            observation: None,
         }
+    }
+
+    pub fn committed(session_id: SessionId, observation: HookObservation) -> Self {
+        let mut invocation = Self::new(observation.point(), session_id);
+        invocation.observation = Some(observation);
+        invocation
     }
 
     pub fn run_started(session_id: SessionId, prompt_input: RunInput) -> Self {
@@ -591,7 +1047,7 @@ impl HookEngineError {
 /// Runtime-independent engine interface.
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
-pub trait HookEngine: Send + Sync {
+pub trait HookEngine: Send + Sync + 'static {
     fn matching_hooks(
         &self,
         _invocation: &HookInvocation,
@@ -605,13 +1061,26 @@ pub trait HookEngine: Send + Sync {
         invocation: HookInvocation,
         overrides: Option<&crate::config::HookRunOverrides>,
     ) -> Result<HookExecutionReport, HookEngineError>;
+
+    /// Execute one post-commit observation inside its dispatcher's owned task.
+    ///
+    /// Implementations must not detach additional work from this future.
+    async fn execute_post_commit(
+        &self,
+        invocation: HookInvocation,
+        overrides: Option<&crate::config::HookRunOverrides>,
+    ) -> Result<HookExecutionReport, HookEngineError> {
+        self.execute(invocation, overrides).await
+    }
 }
 
 #[cfg(test)]
 #[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
+    use crate::comms::{CommsCommand, PeerDeliveryOutcome, PeerId, PeerRoute, SendReceipt};
     use crate::types::{ContentBlock, ToolResult};
+    use std::sync::Arc;
 
     fn text_block(s: &str) -> ContentBlock {
         ContentBlock::Text {
@@ -624,6 +1093,260 @@ mod tests {
             media_type: media_type.to_string(),
             data: data.into(),
         }
+    }
+
+    struct BlockingObserveEngine {
+        entered: tokio::sync::Notify,
+        release: tokio::sync::Notify,
+    }
+
+    #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+    #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+    impl HookEngine for BlockingObserveEngine {
+        async fn execute(
+            &self,
+            invocation: HookInvocation,
+            _overrides: Option<&crate::config::HookRunOverrides>,
+        ) -> Result<HookExecutionReport, HookEngineError> {
+            self.entered.notify_one();
+            self.release.notified().await;
+            Ok(HookExecutionReport {
+                decision: Some(HookDecision::deny(
+                    HookId::new("ignored-denial"),
+                    HookReasonCode::PolicyViolation,
+                    format!("{:?}", invocation.point),
+                    None,
+                )),
+                ..HookExecutionReport::empty()
+            })
+        }
+    }
+
+    #[tokio::test]
+    async fn post_commit_dispatch_does_not_join_or_apply_a_hook_decision() {
+        let engine = Arc::new(BlockingObserveEngine {
+            entered: tokio::sync::Notify::new(),
+            release: tokio::sync::Notify::new(),
+        });
+        let dispatcher = PostCommitHookDispatcher::new(SessionId::new());
+        dispatcher.configure(
+            Some(Arc::clone(&engine) as Arc<dyn HookEngine>),
+            crate::config::HookRunOverrides::default(),
+        );
+
+        dispatcher.dispatch(HookObservation::RuntimeInputAccepted(
+            HookRuntimeInputAccepted {
+                input_id: crate::lifecycle::InputId::new(),
+                input_kind: HookRuntimeInputKind::Prompt,
+                handling_mode: HandlingMode::Queue,
+            },
+        ));
+
+        tokio::time::timeout(std::time::Duration::from_secs(1), engine.entered.notified())
+            .await
+            .expect("post-commit hook should start asynchronously");
+        engine.release.notify_one();
+    }
+
+    struct AbortGuard(Option<tokio::sync::oneshot::Sender<()>>);
+
+    impl Drop for AbortGuard {
+        fn drop(&mut self) {
+            if let Some(sender) = self.0.take() {
+                let _ = sender.send(());
+            }
+        }
+    }
+
+    struct AbortObservedEngine {
+        entered: tokio::sync::Notify,
+        aborted: std::sync::Mutex<Option<tokio::sync::oneshot::Sender<()>>>,
+    }
+
+    #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+    #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+    impl HookEngine for AbortObservedEngine {
+        async fn execute(
+            &self,
+            _invocation: HookInvocation,
+            _overrides: Option<&crate::config::HookRunOverrides>,
+        ) -> Result<HookExecutionReport, HookEngineError> {
+            let sender = self
+                .aborted
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .take();
+            let _guard = AbortGuard(sender);
+            self.entered.notify_one();
+            std::future::pending::<()>().await;
+            Ok(HookExecutionReport::empty())
+        }
+    }
+
+    #[tokio::test]
+    async fn dispatcher_drop_aborts_a_blocked_observation() {
+        let (aborted_tx, aborted_rx) = tokio::sync::oneshot::channel();
+        let engine = Arc::new(AbortObservedEngine {
+            entered: tokio::sync::Notify::new(),
+            aborted: std::sync::Mutex::new(Some(aborted_tx)),
+        });
+        let dispatcher = PostCommitHookDispatcher::new(SessionId::new());
+        dispatcher.configure(
+            Some(Arc::clone(&engine) as Arc<dyn HookEngine>),
+            crate::config::HookRunOverrides::default(),
+        );
+        dispatcher.dispatch(HookObservation::RuntimeInputAccepted(
+            HookRuntimeInputAccepted {
+                input_id: crate::lifecycle::InputId::new(),
+                input_kind: HookRuntimeInputKind::Prompt,
+                handling_mode: HandlingMode::Queue,
+            },
+        ));
+        tokio::time::timeout(std::time::Duration::from_secs(1), engine.entered.notified())
+            .await
+            .expect("blocked observation should start");
+
+        drop(dispatcher);
+
+        tokio::time::timeout(std::time::Duration::from_secs(1), aborted_rx)
+            .await
+            .expect("dispatcher drop should abort its task")
+            .expect("abort guard should report cancellation");
+    }
+
+    struct ImmediateObserveEngine {
+        completed: std::sync::atomic::AtomicUsize,
+    }
+
+    #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+    #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+    impl HookEngine for ImmediateObserveEngine {
+        async fn execute(
+            &self,
+            _invocation: HookInvocation,
+            _overrides: Option<&crate::config::HookRunOverrides>,
+        ) -> Result<HookExecutionReport, HookEngineError> {
+            self.completed
+                .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            Ok(HookExecutionReport::empty())
+        }
+    }
+
+    #[tokio::test]
+    async fn dispatcher_reaps_finished_tasks_before_tracking_new_work() {
+        let engine = Arc::new(ImmediateObserveEngine {
+            completed: std::sync::atomic::AtomicUsize::new(0),
+        });
+        let dispatcher = PostCommitHookDispatcher::new(SessionId::new());
+        dispatcher.configure(
+            Some(Arc::clone(&engine) as Arc<dyn HookEngine>),
+            crate::config::HookRunOverrides::default(),
+        );
+        for _ in 0..32 {
+            dispatcher.dispatch(HookObservation::RuntimeInputAccepted(
+                HookRuntimeInputAccepted {
+                    input_id: crate::lifecycle::InputId::new(),
+                    input_kind: HookRuntimeInputKind::Prompt,
+                    handling_mode: HandlingMode::Queue,
+                },
+            ));
+        }
+        tokio::time::timeout(std::time::Duration::from_secs(1), async {
+            while engine.completed.load(std::sync::atomic::Ordering::SeqCst) != 32 {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("all immediate observations should finish");
+
+        dispatcher.dispatch(HookObservation::RuntimeInputAccepted(
+            HookRuntimeInputAccepted {
+                input_id: crate::lifecycle::InputId::new(),
+                input_kind: HookRuntimeInputKind::Prompt,
+                handling_mode: HandlingMode::Queue,
+            },
+        ));
+        assert_eq!(
+            dispatcher.inflight_count(),
+            1,
+            "finished task handles must be reaped before tracking new work"
+        );
+    }
+
+    #[test]
+    fn committed_agent_event_projects_typed_hook_observations() {
+        let peer_event = crate::event::AgentEvent::PeerContentIngested {
+            kind: CommsNoticeKind::Request,
+            peer: Some(SystemNoticePeer {
+                id: PeerId::new(),
+                display_name: Some("reviewer".to_string()),
+            }),
+            request_id: Some("request-1".to_string()),
+            sender_taint: Some(crate::comms::SenderContentTaint::Tainted),
+        };
+        assert!(matches!(
+            HookObservation::from_committed_agent_event(&peer_event),
+            Some(HookObservation::PeerIngressCommitted(
+                HookPeerIngressCommitted {
+                    kind: CommsNoticeKind::Request,
+                    request_id: Some(request_id),
+                    sender_taint: Some(crate::comms::SenderContentTaint::Tainted),
+                    ..
+                }
+            )) if request_id == "request-1"
+        ));
+
+        let interaction_id = crate::interaction::InteractionId(uuid::Uuid::new_v4());
+        let completion = crate::event::AgentEvent::InteractionComplete {
+            interaction_id,
+            result: "done".to_string(),
+            structured_output: Some(serde_json::json!({"ok": true})),
+        };
+        assert!(matches!(
+            HookObservation::from_committed_agent_event(&completion),
+            Some(HookObservation::InteractionCompleted(HookInteractionCompleted {
+                interaction_id: observed,
+                result,
+                ..
+            })) if observed == interaction_id && result == "done"
+        ));
+    }
+
+    #[test]
+    fn peer_egress_projection_requires_matching_command_and_receipt() {
+        let peer_id = PeerId::new();
+        let command = CommsCommand::PeerMessage {
+            to: PeerRoute::new(peer_id),
+            body: "hello".to_string(),
+            blocks: None,
+            content_taint: None,
+            handling_mode: HandlingMode::Queue,
+            objective_id: None,
+        };
+        let envelope_id = uuid::Uuid::new_v4();
+        let receipt = SendReceipt::PeerMessageSent {
+            envelope_id,
+            delivery: PeerDeliveryOutcome::Acked,
+        };
+        assert!(matches!(
+            HookObservation::from_committed_peer_send(&command, &receipt),
+            Some(HookObservation::PeerEgressCommitted(HookPeerEgressCommitted {
+                kind: HookPeerEgressKind::Message,
+                peer_id: observed_peer,
+                envelope_id: observed_envelope,
+                delivery: PeerDeliveryOutcome::Acked,
+                ..
+            })) if observed_peer == peer_id && observed_envelope == envelope_id
+        ));
+
+        let mismatched = SendReceipt::PeerLifecycleSent {
+            envelope_id,
+            delivery: PeerDeliveryOutcome::Acked,
+        };
+        assert!(
+            HookObservation::from_committed_peer_send(&command, &mismatched).is_none(),
+            "a mismatched custom runtime receipt must not mint a false egress fact"
+        );
     }
 
     #[test]

--- a/meerkat-core/src/hooks.rs
+++ b/meerkat-core/src/hooks.rs
@@ -12,7 +12,7 @@ use async_trait::async_trait;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
 
 /// Stable identifier for a configured hook.
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq, Hash)]
@@ -415,8 +415,13 @@ impl Drop for PostCommitHookTaskCompletion {
 /// being observed.
 pub struct PostCommitHookDispatcher {
     session_id: SessionId,
-    registration: RwLock<Option<PostCommitHookRegistration>>,
-    inflight: std::sync::Mutex<Vec<TrackedPostCommitHookTask>>,
+    state: std::sync::Mutex<PostCommitHookDispatcherState>,
+}
+
+struct PostCommitHookDispatcherState {
+    registration: Option<PostCommitHookRegistration>,
+    inflight: Vec<TrackedPostCommitHookTask>,
+    shutdown: bool,
 }
 
 impl PostCommitHookDispatcher {
@@ -424,8 +429,11 @@ impl PostCommitHookDispatcher {
     pub fn new(session_id: SessionId) -> Self {
         Self {
             session_id,
-            registration: RwLock::new(None),
-            inflight: std::sync::Mutex::new(Vec::new()),
+            state: std::sync::Mutex::new(PostCommitHookDispatcherState {
+                registration: None,
+                inflight: Vec::new(),
+                shutdown: false,
+            }),
         }
     }
 
@@ -434,19 +442,25 @@ impl PostCommitHookDispatcher {
         engine: Option<Arc<dyn HookEngine>>,
         overrides: crate::config::HookRunOverrides,
     ) {
-        let mut registration = self
-            .registration
-            .write()
+        let mut state = self
+            .state
+            .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner);
-        *registration = engine.map(|engine| PostCommitHookRegistration { engine, overrides });
+        if state.shutdown {
+            return;
+        }
+        state.registration = engine.map(|engine| PostCommitHookRegistration { engine, overrides });
     }
 
     pub fn dispatch(&self, observation: HookObservation) {
-        let registration = self
-            .registration
-            .read()
-            .unwrap_or_else(std::sync::PoisonError::into_inner)
-            .clone();
+        let mut state = self
+            .state
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        if state.shutdown {
+            return;
+        }
+        let registration = state.registration.clone();
         let Some(registration) = registration else {
             return;
         };
@@ -478,12 +492,10 @@ impl PostCommitHookDispatcher {
             }
         };
         let handle = tokio::spawn(task);
-        let mut inflight = self
+        state
             .inflight
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner);
-        inflight.retain(|task| !task.finished.load(std::sync::atomic::Ordering::Acquire));
-        inflight.push(TrackedPostCommitHookTask {
+            .retain(|task| !task.finished.load(std::sync::atomic::Ordering::Acquire));
+        state.inflight.push(TrackedPostCommitHookTask {
             abort: handle.abort_handle(),
             finished,
         });
@@ -493,24 +505,26 @@ impl PostCommitHookDispatcher {
     ///
     /// Runtime session teardown calls this explicitly; `Drop` is the fallback.
     pub fn shutdown(&self) {
-        self.registration
-            .write()
-            .unwrap_or_else(std::sync::PoisonError::into_inner)
-            .take();
-        let mut inflight = self
-            .inflight
+        let mut state = self
+            .state
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner);
-        for task in inflight.drain(..) {
+        if state.shutdown {
+            return;
+        }
+        state.shutdown = true;
+        state.registration = None;
+        for task in state.inflight.drain(..) {
             task.abort.abort();
         }
     }
 
     #[cfg(test)]
     fn inflight_count(&self) -> usize {
-        self.inflight
+        self.state
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .inflight
             .len()
     }
 }
@@ -1270,6 +1284,58 @@ mod tests {
             dispatcher.inflight_count(),
             1,
             "finished task handles must be reaped before tracking new work"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn concurrent_dispatch_and_shutdown_leave_no_owned_task() {
+        let engine = Arc::new(AbortObservedEngine {
+            entered: tokio::sync::Notify::new(),
+            aborted: std::sync::Mutex::new(None),
+        });
+        let dispatcher = Arc::new(PostCommitHookDispatcher::new(SessionId::new()));
+        dispatcher.configure(
+            Some(engine as Arc<dyn HookEngine>),
+            crate::config::HookRunOverrides::default(),
+        );
+
+        let mut dispatches = Vec::new();
+        for _ in 0..32 {
+            let dispatcher = Arc::clone(&dispatcher);
+            dispatches.push(tokio::spawn(async move {
+                dispatcher.dispatch(HookObservation::RuntimeInputAccepted(
+                    HookRuntimeInputAccepted {
+                        input_id: crate::lifecycle::InputId::new(),
+                        input_kind: HookRuntimeInputKind::Prompt,
+                        handling_mode: HandlingMode::Queue,
+                    },
+                ));
+            }));
+        }
+        let shutdown = {
+            let dispatcher = Arc::clone(&dispatcher);
+            tokio::spawn(async move {
+                dispatcher.shutdown();
+            })
+        };
+        for dispatch in dispatches {
+            dispatch.await.expect("dispatch task joins");
+        }
+        shutdown.await.expect("shutdown task joins");
+        tokio::task::yield_now().await;
+
+        assert_eq!(dispatcher.inflight_count(), 0);
+        dispatcher.dispatch(HookObservation::RuntimeInputAccepted(
+            HookRuntimeInputAccepted {
+                input_id: crate::lifecycle::InputId::new(),
+                input_kind: HookRuntimeInputKind::Prompt,
+                handling_mode: HandlingMode::Queue,
+            },
+        ));
+        assert_eq!(
+            dispatcher.inflight_count(),
+            0,
+            "shutdown must reject every later dispatch"
         );
     }
 

--- a/meerkat-core/src/lib.rs
+++ b/meerkat-core/src/lib.rs
@@ -112,9 +112,10 @@ pub use agent::{
     CurrentTurnContent, CurrentTurnImageRef, DefaultSystemPromptPolicy, DispatcherCapabilities,
     ExternalToolUpdate, FilteredToolDispatcher, LiveBridgeNoncommittingRunPermit,
     LiveBridgePreparedOperation, LiveBridgeToolDispatchAdmission, LlmStreamResult,
-    RequestAttemptAuthority, SnapshotProjectionError, StickyModelFallbackActivationProof,
-    ToolDispatchContext, dispatch_tool_execution_plan_fenced, resolve_tool_execution_plan_fenced,
-    select_tool_catalog_mode, should_compose_tool_catalog_control_plane,
+    ObservedCommsSender, RequestAttemptAuthority, SnapshotProjectionError,
+    StickyModelFallbackActivationProof, ToolDispatchContext, dispatch_tool_execution_plan_fenced,
+    resolve_tool_execution_plan_fenced, select_tool_catalog_mode,
+    should_compose_tool_catalog_control_plane,
 };
 pub use approval::{
     ApprovalActionKind, ApprovalDecision, ApprovalDecisionRecord, ApprovalError, ApprovalId,
@@ -222,8 +223,12 @@ pub use handles::{
 };
 pub use hooks::{
     HookCapability, HookDecision, HookEngine, HookEngineError, HookExecutionMode,
-    HookExecutionReport, HookFailureReason, HookId, HookInvocation, HookLlmRequest,
-    HookLlmResponse, HookOutcome, HookPoint, HookReasonCode, HookToolCall, HookToolResult,
+    HookExecutionReport, HookFailureReason, HookId, HookInteractionCompleted, HookInvocation,
+    HookLlmRequest, HookLlmResponse, HookObservation, HookOutcome, HookPeerEgressCommitted,
+    HookPeerEgressKind, HookPeerIngressCommitted, HookPoint, HookReasonCode,
+    HookRuntimeInputAccepted, HookRuntimeInputDeduplicated, HookRuntimeInputKind,
+    HookRuntimeInputRejected, HookRuntimeInputRejection, HookRuntimeState, HookToolCall,
+    HookToolResult, PostCommitHookDispatcher,
 };
 pub use image_content::{
     MissingBlobBehavior, RealtimeOpenProjectionAdmission, RealtimeOpenProjectionAdmissionError,

--- a/meerkat-core/src/runtime_epoch.rs
+++ b/meerkat-core/src/runtime_epoch.rs
@@ -20,6 +20,7 @@ use crate::handles::{
     ModelRoutingHandle, PeerCommsHandle, PeerCommsInstallTarget, PeerInteractionHandle,
     SessionAdmissionHandle, SessionClaimHandle, SessionContextHandle, TurnStateHandle,
 };
+use crate::hooks::PostCommitHookDispatcher;
 use crate::ops_lifecycle::CompletionCursorConsumer;
 use crate::ops_lifecycle::OpsLifecycleRegistry;
 use crate::tool_scope::GeneratedToolVisibilityOwner;
@@ -230,6 +231,8 @@ pub struct SessionRuntimeBindings {
     /// Resultful handoff authorizing durable compaction transcript+memory
     /// pairs for this exact session/runtime epoch.
     compaction_commit_coordinator: Arc<dyn crate::memory::CompactionCommitCoordinator>,
+    /// Mechanical observe-only dispatcher shared with the runtime owner.
+    post_commit_hooks: Arc<PostCommitHookDispatcher>,
     runtime_authority: Arc<dyn Any + Send + Sync>,
 }
 
@@ -263,6 +266,7 @@ impl SessionRuntimeBindings {
         session_claim_handle: Arc<dyn SessionClaimHandle>,
         interaction_stream: Arc<dyn InteractionStreamHandle>,
         compaction_commit_coordinator: Arc<dyn crate::memory::CompactionCommitCoordinator>,
+        post_commit_hooks: Arc<PostCommitHookDispatcher>,
         runtime_authority: Arc<dyn Any + Send + Sync>,
     ) -> Self {
         Self {
@@ -285,6 +289,7 @@ impl SessionRuntimeBindings {
             session_claim_handle,
             interaction_stream,
             compaction_commit_coordinator,
+            post_commit_hooks,
             runtime_authority,
         }
     }
@@ -376,6 +381,10 @@ impl SessionRuntimeBindings {
         &self.compaction_commit_coordinator
     }
 
+    pub fn post_commit_hooks(&self) -> &Arc<PostCommitHookDispatcher> {
+        &self.post_commit_hooks
+    }
+
     #[doc(hidden)]
     pub fn __runtime_authority(&self) -> &(dyn Any + Send + Sync) {
         self.runtime_authority.as_ref()
@@ -415,6 +424,7 @@ impl SessionRuntimeBindings {
             session_claim_handle: Arc::clone(&self.session_claim_handle),
             interaction_stream: Arc::clone(&self.interaction_stream),
             compaction_commit_coordinator: Arc::clone(&self.compaction_commit_coordinator),
+            post_commit_hooks: Arc::clone(&self.post_commit_hooks),
             runtime_authority,
         }
     }

--- a/meerkat-core/src/service/mod.rs
+++ b/meerkat-core/src/service/mod.rs
@@ -2716,6 +2716,15 @@ pub trait SessionServiceCommsExt: SessionService {
         None
     }
 
+    async fn send_comms(
+        &self,
+        session_id: &SessionId,
+        command: crate::CommsCommand,
+    ) -> Option<Result<crate::SendReceipt, crate::SendError>> {
+        let runtime = self.comms_runtime(session_id).await?;
+        Some(runtime.send(command).await)
+    }
+
     /// Get the event injector for a session, if available.
     async fn event_injector(
         &self,

--- a/meerkat-core/tests/hooks_contracts.rs
+++ b/meerkat-core/tests/hooks_contracts.rs
@@ -76,6 +76,7 @@ fn hook_invocation_outcome_roundtrip_contract() -> Result<(), Box<dyn std::error
         llm_response: None,
         tool_call: None,
         tool_result: None,
+        observation: None,
     };
 
     let outcome = HookOutcome {

--- a/meerkat-hooks/src/lib.rs
+++ b/meerkat-hooks/src/lib.rs
@@ -559,6 +559,13 @@ impl DefaultHookEngine {
             )));
         }
 
+        if entry.point.is_observe_only() && entry.capability != HookCapability::Observe {
+            return Err(HookEngineError::InvalidConfiguration(format!(
+                "post-commit hook points are observe-only: {}",
+                entry.id
+            )));
+        }
+
         Ok(())
     }
 
@@ -1200,6 +1207,51 @@ impl HookEngine for DefaultHookEngine {
 
         Ok(merged)
     }
+
+    async fn execute_post_commit(
+        &self,
+        invocation: HookInvocation,
+        overrides: Option<&HookRunOverrides>,
+    ) -> Result<HookExecutionReport, HookEngineError> {
+        debug_assert!(invocation.point.is_observe_only());
+        let resolved = self.effective_entries(overrides)?;
+        let mut entries: Vec<(usize, HookEntryConfig, HookAdapterConfig)> = resolved
+            .entries()
+            .iter()
+            .filter(|entry| entry.enabled && entry.point == invocation.point)
+            .cloned()
+            .enumerate()
+            .map(|(registration_index, entry)| {
+                let adapter = resolved.adapter(&entry.id).cloned().ok_or_else(|| {
+                    HookEngineError::InvalidConfiguration(format!(
+                        "no resolved adapter for hook id '{}'",
+                        entry.id
+                    ))
+                })?;
+                Ok((registration_index, entry, adapter))
+            })
+            .collect::<Result<_, HookEngineError>>()?;
+        drop(resolved);
+        entries.sort_by(|(a_idx, a_entry, _), (b_idx, b_entry, _)| {
+            a_entry
+                .priority
+                .cmp(&b_entry.priority)
+                .then_with(|| a_idx.cmp(b_idx))
+        });
+
+        let mut report = HookExecutionReport::empty();
+        for (registration_index, entry, adapter) in entries {
+            report.started.push(entry.id.clone());
+            let outcome = self
+                .execute_one(entry, adapter, registration_index, invocation.clone())
+                .await?;
+            if let Some(decision) = outcome.decision.clone() {
+                report.decision = Some(decision);
+            }
+            report.outcomes.push(outcome);
+        }
+        Ok(report)
+    }
 }
 
 #[cfg(test)]
@@ -1308,6 +1360,7 @@ mod tests {
                     llm_response: None,
                     tool_call: None,
                     tool_result: None,
+                    observation: None,
                 },
                 None,
             )
@@ -1361,6 +1414,7 @@ mod tests {
                     llm_response: None,
                     tool_call: None,
                     tool_result: None,
+                    observation: None,
                 },
                 None,
             )
@@ -1420,6 +1474,7 @@ mod tests {
                     llm_response: None,
                     tool_call: None,
                     tool_result: None,
+                    observation: None,
                 },
                 None,
             )
@@ -1495,6 +1550,7 @@ mod tests {
                     llm_response: None,
                     tool_call: None,
                     tool_result: None,
+                    observation: None,
                 },
                 None,
             )
@@ -1564,6 +1620,7 @@ mod tests {
                     llm_response: None,
                     tool_call: None,
                     tool_result: None,
+                    observation: None,
                 },
                 None,
             )
@@ -1609,6 +1666,7 @@ mod tests {
                     llm_response: None,
                     tool_call: None,
                     tool_result: None,
+                    observation: None,
                 },
                 None,
             )
@@ -1647,6 +1705,7 @@ mod tests {
                     llm_response: None,
                     tool_call: None,
                     tool_result: None,
+                    observation: None,
                 },
                 None,
             )
@@ -1729,6 +1788,7 @@ mod tests {
                     llm_response: None,
                     tool_call: None,
                     tool_result: None,
+                    observation: None,
                 },
                 None,
             )
@@ -1787,6 +1847,7 @@ mod tests {
                     llm_response: None,
                     tool_call: None,
                     tool_result: None,
+                    observation: None,
                 },
                 None,
             )
@@ -1836,6 +1897,7 @@ mod tests {
                     llm_response: None,
                     tool_call: None,
                     tool_result: None,
+                    observation: None,
                 },
                 None,
             )
@@ -1871,11 +1933,36 @@ mod tests {
                     llm_response: None,
                     tool_call: None,
                     tool_result: None,
+                    observation: None,
                 },
                 None,
             )
             .await
             .expect_err("invalid post background guardrail hook must be rejected");
+
+        assert!(matches!(err, HookEngineError::InvalidConfiguration(_)));
+    }
+
+    #[tokio::test]
+    async fn post_commit_point_rejects_foreground_guardrail_capability() {
+        let mut config = HooksConfig::default();
+        config.entries = vec![HookEntryConfig {
+            id: HookId::new("accepted-input-guardrail"),
+            point: HookPoint::RuntimeInputAccepted,
+            mode: HookExecutionMode::Foreground,
+            capability: HookCapability::Guardrail,
+            runtime: runtime_in_process("guardrail"),
+            ..Default::default()
+        }];
+
+        let engine = DefaultHookEngine::new(config);
+        let err = engine
+            .execute(
+                invocation(HookPoint::RuntimeInputAccepted, SessionId::new()),
+                None,
+            )
+            .await
+            .expect_err("post-commit hook points must reject guardrail capability");
 
         assert!(matches!(err, HookEngineError::InvalidConfiguration(_)));
     }
@@ -1912,6 +1999,7 @@ mod tests {
                     llm_response: None,
                     tool_call: None,
                     tool_result: None,
+                    observation: None,
                 },
                 None,
             )
@@ -2024,6 +2112,7 @@ mod tests {
                     llm_response: None,
                     tool_call: None,
                     tool_result: None,
+                    observation: None,
                 },
                 None,
             )
@@ -2049,6 +2138,7 @@ mod tests {
             llm_response: None,
             tool_call: None,
             tool_result: None,
+            observation: None,
         }
     }
 

--- a/meerkat-mcp-server/src/lib.rs
+++ b/meerkat-mcp-server/src/lib.rs
@@ -3783,20 +3783,16 @@ async fn handle_meerkat_comms_send(
 ) -> Result<Value, ToolCallError> {
     let session_id = meerkat::SessionId::parse(input.session_id())
         .map_err(|err| ToolCallError::invalid_params(invalid_session_id_message(err)))?;
-    let comms = state
-        .service
-        .comms_runtime(&session_id)
-        .await
-        .ok_or_else(|| {
-            ToolCallError::new(
-                -32603,
-                format!("Session not found or comms not enabled: {session_id}"),
-                Some(json!({
-                    "code": "session_not_found_or_comms_disabled",
-                    "session_id": session_id.to_string(),
-                })),
-            )
-        })?;
+    if state.service.comms_runtime(&session_id).await.is_none() {
+        return Err(ToolCallError::new(
+            -32603,
+            format!("Session not found or comms not enabled: {session_id}"),
+            Some(json!({
+                "code": "session_not_found_or_comms_disabled",
+                "session_id": session_id.to_string(),
+            })),
+        ));
+    }
     let peer_name = input.peer_label();
     let cmd = input
         .into_command()
@@ -3811,9 +3807,20 @@ async fn handle_meerkat_comms_send(
                 })),
             )
         })?;
-    let receipt = comms
-        .send(cmd)
+    let receipt = state
+        .service
+        .send_comms(&session_id, cmd)
         .await
+        .ok_or_else(|| {
+            ToolCallError::new(
+                -32603,
+                format!("Session not found or comms not enabled: {session_id}"),
+                Some(json!({
+                    "code": "session_not_found_or_comms_disabled",
+                    "session_id": session_id.to_string(),
+                })),
+            )
+        })?
         .map_err(|e| normalize_mcp_comms_send_error(peer_name.as_deref(), &e))?;
     comms_send_tool_payload(receipt).map_err(ToolCallError::internal)
 }

--- a/meerkat-rest/src/lib.rs
+++ b/meerkat-rest/src/lib.rs
@@ -3346,15 +3346,16 @@ async fn comms_send(
 ) -> Result<Json<CommsSendResult>, ApiError> {
     let session_id = resolve_session_id_for_state(req.session_id(), &state)?;
 
-    let comms = state
+    if state
         .session_service
         .comms_runtime(&session_id)
         .await
-        .ok_or_else(|| {
-            ApiError::NotFound(format!(
-                "Session not found or comms not enabled: {session_id}"
-            ))
-        })?;
+        .is_none()
+    {
+        return Err(ApiError::NotFound(format!(
+            "Session not found or comms not enabled: {session_id}"
+        )));
+    }
 
     let peer_name = req.peer_label();
     let cmd = req
@@ -3362,9 +3363,12 @@ async fn comms_send(
         .into_command(&session_id)
         .map_err(|err| ApiError::BadRequest(err.to_string()))?;
 
-    match comms.send(cmd).await {
-        Ok(receipt) => Ok(Json(CommsSendResult::from(receipt))),
-        Err(e) => Err(normalize_rest_comms_send_error(peer_name.as_deref(), &e)),
+    match state.session_service.send_comms(&session_id, cmd).await {
+        Some(Ok(receipt)) => Ok(Json(CommsSendResult::from(receipt))),
+        Some(Err(e)) => Err(normalize_rest_comms_send_error(peer_name.as_deref(), &e)),
+        None => Err(ApiError::NotFound(format!(
+            "Session not found or comms not enabled: {session_id}"
+        ))),
     }
 }
 

--- a/meerkat-rpc/src/handlers/comms.rs
+++ b/meerkat-rpc/src/handlers/comms.rs
@@ -94,8 +94,8 @@ pub async fn handle_send(
         Err(resp) => return resp,
     };
 
-    let comms = match runtime.comms_runtime(&session_id).await {
-        Some(c) => c,
+    match runtime.comms_runtime(&session_id).await {
+        Some(_) => {}
         None => {
             return RpcResponse::error(
                 id,
@@ -128,8 +128,8 @@ pub async fn handle_send(
         }
     };
 
-    match comms.send(cmd).await {
-        Ok(receipt) => match send_receipt_json(receipt) {
+    match runtime.send_comms(&session_id, cmd).await {
+        Some(Ok(receipt)) => match send_receipt_json(receipt) {
             Ok(value) => RpcResponse::success(id, value),
             Err(serialize_error) => RpcResponse::error(
                 id,
@@ -137,7 +137,7 @@ pub async fn handle_send(
                 format!("failed to serialize comms send receipt: {serialize_error}"),
             ),
         },
-        Err(e) => {
+        Some(Err(e)) => {
             let normalized = normalize_send_error(peer_name.as_deref(), &e);
             let message = normalized.message().to_string();
             match serde_json::to_value(&normalized) {
@@ -149,6 +149,11 @@ pub async fn handle_send(
                 ),
             }
         }
+        None => RpcResponse::error(
+            id,
+            error::INVALID_PARAMS,
+            format!("Session not found or comms not enabled: {session_id}"),
+        ),
     }
 }
 

--- a/meerkat-rpc/src/session_runtime.rs
+++ b/meerkat-rpc/src/session_runtime.rs
@@ -10638,6 +10638,14 @@ impl SessionRuntime {
         self.service.comms_runtime(session_id).await
     }
 
+    pub async fn send_comms(
+        &self,
+        session_id: &meerkat_core::SessionId,
+        command: meerkat_core::CommsCommand,
+    ) -> Option<Result<meerkat_core::SendReceipt, meerkat_core::SendError>> {
+        self.service.send_comms(session_id, command).await
+    }
+
     /// Shut down the runtime, closing all sessions.
     pub async fn shutdown(&self) {
         // Clear pending sessions.

--- a/meerkat-runtime/src/hook_observation.rs
+++ b/meerkat-runtime/src/hook_observation.rs
@@ -1,0 +1,194 @@
+use meerkat_core::{
+    HookObservation, HookPeerIngressCommitted, HookRuntimeInputAccepted,
+    HookRuntimeInputDeduplicated, HookRuntimeInputKind, HookRuntimeInputRejected,
+    HookRuntimeInputRejection, HookRuntimeState, PostCommitHookDispatcher,
+};
+
+use crate::accept::{AcceptOutcome, RejectReason, handling_mode_from_policy};
+use crate::identifiers::InputKind;
+use crate::input::{Input, InputOrigin, PeerConvention};
+use crate::runtime_state::RuntimeState;
+use crate::traits::RuntimeDriverError;
+
+pub(crate) struct RuntimeInputHookFacts {
+    input_id: meerkat_core::lifecycle::InputId,
+    input_kind: HookRuntimeInputKind,
+    peer_ingress: Option<HookPeerIngressCommitted>,
+}
+
+impl RuntimeInputHookFacts {
+    pub(crate) fn from_input(input: &Input) -> Self {
+        Self {
+            input_id: input.id().clone(),
+            input_kind: input.kind().into(),
+            peer_ingress: peer_ingress_observation(input),
+        }
+    }
+}
+
+fn peer_ingress_observation(input: &Input) -> Option<HookPeerIngressCommitted> {
+    let Input::Peer(peer_input) = input else {
+        return None;
+    };
+    let InputOrigin::Peer {
+        peer_id,
+        display_identity,
+        ..
+    } = &peer_input.header.source
+    else {
+        return None;
+    };
+    let peer = match meerkat_core::comms::PeerId::parse(peer_id) {
+        Ok(id) => Some(meerkat_core::types::SystemNoticePeer {
+            id,
+            display_name: display_identity.clone(),
+        }),
+        Err(error) => {
+            tracing::warn!(
+                %peer_id,
+                %error,
+                "committed peer ingress carried no parseable canonical peer identity"
+            );
+            None
+        }
+    };
+    let (kind, request_id) = match &peer_input.convention {
+        Some(PeerConvention::Request { request_id, .. }) => (
+            meerkat_core::types::CommsNoticeKind::Request,
+            Some(request_id.clone()),
+        ),
+        Some(PeerConvention::ResponseProgress { request_id, .. }) => (
+            meerkat_core::types::CommsNoticeKind::ResponseProgress,
+            Some(request_id.clone()),
+        ),
+        Some(PeerConvention::ResponseTerminal { request_id, .. }) => (
+            meerkat_core::types::CommsNoticeKind::ResponseTerminal,
+            Some(request_id.clone()),
+        ),
+        Some(PeerConvention::Message) | None => {
+            (meerkat_core::types::CommsNoticeKind::Message, None)
+        }
+    };
+    Some(HookPeerIngressCommitted {
+        kind,
+        peer,
+        request_id,
+        sender_taint: peer_input.sender_taint,
+    })
+}
+
+impl From<InputKind> for HookRuntimeInputKind {
+    fn from(kind: InputKind) -> Self {
+        match kind {
+            InputKind::Prompt => Self::Prompt,
+            InputKind::PeerMessage => Self::PeerMessage,
+            InputKind::PeerRequest => Self::PeerRequest,
+            InputKind::PeerResponseProgress => Self::PeerResponseProgress,
+            InputKind::PeerResponseTerminal => Self::PeerResponseTerminal,
+            InputKind::FlowStep => Self::FlowStep,
+            InputKind::ExternalEvent => Self::ExternalEvent,
+            InputKind::Continuation => Self::Continuation,
+            InputKind::Operation => Self::Operation,
+        }
+    }
+}
+
+impl From<RuntimeState> for HookRuntimeState {
+    fn from(state: RuntimeState) -> Self {
+        match state {
+            RuntimeState::Initializing => Self::Initializing,
+            RuntimeState::Idle => Self::Idle,
+            RuntimeState::Attached => Self::Attached,
+            RuntimeState::Running => Self::Running,
+            RuntimeState::Retired => Self::Retired,
+            RuntimeState::Stopped => Self::Stopped,
+            RuntimeState::Destroyed => Self::Destroyed,
+        }
+    }
+}
+
+impl From<&RejectReason> for HookRuntimeInputRejection {
+    fn from(reason: &RejectReason) -> Self {
+        match reason {
+            RejectReason::NotReady { state } => Self::NotReady {
+                state: (*state).into(),
+            },
+            RejectReason::DurabilityViolation { detail } => Self::DurabilityViolation {
+                detail: detail.clone(),
+            },
+            RejectReason::PeerHandlingModeInvalid { detail } => Self::PeerHandlingModeInvalid {
+                detail: detail.clone(),
+            },
+            RejectReason::PeerResponseTerminalInvalid { detail } => {
+                Self::PeerResponseTerminalInvalid {
+                    detail: detail.clone(),
+                }
+            }
+        }
+    }
+}
+
+pub(crate) fn dispatch_runtime_input_outcome(
+    dispatcher: &PostCommitHookDispatcher,
+    input: &RuntimeInputHookFacts,
+    outcome: &AcceptOutcome,
+) {
+    let observation = match outcome {
+        AcceptOutcome::Accepted {
+            input_id, policy, ..
+        } => HookObservation::RuntimeInputAccepted(HookRuntimeInputAccepted {
+            input_id: input_id.clone(),
+            input_kind: input.input_kind,
+            handling_mode: handling_mode_from_policy(policy),
+        }),
+        AcceptOutcome::Deduplicated {
+            input_id,
+            existing_id,
+            ..
+        } => HookObservation::RuntimeInputDeduplicated(HookRuntimeInputDeduplicated {
+            input_id: input_id.clone(),
+            input_kind: input.input_kind,
+            existing_input_id: existing_id.clone(),
+        }),
+        AcceptOutcome::Rejected { reason } => {
+            HookObservation::RuntimeInputRejected(HookRuntimeInputRejected {
+                input_id: input.input_id.clone(),
+                input_kind: input.input_kind,
+                reason: reason.into(),
+            })
+        }
+    };
+    let accepted = matches!(outcome, AcceptOutcome::Accepted { .. });
+    dispatcher.dispatch(observation);
+    if accepted && let Some(peer_ingress) = input.peer_ingress.clone() {
+        dispatcher.dispatch(HookObservation::PeerIngressCommitted(peer_ingress));
+    }
+}
+
+pub(crate) fn dispatch_runtime_input_error(
+    dispatcher: &PostCommitHookDispatcher,
+    input: &RuntimeInputHookFacts,
+    error: &RuntimeDriverError,
+) {
+    let reason = match error {
+        RuntimeDriverError::NotReady { state } => HookRuntimeInputRejection::NotReady {
+            state: (*state).into(),
+        },
+        RuntimeDriverError::Destroyed => HookRuntimeInputRejection::NotReady {
+            state: HookRuntimeState::Destroyed,
+        },
+        RuntimeDriverError::ValidationFailed { reason } => {
+            HookRuntimeInputRejection::ValidationFailed {
+                detail: reason.clone(),
+            }
+        }
+        _ => return,
+    };
+    dispatcher.dispatch(HookObservation::RuntimeInputRejected(
+        HookRuntimeInputRejected {
+            input_id: input.input_id.clone(),
+            input_kind: input.input_kind,
+            reason,
+        },
+    ));
+}

--- a/meerkat-runtime/src/lib.rs
+++ b/meerkat-runtime/src/lib.rs
@@ -56,6 +56,7 @@ pub mod exact_operation;
 #[doc(hidden)]
 pub mod generated;
 pub mod handles;
+mod hook_observation;
 pub mod identifiers;
 pub mod ingress_types;
 pub mod input;

--- a/meerkat-runtime/src/meerkat_machine/dispatch_control.rs
+++ b/meerkat-runtime/src/meerkat_machine/dispatch_control.rs
@@ -326,6 +326,7 @@ impl MeerkatMachine {
                     active_runtime_generation,
                     active_runtime_epoch_id,
                     publication_handle,
+                    post_commit_hooks,
                 ) = {
                     let sessions = self.sessions.read().await;
                     let entry = sessions.get(&session_id).ok_or(
@@ -363,8 +364,10 @@ impl MeerkatMachine {
                         generation,
                         epoch,
                         entry.publication_handle(),
+                        Arc::clone(&entry.post_commit_hooks),
                     )
                 };
+                let hook_input = crate::hook_observation::RuntimeInputHookFacts::from_input(&input);
 
                 // Use the canonical admission input id (the id the `Input`
                 // already carries, which admission reports back verbatim as
@@ -587,6 +590,11 @@ impl MeerkatMachine {
                         accepted_input_id,
                     )
                 };
+                crate::hook_observation::dispatch_runtime_input_outcome(
+                    &post_commit_hooks,
+                    &hook_input,
+                    &outcome,
+                );
 
                 let live_boundary_plan = if signal.should_interrupt_yielding()
                     && stages_run_boundary

--- a/meerkat-runtime/src/meerkat_machine/dispatch_control.rs
+++ b/meerkat-runtime/src/meerkat_machine/dispatch_control.rs
@@ -397,12 +397,26 @@ impl MeerkatMachine {
                     .preview_session_dsl_input(&session_id, ingest_input.clone(), "Ingest")
                     .await
                 {
-                    return Err(
-                        match self.existing_session_runtime_state(&session_id).await {
-                            Some(state) => RuntimeControlPlaneError::InvalidState { state },
-                            None => RuntimeControlPlaneError::Internal(reason),
-                        },
-                    );
+                    return match self.existing_session_runtime_state(&session_id).await {
+                        Some(state) => {
+                            crate::hook_observation::dispatch_runtime_input_error(
+                                &post_commit_hooks,
+                                &hook_input,
+                                &RuntimeDriverError::NotReady { state },
+                            );
+                            Err(RuntimeControlPlaneError::InvalidState { state })
+                        }
+                        None => {
+                            crate::hook_observation::dispatch_runtime_input_error(
+                                &post_commit_hooks,
+                                &hook_input,
+                                &RuntimeDriverError::ValidationFailed {
+                                    reason: reason.clone(),
+                                },
+                            );
+                            Err(RuntimeControlPlaneError::Internal(reason))
+                        }
+                    };
                 }
                 // Acquire process-owned execution before the first durable
                 // mutation. A committed admission must never be reported as

--- a/meerkat-runtime/src/meerkat_machine/dispatch_ingress.rs
+++ b/meerkat-runtime/src/meerkat_machine/dispatch_ingress.rs
@@ -1072,6 +1072,7 @@ impl MeerkatMachine {
                     Some(guard) => Some(guard),
                     None => Some(Arc::clone(&gate).lock_owned().await),
                 };
+                let hook_input = crate::hook_observation::RuntimeInputHookFacts::from_input(&input);
                 let (
                     wake_tx,
                     effect_tx,
@@ -1079,6 +1080,7 @@ impl MeerkatMachine {
                     attachment_id,
                     dsl_authority,
                     publication_handle,
+                    post_commit_hooks,
                 ) = {
                     let sessions = self.sessions.read().await;
                     let entry =
@@ -1128,6 +1130,7 @@ impl MeerkatMachine {
                         entry.live_attachment_id(),
                         Arc::clone(&entry.dsl_authority),
                         entry.publication_handle(),
+                        Arc::clone(&entry.post_commit_hooks),
                     )
                 };
                 tracing::debug!(
@@ -1156,11 +1159,36 @@ impl MeerkatMachine {
                     visible_state = ?visible_state,
                     "MeerkatMachine::AcceptWithCompletion read runtime state"
                 );
-                Self::reject_visible_terminal_ingress(visible_state)?;
-                self.reject_unregistration_drain_ingress(&session_id, state)
-                    .await?;
-                self.require_directed_terminal_publication_capability(&session_id, &input)
-                    .await?;
+                if let Err(error) = Self::reject_visible_terminal_ingress(visible_state) {
+                    crate::hook_observation::dispatch_runtime_input_error(
+                        &post_commit_hooks,
+                        &hook_input,
+                        &error,
+                    );
+                    return Err(error);
+                }
+                if let Err(error) = self
+                    .reject_unregistration_drain_ingress(&session_id, state)
+                    .await
+                {
+                    crate::hook_observation::dispatch_runtime_input_error(
+                        &post_commit_hooks,
+                        &hook_input,
+                        &error,
+                    );
+                    return Err(error);
+                }
+                if let Err(error) = self
+                    .require_directed_terminal_publication_capability(&session_id, &input)
+                    .await
+                {
+                    crate::hook_observation::dispatch_runtime_input_error(
+                        &post_commit_hooks,
+                        &hook_input,
+                        &error,
+                    );
+                    return Err(error);
+                }
                 // Acquire process-owned execution before mutating either the
                 // driver or generated DSL. Once admission commits, handing
                 // actor-bound work off must be infallible.
@@ -1217,10 +1245,20 @@ impl MeerkatMachine {
                         active_turn_boundary_available,
                         "resolving runtime ingress admission via canonical machine seam"
                     );
-                    let resolved = driver.resolve_admission_with_active_turn_boundary(
+                    let resolved = match driver.resolve_admission_with_active_turn_boundary(
                         &input,
                         active_turn_boundary_available,
-                    )?;
+                    ) {
+                        Ok(resolved) => resolved,
+                        Err(error) => {
+                            crate::hook_observation::dispatch_runtime_input_error(
+                                &post_commit_hooks,
+                                &hook_input,
+                                &error,
+                            );
+                            return Err(error);
+                        }
+                    };
                     let flags = resolved.coarse_flags();
                     let stages_run_boundary = resolved.stages_run_boundary();
                     self.preview_session_dsl_input(
@@ -1327,6 +1365,11 @@ impl MeerkatMachine {
                             }
                         }
                         AcceptOutcome::Rejected { reason } => {
+                            crate::hook_observation::dispatch_runtime_input_outcome(
+                                &post_commit_hooks,
+                                &hook_input,
+                                &result,
+                            );
                             return Err(RuntimeDriverError::ValidationFailed {
                                 reason: reason.to_string(),
                             });
@@ -1436,6 +1479,11 @@ impl MeerkatMachine {
                 } else {
                     (signal, None)
                 };
+                crate::hook_observation::dispatch_runtime_input_outcome(
+                    &post_commit_hooks,
+                    &hook_input,
+                    &outcome,
+                );
 
                 let live_boundary_plan = if signal.should_interrupt_yielding()
                     && stages_run_boundary
@@ -1489,7 +1537,7 @@ impl MeerkatMachine {
                 })
             }
             MeerkatMachineCommand::AcceptWithoutWake { session_id, input } => {
-                let (driver, completions, mutation_gate, publication_handle) = {
+                let (driver, completions, mutation_gate, publication_handle, post_commit_hooks) = {
                     let sessions = self.sessions.read().await;
                     let entry = sessions
                         .get(&session_id)
@@ -1501,8 +1549,10 @@ impl MeerkatMachine {
                         entry.completions.clone(),
                         Arc::clone(&entry.mutation_gate),
                         entry.publication_handle(),
+                        Arc::clone(&entry.post_commit_hooks),
                     )
                 };
+                let hook_input = crate::hook_observation::RuntimeInputHookFacts::from_input(&input);
                 let gate_guard = self
                     .lock_current_session_driver_gate(&session_id, &driver)
                     .await?;
@@ -1515,26 +1565,71 @@ impl MeerkatMachine {
                     .existing_session_visible_runtime_state(&session_id)
                     .await
                     .unwrap_or(RuntimeState::Destroyed);
-                Self::reject_visible_terminal_ingress(visible_state)?;
-                self.reject_unregistration_drain_ingress(&session_id, state)
-                    .await?;
-                self.require_directed_terminal_publication_capability(&session_id, &input)
-                    .await?;
+                if let Err(error) = Self::reject_visible_terminal_ingress(visible_state) {
+                    crate::hook_observation::dispatch_runtime_input_error(
+                        &post_commit_hooks,
+                        &hook_input,
+                        &error,
+                    );
+                    return Err(error);
+                }
+                if let Err(error) = self
+                    .reject_unregistration_drain_ingress(&session_id, state)
+                    .await
+                {
+                    crate::hook_observation::dispatch_runtime_input_error(
+                        &post_commit_hooks,
+                        &hook_input,
+                        &error,
+                    );
+                    return Err(error);
+                }
+                if let Err(error) = self
+                    .require_directed_terminal_publication_capability(&session_id, &input)
+                    .await
+                {
+                    crate::hook_observation::dispatch_runtime_input_error(
+                        &post_commit_hooks,
+                        &hook_input,
+                        &error,
+                    );
+                    return Err(error);
+                }
                 let (outcome, accepted_input_id) = {
                     let mut driver = driver.lock().await;
-                    let resolved = driver
-                        .resolve_admission_without_wake_with_active_turn_boundary(&input, false)?;
-                    self.preview_session_dsl_input(
-                        &session_id,
-                        crate::meerkat_machine::dsl::MeerkatMachineInput::AcceptWithoutWake {
-                            input_id: crate::meerkat_machine::dsl::InputId::from_domain(
-                                &InputId::new(),
-                            ),
-                        },
-                        "AcceptWithoutWake",
-                    )
-                    .await
-                    .map_err(|reason| Self::classify_ingress_dsl_rejection(state, reason))?;
+                    let resolved = match driver
+                        .resolve_admission_without_wake_with_active_turn_boundary(&input, false)
+                    {
+                        Ok(resolved) => resolved,
+                        Err(error) => {
+                            crate::hook_observation::dispatch_runtime_input_error(
+                                &post_commit_hooks,
+                                &hook_input,
+                                &error,
+                            );
+                            return Err(error);
+                        }
+                    };
+                    let preview = self
+                        .preview_session_dsl_input(
+                            &session_id,
+                            crate::meerkat_machine::dsl::MeerkatMachineInput::AcceptWithoutWake {
+                                input_id: crate::meerkat_machine::dsl::InputId::from_domain(
+                                    &InputId::new(),
+                                ),
+                            },
+                            "AcceptWithoutWake",
+                        )
+                        .await
+                        .map_err(|reason| Self::classify_ingress_dsl_rejection(state, reason));
+                    if let Err(error) = preview {
+                        crate::hook_observation::dispatch_runtime_input_error(
+                            &post_commit_hooks,
+                            &hook_input,
+                            &error,
+                        );
+                        return Err(error);
+                    }
                     let result = match driver
                         .accept_resolved_input(input, resolved)
                         .await
@@ -1544,6 +1639,11 @@ impl MeerkatMachine {
                         Err(err) => return Err(err),
                     };
                     if let AcceptOutcome::Rejected { reason } = &result {
+                        crate::hook_observation::dispatch_runtime_input_outcome(
+                            &post_commit_hooks,
+                            &hook_input,
+                            &result,
+                        );
                         return Err(RuntimeDriverError::ValidationFailed {
                             reason: reason.to_string(),
                         });
@@ -1609,6 +1709,11 @@ impl MeerkatMachine {
                                             %terminalization_error,
                                             "AcceptWithoutWake DSL publication failed and exact terminal transfer failed; returning accepted authority"
                                         );
+                                        crate::hook_observation::dispatch_runtime_input_outcome(
+                                            &post_commit_hooks,
+                                            &hook_input,
+                                            &outcome,
+                                        );
                                         return Ok(MeerkatMachineCommandResult::AcceptOutcome(
                                             outcome,
                                         ));
@@ -1633,6 +1738,11 @@ impl MeerkatMachine {
                     );
                 }
 
+                crate::hook_observation::dispatch_runtime_input_outcome(
+                    &post_commit_hooks,
+                    &hook_input,
+                    &outcome,
+                );
                 Ok(MeerkatMachineCommandResult::AcceptOutcome(outcome))
             }
             _ => unreachable!("non-ingress command routed to ingress handler"),

--- a/meerkat-runtime/src/meerkat_machine/dispatch_session.rs
+++ b/meerkat-runtime/src/meerkat_machine/dispatch_session.rs
@@ -1372,6 +1372,7 @@ impl MeerkatMachine {
         epoch_id: meerkat_core::RuntimeEpochId,
         ops_lifecycle: Arc<crate::ops_lifecycle::RuntimeOpsLifecycleRegistry>,
         cursor_state: Arc<meerkat_core::EpochCursorState>,
+        post_commit_hooks: Arc<meerkat_core::PostCommitHookDispatcher>,
         tool_visibility_owner: Arc<MachineToolVisibilityOwner>,
         dsl_authority_shared: Arc<std::sync::Mutex<dsl::MeerkatMachineAuthority>>,
         handle_teardown_gate: Arc<crate::handles::HandleTeardownGate>,
@@ -1454,6 +1455,7 @@ impl MeerkatMachine {
                     dsl_authority: shared_handle_authority,
                     store: self.store.clone(),
                 }),
+                post_commit_hooks,
                 runtime_authority,
             ),
         )
@@ -1477,7 +1479,7 @@ impl MeerkatMachine {
         allow_late_compaction_binding: bool,
         runtime_authority: Arc<dyn std::any::Any + Send + Sync>,
     ) -> Result<meerkat_core::SessionRuntimeBindings, RuntimeDriverError> {
-        let (cached, durability_health) = {
+        let (cached, durability_health, post_commit_hooks) = {
             let sessions = self.sessions.read().await;
             let entry = sessions
                 .get(&session_id)
@@ -1500,6 +1502,7 @@ impl MeerkatMachine {
             (
                 entry.canonical_runtime_bindings.clone(),
                 entry.durability_health.clone(),
+                Arc::clone(&entry.post_commit_hooks),
             )
         };
         if let Some(cached) = cached {
@@ -1511,6 +1514,7 @@ impl MeerkatMachine {
             epoch_id.clone(),
             Arc::clone(&ops_lifecycle),
             Arc::clone(&cursor_state),
+            post_commit_hooks,
             Arc::clone(&tool_visibility_owner),
             Arc::clone(&dsl_authority_shared),
             Arc::clone(&handle_teardown_gate),

--- a/meerkat-runtime/src/meerkat_machine/mod.rs
+++ b/meerkat-runtime/src/meerkat_machine/mod.rs
@@ -4434,7 +4434,6 @@ impl RuntimeSessionEntry {
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner);
         self.handle_teardown_gate.close();
-        self.post_commit_hooks.shutdown();
     }
 
     /// True while the runtime-loop executor registration is `Active` *or*

--- a/meerkat-runtime/src/meerkat_machine/mod.rs
+++ b/meerkat-runtime/src/meerkat_machine/mod.rs
@@ -1395,6 +1395,8 @@ struct RuntimeSessionEntry {
         Arc<std::sync::Mutex<crate::RuntimeActorMaterializationClaimState>>,
     /// Shared consumer cursor state for the epoch.
     cursor_state: Arc<meerkat_core::EpochCursorState>,
+    /// Observe-only hook dispatcher for facts committed by this session.
+    post_commit_hooks: Arc<meerkat_core::PostCommitHookDispatcher>,
     /// Completion waiters (accessed by accept_input_with_completion and RuntimeLoop).
     completions: SharedCompletionRegistry,
     /// Canonical durable visibility owner for this session.
@@ -4432,6 +4434,7 @@ impl RuntimeSessionEntry {
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner);
         self.handle_teardown_gate.close();
+        self.post_commit_hooks.shutdown();
     }
 
     /// True while the runtime-loop executor registration is `Active` *or*
@@ -4773,6 +4776,17 @@ impl RuntimeSessionEntry {
 }
 
 impl MeerkatMachine {
+    pub(crate) async fn post_commit_hooks_for_session(
+        &self,
+        session_id: &SessionId,
+    ) -> Option<Arc<meerkat_core::PostCommitHookDispatcher>> {
+        self.sessions
+            .read()
+            .await
+            .get(session_id)
+            .map(|entry| Arc::clone(&entry.post_commit_hooks))
+    }
+
     /// How many registered sessions currently refuse execution because their
     /// durability gate demands a cold reload.
     ///

--- a/meerkat-runtime/src/meerkat_machine/session_management.rs
+++ b/meerkat-runtime/src/meerkat_machine/session_management.rs
@@ -9152,6 +9152,9 @@ impl MeerkatMachine {
                 return Ok(());
             }
             let removed_entry = sessions.remove(session_id);
+            if let Some(entry) = removed_entry.as_ref() {
+                entry.post_commit_hooks.shutdown();
+            }
             drop(sessions);
             drop(mutation_guard);
             #[cfg(feature = "live")]

--- a/meerkat-runtime/src/meerkat_machine/session_management.rs
+++ b/meerkat-runtime/src/meerkat_machine/session_management.rs
@@ -1768,6 +1768,9 @@ impl MeerkatMachine {
                 ))
             }),
             cursor_state,
+            post_commit_hooks: Arc::new(meerkat_core::PostCommitHookDispatcher::new(
+                session_id.clone(),
+            )),
             completions: Arc::new(Mutex::new(crate::completion::CompletionRegistry::new())),
             tool_visibility_owner,
             canonical_runtime_bindings: None,
@@ -1947,6 +1950,9 @@ impl MeerkatMachine {
                 ))
             }),
             cursor_state,
+            post_commit_hooks: Arc::new(meerkat_core::PostCommitHookDispatcher::new(
+                session_id.clone(),
+            )),
             completions: Arc::new(Mutex::new(crate::completion::CompletionRegistry::new())),
             tool_visibility_owner,
             canonical_runtime_bindings: None,
@@ -2161,6 +2167,9 @@ impl MeerkatMachine {
                 ))
             }),
             cursor_state,
+            post_commit_hooks: Arc::new(meerkat_core::PostCommitHookDispatcher::new(
+                session_id.clone(),
+            )),
             completions: Arc::new(Mutex::new(crate::completion::CompletionRegistry::new())),
             tool_visibility_owner,
             canonical_runtime_bindings: None,
@@ -4002,6 +4011,9 @@ impl MeerkatMachine {
                             crate::RuntimeActorMaterializationClaimState::new(false),
                         )),
                         cursor_state: recovered_cursors,
+                        post_commit_hooks: Arc::new(meerkat_core::PostCommitHookDispatcher::new(
+                            session_id.clone(),
+                        )),
                         completions: completions.clone(),
                         tool_visibility_owner,
                         canonical_runtime_bindings: None,

--- a/meerkat-runtime/src/meerkat_machine/traits.rs
+++ b/meerkat-runtime/src/meerkat_machine/traits.rs
@@ -1677,6 +1677,9 @@ impl MeerkatMachine {
             }
             sessions.remove(session_id)
         };
+        if let Some(entry) = removed.as_ref() {
+            entry.post_commit_hooks.shutdown();
+        }
         drop(removed);
         Ok(())
     }

--- a/meerkat-runtime/src/meerkat_machine_tests.rs
+++ b/meerkat-runtime/src/meerkat_machine_tests.rs
@@ -31104,6 +31104,146 @@ async fn spine_invariants_hold_after_queued_input() {
         .expect("all invariants should hold after queued input");
 }
 
+struct RecordingPostCommitHookEngine {
+    sender: tokio::sync::mpsc::UnboundedSender<meerkat_core::HookInvocation>,
+}
+
+#[async_trait::async_trait]
+impl meerkat_core::HookEngine for RecordingPostCommitHookEngine {
+    async fn execute(
+        &self,
+        invocation: meerkat_core::HookInvocation,
+        _overrides: Option<&meerkat_core::HookRunOverrides>,
+    ) -> Result<meerkat_core::HookExecutionReport, meerkat_core::HookEngineError> {
+        let _ = self.sender.send(invocation);
+        Ok(meerkat_core::HookExecutionReport::empty())
+    }
+}
+
+#[tokio::test]
+async fn runtime_input_hooks_follow_committed_accept_dedup_and_reject_outcomes() {
+    let adapter = Arc::new(MeerkatMachine::ephemeral());
+    let session_id = SessionId::new();
+    let bindings = adapter
+        .prepare_bindings(session_id.clone())
+        .await
+        .expect("prepare runtime bindings");
+    let (sender, mut receiver) = tokio::sync::mpsc::unbounded_channel();
+    bindings.post_commit_hooks().configure(
+        Some(Arc::new(RecordingPostCommitHookEngine { sender })),
+        meerkat_core::HookRunOverrides::default(),
+    );
+
+    let mut first = crate::input::PromptInput::new("first", None);
+    first.header.idempotency_key = Some(crate::IdempotencyKey::new("same-input"));
+    let (accepted, _) = adapter
+        .accept_input_with_completion(&session_id, Input::Prompt(first))
+        .await
+        .expect("first input should commit");
+    assert!(matches!(accepted, crate::AcceptOutcome::Accepted { .. }));
+
+    let mut duplicate = crate::input::PromptInput::new("duplicate", None);
+    duplicate.header.idempotency_key = Some(crate::IdempotencyKey::new("same-input"));
+    let (deduplicated, _) = adapter
+        .accept_input_with_completion(&session_id, Input::Prompt(duplicate))
+        .await
+        .expect("duplicate input should resolve");
+    assert!(matches!(
+        deduplicated,
+        crate::AcceptOutcome::Deduplicated { .. }
+    ));
+
+    let peer_id = meerkat_core::comms::PeerId::new();
+    let valid_peer = Input::Peer(crate::input::PeerInput {
+        header: crate::input::InputHeader {
+            id: meerkat_core::InputId::new(),
+            timestamp: chrono::Utc::now(),
+            source: crate::input::InputOrigin::Peer {
+                peer_id: peer_id.to_string(),
+                display_identity: Some("reviewer".to_string()),
+                runtime_id: None,
+            },
+            durability: crate::input::InputDurability::Durable,
+            visibility: crate::input::InputVisibility::default(),
+            idempotency_key: None,
+            supersession_key: None,
+            correlation_id: None,
+        },
+        directed_interaction_id: None,
+        convention: Some(crate::input::PeerConvention::Message),
+        content: meerkat_core::ContentInput::Text("peer input".to_string()),
+        payload: None,
+        handling_mode: Some(meerkat_core::HandlingMode::Queue),
+        sender_taint: Some(meerkat_core::SenderContentTaint::Tainted),
+        objective_id: None,
+        system_prompts: Vec::new(),
+        injected_context: Vec::new(),
+    });
+    let (peer_accepted, _) = adapter
+        .accept_input_with_completion(&session_id, valid_peer)
+        .await
+        .expect("peer input should commit");
+    assert!(matches!(
+        peer_accepted,
+        crate::AcceptOutcome::Accepted { .. }
+    ));
+
+    let invalid_peer = Input::Peer(crate::input::PeerInput {
+        header: crate::input::InputHeader {
+            id: meerkat_core::InputId::new(),
+            timestamp: chrono::Utc::now(),
+            source: crate::input::InputOrigin::Peer {
+                peer_id: meerkat_core::comms::PeerId::new().to_string(),
+                display_identity: None,
+                runtime_id: None,
+            },
+            durability: crate::input::InputDurability::Durable,
+            visibility: crate::input::InputVisibility::default(),
+            idempotency_key: None,
+            supersession_key: None,
+            correlation_id: None,
+        },
+        directed_interaction_id: None,
+        convention: Some(crate::input::PeerConvention::ResponseProgress {
+            request_id: uuid::Uuid::new_v4().to_string(),
+            phase: meerkat_core::PeerResponseProgressProjectionPhase::InProgress,
+        }),
+        content: meerkat_core::ContentInput::Text(String::new()),
+        payload: None,
+        handling_mode: Some(meerkat_core::HandlingMode::Queue),
+        sender_taint: None,
+        objective_id: None,
+        system_prompts: Vec::new(),
+        injected_context: Vec::new(),
+    });
+    adapter
+        .accept_input_with_completion(&session_id, invalid_peer)
+        .await
+        .expect_err("progress response with handling mode must reject");
+
+    let mut points = Vec::new();
+    for _ in 0..5 {
+        let invocation = tokio::time::timeout(std::time::Duration::from_secs(1), receiver.recv())
+            .await
+            .expect("post-commit hook dispatch should not stall")
+            .expect("hook dispatcher remains connected");
+        points.push(invocation.point);
+    }
+    assert_eq!(
+        points
+            .iter()
+            .filter(|point| **point == meerkat_core::HookPoint::RuntimeInputAccepted)
+            .count(),
+        2
+    );
+    assert!(points.contains(&meerkat_core::HookPoint::RuntimeInputDeduplicated));
+    assert!(points.contains(&meerkat_core::HookPoint::RuntimeInputRejected));
+    assert!(
+        points.contains(&meerkat_core::HookPoint::PeerIngressCommitted),
+        "accepted peer input must emit its committed ingress projection"
+    );
+}
+
 #[tokio::test]
 async fn spine_invariants_hold_after_destroy() {
     let adapter = Arc::new(MeerkatMachine::ephemeral());

--- a/meerkat-runtime/src/meerkat_machine_tests.rs
+++ b/meerkat-runtime/src/meerkat_machine_tests.rs
@@ -31245,6 +31245,55 @@ async fn runtime_input_hooks_follow_committed_accept_dedup_and_reject_outcomes()
 }
 
 #[tokio::test]
+async fn direct_ingest_retired_rejection_emits_typed_not_ready_hook() {
+    let adapter = Arc::new(MeerkatMachine::ephemeral());
+    let session_id = SessionId::new();
+    let bindings = adapter
+        .prepare_bindings(session_id.clone())
+        .await
+        .expect("prepare runtime bindings");
+    let (sender, mut receiver) = tokio::sync::mpsc::unbounded_channel();
+    bindings.post_commit_hooks().configure(
+        Some(Arc::new(RecordingPostCommitHookEngine { sender })),
+        meerkat_core::HookRunOverrides::default(),
+    );
+    let runtime_id = runtime_id_for_session(&session_id);
+    crate::traits::RuntimeControlPlane::retire(adapter.as_ref(), &runtime_id)
+        .await
+        .expect("retire empty runtime");
+
+    let error = crate::traits::RuntimeControlPlane::ingest(
+        adapter.as_ref(),
+        &runtime_id,
+        make_prompt("must reject"),
+    )
+    .await
+    .expect_err("retired runtime must reject direct ingest");
+    assert!(matches!(
+        error,
+        crate::RuntimeControlPlaneError::InvalidState {
+            state: RuntimeState::Retired
+        }
+    ));
+
+    let hook = tokio::time::timeout(std::time::Duration::from_secs(1), receiver.recv())
+        .await
+        .expect("rejection hook should dispatch")
+        .expect("hook dispatcher remains connected");
+    assert!(matches!(
+        hook.observation,
+        Some(meerkat_core::HookObservation::RuntimeInputRejected(
+            meerkat_core::HookRuntimeInputRejected {
+                reason: meerkat_core::HookRuntimeInputRejection::NotReady {
+                    state: meerkat_core::HookRuntimeState::Retired
+                },
+                ..
+            }
+        ))
+    ));
+}
+
+#[tokio::test]
 async fn spine_invariants_hold_after_destroy() {
     let adapter = Arc::new(MeerkatMachine::ephemeral());
     let session_id = SessionId::new();

--- a/meerkat-runtime/src/runtime_loop.rs
+++ b/meerkat-runtime/src/runtime_loop.rs
@@ -760,6 +760,7 @@ impl InteractionTerminalPublicationError {
 #[allow(clippy::too_many_arguments)]
 async fn finalize_publish_and_resolve_runtime_terminals(
     driver: &crate::meerkat_machine::SharedDriver,
+    post_commit_hooks: &std::sync::Arc<meerkat_core::PostCommitHookDispatcher>,
     completions: Option<&crate::meerkat_machine::SharedCompletionRegistry>,
     authority_guard: crate::tokio::sync::OwnedMutexGuard<()>,
     teardown_slot: &RuntimeLoopTeardownSlot,
@@ -800,6 +801,7 @@ async fn finalize_publish_and_resolve_runtime_terminals(
     };
     let result = publish_authorized_runtime_terminal_batch(
         driver,
+        post_commit_hooks,
         completions,
         Some(authority_guard),
         executor,
@@ -1123,6 +1125,7 @@ async fn realize_runtime_loop_terminal_owned(
 #[allow(clippy::too_many_arguments)]
 async fn publish_authorized_runtime_terminal_batch(
     driver: &crate::meerkat_machine::SharedDriver,
+    post_commit_hooks: &std::sync::Arc<meerkat_core::PostCommitHookDispatcher>,
     completions: Option<&crate::meerkat_machine::SharedCompletionRegistry>,
     authority_guard: Option<crate::tokio::sync::OwnedMutexGuard<()>>,
     executor: &mut dyn meerkat_core::lifecycle::CoreExecutor,
@@ -1290,6 +1293,10 @@ async fn publish_authorized_runtime_terminal_batch(
             )
         })?;
     let events = bundle.interaction_events();
+    let observations = events
+        .iter()
+        .filter_map(meerkat_core::HookObservation::from_committed_agent_event)
+        .collect::<Vec<_>>();
 
     if !events.is_empty() {
         let candidate_owner_input_id = match batch_key {
@@ -1379,6 +1386,7 @@ async fn publish_authorized_runtime_terminal_batch(
             let driver_guard = std::sync::Arc::clone(driver).lock_owned().await;
             let completion_guard = std::sync::Arc::clone(completions).lock_owned().await;
             let owned_input_ids = input_ids.to_vec();
+            let post_commit_hooks = std::sync::Arc::clone(post_commit_hooks);
             let handoff = tokio::spawn(async move {
                 let _authority_guard = authority_guard;
                 let mut driver_guard = driver_guard;
@@ -1397,6 +1405,9 @@ async fn publish_authorized_runtime_terminal_batch(
                 let mut completion_guard = completion_guard;
                 completion_guard
                     .resolve_authorized_runtime_terminal_bundle(owned_input_ids, bundle);
+                for observation in observations {
+                    post_commit_hooks.dispatch(observation);
+                }
                 Ok::<(), InteractionTerminalPublicationError>(())
             });
             return handoff.await.map_err(|error| {
@@ -1417,6 +1428,9 @@ async fn publish_authorized_runtime_terminal_batch(
                     error,
                 )
             })?;
+        for observation in observations {
+            post_commit_hooks.dispatch(observation);
+        }
     }
     Ok(())
 }
@@ -1429,6 +1443,7 @@ enum RuntimeProjectionRecoveryAuthority {
 
 async fn drain_recovered_interaction_terminal_outboxes(
     driver: &crate::meerkat_machine::SharedDriver,
+    post_commit_hooks: &std::sync::Arc<meerkat_core::PostCommitHookDispatcher>,
     completions: Option<&crate::meerkat_machine::SharedCompletionRegistry>,
     executor: &mut dyn meerkat_core::lifecycle::CoreExecutor,
     authority_binding: &RuntimeLoopAuthorityBinding,
@@ -1457,6 +1472,7 @@ async fn drain_recovered_interaction_terminal_outboxes(
     })?;
     drain_recovered_interaction_terminal_outboxes_under_authority(
         driver,
+        post_commit_hooks,
         completions,
         executor,
         &authority_guard,
@@ -1466,6 +1482,7 @@ async fn drain_recovered_interaction_terminal_outboxes(
 
 async fn drain_recovered_interaction_terminal_outboxes_under_authority(
     driver: &crate::meerkat_machine::SharedDriver,
+    post_commit_hooks: &std::sync::Arc<meerkat_core::PostCommitHookDispatcher>,
     completions: Option<&crate::meerkat_machine::SharedCompletionRegistry>,
     executor: &mut dyn meerkat_core::lifecycle::CoreExecutor,
     _authority_guard: &crate::tokio::sync::OwnedMutexGuard<()>,
@@ -1617,6 +1634,7 @@ async fn drain_recovered_interaction_terminal_outboxes_under_authority(
                 };
                 publish_authorized_runtime_terminal_batch(
                     driver,
+                    post_commit_hooks,
                     completions,
                     None,
                     executor,
@@ -1639,6 +1657,7 @@ async fn drain_recovered_interaction_terminal_outboxes_under_authority(
             } => {
                 publish_authorized_runtime_terminal_batch(
                     driver,
+                    post_commit_hooks,
                     completions,
                     None,
                     executor,
@@ -1801,6 +1820,7 @@ async fn drain_recovered_interaction_terminal_outboxes_until_clear(
     turn_boundary_already_held: bool,
     authority_kind: RuntimeProjectionRecoveryAuthority,
 ) -> bool {
+    let post_commit_hooks = authority_binding.post_commit_hooks().await;
     let _turn_finalization_guard = if turn_boundary_already_held {
         None
     } else {
@@ -1822,6 +1842,7 @@ async fn drain_recovered_interaction_terminal_outboxes_until_clear(
     loop {
         match drain_recovered_interaction_terminal_outboxes(
             driver,
+            &post_commit_hooks,
             completions,
             executor,
             authority_binding,
@@ -1920,6 +1941,7 @@ async fn recover_committed_runtime_projections_before_teardown(
         Some(OwnedTerminalizationState::PersistedDirectedDrainPending { run_id }) => Some(run_id),
         None => None,
     };
+    let post_commit_hooks = recovery.authority_binding.post_commit_hooks().await;
     // A rejected atomic boundary has no committed current-run compaction
     // outbox, and startup drained every older outbox before admitting work.
     // The whole-run abort above therefore already settled the exact live
@@ -1944,6 +1966,7 @@ async fn recover_committed_runtime_projections_before_teardown(
     if let Some(run_id) = pending_directed_terminalization_run_id.as_ref() {
         let first_drain = drain_recovered_interaction_terminal_outboxes_under_authority(
             driver,
+            &post_commit_hooks,
             recovery.completions.as_ref(),
             executor,
             authority_guard.as_ref().ok_or_else(|| {
@@ -2049,6 +2072,7 @@ async fn recover_committed_runtime_projections_before_teardown(
             };
             publish_authorized_runtime_terminal_batch(
                 driver,
+                &post_commit_hooks,
                 Some(completions),
                 Some(authority_guard.take().ok_or_else(|| {
                     crate::RuntimeDriverError::RecoveryCorruption {
@@ -4362,6 +4386,19 @@ impl RuntimeLoopAuthorityBinding {
         }
     }
 
+    async fn post_commit_hooks(&self) -> std::sync::Arc<meerkat_core::PostCommitHookDispatcher> {
+        if let Some(machine) = self.machine.upgrade()
+            && let Some(dispatcher) = machine
+                .post_commit_hooks_for_session(&self.session_id)
+                .await
+        {
+            return dispatcher;
+        }
+        std::sync::Arc::new(meerkat_core::PostCommitHookDispatcher::new(
+            self.session_id.clone(),
+        ))
+    }
+
     #[cfg(any(test, feature = "test-support"))]
     async fn run_before_queue_authority_test_hook(&self) {
         if let Some(machine) = self.machine.upgrade() {
@@ -4796,6 +4833,7 @@ pub(crate) fn spawn_runtime_loop_with_completions(
     let loop_body = async move {
         let mut loop_handoff_guard = loop_handoff_guard;
         let mut startup_guard = startup_guard;
+        let post_commit_hooks = authority_binding.post_commit_hooks().await;
         macro_rules! executor_or_return {
             () => {
                 match loop_handoff_guard.executor_mut() {
@@ -4952,6 +4990,7 @@ pub(crate) fn spawn_runtime_loop_with_completions(
         }
         if let Err(error) = drain_recovered_interaction_terminal_outboxes_under_authority(
             &driver,
+            &post_commit_hooks,
             completions.as_ref(),
             executor_or_return!(),
             &startup_authority_guard,
@@ -5663,6 +5702,7 @@ async fn process_queue(
     teardown_slot: &std::sync::Arc<RuntimeLoopTeardownSlot>,
     handoff: &mut RuntimeLoopTerminalHandoff,
 ) -> bool {
+    let post_commit_hooks = authority_binding.post_commit_hooks().await;
     loop {
         let turn_finalization_guard = match executor.turn_finalization_boundary_handle() {
             Some(boundary) => match boundary.acquire().await {
@@ -6132,6 +6172,7 @@ async fn process_queue(
                             if let Err(error) =
                                 drain_recovered_interaction_terminal_outboxes_under_authority(
                                     driver,
+                                    &post_commit_hooks,
                                     completions,
                                     executor,
                                     &queue_authority_guard,
@@ -6276,6 +6317,7 @@ async fn process_queue(
                         if let Err(terminalization_error) =
                             drain_recovered_interaction_terminal_outboxes_under_authority(
                                 driver,
+                                &post_commit_hooks,
                                 completions,
                                 executor,
                                 &queue_authority_guard,
@@ -6533,6 +6575,7 @@ async fn process_queue(
                             let publication_error =
                                 finalize_publish_and_resolve_runtime_terminals(
                                     driver,
+                                    &post_commit_hooks,
                                     completions,
                                     terminal_authority_guard,
                                     teardown_slot,
@@ -6608,6 +6651,7 @@ async fn process_queue(
                                     let publication_error =
                                     finalize_publish_and_resolve_runtime_terminals(
                                         driver,
+                                        &post_commit_hooks,
                                         completions,
                                         terminal_authority_guard,
                                         teardown_slot,
@@ -6668,6 +6712,7 @@ async fn process_queue(
 
                         if let Err(err) = finalize_publish_and_resolve_runtime_terminals(
                             driver,
+                            &post_commit_hooks,
                             completions,
                             terminal_authority_guard,
                             teardown_slot,
@@ -6907,6 +6952,7 @@ async fn process_queue(
                             if let Err(error) =
                                 finalize_publish_and_resolve_runtime_terminals(
                                     driver,
+                                    &post_commit_hooks,
                                     completions,
                                     publication_authority_guard,
                                     teardown_slot,
@@ -6966,6 +7012,7 @@ async fn process_queue(
                                 if let Err(error) =
                                     drain_recovered_interaction_terminal_outboxes_under_authority(
                                         driver,
+                                        &post_commit_hooks,
                                         completions,
                                         executor,
                                         drain_authority_guard,

--- a/meerkat-session/src/ephemeral.rs
+++ b/meerkat-session/src/ephemeral.rs
@@ -1428,6 +1428,8 @@ struct SessionHandle {
     interaction_event_injector: Option<Arc<dyn meerkat_core::event_injector::SubscribableInjector>>,
     /// Optional comms runtime for keep-alive commands and stream attachment.
     comms_runtime: Option<Arc<dyn meerkat_core::agent::CommsRuntime>>,
+    /// Session-attributed peer-send surface with post-commit observation.
+    observed_comms_sender: Option<Arc<meerkat_core::ObservedCommsSender>>,
     /// Shared runtime control state for system-context appends.
     transient_turn_context_state: meerkat_core::TransientTurnContextStateHandle,
     /// Mechanical gate closed when an archive snapshot is taken.
@@ -2414,6 +2416,10 @@ pub trait SessionAgent: Send {
     /// runtime is stored in the session handle for surfaces that need comms
     /// command execution and stream attachment.
     fn comms_runtime(&self) -> Option<Arc<dyn meerkat_core::agent::CommsRuntime>> {
+        None
+    }
+
+    fn observed_comms_sender(&self) -> Option<Arc<meerkat_core::ObservedCommsSender>> {
         None
     }
 }
@@ -4717,6 +4723,20 @@ impl<B: SessionAgentBuilder + 'static> EphemeralSessionService<B> {
             .and_then(|h| h.comms_runtime.clone())
     }
 
+    pub async fn send_comms(
+        &self,
+        session_id: &SessionId,
+        command: meerkat_core::CommsCommand,
+    ) -> Option<Result<meerkat_core::SendReceipt, meerkat_core::SendError>> {
+        let sender = {
+            let sessions = self.sessions.read().await;
+            sessions
+                .get(session_id)
+                .and_then(|handle| handle.observed_comms_sender.clone())
+        }?;
+        Some(sender.send(command).await)
+    }
+
     /// Wait for a session to be registered.
     ///
     /// Returns when the next session handle is stored. Used by CLI `--stdin`
@@ -5046,6 +5066,7 @@ impl<B: SessionAgentBuilder + 'static> EphemeralSessionService<B> {
         let event_injector = agent.event_injector();
         let interaction_event_injector = agent.interaction_event_injector();
         let comms_runtime = agent.comms_runtime();
+        let observed_comms_sender = agent.observed_comms_sender();
         let cancel_after_boundary_handle = agent.cancel_after_boundary_handle();
         let turn_state_handle = agent.turn_state_handle();
         // W2-E: capture the session-context DSL handle so the session task
@@ -5137,6 +5158,7 @@ impl<B: SessionAgentBuilder + 'static> EphemeralSessionService<B> {
             event_injector,
             interaction_event_injector,
             comms_runtime,
+            observed_comms_sender,
             transient_turn_context_state,
             archive_snapshot_gate,
             turn_state_handle,
@@ -5785,6 +5807,14 @@ impl<B: SessionAgentBuilder + 'static> SessionServiceCommsExt for EphemeralSessi
         session_id: &SessionId,
     ) -> Option<Arc<dyn meerkat_core::agent::CommsRuntime>> {
         EphemeralSessionService::<B>::comms_runtime(self, session_id).await
+    }
+
+    async fn send_comms(
+        &self,
+        session_id: &SessionId,
+        command: meerkat_core::CommsCommand,
+    ) -> Option<Result<meerkat_core::SendReceipt, meerkat_core::SendError>> {
+        EphemeralSessionService::<B>::send_comms(self, session_id, command).await
     }
 
     async fn event_injector(

--- a/meerkat-session/src/persistent.rs
+++ b/meerkat-session/src/persistent.rs
@@ -11298,6 +11298,14 @@ impl<B: SessionAgentBuilder + 'static> SessionServiceCommsExt for PersistentSess
     ) -> Option<std::sync::Arc<dyn meerkat_core::event_injector::SubscribableInjector>> {
         self.inner.interaction_event_injector(session_id).await
     }
+
+    async fn send_comms(
+        &self,
+        session_id: &SessionId,
+        command: meerkat_core::CommsCommand,
+    ) -> Option<Result<meerkat_core::SendReceipt, meerkat_core::SendError>> {
+        self.inner.send_comms(session_id, command).await
+    }
 }
 
 #[async_trait]
@@ -11734,6 +11742,14 @@ impl<B: SessionAgentBuilder + 'static> PersistentSessionService<B> {
         session_id: &SessionId,
     ) -> Option<std::sync::Arc<dyn meerkat_core::agent::CommsRuntime>> {
         self.inner.comms_runtime(session_id).await
+    }
+
+    pub async fn send_comms(
+        &self,
+        session_id: &SessionId,
+        command: meerkat_core::CommsCommand,
+    ) -> Option<Result<meerkat_core::SendReceipt, meerkat_core::SendError>> {
+        self.inner.send_comms(session_id, command).await
     }
 
     /// Wait for a session to be registered.

--- a/meerkat-tools/src/builtin/comms/surface.rs
+++ b/meerkat-tools/src/builtin/comms/surface.rs
@@ -53,6 +53,26 @@ impl CommsToolSurface {
         }
     }
 
+    pub fn new_with_runtime_and_post_commit_hooks(
+        router: Arc<Router>,
+        trusted_peers: TrustedPeersView,
+        runtime: Arc<dyn meerkat_core::agent::CommsRuntime>,
+        post_commit_hooks: Arc<meerkat_core::PostCommitHookDispatcher>,
+    ) -> Self {
+        let tool_context = ToolContext {
+            router,
+            trusted_peers,
+            runtime: Some(
+                RuntimeCommsCommandHandle::new(runtime).with_post_commit_hooks(post_commit_hooks),
+            ),
+        };
+        let tool_defs: Arc<[Arc<ToolDef>]> = comms_tool_defs().into();
+        Self {
+            tool_context,
+            tool_defs,
+        }
+    }
+
     fn callability_for_tool(&self, name: &str) -> ToolCallability {
         comms_tool_unavailable_reason(&self.tool_context, name)
             .map_or_else(ToolCallability::callable, ToolCallability::unavailable)

--- a/meerkat/src/factory.rs
+++ b/meerkat/src/factory.rs
@@ -70,7 +70,7 @@ use tokio_with_wasm::alias::sync::mpsc;
 use crate::model_fallback::{ModelFallbackCandidate, ModelFallbackClient};
 
 #[cfg(feature = "comms")]
-use crate::compose_tools_with_comms;
+use crate::compose_tools_with_comms_and_post_commit_hooks;
 #[cfg(not(target_arch = "wasm32"))]
 use crate::{create_default_hook_engine, resolve_layered_hooks_config};
 
@@ -5543,6 +5543,12 @@ impl AgentFactory {
         };
 
         let resolved_mode = &build_config.runtime_build_mode;
+        let post_commit_hooks = match resolved_mode {
+            RuntimeBuildMode::SessionOwned(bindings) => Arc::clone(bindings.post_commit_hooks()),
+            RuntimeBuildMode::StandaloneEphemeral => Arc::new(
+                meerkat_core::PostCommitHookDispatcher::new(session.id().clone()),
+            ),
+        };
         // Inject pre-resolved metadata entries after runtime binding
         // validation and before the builder reads metadata for early-stage
         // recovery. Canonical visibility facts are not accepted through this
@@ -5904,11 +5910,13 @@ impl AgentFactory {
         // 9a. Compose tools with comms gateway.
         #[cfg(feature = "comms")]
         if let Some(ref runtime) = comms_runtime {
-            let composed =
-                compose_tools_with_comms(tools, tool_usage_instructions, runtime.tool_material())
-                    .map_err(|e| {
-                    BuildAgentError::Config(format!("Failed to compose comms tools: {e}"))
-                })?;
+            let composed = compose_tools_with_comms_and_post_commit_hooks(
+                tools,
+                tool_usage_instructions,
+                runtime.tool_material(),
+                Arc::clone(&post_commit_hooks),
+            )
+            .map_err(|e| BuildAgentError::Config(format!("Failed to compose comms tools: {e}")))?;
             tools = composed.0;
             tool_usage_instructions = composed.1;
         }
@@ -6187,7 +6195,6 @@ impl AgentFactory {
                 }
             }
         };
-
         // 11. Generate skill inventory section using the engine created in step 6a
         #[cfg(feature = "skills")]
         let skill_inventory_section = {
@@ -6622,6 +6629,7 @@ impl AgentFactory {
                 ..config.retry.clone().into()
             })
             .with_hook_run_overrides(build_config.hooks_override)
+            .with_post_commit_hooks(post_commit_hooks)
             .with_model_defaults_resolver(Arc::new(RegistryBackedDefaultsResolver {
                 registry: Arc::clone(&effective_model_registry),
             }))

--- a/meerkat/src/lib.rs
+++ b/meerkat/src/lib.rs
@@ -594,6 +594,40 @@ pub fn compose_tools_with_comms(
     Ok((Arc::new(composite), instructions))
 }
 
+#[cfg(feature = "comms")]
+fn compose_tools_with_comms_and_post_commit_hooks(
+    base_tools: std::sync::Arc<dyn meerkat_core::AgentToolDispatcher>,
+    tool_usage_instructions: String,
+    material: meerkat_comms::CommsToolMaterial,
+    post_commit_hooks: std::sync::Arc<meerkat_core::PostCommitHookDispatcher>,
+) -> Result<
+    (
+        std::sync::Arc<dyn meerkat_core::AgentToolDispatcher>,
+        String,
+    ),
+    meerkat_tools::ToolError,
+> {
+    use meerkat_tools::CommsToolSurface;
+    use std::sync::Arc;
+    let router = material.router().clone();
+    let trusted_peers = material.trusted_peers_shared();
+    let runtime = material.into_runtime();
+    let comms_surface = CommsToolSurface::new_with_runtime_and_post_commit_hooks(
+        router,
+        trusted_peers,
+        runtime,
+        post_commit_hooks,
+    );
+    let composite =
+        meerkat_core::DynamicToolComposite::new(vec![base_tools, Arc::new(comms_surface)]);
+    let mut instructions = tool_usage_instructions;
+    if !instructions.is_empty() {
+        instructions.push_str("\n\n");
+    }
+    instructions.push_str(CommsToolSurface::usage_instructions());
+    Ok((Arc::new(composite), instructions))
+}
+
 // Re-export provider-runtime types for downstream consumers that used to
 // reach them via meerkat_providers::* or meerkat_client::*.
 pub use meerkat_llm_core::provider_runtime::{

--- a/meerkat/src/service_factory.rs
+++ b/meerkat/src/service_factory.rs
@@ -121,11 +121,7 @@ impl FactoryAgent {
 
     /// Send a canonical comms command through the wrapped agent runtime.
     pub async fn send(&self, cmd: CommsCommand) -> Result<SendReceipt, SendError> {
-        let runtime = self
-            .agent
-            .comms()
-            .ok_or_else(|| SendError::Unsupported("comms runtime is not configured".to_string()))?;
-        runtime.send(cmd).await
+        self.agent.send_comms(cmd).await
     }
 
     /// List peers discoverable to this agent runtime.
@@ -931,6 +927,10 @@ impl SessionAgent for FactoryAgent {
 
     fn comms_runtime(&self) -> Option<Arc<dyn meerkat_core::agent::CommsRuntime>> {
         self.agent.comms_arc()
+    }
+
+    fn observed_comms_sender(&self) -> Option<Arc<meerkat_core::ObservedCommsSender>> {
+        self.agent.observed_comms_sender()
     }
 }
 

--- a/meerkat/tests/agent_builder_policy_canary.rs
+++ b/meerkat/tests/agent_builder_policy_canary.rs
@@ -530,6 +530,7 @@ async fn public_facade_rejects_forged_session_runtime_binding_authority() {
         Arc::clone(prepared.session_claim_handle()),
         Arc::clone(prepared.interaction_stream()),
         Arc::clone(prepared.compaction_commit_coordinator()),
+        Arc::clone(prepared.post_commit_hooks()),
         Arc::new(()),
     );
 

--- a/sdks/python/meerkat/generated/event_types.py
+++ b/sdks/python/meerkat/generated/event_types.py
@@ -46,7 +46,7 @@ HookId = str
 
 
 # Hook points available in V1.
-HookPoint = Literal['run_started', 'run_completed', 'run_failed', 'pre_llm_request', 'post_llm_response', 'pre_tool_execution', 'post_tool_execution', 'turn_boundary']
+HookPoint = Literal['run_started', 'run_completed', 'run_failed', 'pre_llm_request', 'post_llm_response', 'pre_tool_execution', 'post_tool_execution', 'turn_boundary', 'runtime_input_accepted', 'runtime_input_rejected', 'runtime_input_deduplicated', 'peer_ingress_committed', 'peer_egress_committed', 'interaction_completed']
 
 
 # Typed reason codes for guardrail denials.

--- a/sdks/typescript/src/generated/event_types.ts
+++ b/sdks/typescript/src/generated/event_types.ts
@@ -50,7 +50,7 @@ export type HookId = string;
 /**
  * Hook points available in V1.
  */
-export type HookPoint = "run_started" | "run_completed" | "run_failed" | "pre_llm_request" | "post_llm_response" | "pre_tool_execution" | "post_tool_execution" | "turn_boundary";
+export type HookPoint = "run_started" | "run_completed" | "run_failed" | "pre_llm_request" | "post_llm_response" | "pre_tool_execution" | "post_tool_execution" | "turn_boundary" | "runtime_input_accepted" | "runtime_input_rejected" | "runtime_input_deduplicated" | "peer_ingress_committed" | "peer_egress_committed" | "interaction_completed";
 
 /**
  * Typed reason codes for guardrail denials.

--- a/sdks/web/src/generated/events.ts
+++ b/sdks/web/src/generated/events.ts
@@ -232,7 +232,7 @@ export type HookFailureReason = {
 
 export type HookId = string;
 
-export type HookPoint = "run_started" | "run_completed" | "run_failed" | "pre_llm_request" | "post_llm_response" | "pre_tool_execution" | "post_tool_execution" | "turn_boundary";
+export type HookPoint = "run_started" | "run_completed" | "run_failed" | "pre_llm_request" | "post_llm_response" | "pre_tool_execution" | "post_tool_execution" | "turn_boundary" | "runtime_input_accepted" | "runtime_input_rejected" | "runtime_input_deduplicated" | "peer_ingress_committed" | "peer_egress_committed" | "interaction_completed";
 
 export type HookReasonCode = "policy_violation" | "safety_violation" | "schema_violation" | "timeout" | "runtime_error";
 


### PR DESCRIPTION
## Summary

- add six typed observe-only hook points for committed runtime input, peer ingress/egress, and interaction completion facts
- preserve ordered event streams and existing synchronous policy hooks as separate mechanisms
- keep hook decisions/failures unable to alter committed outcomes
- own and abort post-commit hook tasks at the session-scoped dispatcher
- document hooks for reactions versus event streams for ordered transport

## Validation

- focused six-hook contract tests
- pre- and post-rebase all-target checks
- wasm core check
- static and specialist review completed
- local push hooks skipped after the redundant targeted Clippy was stopped; PR CI is authoritative

Closes #222
