### PR TITLE
fix: make keep-alive validation feature-aware

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -177,6 +177,8 @@ test-feature-matrix-lib:
 test-feature-matrix-surface:
 	@echo "$(GREEN)Running surface feature matrix checks...$(NC)"
 	CARGO="$(CARGO)" ./scripts/run-surface-feature-matrix
+	$(CARGO) test -p rkat --no-default-features --features session-store,mcp tests::test_resolve_keep_alive_roundtrip -- --exact
+	$(CARGO) test -p rkat --no-default-features --features session-store,comms,mcp tests::test_resolve_keep_alive_roundtrip -- --exact
 	$(CARGO) nextest run -p rkat --no-default-features --features session-store,mcp --no-capture
 
 # Session capability matrix (A-F builds from spec)

--- a/Makefile
+++ b/Makefile
@@ -179,6 +179,8 @@ test-feature-matrix-surface:
 	CARGO="$(CARGO)" ./scripts/run-surface-feature-matrix
 	$(CARGO) test -p rkat --no-default-features --features session-store,mcp tests::test_resolve_keep_alive_roundtrip -- --exact
 	$(CARGO) test -p rkat --no-default-features --features session-store,comms,mcp tests::test_resolve_keep_alive_roundtrip -- --exact
+	$(CARGO) test -p meerkat-rest --no-default-features tests::test_continue_session_rejects_inherited_persisted_keep_alive_without_comms -- --exact
+	$(CARGO) test -p meerkat-mcp-server --no-default-features tests::test_meerkat_resume_rejects_inherited_persisted_keep_alive_without_comms -- --exact
 	$(CARGO) nextest run -p rkat --no-default-features --features session-store,mcp --no-capture
 
 # Session capability matrix (A-F builds from spec)

--- a/meerkat-cli/src/main.rs
+++ b/meerkat-cli/src/main.rs
@@ -9513,7 +9513,13 @@ async fn create_mcp_tools(
 }
 
 fn resolve_keep_alive(requested: bool) -> anyhow::Result<bool> {
-    meerkat::surface::resolve_keep_alive(requested).map_err(|e| anyhow::anyhow!(e))
+    let support = if cfg!(feature = "comms") {
+        meerkat::surface::KeepAliveSupport::Available
+    } else {
+        meerkat::surface::KeepAliveSupport::Unavailable
+    };
+    meerkat::surface::resolve_keep_alive_for_surface(requested, support)
+        .map_err(|e| anyhow::anyhow!(e))
 }
 
 /// Load MCP tools as an external tool dispatcher for session build options.

--- a/meerkat-comms/src/lib.rs
+++ b/meerkat-comms/src/lib.rs
@@ -135,3 +135,13 @@ inventory::submit! {
 /// their bodies remain owned here.
 #[doc(hidden)]
 pub fn link_embedded_skill_registrations() {}
+
+/// Confirm keep-alive mode availability when this crate is linked.
+///
+/// New product surfaces should call
+/// `meerkat::surface::resolve_keep_alive_for_surface()` with their own typed
+/// compiled-availability witness so dependency feature unification cannot
+/// change the result.
+pub fn validate_keep_alive(requested: bool) -> Result<bool, String> {
+    Ok(requested)
+}

--- a/meerkat-comms/src/lib.rs
+++ b/meerkat-comms/src/lib.rs
@@ -135,18 +135,3 @@ inventory::submit! {
 /// their bodies remain owned here.
 #[doc(hidden)]
 pub fn link_embedded_skill_registrations() {}
-
-/// Confirm keep-alive mode availability when the comms crate is compiled in.
-///
-/// This function is intentionally a passthrough — its existence in the
-/// dependency graph *is* the validation. When `meerkat-comms` is linked,
-/// comms is available and keep-alive mode can be enabled. The feature-gate check
-/// lives in `meerkat::surface::resolve_keep_alive()`, which calls this
-/// function under `#[cfg(feature = "comms")]` and returns an error under
-/// `#[cfg(not(feature = "comms"))]`.
-///
-/// This two-layer design avoids duplicating the `cfg` check in every
-/// surface crate.
-pub fn validate_keep_alive(requested: bool) -> Result<bool, String> {
-    Ok(requested)
-}

--- a/meerkat-mcp-server/src/lib.rs
+++ b/meerkat-mcp-server/src/lib.rs
@@ -1051,14 +1051,12 @@ async fn load_config_async(
 fn resolve_keep_alive(requested: Option<bool>) -> Result<Option<bool>, String> {
     match requested {
         Some(true) => {
-            #[cfg(feature = "comms")]
-            {
-                meerkat::surface::resolve_keep_alive(true).map(Some)
-            }
-            #[cfg(not(feature = "comms"))]
-            {
-                Err("keep_alive requires comms support (build with --features comms)".to_string())
-            }
+            let support = if cfg!(feature = "comms") {
+                meerkat::surface::KeepAliveSupport::Available
+            } else {
+                meerkat::surface::KeepAliveSupport::Unavailable
+            };
+            meerkat::surface::resolve_keep_alive_for_surface(true, support).map(Some)
         }
         other => Ok(other), // None (inherit) or Some(false) (disable) pass through
     }

--- a/meerkat-mcp-server/src/lib.rs
+++ b/meerkat-mcp-server/src/lib.rs
@@ -1050,16 +1050,18 @@ async fn load_config_async(
 /// Resolve an explicit keep_alive override. Returns None when input is None (inherit).
 fn resolve_keep_alive(requested: Option<bool>) -> Result<Option<bool>, String> {
     match requested {
-        Some(true) => {
-            let support = if cfg!(feature = "comms") {
-                meerkat::surface::KeepAliveSupport::Available
-            } else {
-                meerkat::surface::KeepAliveSupport::Unavailable
-            };
-            meerkat::surface::resolve_keep_alive_for_surface(true, support).map(Some)
-        }
+        Some(value) => validate_effective_keep_alive(value).map(|()| Some(value)),
         other => Ok(other), // None (inherit) or Some(false) (disable) pass through
     }
+}
+
+fn validate_effective_keep_alive(keep_alive: bool) -> Result<(), String> {
+    let support = if cfg!(feature = "comms") {
+        meerkat::surface::KeepAliveSupport::Available
+    } else {
+        meerkat::surface::KeepAliveSupport::Unavailable
+    };
+    meerkat::surface::resolve_keep_alive_for_surface(keep_alive, support).map(|_| ())
 }
 
 fn validate_public_peer_meta(peer_meta: Option<&meerkat_core::PeerMeta>) -> Result<(), String> {
@@ -4395,6 +4397,7 @@ async fn handle_meerkat_resume(
         Some(val) => val,
         None => stored_metadata.keep_alive,
     };
+    validate_effective_keep_alive(keep_alive).map_err(ToolCallError::invalid_params)?;
     let comms_name = input
         .comms_name
         .clone()
@@ -7308,6 +7311,60 @@ mod tests {
     fn test_resolve_keep_alive_rejects_when_comms_disabled() {
         let err = resolve_keep_alive(Some(true)).expect_err("keep_alive should be rejected");
         assert!(err.contains("keep_alive requires comms support"));
+    }
+
+    #[cfg(not(feature = "comms"))]
+    #[tokio::test]
+    async fn test_meerkat_resume_rejects_inherited_persisted_keep_alive_without_comms() {
+        let store: Arc<dyn SessionStore> = Arc::new(meerkat::MemoryStore::new());
+        let runtime_store: Arc<dyn meerkat_runtime::RuntimeStore> =
+            Arc::new(meerkat_runtime::InMemoryRuntimeStore::new());
+        let state = MeerkatMcpState::new_with_store_options_and_llm(
+            Arc::clone(&store),
+            Arc::clone(&runtime_store),
+            None,
+            Some(Arc::new(TestClient::for_provider(Provider::Anthropic))),
+        )
+        .await;
+        let mut session = Session::new();
+        let session_id = session.id().clone();
+        session
+            .set_session_metadata(meerkat::SessionMetadata {
+                schema_version: meerkat_core::SESSION_METADATA_SCHEMA_VERSION,
+                model: "claude-opus-4-6".to_string(),
+                max_tokens: 4096,
+                structured_output_retries: 2,
+                provider: Provider::Anthropic,
+                self_hosted_server_id: None,
+                provider_params: None,
+                tooling: meerkat_core::SessionTooling::default(),
+                keep_alive: true,
+                comms_name: Some("persisted-mcp-agent".to_string()),
+                peer_meta: None,
+                realm_id: Some(state.realm_id.clone()),
+                instance_id: state.instance_id.clone(),
+                backend: Some(state.backend.clone()),
+                config_generation: None,
+                auth_binding: None,
+                mob_member_binding: None,
+            })
+            .expect("session metadata should serialize");
+        session
+            .set_build_state(meerkat_core::SessionBuildState::default())
+            .expect("session build state should serialize");
+        store.save(&session).await.expect("persisted session");
+        seed_runtime_authority_session(&runtime_store, &session).await;
+
+        let error = Box::pin(handle_meerkat_resume(
+            &state,
+            bounded_resume_input(session_id.to_string(), vec![]),
+            None,
+            None,
+        ))
+        .await
+        .expect_err("inherited keep_alive should reject without surface comms");
+
+        assert!(error.message.contains("keep_alive requires comms support"));
     }
 
     #[cfg(feature = "comms")]

--- a/meerkat-rest/src/lib.rs
+++ b/meerkat-rest/src/lib.rs
@@ -2038,9 +2038,16 @@ fn realm_origin_from_selection(selection: &RealmSelection) -> RealmOrigin {
 /// Resolve an explicit keep_alive override. Returns None when input is None (inherit).
 fn resolve_keep_alive(requested: Option<bool>) -> Result<Option<bool>, ApiError> {
     match requested {
-        Some(true) => meerkat::surface::resolve_keep_alive(true)
-            .map(Some)
-            .map_err(ApiError::BadRequest),
+        Some(true) => {
+            let support = if cfg!(feature = "comms") {
+                meerkat::surface::KeepAliveSupport::Available
+            } else {
+                meerkat::surface::KeepAliveSupport::Unavailable
+            };
+            meerkat::surface::resolve_keep_alive_for_surface(true, support)
+                .map(Some)
+                .map_err(ApiError::BadRequest)
+        }
         other => Ok(other), // None (inherit) or Some(false) (disable) pass through
     }
 }

--- a/meerkat-rest/src/lib.rs
+++ b/meerkat-rest/src/lib.rs
@@ -2038,18 +2038,20 @@ fn realm_origin_from_selection(selection: &RealmSelection) -> RealmOrigin {
 /// Resolve an explicit keep_alive override. Returns None when input is None (inherit).
 fn resolve_keep_alive(requested: Option<bool>) -> Result<Option<bool>, ApiError> {
     match requested {
-        Some(true) => {
-            let support = if cfg!(feature = "comms") {
-                meerkat::surface::KeepAliveSupport::Available
-            } else {
-                meerkat::surface::KeepAliveSupport::Unavailable
-            };
-            meerkat::surface::resolve_keep_alive_for_surface(true, support)
-                .map(Some)
-                .map_err(ApiError::BadRequest)
-        }
+        Some(value) => validate_effective_keep_alive(value).map(|()| Some(value)),
         other => Ok(other), // None (inherit) or Some(false) (disable) pass through
     }
+}
+
+fn validate_effective_keep_alive(keep_alive: bool) -> Result<(), ApiError> {
+    let support = if cfg!(feature = "comms") {
+        meerkat::surface::KeepAliveSupport::Available
+    } else {
+        meerkat::surface::KeepAliveSupport::Unavailable
+    };
+    meerkat::surface::resolve_keep_alive_for_surface(keep_alive, support)
+        .map(|_| ())
+        .map_err(ApiError::BadRequest)
 }
 
 /// Default keep-alive TTL applied to per-turn metadata when the REST wire
@@ -6302,6 +6304,18 @@ async fn continue_session_inner(
             Some(val) => val,
             None => stored_metadata.keep_alive,
         };
+        if let Err(error) = validate_effective_keep_alive(keep_alive) {
+            let error = unregister_rest_runtime_after_api_error_locked(
+                state,
+                &session_id,
+                runtime_was_registered,
+                error,
+            )
+            .await;
+            drop(caller_event_tx);
+            drain_event_forwarder(&session_id, forward_task).await;
+            return RequestTerminal::RespondWithoutPublish(Err(error));
+        }
         let effective_comms_name = req
             .comms_name
             .clone()
@@ -6833,6 +6847,18 @@ async fn continue_session_inner(
             Some(val) => val,
             None => stored_metadata.keep_alive,
         };
+        if let Err(error) = validate_effective_keep_alive(keep_alive) {
+            let error = unregister_rest_runtime_after_api_error_locked(
+                state,
+                &session_id,
+                runtime_was_registered,
+                error,
+            )
+            .await;
+            drop(caller_event_tx);
+            drain_event_forwarder(&session_id, forward_task).await;
+            return RequestTerminal::RespondWithoutPublish(Err(error));
+        }
         let effective_comms_name = req
             .comms_name
             .clone()
@@ -11883,6 +11909,7 @@ mod tests {
         assert_eq!(create.enable_shell, Some(false));
     }
 
+    #[cfg(feature = "mob")]
     #[tokio::test]
     async fn test_create_session_route_rejects_reserved_mob_peer_meta_labels() {
         use axum::body::Body;
@@ -13518,7 +13545,6 @@ mod tests {
         );
     }
 
-    #[cfg(feature = "comms")]
     fn rest_supervisor_bridge_params() -> Value {
         let pubkey = [7u8; 32];
         json!({
@@ -13539,6 +13565,93 @@ mod tests {
     fn test_resolve_keep_alive_rejects_when_comms_disabled() {
         let err = resolve_keep_alive(Some(true)).expect_err("keep_alive should be rejected");
         assert!(matches!(err, ApiError::BadRequest(_)));
+    }
+
+    #[cfg(not(feature = "comms"))]
+    #[tokio::test]
+    async fn test_continue_session_rejects_inherited_persisted_keep_alive_without_comms() {
+        let temp = TempDir::new().unwrap();
+        let mut state = AppState::load_from(temp.path().to_path_buf())
+            .await
+            .unwrap();
+        state.llm_client_override = Some(Arc::new(MockLlmClient));
+        for force_rebuild in [false, true] {
+            let pre_session = Session::new();
+            let session_id = pre_session.id().clone();
+            let comms_name = format!("persisted-rest-agent-{session_id}");
+            let bindings = state
+                .runtime_adapter
+                .prepare_bindings(session_id.clone())
+                .await
+                .expect("runtime bindings should prepare");
+            let created = state
+                .session_service
+                .create_session(SvcCreateSessionRequest {
+                    injected_context: Vec::new(),
+                    model: resolved_default_model(&state).await,
+                    prompt: "Hello".to_string().into(),
+                    system_prompt: meerkat::SystemPromptOverride::Inherit,
+                    max_tokens: Some(state.max_tokens),
+                    event_tx: None,
+                    initial_turn: InitialTurnPolicy::Defer,
+                    deferred_prompt_policy: DeferredPromptPolicy::Discard,
+                    build: Some(SessionBuildOptions {
+                        resume_session: Some(pre_session),
+                        comms_name: Some(comms_name),
+                        keep_alive: true,
+                        llm_client_override: state
+                            .llm_client_override
+                            .clone()
+                            .map(encode_llm_client_override_for_service),
+                        runtime_build_mode: meerkat_core::RuntimeBuildMode::SessionOwned(bindings),
+                        ..Default::default()
+                    }),
+                    labels: None,
+                })
+                .await
+                .expect("persisted keep-alive fixture should be created");
+
+            let outcome = Box::pin(continue_session_inner(
+                &state,
+                &created.session_id.to_string(),
+                ContinueSessionRequest {
+                    injected_context: None,
+                    transient_turn_context: None,
+                    session_id: created.session_id.to_string(),
+                    prompt: ContentInput::Text("Continue".to_string()),
+                    system_prompt: None,
+                    output_schema: None,
+                    structured_output_retries: None,
+                    keep_alive: None,
+                    comms_name: None,
+                    peer_meta: None,
+                    verbose: false,
+                    model: None,
+                    provider: None,
+                    auth_binding: None,
+                    max_tokens: force_rebuild.then_some(state.max_tokens),
+                    hooks_override: None,
+                    enable_web_search: None,
+                    skill_refs: None,
+                    turn_tool_overlay: None,
+                    additional_instructions: None,
+                },
+                None,
+            ))
+            .await;
+
+            match outcome {
+                RequestTerminal::RespondWithoutPublish(Err(ApiError::BadRequest(message))) => {
+                    assert!(
+                        message.contains("keep_alive requires comms support"),
+                        "unexpected rejection for force_rebuild={force_rebuild}: {message}"
+                    );
+                }
+                other => panic!(
+                    "expected inherited keep_alive rejection for force_rebuild={force_rebuild}, got {other:?}"
+                ),
+            }
+        }
     }
 
     #[cfg(feature = "comms")]

--- a/meerkat/src/surface.rs
+++ b/meerkat/src/surface.rs
@@ -1020,26 +1020,43 @@ pub fn build_models_catalog_response(
     })
 }
 
-/// Validate whether keep-alive mode can be enabled in the current build.
+/// Whether the calling surface compiled the comms support required by keep-alive.
 ///
-/// Delegates to `meerkat_comms::validate_keep_alive()` when the comms feature
-/// is compiled in; returns an error if requested but comms is not available.
+/// This must be supplied by the surface rather than inferred from this crate's
+/// feature set: Cargo can unify `meerkat/comms` through an unrelated dependency
+/// without enabling comms on the surface itself.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum KeepAliveSupport {
+    Available,
+    Unavailable,
+}
+
+/// Validate whether keep-alive mode can be enabled by the calling surface.
 ///
-/// This is the canonical entry point — all surfaces should call this.
+/// This is the canonical policy entry point. Surfaces lower their own compiled
+/// comms feature into [`KeepAliveSupport`] and keep the policy decision here.
+pub fn resolve_keep_alive_for_surface(
+    requested: bool,
+    support: KeepAliveSupport,
+) -> Result<bool, String> {
+    if requested && support == KeepAliveSupport::Unavailable {
+        return Err("keep_alive requires comms support (build with --features comms)".to_string());
+    }
+    Ok(requested)
+}
+
+/// Validate keep-alive against the facade's compiled comms feature.
+///
+/// Runtime-backed product surfaces should call [`resolve_keep_alive_for_surface`]
+/// with their own feature availability so unrelated dependency feature
+/// unification cannot change the result.
 pub fn resolve_keep_alive(requested: bool) -> Result<bool, String> {
-    #[cfg(feature = "comms")]
-    {
-        meerkat_comms::validate_keep_alive(requested)
-    }
-    #[cfg(not(feature = "comms"))]
-    {
-        if requested {
-            return Err(
-                "keep_alive requires comms support (build with --features comms)".to_string(),
-            );
-        }
-        Ok(false)
-    }
+    let support = if cfg!(feature = "comms") {
+        KeepAliveSupport::Available
+    } else {
+        KeepAliveSupport::Unavailable
+    };
+    resolve_keep_alive_for_surface(requested, support)
 }
 
 /// Reject public `PeerMeta` labels that are reserved for mob-managed sessions.
@@ -1305,6 +1322,19 @@ pub async fn emit_mcp_lifecycle_events(
 mod tests {
     use super::*;
     use meerkat_core::Config;
+
+    #[test]
+    fn keep_alive_resolution_uses_explicit_surface_support() {
+        assert_eq!(
+            resolve_keep_alive_for_surface(true, KeepAliveSupport::Available),
+            Ok(true)
+        );
+        assert!(resolve_keep_alive_for_surface(true, KeepAliveSupport::Unavailable).is_err());
+        assert_eq!(
+            resolve_keep_alive_for_surface(false, KeepAliveSupport::Unavailable),
+            Ok(false)
+        );
+    }
 
     #[test]
     fn runtime_host_capabilities_project_multi_host_mob_availability() {


### PR DESCRIPTION
Closes #1060.

## Summary
- make keep-alive support a typed, surface-local capability instead of inferring facade feature unification
- reject effective inherited keep-alive values on no-comms CLI, REST, and MCP builds
- preserve the public `meerkat_comms::validate_keep_alive` compatibility surface

## Validation
- exact no-comms CLI refusal and comms CLI acceptance
- persisted no-comms REST inheritance, live and rebuild
- persisted no-comms MCP inheritance
- full `make test-feature-matrix-surface`
- scoped Clippy/governance and exact-tree normal pre-push

Exact head: `1e9aecdcc8ca570143a1825c26d0ea8f99e8085e`
Tree: `43bbfe1f78bd17f7ff9f72d5be32457e09f23a1e`