### PR TITLE
fix(mob): keep member status reads off actor loop

### DIFF
--- a/meerkat-mob/src/runtime/actor.rs
+++ b/meerkat-mob/src/runtime/actor.rs
@@ -23076,42 +23076,42 @@ impl MobActor {
                     agent_identity,
                     reply_tx,
                 } => {
-                                self.spawn_member_status_projection(agent_identity, reply_tx);
-                            }
-                            MobCommand::ProjectMemberStatusObserved {
+                    self.spawn_member_status_projection(agent_identity, reply_tx);
+                }
+                MobCommand::ProjectMemberStatusObserved {
+                    agent_identity,
+                    expected_target,
+                    observation,
+                    observation_permit,
+                    reply_tx,
+                } => {
+                    if reply_tx.is_closed() {
+                        return ActorLoopControl::ProceedBoundary;
+                    }
+                    match self.member_status_projection_target(&agent_identity) {
+                        Ok(current_target) if current_target == expected_target => {
+                            let result = self
+                                .machine_member_material_from_observation(
+                                    &agent_identity,
+                                    current_target.bridge_session_id,
+                                    current_target.include_local_session_details,
+                                    *observation,
+                                )
+                                .await
+                                .map(|material| material.to_snapshot());
+                            let _ = reply_tx.send(result);
+                        }
+                        Ok(_) => {
+                            self.spawn_member_status_projection_with_permit(
                                 agent_identity,
-                                expected_target,
-                                observation,
-                                observation_permit,
                                 reply_tx,
-                            } => {
-                                if reply_tx.is_closed() {
-                                    return ActorLoopControl::ProceedBoundary;
-                                }
-                                match self.member_status_projection_target(&agent_identity) {
-                                    Ok(current_target) if current_target == expected_target => {
-                                        let result = self
-                                            .machine_member_material_from_observation(
-                                                &agent_identity,
-                                                current_target.bridge_session_id,
-                                                current_target.include_local_session_details,
-                                                *observation,
-                                            )
-                            .await
-                                            .map(|material| material.to_snapshot());
-                                        let _ = reply_tx.send(result);
-                                    }
-                                    Ok(_) => {
-                                        self.spawn_member_status_projection_with_permit(
-                                            agent_identity,
-                                            reply_tx,
-                                            Some(observation_permit),
-                                        );
-                                    }
-                                    Err(error) => {
-                                        let _ = reply_tx.send(Err(error));
-                                    }
-                                }
+                                Some(observation_permit),
+                            );
+                        }
+                        Err(error) => {
+                            let _ = reply_tx.send(Err(error));
+                        }
+                    }
                 }
                 MobCommand::GetIdentityIntent {
                     agent_identity,

--- a/meerkat-mob/src/runtime/actor.rs
+++ b/meerkat-mob/src/runtime/actor.rs
@@ -2687,6 +2687,7 @@ const MAX_CONCURRENT_AUTONOMOUS_STOP_INTERRUPTS: usize = 8;
 pub(super) const MAX_PENDING_PEER_DELIVERIES: usize = 1024;
 #[cfg(test)]
 pub(super) const MAX_PENDING_PEER_DELIVERIES: usize = 4;
+pub(super) const MAX_PENDING_MEMBER_STATUS_OBSERVATIONS: usize = 1;
 
 pub(super) fn advance_rotating_cursor(
     item_count: usize,
@@ -5576,6 +5577,7 @@ pub(super) struct MobActor {
     /// executor instead. Mutating live Open/Control work uses
     /// `member_live_mutation_tasks` below.
     pub(super) actor_io_tasks: tokio::task::JoinSet<()>,
+    pub(super) member_status_observation_permits: Arc<tokio::sync::Semaphore>,
     /// Actor-issued order for member-status observations. MobMachine remains
     /// the authority that accepts or rejects each observation as monotonic.
     pub(super) next_member_status_observed_at_ms: u64,
@@ -5973,11 +5975,52 @@ pub(super) fn advance_member_status_observation_clock(
     let issued = next_floor.max(wall_clock_ms);
     let next = issued.checked_add(1).ok_or_else(|| {
         MobError::Internal(
-            "member-status observation clock exhausted at u64::MAX; refusing duplicate order"
-                .to_string(),
+            "unable to issue a unique monotonic member-status observation order".to_string(),
         )
     })?;
     Ok((issued, next))
+}
+
+pub(super) fn member_status_wall_clock_ms() -> Result<u64, MobError> {
+    let elapsed = meerkat_core::time_compat::SystemTime::now()
+        .duration_since(meerkat_core::time_compat::UNIX_EPOCH)
+        .map_err(|error| {
+            MobError::Internal(format!("member-status observation clock failed: {error}"))
+        })?;
+    u64::try_from(elapsed.as_millis()).map_err(|_| {
+        MobError::Internal("member-status observation clock exceeds u64 milliseconds".to_string())
+    })
+}
+
+pub(super) async fn enqueue_member_status_observation(
+    command_tx: mpsc::Sender<RoutedMobCommand>,
+    agent_identity: AgentIdentity,
+    expected_target: super::state::MemberStatusProjectionTarget,
+    observation: super::state::MemberStatusSessionObservation,
+    observation_permit: tokio::sync::OwnedSemaphorePermit,
+    mut reply_tx: oneshot::Sender<Result<super::MobMemberSnapshot, MobError>>,
+) -> bool {
+    let permit = tokio::select! {
+        biased;
+        () = reply_tx.closed() => return false,
+        permit = command_tx.reserve() => permit,
+    };
+    let Ok(permit) = permit else {
+        return false;
+    };
+    if reply_tx.is_closed() {
+        return false;
+    }
+    permit.send(RoutedMobCommand::internal(
+        MobCommand::ProjectMemberStatusObserved {
+            agent_identity,
+            expected_target,
+            observation: Box::new(observation),
+            observation_permit,
+            reply_tx,
+        },
+    ));
+    true
 }
 
 impl MobActor {
@@ -11170,12 +11213,7 @@ impl MobActor {
     }
 
     fn issue_member_status_observed_at_ms(&mut self) -> Result<u64, MobError> {
-        let wall_clock_ms = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap_or_default()
-            .as_millis()
-            .try_into()
-            .unwrap_or(u64::MAX);
+        let wall_clock_ms = member_status_wall_clock_ms()?;
         let (issued, next) = advance_member_status_observation_clock(
             self.next_member_status_observed_at_ms,
             wall_clock_ms,
@@ -11187,11 +11225,37 @@ impl MobActor {
     fn spawn_member_status_projection(
         &mut self,
         agent_identity: AgentIdentity,
+        reply_tx: oneshot::Sender<Result<super::MobMemberSnapshot, MobError>>,
+    ) {
+        self.spawn_member_status_projection_with_permit(agent_identity, reply_tx, None);
+    }
+
+    fn spawn_member_status_projection_with_permit(
+        &mut self,
+        agent_identity: AgentIdentity,
         mut reply_tx: oneshot::Sender<Result<super::MobMemberSnapshot, MobError>>,
+        observation_permit: Option<tokio::sync::OwnedSemaphorePermit>,
     ) {
         if reply_tx.is_closed() {
             return;
         }
+        let observation_permit = match observation_permit {
+            Some(permit) => permit,
+            None => match self
+                .member_status_observation_permits
+                .clone()
+                .try_acquire_owned()
+            {
+                Ok(permit) => permit,
+                Err(_) => {
+                    let _ = reply_tx.send(Err(MobError::LifecycleOperationAdmissionPending {
+                        intent: "member_status_observation".to_string(),
+                        stage: "observation_lane_saturated",
+                    }));
+                    return;
+                }
+            },
+        };
         let expected_target = match self.member_status_projection_target(&agent_identity) {
             Ok(target) => target,
             Err(error) => {
@@ -11223,25 +11287,15 @@ impl MobActor {
             if reply_tx.is_closed() {
                 return;
             }
-            let permit = tokio::select! {
-                biased;
-                () = reply_tx.closed() => return,
-                permit = command_tx.reserve() => permit,
-            };
-            let Ok(permit) = permit else {
-                return;
-            };
-            if reply_tx.is_closed() {
-                return;
-            }
-            permit.send(RoutedMobCommand::internal(
-                MobCommand::ProjectMemberStatusObserved {
-                    agent_identity,
-                    expected_target,
-                    observation: Box::new(observation),
-                    reply_tx,
-                },
-            ));
+            enqueue_member_status_observation(
+                command_tx,
+                agent_identity,
+                expected_target,
+                observation,
+                observation_permit,
+                reply_tx,
+            )
+            .await;
         });
     }
 
@@ -11264,7 +11318,14 @@ impl MobActor {
             .member_runtime_material_for_identity(&dsl_identity)
             .map(|material| material.to_domain_for_identity(&domain_identity));
         let member_present = roster_entry.is_some();
+        let observation_stale = self
+            .dsl_authority
+            .state()
+            .member_last_observed_at_ms
+            .get(&dsl_identity)
+            .is_some_and(|last_observed| *last_observed > observation.observed_at_ms);
         if observation.genuinely_absent
+            && !observation_stale
             && let Some(bridge_session_id) = current_bridge_session_id.as_ref()
         {
             let _ = self
@@ -23021,6 +23082,7 @@ impl MobActor {
                                 agent_identity,
                                 expected_target,
                                 observation,
+                                observation_permit,
                                 reply_tx,
                             } => {
                                 if reply_tx.is_closed() {
@@ -23040,7 +23102,11 @@ impl MobActor {
                                         let _ = reply_tx.send(result);
                                     }
                                     Ok(_) => {
-                                        self.spawn_member_status_projection(agent_identity, reply_tx);
+                                        self.spawn_member_status_projection_with_permit(
+                                            agent_identity,
+                                            reply_tx,
+                                            Some(observation_permit),
+                                        );
                                     }
                                     Err(error) => {
                                         let _ = reply_tx.send(Err(error));

--- a/meerkat-mob/src/runtime/actor.rs
+++ b/meerkat-mob/src/runtime/actor.rs
@@ -5576,6 +5576,9 @@ pub(super) struct MobActor {
     /// executor instead. Mutating live Open/Control work uses
     /// `member_live_mutation_tasks` below.
     pub(super) actor_io_tasks: tokio::task::JoinSet<()>,
+    /// Actor-issued order for member-status observations. MobMachine remains
+    /// the authority that accepts or rejects each observation as monotonic.
+    pub(super) next_member_status_observed_at_ms: u64,
     /// Mutating member-live operations (Open/Control) have their own actor-owned
     /// lane. Lifecycle admission drains this set before publishing its durable
     /// work-origin fence, so an operation admitted while Running linearizes
@@ -5949,6 +5952,32 @@ struct ExactRemoteTurnResidency<'a> {
     member_session_id: &'a mob_dsl::SessionId,
     generation: u64,
     fence_token: u64,
+}
+
+pub(super) fn unavailable_member_progress(
+    include_local_session_details: bool,
+) -> Option<super::handle::MemberProgressSnapshot> {
+    include_local_session_details.then_some(super::handle::MemberProgressSnapshot {
+        run_state: super::handle::MemberRunState::Unknown,
+        in_flight_work: 0,
+        last_progress_at_ms: 0,
+        last_progress_event: super::handle::MemberProgressEvent::Unchanged,
+        health: super::handle::MemberHealthClass::Unknown,
+    })
+}
+
+pub(super) fn advance_member_status_observation_clock(
+    next_floor: u64,
+    wall_clock_ms: u64,
+) -> Result<(u64, u64), MobError> {
+    let issued = next_floor.max(wall_clock_ms);
+    let next = issued.checked_add(1).ok_or_else(|| {
+        MobError::Internal(
+            "member-status observation clock exhausted at u64::MAX; refusing duplicate order"
+                .to_string(),
+        )
+    })?;
+    Ok((issued, next))
 }
 
 impl MobActor {
@@ -11052,49 +11081,49 @@ impl MobActor {
         )
     }
 
-    async fn machine_member_material(
-        &mut self,
+    fn member_status_projection_target(
+        &self,
         agent_identity: &AgentIdentity,
-        include_session_details: bool,
-    ) -> Result<CanonicalMemberSnapshotMaterial, MobError> {
-        let roster_entry = {
-            let roster = self.roster.read().await;
-            roster.get(agent_identity).cloned()
-        };
+    ) -> Result<super::state::MemberStatusProjectionTarget, MobError> {
         let domain_identity = crate::ids::AgentIdentity::from(agent_identity.as_str());
         let dsl_identity = mob_dsl::AgentIdentity::from_domain(&domain_identity);
-        let include_local_session_details = include_session_details
-            && !self
-                .dsl_authority
-                .state()
-                .member_placement
-                .contains_key(&dsl_identity);
-        let current_bridge_session_id =
-            self.machine_bridge_session_id_for_identity(&domain_identity)?;
-        let machine_runtime = self
+        let runtime_material = self
             .dsl_authority
             .state()
             .member_runtime_material_for_identity(&dsl_identity)
             .map(|material| material.to_domain_for_identity(&domain_identity));
-        let member_present = roster_entry.is_some();
+        Ok(super::state::MemberStatusProjectionTarget {
+            bridge_session_id: self.machine_bridge_session_id_for_identity(&domain_identity)?,
+            include_local_session_details: !self
+                .dsl_authority
+                .state()
+                .member_placement
+                .contains_key(&dsl_identity),
+            agent_runtime_id: runtime_material
+                .as_ref()
+                .map(|(agent_runtime_id, _)| agent_runtime_id.clone()),
+            fence_token: runtime_material.map(|(_, fence_token)| fence_token),
+        })
+    }
 
-        let (output_preview, tokens_used) = match current_bridge_session_id.as_ref() {
-            None => (None, 0),
+    pub(super) async fn observe_member_status_session(
+        session_service: Arc<dyn MobSessionService>,
+        agent_identity: AgentIdentity,
+        bridge_session_id: Option<SessionId>,
+        include_local_session_details: bool,
+        observed_at_ms: u64,
+    ) -> super::state::MemberStatusSessionObservation {
+        let (output_preview, tokens_used, genuinely_absent) = match bridge_session_id.as_ref() {
             Some(bridge_session_id) if include_local_session_details => {
-                match self.session_service.read(bridge_session_id).await {
+                match session_service.read(bridge_session_id).await {
                     Ok(view) => (
-                        view.state.last_assistant_text.clone(),
+                        view.state.last_assistant_text,
                         view.billing.total_tokens,
+                        false,
                     ),
                     Err(meerkat_core::service::SessionError::NotFound { .. }) => {
-                        // An ordinary read hides archived documents, so its
-                        // NotFound is NOT proof of absence. Only the typed
-                        // resume seam's explicit Absent may record the
-                        // permanent missing-session fact; an intact archived
-                        // document (revivable or held) simply reports no
-                        // local details.
                         let genuinely_absent = matches!(
-                            self.session_service
+                            session_service
                                 .observe_session_resume_authority(bridge_session_id)
                                 .await,
                             Ok(authority)
@@ -11103,15 +11132,7 @@ impl MobActor {
                                     super::session_service::SessionResumeLifecycle::NoCurrentDurableAuthority
                                 )
                         );
-                        if genuinely_absent {
-                            let _ = self
-                                .record_missing_member_bridge_session(
-                                    agent_identity,
-                                    bridge_session_id,
-                                    "member_status",
-                                )
-                                .await;
-                        } else {
+                        if !genuinely_absent {
                             tracing::debug!(
                                 %agent_identity,
                                 %bridge_session_id,
@@ -11120,13 +11141,140 @@ impl MobActor {
                                  missing bridge session"
                             );
                         }
-                        (None, 0)
+                        (None, 0, genuinely_absent)
                     }
-                    Err(_) => (None, 0),
+                    Err(_) => (None, 0, false),
                 }
             }
-            Some(_) => (None, 0),
+            Some(_) | None => (None, 0, false),
         };
+        let execution_snapshot = match (include_local_session_details, bridge_session_id.as_ref()) {
+            (true, Some(session_id)) => match tokio::time::timeout(
+                MEMBER_PROGRESS_OBSERVATION_TIMEOUT,
+                session_service.execution_snapshot(session_id),
+            )
+            .await
+            {
+                Ok(Ok(snapshot)) => snapshot,
+                Ok(Err(_)) | Err(_) => None,
+            },
+            (false, _) | (true, None) => None,
+        };
+        super::state::MemberStatusSessionObservation {
+            output_preview,
+            tokens_used,
+            genuinely_absent,
+            execution_snapshot,
+            observed_at_ms,
+        }
+    }
+
+    fn issue_member_status_observed_at_ms(&mut self) -> Result<u64, MobError> {
+        let wall_clock_ms = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_millis()
+            .try_into()
+            .unwrap_or(u64::MAX);
+        let (issued, next) = advance_member_status_observation_clock(
+            self.next_member_status_observed_at_ms,
+            wall_clock_ms,
+        )?;
+        self.next_member_status_observed_at_ms = next;
+        Ok(issued)
+    }
+
+    fn spawn_member_status_projection(
+        &mut self,
+        agent_identity: AgentIdentity,
+        mut reply_tx: oneshot::Sender<Result<super::MobMemberSnapshot, MobError>>,
+    ) {
+        if reply_tx.is_closed() {
+            return;
+        }
+        let expected_target = match self.member_status_projection_target(&agent_identity) {
+            Ok(target) => target,
+            Err(error) => {
+                let _ = reply_tx.send(Err(error));
+                return;
+            }
+        };
+        let observed_at_ms = match self.issue_member_status_observed_at_ms() {
+            Ok(observed_at_ms) => observed_at_ms,
+            Err(error) => {
+                let _ = reply_tx.send(Err(error));
+                return;
+            }
+        };
+        let session_service = Arc::clone(&self.session_service);
+        let command_tx = self.command_tx.clone();
+        self.actor_io_tasks.spawn(async move {
+            let observation = tokio::select! {
+                biased;
+                () = reply_tx.closed() => return,
+                observation = Self::observe_member_status_session(
+                    session_service,
+                    agent_identity.clone(),
+                    expected_target.bridge_session_id.clone(),
+                    expected_target.include_local_session_details,
+                    observed_at_ms,
+                ) => observation,
+            };
+            if reply_tx.is_closed() {
+                return;
+            }
+            let permit = tokio::select! {
+                biased;
+                () = reply_tx.closed() => return,
+                permit = command_tx.reserve() => permit,
+            };
+            let Ok(permit) = permit else {
+                return;
+            };
+            if reply_tx.is_closed() {
+                return;
+            }
+            permit.send(RoutedMobCommand::internal(
+                MobCommand::ProjectMemberStatusObserved {
+                    agent_identity,
+                    expected_target,
+                    observation: Box::new(observation),
+                    reply_tx,
+                },
+            ));
+        });
+    }
+
+    async fn machine_member_material_from_observation(
+        &mut self,
+        agent_identity: &AgentIdentity,
+        current_bridge_session_id: Option<SessionId>,
+        include_local_session_details: bool,
+        observation: super::state::MemberStatusSessionObservation,
+    ) -> Result<CanonicalMemberSnapshotMaterial, MobError> {
+        let roster_entry = {
+            let roster = self.roster.read().await;
+            roster.get(agent_identity).cloned()
+        };
+        let domain_identity = crate::ids::AgentIdentity::from(agent_identity.as_str());
+        let dsl_identity = mob_dsl::AgentIdentity::from_domain(&domain_identity);
+        let machine_runtime = self
+            .dsl_authority
+            .state()
+            .member_runtime_material_for_identity(&dsl_identity)
+            .map(|material| material.to_domain_for_identity(&domain_identity));
+        let member_present = roster_entry.is_some();
+        if observation.genuinely_absent
+            && let Some(bridge_session_id) = current_bridge_session_id.as_ref()
+        {
+            let _ = self
+                .record_missing_member_bridge_session(
+                    agent_identity,
+                    bridge_session_id,
+                    "member_status",
+                )
+                .await;
+        }
         let machine_lifecycle = self
             .dsl_authority
             .state()
@@ -11139,139 +11287,107 @@ impl MobActor {
                 .and_then(|entry| entry.kickoff.as_ref()),
         );
 
-        let progress = if include_local_session_details {
-            match current_bridge_session_id.as_ref() {
-                Some(session_id) => match tokio::time::timeout(
-                    MEMBER_PROGRESS_OBSERVATION_TIMEOUT,
-                    self.session_service.execution_snapshot(session_id),
-                )
-                .await
+        let progress = match observation.execution_snapshot {
+            Some(snapshot) => {
+                let run_open = snapshot.active_run_id.is_some() && !snapshot.turn_terminal;
+                let pending_operations = snapshot
+                    .pending_operation_ids
+                    .as_ref()
+                    .map_or(0_u64, |ids| ids.len() as u64);
+                let in_flight_work = pending_operations
+                    .saturating_add(u64::from(snapshot.tool_calls_pending))
+                    .saturating_add(u64::from(run_open));
+                let progress_token = format!(
+                    "{:?}|{:?}|{}|{}|{}|{}",
+                    snapshot.active_run_id,
+                    snapshot.turn_phase,
+                    snapshot.boundary_count,
+                    snapshot.applied_cursor,
+                    snapshot.tool_calls_pending,
+                    pending_operations,
+                );
+                let observed_at_ms = observation.observed_at_ms;
+                if self.dsl_authority.state().lifecycle_phase == mob_dsl::MobPhase::Running {
+                    self.apply_dsl_input(
+                        mob_dsl::MobMachineInput::ObserveMemberProgress {
+                            agent_identity: dsl_identity.clone(),
+                            run_open,
+                            in_flight_work,
+                            progress_token,
+                            observed_at_ms,
+                        },
+                        "member_status_observe_progress",
+                    )?;
+                }
+                let state = self.dsl_authority.state();
+                let run_state = if state
+                    .member_run_open
+                    .get(&dsl_identity)
+                    .copied()
+                    .unwrap_or(false)
                 {
-                    Ok(Ok(Some(snapshot))) => {
-                        let run_open = snapshot.active_run_id.is_some() && !snapshot.turn_terminal;
-                        let pending_operations = snapshot
-                            .pending_operation_ids
-                            .as_ref()
-                            .map_or(0_u64, |ids| ids.len() as u64);
-                        let in_flight_work = pending_operations
-                            .saturating_add(u64::from(snapshot.tool_calls_pending))
-                            .saturating_add(u64::from(run_open));
-                        let progress_token = format!(
-                            "{:?}|{:?}|{}|{}|{}|{}",
-                            snapshot.active_run_id,
-                            snapshot.turn_phase,
-                            snapshot.boundary_count,
-                            snapshot.applied_cursor,
-                            snapshot.tool_calls_pending,
-                            pending_operations,
-                        );
-                        let observed_at_ms = std::time::SystemTime::now()
-                            .duration_since(std::time::UNIX_EPOCH)
-                            .unwrap_or_default()
-                            .as_millis()
-                            .try_into()
-                            .unwrap_or(u64::MAX);
-                        if self.dsl_authority.state().lifecycle_phase == mob_dsl::MobPhase::Running
-                        {
-                            self.apply_dsl_input(
-                                mob_dsl::MobMachineInput::ObserveMemberProgress {
-                                    agent_identity: dsl_identity.clone(),
-                                    run_open,
-                                    in_flight_work,
-                                    progress_token,
-                                    observed_at_ms,
-                                },
-                                "member_status_observe_progress",
-                            )?;
-                        }
-                        let state = self.dsl_authority.state();
-                        let run_state = if state
-                            .member_run_open
-                            .get(&dsl_identity)
-                            .copied()
-                            .unwrap_or(false)
-                        {
-                            super::handle::MemberRunState::RunOpen
-                        } else {
-                            super::handle::MemberRunState::Idle
-                        };
-                        let last_progress_event = match state
-                            .member_last_progress_event
-                            .get(&dsl_identity)
-                            .copied()
-                            .unwrap_or(mob_dsl::MemberProgressEventKind::Unchanged)
-                        {
-                            mob_dsl::MemberProgressEventKind::ExecutionAdvanced => {
-                                super::handle::MemberProgressEvent::ExecutionAdvanced
-                            }
-                            mob_dsl::MemberProgressEventKind::BecameIdle => {
-                                super::handle::MemberProgressEvent::BecameIdle
-                            }
-                            mob_dsl::MemberProgressEventKind::Unchanged => {
-                                super::handle::MemberProgressEvent::Unchanged
-                            }
-                        };
-                        let health = match state
-                            .member_health_class
-                            .get(&dsl_identity)
-                            .copied()
-                            .unwrap_or(mob_dsl::MemberHealthClass::Unknown)
-                        {
-                            mob_dsl::MemberHealthClass::Healthy => {
-                                super::handle::MemberHealthClass::Healthy
-                            }
-                            mob_dsl::MemberHealthClass::Degraded => {
-                                super::handle::MemberHealthClass::Degraded
-                            }
-                            mob_dsl::MemberHealthClass::Wedged => {
-                                super::handle::MemberHealthClass::Wedged
-                            }
-                            mob_dsl::MemberHealthClass::Unknown => {
-                                super::handle::MemberHealthClass::Unknown
-                            }
-                        };
-                        Some(super::handle::MemberProgressSnapshot {
-                            run_state,
-                            in_flight_work: state
-                                .member_in_flight_work
-                                .get(&dsl_identity)
-                                .copied()
-                                .unwrap_or(0),
-                            last_progress_at_ms: state
-                                .member_last_progress_at_ms
-                                .get(&dsl_identity)
-                                .copied()
-                                .unwrap_or(observed_at_ms),
-                            last_progress_event,
-                            health,
-                        })
+                    super::handle::MemberRunState::RunOpen
+                } else {
+                    super::handle::MemberRunState::Idle
+                };
+                let last_progress_event = match state
+                    .member_last_progress_event
+                    .get(&dsl_identity)
+                    .copied()
+                    .unwrap_or(mob_dsl::MemberProgressEventKind::Unchanged)
+                {
+                    mob_dsl::MemberProgressEventKind::ExecutionAdvanced => {
+                        super::handle::MemberProgressEvent::ExecutionAdvanced
                     }
-                    Ok(Ok(None) | Err(_)) | Err(_) => Some(super::handle::MemberProgressSnapshot {
-                        run_state: super::handle::MemberRunState::Unknown,
-                        in_flight_work: 0,
-                        last_progress_at_ms: 0,
-                        last_progress_event: super::handle::MemberProgressEvent::Unchanged,
-                        health: super::handle::MemberHealthClass::Unknown,
-                    }),
-                },
-                None => Some(super::handle::MemberProgressSnapshot {
-                    run_state: super::handle::MemberRunState::Unknown,
-                    in_flight_work: 0,
-                    last_progress_at_ms: 0,
-                    last_progress_event: super::handle::MemberProgressEvent::Unchanged,
-                    health: super::handle::MemberHealthClass::Unknown,
-                }),
+                    mob_dsl::MemberProgressEventKind::BecameIdle => {
+                        super::handle::MemberProgressEvent::BecameIdle
+                    }
+                    mob_dsl::MemberProgressEventKind::Unchanged => {
+                        super::handle::MemberProgressEvent::Unchanged
+                    }
+                };
+                let health = match state
+                    .member_health_class
+                    .get(&dsl_identity)
+                    .copied()
+                    .unwrap_or(mob_dsl::MemberHealthClass::Unknown)
+                {
+                    mob_dsl::MemberHealthClass::Healthy => {
+                        super::handle::MemberHealthClass::Healthy
+                    }
+                    mob_dsl::MemberHealthClass::Degraded => {
+                        super::handle::MemberHealthClass::Degraded
+                    }
+                    mob_dsl::MemberHealthClass::Wedged => super::handle::MemberHealthClass::Wedged,
+                    mob_dsl::MemberHealthClass::Unknown => {
+                        super::handle::MemberHealthClass::Unknown
+                    }
+                };
+                Some(super::handle::MemberProgressSnapshot {
+                    run_state,
+                    in_flight_work: state
+                        .member_in_flight_work
+                        .get(&dsl_identity)
+                        .copied()
+                        .unwrap_or(0),
+                    last_progress_at_ms: state
+                        .member_last_progress_at_ms
+                        .get(&dsl_identity)
+                        .copied()
+                        .unwrap_or(observed_at_ms),
+                    last_progress_event,
+                    health,
+                })
             }
-        } else {
-            None
+            None => unavailable_member_progress(include_local_session_details),
         };
 
         Ok(MobMemberLifecycleProjection::materialize(
             MobMemberLifecycleInput {
                 member_present,
                 machine_lifecycle,
-                output_preview,
-                tokens_used,
+                output_preview: observation.output_preview,
+                tokens_used: observation.tokens_used,
                 agent_identity: domain_identity,
                 agent_runtime_id: machine_runtime
                     .as_ref()
@@ -22899,11 +23015,37 @@ impl MobActor {
                     agent_identity,
                     reply_tx,
                 } => {
-                    let _ = reply_tx.send(
-                        self.machine_member_material(&agent_identity, true)
+                                self.spawn_member_status_projection(agent_identity, reply_tx);
+                            }
+                            MobCommand::ProjectMemberStatusObserved {
+                                agent_identity,
+                                expected_target,
+                                observation,
+                                reply_tx,
+                            } => {
+                                if reply_tx.is_closed() {
+                                    return ActorLoopControl::ProceedBoundary;
+                                }
+                                match self.member_status_projection_target(&agent_identity) {
+                                    Ok(current_target) if current_target == expected_target => {
+                                        let result = self
+                                            .machine_member_material_from_observation(
+                                                &agent_identity,
+                                                current_target.bridge_session_id,
+                                                current_target.include_local_session_details,
+                                                *observation,
+                                            )
                             .await
-                            .map(|material| material.to_snapshot()),
-                    );
+                                            .map(|material| material.to_snapshot());
+                                        let _ = reply_tx.send(result);
+                                    }
+                                    Ok(_) => {
+                                        self.spawn_member_status_projection(agent_identity, reply_tx);
+                                    }
+                                    Err(error) => {
+                                        let _ = reply_tx.send(Err(error));
+                                    }
+                                }
                 }
                 MobCommand::GetIdentityIntent {
                     agent_identity,

--- a/meerkat-mob/src/runtime/builder.rs
+++ b/meerkat-mob/src/runtime/builder.rs
@@ -10070,6 +10070,22 @@ impl MobBuilder {
             let identity_reconcile_holder_id = format!("mob:{}", definition.id);
             let identity_reconcile_incarnation_id =
                 meerkat_core::ops::OperationId::new().to_string();
+            let recovered_member_status_observed_at_ms = dsl_authority
+                .state()
+                .member_last_observed_at_ms
+                .values()
+                .copied()
+                .max()
+                .unwrap_or(0)
+                .saturating_add(1);
+            let wall_clock_ms = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_millis()
+                .try_into()
+                .unwrap_or(u64::MAX);
+            let next_member_status_observed_at_ms =
+                recovered_member_status_observed_at_ms.max(wall_clock_ms);
 
             let mut actor = MobActor {
                 definition,
@@ -10122,6 +10138,7 @@ impl MobBuilder {
                 lifecycle_tasks: tokio::task::JoinSet::new(),
                 pending_lifecycle_delivery_error: None,
                 actor_io_tasks: tokio::task::JoinSet::new(),
+                next_member_status_observed_at_ms,
                 member_live_mutation_tasks: tokio::task::JoinSet::new(),
                 member_live_open_cleanup_obligations: BTreeMap::new(),
                 member_live_open_cleanup_inflight: BTreeSet::new(),

--- a/meerkat-mob/src/runtime/builder.rs
+++ b/meerkat-mob/src/runtime/builder.rs
@@ -10076,16 +10076,12 @@ impl MobBuilder {
                 .values()
                 .copied()
                 .max()
-                .unwrap_or(0)
-                .saturating_add(1);
-            let wall_clock_ms = std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap_or_default()
-                .as_millis()
-                .try_into()
-                .unwrap_or(u64::MAX);
-            let next_member_status_observed_at_ms =
-                recovered_member_status_observed_at_ms.max(wall_clock_ms);
+                .unwrap_or(0);
+            let (_, next_member_status_observed_at_ms) =
+                super::actor::advance_member_status_observation_clock(
+                    recovered_member_status_observed_at_ms,
+                    super::actor::member_status_wall_clock_ms()?,
+                )?;
 
             let mut actor = MobActor {
                 definition,
@@ -10138,6 +10134,9 @@ impl MobBuilder {
                 lifecycle_tasks: tokio::task::JoinSet::new(),
                 pending_lifecycle_delivery_error: None,
                 actor_io_tasks: tokio::task::JoinSet::new(),
+                member_status_observation_permits: Arc::new(tokio::sync::Semaphore::new(
+                    super::actor::MAX_PENDING_MEMBER_STATUS_OBSERVATIONS,
+                )),
                 next_member_status_observed_at_ms,
                 member_live_mutation_tasks: tokio::task::JoinSet::new(),
                 member_live_open_cleanup_obligations: BTreeMap::new(),

--- a/meerkat-mob/src/runtime/handle.rs
+++ b/meerkat-mob/src/runtime/handle.rs
@@ -5139,6 +5139,22 @@ impl MobHandle {
             .map_err(|_| MobError::ActorReplyChannelClosed)
     }
 
+    #[cfg(test)]
+    pub(super) async fn enqueue_actor_command_for_test<R>(
+        &self,
+        build: impl FnOnce(oneshot::Sender<R>) -> MobCommand,
+    ) -> Result<oneshot::Receiver<R>, MobError> {
+        let (reply_tx, reply_rx) = oneshot::channel();
+        self.command_tx
+            .send(super::scope_gate::RoutedMobCommand {
+                authority: self.command_authority.clone(),
+                cmd: build(reply_tx),
+            })
+            .await
+            .map_err(|_| MobError::ActorCommandChannelClosed)?;
+        Ok(reply_rx)
+    }
+
     async fn drive_resume_actor_operation(&self, operation: Arc<PendingResumeOperation>) {
         let terminal = match operation.deadline.checked_duration_since(Instant::now()) {
             None => Err(MobError::LifecycleOperationAdmissionPending {

--- a/meerkat-mob/src/runtime/scope_gate.rs
+++ b/meerkat-mob/src/runtime/scope_gate.rs
@@ -183,6 +183,7 @@ impl MobCommand {
             | Self::HostRuntimeIncarnationObserved { .. }
             | Self::HostOrphanReleaseCompleted { .. }
             | Self::PlacedBehaviorCompleted { .. }
+            | Self::ProjectMemberStatusObserved { .. }
             | Self::CommitFlowRunCommand { .. }
             | Self::CommitFlowTerminalization { .. }
             | Self::CommitFlowFrameStorePlan { .. }
@@ -321,6 +322,9 @@ impl MobCommand {
                 let _ = reply_tx.send(Err(error));
             }
             Self::ProjectMemberStatus { reply_tx, .. } => {
+                let _ = reply_tx.send(Err(error));
+            }
+            Self::ProjectMemberStatusObserved { reply_tx, .. } => {
                 let _ = reply_tx.send(Err(error));
             }
             Self::GetIdentityIntent { reply_tx, .. } => {

--- a/meerkat-mob/src/runtime/state.rs
+++ b/meerkat-mob/src/runtime/state.rs
@@ -1013,6 +1013,7 @@ pub(super) enum MobCommand {
         agent_identity: crate::ids::AgentIdentity,
         expected_target: MemberStatusProjectionTarget,
         observation: Box<MemberStatusSessionObservation>,
+        observation_permit: tokio::sync::OwnedSemaphorePermit,
         reply_tx: oneshot::Sender<Result<super::MobMemberSnapshot, crate::MobError>>,
     },
     GetIdentityIntent {

--- a/meerkat-mob/src/runtime/state.rs
+++ b/meerkat-mob/src/runtime/state.rs
@@ -590,6 +590,22 @@ impl LifecycleProgressSignal {
     }
 }
 
+pub(super) struct MemberStatusSessionObservation {
+    pub(super) output_preview: Option<String>,
+    pub(super) tokens_used: u64,
+    pub(super) genuinely_absent: bool,
+    pub(super) execution_snapshot: Option<meerkat_core::agent::AgentExecutionSnapshot>,
+    pub(super) observed_at_ms: u64,
+}
+
+#[derive(Clone, PartialEq, Eq)]
+pub(super) struct MemberStatusProjectionTarget {
+    pub(super) bridge_session_id: Option<SessionId>,
+    pub(super) include_local_session_details: bool,
+    pub(super) agent_runtime_id: Option<AgentRuntimeId>,
+    pub(super) fence_token: Option<FenceToken>,
+}
+
 pub(super) enum MobCommand {
     Spawn {
         spec: Box<super::handle::SpawnMemberSpec>,
@@ -991,6 +1007,12 @@ pub(super) enum MobCommand {
     },
     ProjectMemberStatus {
         agent_identity: crate::ids::AgentIdentity,
+        reply_tx: oneshot::Sender<Result<super::MobMemberSnapshot, crate::MobError>>,
+    },
+    ProjectMemberStatusObserved {
+        agent_identity: crate::ids::AgentIdentity,
+        expected_target: MemberStatusProjectionTarget,
+        observation: Box<MemberStatusSessionObservation>,
         reply_tx: oneshot::Sender<Result<super::MobMemberSnapshot, crate::MobError>>,
     },
     GetIdentityIntent {
@@ -1499,6 +1521,7 @@ impl MobCommand {
             Self::StartupKickoffSnapshot { .. } => "StartupKickoffSnapshot",
             Self::ProjectMemberList { .. } => "ProjectMemberList",
             Self::ProjectMemberStatus { .. } => "ProjectMemberStatus",
+            Self::ProjectMemberStatusObserved { .. } => "ProjectMemberStatusObserved",
             Self::GetIdentityIntent { .. } => "GetIdentityIntent",
             Self::GetIdentityConvergenceStatus { .. } => "GetIdentityConvergenceStatus",
             Self::AdoptMemberIdentityDeclaration { .. } => "AdoptMemberIdentityDeclaration",

--- a/meerkat-mob/src/runtime/tests.rs
+++ b/meerkat-mob/src/runtime/tests.rs
@@ -67,7 +67,7 @@ use meerkat_store::{MemoryStore, SessionStore};
 use serde::Serialize;
 use serde_json::value::RawValue;
 use sha2::{Digest, Sha256};
-use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
+use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet, VecDeque};
 use std::io::Write;
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
@@ -1828,6 +1828,10 @@ struct MockSessionService {
     flow_turn_max_in_flight: Arc<AtomicU64>,
     execution_snapshot_delay_ms: AtomicU64,
     execution_snapshot_started: tokio::sync::Notify,
+    execution_snapshot_calls: AtomicU64,
+    execution_snapshots: std::sync::Mutex<VecDeque<meerkat_core::agent::AgentExecutionSnapshot>>,
+    session_read_barriers: RwLock<HashMap<SessionId, Arc<TestRuntimeControlBarrier>>>,
+    session_read_started: tokio::sync::Notify,
     create_session_delay_ms: AtomicU64,
     load_persisted_session_delay_ms: AtomicU64,
     load_persisted_session_started: tokio::sync::Notify,
@@ -1957,6 +1961,10 @@ impl MockSessionService {
             flow_turn_max_in_flight: Arc::new(AtomicU64::new(0)),
             execution_snapshot_delay_ms: AtomicU64::new(0),
             execution_snapshot_started: tokio::sync::Notify::new(),
+            execution_snapshot_calls: AtomicU64::new(0),
+            execution_snapshots: std::sync::Mutex::new(VecDeque::new()),
+            session_read_barriers: RwLock::new(HashMap::new()),
+            session_read_started: tokio::sync::Notify::new(),
             create_session_delay_ms: AtomicU64::new(0),
             load_persisted_session_delay_ms: AtomicU64::new(0),
             load_persisted_session_started: tokio::sync::Notify::new(),
@@ -2529,12 +2537,42 @@ impl MockSessionService {
             .store(delay_ms, Ordering::Relaxed);
     }
 
+    fn set_execution_snapshots(
+        &self,
+        snapshots: impl IntoIterator<Item = meerkat_core::agent::AgentExecutionSnapshot>,
+    ) {
+        *self
+            .execution_snapshots
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner) = snapshots.into_iter().collect();
+    }
+
+    fn execution_snapshot_calls(&self) -> u64 {
+        self.execution_snapshot_calls.load(Ordering::Relaxed)
+    }
+
     fn session_read_calls(&self) -> u64 {
         self.session_read_calls.load(Ordering::Relaxed)
     }
 
     async fn wait_for_execution_snapshot(&self) {
         self.execution_snapshot_started.notified().await;
+    }
+
+    async fn install_session_read_barrier(
+        &self,
+        session_id: SessionId,
+    ) -> Arc<TestRuntimeControlBarrier> {
+        let barrier = Arc::new(TestRuntimeControlBarrier::new());
+        self.session_read_barriers
+            .write()
+            .await
+            .insert(session_id, Arc::clone(&barrier));
+        barrier
+    }
+
+    async fn wait_for_session_read(&self) {
+        self.session_read_started.notified().await;
     }
 
     async fn wait_for_load_persisted_session(&self) {
@@ -3418,6 +3456,11 @@ impl SessionService for MockSessionService {
 
     async fn read(&self, id: &SessionId) -> Result<SessionView, SessionError> {
         self.session_read_calls.fetch_add(1, Ordering::Relaxed);
+        let barrier = self.session_read_barriers.write().await.remove(id);
+        if let Some(barrier) = barrier {
+            self.session_read_started.notify_one();
+            barrier.wait_for_release().await;
+        }
         let session = self
             .live_session_clone(id)
             .await
@@ -4207,12 +4250,18 @@ impl MobSessionService for MockSessionService {
         &self,
         _session_id: &SessionId,
     ) -> Result<Option<meerkat_core::agent::AgentExecutionSnapshot>, SessionError> {
+        self.execution_snapshot_calls
+            .fetch_add(1, Ordering::Relaxed);
         self.execution_snapshot_started.notify_one();
         let delay_ms = self.execution_snapshot_delay_ms.load(Ordering::Relaxed);
         if delay_ms > 0 {
             tokio::time::sleep(Duration::from_millis(delay_ms)).await;
         }
-        Ok(None)
+        Ok(self
+            .execution_snapshots
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .pop_front())
     }
 
     async fn archive_with_mob_lifecycle_authority(
@@ -51489,7 +51538,7 @@ fn test_runtime_owner_is_derived_from_machine_placement_before_session_shape() {
     use crate::machines::mob_machine as mob_dsl;
 
     let identity = AgentIdentity::from("placed-owner-predicate");
-    let dsl_identity = mob_dsl::AgentIdentity::from_domain(&identity);
+    let dsl_identity = crate::machines::mob_machine::AgentIdentity::from_domain(&identity);
     let mut state = mob_dsl::MobMachineAuthority::new().state().clone();
 
     // `Some(session_id)` alone is not local ownership: host-materialized refs
@@ -54131,6 +54180,489 @@ async fn test_busy_member_execution_snapshot_cannot_block_mob_lifecycle_commands
         Some(crate::runtime::handle::MemberRunState::Unknown),
         "a timed-out execution observation must be represented truthfully as unknown"
     );
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum TestActorLoopProbeEvent {
+    ActorLoopStalled { stall_id: u64 },
+    ActorLoopRecovered { stall_id: u64 },
+}
+
+async fn run_single_actor_loop_probe(
+    mut reply_rx: tokio::sync::oneshot::Receiver<Result<MobState, MobError>>,
+    budget: Duration,
+    event_tx: tokio::sync::mpsc::UnboundedSender<TestActorLoopProbeEvent>,
+) -> Result<MobState, MobError> {
+    match tokio::time::timeout(budget, &mut reply_rx).await {
+        Ok(reply) => reply
+            .map_err(|_| MobError::ActorReplyChannelClosed)
+            .and_then(std::convert::identity),
+        Err(_) => {
+            let stall_id = 1;
+            event_tx
+                .send(TestActorLoopProbeEvent::ActorLoopStalled { stall_id })
+                .map_err(|_| MobError::Internal("test actor-loop probe sink closed".to_string()))?;
+            let result = reply_rx
+                .await
+                .map_err(|_| MobError::ActorReplyChannelClosed)
+                .and_then(std::convert::identity);
+            event_tx
+                .send(TestActorLoopProbeEvent::ActorLoopRecovered { stall_id })
+                .map_err(|_| MobError::Internal("test actor-loop probe sink closed".to_string()))?;
+            result
+        }
+    }
+}
+
+fn test_member_execution_snapshot(
+    boundary_count: u32,
+    tool_calls_pending: u32,
+) -> meerkat_core::agent::AgentExecutionSnapshot {
+    meerkat_core::agent::AgentExecutionSnapshot {
+        loop_state: meerkat_core::state::LoopState::WaitingForOps,
+        turn_phase: meerkat_core::turn_execution_authority::TurnPhase::WaitingForOps,
+        turn_terminal: false,
+        active_run_id: Some(meerkat_core::RunId::new()),
+        terminal_run_id: None,
+        primitive_kind: meerkat_core::turn_execution_authority::TurnPrimitiveKind::ConversationTurn,
+        admitted_content_shape: Some(
+            meerkat_core::turn_execution_authority::ContentShape::Conversation,
+        ),
+        vision_enabled: false,
+        image_tool_results_enabled: false,
+        tool_calls_pending,
+        pending_operation_ids: None,
+        barrier_operation_ids: Vec::new(),
+        has_barrier_ops: false,
+        barrier_satisfied: true,
+        boundary_count,
+        cancel_after_boundary: false,
+        terminal_outcome: meerkat_core::turn_execution_authority::TurnTerminalOutcome::None,
+        terminal_cause_kind: None,
+        extraction_attempts: 0,
+        max_extraction_retries: 0,
+        applied_cursor: 0,
+    }
+}
+
+#[tokio::test]
+async fn test_placed_member_status_skips_controller_session_progress_observation() {
+    let service = Arc::new(MockSessionService::new());
+    let session_service: Arc<dyn MobSessionService> = service.clone();
+    let observation = super::actor::MobActor::observe_member_status_session(
+        session_service,
+        AgentIdentity::from("placed-status"),
+        Some(SessionId::new()),
+        false,
+        41,
+    )
+    .await;
+
+    assert_eq!(service.session_read_calls(), 0);
+    assert_eq!(service.execution_snapshot_calls(), 0);
+    assert!(observation.execution_snapshot.is_none());
+    assert!(super::actor::unavailable_member_progress(false).is_none());
+    assert_eq!(observation.observed_at_ms, 41);
+}
+
+#[tokio::test]
+async fn test_same_millisecond_reordered_member_status_completion_stays_monotonic() {
+    assert_eq!(
+        super::actor::advance_member_status_observation_clock(100, 200)
+            .expect("wall clock advancement"),
+        (200, 201)
+    );
+    assert_eq!(
+        super::actor::advance_member_status_observation_clock(201, 200)
+            .expect("same-millisecond logical advancement"),
+        (201, 202)
+    );
+    assert!(
+        super::actor::advance_member_status_observation_clock(u64::MAX, u64::MAX).is_err(),
+        "clock exhaustion must refuse rather than issue a duplicate order"
+    );
+
+    let (handle, service) = create_test_mob(sample_definition()).await;
+    let identity = AgentIdentity::from("status-reordered");
+    let session_id = handle
+        .spawn(ProfileName::from("worker"), identity.clone(), None)
+        .await
+        .expect("spawn reordered-status member")
+        .bridge_session_id()
+        .expect("reordered-status member is session-backed")
+        .clone();
+    service.set_execution_snapshots([
+        test_member_execution_snapshot(2, 2),
+        test_member_execution_snapshot(1, 1),
+        test_member_execution_snapshot(3, 3),
+    ]);
+    let first_read_barrier = service.install_session_read_barrier(session_id).await;
+
+    let first_rx = handle
+        .enqueue_actor_command_for_test(|reply_tx| MobCommand::ProjectMemberStatus {
+            agent_identity: identity.clone(),
+            reply_tx,
+        })
+        .await
+        .expect("enqueue first status observation");
+    tokio::time::timeout(Duration::from_secs(1), service.wait_for_session_read())
+        .await
+        .expect("first status observation should enter its session read");
+    let second_rx = handle
+        .enqueue_actor_command_for_test(|reply_tx| MobCommand::ProjectMemberStatus {
+            agent_identity: identity.clone(),
+            reply_tx,
+        })
+        .await
+        .expect("enqueue second status observation");
+    second_rx
+        .await
+        .expect("second status reply channel")
+        .expect("second status observation");
+
+    let dsl_identity = crate::machines::mob_machine::AgentIdentity::from_domain(&identity);
+    let (second_order, second_progress_token) = {
+        let state = handle.machine_state_watch_rx.borrow();
+        (
+            *state
+                .member_last_observed_at_ms
+                .get(&dsl_identity)
+                .expect("second observation order"),
+            state
+                .member_progress_tokens
+                .get(&dsl_identity)
+                .expect("second progress token")
+                .clone(),
+        )
+    };
+
+    first_read_barrier.release_all();
+    first_rx
+        .await
+        .expect("first status reply channel")
+        .expect("stale first observation should still return a current projection");
+    {
+        let state = handle.machine_state_watch_rx.borrow();
+        assert_eq!(
+            state.member_last_observed_at_ms.get(&dsl_identity),
+            Some(&second_order)
+        );
+        assert_eq!(
+            state.member_progress_tokens.get(&dsl_identity),
+            Some(&second_progress_token),
+            "late first completion must take the generated stale transition"
+        );
+    }
+
+    let third_rx = handle
+        .enqueue_actor_command_for_test(|reply_tx| MobCommand::ProjectMemberStatus {
+            agent_identity: identity,
+            reply_tx,
+        })
+        .await
+        .expect("enqueue third status observation");
+    third_rx
+        .await
+        .expect("third status reply channel")
+        .expect("third status observation");
+    assert!(
+        handle
+            .machine_state_watch_rx
+            .borrow()
+            .member_last_observed_at_ms
+            .get(&dsl_identity)
+            .is_some_and(|third_order| *third_order > second_order),
+        "actor-issued order must increase strictly across wall-clock advancement"
+    );
+
+    handle.shutdown().await.expect("shutdown test mob");
+}
+
+#[tokio::test]
+async fn test_member_status_session_read_does_not_close_actor_tool_dependency_cycle() {
+    let (handle, service) = create_test_mob(sample_definition()).await;
+    let blocked_identity = AgentIdentity::from("status-cycle-member");
+    let blocked_session_id = handle
+        .spawn(ProfileName::from("worker"), blocked_identity.clone(), None)
+        .await
+        .expect("spawn cycle member")
+        .bridge_session_id()
+        .expect("cycle member is session-backed")
+        .clone();
+    let observer_identity = AgentIdentity::from("status-cycle-observer");
+    handle
+        .spawn(ProfileName::from("worker"), observer_identity.clone(), None)
+        .await
+        .expect("spawn observer member");
+    service
+        .active_sessions
+        .write()
+        .await
+        .insert(blocked_session_id.clone());
+    let session_read_barrier = service
+        .install_session_read_barrier(blocked_session_id.clone())
+        .await;
+
+    let blocked_status_rx = handle
+        .enqueue_actor_command_for_test(|reply_tx| MobCommand::ProjectMemberStatus {
+            agent_identity: blocked_identity,
+            reply_tx,
+        })
+        .await
+        .expect("enqueue blocking member status");
+    tokio::time::timeout(Duration::from_secs(1), service.wait_for_session_read())
+        .await
+        .expect("member status should enter the session read");
+
+    let heartbeat_rx = handle
+        .enqueue_actor_command_for_test(|reply_tx| MobCommand::QueryPhase { reply_tx })
+        .await
+        .expect("enqueue actor heartbeat");
+    let (probe_event_tx, mut probe_event_rx) = tokio::sync::mpsc::unbounded_channel();
+    let mut probe_task = tokio::spawn(run_single_actor_loop_probe(
+        heartbeat_rx,
+        Duration::from_millis(250),
+        probe_event_tx,
+    ));
+
+    let tool_list_rx = handle
+        .enqueue_actor_command_for_test(|reply_tx| MobCommand::ProjectMemberList {
+            include_retiring: false,
+            reply_tx,
+        })
+        .await
+        .expect("enqueue active-turn mob_list_members tool command");
+    let tool_release = Arc::clone(&session_read_barrier);
+    let active_turn_tool = tokio::spawn(async move {
+        let result = tool_list_rx
+            .await
+            .map_err(|_| MobError::ActorReplyChannelClosed)
+            .and_then(std::convert::identity);
+        tool_release.release_all();
+        result
+    });
+    let unrelated_status_rx = handle
+        .enqueue_actor_command_for_test(|reply_tx| MobCommand::ProjectMemberStatus {
+            agent_identity: observer_identity,
+            reply_tx,
+        })
+        .await
+        .expect("enqueue unrelated member status");
+
+    let heartbeat = match tokio::time::timeout(Duration::from_secs(1), &mut probe_task).await {
+        Ok(result) => result
+            .expect("probe task should not panic")
+            .expect("heartbeat should return the mob phase"),
+        Err(_) => {
+            session_read_barrier.release_all();
+            let _ = active_turn_tool.await;
+            let _ = blocked_status_rx.await;
+            let _ = unrelated_status_rx.await;
+            panic!("member status session I/O stalled the actor");
+        }
+    };
+    assert_eq!(heartbeat, MobState::Running);
+    assert!(matches!(
+        probe_event_rx.try_recv(),
+        Err(tokio::sync::mpsc::error::TryRecvError::Disconnected)
+    ));
+    active_turn_tool
+        .await
+        .expect("active-turn tool task should not panic")
+        .expect("actor-routed list command should complete and release the turn");
+    blocked_status_rx
+        .await
+        .expect("blocking status reply channel")
+        .expect("off-actor session read should complete after turn release");
+    unrelated_status_rx
+        .await
+        .expect("unrelated status reply channel")
+        .expect("unrelated status should drain while the first read is pending");
+
+    service
+        .active_sessions
+        .write()
+        .await
+        .remove(&blocked_session_id);
+    handle.shutdown().await.expect("shutdown test mob");
+}
+
+#[tokio::test]
+async fn test_actor_loop_probe_emits_one_correlated_recovery_for_blocked_head() {
+    let (handle, _service) = create_test_mob(sample_definition()).await;
+    let (entered_tx, entered_rx) = tokio::sync::oneshot::channel();
+    let (release_tx, release_rx) = tokio::sync::oneshot::channel();
+    let blocked_head_rx = handle
+        .enqueue_actor_command_for_test(|reply_tx| MobCommand::ParkActorForObservationTest {
+            entered_tx,
+            release_rx,
+            reply_tx,
+        })
+        .await
+        .expect("enqueue test-only blocked head");
+    entered_rx.await.expect("actor should enter blocked head");
+
+    let heartbeat_rx = handle
+        .enqueue_actor_command_for_test(|reply_tx| MobCommand::QueryPhase { reply_tx })
+        .await
+        .expect("enqueue actor heartbeat behind blocked head");
+    let (probe_event_tx, mut probe_event_rx) = tokio::sync::mpsc::unbounded_channel();
+    let probe_task = tokio::spawn(run_single_actor_loop_probe(
+        heartbeat_rx,
+        Duration::from_millis(250),
+        probe_event_tx,
+    ));
+
+    assert_eq!(
+        tokio::time::timeout(Duration::from_secs(1), probe_event_rx.recv())
+            .await
+            .expect("blocked heartbeat should emit a stall")
+            .expect("probe event channel should remain open"),
+        TestActorLoopProbeEvent::ActorLoopStalled { stall_id: 1 }
+    );
+    tokio::time::sleep(Duration::from_millis(750)).await;
+    assert!(matches!(
+        probe_event_rx.try_recv(),
+        Err(tokio::sync::mpsc::error::TryRecvError::Empty)
+    ));
+
+    release_tx.send(()).expect("release blocked actor head");
+    blocked_head_rx
+        .await
+        .expect("blocked head reply should be delivered")
+        .expect("test-only blocked head should release cleanly");
+    assert_eq!(
+        probe_task
+            .await
+            .expect("probe task should not panic")
+            .expect("heartbeat should recover"),
+        MobState::Running
+    );
+    assert_eq!(
+        probe_event_rx
+            .recv()
+            .await
+            .expect("probe should emit exact correlated recovery"),
+        TestActorLoopProbeEvent::ActorLoopRecovered { stall_id: 1 }
+    );
+    assert!(matches!(
+        probe_event_rx.try_recv(),
+        Err(tokio::sync::mpsc::error::TryRecvError::Disconnected)
+    ));
+
+    handle.shutdown().await.expect("shutdown test mob");
+}
+
+#[tokio::test]
+async fn test_actor_loop_probe_does_not_stall_when_member_status_read_is_available() {
+    let (handle, _service) = create_test_mob(sample_definition()).await;
+    let identity = AgentIdentity::from("status-cycle-falsifier");
+    handle
+        .spawn(ProfileName::from("worker"), identity.clone(), None)
+        .await
+        .expect("spawn falsifier member");
+
+    let status_rx = handle
+        .enqueue_actor_command_for_test(|reply_tx| MobCommand::ProjectMemberStatus {
+            agent_identity: identity,
+            reply_tx,
+        })
+        .await
+        .expect("enqueue immediately readable member status");
+    let heartbeat_rx = handle
+        .enqueue_actor_command_for_test(|reply_tx| MobCommand::QueryPhase { reply_tx })
+        .await
+        .expect("enqueue actor heartbeat");
+    let (probe_event_tx, mut probe_event_rx) = tokio::sync::mpsc::unbounded_channel();
+
+    status_rx
+        .await
+        .expect("status reply channel")
+        .expect("available member status should complete");
+    assert_eq!(
+        run_single_actor_loop_probe(heartbeat_rx, Duration::from_secs(1), probe_event_tx)
+            .await
+            .expect("heartbeat should complete within its budget"),
+        MobState::Running
+    );
+    assert!(matches!(
+        probe_event_rx.try_recv(),
+        Err(tokio::sync::mpsc::error::TryRecvError::Disconnected)
+    ));
+
+    handle.shutdown().await.expect("shutdown test mob");
+}
+
+#[tokio::test]
+async fn test_dropped_member_status_receiver_cancels_owned_session_read() {
+    let (handle, service) = create_test_mob(sample_definition()).await;
+    let identity = AgentIdentity::from("status-closed-receiver");
+    let session_id = handle
+        .spawn(ProfileName::from("worker"), identity.clone(), None)
+        .await
+        .expect("spawn closed-receiver member")
+        .bridge_session_id()
+        .expect("closed-receiver member is session-backed")
+        .clone();
+    let read_barrier = service.install_session_read_barrier(session_id).await;
+    let status_rx = handle
+        .enqueue_actor_command_for_test(|reply_tx| MobCommand::ProjectMemberStatus {
+            agent_identity: identity,
+            reply_tx,
+        })
+        .await
+        .expect("enqueue cancellable member status");
+    tokio::time::timeout(Duration::from_secs(1), service.wait_for_session_read())
+        .await
+        .expect("owned session read should start");
+    assert_eq!(Arc::strong_count(&read_barrier), 2);
+
+    drop(status_rx);
+    tokio::time::timeout(Duration::from_secs(1), async {
+        while Arc::strong_count(&read_barrier) != 1 {
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("closed receiver should cancel the owned read future");
+    assert_eq!(
+        handle.status().await.expect("actor remains responsive"),
+        MobState::Running
+    );
+
+    handle.shutdown().await.expect("shutdown test mob");
+}
+
+#[tokio::test]
+async fn test_shutdown_aborts_owned_member_status_read() {
+    let (handle, service) = create_test_mob(sample_definition()).await;
+    let identity = AgentIdentity::from("status-shutdown-cleanup");
+    let session_id = handle
+        .spawn(ProfileName::from("worker"), identity.clone(), None)
+        .await
+        .expect("spawn shutdown-cleanup member")
+        .bridge_session_id()
+        .expect("shutdown-cleanup member is session-backed")
+        .clone();
+    let read_barrier = service.install_session_read_barrier(session_id).await;
+    let status_rx = handle
+        .enqueue_actor_command_for_test(|reply_tx| MobCommand::ProjectMemberStatus {
+            agent_identity: identity,
+            reply_tx,
+        })
+        .await
+        .expect("enqueue member status before shutdown");
+    tokio::time::timeout(Duration::from_secs(1), service.wait_for_session_read())
+        .await
+        .expect("owned session read should start");
+    assert_eq!(Arc::strong_count(&read_barrier), 2);
+
+    tokio::time::timeout(Duration::from_secs(1), handle.shutdown())
+        .await
+        .expect("shutdown should abort and join owned session reads")
+        .expect("shutdown should succeed");
+    assert_eq!(Arc::strong_count(&read_barrier), 1);
+    assert!(status_rx.await.is_err());
 }
 
 #[tokio::test]

--- a/meerkat-mob/src/runtime/tests.rs
+++ b/meerkat-mob/src/runtime/tests.rs
@@ -1715,6 +1715,8 @@ struct MockSessionService {
     /// Records (session_id, prompt) for each create_session call.
     prompts: RwLock<Vec<(SessionId, String)>>,
     session_read_calls: AtomicU64,
+    session_read_not_found_remaining: AtomicU64,
+    resume_authority_absent_remaining: AtomicU64,
     create_requests: RwLock<Vec<CreateSessionRecord>>,
     /// Records whether each create_session had external_tools configured.
     create_with_external_tools: RwLock<Vec<bool>>,
@@ -1902,6 +1904,8 @@ impl MockSessionService {
             session_counter: AtomicU64::new(0),
             prompts: RwLock::new(Vec::new()),
             session_read_calls: AtomicU64::new(0),
+            session_read_not_found_remaining: AtomicU64::new(0),
+            resume_authority_absent_remaining: AtomicU64::new(0),
             create_requests: RwLock::new(Vec::new()),
             create_with_external_tools: RwLock::new(Vec::new()),
             create_with_compaction_curators: RwLock::new(Vec::new()),
@@ -2553,6 +2557,13 @@ impl MockSessionService {
 
     fn session_read_calls(&self) -> u64 {
         self.session_read_calls.load(Ordering::Relaxed)
+    }
+
+    fn fail_next_session_read_as_absent(&self) {
+        self.session_read_not_found_remaining
+            .store(1, Ordering::Release);
+        self.resume_authority_absent_remaining
+            .store(1, Ordering::Release);
     }
 
     async fn wait_for_execution_snapshot(&self) {
@@ -3456,10 +3467,19 @@ impl SessionService for MockSessionService {
 
     async fn read(&self, id: &SessionId) -> Result<SessionView, SessionError> {
         self.session_read_calls.fetch_add(1, Ordering::Relaxed);
+        let return_not_found = self
+            .session_read_not_found_remaining
+            .fetch_update(Ordering::AcqRel, Ordering::Acquire, |remaining| {
+                remaining.checked_sub(1)
+            })
+            .is_ok();
         let barrier = self.session_read_barriers.write().await.remove(id);
         if let Some(barrier) = barrier {
             self.session_read_started.notify_one();
             barrier.wait_for_release().await;
+        }
+        if return_not_found {
+            return Err(SessionError::NotFound { id: id.clone() });
         }
         let session = self
             .live_session_clone(id)
@@ -3936,6 +3956,15 @@ impl MobSessionService for MockSessionService {
         &self,
         session_id: &SessionId,
     ) -> Result<SessionResumeAuthority, SessionError> {
+        if self
+            .resume_authority_absent_remaining
+            .fetch_update(Ordering::AcqRel, Ordering::Acquire, |remaining| {
+                remaining.checked_sub(1)
+            })
+            .is_ok()
+        {
+            return Ok(SessionResumeAuthority::default());
+        }
         let _authority_guard = self.resume_authority_gate.lock().await;
         let session = self
             .persisted_sessions
@@ -8707,7 +8736,7 @@ async fn apply_operator_race_machine_input(
         .expect("operator execution-fence race setup transition");
 }
 
-async fn seed_operator_execution_residency(handle: &MobHandle) {
+async fn seed_operator_execution_residency(handle: &MobHandle, member_session_id: &str) {
     use crate::machines::mob_machine as dsl;
 
     let identity = dsl::AgentIdentity::from("member-a");
@@ -8820,7 +8849,7 @@ async fn seed_operator_execution_residency(handle: &MobHandle) {
             profile_material_digest: profile_digest,
             external_addressable: false,
             runtime_mode: dsl::SpawnPolicyRuntimeMode::TurnDriven,
-            bridge_session_id: Some(dsl::SessionId::from("member-session-a")),
+            bridge_session_id: Some(dsl::SessionId::from(member_session_id)),
             replacing: None,
             member_peer_endpoint: Some(dsl::MemberPeerEndpoint {
                 name: dsl::PeerName::from("member-a"),
@@ -8923,7 +8952,7 @@ async fn pending_member_operator_request_is_revalidated_at_actor_dispatch_after_
         .create()
         .await
         .expect("create operator execution-fence race mob");
-    seed_operator_execution_residency(&handle).await;
+    seed_operator_execution_residency(&handle, "member-session-a").await;
 
     let seams = Arc::new(OperatorExecutionRaceSeams {
         mob_id: handle.mob_id().clone(),
@@ -9161,7 +9190,7 @@ async fn member_operator_projection_is_revalidated_after_result_capture() {
 
     let definition = with_unique_mob_id(sample_definition(), "operator-projection-fence-race");
     let (handle, _service) = create_test_mob(definition).await;
-    seed_operator_execution_residency(&handle).await;
+    seed_operator_execution_residency(&handle, "member-session-a").await;
 
     let projection_captured = Arc::new(tokio::sync::Notify::new());
     let release_validation = Arc::new(tokio::sync::Notify::new());
@@ -54247,26 +54276,25 @@ fn test_member_execution_snapshot(
 
 #[tokio::test]
 async fn test_placed_member_status_skips_controller_session_progress_observation() {
-    let service = Arc::new(MockSessionService::new());
-    let session_service: Arc<dyn MobSessionService> = service.clone();
-    let observation = super::actor::MobActor::observe_member_status_session(
-        session_service,
-        AgentIdentity::from("placed-status"),
-        Some(SessionId::new()),
-        false,
-        41,
-    )
-    .await;
+    let (handle, service) = create_test_mob(sample_definition()).await;
+    let placed_session_id = SessionId::new();
+    seed_operator_execution_residency(&handle, &placed_session_id.to_string()).await;
+    let snapshot = handle
+        .member_status(&AgentIdentity::from("member-a"))
+        .await
+        .expect("placed member status");
 
     assert_eq!(service.session_read_calls(), 0);
     assert_eq!(service.execution_snapshot_calls(), 0);
-    assert!(observation.execution_snapshot.is_none());
-    assert!(super::actor::unavailable_member_progress(false).is_none());
-    assert_eq!(observation.observed_at_ms, 41);
+    assert!(
+        snapshot.progress.is_none(),
+        "placed member progress is not controller-local"
+    );
+    handle.shutdown().await.expect("shutdown test mob");
 }
 
 #[tokio::test]
-async fn test_same_millisecond_reordered_member_status_completion_stays_monotonic() {
+async fn test_member_status_observation_clock_is_unique_and_tracks_wall_time() {
     assert_eq!(
         super::actor::advance_member_status_observation_clock(100, 200)
             .expect("wall clock advancement"),
@@ -54277,105 +54305,278 @@ async fn test_same_millisecond_reordered_member_status_completion_stays_monotoni
             .expect("same-millisecond logical advancement"),
         (201, 202)
     );
-    assert!(
-        super::actor::advance_member_status_observation_clock(u64::MAX, u64::MAX).is_err(),
-        "clock exhaustion must refuse rather than issue a duplicate order"
-    );
+    assert!(matches!(
+        super::actor::advance_member_status_observation_clock(u64::MAX, u64::MAX),
+        Err(MobError::Internal(_))
+    ));
 
     let (handle, service) = create_test_mob(sample_definition()).await;
-    let identity = AgentIdentity::from("status-reordered");
-    let session_id = handle
+    let identity = AgentIdentity::from("status-clock");
+    handle
         .spawn(ProfileName::from("worker"), identity.clone(), None)
         .await
-        .expect("spawn reordered-status member")
-        .bridge_session_id()
-        .expect("reordered-status member is session-backed")
-        .clone();
+        .expect("spawn clock member");
     service.set_execution_snapshots([
-        test_member_execution_snapshot(2, 2),
         test_member_execution_snapshot(1, 1),
-        test_member_execution_snapshot(3, 3),
+        test_member_execution_snapshot(2, 2),
     ]);
-    let first_read_barrier = service.install_session_read_barrier(session_id).await;
-
-    let first_rx = handle
-        .enqueue_actor_command_for_test(|reply_tx| MobCommand::ProjectMemberStatus {
-            agent_identity: identity.clone(),
-            reply_tx,
-        })
+    handle
+        .member_status(&identity)
         .await
-        .expect("enqueue first status observation");
-    tokio::time::timeout(Duration::from_secs(1), service.wait_for_session_read())
-        .await
-        .expect("first status observation should enter its session read");
-    let second_rx = handle
-        .enqueue_actor_command_for_test(|reply_tx| MobCommand::ProjectMemberStatus {
-            agent_identity: identity.clone(),
-            reply_tx,
-        })
-        .await
-        .expect("enqueue second status observation");
-    second_rx
-        .await
-        .expect("second status reply channel")
-        .expect("second status observation");
-
+        .expect("first status observation");
     let dsl_identity = crate::machines::mob_machine::AgentIdentity::from_domain(&identity);
-    let (second_order, second_progress_token) = {
-        let state = handle.machine_state_watch_rx.borrow();
-        (
-            *state
-                .member_last_observed_at_ms
-                .get(&dsl_identity)
-                .expect("second observation order"),
-            state
-                .member_progress_tokens
-                .get(&dsl_identity)
-                .expect("second progress token")
-                .clone(),
-        )
-    };
-
-    first_read_barrier.release_all();
-    first_rx
+    let first_order = *handle
+        .machine_state_watch_rx
+        .borrow()
+        .member_last_observed_at_ms
+        .get(&dsl_identity)
+        .expect("first observation order");
+    handle
+        .member_status(&identity)
         .await
-        .expect("first status reply channel")
-        .expect("stale first observation should still return a current projection");
-    {
-        let state = handle.machine_state_watch_rx.borrow();
-        assert_eq!(
-            state.member_last_observed_at_ms.get(&dsl_identity),
-            Some(&second_order)
-        );
-        assert_eq!(
-            state.member_progress_tokens.get(&dsl_identity),
-            Some(&second_progress_token),
-            "late first completion must take the generated stale transition"
-        );
-    }
-
-    let third_rx = handle
-        .enqueue_actor_command_for_test(|reply_tx| MobCommand::ProjectMemberStatus {
-            agent_identity: identity,
-            reply_tx,
-        })
-        .await
-        .expect("enqueue third status observation");
-    third_rx
-        .await
-        .expect("third status reply channel")
-        .expect("third status observation");
+        .expect("second status observation");
     assert!(
         handle
             .machine_state_watch_rx
             .borrow()
             .member_last_observed_at_ms
             .get(&dsl_identity)
-            .is_some_and(|third_order| *third_order > second_order),
-        "actor-issued order must increase strictly across wall-clock advancement"
+            .is_some_and(|second_order| *second_order > first_order),
+        "actor-issued order must increase strictly for sequential observations"
+    );
+    handle.shutdown().await.expect("shutdown test mob");
+}
+
+#[tokio::test]
+async fn test_member_status_lane_serializes_absence_before_success() {
+    let (handle, service) = create_test_mob(sample_definition()).await;
+    let identity = AgentIdentity::from("status-late-absence");
+    let session_id = handle
+        .spawn(ProfileName::from("worker"), identity.clone(), None)
+        .await
+        .expect("spawn late-absence member")
+        .bridge_session_id()
+        .expect("late-absence member is session-backed")
+        .clone();
+    service.fail_next_session_read_as_absent();
+    let first_read_barrier = service.install_session_read_barrier(session_id).await;
+
+    let stale_absence_rx = handle
+        .enqueue_actor_command_for_test(|reply_tx| MobCommand::ProjectMemberStatus {
+            agent_identity: identity.clone(),
+            reply_tx,
+        })
+        .await
+        .expect("enqueue stale absence observation");
+    tokio::time::timeout(Duration::from_secs(1), service.wait_for_session_read())
+        .await
+        .expect("stale absence should enter its session read");
+    let busy = handle
+        .member_status(&identity)
+        .await
+        .expect_err("a second observation must not overlap the first");
+    assert!(matches!(
+        busy,
+        MobError::LifecycleOperationAdmissionPending {
+            ref intent,
+            stage: "observation_lane_saturated"
+        } if intent == "member_status_observation"
+    ));
+
+    first_read_barrier.release_all();
+    stale_absence_rx
+        .await
+        .expect("stale absence reply channel")
+        .expect("first absence should resolve under exclusive lane custody");
+    handle.shutdown().await.expect("shutdown test mob");
+}
+
+#[tokio::test]
+async fn test_member_status_observation_lane_saturates_and_releases() {
+    let (handle, service) = create_test_mob(sample_definition()).await;
+    let mut blocked = Vec::new();
+    for index in 0..super::actor::MAX_PENDING_MEMBER_STATUS_OBSERVATIONS {
+        let identity = AgentIdentity::from(format!("status-saturated-{index}"));
+        let session_id = handle
+            .spawn(ProfileName::from("worker"), identity.clone(), None)
+            .await
+            .expect("spawn saturation member")
+            .bridge_session_id()
+            .expect("saturation member is session-backed")
+            .clone();
+        let barrier = service.install_session_read_barrier(session_id).await;
+        let reply_rx = handle
+            .enqueue_actor_command_for_test(|reply_tx| MobCommand::ProjectMemberStatus {
+                agent_identity: identity,
+                reply_tx,
+            })
+            .await
+            .expect("enqueue saturated status");
+        tokio::time::timeout(Duration::from_secs(1), service.wait_for_session_read())
+            .await
+            .expect("status observation should occupy its lane permit");
+        blocked.push((barrier, reply_rx));
+    }
+
+    let overflow_identity = AgentIdentity::from("status-saturated-overflow");
+    handle
+        .spawn(ProfileName::from("worker"), overflow_identity.clone(), None)
+        .await
+        .expect("spawn overflow member");
+    let overflow = handle
+        .member_status(&overflow_identity)
+        .await
+        .expect_err("full observation lane must refuse immediately");
+    assert!(matches!(
+        overflow,
+        MobError::LifecycleOperationAdmissionPending {
+            ref intent,
+            stage: "observation_lane_saturated"
+        } if intent == "member_status_observation"
+    ));
+    assert_eq!(
+        overflow.failure_class(),
+        crate::MobFailureClass::RuntimeRejected
+    );
+    assert_eq!(
+        overflow.wire_error_code(),
+        Some(meerkat_contracts::ErrorCode::SessionBusy)
+    );
+    assert_eq!(
+        overflow
+            .structured_data()
+            .expect("busy observation carries typed data")["authority_retained"],
+        false
     );
 
+    let (released_barrier, released_rx) = blocked.remove(0);
+    released_barrier.release_all();
+    released_rx
+        .await
+        .expect("released observation reply channel")
+        .expect("released observation completes");
+    handle
+        .member_status(&overflow_identity)
+        .await
+        .expect("released permit admits a subsequent observation");
+
+    for (barrier, reply_rx) in blocked {
+        barrier.release_all();
+        reply_rx
+            .await
+            .expect("blocked observation reply channel")
+            .expect("blocked observation completes");
+    }
     handle.shutdown().await.expect("shutdown test mob");
+}
+
+#[tokio::test]
+async fn test_member_status_target_change_redrives_after_respawn() {
+    let (handle, service) = create_test_mob(sample_definition()).await;
+    let identity = AgentIdentity::from("status-target-redrive");
+    let old_session_id = handle
+        .spawn(ProfileName::from("worker"), identity.clone(), None)
+        .await
+        .expect("spawn redrive predecessor")
+        .bridge_session_id()
+        .expect("redrive predecessor is session-backed")
+        .clone();
+    let old_read_barrier = service.install_session_read_barrier(old_session_id).await;
+    let status_rx = handle
+        .enqueue_actor_command_for_test(|reply_tx| MobCommand::ProjectMemberStatus {
+            agent_identity: identity.clone(),
+            reply_tx,
+        })
+        .await
+        .expect("enqueue predecessor status observation");
+    tokio::time::timeout(Duration::from_secs(1), service.wait_for_session_read())
+        .await
+        .expect("predecessor status should enter its session read");
+
+    let replacement = handle
+        .respawn(identity, None)
+        .await
+        .expect("respawn status target");
+    let replacement_session_id = handle
+        .get_member(&replacement.identity)
+        .await
+        .expect("replacement member lookup")
+        .expect("replacement member")
+        .member_ref
+        .bridge_session_id()
+        .expect("replacement is session-backed")
+        .clone();
+    old_read_barrier.release_all();
+    let snapshot = tokio::time::timeout(Duration::from_secs(2), status_rx)
+        .await
+        .expect("status redrive should complete")
+        .expect("status redrive reply channel")
+        .expect("status redrive result");
+    assert_eq!(
+        snapshot.current_bridge_session_id(),
+        Some(&replacement_session_id)
+    );
+    assert_eq!(
+        snapshot.runtime_identity_fields(),
+        Some((&replacement.agent_runtime_id, replacement.fence_token))
+    );
+    handle.shutdown().await.expect("shutdown test mob");
+}
+
+#[tokio::test]
+async fn test_member_status_completion_cancels_while_mailbox_is_full() {
+    let (command_tx, mut command_rx) = tokio::sync::mpsc::channel(1);
+    let (queued_reply_tx, _queued_reply_rx) = tokio::sync::oneshot::channel();
+    command_tx
+        .send(super::scope_gate::RoutedMobCommand::internal(
+            MobCommand::QueryPhase {
+                reply_tx: queued_reply_tx,
+            },
+        ))
+        .await
+        .expect("fill test mailbox");
+    let (reply_tx, reply_rx) = tokio::sync::oneshot::channel();
+    let observation_permits = Arc::new(tokio::sync::Semaphore::new(1));
+    let observation_permit = Arc::clone(&observation_permits)
+        .try_acquire_owned()
+        .expect("test observation permit");
+    let completion = tokio::spawn(super::actor::enqueue_member_status_observation(
+        command_tx,
+        AgentIdentity::from("status-full-mailbox"),
+        super::state::MemberStatusProjectionTarget {
+            bridge_session_id: None,
+            include_local_session_details: false,
+            agent_runtime_id: None,
+            fence_token: None,
+        },
+        super::state::MemberStatusSessionObservation {
+            output_preview: None,
+            tokens_used: 0,
+            genuinely_absent: false,
+            execution_snapshot: None,
+            observed_at_ms: 1,
+        },
+        observation_permit,
+        reply_tx,
+    ));
+    tokio::task::yield_now().await;
+    drop(reply_rx);
+    assert!(
+        !tokio::time::timeout(Duration::from_secs(1), completion)
+            .await
+            .expect("closed receiver should release mailbox reservation wait")
+            .expect("completion task should not panic")
+    );
+    assert_eq!(
+        observation_permits.available_permits(),
+        1,
+        "cancellation must release the transferred observation permit"
+    );
+    assert!(
+        command_rx.try_recv().is_ok(),
+        "cancellation must not enqueue the abandoned completion"
+    );
+    assert!(command_rx.try_recv().is_err());
 }
 
 #[tokio::test]
@@ -54448,6 +54649,17 @@ async fn test_member_status_session_read_does_not_close_actor_tool_dependency_cy
         })
         .await
         .expect("enqueue unrelated member status");
+    let unrelated_error = unrelated_status_rx
+        .await
+        .expect("unrelated status reply channel")
+        .expect_err("the single observation lane must reject overlap");
+    assert!(matches!(
+        unrelated_error,
+        MobError::LifecycleOperationAdmissionPending {
+            intent,
+            stage: "observation_lane_saturated"
+        } if intent == "member_status_observation"
+    ));
 
     let heartbeat = match tokio::time::timeout(Duration::from_secs(1), &mut probe_task).await {
         Ok(result) => result
@@ -54457,7 +54669,6 @@ async fn test_member_status_session_read_does_not_close_actor_tool_dependency_cy
             session_read_barrier.release_all();
             let _ = active_turn_tool.await;
             let _ = blocked_status_rx.await;
-            let _ = unrelated_status_rx.await;
             panic!("member status session I/O stalled the actor");
         }
     };
@@ -54474,10 +54685,6 @@ async fn test_member_status_session_read_does_not_close_actor_tool_dependency_cy
         .await
         .expect("blocking status reply channel")
         .expect("off-actor session read should complete after turn release");
-    unrelated_status_rx
-        .await
-        .expect("unrelated status reply channel")
-        .expect("unrelated status should drain while the first read is pending");
 
     service
         .active_sessions

--- a/meerkat-mob/src/runtime/tests.rs
+++ b/meerkat-mob/src/runtime/tests.rs
@@ -51567,7 +51567,7 @@ fn test_runtime_owner_is_derived_from_machine_placement_before_session_shape() {
     use crate::machines::mob_machine as mob_dsl;
 
     let identity = AgentIdentity::from("placed-owner-predicate");
-    let dsl_identity = crate::machines::mob_machine::AgentIdentity::from_domain(&identity);
+    let dsl_identity = mob_dsl::AgentIdentity::from_domain(&identity);
     let mut state = mob_dsl::MobMachineAuthority::new().state().clone();
 
     // `Some(session_id)` alone is not local ownership: host-materialized refs


### PR DESCRIPTION
Closes #1065.

## Summary
- move `ProjectMemberStatus` session reads/execution snapshots into actor-owned asynchronous I/O while keeping semantic projection and MobMachine mutation on the serialized actor
- bound status observations to one transferable permit, preserving cancellation, target redrive, placed-member semantics, shutdown cleanup, and source compatibility
- retain #1066 abandoned-observation skipping and normal actor boundary flushing

## Evidence
- HomeCore field trace: seven `ProjectMemberStatus` commands immediately before `ActorLoopStalled`
- deterministic cycle regression, correlated recovery, available-read falsifier, cancellation, shutdown, placement, target-change, saturation, and full-mailbox tests
- qualified focused selectors: 12/12 plus final affected 6/6
- scoped all-feature/all-target Clippy
- final meerkat-rust-zealot, rust-quality, and integration-sheriff PASS
- exact-tree normal pre-push: every hook passed, including workspace deterministic unit+integration+e2e

Base: `5aad28eb92ffbaa35746f2560ceee414a45c3dc4`
Head: `ca1ae4e61a9348d1252a667146330e9354c4a5fc`
Tree: `13a5f594d5d0c1299106bfd00d067b61d9ac6146`
Commit patch IDs: `30f5155526764c705847234b8ee07527cd757d98`, `92266820d18e1fc70a7909048affb1d978db4fac`, `6c069d34283e36408c141bcf181007c5ade61e45`