### PR TITLE
test(runtime): pin unknown model routing status

### DIFF
--- a/meerkat-runtime/src/meerkat_machine_tests.rs
+++ b/meerkat-runtime/src/meerkat_machine_tests.rs
@@ -10020,6 +10020,25 @@ fn recovered_idle_exact_binding_survives_authoritative_prepare_then_executor_att
 }
 
 #[tokio::test]
+async fn model_routing_status_rejects_unknown_session() {
+    let adapter = MeerkatMachine::ephemeral();
+    let session_id = SessionId::new();
+
+    let error = <MeerkatMachine as SessionServiceRuntimeExt>::session_model_routing_status(
+        &adapter,
+        &session_id,
+    )
+    .await
+    .expect_err("unknown session must not project a default routing status");
+
+    assert!(matches!(
+        error,
+        RuntimeDriverError::NotFound { runtime_id }
+            if runtime_id == MeerkatMachine::logical_runtime_id(&session_id)
+    ));
+}
+
+#[tokio::test]
 async fn model_routing_status_proves_finite_turn_and_operation_precedence() {
     let adapter = Arc::new(MeerkatMachine::ephemeral());
     let session_id = SessionId::new();


### PR DESCRIPTION
## Summary

Pins the upstream routing-status contract required by the paired MobKit surface: an unknown session must return typed `NotFound`, never a success-shaped default.

This is intentionally test-only and does not begin `brain_swap`.

## Validation

- targeted runtime test: 1 passed
- scoped runtime all-features lib/tests Clippy with `-D warnings`
- exact-tree SSH pre-push suite

Base: `40bb30a37914e62fffbb79bd75a6b451148a2cc6`
Head: `6076889333a4064f052f7559cdae73b22e42da3c`
Tree: `c6d570941054ec014d9bd66ef07b9a436ee09d86`
Patch ID: `7e740c96373d049b2fce887b69ca547bb2adf99b`