### PR TITLE
feat: add typed cross-provider replay contracts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,16 @@ them.
 
 ## [Unreleased]
 
+### Breaking
+
+- **Provider replay now fails closed before dispatch when canonical tool
+  adjacency, media capability, or cross-provider continuity metadata cannot be
+  represented safely.** New Rust contracts include `ReplayPlan`,
+  `ReplayApplication`, `ReplayTarget`, `ReplayWireFamily`,
+  `ReplayToolResultProjection`, `ReplayReasoningProjection`,
+  `ReplayDisposition`, `ReplaySubject`, `ReplayCapability`, `ReplayPlanError`,
+  `ReplayPlanEntry`, and typed replay index newtypes.
+
 ## [0.8.31] - 2026-08-28
 
 ### Breaking

--- a/meerkat-anthropic/src/client.rs
+++ b/meerkat-anthropic/src/client.rs
@@ -245,45 +245,9 @@ fn project_anthropic_tool_result(
     result_index: meerkat_core::ReplayToolResultIndex,
     result: &ToolResult,
 ) -> Result<ToolResult, LlmError> {
-    if result.has_video() {
-        return Err(invalid_replay(
-            "video blocks are not supported in Anthropic tool results",
-        ));
-    }
-    Ok(ToolResult::with_blocks(
-        result.tool_use_id.clone(),
-        result
-            .content
-            .iter()
-            .enumerate()
-            .map(|(block_index, block)| {
-                let subject = meerkat_core::ReplaySubject::ToolResultContent {
-                    message,
-                    result: result_index,
-                    block: meerkat_core::ReplayToolResultContentIndex(block_index),
-                };
-                let projected = match replay_application
-                    .next(subject)
-                    .map_err(|error| invalid_replay(error.to_string()))?
-                {
-                    meerkat_core::ReplayDisposition::Preserve => block.clone(),
-                    meerkat_core::ReplayDisposition::LowerToText => ContentBlock::Text {
-                        text: block.text_projection().into_owned(),
-                    },
-                    disposition => {
-                        return Err(invalid_replay(format!(
-                            "Anthropic replay cannot apply tool-result disposition {disposition:?}"
-                        )));
-                    }
-                };
-                replay_application
-                    .record_content(subject, block, &projected)
-                    .map_err(|error| invalid_replay(error.to_string()))?;
-                Ok(projected)
-            })
-            .collect::<Result<Vec<_>, _>>()?,
-        result.is_error,
-    ))
+    replay_application
+        .project_tool_result(message, result_index, result)
+        .map_err(|error| invalid_replay(error.to_string()))
 }
 
 fn anthropic_server_tool_content_replayable(content: &Value) -> bool {
@@ -377,6 +341,8 @@ fn project_anthropic_replay_messages(messages: &[Message]) -> Result<Vec<Message
             true,
             false,
             true,
+            meerkat_core::ReplayToolResultProjection::PreserveBlocks,
+            meerkat_core::ReplayReasoningProjection::ProviderNative,
         ),
     )
     .map_err(|error| invalid_replay(error.to_string()))?;
@@ -385,12 +351,19 @@ fn project_anthropic_replay_messages(messages: &[Message]) -> Result<Vec<Message
 
     for (message_index, message) in messages.iter().enumerate() {
         let message_index = meerkat_core::ReplayMessageIndex(message_index);
+        if let Message::SystemNotice(notice) = message {
+            let projected_notice = replay_application
+                .project_system_notice(message_index, notice)
+                .map_err(|error| invalid_replay(error.to_string()))?;
+            projected.push(Message::SystemNotice(projected_notice));
+            continue;
+        }
         replay_application
             .record_message(
                 meerkat_core::ReplaySubject::Message(message_index),
                 message,
                 match message {
-                    Message::System(_) | Message::SystemNotice(_) => Some(message),
+                    Message::System(_) => Some(message),
                     _ => None,
                 },
             )
@@ -420,7 +393,8 @@ fn project_anthropic_replay_messages(messages: &[Message]) -> Result<Vec<Message
         }
 
         let next_message = match message {
-            Message::System(_) | Message::SystemNotice(_) => Some(message.clone()),
+            Message::System(_) => Some(message.clone()),
+            Message::SystemNotice(_) => unreachable!("handled above"),
             Message::User(user) => Some(Message::User(meerkat_core::UserMessage {
                 content: project_anthropic_content_blocks(
                     &mut replay_application,
@@ -4538,7 +4512,7 @@ mod tests {
     fn anthropic_system_notice_with_image_emits_typed_image_part()
     -> Result<(), Box<dyn std::error::Error>> {
         let client = AnthropicClient::new("test-key".to_string())?;
-        let request = LlmRequest::new(
+        let mut request = LlmRequest::new(
             "claude-sonnet-4-5",
             vec![Message::SystemNotice(
                 meerkat_core::SystemNoticeMessage::with_block(
@@ -4567,6 +4541,7 @@ mod tests {
                 ),
             )],
         );
+        request.messages = client.project_replay_messages(&request.messages)?;
 
         let body = client.build_request_body(&request)?;
         let messages = body["messages"].as_array().unwrap();

--- a/meerkat-anthropic/src/client.rs
+++ b/meerkat-anthropic/src/client.rs
@@ -20,7 +20,6 @@ use meerkat_llm_core::{LlmClient, LlmDoneOutcome, LlmEvent, LlmRequest, LlmStrea
 use meerkat_llm_core::{http, streaming};
 use serde::Deserialize;
 use serde_json::{Map, Value};
-use std::collections::HashSet;
 use std::time::Duration;
 
 /// Default connect timeout
@@ -205,26 +204,47 @@ fn invalid_replay(message: impl Into<String>) -> LlmError {
     }
 }
 
-fn project_anthropic_content_blocks(blocks: &[ContentBlock]) -> Vec<ContentBlock> {
+fn project_anthropic_content_blocks(
+    replay_application: &mut meerkat_core::ReplayApplication<'_>,
+    message: meerkat_core::ReplayMessageIndex,
+    blocks: &[ContentBlock],
+) -> Result<Vec<ContentBlock>, LlmError> {
     blocks
         .iter()
-        .map(|block| match block {
-            ContentBlock::Text { .. } => block.clone(),
-            ContentBlock::Image {
-                data: ImageData::Inline { .. },
-                ..
-            } => block.clone(),
-            ContentBlock::Image { .. } | ContentBlock::Video { .. } => ContentBlock::Text {
-                text: block.text_projection().into_owned(),
-            },
-            _ => ContentBlock::Text {
-                text: block.text_projection().into_owned(),
-            },
+        .enumerate()
+        .map(|(block_index, block)| {
+            let subject = meerkat_core::ReplaySubject::UserContent {
+                message,
+                block: meerkat_core::ReplayUserContentIndex(block_index),
+            };
+            let projected = match replay_application
+                .next(subject)
+                .map_err(|error| invalid_replay(error.to_string()))?
+            {
+                meerkat_core::ReplayDisposition::Preserve => block.clone(),
+                meerkat_core::ReplayDisposition::LowerToText => ContentBlock::Text {
+                    text: block.text_projection().into_owned(),
+                },
+                disposition => {
+                    return Err(invalid_replay(format!(
+                        "Anthropic replay cannot apply user-content disposition {disposition:?}"
+                    )));
+                }
+            };
+            replay_application
+                .record_content(subject, block, &projected)
+                .map_err(|error| invalid_replay(error.to_string()))?;
+            Ok(projected)
         })
         .collect()
 }
 
-fn project_anthropic_tool_result(result: &ToolResult) -> Result<ToolResult, LlmError> {
+fn project_anthropic_tool_result(
+    replay_application: &mut meerkat_core::ReplayApplication<'_>,
+    message: meerkat_core::ReplayMessageIndex,
+    result_index: meerkat_core::ReplayToolResultIndex,
+    result: &ToolResult,
+) -> Result<ToolResult, LlmError> {
     if result.has_video() {
         return Err(invalid_replay(
             "video blocks are not supported in Anthropic tool results",
@@ -232,7 +252,36 @@ fn project_anthropic_tool_result(result: &ToolResult) -> Result<ToolResult, LlmE
     }
     Ok(ToolResult::with_blocks(
         result.tool_use_id.clone(),
-        project_anthropic_content_blocks(&result.content),
+        result
+            .content
+            .iter()
+            .enumerate()
+            .map(|(block_index, block)| {
+                let subject = meerkat_core::ReplaySubject::ToolResultContent {
+                    message,
+                    result: result_index,
+                    block: meerkat_core::ReplayToolResultContentIndex(block_index),
+                };
+                let projected = match replay_application
+                    .next(subject)
+                    .map_err(|error| invalid_replay(error.to_string()))?
+                {
+                    meerkat_core::ReplayDisposition::Preserve => block.clone(),
+                    meerkat_core::ReplayDisposition::LowerToText => ContentBlock::Text {
+                        text: block.text_projection().into_owned(),
+                    },
+                    disposition => {
+                        return Err(invalid_replay(format!(
+                            "Anthropic replay cannot apply tool-result disposition {disposition:?}"
+                        )));
+                    }
+                };
+                replay_application
+                    .record_content(subject, block, &projected)
+                    .map_err(|error| invalid_replay(error.to_string()))?;
+                Ok(projected)
+            })
+            .collect::<Result<Vec<_>, _>>()?,
         result.is_error,
     ))
 }
@@ -244,92 +293,124 @@ fn anthropic_server_tool_content_replayable(content: &Value) -> bool {
     )
 }
 
-fn project_anthropic_assistant_blocks(blocks: &[AssistantBlock]) -> Vec<AssistantBlock> {
+fn project_anthropic_assistant_blocks(
+    replay_application: &mut meerkat_core::ReplayApplication<'_>,
+    message: meerkat_core::ReplayMessageIndex,
+    blocks: &[AssistantBlock],
+) -> Result<Vec<AssistantBlock>, LlmError> {
     blocks
         .iter()
-        .filter_map(|block| match block {
-            AssistantBlock::Text { text, .. } if text.is_empty() => None,
-            AssistantBlock::Text { .. } | AssistantBlock::ToolUse { .. } => Some(block.clone()),
-            // Spoken transcripts replay back as plain text. Anthropic does
-            // not have a realtime audio surface today; if a Meerkat session
-            // contains transcript blocks (e.g. cross-provider replay),
-            // surface them as plain text so the assistant history is
-            // visible to the model.
-            AssistantBlock::Transcript { text, .. } if text.is_empty() => None,
-            AssistantBlock::Transcript { text, .. } => Some(AssistantBlock::Text {
-                text: text.clone(),
-                meta: None,
-            }),
-            AssistantBlock::Reasoning { meta, .. } => match meta.as_deref() {
-                Some(
-                    meerkat_core::ProviderMeta::Anthropic { .. }
-                    | meerkat_core::ProviderMeta::AnthropicRedacted { .. }
-                    | meerkat_core::ProviderMeta::AnthropicCompaction { .. },
-                ) => Some(block.clone()),
-                _ => None,
-            },
-            AssistantBlock::ServerToolContent { content, .. }
-                if anthropic_server_tool_content_replayable(content) =>
-            {
-                Some(block.clone())
+        .enumerate()
+        .map(|(block_index, block)| {
+            let subject = meerkat_core::ReplaySubject::AssistantBlock {
+                message,
+                block: meerkat_core::ReplayAssistantBlockIndex(block_index),
+            };
+            let projected = match block {
+                AssistantBlock::Text { text, .. } if text.is_empty() => None,
+                AssistantBlock::Text { .. } | AssistantBlock::ToolUse { .. } => Some(
+                    meerkat_core::ReplayWireFamily::Anthropic.strip_foreign_metadata(block.clone()),
+                ),
+                // Spoken transcripts replay back as plain text. Anthropic does
+                // not have a realtime audio surface today; if a Meerkat session
+                // contains transcript blocks (e.g. cross-provider replay),
+                // surface them as plain text so the assistant history is
+                // visible to the model.
+                AssistantBlock::Transcript { text, .. } if text.is_empty() => None,
+                AssistantBlock::Transcript { text, .. } => Some(AssistantBlock::Text {
+                    text: text.clone(),
+                    meta: None,
+                }),
+                AssistantBlock::Reasoning { meta, .. } => match meta.as_deref() {
+                    Some(
+                        meerkat_core::ProviderMeta::Anthropic { .. }
+                        | meerkat_core::ProviderMeta::AnthropicRedacted { .. }
+                        | meerkat_core::ProviderMeta::AnthropicCompaction { .. },
+                    ) => Some(
+                        meerkat_core::ReplayWireFamily::Anthropic
+                            .strip_foreign_metadata(block.clone()),
+                    ),
+                    _ => None,
+                },
+                AssistantBlock::ServerToolContent { content, .. }
+                    if anthropic_server_tool_content_replayable(content) =>
+                {
+                    Some(
+                        meerkat_core::ReplayWireFamily::Anthropic
+                            .strip_foreign_metadata(block.clone()),
+                    )
+                }
+                AssistantBlock::Image { .. } | AssistantBlock::ServerToolContent { .. } => None,
+                _ => {
+                    return Err(invalid_replay(
+                        "Anthropic replay cannot project unknown assistant block",
+                    ));
+                }
+            };
+            replay_application
+                .record_assistant(subject, block, projected.as_ref())
+                .map_err(|error| invalid_replay(error.to_string()))?;
+            if let Some(meta) = meerkat_core::replay_provider_metadata(block) {
+                replay_application
+                    .record_provider_metadata(
+                        meerkat_core::ReplaySubject::ProviderMetadata {
+                            message,
+                            block: meerkat_core::ReplayAssistantBlockIndex(block_index),
+                        },
+                        meta,
+                        block,
+                        projected.as_ref(),
+                    )
+                    .map_err(|error| invalid_replay(error.to_string()))?;
             }
-            AssistantBlock::Image { .. } | AssistantBlock::ServerToolContent { .. } => None,
-            _ => None,
+            Ok(projected)
         })
+        .filter_map(|result| result.transpose())
         .collect()
 }
 
-fn tool_ids_from_assistant(message: &Message) -> HashSet<String> {
-    match message {
-        Message::BlockAssistant(assistant) => assistant
-            .blocks
-            .iter()
-            .filter_map(|block| match block {
-                AssistantBlock::ToolUse { id, .. } => Some(id.clone()),
-                _ => None,
-            })
-            .collect(),
-        _ => HashSet::new(),
-    }
-}
-
-fn validate_tool_results(
-    provider: &str,
-    pending: HashSet<String>,
-    results: &[ToolResult],
-) -> Result<(), LlmError> {
-    let actual: HashSet<String> = results
-        .iter()
-        .map(|result| result.tool_use_id.clone())
-        .collect();
-    if actual == pending {
-        Ok(())
-    } else {
-        Err(invalid_replay(format!(
-            "{provider} replay projection found tool results that are not adjacent to matching tool uses"
-        )))
-    }
-}
-
 fn project_anthropic_replay_messages(messages: &[Message]) -> Result<Vec<Message>, LlmError> {
+    let replay_plan = meerkat_core::ReplayPlan::build(
+        messages,
+        meerkat_core::ReplayTarget::new(
+            meerkat_core::ReplayWireFamily::Anthropic,
+            true,
+            false,
+            true,
+        ),
+    )
+    .map_err(|error| invalid_replay(error.to_string()))?;
+    let mut replay_application = replay_plan.application();
     let mut projected = Vec::with_capacity(messages.len());
-    let mut pending_tool_ids: Option<HashSet<String>> = None;
 
-    for message in messages {
+    for (message_index, message) in messages.iter().enumerate() {
+        let message_index = meerkat_core::ReplayMessageIndex(message_index);
+        replay_application
+            .record_message(
+                meerkat_core::ReplaySubject::Message(message_index),
+                message,
+                match message {
+                    Message::System(_) | Message::SystemNotice(_) => Some(message),
+                    _ => None,
+                },
+            )
+            .map_err(|error| invalid_replay(error.to_string()))?;
         if let Message::ToolResults {
             results,
             created_at,
         } = message
         {
-            let Some(pending) = pending_tool_ids.take() else {
-                return Err(invalid_replay(
-                    "Anthropic replay projection found tool results without preceding tool use",
-                ));
-            };
-            validate_tool_results("Anthropic", pending, results)?;
             let results = results
                 .iter()
-                .map(project_anthropic_tool_result)
+                .enumerate()
+                .map(|(result_index, result)| {
+                    project_anthropic_tool_result(
+                        &mut replay_application,
+                        message_index,
+                        meerkat_core::ReplayToolResultIndex(result_index),
+                        result,
+                    )
+                })
                 .collect::<Result<Vec<_>, _>>()?;
             projected.push(Message::ToolResults {
                 results,
@@ -338,23 +419,25 @@ fn project_anthropic_replay_messages(messages: &[Message]) -> Result<Vec<Message
             continue;
         }
 
-        if pending_tool_ids.is_some() {
-            return Err(invalid_replay(
-                "Anthropic replay projection found a tool use without adjacent tool results",
-            ));
-        }
-
         let next_message = match message {
             Message::System(_) | Message::SystemNotice(_) => Some(message.clone()),
             Message::User(user) => Some(Message::User(meerkat_core::UserMessage {
-                content: project_anthropic_content_blocks(&user.content),
+                content: project_anthropic_content_blocks(
+                    &mut replay_application,
+                    message_index,
+                    &user.content,
+                )?,
                 render_metadata: user.render_metadata.clone(),
                 identity: user.identity.clone(),
                 transcript_role: user.transcript_role,
                 created_at: user.created_at,
             })),
             Message::BlockAssistant(assistant) => {
-                let blocks = project_anthropic_assistant_blocks(&assistant.blocks);
+                let blocks = project_anthropic_assistant_blocks(
+                    &mut replay_application,
+                    message_index,
+                    &assistant.blocks,
+                )?;
                 if blocks.is_empty() {
                     None
                 } else {
@@ -370,20 +453,13 @@ fn project_anthropic_replay_messages(messages: &[Message]) -> Result<Vec<Message
         };
 
         if let Some(message) = next_message {
-            let tool_ids = tool_ids_from_assistant(&message);
-            if !tool_ids.is_empty() {
-                pending_tool_ids = Some(tool_ids);
-            }
             projected.push(message);
         }
     }
 
-    if pending_tool_ids.is_some() {
-        return Err(invalid_replay(
-            "Anthropic replay projection found a trailing tool use without tool results",
-        ));
-    }
-
+    replay_plan
+        .validate_projected(messages, &projected, replay_application)
+        .map_err(|error| invalid_replay(error.to_string()))?;
     Ok(projected)
 }
 
@@ -2431,6 +2507,15 @@ mod tests {
                         text: "unsigned plan".to_string(),
                         meta: None,
                     },
+                    AssistantBlock::Reasoning {
+                        text: "foreign plan".to_string(),
+                        meta: Some(Box::new(ProviderMeta::OpenAi {
+                            id: "reasoning_1".to_string(),
+                            encrypted_content: Some("encrypted".to_string()),
+                            phase: None,
+                            response_id: None,
+                        })),
+                    },
                     AssistantBlock::ServerToolContent {
                         id: Some("srv_1".to_string()),
                         kind: ServerToolKind::WebSearch,
@@ -2478,6 +2563,10 @@ mod tests {
                 ],
                 false,
             )]),
+            Message::SystemNotice(SystemNoticeMessage::new(
+                meerkat_core::SystemNoticeKind::Generic,
+                "control intent",
+            )),
         ];
 
         let projected = client.project_replay_messages(&messages)?;
@@ -2521,6 +2610,10 @@ mod tests {
             block,
             AssistantBlock::Reasoning { text, .. } if text == "unsigned plan"
         )));
+        assert!(!assistant.blocks.iter().any(|block| matches!(
+            block,
+            AssistantBlock::Reasoning { text, .. } if text == "foreign plan"
+        )));
         assert!(assistant.blocks.iter().any(|block| matches!(
             block,
             AssistantBlock::ServerToolContent { content, .. }
@@ -2546,6 +2639,7 @@ mod tests {
             results[0].has_images(),
             "Anthropic should retain inline image tool results"
         );
+        assert!(matches!(projected[3], Message::SystemNotice(_)));
         Ok(())
     }
 
@@ -4597,5 +4691,96 @@ mod tests {
             "web_search should not be a top-level body key"
         );
         Ok(())
+    }
+
+    #[test]
+    fn replay_projection_rejects_duplicate_tool_use_ids() {
+        let client = AnthropicClient::new("test-key".to_string())
+            .unwrap_or_else(|error| panic!("client: {error}"));
+        let args = serde_json::value::RawValue::from_string("{}".to_string())
+            .unwrap_or_else(|error| panic!("test args: {error}"));
+        let messages = [
+            Message::BlockAssistant(BlockAssistantMessage::new(
+                vec![
+                    AssistantBlock::ToolUse {
+                        id: "duplicate".to_string(),
+                        name: "a".to_string(),
+                        args: args.clone(),
+                        meta: None,
+                    },
+                    AssistantBlock::ToolUse {
+                        id: "duplicate".to_string(),
+                        name: "b".to_string(),
+                        args,
+                        meta: None,
+                    },
+                ],
+                StopReason::ToolUse,
+            )),
+            Message::tool_results(vec![ToolResult::new(
+                "duplicate".to_string(),
+                "result".to_string(),
+                false,
+            )]),
+        ];
+        assert!(matches!(
+            client.project_replay_messages(&messages),
+            Err(LlmError::InvalidRequest { .. })
+        ));
+    }
+
+    #[test]
+    fn replay_projection_rejects_duplicate_tool_result_ids() {
+        let client = AnthropicClient::new("test-key".to_string())
+            .unwrap_or_else(|error| panic!("client: {error}"));
+        let args = serde_json::value::RawValue::from_string("{}".to_string())
+            .unwrap_or_else(|error| panic!("test args: {error}"));
+        let messages = [
+            Message::BlockAssistant(BlockAssistantMessage::new(
+                vec![AssistantBlock::ToolUse {
+                    id: "tool".to_string(),
+                    name: "a".to_string(),
+                    args,
+                    meta: None,
+                }],
+                StopReason::ToolUse,
+            )),
+            Message::tool_results(vec![
+                ToolResult::new("tool".to_string(), "first".to_string(), false),
+                ToolResult::new("tool".to_string(), "second".to_string(), false),
+            ]),
+        ];
+        assert!(matches!(
+            client.project_replay_messages(&messages),
+            Err(LlmError::InvalidRequest { .. })
+        ));
+    }
+
+    #[test]
+    fn replay_projection_rejects_mismatched_tool_result_id() {
+        let client = AnthropicClient::new("test-key".to_string())
+            .unwrap_or_else(|error| panic!("client: {error}"));
+        let args = serde_json::value::RawValue::from_string("{}".to_string())
+            .unwrap_or_else(|error| panic!("test args: {error}"));
+        let messages = [
+            Message::BlockAssistant(BlockAssistantMessage::new(
+                vec![AssistantBlock::ToolUse {
+                    id: "tool".to_string(),
+                    name: "a".to_string(),
+                    args,
+                    meta: None,
+                }],
+                StopReason::ToolUse,
+            )),
+            Message::tool_results(vec![ToolResult::new(
+                "other".to_string(),
+                "result".to_string(),
+                false,
+            )]),
+        ];
+        assert!(matches!(
+            client.project_replay_messages(&messages),
+            Err(LlmError::InvalidRequest { .. })
+        ));
     }
 }

--- a/meerkat-copilot/src/runtime.rs
+++ b/meerkat-copilot/src/runtime.rs
@@ -453,6 +453,7 @@ pub struct CopilotChatCompletionsClientSpec {
     supports_temperature: bool,
     supports_thinking: bool,
     supports_reasoning: bool,
+    supports_image_input: bool,
     supports_image_tool_results: bool,
 }
 
@@ -476,8 +477,20 @@ impl CopilotChatCompletionsClientSpec {
             supports_temperature,
             supports_thinking,
             supports_reasoning,
+            supports_image_input: false,
             supports_image_tool_results,
         }
+    }
+
+    #[must_use]
+    pub fn with_image_input_support(mut self, supports_image_input: bool) -> Self {
+        self.supports_image_input = supports_image_input;
+        self
+    }
+
+    #[must_use]
+    pub const fn supports_image_input(&self) -> bool {
+        self.supports_image_input
     }
 
     #[allow(clippy::type_complexity)]

--- a/meerkat-core/src/lib.rs
+++ b/meerkat-core/src/lib.rs
@@ -97,6 +97,7 @@ pub mod tool_consequence_policy;
 pub mod tool_execution;
 pub mod tool_execution_policy;
 pub mod tool_scope;
+pub mod transcript_replay;
 pub mod turn_boundary;
 pub mod turn_execution_authority;
 pub mod turn_terminal;
@@ -498,6 +499,12 @@ pub use tool_scope::{
     ExternalToolSurfaceStagedOp, GeneratedToolVisibilityOwner, LocalToolVisibilityOwner,
     ToolFilter, ToolScope, ToolScopeApplyError, ToolScopeHandle, ToolScopeRevision,
     ToolScopeSnapshot, ToolScopeStageError, ToolVisibilityOwner,
+};
+pub use transcript_replay::{
+    ReplayApplication, ReplayAssistantBlockIndex, ReplayCapability, ReplayDisposition,
+    ReplayMessageIndex, ReplayPlan, ReplayPlanEntry, ReplayPlanError, ReplaySubject, ReplayTarget,
+    ReplayToolResultContentIndex, ReplayToolResultIndex, ReplayUserContentIndex, ReplayWireFamily,
+    replay_provider_metadata,
 };
 pub use turn_boundary::{TurnBoundaryHook, TurnBoundaryMessage};
 pub use turn_execution_authority::{

--- a/meerkat-core/src/lib.rs
+++ b/meerkat-core/src/lib.rs
@@ -502,9 +502,10 @@ pub use tool_scope::{
 };
 pub use transcript_replay::{
     ReplayApplication, ReplayAssistantBlockIndex, ReplayCapability, ReplayDisposition,
-    ReplayMessageIndex, ReplayPlan, ReplayPlanEntry, ReplayPlanError, ReplaySubject, ReplayTarget,
-    ReplayToolResultContentIndex, ReplayToolResultIndex, ReplayUserContentIndex, ReplayWireFamily,
-    replay_provider_metadata,
+    ReplayMessageIndex, ReplayPlan, ReplayPlanEntry, ReplayPlanError, ReplayReasoningProjection,
+    ReplaySubject, ReplaySystemNoticeBlockIndex, ReplaySystemNoticeContentIndex, ReplayTarget,
+    ReplayToolResultContentIndex, ReplayToolResultIndex, ReplayToolResultProjection,
+    ReplayUserContentIndex, ReplayWireFamily, replay_provider_metadata,
 };
 pub use turn_boundary::{TurnBoundaryHook, TurnBoundaryMessage};
 pub use turn_execution_authority::{

--- a/meerkat-core/src/transcript_replay.rs
+++ b/meerkat-core/src/transcript_replay.rs
@@ -1,0 +1,727 @@
+//! Provider-neutral replay planning and verified adapter lowering.
+
+use crate::{AssistantBlock, ContentBlock, Message, ProviderMeta};
+use std::collections::HashSet;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct ReplayMessageIndex(pub usize);
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct ReplayAssistantBlockIndex(pub usize);
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct ReplayUserContentIndex(pub usize);
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct ReplayToolResultIndex(pub usize);
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct ReplayToolResultContentIndex(pub usize);
+
+/// The provider wire grammar that receives replay, independently of account
+/// provider identity. Self-hosted and Copilot OpenAI-compatible endpoints use
+/// [`Self::OpenAi`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ReplayWireFamily {
+    Anthropic,
+    OpenAi,
+    Gemini,
+}
+
+impl ReplayWireFamily {
+    #[must_use]
+    pub const fn from_provider_metadata(metadata: &ProviderMeta) -> Self {
+        match metadata {
+            ProviderMeta::Anthropic { .. }
+            | ProviderMeta::AnthropicRedacted { .. }
+            | ProviderMeta::AnthropicCompaction { .. } => Self::Anthropic,
+            ProviderMeta::Gemini { .. } => Self::Gemini,
+            ProviderMeta::OpenAi { .. } | ProviderMeta::OpenAiResponse { .. } => Self::OpenAi,
+        }
+    }
+
+    /// Remove continuity metadata that was issued by a different wire family.
+    #[must_use]
+    pub fn strip_foreign_metadata(self, mut block: AssistantBlock) -> AssistantBlock {
+        if replay_provider_metadata(&block)
+            .is_some_and(|metadata| Self::from_provider_metadata(metadata) != self)
+        {
+            match &mut block {
+                AssistantBlock::Text { meta, .. }
+                | AssistantBlock::Transcript { meta, .. }
+                | AssistantBlock::Reasoning { meta, .. }
+                | AssistantBlock::ToolUse { meta, .. }
+                | AssistantBlock::ServerToolContent { meta, .. } => *meta = None,
+                AssistantBlock::Image { .. } => {}
+            }
+        }
+        block
+    }
+}
+
+/// Read provider continuity metadata from an assistant block.
+#[must_use]
+pub fn replay_provider_metadata(block: &AssistantBlock) -> Option<&ProviderMeta> {
+    match block {
+        AssistantBlock::Text { meta, .. }
+        | AssistantBlock::Transcript { meta, .. }
+        | AssistantBlock::Reasoning { meta, .. }
+        | AssistantBlock::ToolUse { meta, .. }
+        | AssistantBlock::ServerToolContent { meta, .. } => meta.as_deref(),
+        AssistantBlock::Image { .. } => None,
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum ReplaySubject {
+    Message(ReplayMessageIndex),
+    AssistantBlock {
+        message: ReplayMessageIndex,
+        block: ReplayAssistantBlockIndex,
+    },
+    UserContent {
+        message: ReplayMessageIndex,
+        block: ReplayUserContentIndex,
+    },
+    ToolResultContent {
+        message: ReplayMessageIndex,
+        result: ReplayToolResultIndex,
+        block: ReplayToolResultContentIndex,
+    },
+    ProviderMetadata {
+        message: ReplayMessageIndex,
+        block: ReplayAssistantBlockIndex,
+    },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ReplayCapability {
+    ToolResultVideo,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ReplayDisposition {
+    Preserve,
+    LowerToText,
+    Omit,
+    /// The provider adapter owns wire-specific replay legality.
+    ProviderNative,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ReplayPlanEntry {
+    pub subject: ReplaySubject,
+    pub disposition: ReplayDisposition,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ReplayTarget {
+    pub wire_family: ReplayWireFamily,
+    pub image_input: bool,
+    pub inline_video: bool,
+    pub image_tool_results: bool,
+}
+
+impl ReplayTarget {
+    #[must_use]
+    pub const fn new(
+        wire_family: ReplayWireFamily,
+        image_input: bool,
+        inline_video: bool,
+        image_tool_results: bool,
+    ) -> Self {
+        Self {
+            wire_family,
+            image_input,
+            inline_video,
+            image_tool_results,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum ReplayPlanError {
+    #[error("replay application expected {expected:?}, received {actual:?}")]
+    UnexpectedSubject {
+        expected: Option<ReplaySubject>,
+        actual: ReplaySubject,
+    },
+    #[error("replay projection does not satisfy {disposition:?} for {subject:?}")]
+    ProjectionMismatch {
+        subject: ReplaySubject,
+        disposition: ReplayDisposition,
+    },
+    #[error("replay projection changed or omitted an ordered system message")]
+    PreservedSystemMessageMismatch,
+    #[error(
+        "replay application ended before its complete plan was consumed; next subject is {next:?}"
+    )]
+    IncompleteApplication { next: ReplaySubject },
+    #[error("tool results at message {message:?} have no immediately preceding tool use")]
+    ToolResultsWithoutToolUse { message: ReplayMessageIndex },
+    #[error("tool uses at message {message:?} have no immediately adjacent tool results")]
+    ToolUseWithoutToolResults { message: ReplayMessageIndex },
+    #[error("tool results at message {message:?} do not exactly match the preceding tool uses")]
+    ToolResultMismatch { message: ReplayMessageIndex },
+    #[error("tool uses at message {message:?} reuse a tool-use ID")]
+    DuplicateToolUseId { message: ReplayMessageIndex },
+    #[error("tool results at message {message:?} reuse a tool-result ID")]
+    DuplicateToolResultId { message: ReplayMessageIndex },
+    #[error("replay subject {subject:?} requires unsupported capability {capability:?}")]
+    UnsupportedCapability {
+        subject: ReplaySubject,
+        capability: ReplayCapability,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ReplayPlan {
+    target: ReplayTarget,
+    entries: Vec<ReplayPlanEntry>,
+}
+
+/// O(1) ordered replay-plan verifier. Adapters pass the source and their
+/// concrete projected output to the typed record methods; labels cannot be
+/// self-attested.
+pub struct ReplayApplication<'a> {
+    plan: &'a ReplayPlan,
+    cursor: usize,
+}
+
+impl ReplayApplication<'_> {
+    pub fn next(&self, subject: ReplaySubject) -> Result<ReplayDisposition, ReplayPlanError> {
+        let expected = self.plan.entries.get(self.cursor);
+        if expected.map(|entry| entry.subject) != Some(subject) {
+            return Err(ReplayPlanError::UnexpectedSubject {
+                expected: expected.map(|entry| entry.subject),
+                actual: subject,
+            });
+        }
+        Ok(expected
+            .map(|entry| entry.disposition)
+            .unwrap_or(ReplayDisposition::Omit))
+    }
+
+    fn consume(&mut self, subject: ReplaySubject) -> Result<ReplayDisposition, ReplayPlanError> {
+        let disposition = self.next(subject)?;
+        self.cursor += 1;
+        Ok(disposition)
+    }
+
+    pub fn record_message(
+        &mut self,
+        subject: ReplaySubject,
+        source: &Message,
+        projected: Option<&Message>,
+    ) -> Result<(), ReplayPlanError> {
+        let disposition = self.consume(subject)?;
+        if matches!(disposition, ReplayDisposition::Preserve) && projected != Some(source) {
+            return Err(ReplayPlanError::ProjectionMismatch {
+                subject,
+                disposition,
+            });
+        }
+        Ok(())
+    }
+
+    pub fn record_content(
+        &mut self,
+        subject: ReplaySubject,
+        source: &ContentBlock,
+        projected: &ContentBlock,
+    ) -> Result<(), ReplayPlanError> {
+        let disposition = self.consume(subject)?;
+        let valid = match disposition {
+            ReplayDisposition::Preserve => projected == source,
+            ReplayDisposition::LowerToText => is_text_projection(source, projected),
+            ReplayDisposition::ProviderNative | ReplayDisposition::Omit => false,
+        };
+        if valid {
+            Ok(())
+        } else {
+            Err(ReplayPlanError::ProjectionMismatch {
+                subject,
+                disposition,
+            })
+        }
+    }
+
+    pub fn record_assistant(
+        &mut self,
+        subject: ReplaySubject,
+        source: &AssistantBlock,
+        projected: Option<&AssistantBlock>,
+    ) -> Result<(), ReplayPlanError> {
+        let disposition = self.consume(subject)?;
+        if assistant_meta(source).is_none() && projected.and_then(assistant_meta).is_some() {
+            return Err(ReplayPlanError::ProjectionMismatch {
+                subject,
+                disposition,
+            });
+        }
+        let valid = match disposition {
+            ReplayDisposition::Preserve => assistant_payload_eq(source, projected),
+            ReplayDisposition::LowerToText => projected.is_some_and(|block| {
+                matches!(block, AssistantBlock::Text { text, meta: None } if *text == source_text_projection(source))
+            }),
+            ReplayDisposition::Omit => projected.is_none(),
+            ReplayDisposition::ProviderNative => native_assistant_outcome(source, projected),
+        };
+        if valid {
+            Ok(())
+        } else {
+            Err(ReplayPlanError::ProjectionMismatch {
+                subject,
+                disposition,
+            })
+        }
+    }
+
+    pub fn record_provider_metadata(
+        &mut self,
+        subject: ReplaySubject,
+        source: &ProviderMeta,
+        source_block: &AssistantBlock,
+        projected: Option<&AssistantBlock>,
+    ) -> Result<(), ReplayPlanError> {
+        let disposition = self.consume(subject)?;
+        let valid = match disposition {
+            ReplayDisposition::Omit => projected.and_then(assistant_meta).is_none(),
+            ReplayDisposition::ProviderNative => {
+                if assistant_payload_eq(source_block, projected) {
+                    projected.and_then(assistant_meta) == Some(source)
+                } else {
+                    projected.and_then(assistant_meta).is_none()
+                }
+            }
+            ReplayDisposition::Preserve | ReplayDisposition::LowerToText => false,
+        };
+        if valid {
+            Ok(())
+        } else {
+            Err(ReplayPlanError::ProjectionMismatch {
+                subject,
+                disposition,
+            })
+        }
+    }
+
+    pub fn finish(self) -> Result<(), ReplayPlanError> {
+        self.plan
+            .entries
+            .get(self.cursor)
+            .map(|entry| ReplayPlanError::IncompleteApplication {
+                next: entry.subject,
+            })
+            .map_or(Ok(()), Err)
+    }
+}
+
+impl ReplayPlan {
+    pub fn build(messages: &[Message], target: ReplayTarget) -> Result<Self, ReplayPlanError> {
+        validate_source_tool_adjacency(messages)?;
+        let mut entries = Vec::new();
+        for (message_index, message) in messages.iter().enumerate() {
+            let index = ReplayMessageIndex(message_index);
+            entries.push(ReplayPlanEntry {
+                subject: ReplaySubject::Message(index),
+                disposition: match message {
+                    Message::System(_) | Message::SystemNotice(_) => ReplayDisposition::Preserve,
+                    _ => ReplayDisposition::ProviderNative,
+                },
+            });
+            match message {
+                Message::User(user) => {
+                    for (block, content) in user.content.iter().enumerate() {
+                        entries.push(ReplayPlanEntry {
+                            subject: ReplaySubject::UserContent {
+                                message: index,
+                                block: ReplayUserContentIndex(block),
+                            },
+                            disposition: content_disposition(content, target, false),
+                        });
+                    }
+                }
+                Message::BlockAssistant(assistant) => {
+                    for (block, assistant) in assistant.blocks.iter().enumerate() {
+                        let block_index = ReplayAssistantBlockIndex(block);
+                        entries.push(ReplayPlanEntry {
+                            subject: ReplaySubject::AssistantBlock {
+                                message: index,
+                                block: block_index,
+                            },
+                            disposition: assistant_disposition(assistant),
+                        });
+                        if let Some(meta) = assistant_meta(assistant) {
+                            entries.push(ReplayPlanEntry {
+                                subject: ReplaySubject::ProviderMetadata {
+                                    message: index,
+                                    block: block_index,
+                                },
+                                disposition: if ReplayWireFamily::from_provider_metadata(meta)
+                                    == target.wire_family
+                                {
+                                    ReplayDisposition::ProviderNative
+                                } else {
+                                    ReplayDisposition::Omit
+                                },
+                            });
+                        }
+                    }
+                }
+                Message::ToolResults { results, .. } => {
+                    for (result, tool_result) in results.iter().enumerate() {
+                        for (block, content) in tool_result.content.iter().enumerate() {
+                            let subject = ReplaySubject::ToolResultContent {
+                                message: index,
+                                result: ReplayToolResultIndex(result),
+                                block: ReplayToolResultContentIndex(block),
+                            };
+                            if matches!(content, ContentBlock::Video { .. }) {
+                                return Err(ReplayPlanError::UnsupportedCapability {
+                                    subject,
+                                    capability: ReplayCapability::ToolResultVideo,
+                                });
+                            }
+                            entries.push(ReplayPlanEntry {
+                                subject,
+                                disposition: content_disposition(content, target, true),
+                            });
+                        }
+                    }
+                }
+                Message::System(_) | Message::SystemNotice(_) => {}
+            }
+        }
+        Ok(Self { target, entries })
+    }
+
+    #[must_use]
+    pub const fn target(&self) -> ReplayTarget {
+        self.target
+    }
+
+    pub fn entries(&self) -> impl ExactSizeIterator<Item = &ReplayPlanEntry> {
+        self.entries.iter()
+    }
+
+    #[must_use]
+    pub const fn application(&self) -> ReplayApplication<'_> {
+        ReplayApplication {
+            plan: self,
+            cursor: 0,
+        }
+    }
+
+    pub fn validate_projected(
+        &self,
+        source: &[Message],
+        projected: &[Message],
+        application: ReplayApplication<'_>,
+    ) -> Result<(), ReplayPlanError> {
+        application.finish()?;
+        let source_system = source
+            .iter()
+            .filter(|message| matches!(message, Message::System(_) | Message::SystemNotice(_)));
+        let projected_system = projected
+            .iter()
+            .filter(|message| matches!(message, Message::System(_) | Message::SystemNotice(_)));
+        if !source_system.eq(projected_system) {
+            return Err(ReplayPlanError::PreservedSystemMessageMismatch);
+        }
+        validate_tool_adjacency(projected)
+    }
+}
+
+fn assistant_disposition(block: &AssistantBlock) -> ReplayDisposition {
+    match block {
+        AssistantBlock::Text { text, .. } if text.is_empty() => ReplayDisposition::Omit,
+        AssistantBlock::Text { .. } | AssistantBlock::ToolUse { .. } => ReplayDisposition::Preserve,
+        AssistantBlock::Transcript { text, .. } if text.is_empty() => ReplayDisposition::Omit,
+        AssistantBlock::Transcript { .. } => ReplayDisposition::LowerToText,
+        AssistantBlock::Reasoning { .. } | AssistantBlock::ServerToolContent { .. } => {
+            ReplayDisposition::ProviderNative
+        }
+        AssistantBlock::Image { .. } => ReplayDisposition::Omit,
+    }
+}
+
+fn content_disposition(
+    block: &ContentBlock,
+    target: ReplayTarget,
+    tool_result: bool,
+) -> ReplayDisposition {
+    match block {
+        ContentBlock::Text { .. } => ReplayDisposition::Preserve,
+        ContentBlock::Structured { .. } | ContentBlock::SkillContext { .. } => {
+            ReplayDisposition::LowerToText
+        }
+        ContentBlock::Image { data, .. } => match data {
+            crate::ImageData::Blob { .. } => ReplayDisposition::LowerToText,
+            crate::ImageData::Inline { .. } if tool_result && !target.image_tool_results => {
+                ReplayDisposition::LowerToText
+            }
+            crate::ImageData::Inline { .. } if !tool_result && !target.image_input => {
+                ReplayDisposition::LowerToText
+            }
+            crate::ImageData::Inline { .. } => ReplayDisposition::Preserve,
+        },
+        ContentBlock::Video { .. } if target.inline_video => ReplayDisposition::Preserve,
+        ContentBlock::Video { .. } => ReplayDisposition::LowerToText,
+    }
+}
+
+fn assistant_meta(block: &AssistantBlock) -> Option<&ProviderMeta> {
+    replay_provider_metadata(block)
+}
+
+fn is_text_projection(source: &ContentBlock, projected: &ContentBlock) -> bool {
+    matches!(projected, ContentBlock::Text { text } if *text == source.text_projection())
+}
+
+fn source_text_projection(source: &AssistantBlock) -> String {
+    match source {
+        AssistantBlock::Transcript { text, .. } => text.clone(),
+        _ => String::new(),
+    }
+}
+
+fn assistant_payload_eq(source: &AssistantBlock, projected: Option<&AssistantBlock>) -> bool {
+    let Some(projected) = projected else {
+        return false;
+    };
+    match (source, projected) {
+        (AssistantBlock::Text { text: left, .. }, AssistantBlock::Text { text: right, .. })
+        | (
+            AssistantBlock::Transcript { text: left, .. },
+            AssistantBlock::Transcript { text: right, .. },
+        )
+        | (
+            AssistantBlock::Reasoning { text: left, .. },
+            AssistantBlock::Reasoning { text: right, .. },
+        ) => left == right,
+        (
+            AssistantBlock::ToolUse {
+                id: left_id,
+                name: left_name,
+                args: left_args,
+                ..
+            },
+            AssistantBlock::ToolUse {
+                id: right_id,
+                name: right_name,
+                args: right_args,
+                ..
+            },
+        ) => left_id == right_id && left_name == right_name && left_args.get() == right_args.get(),
+        (
+            AssistantBlock::ServerToolContent {
+                id: left_id,
+                kind: left_kind,
+                content: left_content,
+                ..
+            },
+            AssistantBlock::ServerToolContent {
+                id: right_id,
+                kind: right_kind,
+                content: right_content,
+                ..
+            },
+        ) => left_id == right_id && left_kind == right_kind && left_content == right_content,
+        (AssistantBlock::Image { .. }, AssistantBlock::Image { .. }) => source == projected,
+        _ => false,
+    }
+}
+
+fn native_assistant_outcome(source: &AssistantBlock, projected: Option<&AssistantBlock>) -> bool {
+    projected.is_none()
+        || assistant_payload_eq(source, projected)
+        || matches!(
+            (source, projected),
+            (
+                AssistantBlock::Reasoning { .. },
+                Some(AssistantBlock::Text { meta: None, .. })
+            )
+        )
+}
+
+fn tool_use_ids(message: &Message) -> Vec<&str> {
+    match message {
+        Message::BlockAssistant(assistant) => assistant
+            .blocks
+            .iter()
+            .filter_map(|block| match block {
+                AssistantBlock::ToolUse { id, .. } => Some(id.as_str()),
+                _ => None,
+            })
+            .collect(),
+        _ => Vec::new(),
+    }
+}
+
+fn has_duplicate_ids(ids: &[&str]) -> bool {
+    let mut seen = HashSet::with_capacity(ids.len());
+    ids.iter().any(|id| !seen.insert(*id))
+}
+
+fn validate_tool_adjacency(messages: &[Message]) -> Result<(), ReplayPlanError> {
+    validate_adjacency(messages, false)
+}
+
+fn validate_source_tool_adjacency(messages: &[Message]) -> Result<(), ReplayPlanError> {
+    validate_adjacency(messages, true)
+}
+
+fn validate_adjacency(messages: &[Message], allow_omitted: bool) -> Result<(), ReplayPlanError> {
+    let mut pending: Option<(ReplayMessageIndex, Vec<&str>)> = None;
+    for (index, message) in messages.iter().enumerate() {
+        let message_index = ReplayMessageIndex(index);
+        if allow_omitted && pending.is_some() && source_message_is_replay_omitted(message) {
+            continue;
+        }
+        if let Message::ToolResults { results, .. } = message {
+            let Some((_, expected)) = pending.take() else {
+                return Err(ReplayPlanError::ToolResultsWithoutToolUse {
+                    message: message_index,
+                });
+            };
+            let actual = results
+                .iter()
+                .map(|result| result.tool_use_id.as_str())
+                .collect::<Vec<_>>();
+            if has_duplicate_ids(&actual) {
+                return Err(ReplayPlanError::DuplicateToolResultId {
+                    message: message_index,
+                });
+            }
+            let expected = expected.into_iter().collect::<HashSet<_>>();
+            let actual = actual.into_iter().collect::<HashSet<_>>();
+            if actual != expected {
+                return Err(ReplayPlanError::ToolResultMismatch {
+                    message: message_index,
+                });
+            }
+            continue;
+        }
+        if let Some((message, _)) = pending {
+            return Err(ReplayPlanError::ToolUseWithoutToolResults { message });
+        }
+        let ids = tool_use_ids(message);
+        if has_duplicate_ids(&ids) {
+            return Err(ReplayPlanError::DuplicateToolUseId {
+                message: message_index,
+            });
+        }
+        if !ids.is_empty() {
+            pending = Some((message_index, ids));
+        }
+    }
+    pending
+        .map(|(message, _)| Err(ReplayPlanError::ToolUseWithoutToolResults { message }))
+        .unwrap_or(Ok(()))
+}
+
+fn source_message_is_replay_omitted(message: &Message) -> bool {
+    matches!(
+        message,
+        Message::BlockAssistant(assistant)
+            if assistant.blocks.iter().all(|block| matches!(
+                assistant_disposition(block),
+                ReplayDisposition::Omit | ReplayDisposition::ProviderNative
+            ))
+    )
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+mod tests {
+    use super::*;
+    use crate::{BlockAssistantMessage, StopReason, UserMessage};
+
+    #[test]
+    fn rejects_wrong_lowering_from_actual_projected_content() {
+        let source = ContentBlock::Structured {
+            data: serde_json::value::RawValue::from_string(r#"{"key":"value"}"#.to_string())
+                .unwrap_or_else(|error| panic!("test structured content: {error}")),
+        };
+        let messages = [Message::User(UserMessage::with_blocks(vec![
+            source.clone(),
+        ]))];
+        let plan = ReplayPlan::build(
+            &messages,
+            ReplayTarget::new(ReplayWireFamily::OpenAi, false, false, false),
+        )
+        .unwrap_or_else(|error| panic!("test replay plan: {error}"));
+        let mut application = plan.application();
+        application
+            .record_message(
+                ReplaySubject::Message(ReplayMessageIndex(0)),
+                &messages[0],
+                None,
+            )
+            .unwrap_or_else(|error| panic!("test message: {error}"));
+        assert!(matches!(
+            application.record_content(
+                ReplaySubject::UserContent {
+                    message: ReplayMessageIndex(0),
+                    block: ReplayUserContentIndex(0),
+                },
+                &source,
+                &source,
+            ),
+            Err(ReplayPlanError::ProjectionMismatch {
+                disposition: ReplayDisposition::LowerToText,
+                ..
+            })
+        ));
+    }
+
+    #[test]
+    fn rejects_leaked_foreign_provider_metadata() {
+        let metadata = ProviderMeta::OpenAiResponse {
+            response_id: "response".to_string(),
+        };
+        let block = AssistantBlock::Reasoning {
+            text: "thought".to_string(),
+            meta: Some(Box::new(metadata.clone())),
+        };
+        let messages = [Message::BlockAssistant(BlockAssistantMessage::new(
+            vec![block.clone()],
+            StopReason::EndTurn,
+        ))];
+        let plan = ReplayPlan::build(
+            &messages,
+            ReplayTarget::new(ReplayWireFamily::Anthropic, true, false, true),
+        )
+        .unwrap_or_else(|error| panic!("test replay plan: {error}"));
+        let mut application = plan.application();
+        application
+            .record_message(
+                ReplaySubject::Message(ReplayMessageIndex(0)),
+                &messages[0],
+                None,
+            )
+            .unwrap_or_else(|error| panic!("test message: {error}"));
+        application
+            .record_assistant(
+                ReplaySubject::AssistantBlock {
+                    message: ReplayMessageIndex(0),
+                    block: ReplayAssistantBlockIndex(0),
+                },
+                &block,
+                None,
+            )
+            .unwrap_or_else(|error| panic!("test assistant: {error}"));
+        assert!(matches!(
+            application.record_provider_metadata(
+                ReplaySubject::ProviderMetadata {
+                    message: ReplayMessageIndex(0),
+                    block: ReplayAssistantBlockIndex(0),
+                },
+                &metadata,
+                &block,
+                Some(&block),
+            ),
+            Err(ReplayPlanError::ProjectionMismatch {
+                disposition: ReplayDisposition::Omit,
+                ..
+            })
+        ));
+    }
+}

--- a/meerkat-core/src/transcript_replay.rs
+++ b/meerkat-core/src/transcript_replay.rs
@@ -1,6 +1,9 @@
 //! Provider-neutral replay planning and verified adapter lowering.
 
-use crate::{AssistantBlock, ContentBlock, Message, ProviderMeta};
+use crate::{
+    AssistantBlock, ContentBlock, Message, ProviderMeta, SystemNoticeBlock, SystemNoticeMessage,
+    ToolResult,
+};
 use std::collections::HashSet;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -13,6 +16,10 @@ pub struct ReplayUserContentIndex(pub usize);
 pub struct ReplayToolResultIndex(pub usize);
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ReplayToolResultContentIndex(pub usize);
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct ReplaySystemNoticeBlockIndex(pub usize);
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct ReplaySystemNoticeContentIndex(pub usize);
 
 /// The provider wire grammar that receives replay, independently of account
 /// provider identity. Self-hosted and Copilot OpenAI-compatible endpoints use
@@ -84,6 +91,15 @@ pub enum ReplaySubject {
         result: ReplayToolResultIndex,
         block: ReplayToolResultContentIndex,
     },
+    ToolResult {
+        message: ReplayMessageIndex,
+        result: ReplayToolResultIndex,
+    },
+    SystemNoticeContent {
+        message: ReplayMessageIndex,
+        notice_block: ReplaySystemNoticeBlockIndex,
+        content_block: ReplaySystemNoticeContentIndex,
+    },
     ProviderMetadata {
         message: ReplayMessageIndex,
         block: ReplayAssistantBlockIndex,
@@ -99,6 +115,7 @@ pub enum ReplayCapability {
 pub enum ReplayDisposition {
     Preserve,
     LowerToText,
+    CollapseToText,
     Omit,
     /// The provider adapter owns wire-specific replay legality.
     ProviderNative,
@@ -116,6 +133,21 @@ pub struct ReplayTarget {
     pub image_input: bool,
     pub inline_video: bool,
     pub image_tool_results: bool,
+    pub tool_result_projection: ReplayToolResultProjection,
+    pub reasoning_projection: ReplayReasoningProjection,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ReplayToolResultProjection {
+    PreserveBlocks,
+    CollapseToText,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ReplayReasoningProjection {
+    ProviderNative,
+    LowerToText,
+    Omit,
 }
 
 impl ReplayTarget {
@@ -125,12 +157,16 @@ impl ReplayTarget {
         image_input: bool,
         inline_video: bool,
         image_tool_results: bool,
+        tool_result_projection: ReplayToolResultProjection,
+        reasoning_projection: ReplayReasoningProjection,
     ) -> Self {
         Self {
             wire_family,
             image_input,
             inline_video,
             image_tool_results,
+            tool_result_projection,
+            reasoning_projection,
         }
     }
 }
@@ -230,7 +266,9 @@ impl ReplayApplication<'_> {
         let valid = match disposition {
             ReplayDisposition::Preserve => projected == source,
             ReplayDisposition::LowerToText => is_text_projection(source, projected),
-            ReplayDisposition::ProviderNative | ReplayDisposition::Omit => false,
+            ReplayDisposition::CollapseToText
+            | ReplayDisposition::ProviderNative
+            | ReplayDisposition::Omit => false,
         };
         if valid {
             Ok(())
@@ -240,6 +278,120 @@ impl ReplayApplication<'_> {
                 disposition,
             })
         }
+    }
+
+    /// Build and validate one complete tool result, including provider-required
+    /// collapse of multiple canonical blocks into one text payload.
+    pub fn project_tool_result(
+        &mut self,
+        message: ReplayMessageIndex,
+        result_index: ReplayToolResultIndex,
+        source: &ToolResult,
+    ) -> Result<ToolResult, ReplayPlanError> {
+        let mut projected_blocks = Vec::with_capacity(source.content.len());
+        for (block_index, block) in source.content.iter().enumerate() {
+            let subject = ReplaySubject::ToolResultContent {
+                message,
+                result: result_index,
+                block: ReplayToolResultContentIndex(block_index),
+            };
+            let projected = match self.next(subject)? {
+                ReplayDisposition::Preserve => block.clone(),
+                ReplayDisposition::LowerToText => ContentBlock::Text {
+                    text: block.text_projection().into_owned(),
+                },
+                disposition => {
+                    return Err(ReplayPlanError::ProjectionMismatch {
+                        subject,
+                        disposition,
+                    });
+                }
+            };
+            self.record_content(subject, block, &projected)?;
+            projected_blocks.push(projected);
+        }
+
+        let subject = ReplaySubject::ToolResult {
+            message,
+            result: result_index,
+        };
+        let disposition = self.consume(subject)?;
+        let content = match disposition {
+            ReplayDisposition::ProviderNative => projected_blocks,
+            ReplayDisposition::CollapseToText => {
+                ContentBlock::text_vec(crate::types::text_content(&projected_blocks))
+            }
+            _ => {
+                return Err(ReplayPlanError::ProjectionMismatch {
+                    subject,
+                    disposition,
+                });
+            }
+        };
+        Ok(ToolResult::with_blocks(
+            source.tool_use_id.clone(),
+            content,
+            source.is_error,
+        ))
+    }
+
+    pub fn project_system_notice(
+        &mut self,
+        message: ReplayMessageIndex,
+        notice: &SystemNoticeMessage,
+    ) -> Result<SystemNoticeMessage, ReplayPlanError> {
+        self.consume(ReplaySubject::Message(message))?;
+        let mut projected = notice.clone();
+        for (notice_block_index, (source_block, projected_block)) in notice
+            .blocks
+            .iter()
+            .zip(projected.blocks.iter_mut())
+            .enumerate()
+        {
+            let (source_content, projected_content) = match (source_block, projected_block) {
+                (
+                    SystemNoticeBlock::Comms {
+                        content: source, ..
+                    },
+                    SystemNoticeBlock::Comms {
+                        content: projected, ..
+                    },
+                )
+                | (
+                    SystemNoticeBlock::ExternalEvent {
+                        content: source, ..
+                    },
+                    SystemNoticeBlock::ExternalEvent {
+                        content: projected, ..
+                    },
+                ) => (source, projected),
+                _ => continue,
+            };
+            let mut next_content = Vec::with_capacity(source_content.len());
+            for (content_index, source) in source_content.iter().enumerate() {
+                let subject = ReplaySubject::SystemNoticeContent {
+                    message,
+                    notice_block: ReplaySystemNoticeBlockIndex(notice_block_index),
+                    content_block: ReplaySystemNoticeContentIndex(content_index),
+                };
+                let next = match self.next(subject)? {
+                    ReplayDisposition::Preserve => source.clone(),
+                    ReplayDisposition::LowerToText => ContentBlock::Text {
+                        text: source.text_projection().into_owned(),
+                    },
+                    disposition => {
+                        return Err(ReplayPlanError::ProjectionMismatch {
+                            subject,
+                            disposition,
+                        });
+                    }
+                };
+                self.record_content(subject, source, &next)?;
+                next_content.push(next);
+            }
+            *projected_content = next_content;
+        }
+        Ok(projected)
     }
 
     pub fn record_assistant(
@@ -260,6 +412,7 @@ impl ReplayApplication<'_> {
             ReplayDisposition::LowerToText => projected.is_some_and(|block| {
                 matches!(block, AssistantBlock::Text { text, meta: None } if *text == source_text_projection(source))
             }),
+            ReplayDisposition::CollapseToText => false,
             ReplayDisposition::Omit => projected.is_none(),
             ReplayDisposition::ProviderNative => native_assistant_outcome(source, projected),
         };
@@ -290,7 +443,9 @@ impl ReplayApplication<'_> {
                     projected.and_then(assistant_meta).is_none()
                 }
             }
-            ReplayDisposition::Preserve | ReplayDisposition::LowerToText => false,
+            ReplayDisposition::Preserve
+            | ReplayDisposition::LowerToText
+            | ReplayDisposition::CollapseToText => false,
         };
         if valid {
             Ok(())
@@ -315,14 +470,14 @@ impl ReplayApplication<'_> {
 
 impl ReplayPlan {
     pub fn build(messages: &[Message], target: ReplayTarget) -> Result<Self, ReplayPlanError> {
-        validate_source_tool_adjacency(messages)?;
         let mut entries = Vec::new();
         for (message_index, message) in messages.iter().enumerate() {
             let index = ReplayMessageIndex(message_index);
             entries.push(ReplayPlanEntry {
                 subject: ReplaySubject::Message(index),
                 disposition: match message {
-                    Message::System(_) | Message::SystemNotice(_) => ReplayDisposition::Preserve,
+                    Message::System(_) => ReplayDisposition::Preserve,
+                    Message::SystemNotice(_) => ReplayDisposition::ProviderNative,
                     _ => ReplayDisposition::ProviderNative,
                 },
             });
@@ -346,7 +501,7 @@ impl ReplayPlan {
                                 message: index,
                                 block: block_index,
                             },
-                            disposition: assistant_disposition(assistant),
+                            disposition: assistant_disposition(assistant, target),
                         });
                         if let Some(meta) = assistant_meta(assistant) {
                             entries.push(ReplayPlanEntry {
@@ -384,9 +539,42 @@ impl ReplayPlan {
                                 disposition: content_disposition(content, target, true),
                             });
                         }
+                        entries.push(ReplayPlanEntry {
+                            subject: ReplaySubject::ToolResult {
+                                message: index,
+                                result: ReplayToolResultIndex(result),
+                            },
+                            disposition: match target.tool_result_projection {
+                                ReplayToolResultProjection::PreserveBlocks => {
+                                    ReplayDisposition::ProviderNative
+                                }
+                                ReplayToolResultProjection::CollapseToText => {
+                                    ReplayDisposition::CollapseToText
+                                }
+                            },
+                        });
                     }
                 }
-                Message::System(_) | Message::SystemNotice(_) => {}
+                Message::SystemNotice(notice) => {
+                    for (notice_block, block) in notice.blocks.iter().enumerate() {
+                        let content = match block {
+                            SystemNoticeBlock::Comms { content, .. }
+                            | SystemNoticeBlock::ExternalEvent { content, .. } => content,
+                            _ => continue,
+                        };
+                        for (content_block, content) in content.iter().enumerate() {
+                            entries.push(ReplayPlanEntry {
+                                subject: ReplaySubject::SystemNoticeContent {
+                                    message: index,
+                                    notice_block: ReplaySystemNoticeBlockIndex(notice_block),
+                                    content_block: ReplaySystemNoticeContentIndex(content_block),
+                                },
+                                disposition: content_disposition(content, target, false),
+                            });
+                        }
+                    }
+                }
+                Message::System(_) => {}
             }
         }
         Ok(Self { target, entries })
@@ -418,10 +606,10 @@ impl ReplayPlan {
         application.finish()?;
         let source_system = source
             .iter()
-            .filter(|message| matches!(message, Message::System(_) | Message::SystemNotice(_)));
+            .filter(|message| matches!(message, Message::System(_)));
         let projected_system = projected
             .iter()
-            .filter(|message| matches!(message, Message::System(_) | Message::SystemNotice(_)));
+            .filter(|message| matches!(message, Message::System(_)));
         if !source_system.eq(projected_system) {
             return Err(ReplayPlanError::PreservedSystemMessageMismatch);
         }
@@ -429,15 +617,27 @@ impl ReplayPlan {
     }
 }
 
-fn assistant_disposition(block: &AssistantBlock) -> ReplayDisposition {
+fn assistant_disposition(block: &AssistantBlock, target: ReplayTarget) -> ReplayDisposition {
     match block {
         AssistantBlock::Text { text, .. } if text.is_empty() => ReplayDisposition::Omit,
         AssistantBlock::Text { .. } | AssistantBlock::ToolUse { .. } => ReplayDisposition::Preserve,
         AssistantBlock::Transcript { text, .. } if text.is_empty() => ReplayDisposition::Omit,
         AssistantBlock::Transcript { .. } => ReplayDisposition::LowerToText,
-        AssistantBlock::Reasoning { .. } | AssistantBlock::ServerToolContent { .. } => {
-            ReplayDisposition::ProviderNative
+        AssistantBlock::Reasoning { text, .. }
+            if text.is_empty()
+                && matches!(
+                    target.reasoning_projection,
+                    ReplayReasoningProjection::LowerToText
+                ) =>
+        {
+            ReplayDisposition::Omit
         }
+        AssistantBlock::Reasoning { .. } => match target.reasoning_projection {
+            ReplayReasoningProjection::ProviderNative => ReplayDisposition::ProviderNative,
+            ReplayReasoningProjection::LowerToText => ReplayDisposition::LowerToText,
+            ReplayReasoningProjection::Omit => ReplayDisposition::Omit,
+        },
+        AssistantBlock::ServerToolContent { .. } => ReplayDisposition::ProviderNative,
         AssistantBlock::Image { .. } => ReplayDisposition::Omit,
     }
 }
@@ -478,6 +678,7 @@ fn is_text_projection(source: &ContentBlock, projected: &ContentBlock) -> bool {
 fn source_text_projection(source: &AssistantBlock) -> String {
     match source {
         AssistantBlock::Transcript { text, .. } => text.clone(),
+        AssistantBlock::Reasoning { text, .. } => format!("[Reasoning: {text}]"),
         _ => String::new(),
     }
 }
@@ -530,15 +731,7 @@ fn assistant_payload_eq(source: &AssistantBlock, projected: Option<&AssistantBlo
 }
 
 fn native_assistant_outcome(source: &AssistantBlock, projected: Option<&AssistantBlock>) -> bool {
-    projected.is_none()
-        || assistant_payload_eq(source, projected)
-        || matches!(
-            (source, projected),
-            (
-                AssistantBlock::Reasoning { .. },
-                Some(AssistantBlock::Text { meta: None, .. })
-            )
-        )
+    projected.is_none() || assistant_payload_eq(source, projected)
 }
 
 fn tool_use_ids(message: &Message) -> Vec<&str> {
@@ -561,20 +754,9 @@ fn has_duplicate_ids(ids: &[&str]) -> bool {
 }
 
 fn validate_tool_adjacency(messages: &[Message]) -> Result<(), ReplayPlanError> {
-    validate_adjacency(messages, false)
-}
-
-fn validate_source_tool_adjacency(messages: &[Message]) -> Result<(), ReplayPlanError> {
-    validate_adjacency(messages, true)
-}
-
-fn validate_adjacency(messages: &[Message], allow_omitted: bool) -> Result<(), ReplayPlanError> {
     let mut pending: Option<(ReplayMessageIndex, Vec<&str>)> = None;
     for (index, message) in messages.iter().enumerate() {
         let message_index = ReplayMessageIndex(index);
-        if allow_omitted && pending.is_some() && source_message_is_replay_omitted(message) {
-            continue;
-        }
         if let Message::ToolResults { results, .. } = message {
             let Some((_, expected)) = pending.take() else {
                 return Err(ReplayPlanError::ToolResultsWithoutToolUse {
@@ -617,17 +799,6 @@ fn validate_adjacency(messages: &[Message], allow_omitted: bool) -> Result<(), R
         .unwrap_or(Ok(()))
 }
 
-fn source_message_is_replay_omitted(message: &Message) -> bool {
-    matches!(
-        message,
-        Message::BlockAssistant(assistant)
-            if assistant.blocks.iter().all(|block| matches!(
-                assistant_disposition(block),
-                ReplayDisposition::Omit | ReplayDisposition::ProviderNative
-            ))
-    )
-}
-
 #[cfg(test)]
 #[allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
 mod tests {
@@ -645,7 +816,14 @@ mod tests {
         ]))];
         let plan = ReplayPlan::build(
             &messages,
-            ReplayTarget::new(ReplayWireFamily::OpenAi, false, false, false),
+            ReplayTarget::new(
+                ReplayWireFamily::OpenAi,
+                false,
+                false,
+                false,
+                ReplayToolResultProjection::CollapseToText,
+                ReplayReasoningProjection::Omit,
+            ),
         )
         .unwrap_or_else(|error| panic!("test replay plan: {error}"));
         let mut application = plan.application();
@@ -687,7 +865,14 @@ mod tests {
         ))];
         let plan = ReplayPlan::build(
             &messages,
-            ReplayTarget::new(ReplayWireFamily::Anthropic, true, false, true),
+            ReplayTarget::new(
+                ReplayWireFamily::Anthropic,
+                true,
+                false,
+                true,
+                ReplayToolResultProjection::PreserveBlocks,
+                ReplayReasoningProjection::ProviderNative,
+            ),
         )
         .unwrap_or_else(|error| panic!("test replay plan: {error}"));
         let mut application = plan.application();
@@ -723,5 +908,36 @@ mod tests {
                 ..
             })
         ));
+    }
+
+    #[test]
+    fn empty_reasoning_is_omitted_when_target_lowers_reasoning_to_text() {
+        let messages = [Message::BlockAssistant(BlockAssistantMessage::new(
+            vec![AssistantBlock::Reasoning {
+                text: String::new(),
+                meta: Some(Box::new(ProviderMeta::AnthropicRedacted {
+                    data: "encrypted".to_string(),
+                })),
+            }],
+            StopReason::EndTurn,
+        ))];
+        let plan = ReplayPlan::build(
+            &messages,
+            ReplayTarget::new(
+                ReplayWireFamily::Gemini,
+                true,
+                true,
+                true,
+                ReplayToolResultProjection::PreserveBlocks,
+                ReplayReasoningProjection::LowerToText,
+            ),
+        )
+        .unwrap_or_else(|error| panic!("test replay plan: {error}"));
+        assert_eq!(
+            plan.entries()
+                .find(|entry| matches!(entry.subject, ReplaySubject::AssistantBlock { .. }))
+                .map(|entry| entry.disposition),
+            Some(ReplayDisposition::Omit)
+        );
     }
 }

--- a/meerkat-gemini/src/client.rs
+++ b/meerkat-gemini/src/client.rs
@@ -127,45 +127,9 @@ fn project_gemini_tool_result(
     result_index: meerkat_core::ReplayToolResultIndex,
     result: &ToolResult,
 ) -> Result<ToolResult, LlmError> {
-    if result.has_video() {
-        return Err(invalid_replay(
-            "video blocks are not supported in Gemini tool results",
-        ));
-    }
-    Ok(ToolResult::with_blocks(
-        result.tool_use_id.clone(),
-        result
-            .content
-            .iter()
-            .enumerate()
-            .map(|(block_index, block)| {
-                let subject = meerkat_core::ReplaySubject::ToolResultContent {
-                    message,
-                    result: result_index,
-                    block: meerkat_core::ReplayToolResultContentIndex(block_index),
-                };
-                let projected = match replay_application
-                    .next(subject)
-                    .map_err(|error| invalid_replay(error.to_string()))?
-                {
-                    meerkat_core::ReplayDisposition::Preserve => block.clone(),
-                    meerkat_core::ReplayDisposition::LowerToText => ContentBlock::Text {
-                        text: block.text_projection().into_owned(),
-                    },
-                    disposition => {
-                        return Err(invalid_replay(format!(
-                            "Gemini replay cannot apply tool-result disposition {disposition:?}"
-                        )));
-                    }
-                };
-                replay_application
-                    .record_content(subject, block, &projected)
-                    .map_err(|error| invalid_replay(error.to_string()))?;
-                Ok(projected)
-            })
-            .collect::<Result<Vec<_>, _>>()?,
-        result.is_error,
-    ))
+    replay_application
+        .project_tool_result(message, result_index, result)
+        .map_err(|error| invalid_replay(error.to_string()))
 }
 
 fn project_gemini_assistant_blocks(
@@ -231,7 +195,14 @@ fn project_gemini_assistant_blocks(
 fn project_gemini_replay_messages(messages: &[Message]) -> Result<Vec<Message>, LlmError> {
     let replay_plan = meerkat_core::ReplayPlan::build(
         messages,
-        meerkat_core::ReplayTarget::new(meerkat_core::ReplayWireFamily::Gemini, true, true, true),
+        meerkat_core::ReplayTarget::new(
+            meerkat_core::ReplayWireFamily::Gemini,
+            true,
+            true,
+            true,
+            meerkat_core::ReplayToolResultProjection::PreserveBlocks,
+            meerkat_core::ReplayReasoningProjection::LowerToText,
+        ),
     )
     .map_err(|error| invalid_replay(error.to_string()))?;
     let mut replay_application = replay_plan.application();
@@ -239,12 +210,19 @@ fn project_gemini_replay_messages(messages: &[Message]) -> Result<Vec<Message>, 
 
     for (message_index, message) in messages.iter().enumerate() {
         let message_index = meerkat_core::ReplayMessageIndex(message_index);
+        if let Message::SystemNotice(notice) = message {
+            let projected_notice = replay_application
+                .project_system_notice(message_index, notice)
+                .map_err(|error| invalid_replay(error.to_string()))?;
+            projected.push(Message::SystemNotice(projected_notice));
+            continue;
+        }
         replay_application
             .record_message(
                 meerkat_core::ReplaySubject::Message(message_index),
                 message,
                 match message {
-                    Message::System(_) | Message::SystemNotice(_) => Some(message),
+                    Message::System(_) => Some(message),
                     _ => None,
                 },
             )
@@ -274,7 +252,8 @@ fn project_gemini_replay_messages(messages: &[Message]) -> Result<Vec<Message>, 
         }
 
         let next_message = match message {
-            Message::System(_) | Message::SystemNotice(_) => Some(message.clone()),
+            Message::System(_) => Some(message.clone()),
+            Message::SystemNotice(_) => unreachable!("handled above"),
             Message::User(user) => Some(Message::User(UserMessage {
                 content: project_gemini_content_blocks(
                     &mut replay_application,
@@ -2457,6 +2436,12 @@ mod tests {
                             signature: "signature".to_string(),
                         })),
                     },
+                    AssistantBlock::Reasoning {
+                        text: String::new(),
+                        meta: Some(Box::new(ProviderMeta::AnthropicRedacted {
+                            data: "encrypted".to_string(),
+                        })),
+                    },
                     AssistantBlock::ServerToolContent {
                         id: None,
                         kind: ServerToolKind::GoogleSearch,
@@ -2533,6 +2518,10 @@ mod tests {
         assert!(assistant.blocks.iter().any(|block| matches!(
             block,
             AssistantBlock::Text { text, meta: None } if text == "[Reasoning: foreign thought]"
+        )));
+        assert!(!assistant.blocks.iter().any(|block| matches!(
+            block,
+            AssistantBlock::Text { text, .. } if text == "[Reasoning: ]"
         )));
         assert!(
             !assistant
@@ -5109,7 +5098,7 @@ mod tests {
     fn gemini_system_notice_with_image_emits_inline_data_part()
     -> Result<(), Box<dyn std::error::Error>> {
         let client = GeminiClient::new("test-key".to_string());
-        let request = LlmRequest::new(
+        let mut request = LlmRequest::new(
             "gemini-3.1-pro-preview",
             vec![Message::SystemNotice(
                 meerkat_core::SystemNoticeMessage::with_block(
@@ -5131,6 +5120,7 @@ mod tests {
                 ),
             )],
         );
+        request.messages = client.project_replay_messages(&request.messages)?;
 
         let body = client.build_request_body(&request)?;
         let contents = body["contents"].as_array().ok_or("missing contents")?;

--- a/meerkat-gemini/src/client.rs
+++ b/meerkat-gemini/src/client.rs
@@ -24,7 +24,7 @@ use meerkat_llm_core::{
 use meerkat_llm_core::{http, streaming};
 use serde::Deserialize;
 use serde_json::{Map, Value, json};
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::time::Duration;
 #[cfg(not(target_arch = "wasm32"))]
 use tokio::time as async_time;
@@ -86,27 +86,47 @@ fn invalid_replay(message: impl Into<String>) -> LlmError {
     }
 }
 
-fn project_gemini_content_blocks(blocks: &[ContentBlock]) -> Vec<ContentBlock> {
+fn project_gemini_content_blocks(
+    replay_application: &mut meerkat_core::ReplayApplication<'_>,
+    message: meerkat_core::ReplayMessageIndex,
+    blocks: &[ContentBlock],
+) -> Result<Vec<ContentBlock>, LlmError> {
     blocks
         .iter()
-        .map(|block| match block {
-            ContentBlock::Text { .. } => block.clone(),
-            ContentBlock::Image {
-                data: ImageData::Inline { .. },
-                ..
-            } => block.clone(),
-            ContentBlock::Video { .. } => block.clone(),
-            ContentBlock::Image { .. } => ContentBlock::Text {
-                text: block.text_projection().into_owned(),
-            },
-            _ => ContentBlock::Text {
-                text: block.text_projection().into_owned(),
-            },
+        .enumerate()
+        .map(|(block_index, block)| {
+            let subject = meerkat_core::ReplaySubject::UserContent {
+                message,
+                block: meerkat_core::ReplayUserContentIndex(block_index),
+            };
+            let projected = match replay_application
+                .next(subject)
+                .map_err(|error| invalid_replay(error.to_string()))?
+            {
+                meerkat_core::ReplayDisposition::Preserve => block.clone(),
+                meerkat_core::ReplayDisposition::LowerToText => ContentBlock::Text {
+                    text: block.text_projection().into_owned(),
+                },
+                disposition => {
+                    return Err(invalid_replay(format!(
+                        "Gemini replay cannot apply user-content disposition {disposition:?}"
+                    )));
+                }
+            };
+            replay_application
+                .record_content(subject, block, &projected)
+                .map_err(|error| invalid_replay(error.to_string()))?;
+            Ok(projected)
         })
         .collect()
 }
 
-fn project_gemini_tool_result(result: &ToolResult) -> Result<ToolResult, LlmError> {
+fn project_gemini_tool_result(
+    replay_application: &mut meerkat_core::ReplayApplication<'_>,
+    message: meerkat_core::ReplayMessageIndex,
+    result_index: meerkat_core::ReplayToolResultIndex,
+    result: &ToolResult,
+) -> Result<ToolResult, LlmError> {
     if result.has_video() {
         return Err(invalid_replay(
             "video blocks are not supported in Gemini tool results",
@@ -114,90 +134,137 @@ fn project_gemini_tool_result(result: &ToolResult) -> Result<ToolResult, LlmErro
     }
     Ok(ToolResult::with_blocks(
         result.tool_use_id.clone(),
-        project_gemini_content_blocks(&result.content),
+        result
+            .content
+            .iter()
+            .enumerate()
+            .map(|(block_index, block)| {
+                let subject = meerkat_core::ReplaySubject::ToolResultContent {
+                    message,
+                    result: result_index,
+                    block: meerkat_core::ReplayToolResultContentIndex(block_index),
+                };
+                let projected = match replay_application
+                    .next(subject)
+                    .map_err(|error| invalid_replay(error.to_string()))?
+                {
+                    meerkat_core::ReplayDisposition::Preserve => block.clone(),
+                    meerkat_core::ReplayDisposition::LowerToText => ContentBlock::Text {
+                        text: block.text_projection().into_owned(),
+                    },
+                    disposition => {
+                        return Err(invalid_replay(format!(
+                            "Gemini replay cannot apply tool-result disposition {disposition:?}"
+                        )));
+                    }
+                };
+                replay_application
+                    .record_content(subject, block, &projected)
+                    .map_err(|error| invalid_replay(error.to_string()))?;
+                Ok(projected)
+            })
+            .collect::<Result<Vec<_>, _>>()?,
         result.is_error,
     ))
 }
 
-fn project_gemini_assistant_blocks(blocks: &[AssistantBlock]) -> Vec<AssistantBlock> {
+fn project_gemini_assistant_blocks(
+    replay_application: &mut meerkat_core::ReplayApplication<'_>,
+    message: meerkat_core::ReplayMessageIndex,
+    blocks: &[AssistantBlock],
+) -> Result<Vec<AssistantBlock>, LlmError> {
     blocks
         .iter()
-        .filter_map(|block| match block {
-            AssistantBlock::Text { text, .. } if text.is_empty() => None,
-            AssistantBlock::Text { .. } | AssistantBlock::ToolUse { .. } => Some(block.clone()),
-            // Spoken transcripts replay to the provider as plain text
-            // (lane provenance is a Meerkat-side fact; Gemini sees the
-            // assistant's visible output).
-            AssistantBlock::Transcript { text, .. } if text.is_empty() => None,
-            AssistantBlock::Transcript { text, .. } => Some(AssistantBlock::Text {
-                text: text.clone(),
-                meta: None,
-            }),
-            AssistantBlock::Reasoning { text, .. } if !text.is_empty() => {
-                Some(AssistantBlock::Text {
-                    text: format!("[Reasoning: {text}]"),
+        .enumerate()
+        .map(|(block_index, block)| {
+            let subject = meerkat_core::ReplaySubject::AssistantBlock {
+                message,
+                block: meerkat_core::ReplayAssistantBlockIndex(block_index),
+            };
+            let projected = match block {
+                AssistantBlock::Text { text, .. } if text.is_empty() => None,
+                AssistantBlock::Text { .. } | AssistantBlock::ToolUse { .. } => Some(
+                    meerkat_core::ReplayWireFamily::Gemini.strip_foreign_metadata(block.clone()),
+                ),
+                AssistantBlock::Transcript { text, .. } if text.is_empty() => None,
+                AssistantBlock::Transcript { text, .. } => Some(AssistantBlock::Text {
+                    text: text.clone(),
                     meta: None,
-                })
+                }),
+                AssistantBlock::Reasoning { text, .. } if !text.is_empty() => {
+                    Some(AssistantBlock::Text {
+                        text: format!("[Reasoning: {text}]"),
+                        meta: None,
+                    })
+                }
+                AssistantBlock::Reasoning { .. }
+                | AssistantBlock::ServerToolContent { .. }
+                | AssistantBlock::Image { .. } => None,
+                _ => {
+                    return Err(invalid_replay(
+                        "Gemini replay cannot project unknown assistant block",
+                    ));
+                }
+            };
+            replay_application
+                .record_assistant(subject, block, projected.as_ref())
+                .map_err(|error| invalid_replay(error.to_string()))?;
+            if let Some(meta) = meerkat_core::replay_provider_metadata(block) {
+                replay_application
+                    .record_provider_metadata(
+                        meerkat_core::ReplaySubject::ProviderMetadata {
+                            message,
+                            block: meerkat_core::ReplayAssistantBlockIndex(block_index),
+                        },
+                        meta,
+                        block,
+                        projected.as_ref(),
+                    )
+                    .map_err(|error| invalid_replay(error.to_string()))?;
             }
-            AssistantBlock::Reasoning { .. }
-            | AssistantBlock::ServerToolContent { .. }
-            | AssistantBlock::Image { .. } => None,
-            _ => None,
+            Ok(projected)
         })
+        .filter_map(|result| result.transpose())
         .collect()
 }
 
-fn tool_ids_from_assistant(message: &Message) -> HashSet<String> {
-    match message {
-        Message::BlockAssistant(assistant) => assistant
-            .blocks
-            .iter()
-            .filter_map(|block| match block {
-                AssistantBlock::ToolUse { id, .. } => Some(id.clone()),
-                _ => None,
-            })
-            .collect(),
-        _ => HashSet::new(),
-    }
-}
-
-fn validate_tool_results(
-    provider: &str,
-    pending: HashSet<String>,
-    results: &[ToolResult],
-) -> Result<(), LlmError> {
-    let actual: HashSet<String> = results
-        .iter()
-        .map(|result| result.tool_use_id.clone())
-        .collect();
-    if actual == pending {
-        Ok(())
-    } else {
-        Err(invalid_replay(format!(
-            "{provider} replay projection found tool results that are not adjacent to matching tool uses"
-        )))
-    }
-}
-
 fn project_gemini_replay_messages(messages: &[Message]) -> Result<Vec<Message>, LlmError> {
+    let replay_plan = meerkat_core::ReplayPlan::build(
+        messages,
+        meerkat_core::ReplayTarget::new(meerkat_core::ReplayWireFamily::Gemini, true, true, true),
+    )
+    .map_err(|error| invalid_replay(error.to_string()))?;
+    let mut replay_application = replay_plan.application();
     let mut projected = Vec::with_capacity(messages.len());
-    let mut pending_tool_ids: Option<HashSet<String>> = None;
 
-    for message in messages {
+    for (message_index, message) in messages.iter().enumerate() {
+        let message_index = meerkat_core::ReplayMessageIndex(message_index);
+        replay_application
+            .record_message(
+                meerkat_core::ReplaySubject::Message(message_index),
+                message,
+                match message {
+                    Message::System(_) | Message::SystemNotice(_) => Some(message),
+                    _ => None,
+                },
+            )
+            .map_err(|error| invalid_replay(error.to_string()))?;
         if let Message::ToolResults {
             results,
             created_at,
         } = message
         {
-            let Some(pending) = pending_tool_ids.take() else {
-                return Err(invalid_replay(
-                    "Gemini replay projection found tool results without preceding tool use",
-                ));
-            };
-            validate_tool_results("Gemini", pending, results)?;
             let results = results
                 .iter()
-                .map(project_gemini_tool_result)
+                .enumerate()
+                .map(|(result_index, result)| {
+                    project_gemini_tool_result(
+                        &mut replay_application,
+                        message_index,
+                        meerkat_core::ReplayToolResultIndex(result_index),
+                        result,
+                    )
+                })
                 .collect::<Result<Vec<_>, _>>()?;
             projected.push(Message::ToolResults {
                 results,
@@ -206,23 +273,25 @@ fn project_gemini_replay_messages(messages: &[Message]) -> Result<Vec<Message>, 
             continue;
         }
 
-        if pending_tool_ids.is_some() {
-            return Err(invalid_replay(
-                "Gemini replay projection found a tool use without adjacent tool results",
-            ));
-        }
-
         let next_message = match message {
             Message::System(_) | Message::SystemNotice(_) => Some(message.clone()),
             Message::User(user) => Some(Message::User(UserMessage {
-                content: project_gemini_content_blocks(&user.content),
+                content: project_gemini_content_blocks(
+                    &mut replay_application,
+                    message_index,
+                    &user.content,
+                )?,
                 render_metadata: user.render_metadata.clone(),
                 identity: user.identity.clone(),
                 transcript_role: user.transcript_role,
                 created_at: user.created_at,
             })),
             Message::BlockAssistant(assistant) => {
-                let blocks = project_gemini_assistant_blocks(&assistant.blocks);
+                let blocks = project_gemini_assistant_blocks(
+                    &mut replay_application,
+                    message_index,
+                    &assistant.blocks,
+                )?;
                 if blocks.is_empty() {
                     None
                 } else {
@@ -238,20 +307,13 @@ fn project_gemini_replay_messages(messages: &[Message]) -> Result<Vec<Message>, 
         };
 
         if let Some(message) = next_message {
-            let tool_ids = tool_ids_from_assistant(&message);
-            if !tool_ids.is_empty() {
-                pending_tool_ids = Some(tool_ids);
-            }
             projected.push(message);
         }
     }
 
-    if pending_tool_ids.is_some() {
-        return Err(invalid_replay(
-            "Gemini replay projection found a trailing tool use without tool results",
-        ));
-    }
-
+    replay_plan
+        .validate_projected(messages, &projected, replay_application)
+        .map_err(|error| invalid_replay(error.to_string()))?;
     Ok(projected)
 }
 
@@ -2389,6 +2451,12 @@ mod tests {
                         text: "model thought".to_string(),
                         meta: None,
                     },
+                    AssistantBlock::Reasoning {
+                        text: "foreign thought".to_string(),
+                        meta: Some(Box::new(ProviderMeta::Anthropic {
+                            signature: "signature".to_string(),
+                        })),
+                    },
                     AssistantBlock::ServerToolContent {
                         id: None,
                         kind: ServerToolKind::GoogleSearch,
@@ -2428,6 +2496,10 @@ mod tests {
                 ],
                 false,
             )]),
+            Message::SystemNotice(SystemNoticeMessage::new(
+                meerkat_core::SystemNoticeKind::Generic,
+                "control intent",
+            )),
         ];
 
         let projected = client.project_replay_messages(&messages)?;
@@ -2458,6 +2530,10 @@ mod tests {
             )),
             "Gemini should project reasoning into text context"
         );
+        assert!(assistant.blocks.iter().any(|block| matches!(
+            block,
+            AssistantBlock::Text { text, meta: None } if text == "[Reasoning: foreign thought]"
+        )));
         assert!(
             !assistant
                 .blocks
@@ -2480,6 +2556,7 @@ mod tests {
             results[0].has_images(),
             "Gemini should retain inline image tool results"
         );
+        assert!(matches!(projected[3], Message::SystemNotice(_)));
         Ok(())
     }
 
@@ -5267,5 +5344,93 @@ mod tests {
             "functionDeclarations alone should not force toolConfig"
         );
         Ok(())
+    }
+
+    #[test]
+    fn replay_projection_rejects_duplicate_tool_use_ids() {
+        let client = GeminiClient::new("test-key".to_string());
+        let args = serde_json::value::RawValue::from_string("{}".to_string())
+            .unwrap_or_else(|error| panic!("test args: {error}"));
+        let messages = [
+            Message::BlockAssistant(BlockAssistantMessage::new(
+                vec![
+                    AssistantBlock::ToolUse {
+                        id: "duplicate".to_string(),
+                        name: "a".to_string(),
+                        args: args.clone(),
+                        meta: None,
+                    },
+                    AssistantBlock::ToolUse {
+                        id: "duplicate".to_string(),
+                        name: "b".to_string(),
+                        args,
+                        meta: None,
+                    },
+                ],
+                StopReason::ToolUse,
+            )),
+            Message::tool_results(vec![ToolResult::new(
+                "duplicate".to_string(),
+                "result".to_string(),
+                false,
+            )]),
+        ];
+        assert!(matches!(
+            client.project_replay_messages(&messages),
+            Err(LlmError::InvalidRequest { .. })
+        ));
+    }
+
+    #[test]
+    fn replay_projection_rejects_duplicate_tool_result_ids() {
+        let client = GeminiClient::new("test-key".to_string());
+        let args = serde_json::value::RawValue::from_string("{}".to_string())
+            .unwrap_or_else(|error| panic!("test args: {error}"));
+        let messages = [
+            Message::BlockAssistant(BlockAssistantMessage::new(
+                vec![AssistantBlock::ToolUse {
+                    id: "tool".to_string(),
+                    name: "a".to_string(),
+                    args,
+                    meta: None,
+                }],
+                StopReason::ToolUse,
+            )),
+            Message::tool_results(vec![
+                ToolResult::new("tool".to_string(), "first".to_string(), false),
+                ToolResult::new("tool".to_string(), "second".to_string(), false),
+            ]),
+        ];
+        assert!(matches!(
+            client.project_replay_messages(&messages),
+            Err(LlmError::InvalidRequest { .. })
+        ));
+    }
+
+    #[test]
+    fn replay_projection_rejects_mismatched_tool_result_id() {
+        let client = GeminiClient::new("test-key".to_string());
+        let args = serde_json::value::RawValue::from_string("{}".to_string())
+            .unwrap_or_else(|error| panic!("test args: {error}"));
+        let messages = [
+            Message::BlockAssistant(BlockAssistantMessage::new(
+                vec![AssistantBlock::ToolUse {
+                    id: "tool".to_string(),
+                    name: "a".to_string(),
+                    args,
+                    meta: None,
+                }],
+                StopReason::ToolUse,
+            )),
+            Message::tool_results(vec![ToolResult::new(
+                "other".to_string(),
+                "result".to_string(),
+                false,
+            )]),
+        ];
+        assert!(matches!(
+            client.project_replay_messages(&messages),
+            Err(LlmError::InvalidRequest { .. })
+        ));
     }
 }

--- a/meerkat-gemini/src/runtime/mod.rs
+++ b/meerkat-gemini/src/runtime/mod.rs
@@ -1021,6 +1021,7 @@ impl ProviderRuntime for GoogleProviderRuntime {
                 .clone();
             let model = identity.model.clone();
             let supports_temperature = profile.profile().supports_temperature;
+            let supports_image_input = profile.profile().image_input;
             let supports_image_tool_results = profile.profile().image_tool_results;
             let factory: meerkat_copilot::CopilotRouteClientFactory =
                 Arc::new(move |route, connection| {
@@ -1067,7 +1068,8 @@ impl ProviderRuntime for GoogleProviderRuntime {
                             true,
                             true,
                             supports_image_tool_results,
-                        ),
+                        )
+                        .with_image_input_support(supports_image_input),
                     )?;
                     Ok(Arc::new(GeminiCopilotChatClient { inner: client }))
                 });

--- a/meerkat-openai/src/client.rs
+++ b/meerkat-openai/src/client.rs
@@ -63,6 +63,7 @@ pub struct OpenAiClient {
     /// invocation. Used for ExternalAuthorizer flows that produce a
     /// DynamicAuthorizer envelope (host-managed OAuth refresh, etc.).
     authorizer: Option<std::sync::Arc<dyn meerkat_core::HttpAuthorizer>>,
+    supports_image_input: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -431,19 +432,21 @@ fn project_openai_assistant_blocks(
     Ok(projected)
 }
 
+#[cfg(test)]
 fn project_openai_replay_messages(
     messages: &[Message],
     mode: OpenAiReplayProjectionMode,
 ) -> Result<Vec<Message>, LlmError> {
-    project_openai_replay_messages_for_capabilities(messages, mode, true)
+    project_openai_replay_messages_for_capabilities(messages, mode, true, true)
 }
 
 pub(crate) fn project_openai_replay_messages_for_capabilities(
     messages: &[Message],
     mode: OpenAiReplayProjectionMode,
+    image_input: bool,
     image_tool_results: bool,
 ) -> Result<Vec<Message>, LlmError> {
-    project_openai_replay_messages_for_target(messages, mode, true, image_tool_results)
+    project_openai_replay_messages_for_target(messages, mode, image_input, image_tool_results)
 }
 
 pub(crate) fn project_openai_replay_messages_for_target(
@@ -604,6 +607,7 @@ impl OpenAiClient {
             http,
             extra_headers: Vec::new(),
             authorizer: None,
+            supports_image_input: true,
         }
     }
 
@@ -645,6 +649,12 @@ impl OpenAiClient {
         authorizer: std::sync::Arc<dyn meerkat_core::HttpAuthorizer>,
     ) -> Self {
         self.authorizer = Some(authorizer);
+        self
+    }
+
+    #[must_use]
+    pub fn with_image_input_support(mut self, supports_image_input: bool) -> Self {
+        self.supports_image_input = supports_image_input;
         self
     }
 
@@ -2267,7 +2277,12 @@ fn ensure_additional_properties_false(value: &mut Value) {
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 impl LlmClient for OpenAiClient {
     fn project_replay_messages(&self, messages: &[Message]) -> Result<Vec<Message>, LlmError> {
-        project_openai_replay_messages(messages, OpenAiReplayProjectionMode::Responses)
+        project_openai_replay_messages_for_capabilities(
+            messages,
+            OpenAiReplayProjectionMode::Responses,
+            self.supports_image_input,
+            true,
+        )
     }
 
     fn request_pressure(
@@ -3540,6 +3555,30 @@ mod tests {
         assert_eq!(output[1]["type"], "input_image");
         assert_eq!(output[1]["image_url"], "data:image/png;base64,CCCC");
         assert!(matches!(projected[3], Message::SystemNotice(_)));
+        Ok(())
+    }
+
+    #[test]
+    fn non_vision_openai_replay_lowers_inline_images_to_text()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let client = OpenAiClient::new("test-key".to_string()).with_image_input_support(false);
+        let messages = vec![Message::User(UserMessage::with_blocks(vec![
+            ContentBlock::Image {
+                media_type: "image/png".to_string(),
+                data: ImageData::Inline {
+                    data: "AAAA".to_string(),
+                },
+            },
+        ]))];
+
+        let projected = client.project_replay_messages(&messages)?;
+        let Message::User(user) = &projected[0] else {
+            return Err("expected projected user message".into());
+        };
+        assert!(matches!(
+            user.content.as_slice(),
+            [ContentBlock::Text { .. }]
+        ));
         Ok(())
     }
 

--- a/meerkat-openai/src/client.rs
+++ b/meerkat-openai/src/client.rs
@@ -131,26 +131,45 @@ fn web_search_message_annotations(value: &Value) -> Option<Vec<Value>> {
     (!web_citations.is_empty()).then_some(web_citations)
 }
 
-fn project_openai_content_blocks(blocks: &[ContentBlock]) -> Vec<ContentBlock> {
+fn project_openai_content_blocks(
+    replay_application: &mut meerkat_core::ReplayApplication<'_>,
+    message: meerkat_core::ReplayMessageIndex,
+    blocks: &[ContentBlock],
+) -> Result<Vec<ContentBlock>, LlmError> {
     blocks
         .iter()
-        .map(|block| match block {
-            ContentBlock::Text { .. } => block.clone(),
-            ContentBlock::Image {
-                data: ImageData::Inline { .. },
-                ..
-            } => block.clone(),
-            ContentBlock::Image { .. } | ContentBlock::Video { .. } => ContentBlock::Text {
-                text: block.text_projection().into_owned(),
-            },
-            _ => ContentBlock::Text {
-                text: block.text_projection().into_owned(),
-            },
+        .enumerate()
+        .map(|(block_index, block)| {
+            let subject = meerkat_core::ReplaySubject::UserContent {
+                message,
+                block: meerkat_core::ReplayUserContentIndex(block_index),
+            };
+            let projected = match replay_application
+                .next(subject)
+                .map_err(|error| invalid_replay(error.to_string()))?
+            {
+                meerkat_core::ReplayDisposition::Preserve => block.clone(),
+                meerkat_core::ReplayDisposition::LowerToText => ContentBlock::Text {
+                    text: block.text_projection().into_owned(),
+                },
+                disposition => {
+                    return Err(invalid_replay(format!(
+                        "OpenAI replay cannot apply user-content disposition {disposition:?}"
+                    )));
+                }
+            };
+            replay_application
+                .record_content(subject, block, &projected)
+                .map_err(|error| invalid_replay(error.to_string()))?;
+            Ok(projected)
         })
         .collect()
 }
 
 fn project_openai_tool_result(
+    replay_application: &mut meerkat_core::ReplayApplication<'_>,
+    message: meerkat_core::ReplayMessageIndex,
+    result_index: meerkat_core::ReplayToolResultIndex,
     result: &ToolResult,
     image_tool_results: bool,
 ) -> Result<ToolResult, LlmError> {
@@ -160,15 +179,70 @@ fn project_openai_tool_result(
         ));
     }
     if !image_tool_results {
+        let mut projected_blocks = Vec::with_capacity(result.content.len());
+        for (block_index, block) in result.content.iter().enumerate() {
+            let subject = meerkat_core::ReplaySubject::ToolResultContent {
+                message,
+                result: result_index,
+                block: meerkat_core::ReplayToolResultContentIndex(block_index),
+            };
+            let projected = match replay_application
+                .next(subject)
+                .map_err(|error| invalid_replay(error.to_string()))?
+            {
+                meerkat_core::ReplayDisposition::Preserve => block.clone(),
+                meerkat_core::ReplayDisposition::LowerToText => ContentBlock::Text {
+                    text: block.text_projection().into_owned(),
+                },
+                disposition => {
+                    return Err(invalid_replay(format!(
+                        "OpenAI replay cannot apply tool-result disposition {disposition:?}"
+                    )));
+                }
+            };
+            replay_application
+                .record_content(subject, block, &projected)
+                .map_err(|error| invalid_replay(error.to_string()))?;
+            projected_blocks.push(projected);
+        }
         return Ok(ToolResult::new(
             result.tool_use_id.clone(),
-            result.text_content(),
+            meerkat_core::types::text_content(&projected_blocks),
             result.is_error,
         ));
     }
     Ok(ToolResult::with_blocks(
         result.tool_use_id.clone(),
-        project_openai_content_blocks(&result.content),
+        result
+            .content
+            .iter()
+            .enumerate()
+            .map(|(block_index, block)| {
+                let subject = meerkat_core::ReplaySubject::ToolResultContent {
+                    message,
+                    result: result_index,
+                    block: meerkat_core::ReplayToolResultContentIndex(block_index),
+                };
+                let projected = match replay_application
+                    .next(subject)
+                    .map_err(|error| invalid_replay(error.to_string()))?
+                {
+                    meerkat_core::ReplayDisposition::Preserve => block.clone(),
+                    meerkat_core::ReplayDisposition::LowerToText => ContentBlock::Text {
+                        text: block.text_projection().into_owned(),
+                    },
+                    disposition => {
+                        return Err(invalid_replay(format!(
+                            "OpenAI replay cannot apply tool-result disposition {disposition:?}"
+                        )));
+                    }
+                };
+                replay_application
+                    .record_content(subject, block, &projected)
+                    .map_err(|error| invalid_replay(error.to_string()))?;
+                Ok(projected)
+            })
+            .collect::<Result<Vec<_>, _>>()?,
         result.is_error,
     ))
 }
@@ -273,90 +347,91 @@ fn openai_continuation_plan(request: &LlmRequest) -> Option<OpenAiContinuationPl
 }
 
 fn project_openai_assistant_blocks(
+    replay_application: &mut meerkat_core::ReplayApplication<'_>,
+    message: meerkat_core::ReplayMessageIndex,
     mode: OpenAiReplayProjectionMode,
     blocks: &[AssistantBlock],
-) -> Vec<AssistantBlock> {
+) -> Result<Vec<AssistantBlock>, LlmError> {
     let mut projected = Vec::with_capacity(blocks.len());
-    let mut has_output_item = false;
+    let has_output_item = blocks.iter().any(|block| match block {
+        AssistantBlock::Text { text, .. } | AssistantBlock::Transcript { text, .. } => {
+            !text.is_empty()
+        }
+        AssistantBlock::ToolUse { .. } => true,
+        AssistantBlock::ServerToolContent { content, .. } => {
+            openai_server_tool_content_replayable(mode, content)
+        }
+        AssistantBlock::Reasoning { .. } | AssistantBlock::Image { .. } => false,
+        _ => false,
+    });
 
-    for block in blocks {
+    for (block_index, block) in blocks.iter().enumerate() {
         let projected_block = match block {
             AssistantBlock::Text { text, .. } if text.is_empty() => None,
             AssistantBlock::Text { .. } | AssistantBlock::ToolUse { .. } => {
-                has_output_item = true;
-                Some(block.clone())
+                Some(meerkat_core::ReplayWireFamily::OpenAi.strip_foreign_metadata(block.clone()))
             }
             // Spoken transcripts replay back to the provider as plain text;
             // OpenAI Responses API sees the assistant's visible output
             // regardless of capture lane.
             AssistantBlock::Transcript { text, .. } if text.is_empty() => None,
-            AssistantBlock::Transcript { text, .. } => {
-                has_output_item = true;
-                Some(AssistantBlock::Text {
-                    text: text.clone(),
-                    meta: None,
-                })
-            }
-            AssistantBlock::Reasoning { meta, .. } if openai_reasoning_replayable(mode, meta) => {
-                Some(block.clone())
+            AssistantBlock::Transcript { text, .. } => Some(AssistantBlock::Text {
+                text: text.clone(),
+                meta: None,
+            }),
+            AssistantBlock::Reasoning { meta, .. }
+                if has_output_item && openai_reasoning_replayable(mode, meta) =>
+            {
+                Some(meerkat_core::ReplayWireFamily::OpenAi.strip_foreign_metadata(block.clone()))
             }
             AssistantBlock::ServerToolContent { content, .. }
                 if openai_server_tool_content_replayable(mode, content) =>
             {
-                has_output_item = true;
-                Some(block.clone())
+                Some(meerkat_core::ReplayWireFamily::OpenAi.strip_foreign_metadata(block.clone()))
             }
             AssistantBlock::Reasoning { .. }
             | AssistantBlock::ServerToolContent { .. }
             | AssistantBlock::Image { .. } => None,
-            _ => None,
+            _ => {
+                return Err(invalid_replay(
+                    "OpenAI replay cannot project an unknown assistant block",
+                ));
+            }
         };
+        replay_application
+            .record_assistant(
+                meerkat_core::ReplaySubject::AssistantBlock {
+                    message,
+                    block: meerkat_core::ReplayAssistantBlockIndex(block_index),
+                },
+                block,
+                projected_block.as_ref(),
+            )
+            .map_err(|error| invalid_replay(error.to_string()))?;
+        let source_meta = meerkat_core::replay_provider_metadata(block);
+        if let Some(meta) = source_meta {
+            replay_application
+                .record_provider_metadata(
+                    meerkat_core::ReplaySubject::ProviderMetadata {
+                        message,
+                        block: meerkat_core::ReplayAssistantBlockIndex(block_index),
+                    },
+                    meta,
+                    block,
+                    projected_block.as_ref(),
+                )
+                .map_err(|error| invalid_replay(error.to_string()))?;
+        }
 
         if let Some(block) = projected_block {
             projected.push(block);
         }
     }
 
-    if has_output_item {
-        projected
-    } else {
-        Vec::new()
-    }
+    Ok(projected)
 }
 
-fn tool_ids_from_assistant(message: &Message) -> HashSet<String> {
-    match message {
-        Message::BlockAssistant(assistant) => assistant
-            .blocks
-            .iter()
-            .filter_map(|block| match block {
-                AssistantBlock::ToolUse { id, .. } => Some(id.clone()),
-                _ => None,
-            })
-            .collect(),
-        _ => HashSet::new(),
-    }
-}
-
-fn validate_tool_results(
-    provider: &str,
-    pending: HashSet<String>,
-    results: &[ToolResult],
-) -> Result<(), LlmError> {
-    let actual: HashSet<String> = results
-        .iter()
-        .map(|result| result.tool_use_id.clone())
-        .collect();
-    if actual == pending {
-        Ok(())
-    } else {
-        Err(invalid_replay(format!(
-            "{provider} replay projection found tool results that are not adjacent to matching tool uses"
-        )))
-    }
-}
-
-pub(crate) fn project_openai_replay_messages(
+fn project_openai_replay_messages(
     messages: &[Message],
     mode: OpenAiReplayProjectionMode,
 ) -> Result<Vec<Message>, LlmError> {
@@ -368,8 +443,16 @@ pub(crate) fn project_openai_replay_messages_for_capabilities(
     mode: OpenAiReplayProjectionMode,
     image_tool_results: bool,
 ) -> Result<Vec<Message>, LlmError> {
+    project_openai_replay_messages_for_target(messages, mode, true, image_tool_results)
+}
+
+pub(crate) fn project_openai_replay_messages_for_target(
+    messages: &[Message],
+    mode: OpenAiReplayProjectionMode,
+    image_input: bool,
+    image_tool_results: bool,
+) -> Result<Vec<Message>, LlmError> {
     let mut projected = Vec::with_capacity(messages.len());
-    let mut pending_tool_ids: Option<HashSet<String>> = None;
     // Responses can now accept image parts in `function_call_output.output`.
     // This projection intentionally preserves inline tool-result images across
     // the replayed history for capable models, matching Anthropic semantics.
@@ -377,22 +460,47 @@ pub(crate) fn project_openai_replay_messages_for_capabilities(
     // fresh-vs-historical projection policy instead of changing this default.
     let image_tool_results =
         matches!(mode, OpenAiReplayProjectionMode::Responses) && image_tool_results;
+    let replay_plan = meerkat_core::ReplayPlan::build(
+        messages,
+        meerkat_core::ReplayTarget::new(
+            meerkat_core::ReplayWireFamily::OpenAi,
+            image_input,
+            false,
+            image_tool_results,
+        ),
+    )
+    .map_err(|error| invalid_replay(error.to_string()))?;
+    let mut replay_application = replay_plan.application();
 
-    for message in messages {
+    for (message_index, message) in messages.iter().enumerate() {
+        let message_index = meerkat_core::ReplayMessageIndex(message_index);
+        replay_application
+            .record_message(
+                meerkat_core::ReplaySubject::Message(message_index),
+                message,
+                match message {
+                    Message::System(_) | Message::SystemNotice(_) => Some(message),
+                    _ => None,
+                },
+            )
+            .map_err(|error| invalid_replay(error.to_string()))?;
         if let Message::ToolResults {
             results,
             created_at,
         } = message
         {
-            let Some(pending) = pending_tool_ids.take() else {
-                return Err(invalid_replay(
-                    "OpenAI replay projection found tool results without preceding tool use",
-                ));
-            };
-            validate_tool_results("OpenAI", pending, results)?;
             let results = results
                 .iter()
-                .map(|result| project_openai_tool_result(result, image_tool_results))
+                .enumerate()
+                .map(|(result_index, result)| {
+                    project_openai_tool_result(
+                        &mut replay_application,
+                        message_index,
+                        meerkat_core::ReplayToolResultIndex(result_index),
+                        result,
+                        image_tool_results,
+                    )
+                })
                 .collect::<Result<Vec<_>, _>>()?;
             projected.push(Message::ToolResults {
                 results,
@@ -404,14 +512,23 @@ pub(crate) fn project_openai_replay_messages_for_capabilities(
         let next_message = match message {
             Message::System(_) | Message::SystemNotice(_) => Some(message.clone()),
             Message::User(user) => Some(Message::User(UserMessage {
-                content: project_openai_content_blocks(&user.content),
+                content: project_openai_content_blocks(
+                    &mut replay_application,
+                    message_index,
+                    &user.content,
+                )?,
                 render_metadata: user.render_metadata.clone(),
                 identity: user.identity.clone(),
                 transcript_role: user.transcript_role,
                 created_at: user.created_at,
             })),
             Message::BlockAssistant(assistant) => {
-                let blocks = project_openai_assistant_blocks(mode, &assistant.blocks);
+                let blocks = project_openai_assistant_blocks(
+                    &mut replay_application,
+                    message_index,
+                    mode,
+                    &assistant.blocks,
+                )?;
                 if blocks.is_empty() {
                     None
                 } else {
@@ -429,26 +546,12 @@ pub(crate) fn project_openai_replay_messages_for_capabilities(
         let Some(message) = next_message else {
             continue;
         };
-
-        if pending_tool_ids.is_some() {
-            return Err(invalid_replay(
-                "OpenAI replay projection found a tool use without adjacent tool results",
-            ));
-        }
-
-        let tool_ids = tool_ids_from_assistant(&message);
-        if !tool_ids.is_empty() {
-            pending_tool_ids = Some(tool_ids);
-        }
         projected.push(message);
     }
 
-    if pending_tool_ids.is_some() {
-        return Err(invalid_replay(
-            "OpenAI replay projection found a trailing tool use without tool results",
-        ));
-    }
-
+    replay_plan
+        .validate_projected(messages, &projected, replay_application)
+        .map_err(|error| invalid_replay(error.to_string()))?;
     Ok(projected)
 }
 
@@ -3269,6 +3372,12 @@ mod tests {
                             response_id: None,
                         })),
                     },
+                    AssistantBlock::Reasoning {
+                        text: "foreign reasoning".to_string(),
+                        meta: Some(Box::new(ProviderMeta::Anthropic {
+                            signature: "signature".to_string(),
+                        })),
+                    },
                     AssistantBlock::ServerToolContent {
                         id: Some("ws_status".to_string()),
                         kind: ServerToolKind::WebSearch,
@@ -3326,6 +3435,10 @@ mod tests {
                 ],
                 false,
             )]),
+            Message::SystemNotice(SystemNoticeMessage::new(
+                meerkat_core::SystemNoticeKind::Generic,
+                "control intent",
+            )),
         ];
 
         let projected = client.project_replay_messages(&messages)?;
@@ -3357,6 +3470,10 @@ mod tests {
                 .any(|block| matches!(block, AssistantBlock::Reasoning { .. })),
             "OpenAI Responses replay projection should keep OpenAI reasoning blocks"
         );
+        assert!(!assistant.blocks.iter().any(|block| matches!(
+            block,
+            AssistantBlock::Reasoning { text, .. } if text == "foreign reasoning"
+        )));
         assert!(assistant.blocks.iter().any(|block| matches!(
             block,
             AssistantBlock::ServerToolContent { content, .. }
@@ -3422,6 +3539,7 @@ mod tests {
         assert_eq!(output[0]["text"], "tool text");
         assert_eq!(output[1]["type"], "input_image");
         assert_eq!(output[1]["image_url"], "data:image/png;base64,CCCC");
+        assert!(matches!(projected[3], Message::SystemNotice(_)));
         Ok(())
     }
 
@@ -8104,5 +8222,93 @@ mod tests {
         let tools = body["tools"].as_array().expect("tools should be array");
         assert_eq!(tools.len(), 1, "should only have the regular tool");
         assert_eq!(tools[0]["type"], "function");
+    }
+
+    #[test]
+    fn replay_projection_rejects_duplicate_tool_use_ids() {
+        let client = OpenAiClient::new("test-key".to_string());
+        let args = serde_json::value::RawValue::from_string("{}".to_string())
+            .unwrap_or_else(|error| panic!("test args: {error}"));
+        let messages = [
+            Message::BlockAssistant(BlockAssistantMessage::new(
+                vec![
+                    AssistantBlock::ToolUse {
+                        id: "duplicate".to_string(),
+                        name: "a".to_string(),
+                        args: args.clone(),
+                        meta: None,
+                    },
+                    AssistantBlock::ToolUse {
+                        id: "duplicate".to_string(),
+                        name: "b".to_string(),
+                        args,
+                        meta: None,
+                    },
+                ],
+                StopReason::ToolUse,
+            )),
+            Message::tool_results(vec![ToolResult::new(
+                "duplicate".to_string(),
+                "result".to_string(),
+                false,
+            )]),
+        ];
+        assert!(matches!(
+            client.project_replay_messages(&messages),
+            Err(LlmError::InvalidRequest { .. })
+        ));
+    }
+
+    #[test]
+    fn replay_projection_rejects_duplicate_tool_result_ids() {
+        let client = OpenAiClient::new("test-key".to_string());
+        let args = serde_json::value::RawValue::from_string("{}".to_string())
+            .unwrap_or_else(|error| panic!("test args: {error}"));
+        let messages = [
+            Message::BlockAssistant(BlockAssistantMessage::new(
+                vec![AssistantBlock::ToolUse {
+                    id: "tool".to_string(),
+                    name: "a".to_string(),
+                    args,
+                    meta: None,
+                }],
+                StopReason::ToolUse,
+            )),
+            Message::tool_results(vec![
+                ToolResult::new("tool".to_string(), "first".to_string(), false),
+                ToolResult::new("tool".to_string(), "second".to_string(), false),
+            ]),
+        ];
+        assert!(matches!(
+            client.project_replay_messages(&messages),
+            Err(LlmError::InvalidRequest { .. })
+        ));
+    }
+
+    #[test]
+    fn replay_projection_rejects_mismatched_tool_result_id() {
+        let client = OpenAiClient::new("test-key".to_string());
+        let args = serde_json::value::RawValue::from_string("{}".to_string())
+            .unwrap_or_else(|error| panic!("test args: {error}"));
+        let messages = [
+            Message::BlockAssistant(BlockAssistantMessage::new(
+                vec![AssistantBlock::ToolUse {
+                    id: "tool".to_string(),
+                    name: "a".to_string(),
+                    args,
+                    meta: None,
+                }],
+                StopReason::ToolUse,
+            )),
+            Message::tool_results(vec![ToolResult::new(
+                "other".to_string(),
+                "result".to_string(),
+                false,
+            )]),
+        ];
+        assert!(matches!(
+            client.project_replay_messages(&messages),
+            Err(LlmError::InvalidRequest { .. })
+        ));
     }
 }

--- a/meerkat-openai/src/client.rs
+++ b/meerkat-openai/src/client.rs
@@ -172,80 +172,10 @@ fn project_openai_tool_result(
     message: meerkat_core::ReplayMessageIndex,
     result_index: meerkat_core::ReplayToolResultIndex,
     result: &ToolResult,
-    image_tool_results: bool,
 ) -> Result<ToolResult, LlmError> {
-    if result.has_video() {
-        return Err(invalid_replay(
-            "video blocks are not supported in OpenAI tool results",
-        ));
-    }
-    if !image_tool_results {
-        let mut projected_blocks = Vec::with_capacity(result.content.len());
-        for (block_index, block) in result.content.iter().enumerate() {
-            let subject = meerkat_core::ReplaySubject::ToolResultContent {
-                message,
-                result: result_index,
-                block: meerkat_core::ReplayToolResultContentIndex(block_index),
-            };
-            let projected = match replay_application
-                .next(subject)
-                .map_err(|error| invalid_replay(error.to_string()))?
-            {
-                meerkat_core::ReplayDisposition::Preserve => block.clone(),
-                meerkat_core::ReplayDisposition::LowerToText => ContentBlock::Text {
-                    text: block.text_projection().into_owned(),
-                },
-                disposition => {
-                    return Err(invalid_replay(format!(
-                        "OpenAI replay cannot apply tool-result disposition {disposition:?}"
-                    )));
-                }
-            };
-            replay_application
-                .record_content(subject, block, &projected)
-                .map_err(|error| invalid_replay(error.to_string()))?;
-            projected_blocks.push(projected);
-        }
-        return Ok(ToolResult::new(
-            result.tool_use_id.clone(),
-            meerkat_core::types::text_content(&projected_blocks),
-            result.is_error,
-        ));
-    }
-    Ok(ToolResult::with_blocks(
-        result.tool_use_id.clone(),
-        result
-            .content
-            .iter()
-            .enumerate()
-            .map(|(block_index, block)| {
-                let subject = meerkat_core::ReplaySubject::ToolResultContent {
-                    message,
-                    result: result_index,
-                    block: meerkat_core::ReplayToolResultContentIndex(block_index),
-                };
-                let projected = match replay_application
-                    .next(subject)
-                    .map_err(|error| invalid_replay(error.to_string()))?
-                {
-                    meerkat_core::ReplayDisposition::Preserve => block.clone(),
-                    meerkat_core::ReplayDisposition::LowerToText => ContentBlock::Text {
-                        text: block.text_projection().into_owned(),
-                    },
-                    disposition => {
-                        return Err(invalid_replay(format!(
-                            "OpenAI replay cannot apply tool-result disposition {disposition:?}"
-                        )));
-                    }
-                };
-                replay_application
-                    .record_content(subject, block, &projected)
-                    .map_err(|error| invalid_replay(error.to_string()))?;
-                Ok(projected)
-            })
-            .collect::<Result<Vec<_>, _>>()?,
-        result.is_error,
-    ))
+    replay_application
+        .project_tool_result(message, result_index, result)
+        .map_err(|error| invalid_replay(error.to_string()))
 }
 
 fn openai_reasoning_replayable(
@@ -470,6 +400,19 @@ pub(crate) fn project_openai_replay_messages_for_target(
             image_input,
             false,
             image_tool_results,
+            if image_tool_results {
+                meerkat_core::ReplayToolResultProjection::PreserveBlocks
+            } else {
+                meerkat_core::ReplayToolResultProjection::CollapseToText
+            },
+            match mode {
+                OpenAiReplayProjectionMode::Responses => {
+                    meerkat_core::ReplayReasoningProjection::ProviderNative
+                }
+                OpenAiReplayProjectionMode::ChatCompletions => {
+                    meerkat_core::ReplayReasoningProjection::Omit
+                }
+            },
         ),
     )
     .map_err(|error| invalid_replay(error.to_string()))?;
@@ -477,12 +420,19 @@ pub(crate) fn project_openai_replay_messages_for_target(
 
     for (message_index, message) in messages.iter().enumerate() {
         let message_index = meerkat_core::ReplayMessageIndex(message_index);
+        if let Message::SystemNotice(notice) = message {
+            let projected_notice = replay_application
+                .project_system_notice(message_index, notice)
+                .map_err(|error| invalid_replay(error.to_string()))?;
+            projected.push(Message::SystemNotice(projected_notice));
+            continue;
+        }
         replay_application
             .record_message(
                 meerkat_core::ReplaySubject::Message(message_index),
                 message,
                 match message {
-                    Message::System(_) | Message::SystemNotice(_) => Some(message),
+                    Message::System(_) => Some(message),
                     _ => None,
                 },
             )
@@ -501,7 +451,6 @@ pub(crate) fn project_openai_replay_messages_for_target(
                         message_index,
                         meerkat_core::ReplayToolResultIndex(result_index),
                         result,
-                        image_tool_results,
                     )
                 })
                 .collect::<Result<Vec<_>, _>>()?;
@@ -513,7 +462,8 @@ pub(crate) fn project_openai_replay_messages_for_target(
         }
 
         let next_message = match message {
-            Message::System(_) | Message::SystemNotice(_) => Some(message.clone()),
+            Message::System(_) => Some(message.clone()),
+            Message::SystemNotice(_) => unreachable!("handled above"),
             Message::User(user) => Some(Message::User(UserMessage {
                 content: project_openai_content_blocks(
                     &mut replay_application,
@@ -749,7 +699,7 @@ impl OpenAiClient {
     }
 
     /// Build request body for OpenAI Responses API
-    fn build_request_body(&self, request: &LlmRequest) -> Result<Value, LlmError> {
+    pub(crate) fn build_request_body(&self, request: &LlmRequest) -> Result<Value, LlmError> {
         let author_explicit_breakpoints = openai_tag(request).is_some_and(|tag| {
             tag.prompt_cache_enabled != Some(false)
                 && tag.prompt_cache_options.is_some_and(|options| {
@@ -8044,7 +7994,7 @@ mod tests {
         };
 
         let client = OpenAiClient::new("test-key".to_string());
-        let request = LlmRequest::new(
+        let mut request = LlmRequest::new(
             "gpt-5.4",
             vec![Message::SystemNotice(SystemNoticeMessage::with_block(
                 SystemNoticeKind::Comms,
@@ -8076,6 +8026,9 @@ mod tests {
                 },
             ))],
         );
+        request.messages = client
+            .project_replay_messages(&request.messages)
+            .expect("project system notice");
 
         let body = client.build_request_body(&request).expect("build request");
         let input = body["input"].as_array().expect("input array");

--- a/meerkat-openai/src/client_compatible.rs
+++ b/meerkat-openai/src/client_compatible.rs
@@ -1774,8 +1774,16 @@ mod tests {
     fn chat_completions_system_notice_with_image_emits_typed_image_part() {
         use meerkat_core::{ContentBlock, ImageData, SystemNoticeKind, SystemNoticeMessage};
 
-        let messages = OpenAiCompatibleClient::convert_to_chat_messages(&[Message::SystemNotice(
-            SystemNoticeMessage::with_block(
+        let client = OpenAiCompatibleClient::new_with_options(
+            OpenAiCompatibleMode::ChatCompletions,
+            "remote-model".to_string(),
+            "https://example.test".to_string(),
+            None,
+            options(true, true, true, true),
+        )
+        .with_image_input_support(true);
+        let projected = client
+            .project_replay_messages(&[Message::SystemNotice(SystemNoticeMessage::with_block(
                 SystemNoticeKind::ExternalEvent,
                 None,
                 SystemNoticeBlock::ExternalEvent {
@@ -1791,9 +1799,10 @@ mod tests {
                         },
                     }],
                 },
-            ),
-        )])
-        .expect("convert chat messages");
+            ))])
+            .expect("project chat messages");
+        let messages =
+            OpenAiCompatibleClient::convert_to_chat_messages(&projected).expect("convert chat");
 
         assert_eq!(messages[0]["role"], "user");
         let content = messages[0]["content"].as_array().expect("content array");
@@ -3193,5 +3202,123 @@ mod tests {
             user.content.as_slice(),
             [ContentBlock::Text { .. }]
         ));
+    }
+
+    #[test]
+    fn non_vision_compatible_modes_strip_nested_notice_images_from_serialized_requests() {
+        use meerkat_core::{SystemNoticeKind, SystemNoticeMessage};
+
+        for mode in [
+            OpenAiCompatibleMode::Responses,
+            OpenAiCompatibleMode::ChatCompletions,
+        ] {
+            let client = OpenAiCompatibleClient::new_with_options(
+                mode,
+                "remote-model".to_string(),
+                "https://example.test".to_string(),
+                None,
+                options(true, true, true, true),
+            )
+            .with_image_input_support(false);
+            let mut request = LlmRequest::new(
+                "remote-model",
+                vec![Message::SystemNotice(SystemNoticeMessage::with_block(
+                    SystemNoticeKind::ExternalEvent,
+                    None,
+                    SystemNoticeBlock::ExternalEvent {
+                        source: "console".to_string(),
+                        event_type: "operator_message".to_string(),
+                        summary: None,
+                        body: Some("inspect this".to_string()),
+                        payload: None,
+                        content: vec![ContentBlock::Image {
+                            media_type: "image/png".to_string(),
+                            data: ImageData::Inline {
+                                data: "NESTED_IMAGE_BYTES".to_string(),
+                            },
+                        }],
+                    },
+                ))],
+            );
+            request.messages = client
+                .project_replay_messages(&request.messages)
+                .expect("project non-vision notice");
+
+            let body = match mode {
+                OpenAiCompatibleMode::Responses => client
+                    .responses_delegate
+                    .as_ref()
+                    .expect("responses delegate")
+                    .build_request_body(&client.request_with_remote_model(&request))
+                    .expect("build responses body"),
+                OpenAiCompatibleMode::ChatCompletions => client
+                    .build_chat_completions_body(&request)
+                    .expect("build chat body"),
+            };
+            let encoded = serde_json::to_string(&body).expect("encode request body");
+            assert!(!encoded.contains("NESTED_IMAGE_BYTES"));
+            assert!(!encoded.contains("input_image"));
+            assert!(!encoded.contains("image_url"));
+            assert!(encoded.contains("[image: image/png]"));
+        }
+    }
+
+    #[test]
+    fn compatible_modes_serialize_the_verified_collapsed_tool_result() {
+        for mode in [
+            OpenAiCompatibleMode::Responses,
+            OpenAiCompatibleMode::ChatCompletions,
+        ] {
+            let client = OpenAiCompatibleClient::new_with_options(
+                mode,
+                "remote-model".to_string(),
+                "https://example.test".to_string(),
+                None,
+                options(true, true, true, false),
+            );
+            let mut request = LlmRequest::new(
+                "remote-model",
+                vec![
+                    Message::BlockAssistant(BlockAssistantMessage::new(
+                        vec![AssistantBlock::ToolUse {
+                            id: "call-1".to_string(),
+                            name: "lookup".to_string(),
+                            args: serde_json::value::RawValue::from_string("{}".to_string())
+                                .expect("valid tool arguments"),
+                            meta: None,
+                        }],
+                        StopReason::ToolUse,
+                    )),
+                    Message::tool_results(vec![ToolResult::with_blocks(
+                        "call-1".to_string(),
+                        vec![
+                            ContentBlock::Text {
+                                text: "first".to_string(),
+                            },
+                            ContentBlock::Text {
+                                text: "second".to_string(),
+                            },
+                        ],
+                        false,
+                    )]),
+                ],
+            );
+            request.messages = client
+                .project_replay_messages(&request.messages)
+                .expect("project compatible tool result");
+            let body = match mode {
+                OpenAiCompatibleMode::Responses => client
+                    .responses_delegate
+                    .as_ref()
+                    .expect("responses delegate")
+                    .build_request_body(&client.request_with_remote_model(&request))
+                    .expect("build responses body"),
+                OpenAiCompatibleMode::ChatCompletions => client
+                    .build_chat_completions_body(&request)
+                    .expect("build chat body"),
+            };
+            let encoded = serde_json::to_string(&body).expect("encode request body");
+            assert!(encoded.contains("first\\nsecond"));
+        }
     }
 }

--- a/meerkat-openai/src/client_compatible.rs
+++ b/meerkat-openai/src/client_compatible.rs
@@ -92,6 +92,7 @@ pub struct OpenAiCompatibleClient {
     supports_temperature: bool,
     supports_thinking: bool,
     supports_reasoning: bool,
+    supports_image_input: bool,
     supports_image_tool_results: bool,
     post_finish_trailer_window: Duration,
 }
@@ -147,6 +148,7 @@ impl OpenAiCompatibleClient {
             supports_temperature: options.supports_temperature,
             supports_thinking: options.supports_thinking,
             supports_reasoning: options.supports_reasoning,
+            supports_image_input: true,
             supports_image_tool_results: options.supports_image_tool_results,
             post_finish_trailer_window: DEFAULT_POST_FINISH_TRAILER_WINDOW,
         }
@@ -163,6 +165,12 @@ impl OpenAiCompatibleClient {
 
     pub fn with_provider(mut self, provider: Provider) -> Self {
         self.provider = provider;
+        self
+    }
+
+    #[must_use]
+    pub fn with_image_input_support(mut self, supports_image_input: bool) -> Self {
+        self.supports_image_input = supports_image_input;
         self
     }
 
@@ -676,6 +684,7 @@ impl LlmClient for OpenAiCompatibleClient {
         project_openai_replay_messages_for_capabilities(
             messages,
             mode,
+            self.supports_image_input,
             self.supports_image_tool_results,
         )
     }
@@ -3153,5 +3162,36 @@ mod tests {
             block,
             AssistantBlock::Reasoning { text, .. } if text == "anthropic" || text == "gemini"
         )));
+    }
+
+    #[test]
+    fn non_vision_self_hosted_replay_lowers_inline_images_to_text() {
+        let client = OpenAiCompatibleClient::new_with_options(
+            OpenAiCompatibleMode::Responses,
+            "remote-model".to_string(),
+            "https://example.test".to_string(),
+            None,
+            options(true, true, true, true),
+        )
+        .with_image_input_support(false);
+        let messages = vec![Message::User(UserMessage::with_blocks(vec![
+            ContentBlock::Image {
+                media_type: "image/png".to_string(),
+                data: ImageData::Inline {
+                    data: "AAAA".to_string(),
+                },
+            },
+        ]))];
+
+        let projected = client
+            .project_replay_messages(&messages)
+            .expect("non-vision SelfHosted replay should lower image history");
+        let Message::User(user) = &projected[0] else {
+            panic!("expected projected user message");
+        };
+        assert!(matches!(
+            user.content.as_slice(),
+            [ContentBlock::Text { .. }]
+        ));
     }
 }

--- a/meerkat-openai/src/client_compatible.rs
+++ b/meerkat-openai/src/client_compatible.rs
@@ -1350,7 +1350,7 @@ struct ChatPromptTokensDetails {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
+#[allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
 mod tests {
     use super::*;
     use axum::body::to_bytes;
@@ -3094,5 +3094,64 @@ mod tests {
             value["properties"]["outer"]["properties"]["inner"]["additionalProperties"],
             Value::Bool(false)
         );
+    }
+
+    #[test]
+    fn self_hosted_replay_uses_openai_wire_family_for_metadata() {
+        use meerkat_core::ProviderMeta;
+
+        let client = OpenAiCompatibleClient::new_with_options(
+            OpenAiCompatibleMode::Responses,
+            "remote-model".to_string(),
+            "https://example.test".to_string(),
+            None,
+            options(true, true, true, true),
+        );
+        assert_eq!(client.provider(), Provider::SelfHosted);
+        let messages = vec![Message::BlockAssistant(BlockAssistantMessage::new(
+            vec![
+                AssistantBlock::Text {
+                    text: "visible".to_string(),
+                    meta: None,
+                },
+                AssistantBlock::Reasoning {
+                    text: "openai".to_string(),
+                    meta: Some(Box::new(ProviderMeta::OpenAi {
+                        id: "rs_1".to_string(),
+                        encrypted_content: Some("ciphertext".to_string()),
+                        phase: Some("reasoning".to_string()),
+                        response_id: None,
+                    })),
+                },
+                AssistantBlock::Reasoning {
+                    text: "anthropic".to_string(),
+                    meta: Some(Box::new(ProviderMeta::Anthropic {
+                        signature: "foreign".to_string(),
+                    })),
+                },
+                AssistantBlock::Reasoning {
+                    text: "gemini".to_string(),
+                    meta: Some(Box::new(ProviderMeta::Gemini {
+                        thought_signature: "foreign".to_string(),
+                    })),
+                },
+            ],
+            StopReason::EndTurn,
+        ))];
+
+        let projected = client
+            .project_replay_messages(&messages)
+            .expect("SelfHosted OpenAI-family projection");
+        let Message::BlockAssistant(assistant) = &projected[0] else {
+            panic!("expected projected assistant message");
+        };
+        assert_eq!(assistant.blocks.len(), 2);
+        assert!(
+            matches!(assistant.blocks[1], AssistantBlock::Reasoning { meta: Some(ref meta), .. } if matches!(meta.as_ref(), ProviderMeta::OpenAi { .. }))
+        );
+        assert!(assistant.blocks.iter().all(|block| !matches!(
+            block,
+            AssistantBlock::Reasoning { text, .. } if text == "anthropic" || text == "gemini"
+        )));
     }
 }

--- a/meerkat-openai/src/runtime/mod.rs
+++ b/meerkat-openai/src/runtime/mod.rs
@@ -240,6 +240,7 @@ impl meerkat_copilot::CopilotChatCompletionsClientFactory
         &self,
         spec: meerkat_copilot::CopilotChatCompletionsClientSpec,
     ) -> Result<Arc<dyn LlmClient>, ProviderClientError> {
+        let supports_image_input = spec.supports_image_input();
         let (
             provider,
             model,
@@ -263,6 +264,7 @@ impl meerkat_copilot::CopilotChatCompletionsClientFactory
                     supports_image_tool_results,
                 },
             )
+            .with_image_input_support(supports_image_input)
             .with_authorizer(authorizer)
             .with_provider(provider),
         ))
@@ -625,6 +627,7 @@ impl ProviderRuntime for OpenAiProviderRuntime {
             let (identity, profile, connection) = target.into_parts();
             let model = identity.model.clone();
             let supports_temperature = profile.profile().supports_temperature;
+            let supports_image_input = profile.profile().image_input;
             let supports_image_tool_results = profile.profile().image_tool_results;
             let factory: meerkat_copilot::CopilotRouteClientFactory =
                 Arc::new(move |route, connection| {
@@ -660,6 +663,7 @@ impl ProviderRuntime for OpenAiProviderRuntime {
                                 None,
                                 route.api_base.clone(),
                             )
+                            .with_image_input_support(supports_image_input)
                             .with_authorizer(authorizer)
                             .with_responses_path("responses"),
                         )
@@ -677,6 +681,7 @@ impl ProviderRuntime for OpenAiProviderRuntime {
                                     supports_image_tool_results,
                                 },
                             )
+                            .with_image_input_support(supports_image_input)
                             .with_authorizer(authorizer)
                             .with_provider(Provider::OpenAI),
                         )

--- a/meerkat-openai/src/text_adapter.rs
+++ b/meerkat-openai/src/text_adapter.rs
@@ -27,8 +27,7 @@ use async_stream::try_stream;
 use async_trait::async_trait;
 use meerkat_core::schema::{CompiledSchema, SchemaError};
 use meerkat_core::{
-    AssistantBlock, BlockAssistantMessage, ContentBlock, ImageData, Message, OutputSchema,
-    StopReason, ToolResult, Usage, UserMessage,
+    AssistantBlock, ContentBlock, ImageData, Message, OutputSchema, StopReason, Usage,
 };
 use meerkat_llm_core::{LlmClient, LlmDoneOutcome, LlmError, LlmEvent, LlmRequest, LlmStream};
 
@@ -37,7 +36,6 @@ use oai_rt_rs::protocol::models::{
     SessionUpdate, SessionUpdateConfig, Temperature, Tool, Usage as OaiUsage,
 };
 use oai_rt_rs::{ClientEvent, RealtimeClient, ServerEvent};
-use std::collections::HashSet;
 
 /// OpenAI's Realtime API caps `response.max_output_tokens` at 4096 for
 /// integer values; larger values fail with `integer above maximum value`.
@@ -98,160 +96,13 @@ pub struct OpenAiRealtimeTextAdapter {
     api_key: String,
 }
 
-fn invalid_replay(message: impl Into<String>) -> LlmError {
-    LlmError::InvalidRequest {
-        message: message.into(),
-    }
-}
-
-fn project_realtime_content_blocks(blocks: &[ContentBlock]) -> Vec<ContentBlock> {
-    blocks
-        .iter()
-        .map(|block| match block {
-            ContentBlock::Text { .. } => block.clone(),
-            _ => ContentBlock::Text {
-                text: block.text_projection().into_owned(),
-            },
-        })
-        .collect()
-}
-
-fn project_realtime_tool_result(result: &ToolResult) -> Result<ToolResult, LlmError> {
-    if result.has_video() {
-        return Err(invalid_replay(
-            "video blocks are not supported in OpenAI realtime tool results",
-        ));
-    }
-    Ok(ToolResult::new(
-        result.tool_use_id.clone(),
-        result.text_content(),
-        result.is_error,
-    ))
-}
-
-fn project_realtime_assistant_blocks(blocks: &[AssistantBlock]) -> Vec<AssistantBlock> {
-    blocks
-        .iter()
-        .filter_map(|block| match block {
-            AssistantBlock::Text { text, .. } if text.is_empty() => None,
-            AssistantBlock::Text { .. } | AssistantBlock::ToolUse { .. } => Some(block.clone()),
-            // Spoken transcripts replay back as plain text; provider sees
-            // the assistant's visible output regardless of capture lane.
-            AssistantBlock::Transcript { text, .. } if text.is_empty() => None,
-            AssistantBlock::Transcript { text, .. } => Some(AssistantBlock::Text {
-                text: text.clone(),
-                meta: None,
-            }),
-            AssistantBlock::Reasoning { .. }
-            | AssistantBlock::ServerToolContent { .. }
-            | AssistantBlock::Image { .. } => None,
-            _ => None,
-        })
-        .collect()
-}
-
-fn tool_ids_from_assistant(message: &Message) -> HashSet<String> {
-    match message {
-        Message::BlockAssistant(assistant) => assistant
-            .blocks
-            .iter()
-            .filter_map(|block| match block {
-                AssistantBlock::ToolUse { id, .. } => Some(id.clone()),
-                _ => None,
-            })
-            .collect(),
-        _ => HashSet::new(),
-    }
-}
-
-fn validate_tool_results(pending: HashSet<String>, results: &[ToolResult]) -> Result<(), LlmError> {
-    let actual: HashSet<String> = results
-        .iter()
-        .map(|result| result.tool_use_id.clone())
-        .collect();
-    if actual == pending {
-        Ok(())
-    } else {
-        Err(invalid_replay(
-            "OpenAI realtime replay projection found tool results that are not adjacent to matching tool uses",
-        ))
-    }
-}
-
 fn project_realtime_replay_messages(messages: &[Message]) -> Result<Vec<Message>, LlmError> {
-    let mut projected = Vec::with_capacity(messages.len());
-    let mut pending_tool_ids: Option<HashSet<String>> = None;
-
-    for message in messages {
-        if let Message::ToolResults {
-            results,
-            created_at,
-        } = message
-        {
-            let Some(pending) = pending_tool_ids.take() else {
-                return Err(invalid_replay(
-                    "OpenAI realtime replay projection found tool results without preceding tool use",
-                ));
-            };
-            validate_tool_results(pending, results)?;
-            let results = results
-                .iter()
-                .map(project_realtime_tool_result)
-                .collect::<Result<Vec<_>, _>>()?;
-            projected.push(Message::ToolResults {
-                results,
-                created_at: *created_at,
-            });
-            continue;
-        }
-
-        if pending_tool_ids.is_some() {
-            return Err(invalid_replay(
-                "OpenAI realtime replay projection found a tool use without adjacent tool results",
-            ));
-        }
-
-        let next_message = match message {
-            Message::System(_) | Message::SystemNotice(_) => Some(message.clone()),
-            Message::User(user) => Some(Message::User(UserMessage {
-                content: project_realtime_content_blocks(&user.content),
-                render_metadata: user.render_metadata.clone(),
-                identity: user.identity.clone(),
-                transcript_role: user.transcript_role,
-                created_at: user.created_at,
-            })),
-            Message::BlockAssistant(assistant) => {
-                let blocks = project_realtime_assistant_blocks(&assistant.blocks);
-                if blocks.is_empty() {
-                    None
-                } else {
-                    Some(Message::BlockAssistant(BlockAssistantMessage {
-                        blocks,
-                        stop_reason: assistant.stop_reason,
-                        identity: assistant.identity.clone(),
-                        created_at: assistant.created_at,
-                    }))
-                }
-            }
-            Message::ToolResults { .. } => unreachable!("handled above"),
-        };
-
-        if let Some(message) = next_message {
-            let tool_ids = tool_ids_from_assistant(&message);
-            if !tool_ids.is_empty() {
-                pending_tool_ids = Some(tool_ids);
-            }
-            projected.push(message);
-        }
-    }
-
-    if pending_tool_ids.is_some() {
-        return Err(invalid_replay(
-            "OpenAI realtime replay projection found a trailing tool use without tool results",
-        ));
-    }
-
-    Ok(projected)
+    crate::client::project_openai_replay_messages_for_target(
+        messages,
+        crate::client::OpenAiReplayProjectionMode::ChatCompletions,
+        false,
+        false,
+    )
 }
 
 impl OpenAiRealtimeTextAdapter {
@@ -1199,5 +1050,93 @@ mod tests {
         let negative = resolve_realtime_temperature(Some(-1.0))
             .expect_err("a negative temperature must be a typed reject");
         assert!(matches!(negative, LlmError::InvalidRequest { .. }));
+    }
+
+    #[test]
+    fn replay_projection_rejects_duplicate_tool_use_ids() {
+        let client = OpenAiRealtimeTextAdapter::new("test-key");
+        let args = serde_json::value::RawValue::from_string("{}".to_string())
+            .unwrap_or_else(|error| panic!("test args: {error}"));
+        let messages = [
+            Message::BlockAssistant(BlockAssistantMessage::new(
+                vec![
+                    AssistantBlock::ToolUse {
+                        id: "duplicate".to_string(),
+                        name: "a".to_string(),
+                        args: args.clone(),
+                        meta: None,
+                    },
+                    AssistantBlock::ToolUse {
+                        id: "duplicate".to_string(),
+                        name: "b".to_string(),
+                        args,
+                        meta: None,
+                    },
+                ],
+                StopReason::ToolUse,
+            )),
+            Message::tool_results(vec![ToolResult::new(
+                "duplicate".to_string(),
+                "result".to_string(),
+                false,
+            )]),
+        ];
+        assert!(matches!(
+            client.project_replay_messages(&messages),
+            Err(LlmError::InvalidRequest { .. })
+        ));
+    }
+
+    #[test]
+    fn replay_projection_rejects_duplicate_tool_result_ids() {
+        let client = OpenAiRealtimeTextAdapter::new("test-key");
+        let args = serde_json::value::RawValue::from_string("{}".to_string())
+            .unwrap_or_else(|error| panic!("test args: {error}"));
+        let messages = [
+            Message::BlockAssistant(BlockAssistantMessage::new(
+                vec![AssistantBlock::ToolUse {
+                    id: "tool".to_string(),
+                    name: "a".to_string(),
+                    args,
+                    meta: None,
+                }],
+                StopReason::ToolUse,
+            )),
+            Message::tool_results(vec![
+                ToolResult::new("tool".to_string(), "first".to_string(), false),
+                ToolResult::new("tool".to_string(), "second".to_string(), false),
+            ]),
+        ];
+        assert!(matches!(
+            client.project_replay_messages(&messages),
+            Err(LlmError::InvalidRequest { .. })
+        ));
+    }
+
+    #[test]
+    fn replay_projection_rejects_mismatched_tool_result_id() {
+        let client = OpenAiRealtimeTextAdapter::new("test-key");
+        let args = serde_json::value::RawValue::from_string("{}".to_string())
+            .unwrap_or_else(|error| panic!("test args: {error}"));
+        let messages = [
+            Message::BlockAssistant(BlockAssistantMessage::new(
+                vec![AssistantBlock::ToolUse {
+                    id: "tool".to_string(),
+                    name: "a".to_string(),
+                    args,
+                    meta: None,
+                }],
+                StopReason::ToolUse,
+            )),
+            Message::tool_results(vec![ToolResult::new(
+                "other".to_string(),
+                "result".to_string(),
+                false,
+            )]),
+        ];
+        assert!(matches!(
+            client.project_replay_messages(&messages),
+            Err(LlmError::InvalidRequest { .. })
+        ));
     }
 }

--- a/meerkat/src/factory.rs
+++ b/meerkat/src/factory.rs
@@ -1722,6 +1722,7 @@ struct SelfHostedClientSpec {
     supports_temperature: bool,
     supports_thinking: bool,
     supports_reasoning: bool,
+    supports_image_input: bool,
     supports_image_tool_results: bool,
 }
 
@@ -4569,6 +4570,7 @@ impl AgentFactory {
             supports_temperature: profile.supports_temperature,
             supports_thinking: profile.supports_thinking,
             supports_reasoning: profile.supports_reasoning,
+            supports_image_input: profile.image_input,
             supports_image_tool_results: profile.image_tool_results,
         })
     }
@@ -4639,18 +4641,21 @@ impl AgentFactory {
                 .clone()
                 .unwrap_or(spec.base_url);
             Ok(SelfHostedClientBuild {
-                client: Arc::new(OpenAiCompatibleClient::new_with_options(
-                    spec.mode,
-                    spec.remote_model,
-                    base_url,
-                    bearer_token,
-                    OpenAiCompatibleClientOptions {
-                        supports_temperature: spec.supports_temperature,
-                        supports_thinking: spec.supports_thinking,
-                        supports_reasoning: spec.supports_reasoning,
-                        supports_image_tool_results: spec.supports_image_tool_results,
-                    },
-                )),
+                client: Arc::new(
+                    OpenAiCompatibleClient::new_with_options(
+                        spec.mode,
+                        spec.remote_model,
+                        base_url,
+                        bearer_token,
+                        OpenAiCompatibleClientOptions {
+                            supports_temperature: spec.supports_temperature,
+                            supports_thinking: spec.supports_thinking,
+                            supports_reasoning: spec.supports_reasoning,
+                            supports_image_tool_results: spec.supports_image_tool_results,
+                        },
+                    )
+                    .with_image_input_support(spec.supports_image_input),
+                ),
                 durable_auth_binding,
                 credential_identity: connection.credential_identity,
             })


### PR DESCRIPTION
## Summary

- add a core-owned typed replay plan over canonical transcript messages, nested notices, reasoning, metadata, media, and complete tool results
- validate the actual provider projection before dispatch, including provider-required tool-result collapse and final tool adjacency
- enforce the contract in Anthropic, OpenAI Responses/OpenAI-compatible/OpenAI realtime, and Gemini adapters
- preserve OpenAI wire-family continuity for self-hosted/Copilot routes while honoring target vision capability

This is the replay-only first delivery for #360. It intentionally does **not** close the issue; the model-authored `brain_swap` builtin follows separately.

## Validation

- exact-tree pre-push gate passed
- affected provider/core/Copilot library tests passed
- individual Clippy `-D warnings` passed for affected crates
- `make rmat-audit` passed
- disposition mutation made Anthropic, OpenAI, and Gemini replay suites fail
- independent correctness, Rust quality, and architecture reviews passed