### PR TITLE
fix: seal council source context atomically

### DIFF
--- a/meerkat-contracts/src/wire/supervisor_bridge.rs
+++ b/meerkat-contracts/src/wire/supervisor_bridge.rs
@@ -687,6 +687,7 @@ fn bridge_command_minimum_protocol(
         "retire_member" => "RetireMember",
         "create_forked_participant" => "CreateForkedParticipant",
         "revoke_forked_participant" => "RevokeForkedParticipant",
+        "issue_host_binding_descriptor" => "IssueHostBindingDescriptor",
         "hard_cancel_member" => "HardCancelMember",
         "cancel_tracked_member_input" => "CancelTrackedMemberInput",
         "read_member_history" => "ReadMemberHistory",

--- a/meerkat-mob-mcp/src/temporary_council.rs
+++ b/meerkat-mob-mcp/src/temporary_council.rs
@@ -1359,10 +1359,47 @@ impl TemporaryCouncilCoordinator {
         record.claim_lease_expires_at = active_claim_lease_expiry(&self.state, record.deadline);
         // The deadline the record carries is authority; a takeover inherits it.
         validated.deadline = Some(record.deadline);
-        let record = store
-            .commit(&record)
-            .await
-            .map_err(TemporaryCouncilError::store)?;
+        let record = match store.commit(&record).await {
+            Ok(record) => record,
+            Err(MobStoreError::CasConflict(_)) => {
+                let winner = store
+                    .load(&council_id)
+                    .await
+                    .map_err(TemporaryCouncilError::store)?
+                    .ok_or_else(|| TemporaryCouncilError::CoordinatorUnavailable {
+                        detail: format!(
+                            "council {council_id} claim conflicted but no winning record could be loaded"
+                        ),
+                    })?;
+                if winner.result.is_some() {
+                    return self.admit_existing_record(&validated, winner).await;
+                }
+                let lease_expired =
+                    winner.claim_lease_expires_at <= self.state.temporary_council_now();
+                let (_, outcome) = present_claim(&winner.machine_state, &claim_id, lease_expired)?;
+                return match outcome {
+                    ClaimOutcome::Busy {
+                        current_claim_epoch,
+                    } => Err(TemporaryCouncilError::HeldByAnotherCoordinator {
+                        council_id,
+                        current_claim_epoch,
+                    }),
+                    ClaimOutcome::Settled => Err(TemporaryCouncilError::CoordinatorUnavailable {
+                        detail: format!(
+                            "council {council_id} settled during claim arbitration without a result"
+                        ),
+                    }),
+                    ClaimOutcome::Granted(_) => {
+                        Err(TemporaryCouncilError::CoordinatorUnavailable {
+                            detail: format!(
+                                "council {council_id} claim conflict had no durable winning claim"
+                            ),
+                        })
+                    }
+                };
+            }
+            Err(error) => return Err(TemporaryCouncilError::store(error)),
+        };
 
         let state = self.state.clone();
         // OWNED task: the caller's await may be dropped; this may not.
@@ -2109,7 +2146,7 @@ impl CouncilRun {
                 }
             };
             let source_profile = source
-                .effective_member_profile(&custody.source_identity)
+                .effective_member_profile_witness(&custody.source_identity)
                 .await
                 .map_err(
                     |error| TemporaryCouncilExitReason::ParticipantSeatingFailed {
@@ -2132,7 +2169,7 @@ impl CouncilRun {
                         custody.target_profile
                     ),
                 })?;
-            if !same_source_execution_profile(target_profile, &source_profile) {
+            if !same_source_execution_profile(target_profile, source_profile.profile()) {
                 return Err(TemporaryCouncilExitReason::ParticipantSeatingFailed {
                     participant_order: custody.order,
                     detail: format!(
@@ -2172,9 +2209,10 @@ impl CouncilRun {
             // executes at the source owner and can block on a remote host.
             let created = tokio::time::timeout(
                 remaining,
-                source.create_forked_participant(
+                source.create_forked_participant_with_profile_witness(
                     self.state.console_principal_snapshot(),
                     custody.source_identity.clone(),
+                    source_profile,
                     custody.capability_request_id.clone(),
                     self.validated
                         .request

--- a/meerkat-mob/src/runtime/actor.rs
+++ b/meerkat-mob/src/runtime/actor.rs
@@ -31380,6 +31380,38 @@ impl MobActor {
         let Some(entry) = entry else {
             return Err(MobError::MemberNotFound(source_identity));
         };
+        if let Some(expected) = request.expected_profile.as_ref() {
+            let mut current_profile = match entry.effective_profile_override.clone() {
+                Some(profile) => profile,
+                None => self
+                    .definition
+                    .profiles
+                    .get(&entry.role)
+                    .and_then(crate::profile::ProfileBinding::as_inline)
+                    .cloned()
+                    .ok_or_else(|| MobError::ForkedParticipantAttachedSpawnSpecRejected {
+                        detail: format!(
+                            "source member '{}' has no stable inline execution profile",
+                            entry.agent_identity
+                        ),
+                    })?,
+            };
+            if let Some(model) = &entry.effective_model_override {
+                current_profile.model.clone_from(model);
+            }
+            current_profile.image_generation_provider = current_profile
+                .image_generation_provider
+                .or(self.definition.image_generation_provider);
+            if entry.generation != expected.generation || current_profile != expected.profile {
+                return Err(MobError::ForkedParticipantAttachedSpawnSpecRejected {
+                    detail: format!(
+                        "source member '{}' changed generation or execution profile before \
+                         capability creation",
+                        entry.agent_identity
+                    ),
+                });
+            }
+        }
         let dsl_identity = mob_dsl::AgentIdentity::from_domain(&source_identity);
         let placement = self
             .dsl_authority

--- a/meerkat-mob/src/runtime/bridge_protocol.rs
+++ b/meerkat-mob/src/runtime/bridge_protocol.rs
@@ -758,6 +758,62 @@ mod tests {
     }
 
     #[test]
+    fn delegated_host_bind_proof_binds_the_target_not_source_supervisor() {
+        let raw_token = "host-token";
+        let source = BridgePeerSpec {
+            name: "source/supervisor".to_string(),
+            peer_id: "peer-source".to_string(),
+            address: "inproc://source".to_string(),
+            pubkey: [3; 32],
+        };
+        let target = BridgePeerSpec {
+            name: "council/supervisor".to_string(),
+            peer_id: "peer-council".to_string(),
+            address: "inproc://council".to_string(),
+            pubkey: [7; 32],
+        };
+        let proof = derive_delegated_host_bind_proof(
+            raw_token,
+            &target,
+            "council--123",
+            "peer-host",
+            "tcp://127.0.0.1:9000",
+        );
+        assert_eq!(
+            proof,
+            derive_delegated_host_bind_proof(
+                raw_token,
+                &target,
+                "council--123",
+                "peer-host",
+                "tcp://127.0.0.1:9000",
+            )
+        );
+        assert_ne!(
+            proof,
+            derive_delegated_host_bind_proof(
+                raw_token,
+                &source,
+                "council--123",
+                "peer-host",
+                "tcp://127.0.0.1:9000",
+            ),
+            "a proof issued for the target supervisor must reject the source supervisor"
+        );
+        assert_ne!(
+            proof,
+            derive_delegated_host_bind_proof(
+                raw_token,
+                &target,
+                "council--other",
+                "peer-host",
+                "tcp://127.0.0.1:9000",
+            ),
+            "a proof cannot be replayed into another temporary mob"
+        );
+    }
+
+    #[test]
     fn host_bind_wire_and_debug_never_contain_raw_bootstrap_token() {
         let raw_token = "raw-host-token-kept-out-of-band";
         let command = BridgeCommand::BindHost(seal_host_bind_bootstrap_proof(

--- a/meerkat-mob/src/runtime/forked_participant_routing.rs
+++ b/meerkat-mob/src/runtime/forked_participant_routing.rs
@@ -58,10 +58,13 @@ pub(super) const FORKED_PARTICIPANT_BRIDGE_TIMEOUT: Duration = Duration::from_se
 /// member actually lives, so a caller cannot aim a capability at a realm or
 /// host that does not own the source. There is likewise no tool-policy field —
 /// the branch inherits the source's effective execution context.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct ForkedParticipantCreateRequest {
     /// Source member whose conversation is forked.
     pub source_identity: AgentIdentity,
+    /// Optional exact source generation/profile observation. The serialized
+    /// actor validates it immediately before capability creation.
+    pub expected_profile: Option<super::handle::MemberExecutionProfileWitness>,
     /// Caller-stable idempotency identity. The same exact request replays.
     pub request_id: ForkedParticipantRequestId,
     /// Complete-boundary prefix length; `None` selects the whole transcript.

--- a/meerkat-mob/src/runtime/handle.rs
+++ b/meerkat-mob/src/runtime/handle.rs
@@ -518,7 +518,7 @@ pub enum SpawnMemberAdmission {
 /// The private field makes this unforgeable outside `meerkat-mob`; adaptive
 /// driver code can hold and pass it back to the narrow adaptive seam, but it
 /// cannot manufacture one or write raw machine inputs.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct AdaptiveDriverCapability {
     adaptive_run_id: String,
     _private: (),

--- a/meerkat-mob/src/runtime/handle.rs
+++ b/meerkat-mob/src/runtime/handle.rs
@@ -518,7 +518,7 @@ pub enum SpawnMemberAdmission {
 /// The private field makes this unforgeable outside `meerkat-mob`; adaptive
 /// driver code can hold and pass it back to the narrow adaptive seam, but it
 /// cannot manufacture one or write raw machine inputs.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct AdaptiveDriverCapability {
     adaptive_run_id: String,
     _private: (),
@@ -1277,6 +1277,21 @@ pub struct MobMemberListEntry {
     pub(crate) current_session_id: Option<SessionId>,
     #[serde(skip)]
     pub(crate) current_bridge_session_id: Option<SessionId>,
+}
+
+/// Immutable source-generation/profile observation used to make council
+/// capability creation atomic with its no-widening check.
+#[derive(Debug, Clone, PartialEq)]
+pub struct MemberExecutionProfileWitness {
+    pub(crate) generation: Generation,
+    pub(crate) profile: crate::profile::Profile,
+}
+
+impl MemberExecutionProfileWitness {
+    #[must_use]
+    pub fn profile(&self) -> &crate::profile::Profile {
+        &self.profile
+    }
 }
 
 impl MobMemberListEntry {
@@ -6280,6 +6295,18 @@ impl MobHandle {
         &self,
         identity: &AgentIdentity,
     ) -> Result<crate::profile::Profile, MobError> {
+        Ok(self
+            .effective_member_profile_witness(identity)
+            .await?
+            .profile)
+    }
+
+    /// Capture the exact live generation and effective profile together.
+    #[doc(hidden)]
+    pub async fn effective_member_profile_witness(
+        &self,
+        identity: &AgentIdentity,
+    ) -> Result<MemberExecutionProfileWitness, MobError> {
         let roster = self.roster.read().await;
         let entry = roster
             .get(identity)
@@ -6302,7 +6329,13 @@ impl MobHandle {
         if let Some(model) = &entry.effective_model_override {
             profile.model.clone_from(model);
         }
-        Ok(profile)
+        profile.image_generation_provider = profile
+            .image_generation_provider
+            .or(self.definition.image_generation_provider);
+        Ok(MemberExecutionProfileWitness {
+            generation: entry.generation,
+            profile,
+        })
     }
 
     /// Read-only projection of generated owner bridge-session lifecycle authority.
@@ -6766,6 +6799,41 @@ impl MobHandle {
                     request: Box::new(
                         super::forked_participant_routing::ForkedParticipantCreateRequest {
                             source_identity,
+                            expected_profile: None,
+                            request_id,
+                            prefix_message_count,
+                            scope,
+                            reuse,
+                            ttl,
+                        },
+                    ),
+                    reply_tx,
+                },
+            )
+            .await?
+    }
+
+    #[doc(hidden)]
+    #[allow(clippy::too_many_arguments)]
+    pub async fn create_forked_participant_with_profile_witness(
+        &self,
+        caller: crate::control_policy::MobControlPrincipal,
+        source_identity: AgentIdentity,
+        expected_profile: MemberExecutionProfileWitness,
+        request_id: crate::forked_participant::ForkedParticipantRequestId,
+        prefix_message_count: Option<usize>,
+        scope: crate::forked_participant::ForkedParticipantOperationScope,
+        reuse: crate::forked_participant::ForkedParticipantReusePolicy,
+        ttl: std::time::Duration,
+    ) -> Result<crate::forked_participant::ForkedParticipantRef, MobError> {
+        self.clone()
+            .with_command_authority(crate::control_policy::CommandAuthority::principal(caller))
+            .send_actor_command(
+                |reply_tx| super::state::MobCommand::CreateForkedParticipant {
+                    request: Box::new(
+                        super::forked_participant_routing::ForkedParticipantCreateRequest {
+                            source_identity,
+                            expected_profile: Some(expected_profile),
                             request_id,
                             prefix_message_count,
                             scope,

--- a/meerkat-mob/src/runtime/host_actor.rs
+++ b/meerkat-mob/src/runtime/host_actor.rs
@@ -6013,6 +6013,10 @@ pub struct MobHostActor {
     host_comms: Arc<dyn CoreCommsRuntime>,
     host_dsl: Arc<meerkat_runtime::HandleDslAuthority>,
     bootstrap_token: HostBootstrapTokenSlot,
+    /// Actor-lifetime secret for target-bound delegated council proofs. Unlike
+    /// the operator bootstrap token, successful unrelated binds do not rotate
+    /// it and invalidate already-issued independent grants.
+    delegated_bind_key: String,
     capabilities: HostCapabilitiesComposer,
     capability_facts: HostCapabilityFacts,
     descriptor: DescriptorRefresher,
@@ -6226,6 +6230,7 @@ pub async fn spawn_mob_host_actor(
         host_comms,
         host_dsl,
         bootstrap_token,
+        delegated_bind_key: mint_bootstrap_token(),
         capabilities,
         capability_facts,
         descriptor,
@@ -6347,7 +6352,7 @@ async fn run_host_responder(
     let notify = actor.host_runtime.inbox_notify();
     let mut forked_participant_tick = tokio::time::interval(forked_participant_sweep_interval);
     forked_participant_tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
-    loop {
+    'responder: loop {
         let notified = notify.notified();
         tokio::pin!(notified);
         // `inbox_notify` fires with `notify_waiters()`, so merely creating the
@@ -6372,7 +6377,7 @@ async fn run_host_responder(
                         %error,
                         "host peer-input responder stopped with FIFO head retained"
                     );
-                    return;
+                    break 'responder;
                 }
             }
         }
@@ -10251,7 +10256,7 @@ impl MobHostActor {
         let descriptor = self.descriptor.descriptor("");
         let delegated_bootstrap_proof =
             crate::runtime::bridge_protocol::derive_delegated_host_bind_proof(
-                self.bootstrap_token.current(),
+                &self.delegated_bind_key,
                 &payload.target_supervisor,
                 &payload.target_mob_id,
                 &expected_host_peer_id,
@@ -10590,14 +10595,17 @@ impl MobHostActor {
                     .delegated_bootstrap_proof
                     .as_ref()
                     .is_some_and(|proof| {
-                        proof
-                            == &crate::runtime::bridge_protocol::derive_delegated_host_bind_proof(
-                                self.bootstrap_token.current(),
+                        meerkat_comms::constant_time_str_eq(
+                            proof.as_str(),
+                            crate::runtime::bridge_protocol::derive_delegated_host_bind_proof(
+                                &self.delegated_bind_key,
                                 &payload.supervisor,
                                 &payload.mob_id,
                                 &payload.expected_host_peer_id,
                                 &payload.expected_address,
                             )
+                            .as_str(),
+                        )
                     }),
             accepted_capabilities: capabilities,
             supervisor,


### PR DESCRIPTION
Follow-up to #1038 after final adversarial review.

- binds capability creation to the source member generation and full effective profile
- keeps delegated host grants valid across unrelated binds and compares proofs in constant time
- preserves the host responder cleanup tail on intake failures
- materializes mob-level image provider fallback in the effective profile
- classifies council claim CAS winners instead of leaking raw conflicts
- adds the missing V6 command-name mapping

Validation: forked participant 46/46; temporary council 36/36; mixed local + host E2E passed; schema and SDK freshness passed.