### PR TITLE
fix(runtime): deliver abandoned input terminals

### DIFF
--- a/meerkat-machine-schema/src/catalog/dsl/meerkat_machine.rs
+++ b/meerkat-machine-schema/src/catalog/dsl/meerkat_machine.rs
@@ -12416,6 +12416,11 @@ macro_rules! meerkat_catalog_machine_dsl {
         // Keep both correlation and terminal truth single-valued: divergent
         // recovery facts are corruption, not an invitation for the shell to
         // overwrite machine truth.
+        //
+        // Retained facts are comparable only when `turn_terminal_run_id`
+        // attributes them to the recovered run. A run abandoned before turn
+        // start has no such attribution and must not be rejected because an
+        // earlier run left a different terminal outcome.
         transition RecoverRuntimeCompletionResultCorrelation {
             per_phase [Initializing, Idle, Attached, Running, Retired, Stopped]
             on input RecoverRuntimeCompletionResultCorrelation { run_id, terminal_outcome, terminal_cause_kind }
@@ -12454,16 +12459,28 @@ macro_rules! meerkat_catalog_machine_dsl {
             guard "terminal_outcome_absent_or_same" {
                 terminal_outcome == None
                 || self.terminal_outcome == None
+                || (
+                    self.runtime_completion_result_run_id == None
+                    && self.turn_terminal_run_id != Some(run_id)
+                )
                 || self.terminal_outcome == terminal_outcome
             }
             guard "terminal_cause_absent_or_same" {
                 terminal_cause_kind == None
                 || self.terminal_cause_kind == None
+                || (
+                    self.runtime_completion_result_run_id == None
+                    && self.turn_terminal_run_id != Some(run_id)
+                )
                 || self.terminal_cause_kind == terminal_cause_kind
             }
             guard "cancelled_has_no_existing_failure_cause" {
                 terminal_outcome != Some(TurnTerminalOutcome::Cancelled)
                 || self.terminal_cause_kind == None
+                || (
+                    self.runtime_completion_result_run_id == None
+                    && self.turn_terminal_run_id != Some(run_id)
+                )
             }
             update {
                 self.runtime_completion_result_run_id = Some(run_id);

--- a/meerkat-runtime/src/completion.rs
+++ b/meerkat-runtime/src/completion.rs
@@ -126,6 +126,37 @@ pub enum CompletionOutcome {
     },
 }
 
+/// Public completion plus the exact committed input terminal observed by the
+/// completion witness.
+#[derive(Debug, Clone)]
+#[non_exhaustive]
+pub struct CompletionObservation {
+    outcome: CompletionOutcome,
+    input_terminal_outcome: Option<crate::input_state::InputTerminalOutcome>,
+}
+
+impl CompletionObservation {
+    #[must_use]
+    pub fn outcome(&self) -> &CompletionOutcome {
+        &self.outcome
+    }
+
+    #[must_use]
+    pub fn input_terminal_outcome(&self) -> Option<&crate::input_state::InputTerminalOutcome> {
+        self.input_terminal_outcome.as_ref()
+    }
+
+    #[must_use]
+    pub fn into_parts(
+        self,
+    ) -> (
+        CompletionOutcome,
+        Option<crate::input_state::InputTerminalOutcome>,
+    ) {
+        (self.outcome, self.input_terminal_outcome)
+    }
+}
+
 /// Project one generated-authority completion onto the canonical
 /// interaction-scoped terminal event. Both the comms live stream and durable
 /// placed-turn observation use this single mapping so result/failure semantics
@@ -291,6 +322,7 @@ impl CompletionCleanupObservation {
 struct CompletionDelivery {
     outcome: CompletionOutcome,
     cleanup_observation: CompletionCleanupObservation,
+    terminal_outcome: Option<crate::input_state::InputTerminalOutcome>,
 }
 
 /// Snapshot of one input's registered completion waiters.
@@ -362,6 +394,18 @@ impl CompletionHandle {
     ) -> Result<(CompletionOutcome, CompletionCleanupObservation), CompletionWaitError> {
         let delivery = self.try_wait_delivery().await?;
         Ok((delivery.outcome, delivery.cleanup_observation))
+    }
+
+    /// Wait for completion together with the exact committed input terminal
+    /// observed by the terminal-completion witness.
+    pub async fn try_wait_with_terminal_outcome(
+        self,
+    ) -> Result<CompletionObservation, CompletionWaitError> {
+        let delivery = self.try_wait_delivery().await?;
+        Ok(CompletionObservation {
+            outcome: delivery.outcome,
+            input_terminal_outcome: delivery.terminal_outcome,
+        })
     }
 
     /// Wait for the generated execution result or report mechanical waiter failure.
@@ -492,6 +536,7 @@ impl CompletionHandle {
         let _ = tx.send(Ok(CompletionDelivery {
             outcome,
             cleanup_observation: CompletionCleanupObservation::from_realized_result(realized),
+            terminal_outcome: None,
         }));
         Self {
             rx: Some(rx),
@@ -984,11 +1029,21 @@ impl CompletionRegistry {
         outcome: CompletionOutcome,
         cleanup_observation: CompletionCleanupObservation,
     ) {
+        Self::send_outcome_with_terminal(senders, outcome, cleanup_observation, None);
+    }
+
+    fn send_outcome_with_terminal(
+        senders: Vec<oneshot::Sender<Result<CompletionDelivery, CompletionWaitError>>>,
+        outcome: CompletionOutcome,
+        cleanup_observation: CompletionCleanupObservation,
+        terminal_outcome: Option<crate::input_state::InputTerminalOutcome>,
+    ) {
         for tx in senders {
             let outcome = outcome.clone();
             let _ = tx.send(Ok(CompletionDelivery {
                 outcome,
                 cleanup_observation: cleanup_observation.clone(),
+                terminal_outcome: terminal_outcome.clone(),
             }));
         }
     }
@@ -1161,10 +1216,15 @@ impl CompletionRegistry {
     {
         for input_id in input_ids {
             if let Some(senders) = self.take_waiters(&input_id) {
-                Self::send_outcome(
+                let terminal_outcome = bundle
+                    .terminal_completion_witness
+                    .terminal_outcome(&input_id)
+                    .cloned();
+                Self::send_outcome_with_terminal(
                     senders,
                     bundle.outcome.clone(),
                     bundle.cleanup_observation.clone(),
+                    terminal_outcome,
                 );
             }
         }
@@ -1763,6 +1823,65 @@ mod tests {
             CompletionWaitError::AuthorityUnavailable(reason)
                 if reason.contains("exact pending batch candidate")
         ));
+    }
+
+    #[test]
+    fn released_0831_abandoned_completion_json_remains_byte_identical() {
+        let outcome = CompletionOutcome::AbandonedWithError {
+            reason: "runtime apply failed".to_string(),
+            error: TurnErrorMetadata::runtime_apply_failure("runtime apply failed"),
+        };
+        let encoded = serde_json::to_string(&outcome).unwrap();
+        assert_eq!(
+            encoded,
+            r#"{"completion_type":"abandoned_with_error","reason":"runtime apply failed","error":{"kind":"runtime_apply_failure","terminal":true,"outcome":"failed","detail":"runtime apply failed"}}"#
+        );
+        let decoded: CompletionOutcome = serde_json::from_str(&encoded).unwrap();
+        assert!(matches!(
+            decoded,
+            CompletionOutcome::AbandonedWithError { .. }
+        ));
+    }
+
+    #[tokio::test]
+    async fn additive_wait_api_returns_the_witness_derived_terminal() {
+        let mut pending = CompletionHandle::pending_for_test();
+        let handle = pending.take_handle();
+        let authority = authority(
+            RuntimeCompletionResultClass::AbandonedWithError,
+            RuntimeCompletionObservedOutcome::RuntimeApplyFailed,
+        );
+        let attempt = authority.begin_surface_resolution();
+        pending
+            .tx
+            .send(Ok(CompletionDelivery {
+                outcome: CompletionOutcome::AbandonedWithError {
+                    reason: "never executed".to_string(),
+                    error: TurnErrorMetadata::runtime_apply_failure("never executed"),
+                },
+                cleanup_observation: CompletionCleanupObservation::from_realized_result(
+                    attempt.realize(),
+                ),
+                terminal_outcome: Some(crate::input_state::InputTerminalOutcome::Abandoned {
+                    reason: crate::input_state::InputAbandonReason::NeverExecuted,
+                }),
+            }))
+            .expect("test completion receiver remains live");
+
+        let observation = handle
+            .try_wait_with_terminal_outcome()
+            .await
+            .expect("typed waiter delivery");
+        assert!(matches!(
+            observation.outcome(),
+            CompletionOutcome::AbandonedWithError { .. }
+        ));
+        assert_eq!(
+            observation.input_terminal_outcome(),
+            Some(&crate::input_state::InputTerminalOutcome::Abandoned {
+                reason: crate::input_state::InputAbandonReason::NeverExecuted,
+            })
+        );
     }
 
     #[tokio::test]

--- a/meerkat-runtime/src/driver/persistent.rs
+++ b/meerkat-runtime/src/driver/persistent.rs
@@ -65,6 +65,27 @@ enum PreparedProvisionalPromotion {
     HeadCanonical(PreparedHeadCanonicalProvisionalPromotion),
 }
 
+#[must_use = "prepared unstageable-input resolution must be committed or explicitly aborted"]
+pub(crate) struct PreparedUnstageableQueuedResolution {
+    checkpoint: Option<EphemeralDriverRollbackSnapshot>,
+    changed_input_ids: Vec<InputId>,
+    abandoned_input_ids: Vec<InputId>,
+    cancellation_guard:
+        Option<crate::meerkat_machine::driver::PersistentTerminalTransitionCancellationGuard>,
+}
+
+impl PreparedUnstageableQueuedResolution {
+    pub(crate) fn abandoned_input_ids(&self) -> &[InputId] {
+        &self.abandoned_input_ids
+    }
+
+    fn disarm(&mut self) {
+        if let Some(mut guard) = self.cancellation_guard.take() {
+            guard.disarm();
+        }
+    }
+}
+
 impl PersistentRuntimeDriver {
     fn prepare_provisional_promotion(
         &self,
@@ -1949,10 +1970,20 @@ impl PersistentRuntimeDriver {
     ///
     /// Fail-closed: every fallible step between the staged DSL transition and
     /// the durable commit restores the pre-transition checkpoint (K11).
+    #[cfg(test)]
     pub(crate) async fn resolve_unstageable_queued_inputs(
         &mut self,
         input_ids: &[InputId],
     ) -> Result<Vec<InputId>, crate::traits::RuntimeDriverError> {
+        let prepared = self.prepare_unstageable_queued_inputs(input_ids)?;
+        self.commit_prepared_unstageable_queued_inputs(prepared)
+            .await
+    }
+
+    pub(crate) fn prepare_unstageable_queued_inputs(
+        &mut self,
+        input_ids: &[InputId],
+    ) -> Result<PreparedUnstageableQueuedResolution, crate::traits::RuntimeDriverError> {
         self.require_durability_ready()?;
         let checkpoint = self.persistence_rollback_checkpoint();
         // The change set mirrors the inner skip: the persistence helpers fail
@@ -1975,8 +2006,39 @@ impl PersistentRuntimeDriver {
                 ));
             }
         };
+        Ok(PreparedUnstageableQueuedResolution {
+            checkpoint,
+            changed_input_ids,
+            abandoned_input_ids: abandoned,
+            cancellation_guard: Some(
+                crate::meerkat_machine::driver::PersistentTerminalTransitionCancellationGuard::new(
+                    self.durability_health.clone(),
+                    "unstageable_queued_resolution",
+                ),
+            ),
+        })
+    }
+
+    pub(crate) fn abort_prepared_unstageable_queued_inputs(
+        &mut self,
+        mut prepared: PreparedUnstageableQueuedResolution,
+        operation: &'static str,
+        error: crate::traits::RuntimeDriverError,
+    ) -> crate::traits::RuntimeDriverError {
+        let checkpoint = prepared.checkpoint.take();
+        prepared.disarm();
+        self.post_transition_failure(checkpoint, operation, error.to_string())
+    }
+
+    pub(crate) async fn commit_prepared_unstageable_queued_inputs(
+        &mut self,
+        mut prepared: PreparedUnstageableQueuedResolution,
+    ) -> Result<Vec<InputId>, crate::traits::RuntimeDriverError> {
+        let checkpoint = prepared.checkpoint.take();
+        let changed_input_ids = std::mem::take(&mut prepared.changed_input_ids);
         if changed_input_ids.is_empty() {
-            return Ok(abandoned);
+            prepared.disarm();
+            return Ok(std::mem::take(&mut prepared.abandoned_input_ids));
         }
         let (checkpoint, input_states, commit) = self.lifecycle_persistence_payload_with_rollback(
             checkpoint,
@@ -1988,23 +2050,28 @@ impl PersistentRuntimeDriver {
             .commit_machine_lifecycle(&self.runtime_id, commit, &input_states)
             .await
         {
-            return Err(self.post_transition_failure(
+            let error = self.post_transition_failure(
                 checkpoint,
                 "resolve_unstageable_queued_inputs_commit",
                 format!("unstageable queued input resolution persist failed: {error}"),
-            ));
+            );
+            prepared.disarm();
+            return Err(error);
         }
         if let Err(error) = self
             .inner
             .archive_archivable_terminal_inputs_after_durable_commit(&changed_input_ids)
         {
-            return Err(self.post_transition_failure(
+            let error = self.post_transition_failure(
                 None,
                 "resolve_unstageable_queued_inputs_archive",
                 error.to_string(),
-            ));
+            );
+            prepared.disarm();
+            return Err(error);
         }
-        Ok(abandoned)
+        prepared.disarm();
+        Ok(std::mem::take(&mut prepared.abandoned_input_ids))
     }
 
     /// Persist the just-staged run bindings BEFORE the run executes.

--- a/meerkat-runtime/src/meerkat_machine/driver.rs
+++ b/meerkat-runtime/src/meerkat_machine/driver.rs
@@ -181,7 +181,7 @@ pub(crate) struct InputTerminalCompletionAuthorizationWitness {
     batch_key: crate::input_state::InputTerminalCompletionBatchKey,
     candidate_digest: String,
     completion_input_ids_digest: String,
-    input_ids: Vec<InputId>,
+    recipients: indexmap::IndexMap<InputId, InputTerminalOutcome>,
     cas_profile: crate::store::InputStateBatchCasImplementationProfile,
     write_fence: Option<InputTerminalCompletionWriteFence>,
 }
@@ -195,8 +195,12 @@ impl InputTerminalCompletionAuthorizationWitness {
         &self.candidate_digest
     }
 
-    pub(crate) fn input_ids(&self) -> &[InputId] {
-        &self.input_ids
+    pub(crate) fn input_ids(&self) -> impl Iterator<Item = &InputId> {
+        self.recipients.keys()
+    }
+
+    pub(crate) fn terminal_outcome(&self, input_id: &InputId) -> Option<&InputTerminalOutcome> {
+        self.recipients.get(input_id)
     }
 }
 
@@ -424,6 +428,24 @@ impl RuntimeCompletionResultAuthority {
         let mut input_ids = input_ids;
         input_ids.sort_by_key(|input_id| input_id.0);
         let owner_input_id = input_ids[0].clone();
+        let terminal_outcome = match &candidate {
+            crate::input_state::InteractionTerminalCandidate::Cancelled => {
+                InputTerminalOutcome::Abandoned {
+                    reason: crate::input_state::InputAbandonReason::Cancelled,
+                }
+            }
+            crate::input_state::InteractionTerminalCandidate::RuntimeTerminated { .. } => {
+                InputTerminalOutcome::Abandoned {
+                    reason: crate::input_state::InputAbandonReason::Destroyed,
+                }
+            }
+            crate::input_state::InteractionTerminalCandidate::MachineTerminalFailure { .. } => {
+                InputTerminalOutcome::Abandoned {
+                    reason: crate::input_state::InputAbandonReason::NeverExecuted,
+                }
+            }
+            _ => InputTerminalOutcome::Consumed,
+        };
         InputTerminalCompletionAuthorizationWitness {
             runtime_id: LogicalRuntimeId::new("test-runtime"),
             session_id: self.session_id.clone(),
@@ -441,7 +463,10 @@ impl RuntimeCompletionResultAuthority {
                 .expect("test terminal candidate should serialize"),
             completion_input_ids_digest: interaction_terminal_payload_digest(&input_ids)
                 .expect("test terminal recipients should serialize"),
-            input_ids,
+            recipients: input_ids
+                .into_iter()
+                .map(|input_id| (input_id, terminal_outcome.clone()))
+                .collect(),
             cas_profile: crate::store::InputStateBatchCasImplementationProfile::MultiWriter,
             write_fence: None,
         }
@@ -797,14 +822,17 @@ enum TerminalTransitionCheckpoint {
 /// commit. Async cancellation drops the future without running ordinary error
 /// handling, so the guard owns a clone of the shared durability gate and
 /// degrades it synchronously unless the exact durable operation completed.
-struct PersistentTerminalTransitionCancellationGuard {
+pub(crate) struct PersistentTerminalTransitionCancellationGuard {
     durability_health: Option<DurabilityHealthHandle>,
     operation: &'static str,
     armed: bool,
 }
 
 impl PersistentTerminalTransitionCancellationGuard {
-    fn new(durability_health: Option<DurabilityHealthHandle>, operation: &'static str) -> Self {
+    pub(crate) fn new(
+        durability_health: Option<DurabilityHealthHandle>,
+        operation: &'static str,
+    ) -> Self {
         Self {
             durability_health,
             operation,
@@ -812,7 +840,7 @@ impl PersistentTerminalTransitionCancellationGuard {
         }
     }
 
-    fn disarm(&mut self) {
+    pub(crate) fn disarm(&mut self) {
         self.armed = false;
     }
 }
@@ -3059,6 +3087,21 @@ impl DriverEntry {
                         .to_string(),
             });
         }
+        let recipients = persisted_input_ids
+            .iter()
+            .map(|input_id| {
+                let terminal_outcome = self
+                    .as_driver()
+                    .stored_input_state(input_id)
+                    .and_then(|stored| stored.seed.terminal_outcome)
+                    .ok_or_else(|| RuntimeDriverError::RecoveryCorruption {
+                        reason: format!(
+                            "terminal completion witness lost terminal outcome for recipient {input_id}"
+                        ),
+                    })?;
+                Ok((input_id.clone(), terminal_outcome))
+            })
+            .collect::<Result<indexmap::IndexMap<_, _>, _>>()?;
         let authority = self.shared_dsl_authority();
         let authority = authority
             .lock()
@@ -3128,7 +3171,7 @@ impl DriverEntry {
             batch_key: owner.batch_key.clone(),
             candidate_digest: owner.candidate_digest.clone(),
             completion_input_ids_digest: owner.completion_input_ids_digest.clone(),
-            input_ids: persisted_input_ids.clone(),
+            recipients,
             cas_profile,
             write_fence,
         })
@@ -3293,15 +3336,14 @@ impl DriverEntry {
                     .to_string(),
             });
         }
-        let current_witness =
-            self.input_terminal_completion_authorization_witness(authorized_witness.input_ids())?;
+        let input_ids = authorized_witness.input_ids().cloned().collect::<Vec<_>>();
+        let current_witness = self.input_terminal_completion_authorization_witness(&input_ids)?;
         if current_witness != authorized_witness {
             return Err(RuntimeDriverError::StaleAuthority {
                 reason: "terminal completion authority no longer matches the exact owner, run, candidate, or recipient batch"
                     .to_string(),
             });
         }
-        let input_ids = authorized_witness.input_ids();
         let requested = input_ids.iter().collect::<std::collections::HashSet<_>>();
         let expected = input_ids
             .iter()
@@ -3430,7 +3472,7 @@ impl DriverEntry {
                     .await?;
                 }
                 if !has_interaction_terminal_outbox && let DriverEntry::Persistent(driver) = self {
-                    driver.archive_terminal_inputs_after_durable_obligations(input_ids)?;
+                    driver.archive_terminal_inputs_after_durable_obligations(&input_ids)?;
                 }
                 return Ok(());
             }
@@ -3480,7 +3522,7 @@ impl DriverEntry {
         )
         .await?;
         if !has_interaction_terminal_outbox && let DriverEntry::Persistent(driver) = self {
-            driver.archive_terminal_inputs_after_durable_obligations(input_ids)?;
+            driver.archive_terminal_inputs_after_durable_obligations(&input_ids)?;
         }
         Ok(())
     }
@@ -4885,12 +4927,137 @@ impl DriverEntry {
     /// machine's disposition durably before returning it.
     pub(crate) async fn resolve_unstageable_queued_inputs(
         &mut self,
+        run_id: &RunId,
         input_ids: &[InputId],
+        refusal_reason: &str,
     ) -> Result<Vec<InputId>, crate::traits::RuntimeDriverError> {
         match self {
-            DriverEntry::Ephemeral(d) => d.resolve_unstageable_queued_inputs(input_ids),
-            DriverEntry::Persistent(d) => d.resolve_unstageable_queued_inputs(input_ids).await,
+            DriverEntry::Ephemeral(d) => {
+                let checkpoint = d.rollback_snapshot();
+                let abandoned = match d.resolve_unstageable_queued_inputs(input_ids) {
+                    Ok(abandoned) => abandoned,
+                    Err(error) => {
+                        d.restore_rollback_snapshot(checkpoint);
+                        return Err(self.rollback_refused_run_after_error(run_id, error));
+                    }
+                };
+                if !abandoned.is_empty()
+                    && let Err(error) = self.stage_stage_refusal_terminal_carriers(
+                        run_id,
+                        &abandoned,
+                        refusal_reason,
+                    )
+                {
+                    let DriverEntry::Ephemeral(d) = self else {
+                        unreachable!("driver kind cannot change while staging a terminal")
+                    };
+                    d.restore_rollback_snapshot(checkpoint);
+                    return Err(self.rollback_refused_run_after_error(run_id, error));
+                }
+                if let Err(error) = machine_apply_run_return_projection(
+                    self,
+                    run_id,
+                    RunReturnDisposition::Rollback,
+                ) {
+                    let DriverEntry::Ephemeral(d) = self else {
+                        unreachable!("driver kind cannot change while returning a refused run")
+                    };
+                    d.restore_rollback_snapshot(checkpoint);
+                    return Err(RuntimeDriverError::Internal(format!(
+                        "failed to return refused runtime run: {error}"
+                    )));
+                }
+                Ok(abandoned)
+            }
+            DriverEntry::Persistent(d) => {
+                let prepared = match d.prepare_unstageable_queued_inputs(input_ids) {
+                    Ok(prepared) => prepared,
+                    Err(error) => return Err(self.rollback_refused_run_after_error(run_id, error)),
+                };
+                if !prepared.abandoned_input_ids().is_empty()
+                    && let Err(error) = self.stage_stage_refusal_terminal_carriers(
+                        run_id,
+                        prepared.abandoned_input_ids(),
+                        refusal_reason,
+                    )
+                {
+                    let DriverEntry::Persistent(d) = self else {
+                        unreachable!("driver kind cannot change while staging a terminal")
+                    };
+                    let error = d.abort_prepared_unstageable_queued_inputs(
+                        prepared,
+                        "stage_refusal_terminal_carriers",
+                        error,
+                    );
+                    return Err(self.rollback_refused_run_after_error(run_id, error));
+                }
+                if let Err(error) = machine_apply_run_return_projection(
+                    self,
+                    run_id,
+                    RunReturnDisposition::Rollback,
+                ) {
+                    let DriverEntry::Persistent(d) = self else {
+                        unreachable!("driver kind cannot change while returning a refused run")
+                    };
+                    return Err(d.abort_prepared_unstageable_queued_inputs(
+                        prepared,
+                        "stage_refusal_run_return",
+                        RuntimeDriverError::Internal(format!(
+                            "failed to return refused runtime run: {error}"
+                        )),
+                    ));
+                }
+                let DriverEntry::Persistent(d) = self else {
+                    unreachable!("driver kind cannot change while staging a terminal")
+                };
+                match d.commit_prepared_unstageable_queued_inputs(prepared).await {
+                    Ok(abandoned) => Ok(abandoned),
+                    Err(error) => Err(self.rollback_refused_run_after_error(run_id, error)),
+                }
+            }
         }
+    }
+
+    fn rollback_refused_run_after_error(
+        &mut self,
+        run_id: &RunId,
+        error: RuntimeDriverError,
+    ) -> RuntimeDriverError {
+        if self.current_run_id().as_ref() != Some(run_id) {
+            return error;
+        }
+        match machine_apply_run_return_projection(self, run_id, RunReturnDisposition::Rollback) {
+            Ok(_) => error,
+            Err(rollback_error) => RuntimeDriverError::Internal(format!(
+                "failed to return refused run after terminal handling error: {rollback_error}; \
+                 terminal handling failure: {error}"
+            )),
+        }
+    }
+
+    fn stage_stage_refusal_terminal_carriers(
+        &mut self,
+        run_id: &RunId,
+        abandoned_input_ids: &[InputId],
+        refusal_reason: &str,
+    ) -> Result<(), RuntimeDriverError> {
+        let error = meerkat_core::TurnErrorMetadata::runtime_apply_failure(format!(
+            "input abandoned before execution: {refusal_reason}"
+        ));
+        let candidate =
+            crate::input_state::InteractionTerminalCandidate::MachineTerminalFailure { error };
+        let completion_batch = self.stage_input_terminal_completion_batch(
+            InteractionTerminalBatchScope::Run(run_id),
+            abandoned_input_ids,
+            candidate,
+            false,
+        )?;
+        let outboxes = authorized_staged_directed_terminal_outboxes(
+            self,
+            abandoned_input_ids,
+            &completion_batch,
+        )?;
+        self.stage_interaction_terminal_outboxes(outboxes)
     }
 
     pub(crate) async fn abandon_pending_inputs(
@@ -8246,7 +8413,7 @@ pub(crate) async fn prepare_runtime_loop_batch_start(
     run_id: RunId,
     batch: AuthorizedRuntimeLoopBatch,
 ) -> Result<RuntimeLoopBatchStart, RuntimeDriverError> {
-    let mut driver = driver.lock().await;
+    let mut driver = Arc::clone(driver).lock_owned().await;
     let staged_ids = batch.input_ids().to_vec();
     let stage_source = batch.source();
     machine_begin_run(&mut driver, run_id.clone()).map_err(|err| {
@@ -8279,27 +8446,25 @@ pub(crate) async fn prepare_runtime_loop_batch_start(
             // refusal probe cannot attribute a batch-level refusal to any
             // single member, so it would need a whole-batch fallback anyway -
             // a second, untested path through the never-starve floor.
-            let abandoned_input_ids = driver
-                    .resolve_unstageable_queued_inputs(&staged_ids)
+            let handoff = crate::tokio::spawn(async move {
+                let abandoned_input_ids = driver
+                    .resolve_unstageable_queued_inputs(&run_id, &staged_ids, &reason)
                     .await
                     .map_err(|resolve_err| {
                         RuntimeDriverError::Internal(format!(
                             "failed to resolve unstageable queued inputs: {resolve_err}; staging refusal: {reason}"
                         ))
                     })?;
-            if let Err(rollback_err) = machine_apply_run_return_projection(
-                &mut driver,
-                &run_id,
-                RunReturnDisposition::Rollback,
-            ) {
-                return Err(RuntimeDriverError::Internal(format!(
-                    "failed to roll back runtime run after batch staging refusal: {rollback_err}; staging refusal: {reason}"
-                )));
-            }
-            return Ok(RuntimeLoopBatchStart::StageRefused {
-                reason,
-                abandoned_input_ids,
+                Ok(RuntimeLoopBatchStart::StageRefused {
+                    reason,
+                    abandoned_input_ids,
+                })
             });
+            return handoff.await.map_err(|error| {
+                RuntimeDriverError::Internal(format!(
+                    "owned stage-refusal terminal commit task ended before completion: {error}"
+                ))
+            })?;
         }
     };
 

--- a/meerkat-runtime/src/meerkat_machine_tests.rs
+++ b/meerkat-runtime/src/meerkat_machine_tests.rs
@@ -41171,6 +41171,477 @@ async fn prepare_runtime_loop_batch_start_unwinds_run_state_when_staging_rejects
     );
 }
 
+fn stage_refusal_terminal_driver(name: &'static str) -> SharedDriver {
+    let runtime_id = LogicalRuntimeId::new(name);
+    let session_id = SessionId::new();
+    let mut ephemeral = EphemeralRuntimeDriver::new(runtime_id.clone());
+    ephemeral
+        .install_registered_authority_for_test(
+            crate::meerkat_machine::dsl::SessionId::from_domain(&session_id),
+            Some(&runtime_id),
+            Some(1),
+            Some(crate::meerkat_machine::dsl::Generation::from(1)),
+            Some(crate::meerkat_machine::dsl::RuntimeEpochId::from(
+                "stage-refusal-terminal-epoch".to_string(),
+            )),
+            crate::store::SupervisorAuthoritySnapshot::UnboundNoReceipt,
+        )
+        .expect("stage-refusal fixture installs registered runtime authority");
+    Arc::new(tokio::sync::Mutex::new(DriverEntry::Ephemeral(ephemeral)))
+}
+
+fn persistent_stage_refusal_terminal_driver(
+    name: &'static str,
+) -> (
+    SharedDriver,
+    Arc<crate::store::InMemoryRuntimeStore>,
+    LogicalRuntimeId,
+) {
+    let store = Arc::new(crate::store::InMemoryRuntimeStore::new());
+    let runtime_store: Arc<dyn crate::store::RuntimeStore> = store.clone();
+    let blob_store: Arc<dyn meerkat_core::BlobStore> =
+        Arc::new(meerkat_store::MemoryBlobStore::new());
+    let runtime_id = LogicalRuntimeId::new(name);
+    let session_id = SessionId::new();
+    let mut persistent = crate::driver::persistent::PersistentRuntimeDriver::new(
+        runtime_id.clone(),
+        runtime_store,
+        blob_store,
+    );
+    persistent
+        .inner_mut()
+        .install_registered_authority_for_test(
+            crate::meerkat_machine::dsl::SessionId::from_domain(&session_id),
+            Some(&runtime_id),
+            Some(1),
+            Some(crate::meerkat_machine::dsl::Generation::from(1)),
+            Some(crate::meerkat_machine::dsl::RuntimeEpochId::from(
+                "persistent-stage-refusal-epoch".to_string(),
+            )),
+            crate::store::SupervisorAuthoritySnapshot::UnboundNoReceipt,
+        )
+        .expect("persistent fixture installs registered runtime authority");
+    (
+        Arc::new(tokio::sync::Mutex::new(DriverEntry::Persistent(persistent))),
+        store,
+        runtime_id,
+    )
+}
+
+async fn drive_stage_refusal_to_terminal(driver: &SharedDriver, input_id: &InputId) -> RunId {
+    for _ in 0..8 {
+        let run_id = RunId::new();
+        let outcome = prepare_runtime_loop_batch_start(
+            driver,
+            run_id.clone(),
+            crate::meerkat_machine::driver::test_authorized_runtime_loop_batch(vec![
+                input_id.clone(),
+                InputId::new(),
+            ]),
+        )
+        .await
+        .expect("staging refusal remains a typed non-fatal outcome");
+        let crate::meerkat_machine::driver::RuntimeLoopBatchStart::StageRefused {
+            abandoned_input_ids,
+            ..
+        } = outcome
+        else {
+            panic!("an unstageable test batch must be refused");
+        };
+        if abandoned_input_ids == [input_id.clone()] {
+            return run_id;
+        }
+    }
+    panic!("generated staging-attempt cap did not terminalize the input");
+}
+
+#[tokio::test]
+async fn stage_refusal_stages_one_linked_nondirected_terminal_completion() {
+    let driver = stage_refusal_terminal_driver("stage-refusal-nondirected-carrier");
+    let (input, input_id) =
+        interrupt_yielding_peer_input("nondirected input that never starts", None);
+    assert!(
+        driver
+            .lock()
+            .await
+            .as_driver_mut()
+            .accept_input(input)
+            .await
+            .expect("input admission")
+            .is_accepted()
+    );
+
+    let run_id = drive_stage_refusal_to_terminal(&driver, &input_id).await;
+    let entry = driver.lock().await;
+    let batches = entry
+        .input_terminal_completion_recovery_batches()
+        .await
+        .expect("terminal completion carrier must remain recoverable");
+    assert_eq!(batches.len(), 1);
+    assert_eq!(batches[0].input_ids, vec![input_id.clone()]);
+    assert_eq!(
+        batches[0].batch_key,
+        crate::input_state::InputTerminalCompletionBatchKey::Run { run_id }
+    );
+    assert!(
+        !batches[0].has_interaction_terminal_outbox,
+        "nondirected input must not fabricate an interaction outbox"
+    );
+}
+
+#[tokio::test]
+async fn stage_refusal_stages_directed_outbox_from_the_completion_witness() {
+    let driver = stage_refusal_terminal_driver("stage-refusal-directed-carrier");
+    let (input, input_id) =
+        directed_interrupt_yielding_peer_input("directed input that never starts");
+    assert!(
+        driver
+            .lock()
+            .await
+            .as_driver_mut()
+            .accept_input(input)
+            .await
+            .expect("directed input admission")
+            .is_accepted()
+    );
+
+    let run_id = drive_stage_refusal_to_terminal(&driver, &input_id).await;
+    let mut entry = driver.lock().await;
+    let completion_batches = entry
+        .input_terminal_completion_recovery_batches()
+        .await
+        .expect("completion carrier");
+    let interaction_batches = entry
+        .interaction_terminal_recovery_batches()
+        .await
+        .expect("directed publication carrier");
+    assert_eq!(completion_batches.len(), 1);
+    assert_eq!(interaction_batches.len(), 1);
+    assert_eq!(
+        completion_batches[0].batch_key,
+        crate::input_state::InputTerminalCompletionBatchKey::Run {
+            run_id: run_id.clone()
+        }
+    );
+    assert_eq!(
+        interaction_batches[0].batch_key,
+        crate::input_state::InteractionTerminalBatchKey::Run { run_id }
+    );
+    assert_eq!(
+        interaction_batches[0].input_ids,
+        completion_batches[0].input_ids
+    );
+}
+
+#[tokio::test]
+async fn persistent_stage_refusal_commits_terminal_and_delivery_obligations_atomically() {
+    let (driver, store, runtime_id) =
+        persistent_stage_refusal_terminal_driver("persistent-stage-refusal-atomic");
+    let (input, input_id) =
+        directed_interrupt_yielding_peer_input("persistent directed input that never starts");
+    assert!(
+        driver
+            .lock()
+            .await
+            .as_driver_mut()
+            .accept_input(input)
+            .await
+            .expect("directed input admission")
+            .is_accepted()
+    );
+
+    drive_stage_refusal_to_terminal(&driver, &input_id).await;
+    let durable = crate::store::RuntimeStore::load_input_states_strict(store.as_ref(), &runtime_id)
+        .await
+        .expect("load exact durable input rows");
+    let row = durable
+        .into_iter()
+        .find(|row| row.state.input_id == input_id)
+        .expect("terminal input remains durably inspectable");
+    assert_eq!(
+        row.seed.terminal_outcome,
+        Some(crate::input_state::InputTerminalOutcome::Abandoned {
+            reason: crate::input_state::InputAbandonReason::MaxAttemptsExhausted { attempts: 3 },
+        })
+    );
+    assert!(
+        row.state.terminal_completion.is_some(),
+        "the exact completion recipient carrier must commit with terminality"
+    );
+    assert!(
+        row.state.interaction_terminal_outbox.is_some(),
+        "the directed publication obligation must commit with terminality"
+    );
+    let durable_runtime_state = crate::store::load_runtime_state(store.as_ref(), &runtime_id)
+        .await
+        .expect("load durable runtime lifecycle")
+        .expect("stage-refusal commit writes runtime lifecycle");
+    assert_ne!(
+        durable_runtime_state,
+        RuntimeState::Running,
+        "run rollback must commit atomically with terminal input carriers"
+    );
+}
+
+#[tokio::test]
+async fn failed_stage_refusal_commit_publishes_none_of_the_terminal_bundle() {
+    let (driver, store, runtime_id) =
+        persistent_stage_refusal_terminal_driver("persistent-stage-refusal-failure");
+    let (input, input_id) =
+        directed_interrupt_yielding_peer_input("failed atomic stage-refusal commit");
+    assert!(
+        driver
+            .lock()
+            .await
+            .as_driver_mut()
+            .accept_input(input)
+            .await
+            .expect("directed input admission")
+            .is_accepted()
+    );
+
+    for _ in 0..3 {
+        let run_id = RunId::new();
+        let outcome = prepare_runtime_loop_batch_start(
+            &driver,
+            run_id,
+            crate::meerkat_machine::driver::test_authorized_runtime_loop_batch(vec![
+                input_id.clone(),
+                InputId::new(),
+            ]),
+        )
+        .await
+        .expect("pre-terminal refusal remains retryable");
+        assert!(matches!(
+            outcome,
+            crate::meerkat_machine::driver::RuntimeLoopBatchStart::StageRefused {
+                ref abandoned_input_ids,
+                ..
+            } if abandoned_input_ids.is_empty()
+        ));
+    }
+
+    store.fail_next_machine_lifecycle_commit();
+    let error = prepare_runtime_loop_batch_start(
+        &driver,
+        RunId::new(),
+        crate::meerkat_machine::driver::test_authorized_runtime_loop_batch(vec![
+            input_id.clone(),
+            InputId::new(),
+        ]),
+    )
+    .await
+    .expect_err("failed atomic commit must not report a terminal delivery");
+    assert!(
+        error
+            .to_string()
+            .contains("unstageable queued input resolution")
+    );
+
+    let durable = crate::store::RuntimeStore::load_input_states_strict(store.as_ref(), &runtime_id)
+        .await
+        .expect("load durable input after rejected commit");
+    let row = durable
+        .into_iter()
+        .find(|row| row.state.input_id == input_id)
+        .expect("input remains durable after rejected commit");
+    assert_eq!(
+        row.seed.phase,
+        crate::input_state::InputLifecycleState::Queued
+    );
+    assert!(row.seed.terminal_outcome.is_none());
+    assert!(row.state.terminal_completion.is_none());
+    assert!(row.state.interaction_terminal_outbox.is_none());
+}
+
+async fn complete_prior_run_for_stage_refusal_test(driver: &SharedDriver) {
+    let run_id = RunId::new();
+    let mut entry = driver.lock().await;
+    crate::meerkat_machine::driver::machine_begin_run(&mut entry, run_id.clone())
+        .expect("registered session admits a prior run");
+    {
+        let authority = entry.shared_dsl_authority();
+        let mut authority = authority
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        crate::meerkat_machine::dsl::MeerkatMachineMutator::apply(
+            &mut *authority,
+            crate::meerkat_machine::dsl::MeerkatMachineInput::RunCompleted {
+                run_id: crate::meerkat_machine::dsl::RunId::from_domain(&run_id),
+            },
+        )
+        .expect("prior run reaches generated completion");
+    }
+    {
+        let authority = entry.shared_dsl_authority();
+        let mut authority = authority
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        crate::meerkat_machine::dsl::MeerkatMachineMutator::apply(
+            &mut *authority,
+            crate::meerkat_machine::dsl::MeerkatMachineInput::ResolveRuntimeCompletionResult {
+                run_id: Some(crate::meerkat_machine::dsl::RunId::from_domain(&run_id)),
+                terminal:
+                    crate::meerkat_machine::dsl::RuntimeCompletionTerminalObservation::RunResult,
+                finalization:
+                    crate::meerkat_machine::dsl::RuntimeCompletionFinalizationObservation::Succeeded,
+            },
+        )
+        .expect("prior run resolves its generated completion");
+    }
+    crate::meerkat_machine::driver::machine_apply_run_return_projection(
+        &mut entry,
+        &run_id,
+        crate::meerkat_machine::driver::RunReturnDisposition::Rollback,
+    )
+    .expect("prior run returns its runtime binding");
+}
+
+#[tokio::test]
+async fn stage_refusal_terminal_remains_recoverable_after_a_prior_completed_turn() {
+    let driver = stage_refusal_terminal_driver("stage-refusal-after-prior-turn");
+    complete_prior_run_for_stage_refusal_test(&driver).await;
+    let (input, input_id) =
+        directed_interrupt_yielding_peer_input("directed input after a prior turn");
+    assert!(
+        driver
+            .lock()
+            .await
+            .as_driver_mut()
+            .accept_input(input)
+            .await
+            .expect("directed input admission")
+            .is_accepted()
+    );
+
+    let run_id = drive_stage_refusal_to_terminal(&driver, &input_id).await;
+    let mut entry = driver.lock().await;
+    let mut batches = entry
+        .interaction_terminal_recovery_batches()
+        .await
+        .unwrap_or_else(|error| {
+            let authority = entry.shared_dsl_authority();
+            let authority = authority
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            panic!(
+                "prior-run terminal facts must not block exact carrier recovery: {error}; \
+                 requested_run={run_id} result_run={:?} result_resolved={} turn_terminal_run={:?} outcome={:?} cause={:?}",
+                authority.state().runtime_completion_result_run_id,
+                authority.state().runtime_completion_result_resolved,
+                authority.state().turn_terminal_run_id,
+                authority.state().terminal_outcome,
+                authority.state().terminal_cause_kind,
+            )
+        });
+    assert_eq!(batches.len(), 1);
+    let batch = batches.remove(0);
+    assert_eq!(batch.input_ids, vec![input_id.clone()]);
+    crate::meerkat_machine::driver::machine_recover_runtime_completion_result_correlation(
+        &entry,
+        &run_id,
+        batch.terminal_recovery,
+    )
+    .expect("recover exact stage-refusal terminal correlation");
+    assert!(
+        crate::meerkat_machine::driver::machine_recover_runtime_completion_result_correlation(
+            &entry,
+            &run_id,
+            crate::input_state::RuntimeCompletionTerminalRecovery::Cancelled,
+        )
+        .is_err(),
+        "an open recovery correlation must reject a contradictory terminal overwrite"
+    );
+    let authority = crate::meerkat_machine::driver::machine_resolve_runtime_completion_result(
+        &entry,
+        Some(&run_id),
+        batch.terminal_observation,
+        crate::meerkat_machine::dsl::RuntimeCompletionFinalizationObservation::Succeeded,
+    )
+    .expect("resolve the generated stage-refusal terminal");
+    let witness = entry
+        .input_terminal_completion_authorization_witness(&batch.input_ids)
+        .expect("exact terminal completion witness");
+    let bundle = crate::completion::authorize_runtime_terminal_bundle(
+        &batch.interaction_ids,
+        batch.terminal.as_ref(),
+        authority,
+        witness,
+        batch.completion_error_metadata.clone(),
+        None,
+    )
+    .expect("authorize one terminal bundle");
+    let events = bundle.interaction_events().to_vec();
+    assert!(matches!(
+        events.as_slice(),
+        [meerkat_core::event::AgentEvent::InteractionFailed { interaction_id, .. }]
+            if interaction_id.0 == input_id.0
+    ));
+    entry
+        .finalize_input_terminal_completion_batch(bundle.terminal_completion())
+        .await
+        .expect("finalize exact completion receipt");
+    entry
+        .finalize_interaction_terminal_outboxes(
+            &input_id,
+            &events,
+            crate::meerkat_machine::dsl::RuntimeCompletionFinalizationObservation::Succeeded,
+        )
+        .await
+        .expect("finalize exact directed terminal");
+    let receipts = events
+        .iter()
+        .enumerate()
+        .map(|(index, event)| {
+            meerkat_core::lifecycle::core_executor::CoreInteractionTerminalPublicationReceipt::try_new(
+                event,
+                u64::try_from(index).expect("receipt index") + 1,
+            )
+            .expect("exact terminal publication receipt")
+        })
+        .collect::<Vec<_>>();
+    entry
+        .mark_interaction_terminal_outboxes_published(&input_id, &receipts)
+        .await
+        .expect("commit publication receipt");
+    assert!(
+        entry
+            .interaction_terminal_recovery_batches()
+            .await
+            .expect("post-publication recovery scan")
+            .is_empty(),
+        "a published terminal must not be offered for duplicate delivery"
+    );
+    drop(entry);
+
+    let mut completions = crate::completion::CompletionRegistry::new();
+    let handle = completions.register(input_id.clone());
+    completions.resolve_authorized_runtime_terminal_bundle([input_id], bundle);
+    let completion = handle
+        .try_wait_with_terminal_outcome()
+        .await
+        .expect("directed waiter receives the published terminal");
+    assert_eq!(
+        completion.input_terminal_outcome(),
+        Some(&crate::input_state::InputTerminalOutcome::Abandoned {
+            reason: crate::input_state::InputAbandonReason::MaxAttemptsExhausted { attempts: 3 },
+        })
+    );
+}
+
+#[tokio::test]
+async fn legacy_waiter_api_remains_source_and_behavior_compatible() {
+    let handle = crate::completion::CompletionHandle::already_runtime_apply_failed(
+        "runtime apply failed".to_string(),
+        meerkat_core::TurnErrorMetadata::runtime_apply_failure("runtime apply failed"),
+    )
+    .expect("pre-resolved legacy completion");
+    assert!(matches!(
+        handle.try_wait().await,
+        Ok(crate::completion::CompletionOutcome::AbandonedWithError { .. })
+    ));
+}
+
 #[tokio::test]
 async fn modeled_meerkat_accept_with_completion_running_peer_interrupt_signal_matches_runtime() {
     let fixture = build_runtime_parity_fixture(RuntimeParityPhase::Running).await;

--- a/meerkat-runtime/src/runtime_loop.rs
+++ b/meerkat-runtime/src/runtime_loop.rs
@@ -378,6 +378,31 @@ async fn persist_authorized_terminal_completion_owned(
     })?
 }
 
+async fn persist_and_deliver_authorized_terminal_completion_owned(
+    driver: &crate::meerkat_machine::SharedDriver,
+    completions: &crate::meerkat_machine::SharedCompletionRegistry,
+    input_ids: Vec<InputId>,
+    bundle: crate::completion::AuthorizedRuntimeTerminalBundle,
+) -> Result<(), crate::RuntimeDriverError> {
+    let driver = std::sync::Arc::clone(driver);
+    let completions = std::sync::Arc::clone(completions);
+    let handoff = tokio::spawn(async move {
+        let mut driver = driver.lock_owned().await;
+        driver
+            .finalize_input_terminal_completion_batch(bundle.terminal_completion())
+            .await?;
+        drop(driver);
+        let mut completions = completions.lock_owned().await;
+        completions.resolve_authorized_runtime_terminal_bundle(input_ids, bundle);
+        Ok::<(), crate::RuntimeDriverError>(())
+    });
+    handoff.await.map_err(|error| {
+        crate::RuntimeDriverError::Internal(format!(
+            "owned terminal completion delivery task ended before publishing its outcome: {error}"
+        ))
+    })?
+}
+
 /// What an EMPTY compaction outbox obliges the checkpoint refresh to do.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum EmptyOutboxCheckpoint {
@@ -1487,7 +1512,7 @@ async fn drain_recovered_interaction_terminal_outboxes_under_authority(
     executor: &mut dyn meerkat_core::lifecycle::CoreExecutor,
     _authority_guard: &crate::tokio::sync::OwnedMutexGuard<()>,
 ) -> Result<(), InteractionTerminalPublicationError> {
-    drain_recovered_input_terminal_completions(driver, executor).await?;
+    drain_recovered_input_terminal_completions(driver, completions, executor).await?;
     let batches = driver
         .lock()
         .await
@@ -1684,6 +1709,7 @@ async fn drain_recovered_interaction_terminal_outboxes_under_authority(
 /// event publication and waiter delivery.
 async fn drain_recovered_input_terminal_completions(
     driver: &crate::meerkat_machine::SharedDriver,
+    completions: Option<&crate::meerkat_machine::SharedCompletionRegistry>,
     executor: &mut dyn meerkat_core::lifecycle::CoreExecutor,
 ) -> Result<(), InteractionTerminalPublicationError> {
     let batches = driver
@@ -1800,14 +1826,27 @@ async fn drain_recovered_input_terminal_completions(
                 "terminal completion recovery projection failed: {error}"
             ))
         })?;
-        persist_authorized_terminal_completion_owned(driver, bundle.terminal_completion())
-            .await
-            .map_err(|error| {
-                InteractionTerminalPublicationError::from_driver(
-                    "terminal completion recovery receipt persistence failed",
-                    error,
+        match completions {
+            Some(completions) => {
+                persist_and_deliver_authorized_terminal_completion_owned(
+                    driver,
+                    completions,
+                    batch.input_ids,
+                    bundle,
                 )
-            })?;
+                .await
+            }
+            None => {
+                persist_authorized_terminal_completion_owned(driver, bundle.terminal_completion())
+                    .await
+            }
+        }
+        .map_err(|error| {
+            InteractionTerminalPublicationError::from_driver(
+                "terminal completion recovery receipt persistence failed",
+                error,
+            )
+        })?;
     }
     Ok(())
 }
@@ -5999,17 +6038,20 @@ async fn process_queue(
                             abandoned = abandoned_input_ids.len(),
                             "generated staging authority refused an accepted input batch; resolved through machine authority"
                         );
-                        if !abandoned_input_ids.is_empty()
-                            && let Some(completions) = completions.as_ref()
-                        {
-                            let mut completions = completions.lock().await;
-                            fail_completion_waiters(
-                                &mut completions,
-                                &abandoned_input_ids,
-                                format!("runtime batch staging refused: {reason}"),
-                            );
-                        }
                         drop(queue_authority_guard);
+                        if !abandoned_input_ids.is_empty()
+                            && drain_recovered_interaction_terminal_outboxes_until_clear(
+                                driver,
+                                completions,
+                                executor,
+                                authority_binding,
+                                true,
+                                RuntimeProjectionRecoveryAuthority::RuntimeLoop,
+                            )
+                            .await
+                        {
+                            return true;
+                        }
                         continue;
                     }
                     Err(err) => {
@@ -9305,6 +9347,69 @@ mod tests {
         })
     }
 
+    struct CountingTurnFinalizationBoundary {
+        gate: Arc<crate::tokio::sync::Mutex<()>>,
+        acquisitions: Arc<AtomicUsize>,
+    }
+
+    #[async_trait::async_trait]
+    impl meerkat_core::lifecycle::CoreExecutorTurnFinalizationBoundaryHandle
+        for CountingTurnFinalizationBoundary
+    {
+        async fn acquire(
+            &self,
+        ) -> Result<
+            Box<dyn meerkat_core::lifecycle::CoreExecutorTurnFinalizationGuard>,
+            CoreExecutorError,
+        > {
+            self.acquisitions.fetch_add(1, Ordering::SeqCst);
+            Ok(Box::new(Arc::clone(&self.gate).lock_owned().await))
+        }
+    }
+
+    struct BoundaryApplyFailingExecutor {
+        apply_calls: Arc<AtomicUsize>,
+        stop_calls: Arc<AtomicUsize>,
+        boundary: Arc<CountingTurnFinalizationBoundary>,
+    }
+
+    #[async_trait::async_trait]
+    impl meerkat_core::lifecycle::CoreExecutor for BoundaryApplyFailingExecutor {
+        fn turn_finalization_boundary_handle(
+            &self,
+        ) -> Option<Arc<dyn meerkat_core::lifecycle::CoreExecutorTurnFinalizationBoundaryHandle>>
+        {
+            Some(self.boundary.clone())
+        }
+
+        async fn apply(
+            &mut self,
+            _run_id: RunId,
+            _primitive: RunPrimitive,
+        ) -> Result<meerkat_core::lifecycle::core_executor::CoreApplyOutput, CoreExecutorError>
+        {
+            self.apply_calls.fetch_add(1, Ordering::SeqCst);
+            Err(CoreExecutorError::apply_failed_runtime_turn(
+                "synthetic deterministic apply failure",
+            ))
+        }
+
+        async fn cancel_after_boundary(
+            &mut self,
+            _reason: String,
+        ) -> Result<(), CoreExecutorError> {
+            Ok(())
+        }
+
+        async fn stop_runtime_executor(
+            &mut self,
+            _reason: String,
+        ) -> Result<(), CoreExecutorError> {
+            self.stop_calls.fetch_add(1, Ordering::SeqCst);
+            Ok(())
+        }
+    }
+
     /// Field class (0.7.23 crew gateway): a poison input reaching the
     /// machine's max-attempts abandonment mid-wake must not wedge the queue.
     /// Pre-fix, the whole-batch defer sweep hit `GuardRejected` on the
@@ -9346,30 +9451,43 @@ mod tests {
 
         let apply_calls = Arc::new(AtomicUsize::new(0));
         let stop_calls = Arc::new(AtomicUsize::new(0));
-        let mut executor = crate::control_plane::test_support::ApplyFailingExecutor::new(
-            Arc::clone(&apply_calls),
-            Arc::clone(&stop_calls),
-        );
+        let boundary_acquisitions = Arc::new(AtomicUsize::new(0));
+        let mut executor = BoundaryApplyFailingExecutor {
+            apply_calls: Arc::clone(&apply_calls),
+            stop_calls: Arc::clone(&stop_calls),
+            boundary: Arc::new(CountingTurnFinalizationBoundary {
+                gate: Arc::new(crate::tokio::sync::Mutex::new(())),
+                acquisitions: Arc::clone(&boundary_acquisitions),
+            }),
+        };
         let (_effect_tx, mut effect_rx) = tokio::sync::mpsc::channel(1);
         let authority_binding = RuntimeLoopAuthorityBinding::detached_for_test();
         let teardown_slot = RuntimeLoopTeardownSlot::pending();
         let mut terminal_handoff = RuntimeLoopTerminalHandoff::default();
 
-        let should_stop = process_queue(
-            &driver,
-            &mut executor,
-            &mut effect_rx,
-            None,
-            &authority_binding,
-            &teardown_slot,
-            &mut terminal_handoff,
+        let should_stop = tokio::time::timeout(
+            std::time::Duration::from_secs(5),
+            process_queue(
+                &driver,
+                &mut executor,
+                &mut effect_rx,
+                None,
+                &authority_binding,
+                &teardown_slot,
+                &mut terminal_handoff,
+            ),
         )
-        .await;
+        .await
+        .expect("stage-refusal terminal drain must not reacquire the held boundary");
         assert!(
             !should_stop,
             "a machine-policy abandonment must not stop the runtime loop"
         );
         assert_eq!(stop_calls.load(Ordering::SeqCst), 0);
+        assert!(
+            boundary_acquisitions.load(Ordering::SeqCst) > 0,
+            "the regression must exercise a real turn-finalization boundary"
+        );
 
         let guard = driver.lock().await;
         match &*guard {
@@ -9681,8 +9799,13 @@ mod tests {
         );
 
         // Attempt 1: refused, counted, and deferred behind the backlog.
+        let first_refusal_run = RunId::new();
         let abandoned = guard
-            .resolve_unstageable_queued_inputs(std::slice::from_ref(&head_id))
+            .resolve_unstageable_queued_inputs(
+                &first_refusal_run,
+                std::slice::from_ref(&head_id),
+                "test staging refusal",
+            )
             .await
             .expect("machine resolves a refused queued input");
         assert!(
@@ -9710,15 +9833,25 @@ mod tests {
 
         // Burn the remaining generated attempts.
         for _ in 0..2 {
+            let refusal_run = RunId::new();
             let abandoned = guard
-                .resolve_unstageable_queued_inputs(std::slice::from_ref(&head_id))
+                .resolve_unstageable_queued_inputs(
+                    &refusal_run,
+                    std::slice::from_ref(&head_id),
+                    "test staging refusal",
+                )
                 .await
                 .expect("machine resolves a refused queued input");
             assert!(abandoned.is_empty(), "the retry cap is not reached yet");
         }
 
+        let terminal_refusal_run = RunId::new();
         let abandoned = guard
-            .resolve_unstageable_queued_inputs(std::slice::from_ref(&head_id))
+            .resolve_unstageable_queued_inputs(
+                &terminal_refusal_run,
+                std::slice::from_ref(&head_id),
+                "test staging refusal",
+            )
             .await
             .expect("machine resolves a refused queued input");
         assert_eq!(
@@ -9961,13 +10094,14 @@ mod tests {
         // The field evidence was a caller waiting forever. A terminalized input
         // with the caller still hanging would fail this lane's criterion the
         // same way the original defect did.
-        let outcome = tokio::time::timeout(
+        let completion = tokio::time::timeout(
             crate::run_progress::RUN_EXECUTION_START_BOUND,
-            waiter.wait_authorized(),
+            waiter.try_wait_with_terminal_outcome(),
         )
         .await
-        .expect("the caller must stop waiting when its run is terminalized");
-        let reason = match &outcome {
+        .expect("the caller must stop waiting when its run is terminalized")
+        .expect("the caller must receive an authorized terminal");
+        let reason = match completion.outcome() {
             crate::completion::CompletionOutcome::Abandoned { reason, .. }
             | crate::completion::CompletionOutcome::AbandonedWithError { reason, .. } => {
                 reason.clone()
@@ -9977,6 +10111,13 @@ mod tests {
         assert!(
             reason.contains("ExecutorNotProgressing"),
             "the caller's outcome must name why its run could not progress, got: {reason}"
+        );
+        assert_eq!(
+            completion.input_terminal_outcome(),
+            Some(&crate::input_state::InputTerminalOutcome::Abandoned {
+                reason: crate::input_state::InputAbandonReason::NeverExecuted,
+            }),
+            "the additive waiter observation must preserve the exact machine-owned cause"
         );
         let failure = last_apply_failure_message(&authority)
             .expect("the machine must record why the run could not progress");

--- a/specs/machines/meerkat_machine/model.tla
+++ b/specs/machines/meerkat_machine/model.tla
@@ -5749,9 +5749,9 @@ RecoverRuntimeCompletionResultCorrelationInitializing(run_id, arg_terminal_outco
     /\ (session_id # None)
     /\ (IF (runtime_completion_result_run_id = None) THEN TRUE ELSE (runtime_completion_result_run_id = Some(run_id)))
     /\ (IF ((arg_terminal_outcome = None) /\ (arg_terminal_cause_kind = None)) THEN TRUE ELSE (IF ((arg_terminal_outcome = Some("Cancelled")) /\ (arg_terminal_cause_kind = None)) THEN TRUE ELSE (IF ((arg_terminal_outcome = Some("BudgetExhausted")) /\ (arg_terminal_cause_kind = Some("BudgetExhausted"))) THEN TRUE ELSE (IF ((arg_terminal_outcome = Some("TimeBudgetExceeded")) /\ (arg_terminal_cause_kind = Some("TimeBudgetExceeded"))) THEN TRUE ELSE (IF ((arg_terminal_outcome = Some("StructuredOutputValidationFailed")) /\ (arg_terminal_cause_kind = Some("StructuredOutputValidationFailed"))) THEN TRUE ELSE ((arg_terminal_outcome = Some("Failed")) /\ (arg_terminal_cause_kind # None) /\ (arg_terminal_cause_kind # Some("Unknown")) /\ (arg_terminal_cause_kind # Some("BudgetExhausted")) /\ (arg_terminal_cause_kind # Some("TimeBudgetExceeded")) /\ (arg_terminal_cause_kind # Some("StructuredOutputValidationFailed"))))))))
-    /\ (IF (arg_terminal_outcome = None) THEN TRUE ELSE (IF (terminal_outcome = None) THEN TRUE ELSE (terminal_outcome = arg_terminal_outcome)))
-    /\ (IF (arg_terminal_cause_kind = None) THEN TRUE ELSE (IF (terminal_cause_kind = None) THEN TRUE ELSE (terminal_cause_kind = arg_terminal_cause_kind)))
-    /\ (IF (arg_terminal_outcome # Some("Cancelled")) THEN TRUE ELSE (terminal_cause_kind = None))
+    /\ (IF (arg_terminal_outcome = None) THEN TRUE ELSE (IF (terminal_outcome = None) THEN TRUE ELSE (IF ((runtime_completion_result_run_id = None) /\ (turn_terminal_run_id # Some(run_id))) THEN TRUE ELSE (terminal_outcome = arg_terminal_outcome))))
+    /\ (IF (arg_terminal_cause_kind = None) THEN TRUE ELSE (IF (terminal_cause_kind = None) THEN TRUE ELSE (IF ((runtime_completion_result_run_id = None) /\ (turn_terminal_run_id # Some(run_id))) THEN TRUE ELSE (terminal_cause_kind = arg_terminal_cause_kind))))
+    /\ (IF (arg_terminal_outcome # Some("Cancelled")) THEN TRUE ELSE (IF (terminal_cause_kind = None) THEN TRUE ELSE ((runtime_completion_result_run_id = None) /\ (turn_terminal_run_id # Some(run_id)))))
     /\ phase' = "Initializing"
     /\ model_step_count' = model_step_count + 1
     /\ terminal_outcome' = IF (arg_terminal_outcome # None) THEN arg_terminal_outcome ELSE terminal_outcome
@@ -5766,9 +5766,9 @@ RecoverRuntimeCompletionResultCorrelationIdle(run_id, arg_terminal_outcome, arg_
     /\ (session_id # None)
     /\ (IF (runtime_completion_result_run_id = None) THEN TRUE ELSE (runtime_completion_result_run_id = Some(run_id)))
     /\ (IF ((arg_terminal_outcome = None) /\ (arg_terminal_cause_kind = None)) THEN TRUE ELSE (IF ((arg_terminal_outcome = Some("Cancelled")) /\ (arg_terminal_cause_kind = None)) THEN TRUE ELSE (IF ((arg_terminal_outcome = Some("BudgetExhausted")) /\ (arg_terminal_cause_kind = Some("BudgetExhausted"))) THEN TRUE ELSE (IF ((arg_terminal_outcome = Some("TimeBudgetExceeded")) /\ (arg_terminal_cause_kind = Some("TimeBudgetExceeded"))) THEN TRUE ELSE (IF ((arg_terminal_outcome = Some("StructuredOutputValidationFailed")) /\ (arg_terminal_cause_kind = Some("StructuredOutputValidationFailed"))) THEN TRUE ELSE ((arg_terminal_outcome = Some("Failed")) /\ (arg_terminal_cause_kind # None) /\ (arg_terminal_cause_kind # Some("Unknown")) /\ (arg_terminal_cause_kind # Some("BudgetExhausted")) /\ (arg_terminal_cause_kind # Some("TimeBudgetExceeded")) /\ (arg_terminal_cause_kind # Some("StructuredOutputValidationFailed"))))))))
-    /\ (IF (arg_terminal_outcome = None) THEN TRUE ELSE (IF (terminal_outcome = None) THEN TRUE ELSE (terminal_outcome = arg_terminal_outcome)))
-    /\ (IF (arg_terminal_cause_kind = None) THEN TRUE ELSE (IF (terminal_cause_kind = None) THEN TRUE ELSE (terminal_cause_kind = arg_terminal_cause_kind)))
-    /\ (IF (arg_terminal_outcome # Some("Cancelled")) THEN TRUE ELSE (terminal_cause_kind = None))
+    /\ (IF (arg_terminal_outcome = None) THEN TRUE ELSE (IF (terminal_outcome = None) THEN TRUE ELSE (IF ((runtime_completion_result_run_id = None) /\ (turn_terminal_run_id # Some(run_id))) THEN TRUE ELSE (terminal_outcome = arg_terminal_outcome))))
+    /\ (IF (arg_terminal_cause_kind = None) THEN TRUE ELSE (IF (terminal_cause_kind = None) THEN TRUE ELSE (IF ((runtime_completion_result_run_id = None) /\ (turn_terminal_run_id # Some(run_id))) THEN TRUE ELSE (terminal_cause_kind = arg_terminal_cause_kind))))
+    /\ (IF (arg_terminal_outcome # Some("Cancelled")) THEN TRUE ELSE (IF (terminal_cause_kind = None) THEN TRUE ELSE ((runtime_completion_result_run_id = None) /\ (turn_terminal_run_id # Some(run_id)))))
     /\ phase' = "Idle"
     /\ model_step_count' = model_step_count + 1
     /\ terminal_outcome' = IF (arg_terminal_outcome # None) THEN arg_terminal_outcome ELSE terminal_outcome
@@ -5783,9 +5783,9 @@ RecoverRuntimeCompletionResultCorrelationAttached(run_id, arg_terminal_outcome, 
     /\ (session_id # None)
     /\ (IF (runtime_completion_result_run_id = None) THEN TRUE ELSE (runtime_completion_result_run_id = Some(run_id)))
     /\ (IF ((arg_terminal_outcome = None) /\ (arg_terminal_cause_kind = None)) THEN TRUE ELSE (IF ((arg_terminal_outcome = Some("Cancelled")) /\ (arg_terminal_cause_kind = None)) THEN TRUE ELSE (IF ((arg_terminal_outcome = Some("BudgetExhausted")) /\ (arg_terminal_cause_kind = Some("BudgetExhausted"))) THEN TRUE ELSE (IF ((arg_terminal_outcome = Some("TimeBudgetExceeded")) /\ (arg_terminal_cause_kind = Some("TimeBudgetExceeded"))) THEN TRUE ELSE (IF ((arg_terminal_outcome = Some("StructuredOutputValidationFailed")) /\ (arg_terminal_cause_kind = Some("StructuredOutputValidationFailed"))) THEN TRUE ELSE ((arg_terminal_outcome = Some("Failed")) /\ (arg_terminal_cause_kind # None) /\ (arg_terminal_cause_kind # Some("Unknown")) /\ (arg_terminal_cause_kind # Some("BudgetExhausted")) /\ (arg_terminal_cause_kind # Some("TimeBudgetExceeded")) /\ (arg_terminal_cause_kind # Some("StructuredOutputValidationFailed"))))))))
-    /\ (IF (arg_terminal_outcome = None) THEN TRUE ELSE (IF (terminal_outcome = None) THEN TRUE ELSE (terminal_outcome = arg_terminal_outcome)))
-    /\ (IF (arg_terminal_cause_kind = None) THEN TRUE ELSE (IF (terminal_cause_kind = None) THEN TRUE ELSE (terminal_cause_kind = arg_terminal_cause_kind)))
-    /\ (IF (arg_terminal_outcome # Some("Cancelled")) THEN TRUE ELSE (terminal_cause_kind = None))
+    /\ (IF (arg_terminal_outcome = None) THEN TRUE ELSE (IF (terminal_outcome = None) THEN TRUE ELSE (IF ((runtime_completion_result_run_id = None) /\ (turn_terminal_run_id # Some(run_id))) THEN TRUE ELSE (terminal_outcome = arg_terminal_outcome))))
+    /\ (IF (arg_terminal_cause_kind = None) THEN TRUE ELSE (IF (terminal_cause_kind = None) THEN TRUE ELSE (IF ((runtime_completion_result_run_id = None) /\ (turn_terminal_run_id # Some(run_id))) THEN TRUE ELSE (terminal_cause_kind = arg_terminal_cause_kind))))
+    /\ (IF (arg_terminal_outcome # Some("Cancelled")) THEN TRUE ELSE (IF (terminal_cause_kind = None) THEN TRUE ELSE ((runtime_completion_result_run_id = None) /\ (turn_terminal_run_id # Some(run_id)))))
     /\ phase' = "Attached"
     /\ model_step_count' = model_step_count + 1
     /\ terminal_outcome' = IF (arg_terminal_outcome # None) THEN arg_terminal_outcome ELSE terminal_outcome
@@ -5800,9 +5800,9 @@ RecoverRuntimeCompletionResultCorrelationRunning(run_id, arg_terminal_outcome, a
     /\ (session_id # None)
     /\ (IF (runtime_completion_result_run_id = None) THEN TRUE ELSE (runtime_completion_result_run_id = Some(run_id)))
     /\ (IF ((arg_terminal_outcome = None) /\ (arg_terminal_cause_kind = None)) THEN TRUE ELSE (IF ((arg_terminal_outcome = Some("Cancelled")) /\ (arg_terminal_cause_kind = None)) THEN TRUE ELSE (IF ((arg_terminal_outcome = Some("BudgetExhausted")) /\ (arg_terminal_cause_kind = Some("BudgetExhausted"))) THEN TRUE ELSE (IF ((arg_terminal_outcome = Some("TimeBudgetExceeded")) /\ (arg_terminal_cause_kind = Some("TimeBudgetExceeded"))) THEN TRUE ELSE (IF ((arg_terminal_outcome = Some("StructuredOutputValidationFailed")) /\ (arg_terminal_cause_kind = Some("StructuredOutputValidationFailed"))) THEN TRUE ELSE ((arg_terminal_outcome = Some("Failed")) /\ (arg_terminal_cause_kind # None) /\ (arg_terminal_cause_kind # Some("Unknown")) /\ (arg_terminal_cause_kind # Some("BudgetExhausted")) /\ (arg_terminal_cause_kind # Some("TimeBudgetExceeded")) /\ (arg_terminal_cause_kind # Some("StructuredOutputValidationFailed"))))))))
-    /\ (IF (arg_terminal_outcome = None) THEN TRUE ELSE (IF (terminal_outcome = None) THEN TRUE ELSE (terminal_outcome = arg_terminal_outcome)))
-    /\ (IF (arg_terminal_cause_kind = None) THEN TRUE ELSE (IF (terminal_cause_kind = None) THEN TRUE ELSE (terminal_cause_kind = arg_terminal_cause_kind)))
-    /\ (IF (arg_terminal_outcome # Some("Cancelled")) THEN TRUE ELSE (terminal_cause_kind = None))
+    /\ (IF (arg_terminal_outcome = None) THEN TRUE ELSE (IF (terminal_outcome = None) THEN TRUE ELSE (IF ((runtime_completion_result_run_id = None) /\ (turn_terminal_run_id # Some(run_id))) THEN TRUE ELSE (terminal_outcome = arg_terminal_outcome))))
+    /\ (IF (arg_terminal_cause_kind = None) THEN TRUE ELSE (IF (terminal_cause_kind = None) THEN TRUE ELSE (IF ((runtime_completion_result_run_id = None) /\ (turn_terminal_run_id # Some(run_id))) THEN TRUE ELSE (terminal_cause_kind = arg_terminal_cause_kind))))
+    /\ (IF (arg_terminal_outcome # Some("Cancelled")) THEN TRUE ELSE (IF (terminal_cause_kind = None) THEN TRUE ELSE ((runtime_completion_result_run_id = None) /\ (turn_terminal_run_id # Some(run_id)))))
     /\ phase' = "Running"
     /\ model_step_count' = model_step_count + 1
     /\ terminal_outcome' = IF (arg_terminal_outcome # None) THEN arg_terminal_outcome ELSE terminal_outcome
@@ -5817,9 +5817,9 @@ RecoverRuntimeCompletionResultCorrelationRetired(run_id, arg_terminal_outcome, a
     /\ (session_id # None)
     /\ (IF (runtime_completion_result_run_id = None) THEN TRUE ELSE (runtime_completion_result_run_id = Some(run_id)))
     /\ (IF ((arg_terminal_outcome = None) /\ (arg_terminal_cause_kind = None)) THEN TRUE ELSE (IF ((arg_terminal_outcome = Some("Cancelled")) /\ (arg_terminal_cause_kind = None)) THEN TRUE ELSE (IF ((arg_terminal_outcome = Some("BudgetExhausted")) /\ (arg_terminal_cause_kind = Some("BudgetExhausted"))) THEN TRUE ELSE (IF ((arg_terminal_outcome = Some("TimeBudgetExceeded")) /\ (arg_terminal_cause_kind = Some("TimeBudgetExceeded"))) THEN TRUE ELSE (IF ((arg_terminal_outcome = Some("StructuredOutputValidationFailed")) /\ (arg_terminal_cause_kind = Some("StructuredOutputValidationFailed"))) THEN TRUE ELSE ((arg_terminal_outcome = Some("Failed")) /\ (arg_terminal_cause_kind # None) /\ (arg_terminal_cause_kind # Some("Unknown")) /\ (arg_terminal_cause_kind # Some("BudgetExhausted")) /\ (arg_terminal_cause_kind # Some("TimeBudgetExceeded")) /\ (arg_terminal_cause_kind # Some("StructuredOutputValidationFailed"))))))))
-    /\ (IF (arg_terminal_outcome = None) THEN TRUE ELSE (IF (terminal_outcome = None) THEN TRUE ELSE (terminal_outcome = arg_terminal_outcome)))
-    /\ (IF (arg_terminal_cause_kind = None) THEN TRUE ELSE (IF (terminal_cause_kind = None) THEN TRUE ELSE (terminal_cause_kind = arg_terminal_cause_kind)))
-    /\ (IF (arg_terminal_outcome # Some("Cancelled")) THEN TRUE ELSE (terminal_cause_kind = None))
+    /\ (IF (arg_terminal_outcome = None) THEN TRUE ELSE (IF (terminal_outcome = None) THEN TRUE ELSE (IF ((runtime_completion_result_run_id = None) /\ (turn_terminal_run_id # Some(run_id))) THEN TRUE ELSE (terminal_outcome = arg_terminal_outcome))))
+    /\ (IF (arg_terminal_cause_kind = None) THEN TRUE ELSE (IF (terminal_cause_kind = None) THEN TRUE ELSE (IF ((runtime_completion_result_run_id = None) /\ (turn_terminal_run_id # Some(run_id))) THEN TRUE ELSE (terminal_cause_kind = arg_terminal_cause_kind))))
+    /\ (IF (arg_terminal_outcome # Some("Cancelled")) THEN TRUE ELSE (IF (terminal_cause_kind = None) THEN TRUE ELSE ((runtime_completion_result_run_id = None) /\ (turn_terminal_run_id # Some(run_id)))))
     /\ phase' = "Retired"
     /\ model_step_count' = model_step_count + 1
     /\ terminal_outcome' = IF (arg_terminal_outcome # None) THEN arg_terminal_outcome ELSE terminal_outcome
@@ -5834,9 +5834,9 @@ RecoverRuntimeCompletionResultCorrelationStopped(run_id, arg_terminal_outcome, a
     /\ (session_id # None)
     /\ (IF (runtime_completion_result_run_id = None) THEN TRUE ELSE (runtime_completion_result_run_id = Some(run_id)))
     /\ (IF ((arg_terminal_outcome = None) /\ (arg_terminal_cause_kind = None)) THEN TRUE ELSE (IF ((arg_terminal_outcome = Some("Cancelled")) /\ (arg_terminal_cause_kind = None)) THEN TRUE ELSE (IF ((arg_terminal_outcome = Some("BudgetExhausted")) /\ (arg_terminal_cause_kind = Some("BudgetExhausted"))) THEN TRUE ELSE (IF ((arg_terminal_outcome = Some("TimeBudgetExceeded")) /\ (arg_terminal_cause_kind = Some("TimeBudgetExceeded"))) THEN TRUE ELSE (IF ((arg_terminal_outcome = Some("StructuredOutputValidationFailed")) /\ (arg_terminal_cause_kind = Some("StructuredOutputValidationFailed"))) THEN TRUE ELSE ((arg_terminal_outcome = Some("Failed")) /\ (arg_terminal_cause_kind # None) /\ (arg_terminal_cause_kind # Some("Unknown")) /\ (arg_terminal_cause_kind # Some("BudgetExhausted")) /\ (arg_terminal_cause_kind # Some("TimeBudgetExceeded")) /\ (arg_terminal_cause_kind # Some("StructuredOutputValidationFailed"))))))))
-    /\ (IF (arg_terminal_outcome = None) THEN TRUE ELSE (IF (terminal_outcome = None) THEN TRUE ELSE (terminal_outcome = arg_terminal_outcome)))
-    /\ (IF (arg_terminal_cause_kind = None) THEN TRUE ELSE (IF (terminal_cause_kind = None) THEN TRUE ELSE (terminal_cause_kind = arg_terminal_cause_kind)))
-    /\ (IF (arg_terminal_outcome # Some("Cancelled")) THEN TRUE ELSE (terminal_cause_kind = None))
+    /\ (IF (arg_terminal_outcome = None) THEN TRUE ELSE (IF (terminal_outcome = None) THEN TRUE ELSE (IF ((runtime_completion_result_run_id = None) /\ (turn_terminal_run_id # Some(run_id))) THEN TRUE ELSE (terminal_outcome = arg_terminal_outcome))))
+    /\ (IF (arg_terminal_cause_kind = None) THEN TRUE ELSE (IF (terminal_cause_kind = None) THEN TRUE ELSE (IF ((runtime_completion_result_run_id = None) /\ (turn_terminal_run_id # Some(run_id))) THEN TRUE ELSE (terminal_cause_kind = arg_terminal_cause_kind))))
+    /\ (IF (arg_terminal_outcome # Some("Cancelled")) THEN TRUE ELSE (IF (terminal_cause_kind = None) THEN TRUE ELSE ((runtime_completion_result_run_id = None) /\ (turn_terminal_run_id # Some(run_id)))))
     /\ phase' = "Stopped"
     /\ model_step_count' = model_step_count + 1
     /\ terminal_outcome' = IF (arg_terminal_outcome # None) THEN arg_terminal_outcome ELSE terminal_outcome


### PR DESCRIPTION
## Summary

- preserve the public exhaustive `CompletionOutcome` shape while adding an additive typed `CompletionObservation` API
- derive abandoned and never-started terminal observations only from exact committed machine/input witnesses
- atomically stage refusal terminal state, finalized completion, directed outbox, and `RollbackRun`
- make terminal drain cancellation-safe and converge publication/receipt across restart without duplicates
- preserve all legacy wait behavior and serialization

## Evidence

- exact head: `52d7121f9a3fefa161202f138160883afd834276`
- exact tree: `2394e81845ff2d2819cf160d99fdfca955075242`
- base used for the published patch: `47cb3c5fed24dc7cefe388fe8be8d39598fcd579`
- stable patch ID: `eff20355b8794718c02cfbb90fb0441f3cd1059d`
- runtime tests: 1,905/1,905; all-target/all-feature Clippy and machine drift green
- prior unrelated council replay failure disproved: exact test candidate/main 10/10 each; full binary candidate/main 360/360 each
- controlled full pre-push retry passed
- architecture, Rust-quality, adversarial, and boss final reviews found no blocking issues

Closes #1020