### PR TITLE
test: keep deterministic mob system tests credential-free

### DIFF
--- a/meerkat-cli/BUILD.bazel
+++ b/meerkat-cli/BUILD.bazel
@@ -2529,6 +2529,7 @@ rust_test(
         "src/main.rs",
     ],
     srcs = [
+        "tests/support/deterministic_mob_provider.rs",
         "tests/system_mob_cli_verbs.rs",
     ],
     visibility = ["//visibility:public"],
@@ -2631,6 +2632,7 @@ rust_test(
         "src/main.rs",
     ],
     srcs = [
+        "tests/support/deterministic_mob_provider.rs",
         "tests/system_mob_cli_verbs.rs",
     ],
     visibility = ["//visibility:public"],
@@ -2961,6 +2963,7 @@ rust_test(
         "src/main.rs",
     ],
     srcs = [
+        "tests/support/deterministic_mob_provider.rs",
         "tests/system_mob_run_custody.rs",
     ],
     visibility = ["//visibility:public"],
@@ -3063,6 +3066,7 @@ rust_test(
         "src/main.rs",
     ],
     srcs = [
+        "tests/support/deterministic_mob_provider.rs",
         "tests/system_mob_run_custody.rs",
     ],
     visibility = ["//visibility:public"],
@@ -3173,6 +3177,7 @@ rust_test(
         "src/main.rs",
     ],
     srcs = [
+        "tests/support/deterministic_mob_provider.rs",
         "tests/system_mob_run_custody.rs",
     ],
     visibility = ["//visibility:public"],

--- a/meerkat-cli/tests/support/deterministic_mob_provider.rs
+++ b/meerkat-cli/tests/support/deterministic_mob_provider.rs
@@ -1,0 +1,114 @@
+use std::path::Path;
+
+use tokio::io::AsyncReadExt;
+use tokio::process::Command;
+use tokio::task::JoinHandle;
+
+pub const MODEL: &str = "deterministic-mob-stall";
+pub const PROVIDER: &str = "self_hosted";
+
+const PROVIDER_API_KEY_ENV: &[&str] = &[
+    "RKAT_ANTHROPIC_API_KEY",
+    "ANTHROPIC_API_KEY",
+    "RKAT_OPENAI_API_KEY",
+    "OPENAI_API_KEY",
+    "RKAT_GEMINI_API_KEY",
+    "GEMINI_API_KEY",
+    "RKAT_GOOGLE_API_KEY",
+    "GOOGLE_API_KEY",
+    "RKAT_AZURE_OPENAI_API_KEY",
+    "AZURE_OPENAI_API_KEY",
+    "RKAT_SELF_HOSTED_API_KEY",
+];
+
+pub struct DeterministicMobProvider {
+    server_task: JoinHandle<()>,
+}
+
+impl Drop for DeterministicMobProvider {
+    fn drop(&mut self) {
+        self.server_task.abort();
+    }
+}
+
+pub fn remove_ambient_provider_credentials(command: &mut Command) {
+    for name in PROVIDER_API_KEY_ENV {
+        command.env_remove(name);
+    }
+}
+
+pub async fn install(
+    state_root: &Path,
+    config_realm: &str,
+    mob_id: &str,
+) -> (
+    DeterministicMobProvider,
+    tokio::sync::mpsc::UnboundedReceiver<()>,
+) {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind deterministic mob provider");
+    let port = listener
+        .local_addr()
+        .expect("deterministic mob provider address")
+        .port();
+    let (request_tx, requests) = tokio::sync::mpsc::unbounded_channel::<()>();
+    let server_task = tokio::spawn(async move {
+        let mut connections = tokio::task::JoinSet::new();
+        loop {
+            let Ok((mut socket, _)) = listener.accept().await else {
+                return;
+            };
+            let request_tx = request_tx.clone();
+            connections.spawn(async move {
+                let mut request_bytes = [0u8; 1024];
+                if matches!(socket.read(&mut request_bytes).await, Ok(read) if read > 0) {
+                    let _ = request_tx.send(());
+                }
+                std::future::pending::<()>().await;
+                drop(socket);
+            });
+        }
+    });
+
+    let member_realm = meerkat_core::mob_realm_id(mob_id)
+        .expect("valid fixture mob realm")
+        .to_string();
+    let realm_doc_dir = state_root.join(config_realm);
+    tokio::fs::create_dir_all(&realm_doc_dir)
+        .await
+        .expect("realm config dir");
+    tokio::fs::write(
+        realm_doc_dir.join("config.toml"),
+        format!(
+            r#"[self_hosted.servers.deterministic_mob]
+base_url = "http://127.0.0.1:{port}/v1"
+
+[self_hosted.models."{MODEL}"]
+server = "deterministic_mob"
+remote_model = "{MODEL}"
+
+[realm."{member_realm}"]
+default_binding = "deterministic_mob"
+
+[realm."{member_realm}".backend.deterministic_mob]
+provider = "{PROVIDER}"
+backend_kind = "{PROVIDER}"
+server = "deterministic_mob"
+
+[realm."{member_realm}".auth.deterministic_mob]
+provider = "{PROVIDER}"
+auth_method = "none"
+source = {{ kind = "platform_default" }}
+
+[realm."{member_realm}".binding.deterministic_mob]
+backend_profile = "deterministic_mob"
+auth_profile = "deterministic_mob"
+"#
+        ),
+    )
+    .await
+    .expect("write deterministic mob provider config");
+
+    (DeterministicMobProvider { server_task }, requests)
+}

--- a/meerkat-cli/tests/system_mob_cli_verbs.rs
+++ b/meerkat-cli/tests/system_mob_cli_verbs.rs
@@ -26,6 +26,14 @@ use meerkat_mob::runtime::bridge_protocol::WireHostBindingDescriptor;
 use tempfile::TempDir;
 use tokio::process::{Child, Command};
 
+#[path = "support/deterministic_mob_provider.rs"]
+mod deterministic_mob_provider;
+
+use deterministic_mob_provider::{
+    MODEL as DETERMINISTIC_MODEL, PROVIDER as DETERMINISTIC_PROVIDER,
+    remove_ambient_provider_credentials,
+};
+
 const DESCRIPTOR_TIMEOUT: Duration = Duration::from_secs(60);
 /// The bind bridge reply deadline is 60s (actor bind_host send); the verb
 /// budget must comfortably contain it.
@@ -83,7 +91,9 @@ impl DaemonHome {
     }
 
     fn spawn_daemon(&self, rkat: &Path) -> Child {
-        Command::new(rkat)
+        let mut command = Command::new(rkat);
+        remove_ambient_provider_credentials(&mut command);
+        command
             .current_dir(self.temp.path())
             .env("HOME", self.temp.path())
             .env("XDG_CONFIG_HOME", self.temp.path().join("config"))
@@ -168,6 +178,7 @@ impl ConsoleHome {
 
     async fn run_rkat(&self, rkat: &Path, args: &[&str]) -> std::process::Output {
         let mut cmd = Command::new(rkat);
+        remove_ambient_provider_credentials(&mut cmd);
         cmd.current_dir(self.temp.path())
             .env("HOME", self.temp.path())
             .env("XDG_CONFIG_HOME", self.temp.path().join("config"))
@@ -223,8 +234,9 @@ async fn write_mobpack_fixture(project_dir: &Path) -> PathBuf {
   "id":"{MOB_ID}",
   "profiles":{{
     "worker":{{
-      "model":"claude-sonnet-4-5",
-      "tools":{{"comms":true}},
+    "model":"{DETERMINISTIC_MODEL}",
+    "provider":"{DETERMINISTIC_PROVIDER}",
+    "tools":{{"comms":true}},
       "peer_description":"Worker"
     }}
   }},
@@ -259,6 +271,8 @@ async fn shutdown(mut daemon: Child) {
 async fn integration_real_mob_cli_verbs_over_tcp() {
     let rkat = rkat_binary_path().expect("rkat binary not found");
     let console = ConsoleHome::new();
+    let (_provider, _requests) =
+        deterministic_mob_provider::install(&console.path().join("realms"), REALM, MOB_ID).await;
 
     // ---- Install the mob into the console realm (mobpack --detach) ----
     let fixture = write_mobpack_fixture(console.path()).await;

--- a/meerkat-cli/tests/system_mob_run_custody.rs
+++ b/meerkat-cli/tests/system_mob_run_custody.rs
@@ -26,6 +26,14 @@ use tempfile::TempDir;
 use tokio::io::AsyncReadExt;
 use tokio::process::Command;
 
+#[path = "support/deterministic_mob_provider.rs"]
+mod deterministic_mob_provider;
+
+use deterministic_mob_provider::{
+    MODEL as DETERMINISTIC_MODEL, PROVIDER as DETERMINISTIC_PROVIDER,
+    remove_ambient_provider_credentials,
+};
+
 /// Budget for one CLI verb against a cold debug-build realm.
 const VERB_TIMEOUT: Duration = Duration::from_secs(150);
 /// Budget between run start and the stalled member turn's HTTP request.
@@ -88,6 +96,7 @@ impl ConsoleHome {
 
     fn command(&self, rkat: &Path, args: &[&str]) -> Command {
         let mut cmd = Command::new(rkat);
+        remove_ambient_provider_credentials(&mut cmd);
         cmd.current_dir(self.temp.path())
             .env("HOME", self.temp.path())
             .env("XDG_CONFIG_HOME", self.temp.path().join("config"))
@@ -215,37 +224,6 @@ async fn pack_fixture(
     pack_path
 }
 
-/// Local OpenAI-compatible endpoint that accepts connections, observes the
-/// request bytes, and never answers: the member turn stays deterministically
-/// in flight until the run is canceled.
-async fn spawn_stall_server() -> (u16, tokio::sync::mpsc::UnboundedReceiver<()>) {
-    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
-        .await
-        .expect("bind stall server");
-    let stall_port = listener.local_addr().expect("stall server addr").port();
-    let (request_tx, request_rx) = tokio::sync::mpsc::unbounded_channel::<()>();
-    tokio::spawn(async move {
-        let mut held_sockets = Vec::new();
-        loop {
-            let Ok((mut socket, _)) = listener.accept().await else {
-                return;
-            };
-            let request_tx = request_tx.clone();
-            let (held_tx, held_rx) = tokio::sync::oneshot::channel();
-            tokio::spawn(async move {
-                let mut request_bytes = [0u8; 1024];
-                if matches!(socket.read(&mut request_bytes).await, Ok(read) if read > 0) {
-                    let _ = request_tx.send(());
-                }
-                // Park the socket without responding until the test ends.
-                let _ = held_tx.send(socket);
-            });
-            held_sockets.push(held_rx);
-        }
-    });
-    (stall_port, request_rx)
-}
-
 fn send_signal(pid: u32, signal: &str) {
     let status = std::process::Command::new("kill")
         .args([signal, pid.to_string().as_str()])
@@ -263,49 +241,16 @@ async fn integration_real_mob_run_pack_sigterm_converges_to_durable_canceled() {
     let rkat = rkat_binary_path().expect("rkat binary not found");
     let console = ConsoleHome::new("mob-run-sigterm-e2e");
 
-    let (stall_port, mut request_rx) = spawn_stall_server().await;
-    // The self-hosted registry is realm-config-owned: write it into the
-    // realm's config doc under the state root.
-    let realm_doc_dir = console.path().join("realms").join(console.realm);
-    tokio::fs::create_dir_all(&realm_doc_dir)
-        .await
-        .expect("realm config dir");
-    // Mob member sessions build under the mob-scoped realm `mob.<mob_id>`,
-    // so the self-hosted credential binding is declared for that realm.
-    let member_realm = format!("mob.{MOB_ID}");
-    tokio::fs::write(
-        realm_doc_dir.join("config.toml"),
-        format!(
-            r#"[self_hosted.servers.stall]
-base_url = "http://127.0.0.1:{stall_port}/v1"
-
-[self_hosted.models."stall-model"]
-server = "stall"
-remote_model = "stall"
-
-[realm."{member_realm}"]
-default_binding = "stall"
-
-[realm."{member_realm}".backend.stall]
-provider = "self_hosted"
-backend_kind = "self_hosted"
-
-[realm."{member_realm}".auth.stall_auth]
-provider = "self_hosted"
-auth_method = "none"
-source = {{ kind = "platform_default" }}
-
-[realm."{member_realm}".binding.stall]
-backend_profile = "stall"
-auth_profile = "stall_auth"
-"#
-        ),
+    let (_provider, mut requests) =
+        deterministic_mob_provider::install(&console.path().join("realms"), console.realm, MOB_ID)
+            .await;
+    let fixture = write_mobpack_fixture(
+        console.path(),
+        MOB_ID,
+        DETERMINISTIC_MODEL,
+        Some(DETERMINISTIC_PROVIDER),
     )
-    .await
-    .expect("write realm config");
-
-    let fixture =
-        write_mobpack_fixture(console.path(), MOB_ID, "stall-model", Some("self_hosted")).await;
+    .await;
     let pack_path = pack_fixture(&console, &rkat, &fixture, "mob-run-sigterm.mobpack").await;
 
     let mut run_child = console
@@ -341,7 +286,7 @@ auth_profile = "stall_auth"
     // premature CLI exit is surfaced with its output instead of a bare
     // dispatch-budget timeout.
     tokio::select! {
-        request = tokio::time::timeout(DISPATCH_TIMEOUT, request_rx.recv()) => {
+        request = tokio::time::timeout(DISPATCH_TIMEOUT, requests.recv()) => {
             request
                 .expect("flow step never dispatched a member turn before the budget")
                 .expect("stall server closed before observing a member turn");
@@ -452,10 +397,16 @@ async fn integration_real_mob_run_detach_converges_execution_custody_lost() {
     let rkat = rkat_binary_path().expect("rkat binary not found");
     let console = ConsoleHome::new("mob-run-detach-custody-e2e");
 
-    // The worker model is never invoked before the CLI exits, so a catalog
-    // model without credentials is sufficient (same posture as the
-    // `cli-mob-verbs` suite's detach install).
-    let fixture = write_mobpack_fixture(console.path(), MOB_ID, "claude-sonnet-4-5", None).await;
+    let (_provider, _requests) =
+        deterministic_mob_provider::install(&console.path().join("realms"), console.realm, MOB_ID)
+            .await;
+    let fixture = write_mobpack_fixture(
+        console.path(),
+        MOB_ID,
+        DETERMINISTIC_MODEL,
+        Some(DETERMINISTIC_PROVIDER),
+    )
+    .await;
     let pack_path = pack_fixture(&console, &rkat, &fixture, "mob-run-detach.mobpack").await;
 
     let ran = console


### PR DESCRIPTION
## Summary

- route the real CLI/TCP/custody system fixtures through an explicit loopback OpenAI-compatible deterministic provider
- remove ambient Anthropic/OpenAI/Gemini/Azure/self-hosted credentials from every spawned process
- preserve detached startup, custody-loss, process-boundary, and CLI assertions without skips or live keys
- regenerate Bazel source metadata for the shared fixture

## Evidence

- exact commit: `4ca26a9cf1bc38852111bdfd6bdca94db0cd5f59`
- exact tree: `09b54854c00725bdfefef65855334d3319af7dbb`
- both formerly failing e2e-system selectors pass
- targeted all-test Clippy passes
- normal exact-tree pre-push passes
- architecture, Rust-quality, and final independent reviews are clean

Closes #1054