### PR TITLE
fix(mob): skip abandoned actor observations

### DIFF
--- a/meerkat-mob/src/runtime/actor.rs
+++ b/meerkat-mob/src/runtime/actor.rs
@@ -5952,6 +5952,11 @@ struct ExactRemoteTurnResidency<'a> {
 }
 
 impl MobActor {
+    fn abandoned_observation_control(cmd: &MobCommand) -> Option<ActorLoopControl> {
+        cmd.is_abandoned_observation()
+            .then_some(ActorLoopControl::ProceedBoundary)
+    }
+
     fn peer_only_member_control_error(
         runtime_mode: crate::MobRuntimeMode,
         action: &str,
@@ -22684,6 +22689,20 @@ impl MobActor {
                     let _ = reply_tx.send(burst_result);
                 }
                 #[cfg(test)]
+                MobCommand::ParkActorForObservationTest {
+                    entered_tx,
+                    release_rx,
+                    reply_tx,
+                } => {
+                    let _ = entered_tx.send(());
+                    let result = release_rx.await.map_err(|_| {
+                        MobError::Internal(
+                            "observation abandonment test dropped actor release".to_string(),
+                        )
+                    });
+                    let _ = reply_tx.send(result);
+                }
+                #[cfg(test)]
                 MobCommand::DslT2Snapshot { reply_tx } => {
                     let dsl = self.dsl_authority.state();
                     let _ = reply_tx.send(super::state::MobDslT2Snapshot {
@@ -24134,24 +24153,30 @@ impl MobActor {
                 // reply channel by `reject_scope_denied`.
                 ScopeAdmission::Denied => continue,
             };
-            // Only actor-admitted lifecycle authority can invalidate a
-            // retained explicit-Resume terminal. A caller that merely fails
-            // mailbox/scope admission must not erase the still-authoritative
-            // result. This serialized boundary also fences late publication
-            // from the predecessor generation.
-            if matches!(
-                &cmd,
-                MobCommand::Stop { .. }
-                    | MobCommand::Complete { .. }
-                    | MobCommand::Reset { .. }
-                    | MobCommand::Destroy { .. }
-                    | MobCommand::Shutdown { .. }
-            ) {
-                self.explicit_resume_operations
-                    .invalidate_after_lifecycle_admission();
-            }
-            match self
-                .dispatch_command_boxed(
+            let control = if let Some(control) = Self::abandoned_observation_control(&cmd) {
+                tracing::debug!(
+                    command_kind = cmd.kind(),
+                    "MobActor skipped abandoned observation"
+                );
+                control
+            } else {
+                // Only actor-admitted lifecycle authority can invalidate a
+                // retained explicit-Resume terminal. A caller that merely fails
+                // mailbox/scope admission must not erase the still-authoritative
+                // result. This serialized boundary also fences late publication
+                // from the predecessor generation.
+                if matches!(
+                    &cmd,
+                    MobCommand::Stop { .. }
+                        | MobCommand::Complete { .. }
+                        | MobCommand::Reset { .. }
+                        | MobCommand::Destroy { .. }
+                        | MobCommand::Shutdown { .. }
+                ) {
+                    self.explicit_resume_operations
+                        .invalidate_after_lifecycle_admission();
+                }
+                self.dispatch_command_boxed(
                     &authority,
                     cmd,
                     &mut command_rx,
@@ -24159,7 +24184,8 @@ impl MobActor {
                     &mut host_status_polls_in_flight,
                 )
                 .await
-            {
+            };
+            match control {
                 ActorLoopControl::ProceedBoundary => {}
                 ActorLoopControl::SkipBoundary => continue,
                 ActorLoopControl::BreakActor => break,
@@ -57346,6 +57372,22 @@ mod runtime_observation_tests {
 #[allow(clippy::expect_used)]
 mod routed_effect_containment_tests {
     use super::*;
+
+    #[test]
+    fn abandoned_observation_proceeds_through_actor_boundary() {
+        let (reply_tx, reply_rx) = oneshot::channel();
+        drop(reply_rx);
+        let command = MobCommand::ProjectMemberStatus {
+            agent_identity: AgentIdentity::from("abandoned-status"),
+            reply_tx,
+        };
+
+        assert_eq!(
+            MobActor::abandoned_observation_control(&command),
+            Some(ActorLoopControl::ProceedBoundary),
+            "abandonment must skip only handler execution, not fail-stop and routed-effect housekeeping"
+        );
+    }
 
     #[test]
     fn runtime_retire_route_is_deferred_until_correlated_detach_closes() {

--- a/meerkat-mob/src/runtime/scope_gate.rs
+++ b/meerkat-mob/src/runtime/scope_gate.rs
@@ -240,6 +240,7 @@ impl MobCommand {
             | Self::OrchestratorSnapshot { .. }
             | Self::LifecycleSnapshot { .. }
             | Self::LifecycleNotificationBurst { .. }
+            | Self::ParkActorForObservationTest { .. }
             | Self::DslT2Snapshot { .. } => None,
         }
     }
@@ -501,6 +502,10 @@ impl MobCommand {
             }
             #[cfg(test)]
             Self::LifecycleNotificationBurst { reply_tx, .. } => {
+                let _ = reply_tx.send(Err(error));
+            }
+            #[cfg(test)]
+            Self::ParkActorForObservationTest { reply_tx, .. } => {
                 let _ = reply_tx.send(Err(error));
             }
             #[cfg(any(test, feature = "test-support"))]

--- a/meerkat-mob/src/runtime/state.rs
+++ b/meerkat-mob/src/runtime/state.rs
@@ -967,6 +967,12 @@ pub(super) enum MobCommand {
         message: String,
         reply_tx: oneshot::Sender<Result<(), MobError>>,
     },
+    #[cfg(test)]
+    ParkActorForObservationTest {
+        entered_tx: oneshot::Sender<()>,
+        release_rx: oneshot::Receiver<()>,
+        reply_tx: oneshot::Sender<Result<(), MobError>>,
+    },
     /// Snapshot the T2 DSL field projections (member state markers, wiring
     /// edges, identity→runtime map, tasks + task id sets) directly from the
     /// DSL authority. Test-only read seam used by the runtime-parity
@@ -1393,6 +1399,21 @@ pub(super) struct RetireMemberIncarnation {
 }
 
 impl MobCommand {
+    /// Whether this command is an explicitly classified observation whose
+    /// work has no value after its caller drops the reply receiver.
+    ///
+    /// Keep this allowlist narrow. `QueryPhase` is deliberately excluded:
+    /// actor-liveness probes retain and resume that same reply future after
+    /// their initial budget. Reads backed by other authorities are also
+    /// excluded because they may carry reconciliation or custody semantics.
+    pub(super) fn is_abandoned_observation(&self) -> bool {
+        match self {
+            Self::ProjectMemberList { reply_tx, .. } => reply_tx.is_closed(),
+            Self::ProjectMemberStatus { reply_tx, .. } => reply_tx.is_closed(),
+            _ => false,
+        }
+    }
+
     pub(super) fn kind(&self) -> &'static str {
         match self {
             Self::Spawn { .. } => "Spawn",
@@ -1471,6 +1492,8 @@ impl MobCommand {
             Self::LifecycleSnapshot { .. } => "LifecycleSnapshot",
             #[cfg(test)]
             Self::LifecycleNotificationBurst { .. } => "LifecycleNotificationBurst",
+            #[cfg(test)]
+            Self::ParkActorForObservationTest { .. } => "ParkActorForObservationTest",
             #[cfg(test)]
             Self::DslT2Snapshot { .. } => "DslT2Snapshot",
             Self::StartupKickoffSnapshot { .. } => "StartupKickoffSnapshot",

--- a/meerkat-mob/src/runtime/tests.rs
+++ b/meerkat-mob/src/runtime/tests.rs
@@ -1714,6 +1714,7 @@ struct MockSessionService {
     session_counter: AtomicU64,
     /// Records (session_id, prompt) for each create_session call.
     prompts: RwLock<Vec<(SessionId, String)>>,
+    session_read_calls: AtomicU64,
     create_requests: RwLock<Vec<CreateSessionRecord>>,
     /// Records whether each create_session had external_tools configured.
     create_with_external_tools: RwLock<Vec<bool>>,
@@ -1896,6 +1897,7 @@ impl MockSessionService {
             runtime_adapter: Mutex::new(None),
             session_counter: AtomicU64::new(0),
             prompts: RwLock::new(Vec::new()),
+            session_read_calls: AtomicU64::new(0),
             create_requests: RwLock::new(Vec::new()),
             create_with_external_tools: RwLock::new(Vec::new()),
             create_with_compaction_curators: RwLock::new(Vec::new()),
@@ -2525,6 +2527,10 @@ impl MockSessionService {
     fn set_execution_snapshot_delay_ms(&self, delay_ms: u64) {
         self.execution_snapshot_delay_ms
             .store(delay_ms, Ordering::Relaxed);
+    }
+
+    fn session_read_calls(&self) -> u64 {
+        self.session_read_calls.load(Ordering::Relaxed)
     }
 
     async fn wait_for_execution_snapshot(&self) {
@@ -3411,6 +3417,7 @@ impl SessionService for MockSessionService {
     }
 
     async fn read(&self, id: &SessionId) -> Result<SessionView, SessionError> {
+        self.session_read_calls.fetch_add(1, Ordering::Relaxed);
         let session = self
             .live_session_clone(id)
             .await
@@ -53944,6 +53951,123 @@ async fn test_member_status_round_trips_through_machine_command_surface() {
         snapshot.current_bridge_session_id.as_ref(),
         Some(receipt.bridge_session_id().expect("session-backed")),
         "machine-routed member_status should preserve the active session binding"
+    );
+}
+
+#[tokio::test]
+async fn test_abandoned_queued_member_status_observations_do_not_execute() {
+    const ABANDONED_OBSERVATIONS: u64 = 8;
+
+    let (handle, service) = create_test_mob(sample_definition()).await;
+    let identity = AgentIdentity::from("w-abandoned-status");
+    handle
+        .spawn(ProfileName::from("worker"), identity.clone(), None)
+        .await
+        .expect("spawn worker");
+
+    let (entered_tx, entered_rx) = tokio::sync::oneshot::channel();
+    let (release_tx, release_rx) = tokio::sync::oneshot::channel();
+    let (park_reply_tx, park_reply_rx) = tokio::sync::oneshot::channel();
+    handle
+        .command_tx
+        .send(super::scope_gate::RoutedMobCommand::internal(
+            super::state::MobCommand::ParkActorForObservationTest {
+                entered_tx,
+                release_rx,
+                reply_tx: park_reply_tx,
+            },
+        ))
+        .await
+        .expect("queue actor park command");
+    entered_rx.await.expect("actor should enter park command");
+
+    let reads_before = service.session_read_calls();
+    for _ in 0..ABANDONED_OBSERVATIONS {
+        let (reply_tx, reply_rx) = tokio::sync::oneshot::channel();
+        handle
+            .command_tx
+            .send(super::scope_gate::RoutedMobCommand {
+                authority: handle.command_authority.clone(),
+                cmd: super::state::MobCommand::ProjectMemberStatus {
+                    agent_identity: identity.clone(),
+                    reply_tx,
+                },
+            })
+            .await
+            .expect("queue abandoned member-status observation");
+        drop(reply_rx);
+    }
+
+    let (open_reply_tx, open_reply_rx) = tokio::sync::oneshot::channel();
+    handle
+        .command_tx
+        .send(super::scope_gate::RoutedMobCommand {
+            authority: handle.command_authority.clone(),
+            cmd: super::state::MobCommand::ProjectMemberStatus {
+                agent_identity: identity,
+                reply_tx: open_reply_tx,
+            },
+        })
+        .await
+        .expect("queue live member-status observation");
+
+    release_tx.send(()).expect("release parked actor");
+    park_reply_rx
+        .await
+        .expect("park reply channel")
+        .expect("park command");
+    open_reply_rx
+        .await
+        .expect("live observation reply channel")
+        .expect("live member-status observation");
+
+    assert_eq!(
+        service.session_read_calls() - reads_before,
+        1,
+        "closed receivers must skip their queued cross-component reads; the open receiver executes exactly once"
+    );
+}
+
+#[test]
+fn test_abandoned_observation_allowlist_excludes_phase_and_mutations() {
+    let (status_tx, status_rx) = tokio::sync::oneshot::channel();
+    drop(status_rx);
+    let abandoned_status = super::state::MobCommand::ProjectMemberStatus {
+        agent_identity: AgentIdentity::from("abandoned-status"),
+        reply_tx: status_tx,
+    };
+    assert!(abandoned_status.is_abandoned_observation());
+    assert_eq!(
+        abandoned_status.required_control_scope(),
+        Some(crate::machines::mob_machine::ControlScope::List),
+        "abandoned observations must still cross ordinary scope and fence admission"
+    );
+
+    let (list_tx, list_rx) = tokio::sync::oneshot::channel();
+    drop(list_rx);
+    assert!(
+        super::state::MobCommand::ProjectMemberList {
+            include_retiring: false,
+            reply_tx: list_tx,
+        }
+        .is_abandoned_observation()
+    );
+
+    let (phase_tx, phase_rx) = tokio::sync::oneshot::channel();
+    drop(phase_rx);
+    assert!(
+        !super::state::MobCommand::QueryPhase { reply_tx: phase_tx }.is_abandoned_observation(),
+        "QueryPhase liveness probes must always reach actor execution"
+    );
+
+    let (complete_tx, complete_rx) = tokio::sync::oneshot::channel();
+    drop(complete_rx);
+    assert!(
+        !super::state::MobCommand::Complete {
+            reply_tx: complete_tx,
+        }
+        .is_abandoned_observation(),
+        "mutations must survive caller cancellation"
     );
 }
 


### PR DESCRIPTION
Closes #1066.

## Summary
- explicitly classify only safe actor observation commands whose reply receiver has closed
- skip abandoned `ProjectMemberList` and `ProjectMemberStatus` work before handler execution
- preserve `QueryPhase`, mutations, and the normal actor boundary/fail-stop/routed-effect flush

## Validation
- parked-head regression: eight abandoned status reads execute zero; one live receiver executes once
- allowlist/scope negative controls and ProceedBoundary housekeeping control
- eight existing member-status/QueryPhase actor cases
- mutation without the gate goes red with nine reads instead of one
- scoped all-feature/all-target Clippy
- exact-tree normal pre-push, including workspace deterministic unit+integration+e2e
- meerkat-rust-zealot and Rust quality approval

Base used for exact-tree validation: `40bb30a37914e62fffbb79bd75a6b451148a2cc6`
Head: `15d2cfcd72da6c5b05b16cb0538ca38b90f4b246`
Tree: `cd56948ef6648b93b8e40ac27727fcc6086b6486`
Patch ID: `27dd4cdc639411a64c26947d5e0f02d029c87ba2`