### PR TITLE
feat: add typed cross-provider replay contracts

### DIFF
--- a/meerkat-anthropic/src/client.rs
+++ b/meerkat-anthropic/src/client.rs
@@ -245,45 +245,9 @@ fn project_anthropic_tool_result(
     result_index: meerkat_core::ReplayToolResultIndex,
     result: &ToolResult,
 ) -> Result<ToolResult, LlmError> {
-    if result.has_video() {
-        return Err(invalid_replay(
-            "video blocks are not supported in Anthropic tool results",
-        ));
-    }
-    Ok(ToolResult::with_blocks(
-        result.tool_use_id.clone(),
-        result
-            .content
-            .iter()
-            .enumerate()
-            .map(|(block_index, block)| {
-                let subject = meerkat_core::ReplaySubject::ToolResultContent {
-                    message,
-                    result: result_index,
-                    block: meerkat_core::ReplayToolResultContentIndex(block_index),
-                };
-                let projected = match replay_application
-                    .next(subject)
-                    .map_err(|error| invalid_replay(error.to_string()))?
-                {
-                    meerkat_core::ReplayDisposition::Preserve => block.clone(),
-                    meerkat_core::ReplayDisposition::LowerToText => ContentBlock::Text {
-                        text: block.text_projection().into_owned(),
-                    },
-                    disposition => {
-                        return Err(invalid_replay(format!(
-                            "Anthropic replay cannot apply tool-result disposition {disposition:?}"
-                        )));
-                    }
-                };
-                replay_application
-                    .record_content(subject, block, &projected)
-                    .map_err(|error| invalid_replay(error.to_string()))?;
-                Ok(projected)
-            })
-            .collect::<Result<Vec<_>, _>>()?,
-        result.is_error,
-    ))
+    replay_application
+        .project_tool_result(message, result_index, result)
+        .map_err(|error| invalid_replay(error.to_string()))
 }
 
 fn anthropic_server_tool_content_replayable(content: &Value) -> bool {
@@ -377,6 +341,8 @@ fn project_anthropic_replay_messages(messages: &[Message]) -> Result<Vec<Message
             true,
             false,
             true,
+            meerkat_core::ReplayToolResultProjection::PreserveBlocks,
+            meerkat_core::ReplayReasoningProjection::ProviderNative,
         ),
     )
     .map_err(|error| invalid_replay(error.to_string()))?;
@@ -385,12 +351,19 @@ fn project_anthropic_replay_messages(messages: &[Message]) -> Result<Vec<Message
 
     for (message_index, message) in messages.iter().enumerate() {
         let message_index = meerkat_core::ReplayMessageIndex(message_index);
+        if let Message::SystemNotice(notice) = message {
+            let projected_notice = replay_application
+                .project_system_notice(message_index, notice)
+                .map_err(|error| invalid_replay(error.to_string()))?;
+            projected.push(Message::SystemNotice(projected_notice));
+            continue;
+        }
         replay_application
             .record_message(
                 meerkat_core::ReplaySubject::Message(message_index),
                 message,
                 match message {
-                    Message::System(_) | Message::SystemNotice(_) => Some(message),
+                    Message::System(_) => Some(message),
                     _ => None,
                 },
             )
@@ -420,7 +393,8 @@ fn project_anthropic_replay_messages(messages: &[Message]) -> Result<Vec<Message
         }
 
         let next_message = match message {
-            Message::System(_) | Message::SystemNotice(_) => Some(message.clone()),
+            Message::System(_) => Some(message.clone()),
+            Message::SystemNotice(_) => unreachable!("handled above"),
             Message::User(user) => Some(Message::User(meerkat_core::UserMessage {
                 content: project_anthropic_content_blocks(
                     &mut replay_application,
@@ -4538,7 +4512,7 @@ mod tests {
     fn anthropic_system_notice_with_image_emits_typed_image_part()
     -> Result<(), Box<dyn std::error::Error>> {
         let client = AnthropicClient::new("test-key".to_string())?;
-        let request = LlmRequest::new(
+        let mut request = LlmRequest::new(
             "claude-sonnet-4-5",
             vec![Message::SystemNotice(
                 meerkat_core::SystemNoticeMessage::with_block(
@@ -4567,6 +4541,7 @@ mod tests {
                 ),
             )],
         );
+        request.messages = client.project_replay_messages(&request.messages)?;
 
         let body = client.build_request_body(&request)?;
         let messages = body["messages"].as_array().unwrap();

--- a/meerkat-anthropic/src/client.rs
+++ b/meerkat-anthropic/src/client.rs
@@ -20,7 +20,6 @@ use meerkat_llm_core::{LlmClient, LlmDoneOutcome, LlmEvent, LlmRequest, LlmStrea
 use meerkat_llm_core::{http, streaming};
 use serde::Deserialize;
 use serde_json::{Map, Value};
-use std::collections::HashSet;
 use std::time::Duration;
 
 /// Default connect timeout
@@ -205,26 +204,47 @@ fn invalid_replay(message: impl Into<String>) -> LlmError {
     }
 }
 
-fn project_anthropic_content_blocks(blocks: &[ContentBlock]) -> Vec<ContentBlock> {
+fn project_anthropic_content_blocks(
+    replay_application: &mut meerkat_core::ReplayApplication<'_>,
+    message: meerkat_core::ReplayMessageIndex,
+    blocks: &[ContentBlock],
+) -> Result<Vec<ContentBlock>, LlmError> {
     blocks
         .iter()
-        .map(|block| match block {
-            ContentBlock::Text { .. } => block.clone(),
-            ContentBlock::Image {
-                data: ImageData::Inline { .. },
-                ..
-            } => block.clone(),
-            ContentBlock::Image { .. } | ContentBlock::Video { .. } => ContentBlock::Text {
-                text: block.text_projection().into_owned(),
-            },
-            _ => ContentBlock::Text {
-                text: block.text_projection().into_owned(),
-            },
+        .enumerate()
+        .map(|(block_index, block)| {
+            let subject = meerkat_core::ReplaySubject::UserContent {
+                message,
+                block: meerkat_core::ReplayUserContentIndex(block_index),
+            };
+            let projected = match replay_application
+                .next(subject)
+                .map_err(|error| invalid_replay(error.to_string()))?
+            {
+                meerkat_core::ReplayDisposition::Preserve => block.clone(),
+                meerkat_core::ReplayDisposition::LowerToText => ContentBlock::Text {
+                    text: block.text_projection().into_owned(),
+                },
+                disposition => {
+                    return Err(invalid_replay(format!(
+                        "Anthropic replay cannot apply user-content disposition {disposition:?}"
+                    )));
+                }
+            };
+            replay_application
+                .record_content(subject, block, &projected)
+                .map_err(|error| invalid_replay(error.to_string()))?;
+            Ok(projected)
         })
         .collect()
 }
 
-fn project_anthropic_tool_result(result: &ToolResult) -> Result<ToolResult, LlmError> {
+fn project_anthropic_tool_result(
+    replay_application: &mut meerkat_core::ReplayApplication<'_>,
+    message: meerkat_core::ReplayMessageIndex,
+    result_index: meerkat_core::ReplayToolResultIndex,
+    result: &ToolResult,
+) -> Result<ToolResult, LlmError> {
     if result.has_video() {
         return Err(invalid_replay(
             "video blocks are not supported in Anthropic tool results",
@@ -232,7 +252,36 @@ fn project_anthropic_tool_result(result: &ToolResult) -> Result<ToolResult, LlmE
     }
     Ok(ToolResult::with_blocks(
         result.tool_use_id.clone(),
-        project_anthropic_content_blocks(&result.content),
+        result
+            .content
+            .iter()
+            .enumerate()
+            .map(|(block_index, block)| {
+                let subject = meerkat_core::ReplaySubject::ToolResultContent {
+                    message,
+                    result: result_index,
+                    block: meerkat_core::ReplayToolResultContentIndex(block_index),
+                };
+                let projected = match replay_application
+                    .next(subject)
+                    .map_err(|error| invalid_replay(error.to_string()))?
+                {
+                    meerkat_core::ReplayDisposition::Preserve => block.clone(),
+                    meerkat_core::ReplayDisposition::LowerToText => ContentBlock::Text {
+                        text: block.text_projection().into_owned(),
+                    },
+                    disposition => {
+                        return Err(invalid_replay(format!(
+                            "Anthropic replay cannot apply tool-result disposition {disposition:?}"
+                        )));
+                    }
+                };
+                replay_application
+                    .record_content(subject, block, &projected)
+                    .map_err(|error| invalid_replay(error.to_string()))?;
+                Ok(projected)
+            })
+            .collect::<Result<Vec<_>, _>>()?,
         result.is_error,
     ))
 }
@@ -244,92 +293,124 @@ fn anthropic_server_tool_content_replayable(content: &Value) -> bool {
     )
 }
 
-fn project_anthropic_assistant_blocks(blocks: &[AssistantBlock]) -> Vec<AssistantBlock> {
+fn project_anthropic_assistant_blocks(
+    replay_application: &mut meerkat_core::ReplayApplication<'_>,
+    message: meerkat_core::ReplayMessageIndex,
+    blocks: &[AssistantBlock],
+) -> Result<Vec<AssistantBlock>, LlmError> {
     blocks
         .iter()
-        .filter_map(|block| match block {
-            AssistantBlock::Text { text, .. } if text.is_empty() => None,
-            AssistantBlock::Text { .. } | AssistantBlock::ToolUse { .. } => Some(block.clone()),
-            // Spoken transcripts replay back as plain text. Anthropic does
-            // not have a realtime audio surface today; if a Meerkat session
-            // contains transcript blocks (e.g. cross-provider replay),
-            // surface them as plain text so the assistant history is
-            // visible to the model.
-            AssistantBlock::Transcript { text, .. } if text.is_empty() => None,
-            AssistantBlock::Transcript { text, .. } => Some(AssistantBlock::Text {
-                text: text.clone(),
-                meta: None,
-            }),
-            AssistantBlock::Reasoning { meta, .. } => match meta.as_deref() {
-                Some(
-                    meerkat_core::ProviderMeta::Anthropic { .. }
-                    | meerkat_core::ProviderMeta::AnthropicRedacted { .. }
-                    | meerkat_core::ProviderMeta::AnthropicCompaction { .. },
-                ) => Some(block.clone()),
-                _ => None,
-            },
-            AssistantBlock::ServerToolContent { content, .. }
-                if anthropic_server_tool_content_replayable(content) =>
-            {
-                Some(block.clone())
+        .enumerate()
+        .map(|(block_index, block)| {
+            let subject = meerkat_core::ReplaySubject::AssistantBlock {
+                message,
+                block: meerkat_core::ReplayAssistantBlockIndex(block_index),
+            };
+            let projected = match block {
+                AssistantBlock::Text { text, .. } if text.is_empty() => None,
+                AssistantBlock::Text { .. } | AssistantBlock::ToolUse { .. } => Some(
+                    meerkat_core::ReplayWireFamily::Anthropic.strip_foreign_metadata(block.clone()),
+                ),
+                // Spoken transcripts replay back as plain text. Anthropic does
+                // not have a realtime audio surface today; if a Meerkat session
+                // contains transcript blocks (e.g. cross-provider replay),
+                // surface them as plain text so the assistant history is
+                // visible to the model.
+                AssistantBlock::Transcript { text, .. } if text.is_empty() => None,
+                AssistantBlock::Transcript { text, .. } => Some(AssistantBlock::Text {
+                    text: text.clone(),
+                    meta: None,
+                }),
+                AssistantBlock::Reasoning { meta, .. } => match meta.as_deref() {
+                    Some(
+                        meerkat_core::ProviderMeta::Anthropic { .. }
+                        | meerkat_core::ProviderMeta::AnthropicRedacted { .. }
+                        | meerkat_core::ProviderMeta::AnthropicCompaction { .. },
+                    ) => Some(
+                        meerkat_core::ReplayWireFamily::Anthropic
+                            .strip_foreign_metadata(block.clone()),
+                    ),
+                    _ => None,
+                },
+                AssistantBlock::ServerToolContent { content, .. }
+                    if anthropic_server_tool_content_replayable(content) =>
+                {
+                    Some(
+                        meerkat_core::ReplayWireFamily::Anthropic
+                            .strip_foreign_metadata(block.clone()),
+                    )
+                }
+                AssistantBlock::Image { .. } | AssistantBlock::ServerToolContent { .. } => None,
+                _ => {
+                    return Err(invalid_replay(
+                        "Anthropic replay cannot project unknown assistant block",
+                    ));
+                }
+            };
+            replay_application
+                .record_assistant(subject, block, projected.as_ref())
+                .map_err(|error| invalid_replay(error.to_string()))?;
+            if let Some(meta) = meerkat_core::replay_provider_metadata(block) {
+                replay_application
+                    .record_provider_metadata(
+                        meerkat_core::ReplaySubject::ProviderMetadata {
+                            message,
+                            block: meerkat_core::ReplayAssistantBlockIndex(block_index),
+                        },
+                        meta,
+                        block,
+                        projected.as_ref(),
+                    )
+                    .map_err(|error| invalid_replay(error.to_string()))?;
             }
-            AssistantBlock::Image { .. } | AssistantBlock::ServerToolContent { .. } => None,
-            _ => None,
+            Ok(projected)
         })
+        .filter_map(|result| result.transpose())
         .collect()
 }
 
-fn tool_ids_from_assistant(message: &Message) -> HashSet<String> {
-    match message {
-        Message::BlockAssistant(assistant) => assistant
-            .blocks
-            .iter()
-            .filter_map(|block| match block {
-                AssistantBlock::ToolUse { id, .. } => Some(id.clone()),
-                _ => None,
-            })
-            .collect(),
-        _ => HashSet::new(),
-    }
-}
-
-fn validate_tool_results(
-    provider: &str,
-    pending: HashSet<String>,
-    results: &[ToolResult],
-) -> Result<(), LlmError> {
-    let actual: HashSet<String> = results
-        .iter()
-        .map(|result| result.tool_use_id.clone())
-        .collect();
-    if actual == pending {
-        Ok(())
-    } else {
-        Err(invalid_replay(format!(
-            "{provider} replay projection found tool results that are not adjacent to matching tool uses"
-        )))
-    }
-}
-
 fn project_anthropic_replay_messages(messages: &[Message]) -> Result<Vec<Message>, LlmError> {
+    let replay_plan = meerkat_core::ReplayPlan::build(
+        messages,
+        meerkat_core::ReplayTarget::new(
+            meerkat_core::ReplayWireFamily::Anthropic,
+            true,
+            false,
+            true,
+        ),
+    )
+    .map_err(|error| invalid_replay(error.to_string()))?;
+    let mut replay_application = replay_plan.application();
     let mut projected = Vec::with_capacity(messages.len());
-    let mut pending_tool_ids: Option<HashSet<String>> = None;
 
-    for message in messages {
+    for (message_index, message) in messages.iter().enumerate() {
+        let message_index = meerkat_core::ReplayMessageIndex(message_index);
+        replay_application
+            .record_message(
+                meerkat_core::ReplaySubject::Message(message_index),
+                message,
+                match message {
+                    Message::System(_) | Message::SystemNotice(_) => Some(message),
+                    _ => None,
+                },
+            )
+            .map_err(|error| invalid_replay(error.to_string()))?;
         if let Message::ToolResults {
             results,
             created_at,
         } = message
         {
-            let Some(pending) = pending_tool_ids.take() else {
-                return Err(invalid_replay(
-                    "Anthropic replay projection found tool results without preceding tool use",
-                ));
-            };
-            validate_tool_results("Anthropic", pending, results)?;
             let results = results
                 .iter()
-                .map(project_anthropic_tool_result)
+                .enumerate()
+                .map(|(result_index, result)| {
+                    project_anthropic_tool_result(
+                        &mut replay_application,
+                        message_index,
+                        meerkat_core::ReplayToolResultIndex(result_index),
+                        result,
+                    )
+                })
                 .collect::<Result<Vec<_>, _>>()?;
             projected.push(Message::ToolResults {
                 results,
@@ -338,23 +419,25 @@ fn project_anthropic_replay_messages(messages: &[Message]) -> Result<Vec<Message
             continue;
         }
 
-        if pending_tool_ids.is_some() {
-            return Err(invalid_replay(
-                "Anthropic replay projection found a tool use without adjacent tool results",
-            ));
-        }
-
         let next_message = match message {
             Message::System(_) | Message::SystemNotice(_) => Some(message.clone()),
             Message::User(user) => Some(Message::User(meerkat_core::UserMessage {
-                content: project_anthropic_content_blocks(&user.content),
+                content: project_anthropic_content_blocks(
+                    &mut replay_application,
+                    message_index,
+                    &user.content,
+                )?,
                 render_metadata: user.render_metadata.clone(),
                 identity: user.identity.clone(),
                 transcript_role: user.transcript_role,
                 created_at: user.created_at,
             })),
             Message::BlockAssistant(assistant) => {
-                let blocks = project_anthropic_assistant_blocks(&assistant.blocks);
+                let blocks = project_anthropic_assistant_blocks(
+                    &mut replay_application,
+                    message_index,
+                    &assistant.blocks,
+                )?;
                 if blocks.is_empty() {
                     None
                 } else {
@@ -370,20 +453,13 @@ fn project_anthropic_replay_messages(messages: &[Message]) -> Result<Vec<Message
         };
 
         if let Some(message) = next_message {
-            let tool_ids = tool_ids_from_assistant(&message);
-            if !tool_ids.is_empty() {
-                pending_tool_ids = Some(tool_ids);
-            }
             projected.push(message);
         }
     }
 
-    if pending_tool_ids.is_some() {
-        return Err(invalid_replay(
-            "Anthropic replay projection found a trailing tool use without tool results",
-        ));
-    }
-
+    replay_plan
+        .validate_projected(messages, &projected, replay_application)
+        .map_err(|error| invalid_replay(error.to_string()))?;
     Ok(projected)
 }
 
@@ -2431,6 +2507,15 @@ mod tests {
                         text: "unsigned plan".to_string(),
                         meta: None,
                     },
+                    AssistantBlock::Reasoning {
+                        text: "foreign plan".to_string(),
+                        meta: Some(Box::new(ProviderMeta::OpenAi {
+                            id: "reasoning_1".to_string(),
+                            encrypted_content: Some("encrypted".to_string()),
+                            phase: None,
+                            response_id: None,
+                        })),
+                    },
                     AssistantBlock::ServerToolContent {
                         id: Some("srv_1".to_string()),
                         kind: ServerToolKind::WebSearch,
@@ -2478,6 +2563,10 @@ mod tests {
                 ],
                 false,
             )]),
+            Message::SystemNotice(SystemNoticeMessage::new(
+                meerkat_core::SystemNoticeKind::Generic,
+                "control intent",
+            )),
         ];
 
         let projected = client.project_replay_messages(&messages)?;
@@ -2521,6 +2610,10 @@ mod tests {
             block,
             AssistantBlock::Reasoning { text, .. } if text == "unsigned plan"
         )));
+        assert!(!assistant.blocks.iter().any(|block| matches!(
+            block,
+            AssistantBlock::Reasoning { text, .. } if text == "foreign plan"
+        )));
         assert!(assistant.blocks.iter().any(|block| matches!(
             block,
             AssistantBlock::ServerToolContent { content, .. }
@@ -2546,6 +2639,7 @@ mod tests {
             results[0].has_images(),
             "Anthropic should retain inline image tool results"
         );
+        assert!(matches!(projected[3], Message::SystemNotice(_)));
         Ok(())
     }
 
@@ -4597,5 +4691,96 @@ mod tests {
             "web_search should not be a top-level body key"
         );
         Ok(())
+    }
+
+    #[test]
+    fn replay_projection_rejects_duplicate_tool_use_ids() {
+        let client = AnthropicClient::new("test-key".to_string())
+            .unwrap_or_else(|error| panic!("client: {error}"));
+        let args = serde_json::value::RawValue::from_string("{}".to_string())
+            .unwrap_or_else(|error| panic!("test args: {error}"));
+        let messages = [
+            Message::BlockAssistant(BlockAssistantMessage::new(
+                vec![
+                    AssistantBlock::ToolUse {
+                        id: "duplicate".to_string(),
+                        name: "a".to_string(),
+                        args: args.clone(),
+                        meta: None,
+                    },
+                    AssistantBlock::ToolUse {
+                        id: "duplicate".to_string(),
+                        name: "b".to_string(),
+                        args,
+                        meta: None,
+                    },
+                ],
+                StopReason::ToolUse,
+            )),
+            Message::tool_results(vec![ToolResult::new(
+                "duplicate".to_string(),
+                "result".to_string(),
+                false,
+            )]),
+        ];
+        assert!(matches!(
+            client.project_replay_messages(&messages),
+            Err(LlmError::InvalidRequest { .. })
+        ));
+    }
+
+    #[test]
+    fn replay_projection_rejects_duplicate_tool_result_ids() {
+        let client = AnthropicClient::new("test-key".to_string())
+            .unwrap_or_else(|error| panic!("client: {error}"));
+        let args = serde_json::value::RawValue::from_string("{}".to_string())
+            .unwrap_or_else(|error| panic!("test args: {error}"));
+        let messages = [
+            Message::BlockAssistant(BlockAssistantMessage::new(
+                vec![AssistantBlock::ToolUse {
+                    id: "tool".to_string(),
+                    name: "a".to_string(),
+                    args,
+                    meta: None,
+                }],
+                StopReason::ToolUse,
+            )),
+            Message::tool_results(vec![
+                ToolResult::new("tool".to_string(), "first".to_string(), false),
+                ToolResult::new("tool".to_string(), "second".to_string(), false),
+            ]),
+        ];
+        assert!(matches!(
+            client.project_replay_messages(&messages),
+            Err(LlmError::InvalidRequest { .. })
+        ));
+    }
+
+    #[test]
+    fn replay_projection_rejects_mismatched_tool_result_id() {
+        let client = AnthropicClient::new("test-key".to_string())
+            .unwrap_or_else(|error| panic!("client: {error}"));
+        let args = serde_json::value::RawValue::from_string("{}".to_string())
+            .unwrap_or_else(|error| panic!("test args: {error}"));
+        let messages = [
+            Message::BlockAssistant(BlockAssistantMessage::new(
+                vec![AssistantBlock::ToolUse {
+                    id: "tool".to_string(),
+                    name: "a".to_string(),
+                    args,
+                    meta: None,
+                }],
+                StopReason::ToolUse,
+            )),
+            Message::tool_results(vec![ToolResult::new(
+                "other".to_string(),
+                "result".to_string(),
+                false,
+            )]),
+        ];
+        assert!(matches!(
+            client.project_replay_messages(&messages),
+            Err(LlmError::InvalidRequest { .. })
+        ));
     }
 }

--- a/meerkat-anthropic/src/client.rs
+++ b/meerkat-anthropic/src/client.rs
@@ -2245,7 +2245,7 @@ mod tests {
         ImageData, MediaType, ProviderImageMetadata, ProviderMeta, RevisedPromptDisposition,
         SystemMessage, ToolResult, UserMessage,
     };
-    use std::sync::Arc;
+    use std::sync::{Arc, Mutex};
 
     fn assistant_image_block() -> AssistantBlock {
         AssistantBlock::Image {
@@ -3777,7 +3777,9 @@ mod tests {
     // SSE stream regression tests
     // =========================================================================
 
-    use axum::{Router, extract::State, http::StatusCode, response::IntoResponse, routing::post};
+    use axum::{
+        Json, Router, extract::State, http::StatusCode, response::IntoResponse, routing::post,
+    };
     use tokio::net::TcpListener;
 
     async fn messages_sse(State(payload): State<String>) -> impl IntoResponse {
@@ -3796,6 +3798,46 @@ mod tests {
             axum::serve(listener, app).await.expect("serve test server");
         });
         (format!("http://{addr}"), handle)
+    }
+
+    #[derive(Clone)]
+    struct AnthropicReplayCaptureState {
+        payload: String,
+        request_bodies: Arc<Mutex<Vec<Value>>>,
+    }
+
+    async fn anthropic_replay_capture(
+        State(state): State<AnthropicReplayCaptureState>,
+        Json(body): Json<Value>,
+    ) -> impl IntoResponse {
+        state
+            .request_bodies
+            .lock()
+            .expect("request body capture lock")
+            .push(body);
+        ([("content-type", "text/event-stream")], state.payload)
+    }
+
+    async fn spawn_anthropic_replay_capture_server(
+        payload: String,
+    ) -> (String, Arc<Mutex<Vec<Value>>>, tokio::task::JoinHandle<()>) {
+        let request_bodies = Arc::new(Mutex::new(Vec::new()));
+        let app = Router::new()
+            .route("/v1/messages", post(anthropic_replay_capture))
+            .with_state(AnthropicReplayCaptureState {
+                payload,
+                request_bodies: Arc::clone(&request_bodies),
+            });
+        let listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind replay capture server");
+        let addr = listener.local_addr().expect("local addr");
+        let handle = tokio::spawn(async move {
+            axum::serve(listener, app)
+                .await
+                .expect("serve replay capture server");
+        });
+        (format!("http://{addr}"), request_bodies, handle)
     }
 
     #[derive(Clone)]
@@ -4666,6 +4708,53 @@ mod tests {
             "web_search should not be a top-level body key"
         );
         Ok(())
+    }
+
+    #[tokio::test]
+    async fn stream_dispatch_projects_canonical_replay_into_captured_request() {
+        let payload = [
+            r#"data: {"type":"message_start","message":{"usage":{"input_tokens":1,"output_tokens":0}}}"#,
+            r#"data: {"type":"message_delta","usage":{"output_tokens":1},"delta":{"stop_reason":"end_turn"}}"#,
+            r#"data: {"type":"message_stop"}"#,
+            "",
+        ]
+        .join("\n");
+        let (base_url, request_bodies, server) =
+            spawn_anthropic_replay_capture_server(payload).await;
+        let client = AnthropicClient::builder("test-key".to_string())
+            .base_url(base_url)
+            .build()
+            .expect("client");
+        let request = LlmRequest::new(
+            "claude-sonnet-4-5",
+            vec![
+                Message::User(UserMessage::text("listen")),
+                Message::BlockAssistant(BlockAssistantMessage::new(
+                    vec![AssistantBlock::Transcript {
+                        text: "spoken replay".to_string(),
+                        source: meerkat_core::TranscriptSource::Spoken,
+                        meta: None,
+                    }],
+                    StopReason::EndTurn,
+                )),
+                Message::User(UserMessage::text("continue")),
+            ],
+        );
+
+        let events = client.stream(&request).collect::<Vec<_>>().await;
+        assert!(events.iter().all(Result::is_ok));
+        let bodies = request_bodies.lock().expect("request body capture lock");
+        assert_eq!(bodies.len(), 1);
+        let messages = bodies[0]["messages"].as_array().expect("messages array");
+        let assistant = messages
+            .iter()
+            .find(|message| message["role"] == "assistant")
+            .expect("projected assistant message");
+        assert_eq!(
+            assistant["content"][0],
+            serde_json::json!({"type": "text", "text": "spoken replay"})
+        );
+        server.abort();
     }
 
     #[test]

--- a/meerkat-copilot/src/runtime.rs
+++ b/meerkat-copilot/src/runtime.rs
@@ -453,6 +453,7 @@ pub struct CopilotChatCompletionsClientSpec {
     supports_temperature: bool,
     supports_thinking: bool,
     supports_reasoning: bool,
+    supports_image_input: bool,
     supports_image_tool_results: bool,
 }
 
@@ -476,8 +477,20 @@ impl CopilotChatCompletionsClientSpec {
             supports_temperature,
             supports_thinking,
             supports_reasoning,
+            supports_image_input: false,
             supports_image_tool_results,
         }
+    }
+
+    #[must_use]
+    pub fn with_image_input_support(mut self, supports_image_input: bool) -> Self {
+        self.supports_image_input = supports_image_input;
+        self
+    }
+
+    #[must_use]
+    pub const fn supports_image_input(&self) -> bool {
+        self.supports_image_input
     }
 
     #[allow(clippy::type_complexity)]

--- a/meerkat-copilot/src/runtime.rs
+++ b/meerkat-copilot/src/runtime.rs
@@ -477,7 +477,7 @@ impl CopilotChatCompletionsClientSpec {
             supports_temperature,
             supports_thinking,
             supports_reasoning,
-            supports_image_input: false,
+            supports_image_input: true,
             supports_image_tool_results,
         }
     }
@@ -2049,6 +2049,39 @@ mod tests {
     };
     use meerkat_llm_core::provider_runtime::ProviderRuntimeCatalog;
     use std::collections::VecDeque;
+
+    struct SpecAuthorizer;
+
+    #[async_trait]
+    impl HttpAuthorizer for SpecAuthorizer {
+        async fn authorize(
+            &self,
+            _request: &mut HttpAuthorizationRequest<'_>,
+        ) -> Result<(), AuthError> {
+            Ok(())
+        }
+
+        fn label(&self) -> &'static str {
+            "copilot-spec-test"
+        }
+    }
+
+    #[test]
+    fn chat_completions_spec_constructor_preserves_historical_image_input_support() {
+        let spec = CopilotChatCompletionsClientSpec::new(
+            Provider::OpenAI,
+            "model".to_string(),
+            "https://example.test".to_string(),
+            Arc::new(SpecAuthorizer),
+            true,
+            true,
+            true,
+            false,
+        );
+
+        assert!(spec.supports_image_input());
+        assert!(!spec.with_image_input_support(false).supports_image_input());
+    }
 
     fn account_identity() -> AuthCredentialIdentity {
         AuthCredentialIdentity::Account(CredentialAccountRef {

--- a/meerkat-core/src/lib.rs
+++ b/meerkat-core/src/lib.rs
@@ -97,6 +97,7 @@ pub mod tool_consequence_policy;
 pub mod tool_execution;
 pub mod tool_execution_policy;
 pub mod tool_scope;
+pub mod transcript_replay;
 pub mod turn_boundary;
 pub mod turn_execution_authority;
 pub mod turn_terminal;
@@ -498,6 +499,12 @@ pub use tool_scope::{
     ExternalToolSurfaceStagedOp, GeneratedToolVisibilityOwner, LocalToolVisibilityOwner,
     ToolFilter, ToolScope, ToolScopeApplyError, ToolScopeHandle, ToolScopeRevision,
     ToolScopeSnapshot, ToolScopeStageError, ToolVisibilityOwner,
+};
+pub use transcript_replay::{
+    ReplayApplication, ReplayAssistantBlockIndex, ReplayCapability, ReplayDisposition,
+    ReplayMessageIndex, ReplayPlan, ReplayPlanEntry, ReplayPlanError, ReplaySubject, ReplayTarget,
+    ReplayToolResultContentIndex, ReplayToolResultIndex, ReplayUserContentIndex, ReplayWireFamily,
+    replay_provider_metadata,
 };
 pub use turn_boundary::{TurnBoundaryHook, TurnBoundaryMessage};
 pub use turn_execution_authority::{

--- a/meerkat-core/src/lib.rs
+++ b/meerkat-core/src/lib.rs
@@ -502,9 +502,10 @@ pub use tool_scope::{
 };
 pub use transcript_replay::{
     ReplayApplication, ReplayAssistantBlockIndex, ReplayCapability, ReplayDisposition,
-    ReplayMessageIndex, ReplayPlan, ReplayPlanEntry, ReplayPlanError, ReplaySubject, ReplayTarget,
-    ReplayToolResultContentIndex, ReplayToolResultIndex, ReplayUserContentIndex, ReplayWireFamily,
-    replay_provider_metadata,
+    ReplayMessageIndex, ReplayPlan, ReplayPlanEntry, ReplayPlanError, ReplayReasoningProjection,
+    ReplaySubject, ReplaySystemNoticeBlockIndex, ReplaySystemNoticeContentIndex, ReplayTarget,
+    ReplayToolResultContentIndex, ReplayToolResultIndex, ReplayToolResultProjection,
+    ReplayUserContentIndex, ReplayWireFamily, replay_provider_metadata,
 };
 pub use turn_boundary::{TurnBoundaryHook, TurnBoundaryMessage};
 pub use turn_execution_authority::{

--- a/meerkat-core/src/transcript_replay.rs
+++ b/meerkat-core/src/transcript_replay.rs
@@ -1,0 +1,727 @@
+//! Provider-neutral replay planning and verified adapter lowering.
+
+use crate::{AssistantBlock, ContentBlock, Message, ProviderMeta};
+use std::collections::HashSet;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct ReplayMessageIndex(pub usize);
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct ReplayAssistantBlockIndex(pub usize);
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct ReplayUserContentIndex(pub usize);
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct ReplayToolResultIndex(pub usize);
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct ReplayToolResultContentIndex(pub usize);
+
+/// The provider wire grammar that receives replay, independently of account
+/// provider identity. Self-hosted and Copilot OpenAI-compatible endpoints use
+/// [`Self::OpenAi`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ReplayWireFamily {
+    Anthropic,
+    OpenAi,
+    Gemini,
+}
+
+impl ReplayWireFamily {
+    #[must_use]
+    pub const fn from_provider_metadata(metadata: &ProviderMeta) -> Self {
+        match metadata {
+            ProviderMeta::Anthropic { .. }
+            | ProviderMeta::AnthropicRedacted { .. }
+            | ProviderMeta::AnthropicCompaction { .. } => Self::Anthropic,
+            ProviderMeta::Gemini { .. } => Self::Gemini,
+            ProviderMeta::OpenAi { .. } | ProviderMeta::OpenAiResponse { .. } => Self::OpenAi,
+        }
+    }
+
+    /// Remove continuity metadata that was issued by a different wire family.
+    #[must_use]
+    pub fn strip_foreign_metadata(self, mut block: AssistantBlock) -> AssistantBlock {
+        if replay_provider_metadata(&block)
+            .is_some_and(|metadata| Self::from_provider_metadata(metadata) != self)
+        {
+            match &mut block {
+                AssistantBlock::Text { meta, .. }
+                | AssistantBlock::Transcript { meta, .. }
+                | AssistantBlock::Reasoning { meta, .. }
+                | AssistantBlock::ToolUse { meta, .. }
+                | AssistantBlock::ServerToolContent { meta, .. } => *meta = None,
+                AssistantBlock::Image { .. } => {}
+            }
+        }
+        block
+    }
+}
+
+/// Read provider continuity metadata from an assistant block.
+#[must_use]
+pub fn replay_provider_metadata(block: &AssistantBlock) -> Option<&ProviderMeta> {
+    match block {
+        AssistantBlock::Text { meta, .. }
+        | AssistantBlock::Transcript { meta, .. }
+        | AssistantBlock::Reasoning { meta, .. }
+        | AssistantBlock::ToolUse { meta, .. }
+        | AssistantBlock::ServerToolContent { meta, .. } => meta.as_deref(),
+        AssistantBlock::Image { .. } => None,
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum ReplaySubject {
+    Message(ReplayMessageIndex),
+    AssistantBlock {
+        message: ReplayMessageIndex,
+        block: ReplayAssistantBlockIndex,
+    },
+    UserContent {
+        message: ReplayMessageIndex,
+        block: ReplayUserContentIndex,
+    },
+    ToolResultContent {
+        message: ReplayMessageIndex,
+        result: ReplayToolResultIndex,
+        block: ReplayToolResultContentIndex,
+    },
+    ProviderMetadata {
+        message: ReplayMessageIndex,
+        block: ReplayAssistantBlockIndex,
+    },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ReplayCapability {
+    ToolResultVideo,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ReplayDisposition {
+    Preserve,
+    LowerToText,
+    Omit,
+    /// The provider adapter owns wire-specific replay legality.
+    ProviderNative,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ReplayPlanEntry {
+    pub subject: ReplaySubject,
+    pub disposition: ReplayDisposition,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ReplayTarget {
+    pub wire_family: ReplayWireFamily,
+    pub image_input: bool,
+    pub inline_video: bool,
+    pub image_tool_results: bool,
+}
+
+impl ReplayTarget {
+    #[must_use]
+    pub const fn new(
+        wire_family: ReplayWireFamily,
+        image_input: bool,
+        inline_video: bool,
+        image_tool_results: bool,
+    ) -> Self {
+        Self {
+            wire_family,
+            image_input,
+            inline_video,
+            image_tool_results,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum ReplayPlanError {
+    #[error("replay application expected {expected:?}, received {actual:?}")]
+    UnexpectedSubject {
+        expected: Option<ReplaySubject>,
+        actual: ReplaySubject,
+    },
+    #[error("replay projection does not satisfy {disposition:?} for {subject:?}")]
+    ProjectionMismatch {
+        subject: ReplaySubject,
+        disposition: ReplayDisposition,
+    },
+    #[error("replay projection changed or omitted an ordered system message")]
+    PreservedSystemMessageMismatch,
+    #[error(
+        "replay application ended before its complete plan was consumed; next subject is {next:?}"
+    )]
+    IncompleteApplication { next: ReplaySubject },
+    #[error("tool results at message {message:?} have no immediately preceding tool use")]
+    ToolResultsWithoutToolUse { message: ReplayMessageIndex },
+    #[error("tool uses at message {message:?} have no immediately adjacent tool results")]
+    ToolUseWithoutToolResults { message: ReplayMessageIndex },
+    #[error("tool results at message {message:?} do not exactly match the preceding tool uses")]
+    ToolResultMismatch { message: ReplayMessageIndex },
+    #[error("tool uses at message {message:?} reuse a tool-use ID")]
+    DuplicateToolUseId { message: ReplayMessageIndex },
+    #[error("tool results at message {message:?} reuse a tool-result ID")]
+    DuplicateToolResultId { message: ReplayMessageIndex },
+    #[error("replay subject {subject:?} requires unsupported capability {capability:?}")]
+    UnsupportedCapability {
+        subject: ReplaySubject,
+        capability: ReplayCapability,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ReplayPlan {
+    target: ReplayTarget,
+    entries: Vec<ReplayPlanEntry>,
+}
+
+/// O(1) ordered replay-plan verifier. Adapters pass the source and their
+/// concrete projected output to the typed record methods; labels cannot be
+/// self-attested.
+pub struct ReplayApplication<'a> {
+    plan: &'a ReplayPlan,
+    cursor: usize,
+}
+
+impl ReplayApplication<'_> {
+    pub fn next(&self, subject: ReplaySubject) -> Result<ReplayDisposition, ReplayPlanError> {
+        let expected = self.plan.entries.get(self.cursor);
+        if expected.map(|entry| entry.subject) != Some(subject) {
+            return Err(ReplayPlanError::UnexpectedSubject {
+                expected: expected.map(|entry| entry.subject),
+                actual: subject,
+            });
+        }
+        Ok(expected
+            .map(|entry| entry.disposition)
+            .unwrap_or(ReplayDisposition::Omit))
+    }
+
+    fn consume(&mut self, subject: ReplaySubject) -> Result<ReplayDisposition, ReplayPlanError> {
+        let disposition = self.next(subject)?;
+        self.cursor += 1;
+        Ok(disposition)
+    }
+
+    pub fn record_message(
+        &mut self,
+        subject: ReplaySubject,
+        source: &Message,
+        projected: Option<&Message>,
+    ) -> Result<(), ReplayPlanError> {
+        let disposition = self.consume(subject)?;
+        if matches!(disposition, ReplayDisposition::Preserve) && projected != Some(source) {
+            return Err(ReplayPlanError::ProjectionMismatch {
+                subject,
+                disposition,
+            });
+        }
+        Ok(())
+    }
+
+    pub fn record_content(
+        &mut self,
+        subject: ReplaySubject,
+        source: &ContentBlock,
+        projected: &ContentBlock,
+    ) -> Result<(), ReplayPlanError> {
+        let disposition = self.consume(subject)?;
+        let valid = match disposition {
+            ReplayDisposition::Preserve => projected == source,
+            ReplayDisposition::LowerToText => is_text_projection(source, projected),
+            ReplayDisposition::ProviderNative | ReplayDisposition::Omit => false,
+        };
+        if valid {
+            Ok(())
+        } else {
+            Err(ReplayPlanError::ProjectionMismatch {
+                subject,
+                disposition,
+            })
+        }
+    }
+
+    pub fn record_assistant(
+        &mut self,
+        subject: ReplaySubject,
+        source: &AssistantBlock,
+        projected: Option<&AssistantBlock>,
+    ) -> Result<(), ReplayPlanError> {
+        let disposition = self.consume(subject)?;
+        if assistant_meta(source).is_none() && projected.and_then(assistant_meta).is_some() {
+            return Err(ReplayPlanError::ProjectionMismatch {
+                subject,
+                disposition,
+            });
+        }
+        let valid = match disposition {
+            ReplayDisposition::Preserve => assistant_payload_eq(source, projected),
+            ReplayDisposition::LowerToText => projected.is_some_and(|block| {
+                matches!(block, AssistantBlock::Text { text, meta: None } if *text == source_text_projection(source))
+            }),
+            ReplayDisposition::Omit => projected.is_none(),
+            ReplayDisposition::ProviderNative => native_assistant_outcome(source, projected),
+        };
+        if valid {
+            Ok(())
+        } else {
+            Err(ReplayPlanError::ProjectionMismatch {
+                subject,
+                disposition,
+            })
+        }
+    }
+
+    pub fn record_provider_metadata(
+        &mut self,
+        subject: ReplaySubject,
+        source: &ProviderMeta,
+        source_block: &AssistantBlock,
+        projected: Option<&AssistantBlock>,
+    ) -> Result<(), ReplayPlanError> {
+        let disposition = self.consume(subject)?;
+        let valid = match disposition {
+            ReplayDisposition::Omit => projected.and_then(assistant_meta).is_none(),
+            ReplayDisposition::ProviderNative => {
+                if assistant_payload_eq(source_block, projected) {
+                    projected.and_then(assistant_meta) == Some(source)
+                } else {
+                    projected.and_then(assistant_meta).is_none()
+                }
+            }
+            ReplayDisposition::Preserve | ReplayDisposition::LowerToText => false,
+        };
+        if valid {
+            Ok(())
+        } else {
+            Err(ReplayPlanError::ProjectionMismatch {
+                subject,
+                disposition,
+            })
+        }
+    }
+
+    pub fn finish(self) -> Result<(), ReplayPlanError> {
+        self.plan
+            .entries
+            .get(self.cursor)
+            .map(|entry| ReplayPlanError::IncompleteApplication {
+                next: entry.subject,
+            })
+            .map_or(Ok(()), Err)
+    }
+}
+
+impl ReplayPlan {
+    pub fn build(messages: &[Message], target: ReplayTarget) -> Result<Self, ReplayPlanError> {
+        validate_source_tool_adjacency(messages)?;
+        let mut entries = Vec::new();
+        for (message_index, message) in messages.iter().enumerate() {
+            let index = ReplayMessageIndex(message_index);
+            entries.push(ReplayPlanEntry {
+                subject: ReplaySubject::Message(index),
+                disposition: match message {
+                    Message::System(_) | Message::SystemNotice(_) => ReplayDisposition::Preserve,
+                    _ => ReplayDisposition::ProviderNative,
+                },
+            });
+            match message {
+                Message::User(user) => {
+                    for (block, content) in user.content.iter().enumerate() {
+                        entries.push(ReplayPlanEntry {
+                            subject: ReplaySubject::UserContent {
+                                message: index,
+                                block: ReplayUserContentIndex(block),
+                            },
+                            disposition: content_disposition(content, target, false),
+                        });
+                    }
+                }
+                Message::BlockAssistant(assistant) => {
+                    for (block, assistant) in assistant.blocks.iter().enumerate() {
+                        let block_index = ReplayAssistantBlockIndex(block);
+                        entries.push(ReplayPlanEntry {
+                            subject: ReplaySubject::AssistantBlock {
+                                message: index,
+                                block: block_index,
+                            },
+                            disposition: assistant_disposition(assistant),
+                        });
+                        if let Some(meta) = assistant_meta(assistant) {
+                            entries.push(ReplayPlanEntry {
+                                subject: ReplaySubject::ProviderMetadata {
+                                    message: index,
+                                    block: block_index,
+                                },
+                                disposition: if ReplayWireFamily::from_provider_metadata(meta)
+                                    == target.wire_family
+                                {
+                                    ReplayDisposition::ProviderNative
+                                } else {
+                                    ReplayDisposition::Omit
+                                },
+                            });
+                        }
+                    }
+                }
+                Message::ToolResults { results, .. } => {
+                    for (result, tool_result) in results.iter().enumerate() {
+                        for (block, content) in tool_result.content.iter().enumerate() {
+                            let subject = ReplaySubject::ToolResultContent {
+                                message: index,
+                                result: ReplayToolResultIndex(result),
+                                block: ReplayToolResultContentIndex(block),
+                            };
+                            if matches!(content, ContentBlock::Video { .. }) {
+                                return Err(ReplayPlanError::UnsupportedCapability {
+                                    subject,
+                                    capability: ReplayCapability::ToolResultVideo,
+                                });
+                            }
+                            entries.push(ReplayPlanEntry {
+                                subject,
+                                disposition: content_disposition(content, target, true),
+                            });
+                        }
+                    }
+                }
+                Message::System(_) | Message::SystemNotice(_) => {}
+            }
+        }
+        Ok(Self { target, entries })
+    }
+
+    #[must_use]
+    pub const fn target(&self) -> ReplayTarget {
+        self.target
+    }
+
+    pub fn entries(&self) -> impl ExactSizeIterator<Item = &ReplayPlanEntry> {
+        self.entries.iter()
+    }
+
+    #[must_use]
+    pub const fn application(&self) -> ReplayApplication<'_> {
+        ReplayApplication {
+            plan: self,
+            cursor: 0,
+        }
+    }
+
+    pub fn validate_projected(
+        &self,
+        source: &[Message],
+        projected: &[Message],
+        application: ReplayApplication<'_>,
+    ) -> Result<(), ReplayPlanError> {
+        application.finish()?;
+        let source_system = source
+            .iter()
+            .filter(|message| matches!(message, Message::System(_) | Message::SystemNotice(_)));
+        let projected_system = projected
+            .iter()
+            .filter(|message| matches!(message, Message::System(_) | Message::SystemNotice(_)));
+        if !source_system.eq(projected_system) {
+            return Err(ReplayPlanError::PreservedSystemMessageMismatch);
+        }
+        validate_tool_adjacency(projected)
+    }
+}
+
+fn assistant_disposition(block: &AssistantBlock) -> ReplayDisposition {
+    match block {
+        AssistantBlock::Text { text, .. } if text.is_empty() => ReplayDisposition::Omit,
+        AssistantBlock::Text { .. } | AssistantBlock::ToolUse { .. } => ReplayDisposition::Preserve,
+        AssistantBlock::Transcript { text, .. } if text.is_empty() => ReplayDisposition::Omit,
+        AssistantBlock::Transcript { .. } => ReplayDisposition::LowerToText,
+        AssistantBlock::Reasoning { .. } | AssistantBlock::ServerToolContent { .. } => {
+            ReplayDisposition::ProviderNative
+        }
+        AssistantBlock::Image { .. } => ReplayDisposition::Omit,
+    }
+}
+
+fn content_disposition(
+    block: &ContentBlock,
+    target: ReplayTarget,
+    tool_result: bool,
+) -> ReplayDisposition {
+    match block {
+        ContentBlock::Text { .. } => ReplayDisposition::Preserve,
+        ContentBlock::Structured { .. } | ContentBlock::SkillContext { .. } => {
+            ReplayDisposition::LowerToText
+        }
+        ContentBlock::Image { data, .. } => match data {
+            crate::ImageData::Blob { .. } => ReplayDisposition::LowerToText,
+            crate::ImageData::Inline { .. } if tool_result && !target.image_tool_results => {
+                ReplayDisposition::LowerToText
+            }
+            crate::ImageData::Inline { .. } if !tool_result && !target.image_input => {
+                ReplayDisposition::LowerToText
+            }
+            crate::ImageData::Inline { .. } => ReplayDisposition::Preserve,
+        },
+        ContentBlock::Video { .. } if target.inline_video => ReplayDisposition::Preserve,
+        ContentBlock::Video { .. } => ReplayDisposition::LowerToText,
+    }
+}
+
+fn assistant_meta(block: &AssistantBlock) -> Option<&ProviderMeta> {
+    replay_provider_metadata(block)
+}
+
+fn is_text_projection(source: &ContentBlock, projected: &ContentBlock) -> bool {
+    matches!(projected, ContentBlock::Text { text } if *text == source.text_projection())
+}
+
+fn source_text_projection(source: &AssistantBlock) -> String {
+    match source {
+        AssistantBlock::Transcript { text, .. } => text.clone(),
+        _ => String::new(),
+    }
+}
+
+fn assistant_payload_eq(source: &AssistantBlock, projected: Option<&AssistantBlock>) -> bool {
+    let Some(projected) = projected else {
+        return false;
+    };
+    match (source, projected) {
+        (AssistantBlock::Text { text: left, .. }, AssistantBlock::Text { text: right, .. })
+        | (
+            AssistantBlock::Transcript { text: left, .. },
+            AssistantBlock::Transcript { text: right, .. },
+        )
+        | (
+            AssistantBlock::Reasoning { text: left, .. },
+            AssistantBlock::Reasoning { text: right, .. },
+        ) => left == right,
+        (
+            AssistantBlock::ToolUse {
+                id: left_id,
+                name: left_name,
+                args: left_args,
+                ..
+            },
+            AssistantBlock::ToolUse {
+                id: right_id,
+                name: right_name,
+                args: right_args,
+                ..
+            },
+        ) => left_id == right_id && left_name == right_name && left_args.get() == right_args.get(),
+        (
+            AssistantBlock::ServerToolContent {
+                id: left_id,
+                kind: left_kind,
+                content: left_content,
+                ..
+            },
+            AssistantBlock::ServerToolContent {
+                id: right_id,
+                kind: right_kind,
+                content: right_content,
+                ..
+            },
+        ) => left_id == right_id && left_kind == right_kind && left_content == right_content,
+        (AssistantBlock::Image { .. }, AssistantBlock::Image { .. }) => source == projected,
+        _ => false,
+    }
+}
+
+fn native_assistant_outcome(source: &AssistantBlock, projected: Option<&AssistantBlock>) -> bool {
+    projected.is_none()
+        || assistant_payload_eq(source, projected)
+        || matches!(
+            (source, projected),
+            (
+                AssistantBlock::Reasoning { .. },
+                Some(AssistantBlock::Text { meta: None, .. })
+            )
+        )
+}
+
+fn tool_use_ids(message: &Message) -> Vec<&str> {
+    match message {
+        Message::BlockAssistant(assistant) => assistant
+            .blocks
+            .iter()
+            .filter_map(|block| match block {
+                AssistantBlock::ToolUse { id, .. } => Some(id.as_str()),
+                _ => None,
+            })
+            .collect(),
+        _ => Vec::new(),
+    }
+}
+
+fn has_duplicate_ids(ids: &[&str]) -> bool {
+    let mut seen = HashSet::with_capacity(ids.len());
+    ids.iter().any(|id| !seen.insert(*id))
+}
+
+fn validate_tool_adjacency(messages: &[Message]) -> Result<(), ReplayPlanError> {
+    validate_adjacency(messages, false)
+}
+
+fn validate_source_tool_adjacency(messages: &[Message]) -> Result<(), ReplayPlanError> {
+    validate_adjacency(messages, true)
+}
+
+fn validate_adjacency(messages: &[Message], allow_omitted: bool) -> Result<(), ReplayPlanError> {
+    let mut pending: Option<(ReplayMessageIndex, Vec<&str>)> = None;
+    for (index, message) in messages.iter().enumerate() {
+        let message_index = ReplayMessageIndex(index);
+        if allow_omitted && pending.is_some() && source_message_is_replay_omitted(message) {
+            continue;
+        }
+        if let Message::ToolResults { results, .. } = message {
+            let Some((_, expected)) = pending.take() else {
+                return Err(ReplayPlanError::ToolResultsWithoutToolUse {
+                    message: message_index,
+                });
+            };
+            let actual = results
+                .iter()
+                .map(|result| result.tool_use_id.as_str())
+                .collect::<Vec<_>>();
+            if has_duplicate_ids(&actual) {
+                return Err(ReplayPlanError::DuplicateToolResultId {
+                    message: message_index,
+                });
+            }
+            let expected = expected.into_iter().collect::<HashSet<_>>();
+            let actual = actual.into_iter().collect::<HashSet<_>>();
+            if actual != expected {
+                return Err(ReplayPlanError::ToolResultMismatch {
+                    message: message_index,
+                });
+            }
+            continue;
+        }
+        if let Some((message, _)) = pending {
+            return Err(ReplayPlanError::ToolUseWithoutToolResults { message });
+        }
+        let ids = tool_use_ids(message);
+        if has_duplicate_ids(&ids) {
+            return Err(ReplayPlanError::DuplicateToolUseId {
+                message: message_index,
+            });
+        }
+        if !ids.is_empty() {
+            pending = Some((message_index, ids));
+        }
+    }
+    pending
+        .map(|(message, _)| Err(ReplayPlanError::ToolUseWithoutToolResults { message }))
+        .unwrap_or(Ok(()))
+}
+
+fn source_message_is_replay_omitted(message: &Message) -> bool {
+    matches!(
+        message,
+        Message::BlockAssistant(assistant)
+            if assistant.blocks.iter().all(|block| matches!(
+                assistant_disposition(block),
+                ReplayDisposition::Omit | ReplayDisposition::ProviderNative
+            ))
+    )
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+mod tests {
+    use super::*;
+    use crate::{BlockAssistantMessage, StopReason, UserMessage};
+
+    #[test]
+    fn rejects_wrong_lowering_from_actual_projected_content() {
+        let source = ContentBlock::Structured {
+            data: serde_json::value::RawValue::from_string(r#"{"key":"value"}"#.to_string())
+                .unwrap_or_else(|error| panic!("test structured content: {error}")),
+        };
+        let messages = [Message::User(UserMessage::with_blocks(vec![
+            source.clone(),
+        ]))];
+        let plan = ReplayPlan::build(
+            &messages,
+            ReplayTarget::new(ReplayWireFamily::OpenAi, false, false, false),
+        )
+        .unwrap_or_else(|error| panic!("test replay plan: {error}"));
+        let mut application = plan.application();
+        application
+            .record_message(
+                ReplaySubject::Message(ReplayMessageIndex(0)),
+                &messages[0],
+                None,
+            )
+            .unwrap_or_else(|error| panic!("test message: {error}"));
+        assert!(matches!(
+            application.record_content(
+                ReplaySubject::UserContent {
+                    message: ReplayMessageIndex(0),
+                    block: ReplayUserContentIndex(0),
+                },
+                &source,
+                &source,
+            ),
+            Err(ReplayPlanError::ProjectionMismatch {
+                disposition: ReplayDisposition::LowerToText,
+                ..
+            })
+        ));
+    }
+
+    #[test]
+    fn rejects_leaked_foreign_provider_metadata() {
+        let metadata = ProviderMeta::OpenAiResponse {
+            response_id: "response".to_string(),
+        };
+        let block = AssistantBlock::Reasoning {
+            text: "thought".to_string(),
+            meta: Some(Box::new(metadata.clone())),
+        };
+        let messages = [Message::BlockAssistant(BlockAssistantMessage::new(
+            vec![block.clone()],
+            StopReason::EndTurn,
+        ))];
+        let plan = ReplayPlan::build(
+            &messages,
+            ReplayTarget::new(ReplayWireFamily::Anthropic, true, false, true),
+        )
+        .unwrap_or_else(|error| panic!("test replay plan: {error}"));
+        let mut application = plan.application();
+        application
+            .record_message(
+                ReplaySubject::Message(ReplayMessageIndex(0)),
+                &messages[0],
+                None,
+            )
+            .unwrap_or_else(|error| panic!("test message: {error}"));
+        application
+            .record_assistant(
+                ReplaySubject::AssistantBlock {
+                    message: ReplayMessageIndex(0),
+                    block: ReplayAssistantBlockIndex(0),
+                },
+                &block,
+                None,
+            )
+            .unwrap_or_else(|error| panic!("test assistant: {error}"));
+        assert!(matches!(
+            application.record_provider_metadata(
+                ReplaySubject::ProviderMetadata {
+                    message: ReplayMessageIndex(0),
+                    block: ReplayAssistantBlockIndex(0),
+                },
+                &metadata,
+                &block,
+                Some(&block),
+            ),
+            Err(ReplayPlanError::ProjectionMismatch {
+                disposition: ReplayDisposition::Omit,
+                ..
+            })
+        ));
+    }
+}

--- a/meerkat-core/src/transcript_replay.rs
+++ b/meerkat-core/src/transcript_replay.rs
@@ -1,6 +1,9 @@
 //! Provider-neutral replay planning and verified adapter lowering.
 
-use crate::{AssistantBlock, ContentBlock, Message, ProviderMeta};
+use crate::{
+    AssistantBlock, ContentBlock, Message, ProviderMeta, SystemNoticeBlock, SystemNoticeMessage,
+    ToolResult,
+};
 use std::collections::HashSet;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -13,6 +16,10 @@ pub struct ReplayUserContentIndex(pub usize);
 pub struct ReplayToolResultIndex(pub usize);
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ReplayToolResultContentIndex(pub usize);
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct ReplaySystemNoticeBlockIndex(pub usize);
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct ReplaySystemNoticeContentIndex(pub usize);
 
 /// The provider wire grammar that receives replay, independently of account
 /// provider identity. Self-hosted and Copilot OpenAI-compatible endpoints use
@@ -84,6 +91,15 @@ pub enum ReplaySubject {
         result: ReplayToolResultIndex,
         block: ReplayToolResultContentIndex,
     },
+    ToolResult {
+        message: ReplayMessageIndex,
+        result: ReplayToolResultIndex,
+    },
+    SystemNoticeContent {
+        message: ReplayMessageIndex,
+        notice_block: ReplaySystemNoticeBlockIndex,
+        content_block: ReplaySystemNoticeContentIndex,
+    },
     ProviderMetadata {
         message: ReplayMessageIndex,
         block: ReplayAssistantBlockIndex,
@@ -99,6 +115,7 @@ pub enum ReplayCapability {
 pub enum ReplayDisposition {
     Preserve,
     LowerToText,
+    CollapseToText,
     Omit,
     /// The provider adapter owns wire-specific replay legality.
     ProviderNative,
@@ -116,6 +133,21 @@ pub struct ReplayTarget {
     pub image_input: bool,
     pub inline_video: bool,
     pub image_tool_results: bool,
+    pub tool_result_projection: ReplayToolResultProjection,
+    pub reasoning_projection: ReplayReasoningProjection,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ReplayToolResultProjection {
+    PreserveBlocks,
+    CollapseToText,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ReplayReasoningProjection {
+    ProviderNative,
+    LowerToText,
+    Omit,
 }
 
 impl ReplayTarget {
@@ -125,12 +157,16 @@ impl ReplayTarget {
         image_input: bool,
         inline_video: bool,
         image_tool_results: bool,
+        tool_result_projection: ReplayToolResultProjection,
+        reasoning_projection: ReplayReasoningProjection,
     ) -> Self {
         Self {
             wire_family,
             image_input,
             inline_video,
             image_tool_results,
+            tool_result_projection,
+            reasoning_projection,
         }
     }
 }
@@ -230,7 +266,9 @@ impl ReplayApplication<'_> {
         let valid = match disposition {
             ReplayDisposition::Preserve => projected == source,
             ReplayDisposition::LowerToText => is_text_projection(source, projected),
-            ReplayDisposition::ProviderNative | ReplayDisposition::Omit => false,
+            ReplayDisposition::CollapseToText
+            | ReplayDisposition::ProviderNative
+            | ReplayDisposition::Omit => false,
         };
         if valid {
             Ok(())
@@ -240,6 +278,120 @@ impl ReplayApplication<'_> {
                 disposition,
             })
         }
+    }
+
+    /// Build and validate one complete tool result, including provider-required
+    /// collapse of multiple canonical blocks into one text payload.
+    pub fn project_tool_result(
+        &mut self,
+        message: ReplayMessageIndex,
+        result_index: ReplayToolResultIndex,
+        source: &ToolResult,
+    ) -> Result<ToolResult, ReplayPlanError> {
+        let mut projected_blocks = Vec::with_capacity(source.content.len());
+        for (block_index, block) in source.content.iter().enumerate() {
+            let subject = ReplaySubject::ToolResultContent {
+                message,
+                result: result_index,
+                block: ReplayToolResultContentIndex(block_index),
+            };
+            let projected = match self.next(subject)? {
+                ReplayDisposition::Preserve => block.clone(),
+                ReplayDisposition::LowerToText => ContentBlock::Text {
+                    text: block.text_projection().into_owned(),
+                },
+                disposition => {
+                    return Err(ReplayPlanError::ProjectionMismatch {
+                        subject,
+                        disposition,
+                    });
+                }
+            };
+            self.record_content(subject, block, &projected)?;
+            projected_blocks.push(projected);
+        }
+
+        let subject = ReplaySubject::ToolResult {
+            message,
+            result: result_index,
+        };
+        let disposition = self.consume(subject)?;
+        let content = match disposition {
+            ReplayDisposition::ProviderNative => projected_blocks,
+            ReplayDisposition::CollapseToText => {
+                ContentBlock::text_vec(crate::types::text_content(&projected_blocks))
+            }
+            _ => {
+                return Err(ReplayPlanError::ProjectionMismatch {
+                    subject,
+                    disposition,
+                });
+            }
+        };
+        Ok(ToolResult::with_blocks(
+            source.tool_use_id.clone(),
+            content,
+            source.is_error,
+        ))
+    }
+
+    pub fn project_system_notice(
+        &mut self,
+        message: ReplayMessageIndex,
+        notice: &SystemNoticeMessage,
+    ) -> Result<SystemNoticeMessage, ReplayPlanError> {
+        self.consume(ReplaySubject::Message(message))?;
+        let mut projected = notice.clone();
+        for (notice_block_index, (source_block, projected_block)) in notice
+            .blocks
+            .iter()
+            .zip(projected.blocks.iter_mut())
+            .enumerate()
+        {
+            let (source_content, projected_content) = match (source_block, projected_block) {
+                (
+                    SystemNoticeBlock::Comms {
+                        content: source, ..
+                    },
+                    SystemNoticeBlock::Comms {
+                        content: projected, ..
+                    },
+                )
+                | (
+                    SystemNoticeBlock::ExternalEvent {
+                        content: source, ..
+                    },
+                    SystemNoticeBlock::ExternalEvent {
+                        content: projected, ..
+                    },
+                ) => (source, projected),
+                _ => continue,
+            };
+            let mut next_content = Vec::with_capacity(source_content.len());
+            for (content_index, source) in source_content.iter().enumerate() {
+                let subject = ReplaySubject::SystemNoticeContent {
+                    message,
+                    notice_block: ReplaySystemNoticeBlockIndex(notice_block_index),
+                    content_block: ReplaySystemNoticeContentIndex(content_index),
+                };
+                let next = match self.next(subject)? {
+                    ReplayDisposition::Preserve => source.clone(),
+                    ReplayDisposition::LowerToText => ContentBlock::Text {
+                        text: source.text_projection().into_owned(),
+                    },
+                    disposition => {
+                        return Err(ReplayPlanError::ProjectionMismatch {
+                            subject,
+                            disposition,
+                        });
+                    }
+                };
+                self.record_content(subject, source, &next)?;
+                next_content.push(next);
+            }
+            *projected_content = next_content;
+        }
+        Ok(projected)
     }
 
     pub fn record_assistant(
@@ -260,6 +412,7 @@ impl ReplayApplication<'_> {
             ReplayDisposition::LowerToText => projected.is_some_and(|block| {
                 matches!(block, AssistantBlock::Text { text, meta: None } if *text == source_text_projection(source))
             }),
+            ReplayDisposition::CollapseToText => false,
             ReplayDisposition::Omit => projected.is_none(),
             ReplayDisposition::ProviderNative => native_assistant_outcome(source, projected),
         };
@@ -290,7 +443,9 @@ impl ReplayApplication<'_> {
                     projected.and_then(assistant_meta).is_none()
                 }
             }
-            ReplayDisposition::Preserve | ReplayDisposition::LowerToText => false,
+            ReplayDisposition::Preserve
+            | ReplayDisposition::LowerToText
+            | ReplayDisposition::CollapseToText => false,
         };
         if valid {
             Ok(())
@@ -315,14 +470,14 @@ impl ReplayApplication<'_> {
 
 impl ReplayPlan {
     pub fn build(messages: &[Message], target: ReplayTarget) -> Result<Self, ReplayPlanError> {
-        validate_source_tool_adjacency(messages)?;
         let mut entries = Vec::new();
         for (message_index, message) in messages.iter().enumerate() {
             let index = ReplayMessageIndex(message_index);
             entries.push(ReplayPlanEntry {
                 subject: ReplaySubject::Message(index),
                 disposition: match message {
-                    Message::System(_) | Message::SystemNotice(_) => ReplayDisposition::Preserve,
+                    Message::System(_) => ReplayDisposition::Preserve,
+                    Message::SystemNotice(_) => ReplayDisposition::ProviderNative,
                     _ => ReplayDisposition::ProviderNative,
                 },
             });
@@ -346,7 +501,7 @@ impl ReplayPlan {
                                 message: index,
                                 block: block_index,
                             },
-                            disposition: assistant_disposition(assistant),
+                            disposition: assistant_disposition(assistant, target),
                         });
                         if let Some(meta) = assistant_meta(assistant) {
                             entries.push(ReplayPlanEntry {
@@ -384,9 +539,42 @@ impl ReplayPlan {
                                 disposition: content_disposition(content, target, true),
                             });
                         }
+                        entries.push(ReplayPlanEntry {
+                            subject: ReplaySubject::ToolResult {
+                                message: index,
+                                result: ReplayToolResultIndex(result),
+                            },
+                            disposition: match target.tool_result_projection {
+                                ReplayToolResultProjection::PreserveBlocks => {
+                                    ReplayDisposition::ProviderNative
+                                }
+                                ReplayToolResultProjection::CollapseToText => {
+                                    ReplayDisposition::CollapseToText
+                                }
+                            },
+                        });
                     }
                 }
-                Message::System(_) | Message::SystemNotice(_) => {}
+                Message::SystemNotice(notice) => {
+                    for (notice_block, block) in notice.blocks.iter().enumerate() {
+                        let content = match block {
+                            SystemNoticeBlock::Comms { content, .. }
+                            | SystemNoticeBlock::ExternalEvent { content, .. } => content,
+                            _ => continue,
+                        };
+                        for (content_block, content) in content.iter().enumerate() {
+                            entries.push(ReplayPlanEntry {
+                                subject: ReplaySubject::SystemNoticeContent {
+                                    message: index,
+                                    notice_block: ReplaySystemNoticeBlockIndex(notice_block),
+                                    content_block: ReplaySystemNoticeContentIndex(content_block),
+                                },
+                                disposition: content_disposition(content, target, false),
+                            });
+                        }
+                    }
+                }
+                Message::System(_) => {}
             }
         }
         Ok(Self { target, entries })
@@ -418,10 +606,10 @@ impl ReplayPlan {
         application.finish()?;
         let source_system = source
             .iter()
-            .filter(|message| matches!(message, Message::System(_) | Message::SystemNotice(_)));
+            .filter(|message| matches!(message, Message::System(_)));
         let projected_system = projected
             .iter()
-            .filter(|message| matches!(message, Message::System(_) | Message::SystemNotice(_)));
+            .filter(|message| matches!(message, Message::System(_)));
         if !source_system.eq(projected_system) {
             return Err(ReplayPlanError::PreservedSystemMessageMismatch);
         }
@@ -429,15 +617,27 @@ impl ReplayPlan {
     }
 }
 
-fn assistant_disposition(block: &AssistantBlock) -> ReplayDisposition {
+fn assistant_disposition(block: &AssistantBlock, target: ReplayTarget) -> ReplayDisposition {
     match block {
         AssistantBlock::Text { text, .. } if text.is_empty() => ReplayDisposition::Omit,
         AssistantBlock::Text { .. } | AssistantBlock::ToolUse { .. } => ReplayDisposition::Preserve,
         AssistantBlock::Transcript { text, .. } if text.is_empty() => ReplayDisposition::Omit,
         AssistantBlock::Transcript { .. } => ReplayDisposition::LowerToText,
-        AssistantBlock::Reasoning { .. } | AssistantBlock::ServerToolContent { .. } => {
-            ReplayDisposition::ProviderNative
+        AssistantBlock::Reasoning { text, .. }
+            if text.is_empty()
+                && matches!(
+                    target.reasoning_projection,
+                    ReplayReasoningProjection::LowerToText
+                ) =>
+        {
+            ReplayDisposition::Omit
         }
+        AssistantBlock::Reasoning { .. } => match target.reasoning_projection {
+            ReplayReasoningProjection::ProviderNative => ReplayDisposition::ProviderNative,
+            ReplayReasoningProjection::LowerToText => ReplayDisposition::LowerToText,
+            ReplayReasoningProjection::Omit => ReplayDisposition::Omit,
+        },
+        AssistantBlock::ServerToolContent { .. } => ReplayDisposition::ProviderNative,
         AssistantBlock::Image { .. } => ReplayDisposition::Omit,
     }
 }
@@ -478,6 +678,7 @@ fn is_text_projection(source: &ContentBlock, projected: &ContentBlock) -> bool {
 fn source_text_projection(source: &AssistantBlock) -> String {
     match source {
         AssistantBlock::Transcript { text, .. } => text.clone(),
+        AssistantBlock::Reasoning { text, .. } => format!("[Reasoning: {text}]"),
         _ => String::new(),
     }
 }
@@ -530,15 +731,7 @@ fn assistant_payload_eq(source: &AssistantBlock, projected: Option<&AssistantBlo
 }
 
 fn native_assistant_outcome(source: &AssistantBlock, projected: Option<&AssistantBlock>) -> bool {
-    projected.is_none()
-        || assistant_payload_eq(source, projected)
-        || matches!(
-            (source, projected),
-            (
-                AssistantBlock::Reasoning { .. },
-                Some(AssistantBlock::Text { meta: None, .. })
-            )
-        )
+    projected.is_none() || assistant_payload_eq(source, projected)
 }
 
 fn tool_use_ids(message: &Message) -> Vec<&str> {
@@ -561,20 +754,9 @@ fn has_duplicate_ids(ids: &[&str]) -> bool {
 }
 
 fn validate_tool_adjacency(messages: &[Message]) -> Result<(), ReplayPlanError> {
-    validate_adjacency(messages, false)
-}
-
-fn validate_source_tool_adjacency(messages: &[Message]) -> Result<(), ReplayPlanError> {
-    validate_adjacency(messages, true)
-}
-
-fn validate_adjacency(messages: &[Message], allow_omitted: bool) -> Result<(), ReplayPlanError> {
     let mut pending: Option<(ReplayMessageIndex, Vec<&str>)> = None;
     for (index, message) in messages.iter().enumerate() {
         let message_index = ReplayMessageIndex(index);
-        if allow_omitted && pending.is_some() && source_message_is_replay_omitted(message) {
-            continue;
-        }
         if let Message::ToolResults { results, .. } = message {
             let Some((_, expected)) = pending.take() else {
                 return Err(ReplayPlanError::ToolResultsWithoutToolUse {
@@ -617,17 +799,6 @@ fn validate_adjacency(messages: &[Message], allow_omitted: bool) -> Result<(), R
         .unwrap_or(Ok(()))
 }
 
-fn source_message_is_replay_omitted(message: &Message) -> bool {
-    matches!(
-        message,
-        Message::BlockAssistant(assistant)
-            if assistant.blocks.iter().all(|block| matches!(
-                assistant_disposition(block),
-                ReplayDisposition::Omit | ReplayDisposition::ProviderNative
-            ))
-    )
-}
-
 #[cfg(test)]
 #[allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
 mod tests {
@@ -645,7 +816,14 @@ mod tests {
         ]))];
         let plan = ReplayPlan::build(
             &messages,
-            ReplayTarget::new(ReplayWireFamily::OpenAi, false, false, false),
+            ReplayTarget::new(
+                ReplayWireFamily::OpenAi,
+                false,
+                false,
+                false,
+                ReplayToolResultProjection::CollapseToText,
+                ReplayReasoningProjection::Omit,
+            ),
         )
         .unwrap_or_else(|error| panic!("test replay plan: {error}"));
         let mut application = plan.application();
@@ -687,7 +865,14 @@ mod tests {
         ))];
         let plan = ReplayPlan::build(
             &messages,
-            ReplayTarget::new(ReplayWireFamily::Anthropic, true, false, true),
+            ReplayTarget::new(
+                ReplayWireFamily::Anthropic,
+                true,
+                false,
+                true,
+                ReplayToolResultProjection::PreserveBlocks,
+                ReplayReasoningProjection::ProviderNative,
+            ),
         )
         .unwrap_or_else(|error| panic!("test replay plan: {error}"));
         let mut application = plan.application();
@@ -723,5 +908,36 @@ mod tests {
                 ..
             })
         ));
+    }
+
+    #[test]
+    fn empty_reasoning_is_omitted_when_target_lowers_reasoning_to_text() {
+        let messages = [Message::BlockAssistant(BlockAssistantMessage::new(
+            vec![AssistantBlock::Reasoning {
+                text: String::new(),
+                meta: Some(Box::new(ProviderMeta::AnthropicRedacted {
+                    data: "encrypted".to_string(),
+                })),
+            }],
+            StopReason::EndTurn,
+        ))];
+        let plan = ReplayPlan::build(
+            &messages,
+            ReplayTarget::new(
+                ReplayWireFamily::Gemini,
+                true,
+                true,
+                true,
+                ReplayToolResultProjection::PreserveBlocks,
+                ReplayReasoningProjection::LowerToText,
+            ),
+        )
+        .unwrap_or_else(|error| panic!("test replay plan: {error}"));
+        assert_eq!(
+            plan.entries()
+                .find(|entry| matches!(entry.subject, ReplaySubject::AssistantBlock { .. }))
+                .map(|entry| entry.disposition),
+            Some(ReplayDisposition::Omit)
+        );
     }
 }

--- a/meerkat-core/src/transcript_replay.rs
+++ b/meerkat-core/src/transcript_replay.rs
@@ -9,6 +9,8 @@ use std::collections::HashSet;
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ReplayMessageIndex(pub usize);
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct ReplayProjectedMessageIndex(pub usize);
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ReplayAssistantBlockIndex(pub usize);
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ReplayUserContentIndex(pub usize);
@@ -185,6 +187,10 @@ pub enum ReplayPlanError {
     },
     #[error("replay projection changed or omitted an ordered system message")]
     PreservedSystemMessageMismatch,
+    #[error("replay projection has an unexpected message at {projected:?}")]
+    UnexpectedProjectedMessage {
+        projected: ReplayProjectedMessageIndex,
+    },
     #[error(
         "replay application ended before its complete plan was consumed; next subject is {next:?}"
     )]
@@ -342,54 +348,33 @@ impl ReplayApplication<'_> {
     ) -> Result<SystemNoticeMessage, ReplayPlanError> {
         self.consume(ReplaySubject::Message(message))?;
         let mut projected = notice.clone();
-        for (notice_block_index, (source_block, projected_block)) in notice
-            .blocks
-            .iter()
-            .zip(projected.blocks.iter_mut())
-            .enumerate()
-        {
-            let (source_content, projected_content) = match (source_block, projected_block) {
-                (
-                    SystemNoticeBlock::Comms {
-                        content: source, ..
-                    },
-                    SystemNoticeBlock::Comms {
-                        content: projected, ..
-                    },
-                )
-                | (
-                    SystemNoticeBlock::ExternalEvent {
-                        content: source, ..
-                    },
-                    SystemNoticeBlock::ExternalEvent {
-                        content: projected, ..
-                    },
-                ) => (source, projected),
+        for (notice_block_index, projected_block) in projected.blocks.iter_mut().enumerate() {
+            let projected_content = match projected_block {
+                SystemNoticeBlock::Comms { content, .. }
+                | SystemNoticeBlock::ExternalEvent { content, .. } => content,
                 _ => continue,
             };
-            let mut next_content = Vec::with_capacity(source_content.len());
-            for (content_index, source) in source_content.iter().enumerate() {
+            for (content_index, projected) in projected_content.iter_mut().enumerate() {
                 let subject = ReplaySubject::SystemNoticeContent {
                     message,
                     notice_block: ReplaySystemNoticeBlockIndex(notice_block_index),
                     content_block: ReplaySystemNoticeContentIndex(content_index),
                 };
-                let next = match self.next(subject)? {
-                    ReplayDisposition::Preserve => source.clone(),
-                    ReplayDisposition::LowerToText => ContentBlock::Text {
-                        text: source.text_projection().into_owned(),
-                    },
+                match self.consume(subject)? {
+                    ReplayDisposition::Preserve => {}
+                    ReplayDisposition::LowerToText => {
+                        *projected = ContentBlock::Text {
+                            text: projected.text_projection().into_owned(),
+                        };
+                    }
                     disposition => {
                         return Err(ReplayPlanError::ProjectionMismatch {
                             subject,
                             disposition,
                         });
                     }
-                };
-                self.record_content(subject, source, &next)?;
-                next_content.push(next);
+                }
             }
-            *projected_content = next_content;
         }
         Ok(projected)
     }
@@ -604,16 +589,335 @@ impl ReplayPlan {
         application: ReplayApplication<'_>,
     ) -> Result<(), ReplayPlanError> {
         application.finish()?;
-        let source_system = source
-            .iter()
-            .filter(|message| matches!(message, Message::System(_)));
-        let projected_system = projected
-            .iter()
-            .filter(|message| matches!(message, Message::System(_)));
-        if !source_system.eq(projected_system) {
-            return Err(ReplayPlanError::PreservedSystemMessageMismatch);
-        }
+        validate_final_projection(source, projected, self.target)?;
         validate_tool_adjacency(projected)
+    }
+}
+
+fn validate_final_projection(
+    source: &[Message],
+    projected: &[Message],
+    target: ReplayTarget,
+) -> Result<(), ReplayPlanError> {
+    let mut projected_index = 0;
+    for (message_index, source_message) in source.iter().enumerate() {
+        let message_index = ReplayMessageIndex(message_index);
+        if let Message::BlockAssistant(source_assistant) = source_message {
+            let projected_assistant =
+                projected
+                    .get(projected_index)
+                    .and_then(|message| match message {
+                        Message::BlockAssistant(assistant) => Some(assistant),
+                        _ => None,
+                    });
+            let consumed = validate_final_assistant_projection(
+                message_index,
+                source_assistant,
+                projected_assistant,
+                target,
+            )?;
+            projected_index += usize::from(consumed);
+            continue;
+        }
+
+        let Some(projected_message) = projected.get(projected_index) else {
+            return Err(message_projection_mismatch(message_index));
+        };
+        let valid = match (source_message, projected_message) {
+            (Message::System(source), Message::System(actual)) => source == actual,
+            (Message::User(source), Message::User(actual)) => {
+                let expected_content = source
+                    .content
+                    .iter()
+                    .enumerate()
+                    .map(|(block_index, block)| {
+                        project_content_block(
+                            block,
+                            target,
+                            false,
+                            ReplaySubject::UserContent {
+                                message: message_index,
+                                block: ReplayUserContentIndex(block_index),
+                            },
+                        )
+                    })
+                    .collect::<Result<Vec<_>, _>>()?;
+                source.render_metadata == actual.render_metadata
+                    && source.identity == actual.identity
+                    && source.transcript_role == actual.transcript_role
+                    && source.created_at == actual.created_at
+                    && expected_content == actual.content
+            }
+            (
+                Message::ToolResults {
+                    results: source,
+                    created_at: source_created_at,
+                },
+                Message::ToolResults {
+                    results: actual,
+                    created_at: actual_created_at,
+                },
+            ) => {
+                let expected = source
+                    .iter()
+                    .enumerate()
+                    .map(|(result_index, result)| {
+                        project_tool_result_for_target(
+                            message_index,
+                            ReplayToolResultIndex(result_index),
+                            result,
+                            target,
+                        )
+                    })
+                    .collect::<Result<Vec<_>, _>>()?;
+                source_created_at == actual_created_at && expected == *actual
+            }
+            (Message::SystemNotice(source), Message::SystemNotice(actual)) => {
+                project_system_notice_for_target(message_index, source, target)? == *actual
+            }
+            _ => false,
+        };
+        if !valid {
+            return Err(match source_message {
+                Message::System(_) => ReplayPlanError::PreservedSystemMessageMismatch,
+                _ => message_projection_mismatch(message_index),
+            });
+        }
+        projected_index += 1;
+    }
+    if projected_index != projected.len() {
+        return Err(ReplayPlanError::UnexpectedProjectedMessage {
+            projected: ReplayProjectedMessageIndex(projected_index),
+        });
+    }
+    Ok(())
+}
+
+fn validate_final_assistant_projection(
+    message: ReplayMessageIndex,
+    source: &crate::BlockAssistantMessage,
+    projected: Option<&crate::BlockAssistantMessage>,
+    target: ReplayTarget,
+) -> Result<bool, ReplayPlanError> {
+    let requires_message = source.blocks.iter().any(|block| {
+        matches!(
+            assistant_disposition(block, target),
+            ReplayDisposition::Preserve | ReplayDisposition::LowerToText
+        )
+    });
+    let Some(projected) = projected else {
+        return if requires_message {
+            Err(message_projection_mismatch(message))
+        } else {
+            Ok(false)
+        };
+    };
+    if !requires_message
+        && projected.blocks.first().is_some_and(|first| {
+            !source
+                .blocks
+                .iter()
+                .any(|block| assistant_block_matches_target(block, first, target))
+        })
+    {
+        return Ok(false);
+    }
+    if source.stop_reason != projected.stop_reason
+        || source.identity != projected.identity
+        || source.created_at != projected.created_at
+    {
+        return Err(message_projection_mismatch(message));
+    }
+
+    let mut projected_block = 0;
+    for (block_index, source_block) in source.blocks.iter().enumerate() {
+        let subject = ReplaySubject::AssistantBlock {
+            message,
+            block: ReplayAssistantBlockIndex(block_index),
+        };
+        let disposition = assistant_disposition(source_block, target);
+        let actual = projected.blocks.get(projected_block);
+        let consumes = match disposition {
+            ReplayDisposition::Preserve => {
+                validate_final_assistant_block(subject, source_block, actual, target)?;
+                true
+            }
+            ReplayDisposition::LowerToText => {
+                let valid = actual.is_some_and(|block| {
+                    matches!(block, AssistantBlock::Text { text, meta: None } if *text == source_text_projection(source_block))
+                });
+                if !valid {
+                    return Err(projection_mismatch(subject, disposition));
+                }
+                true
+            }
+            ReplayDisposition::Omit => false,
+            ReplayDisposition::ProviderNative => {
+                if actual.is_some_and(|block| {
+                    assistant_block_matches_target(source_block, block, target)
+                }) {
+                    validate_final_assistant_block(subject, source_block, actual, target)?;
+                    true
+                } else {
+                    false
+                }
+            }
+            ReplayDisposition::CollapseToText => {
+                return Err(projection_mismatch(subject, disposition));
+            }
+        };
+        projected_block += usize::from(consumes);
+    }
+    if projected_block != projected.blocks.len() {
+        return Err(message_projection_mismatch(message));
+    }
+    Ok(true)
+}
+
+fn validate_final_assistant_block(
+    subject: ReplaySubject,
+    source: &AssistantBlock,
+    projected: Option<&AssistantBlock>,
+    target: ReplayTarget,
+) -> Result<(), ReplayPlanError> {
+    if !assistant_payload_eq(source, projected) {
+        return Err(projection_mismatch(subject, ReplayDisposition::Preserve));
+    }
+    let source_meta = assistant_meta(source);
+    let projected_meta = projected.and_then(assistant_meta);
+    let expected_meta = source_meta.filter(|metadata| {
+        ReplayWireFamily::from_provider_metadata(metadata) == target.wire_family
+    });
+    if projected_meta != expected_meta {
+        return Err(projection_mismatch(
+            subject,
+            ReplayDisposition::ProviderNative,
+        ));
+    }
+    Ok(())
+}
+
+fn assistant_block_matches_target(
+    source: &AssistantBlock,
+    projected: &AssistantBlock,
+    target: ReplayTarget,
+) -> bool {
+    if !assistant_payload_eq(source, Some(projected)) {
+        return false;
+    }
+    let expected_meta = assistant_meta(source).filter(|metadata| {
+        ReplayWireFamily::from_provider_metadata(metadata) == target.wire_family
+    });
+    assistant_meta(projected) == expected_meta
+}
+
+fn project_content_block(
+    block: &ContentBlock,
+    target: ReplayTarget,
+    tool_result: bool,
+    subject: ReplaySubject,
+) -> Result<ContentBlock, ReplayPlanError> {
+    match content_disposition(block, target, tool_result) {
+        ReplayDisposition::Preserve => Ok(block.clone()),
+        ReplayDisposition::LowerToText => Ok(ContentBlock::Text {
+            text: block.text_projection().into_owned(),
+        }),
+        disposition => Err(projection_mismatch(subject, disposition)),
+    }
+}
+
+fn project_tool_result_for_target(
+    message: ReplayMessageIndex,
+    result: ReplayToolResultIndex,
+    source: &ToolResult,
+    target: ReplayTarget,
+) -> Result<ToolResult, ReplayPlanError> {
+    for (block_index, block) in source.content.iter().enumerate() {
+        if matches!(block, ContentBlock::Video { .. }) {
+            return Err(ReplayPlanError::UnsupportedCapability {
+                subject: ReplaySubject::ToolResultContent {
+                    message,
+                    result,
+                    block: ReplayToolResultContentIndex(block_index),
+                },
+                capability: ReplayCapability::ToolResultVideo,
+            });
+        }
+    }
+    let projected = source
+        .content
+        .iter()
+        .enumerate()
+        .map(|(block_index, block)| {
+            project_content_block(
+                block,
+                target,
+                true,
+                ReplaySubject::ToolResultContent {
+                    message,
+                    result,
+                    block: ReplayToolResultContentIndex(block_index),
+                },
+            )
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+    let content = match target.tool_result_projection {
+        ReplayToolResultProjection::PreserveBlocks => projected,
+        ReplayToolResultProjection::CollapseToText => {
+            ContentBlock::text_vec(crate::types::text_content(&projected))
+        }
+    };
+    Ok(ToolResult::with_blocks(
+        source.tool_use_id.clone(),
+        content,
+        source.is_error,
+    ))
+}
+
+fn project_system_notice_for_target(
+    message: ReplayMessageIndex,
+    source: &SystemNoticeMessage,
+    target: ReplayTarget,
+) -> Result<SystemNoticeMessage, ReplayPlanError> {
+    let mut projected = source.clone();
+    for (notice_block_index, block) in projected.blocks.iter_mut().enumerate() {
+        match block {
+            SystemNoticeBlock::Comms { content, .. }
+            | SystemNoticeBlock::ExternalEvent { content, .. } => {
+                *content = content
+                    .iter()
+                    .enumerate()
+                    .map(|(content_block_index, block)| {
+                        project_content_block(
+                            block,
+                            target,
+                            false,
+                            ReplaySubject::SystemNoticeContent {
+                                message,
+                                notice_block: ReplaySystemNoticeBlockIndex(notice_block_index),
+                                content_block: ReplaySystemNoticeContentIndex(content_block_index),
+                            },
+                        )
+                    })
+                    .collect::<Result<Vec<_>, _>>()?;
+            }
+            _ => {}
+        }
+    }
+    Ok(projected)
+}
+
+fn message_projection_mismatch(message: ReplayMessageIndex) -> ReplayPlanError {
+    projection_mismatch(
+        ReplaySubject::Message(message),
+        ReplayDisposition::ProviderNative,
+    )
+}
+
+fn projection_mismatch(subject: ReplaySubject, disposition: ReplayDisposition) -> ReplayPlanError {
+    ReplayPlanError::ProjectionMismatch {
+        subject,
+        disposition,
     }
 }
 
@@ -939,5 +1243,144 @@ mod tests {
                 .map(|entry| entry.disposition),
             Some(ReplayDisposition::Omit)
         );
+    }
+
+    #[test]
+    fn final_projection_validation_rejects_output_changed_after_recording() {
+        let source_block = ContentBlock::Structured {
+            data: serde_json::value::RawValue::from_string(r#"{"key":"value"}"#.to_string())
+                .unwrap_or_else(|error| panic!("test structured content: {error}")),
+        };
+        let source = [Message::User(UserMessage::with_blocks(vec![
+            source_block.clone(),
+        ]))];
+        let plan = ReplayPlan::build(
+            &source,
+            ReplayTarget::new(
+                ReplayWireFamily::OpenAi,
+                false,
+                false,
+                false,
+                ReplayToolResultProjection::CollapseToText,
+                ReplayReasoningProjection::Omit,
+            ),
+        )
+        .unwrap_or_else(|error| panic!("test replay plan: {error}"));
+        let mut application = plan.application();
+        application
+            .record_message(
+                ReplaySubject::Message(ReplayMessageIndex(0)),
+                &source[0],
+                None,
+            )
+            .unwrap_or_else(|error| panic!("test message: {error}"));
+        let projected_block = ContentBlock::Text {
+            text: source_block.text_projection().into_owned(),
+        };
+        application
+            .record_content(
+                ReplaySubject::UserContent {
+                    message: ReplayMessageIndex(0),
+                    block: ReplayUserContentIndex(0),
+                },
+                &source_block,
+                &projected_block,
+            )
+            .unwrap_or_else(|error| panic!("test content: {error}"));
+
+        assert!(matches!(
+            plan.validate_projected(&source, &source, application),
+            Err(ReplayPlanError::ProjectionMismatch {
+                subject: ReplaySubject::Message(ReplayMessageIndex(0)),
+                ..
+            })
+        ));
+    }
+
+    #[test]
+    fn final_projection_aligns_identical_provider_native_payloads_by_metadata() {
+        let foreign = AssistantBlock::Reasoning {
+            text: "same reasoning".to_string(),
+            meta: Some(Box::new(ProviderMeta::Gemini {
+                thought_signature: "foreign".to_string(),
+            })),
+        };
+        let native = AssistantBlock::Reasoning {
+            text: "same reasoning".to_string(),
+            meta: Some(Box::new(ProviderMeta::Anthropic {
+                signature: "native".to_string(),
+            })),
+        };
+        let source_assistant =
+            BlockAssistantMessage::new(vec![foreign.clone(), native.clone()], StopReason::EndTurn);
+        let mut projected_assistant = source_assistant.clone();
+        projected_assistant.blocks = vec![native.clone()];
+        let source = [Message::BlockAssistant(source_assistant)];
+        let projected = [Message::BlockAssistant(projected_assistant)];
+        let plan = ReplayPlan::build(
+            &source,
+            ReplayTarget::new(
+                ReplayWireFamily::Anthropic,
+                true,
+                false,
+                true,
+                ReplayToolResultProjection::PreserveBlocks,
+                ReplayReasoningProjection::ProviderNative,
+            ),
+        )
+        .unwrap_or_else(|error| panic!("test replay plan: {error}"));
+        let mut application = plan.application();
+        application
+            .record_message(
+                ReplaySubject::Message(ReplayMessageIndex(0)),
+                &source[0],
+                None,
+            )
+            .unwrap_or_else(|error| panic!("test message: {error}"));
+        application
+            .record_assistant(
+                ReplaySubject::AssistantBlock {
+                    message: ReplayMessageIndex(0),
+                    block: ReplayAssistantBlockIndex(0),
+                },
+                &foreign,
+                None,
+            )
+            .unwrap_or_else(|error| panic!("foreign assistant block: {error}"));
+        application
+            .record_provider_metadata(
+                ReplaySubject::ProviderMetadata {
+                    message: ReplayMessageIndex(0),
+                    block: ReplayAssistantBlockIndex(0),
+                },
+                assistant_meta(&foreign).unwrap_or_else(|| panic!("foreign metadata")),
+                &foreign,
+                None,
+            )
+            .unwrap_or_else(|error| panic!("foreign metadata: {error}"));
+        application
+            .record_assistant(
+                ReplaySubject::AssistantBlock {
+                    message: ReplayMessageIndex(0),
+                    block: ReplayAssistantBlockIndex(1),
+                },
+                &native,
+                Some(&native),
+            )
+            .unwrap_or_else(|error| panic!("native assistant block: {error}"));
+        application
+            .record_provider_metadata(
+                ReplaySubject::ProviderMetadata {
+                    message: ReplayMessageIndex(0),
+                    block: ReplayAssistantBlockIndex(1),
+                },
+                assistant_meta(&native).unwrap_or_else(|| panic!("native metadata")),
+                &native,
+                Some(&native),
+            )
+            .unwrap_or_else(|error| panic!("native metadata: {error}"));
+
+        plan.validate_projected(&source, &projected, application)
+            .unwrap_or_else(|error| panic!("valid projection: {error}"));
     }
 }

--- a/meerkat-core/src/types.rs
+++ b/meerkat-core/src/types.rs
@@ -2523,6 +2523,16 @@ impl SystemNoticeMessage {
         Self::with_blocks(kind, body, vec![block])
     }
 
+    /// Whether nested model-facing notice content contains an image.
+    #[must_use]
+    pub fn has_images(&self) -> bool {
+        self.blocks.iter().any(|block| match block {
+            SystemNoticeBlock::Comms { content, .. }
+            | SystemNoticeBlock::ExternalEvent { content, .. } => has_images(content),
+            _ => false,
+        })
+    }
+
     /// Whether this exact notice is an ephemeral refresh projection.
     ///
     /// `McpPending` blocks with `persisted: true` are durable facts despite

--- a/meerkat-gemini/src/client.rs
+++ b/meerkat-gemini/src/client.rs
@@ -127,45 +127,9 @@ fn project_gemini_tool_result(
     result_index: meerkat_core::ReplayToolResultIndex,
     result: &ToolResult,
 ) -> Result<ToolResult, LlmError> {
-    if result.has_video() {
-        return Err(invalid_replay(
-            "video blocks are not supported in Gemini tool results",
-        ));
-    }
-    Ok(ToolResult::with_blocks(
-        result.tool_use_id.clone(),
-        result
-            .content
-            .iter()
-            .enumerate()
-            .map(|(block_index, block)| {
-                let subject = meerkat_core::ReplaySubject::ToolResultContent {
-                    message,
-                    result: result_index,
-                    block: meerkat_core::ReplayToolResultContentIndex(block_index),
-                };
-                let projected = match replay_application
-                    .next(subject)
-                    .map_err(|error| invalid_replay(error.to_string()))?
-                {
-                    meerkat_core::ReplayDisposition::Preserve => block.clone(),
-                    meerkat_core::ReplayDisposition::LowerToText => ContentBlock::Text {
-                        text: block.text_projection().into_owned(),
-                    },
-                    disposition => {
-                        return Err(invalid_replay(format!(
-                            "Gemini replay cannot apply tool-result disposition {disposition:?}"
-                        )));
-                    }
-                };
-                replay_application
-                    .record_content(subject, block, &projected)
-                    .map_err(|error| invalid_replay(error.to_string()))?;
-                Ok(projected)
-            })
-            .collect::<Result<Vec<_>, _>>()?,
-        result.is_error,
-    ))
+    replay_application
+        .project_tool_result(message, result_index, result)
+        .map_err(|error| invalid_replay(error.to_string()))
 }
 
 fn project_gemini_assistant_blocks(
@@ -231,7 +195,14 @@ fn project_gemini_assistant_blocks(
 fn project_gemini_replay_messages(messages: &[Message]) -> Result<Vec<Message>, LlmError> {
     let replay_plan = meerkat_core::ReplayPlan::build(
         messages,
-        meerkat_core::ReplayTarget::new(meerkat_core::ReplayWireFamily::Gemini, true, true, true),
+        meerkat_core::ReplayTarget::new(
+            meerkat_core::ReplayWireFamily::Gemini,
+            true,
+            true,
+            true,
+            meerkat_core::ReplayToolResultProjection::PreserveBlocks,
+            meerkat_core::ReplayReasoningProjection::LowerToText,
+        ),
     )
     .map_err(|error| invalid_replay(error.to_string()))?;
     let mut replay_application = replay_plan.application();
@@ -239,12 +210,19 @@ fn project_gemini_replay_messages(messages: &[Message]) -> Result<Vec<Message>, 
 
     for (message_index, message) in messages.iter().enumerate() {
         let message_index = meerkat_core::ReplayMessageIndex(message_index);
+        if let Message::SystemNotice(notice) = message {
+            let projected_notice = replay_application
+                .project_system_notice(message_index, notice)
+                .map_err(|error| invalid_replay(error.to_string()))?;
+            projected.push(Message::SystemNotice(projected_notice));
+            continue;
+        }
         replay_application
             .record_message(
                 meerkat_core::ReplaySubject::Message(message_index),
                 message,
                 match message {
-                    Message::System(_) | Message::SystemNotice(_) => Some(message),
+                    Message::System(_) => Some(message),
                     _ => None,
                 },
             )
@@ -274,7 +252,8 @@ fn project_gemini_replay_messages(messages: &[Message]) -> Result<Vec<Message>, 
         }
 
         let next_message = match message {
-            Message::System(_) | Message::SystemNotice(_) => Some(message.clone()),
+            Message::System(_) => Some(message.clone()),
+            Message::SystemNotice(_) => unreachable!("handled above"),
             Message::User(user) => Some(Message::User(UserMessage {
                 content: project_gemini_content_blocks(
                     &mut replay_application,
@@ -2457,6 +2436,12 @@ mod tests {
                             signature: "signature".to_string(),
                         })),
                     },
+                    AssistantBlock::Reasoning {
+                        text: String::new(),
+                        meta: Some(Box::new(ProviderMeta::AnthropicRedacted {
+                            data: "encrypted".to_string(),
+                        })),
+                    },
                     AssistantBlock::ServerToolContent {
                         id: None,
                         kind: ServerToolKind::GoogleSearch,
@@ -2533,6 +2518,10 @@ mod tests {
         assert!(assistant.blocks.iter().any(|block| matches!(
             block,
             AssistantBlock::Text { text, meta: None } if text == "[Reasoning: foreign thought]"
+        )));
+        assert!(!assistant.blocks.iter().any(|block| matches!(
+            block,
+            AssistantBlock::Text { text, .. } if text == "[Reasoning: ]"
         )));
         assert!(
             !assistant
@@ -5109,7 +5098,7 @@ mod tests {
     fn gemini_system_notice_with_image_emits_inline_data_part()
     -> Result<(), Box<dyn std::error::Error>> {
         let client = GeminiClient::new("test-key".to_string());
-        let request = LlmRequest::new(
+        let mut request = LlmRequest::new(
             "gemini-3.1-pro-preview",
             vec![Message::SystemNotice(
                 meerkat_core::SystemNoticeMessage::with_block(
@@ -5131,6 +5120,7 @@ mod tests {
                 ),
             )],
         );
+        request.messages = client.project_replay_messages(&request.messages)?;
 
         let body = client.build_request_body(&request)?;
         let contents = body["contents"].as_array().ok_or("missing contents")?;

--- a/meerkat-gemini/src/client.rs
+++ b/meerkat-gemini/src/client.rs
@@ -24,7 +24,7 @@ use meerkat_llm_core::{
 use meerkat_llm_core::{http, streaming};
 use serde::Deserialize;
 use serde_json::{Map, Value, json};
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::time::Duration;
 #[cfg(not(target_arch = "wasm32"))]
 use tokio::time as async_time;
@@ -86,27 +86,47 @@ fn invalid_replay(message: impl Into<String>) -> LlmError {
     }
 }
 
-fn project_gemini_content_blocks(blocks: &[ContentBlock]) -> Vec<ContentBlock> {
+fn project_gemini_content_blocks(
+    replay_application: &mut meerkat_core::ReplayApplication<'_>,
+    message: meerkat_core::ReplayMessageIndex,
+    blocks: &[ContentBlock],
+) -> Result<Vec<ContentBlock>, LlmError> {
     blocks
         .iter()
-        .map(|block| match block {
-            ContentBlock::Text { .. } => block.clone(),
-            ContentBlock::Image {
-                data: ImageData::Inline { .. },
-                ..
-            } => block.clone(),
-            ContentBlock::Video { .. } => block.clone(),
-            ContentBlock::Image { .. } => ContentBlock::Text {
-                text: block.text_projection().into_owned(),
-            },
-            _ => ContentBlock::Text {
-                text: block.text_projection().into_owned(),
-            },
+        .enumerate()
+        .map(|(block_index, block)| {
+            let subject = meerkat_core::ReplaySubject::UserContent {
+                message,
+                block: meerkat_core::ReplayUserContentIndex(block_index),
+            };
+            let projected = match replay_application
+                .next(subject)
+                .map_err(|error| invalid_replay(error.to_string()))?
+            {
+                meerkat_core::ReplayDisposition::Preserve => block.clone(),
+                meerkat_core::ReplayDisposition::LowerToText => ContentBlock::Text {
+                    text: block.text_projection().into_owned(),
+                },
+                disposition => {
+                    return Err(invalid_replay(format!(
+                        "Gemini replay cannot apply user-content disposition {disposition:?}"
+                    )));
+                }
+            };
+            replay_application
+                .record_content(subject, block, &projected)
+                .map_err(|error| invalid_replay(error.to_string()))?;
+            Ok(projected)
         })
         .collect()
 }
 
-fn project_gemini_tool_result(result: &ToolResult) -> Result<ToolResult, LlmError> {
+fn project_gemini_tool_result(
+    replay_application: &mut meerkat_core::ReplayApplication<'_>,
+    message: meerkat_core::ReplayMessageIndex,
+    result_index: meerkat_core::ReplayToolResultIndex,
+    result: &ToolResult,
+) -> Result<ToolResult, LlmError> {
     if result.has_video() {
         return Err(invalid_replay(
             "video blocks are not supported in Gemini tool results",
@@ -114,90 +134,137 @@ fn project_gemini_tool_result(result: &ToolResult) -> Result<ToolResult, LlmErro
     }
     Ok(ToolResult::with_blocks(
         result.tool_use_id.clone(),
-        project_gemini_content_blocks(&result.content),
+        result
+            .content
+            .iter()
+            .enumerate()
+            .map(|(block_index, block)| {
+                let subject = meerkat_core::ReplaySubject::ToolResultContent {
+                    message,
+                    result: result_index,
+                    block: meerkat_core::ReplayToolResultContentIndex(block_index),
+                };
+                let projected = match replay_application
+                    .next(subject)
+                    .map_err(|error| invalid_replay(error.to_string()))?
+                {
+                    meerkat_core::ReplayDisposition::Preserve => block.clone(),
+                    meerkat_core::ReplayDisposition::LowerToText => ContentBlock::Text {
+                        text: block.text_projection().into_owned(),
+                    },
+                    disposition => {
+                        return Err(invalid_replay(format!(
+                            "Gemini replay cannot apply tool-result disposition {disposition:?}"
+                        )));
+                    }
+                };
+                replay_application
+                    .record_content(subject, block, &projected)
+                    .map_err(|error| invalid_replay(error.to_string()))?;
+                Ok(projected)
+            })
+            .collect::<Result<Vec<_>, _>>()?,
         result.is_error,
     ))
 }
 
-fn project_gemini_assistant_blocks(blocks: &[AssistantBlock]) -> Vec<AssistantBlock> {
+fn project_gemini_assistant_blocks(
+    replay_application: &mut meerkat_core::ReplayApplication<'_>,
+    message: meerkat_core::ReplayMessageIndex,
+    blocks: &[AssistantBlock],
+) -> Result<Vec<AssistantBlock>, LlmError> {
     blocks
         .iter()
-        .filter_map(|block| match block {
-            AssistantBlock::Text { text, .. } if text.is_empty() => None,
-            AssistantBlock::Text { .. } | AssistantBlock::ToolUse { .. } => Some(block.clone()),
-            // Spoken transcripts replay to the provider as plain text
-            // (lane provenance is a Meerkat-side fact; Gemini sees the
-            // assistant's visible output).
-            AssistantBlock::Transcript { text, .. } if text.is_empty() => None,
-            AssistantBlock::Transcript { text, .. } => Some(AssistantBlock::Text {
-                text: text.clone(),
-                meta: None,
-            }),
-            AssistantBlock::Reasoning { text, .. } if !text.is_empty() => {
-                Some(AssistantBlock::Text {
-                    text: format!("[Reasoning: {text}]"),
+        .enumerate()
+        .map(|(block_index, block)| {
+            let subject = meerkat_core::ReplaySubject::AssistantBlock {
+                message,
+                block: meerkat_core::ReplayAssistantBlockIndex(block_index),
+            };
+            let projected = match block {
+                AssistantBlock::Text { text, .. } if text.is_empty() => None,
+                AssistantBlock::Text { .. } | AssistantBlock::ToolUse { .. } => Some(
+                    meerkat_core::ReplayWireFamily::Gemini.strip_foreign_metadata(block.clone()),
+                ),
+                AssistantBlock::Transcript { text, .. } if text.is_empty() => None,
+                AssistantBlock::Transcript { text, .. } => Some(AssistantBlock::Text {
+                    text: text.clone(),
                     meta: None,
-                })
+                }),
+                AssistantBlock::Reasoning { text, .. } if !text.is_empty() => {
+                    Some(AssistantBlock::Text {
+                        text: format!("[Reasoning: {text}]"),
+                        meta: None,
+                    })
+                }
+                AssistantBlock::Reasoning { .. }
+                | AssistantBlock::ServerToolContent { .. }
+                | AssistantBlock::Image { .. } => None,
+                _ => {
+                    return Err(invalid_replay(
+                        "Gemini replay cannot project unknown assistant block",
+                    ));
+                }
+            };
+            replay_application
+                .record_assistant(subject, block, projected.as_ref())
+                .map_err(|error| invalid_replay(error.to_string()))?;
+            if let Some(meta) = meerkat_core::replay_provider_metadata(block) {
+                replay_application
+                    .record_provider_metadata(
+                        meerkat_core::ReplaySubject::ProviderMetadata {
+                            message,
+                            block: meerkat_core::ReplayAssistantBlockIndex(block_index),
+                        },
+                        meta,
+                        block,
+                        projected.as_ref(),
+                    )
+                    .map_err(|error| invalid_replay(error.to_string()))?;
             }
-            AssistantBlock::Reasoning { .. }
-            | AssistantBlock::ServerToolContent { .. }
-            | AssistantBlock::Image { .. } => None,
-            _ => None,
+            Ok(projected)
         })
+        .filter_map(|result| result.transpose())
         .collect()
 }
 
-fn tool_ids_from_assistant(message: &Message) -> HashSet<String> {
-    match message {
-        Message::BlockAssistant(assistant) => assistant
-            .blocks
-            .iter()
-            .filter_map(|block| match block {
-                AssistantBlock::ToolUse { id, .. } => Some(id.clone()),
-                _ => None,
-            })
-            .collect(),
-        _ => HashSet::new(),
-    }
-}
-
-fn validate_tool_results(
-    provider: &str,
-    pending: HashSet<String>,
-    results: &[ToolResult],
-) -> Result<(), LlmError> {
-    let actual: HashSet<String> = results
-        .iter()
-        .map(|result| result.tool_use_id.clone())
-        .collect();
-    if actual == pending {
-        Ok(())
-    } else {
-        Err(invalid_replay(format!(
-            "{provider} replay projection found tool results that are not adjacent to matching tool uses"
-        )))
-    }
-}
-
 fn project_gemini_replay_messages(messages: &[Message]) -> Result<Vec<Message>, LlmError> {
+    let replay_plan = meerkat_core::ReplayPlan::build(
+        messages,
+        meerkat_core::ReplayTarget::new(meerkat_core::ReplayWireFamily::Gemini, true, true, true),
+    )
+    .map_err(|error| invalid_replay(error.to_string()))?;
+    let mut replay_application = replay_plan.application();
     let mut projected = Vec::with_capacity(messages.len());
-    let mut pending_tool_ids: Option<HashSet<String>> = None;
 
-    for message in messages {
+    for (message_index, message) in messages.iter().enumerate() {
+        let message_index = meerkat_core::ReplayMessageIndex(message_index);
+        replay_application
+            .record_message(
+                meerkat_core::ReplaySubject::Message(message_index),
+                message,
+                match message {
+                    Message::System(_) | Message::SystemNotice(_) => Some(message),
+                    _ => None,
+                },
+            )
+            .map_err(|error| invalid_replay(error.to_string()))?;
         if let Message::ToolResults {
             results,
             created_at,
         } = message
         {
-            let Some(pending) = pending_tool_ids.take() else {
-                return Err(invalid_replay(
-                    "Gemini replay projection found tool results without preceding tool use",
-                ));
-            };
-            validate_tool_results("Gemini", pending, results)?;
             let results = results
                 .iter()
-                .map(project_gemini_tool_result)
+                .enumerate()
+                .map(|(result_index, result)| {
+                    project_gemini_tool_result(
+                        &mut replay_application,
+                        message_index,
+                        meerkat_core::ReplayToolResultIndex(result_index),
+                        result,
+                    )
+                })
                 .collect::<Result<Vec<_>, _>>()?;
             projected.push(Message::ToolResults {
                 results,
@@ -206,23 +273,25 @@ fn project_gemini_replay_messages(messages: &[Message]) -> Result<Vec<Message>, 
             continue;
         }
 
-        if pending_tool_ids.is_some() {
-            return Err(invalid_replay(
-                "Gemini replay projection found a tool use without adjacent tool results",
-            ));
-        }
-
         let next_message = match message {
             Message::System(_) | Message::SystemNotice(_) => Some(message.clone()),
             Message::User(user) => Some(Message::User(UserMessage {
-                content: project_gemini_content_blocks(&user.content),
+                content: project_gemini_content_blocks(
+                    &mut replay_application,
+                    message_index,
+                    &user.content,
+                )?,
                 render_metadata: user.render_metadata.clone(),
                 identity: user.identity.clone(),
                 transcript_role: user.transcript_role,
                 created_at: user.created_at,
             })),
             Message::BlockAssistant(assistant) => {
-                let blocks = project_gemini_assistant_blocks(&assistant.blocks);
+                let blocks = project_gemini_assistant_blocks(
+                    &mut replay_application,
+                    message_index,
+                    &assistant.blocks,
+                )?;
                 if blocks.is_empty() {
                     None
                 } else {
@@ -238,20 +307,13 @@ fn project_gemini_replay_messages(messages: &[Message]) -> Result<Vec<Message>, 
         };
 
         if let Some(message) = next_message {
-            let tool_ids = tool_ids_from_assistant(&message);
-            if !tool_ids.is_empty() {
-                pending_tool_ids = Some(tool_ids);
-            }
             projected.push(message);
         }
     }
 
-    if pending_tool_ids.is_some() {
-        return Err(invalid_replay(
-            "Gemini replay projection found a trailing tool use without tool results",
-        ));
-    }
-
+    replay_plan
+        .validate_projected(messages, &projected, replay_application)
+        .map_err(|error| invalid_replay(error.to_string()))?;
     Ok(projected)
 }
 
@@ -2389,6 +2451,12 @@ mod tests {
                         text: "model thought".to_string(),
                         meta: None,
                     },
+                    AssistantBlock::Reasoning {
+                        text: "foreign thought".to_string(),
+                        meta: Some(Box::new(ProviderMeta::Anthropic {
+                            signature: "signature".to_string(),
+                        })),
+                    },
                     AssistantBlock::ServerToolContent {
                         id: None,
                         kind: ServerToolKind::GoogleSearch,
@@ -2428,6 +2496,10 @@ mod tests {
                 ],
                 false,
             )]),
+            Message::SystemNotice(SystemNoticeMessage::new(
+                meerkat_core::SystemNoticeKind::Generic,
+                "control intent",
+            )),
         ];
 
         let projected = client.project_replay_messages(&messages)?;
@@ -2458,6 +2530,10 @@ mod tests {
             )),
             "Gemini should project reasoning into text context"
         );
+        assert!(assistant.blocks.iter().any(|block| matches!(
+            block,
+            AssistantBlock::Text { text, meta: None } if text == "[Reasoning: foreign thought]"
+        )));
         assert!(
             !assistant
                 .blocks
@@ -2480,6 +2556,7 @@ mod tests {
             results[0].has_images(),
             "Gemini should retain inline image tool results"
         );
+        assert!(matches!(projected[3], Message::SystemNotice(_)));
         Ok(())
     }
 
@@ -5267,5 +5344,93 @@ mod tests {
             "functionDeclarations alone should not force toolConfig"
         );
         Ok(())
+    }
+
+    #[test]
+    fn replay_projection_rejects_duplicate_tool_use_ids() {
+        let client = GeminiClient::new("test-key".to_string());
+        let args = serde_json::value::RawValue::from_string("{}".to_string())
+            .unwrap_or_else(|error| panic!("test args: {error}"));
+        let messages = [
+            Message::BlockAssistant(BlockAssistantMessage::new(
+                vec![
+                    AssistantBlock::ToolUse {
+                        id: "duplicate".to_string(),
+                        name: "a".to_string(),
+                        args: args.clone(),
+                        meta: None,
+                    },
+                    AssistantBlock::ToolUse {
+                        id: "duplicate".to_string(),
+                        name: "b".to_string(),
+                        args,
+                        meta: None,
+                    },
+                ],
+                StopReason::ToolUse,
+            )),
+            Message::tool_results(vec![ToolResult::new(
+                "duplicate".to_string(),
+                "result".to_string(),
+                false,
+            )]),
+        ];
+        assert!(matches!(
+            client.project_replay_messages(&messages),
+            Err(LlmError::InvalidRequest { .. })
+        ));
+    }
+
+    #[test]
+    fn replay_projection_rejects_duplicate_tool_result_ids() {
+        let client = GeminiClient::new("test-key".to_string());
+        let args = serde_json::value::RawValue::from_string("{}".to_string())
+            .unwrap_or_else(|error| panic!("test args: {error}"));
+        let messages = [
+            Message::BlockAssistant(BlockAssistantMessage::new(
+                vec![AssistantBlock::ToolUse {
+                    id: "tool".to_string(),
+                    name: "a".to_string(),
+                    args,
+                    meta: None,
+                }],
+                StopReason::ToolUse,
+            )),
+            Message::tool_results(vec![
+                ToolResult::new("tool".to_string(), "first".to_string(), false),
+                ToolResult::new("tool".to_string(), "second".to_string(), false),
+            ]),
+        ];
+        assert!(matches!(
+            client.project_replay_messages(&messages),
+            Err(LlmError::InvalidRequest { .. })
+        ));
+    }
+
+    #[test]
+    fn replay_projection_rejects_mismatched_tool_result_id() {
+        let client = GeminiClient::new("test-key".to_string());
+        let args = serde_json::value::RawValue::from_string("{}".to_string())
+            .unwrap_or_else(|error| panic!("test args: {error}"));
+        let messages = [
+            Message::BlockAssistant(BlockAssistantMessage::new(
+                vec![AssistantBlock::ToolUse {
+                    id: "tool".to_string(),
+                    name: "a".to_string(),
+                    args,
+                    meta: None,
+                }],
+                StopReason::ToolUse,
+            )),
+            Message::tool_results(vec![ToolResult::new(
+                "other".to_string(),
+                "result".to_string(),
+                false,
+            )]),
+        ];
+        assert!(matches!(
+            client.project_replay_messages(&messages),
+            Err(LlmError::InvalidRequest { .. })
+        ));
     }
 }

--- a/meerkat-gemini/src/client.rs
+++ b/meerkat-gemini/src/client.rs
@@ -5336,6 +5336,49 @@ mod tests {
         Ok(())
     }
 
+    #[tokio::test]
+    async fn stream_dispatch_projects_canonical_replay_into_captured_request() {
+        let seen = Arc::new(Mutex::new(Vec::new()));
+        let payload = [
+            r#"data: {"candidates":[{"content":{"parts":[{"text":"done"}]},"finishReason":"STOP"}],"usageMetadata":{"promptTokenCount":1,"candidatesTokenCount":1}}"#,
+            "",
+        ]
+        .join("\n");
+        let (base_url, server) =
+            spawn_gemini_stream_stub("gemini-3.5-flash", payload, Arc::clone(&seen)).await;
+        let client = GeminiClient::new_with_base_url("test-key".to_string(), base_url);
+        let request = LlmRequest::new(
+            "gemini-3.5-flash",
+            vec![
+                Message::User(UserMessage::text("listen")),
+                Message::BlockAssistant(BlockAssistantMessage::new(
+                    vec![AssistantBlock::Transcript {
+                        text: "spoken replay".to_string(),
+                        source: meerkat_core::TranscriptSource::Spoken,
+                        meta: None,
+                    }],
+                    StopReason::EndTurn,
+                )),
+                Message::User(UserMessage::text("continue")),
+            ],
+        );
+
+        let events = client.stream(&request).collect::<Vec<_>>().await;
+        assert!(events.iter().all(Result::is_ok));
+        let bodies = seen.lock().expect("request body capture lock");
+        assert_eq!(bodies.len(), 1);
+        let contents = bodies[0]["contents"].as_array().expect("contents array");
+        let assistant = contents
+            .iter()
+            .find(|message| message["role"] == "model")
+            .expect("projected model message");
+        assert_eq!(
+            assistant["parts"],
+            serde_json::json!([{"text": "spoken replay"}])
+        );
+        server.abort();
+    }
+
     #[test]
     fn replay_projection_rejects_duplicate_tool_use_ids() {
         let client = GeminiClient::new("test-key".to_string());

--- a/meerkat-gemini/src/runtime/mod.rs
+++ b/meerkat-gemini/src/runtime/mod.rs
@@ -1021,6 +1021,7 @@ impl ProviderRuntime for GoogleProviderRuntime {
                 .clone();
             let model = identity.model.clone();
             let supports_temperature = profile.profile().supports_temperature;
+            let supports_image_input = profile.profile().image_input;
             let supports_image_tool_results = profile.profile().image_tool_results;
             let factory: meerkat_copilot::CopilotRouteClientFactory =
                 Arc::new(move |route, connection| {
@@ -1067,7 +1068,8 @@ impl ProviderRuntime for GoogleProviderRuntime {
                             true,
                             true,
                             supports_image_tool_results,
-                        ),
+                        )
+                        .with_image_input_support(supports_image_input),
                     )?;
                     Ok(Arc::new(GeminiCopilotChatClient { inner: client }))
                 });

--- a/meerkat-llm-core/src/types.rs
+++ b/meerkat-llm-core/src/types.rs
@@ -369,8 +369,8 @@ impl LlmRequest {
         self
     }
 
-    /// Whether the typed request contains any user, assistant, or tool-result
-    /// image content.
+    /// Whether the typed request contains any user, assistant, tool-result, or
+    /// nested system-notice image content.
     pub fn has_images(&self) -> bool {
         self.messages.iter().any(|message| match message {
             Message::User(user) => user.has_images(),
@@ -379,7 +379,8 @@ impl LlmRequest {
                 .iter()
                 .any(|block| matches!(block, AssistantBlock::Image { .. })),
             Message::ToolResults { results, .. } => results.iter().any(ToolResult::has_images),
-            Message::System(_) | Message::SystemNotice(_) => false,
+            Message::SystemNotice(notice) => notice.has_images(),
+            Message::System(_) => false,
         })
     }
 
@@ -622,6 +623,34 @@ impl ToolCallBuffer {
 #[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn request_image_detection_includes_nested_system_notice_content() {
+        let request = LlmRequest::new(
+            "model",
+            vec![Message::SystemNotice(
+                meerkat_core::SystemNoticeMessage::with_block(
+                    meerkat_core::SystemNoticeKind::ExternalEvent,
+                    None,
+                    meerkat_core::SystemNoticeBlock::ExternalEvent {
+                        source: "test".to_string(),
+                        event_type: "image".to_string(),
+                        summary: None,
+                        body: None,
+                        payload: None,
+                        content: vec![meerkat_core::ContentBlock::Image {
+                            media_type: "image/png".to_string(),
+                            data: meerkat_core::ImageData::Inline {
+                                data: "IMAGE_BYTES".to_string(),
+                            },
+                        }],
+                    },
+                ),
+            )],
+        );
+
+        assert!(request.has_images());
+    }
 
     #[test]
     fn test_llm_event_serialization() -> Result<(), Box<dyn std::error::Error>> {

--- a/meerkat-openai/src/client.rs
+++ b/meerkat-openai/src/client.rs
@@ -63,6 +63,7 @@ pub struct OpenAiClient {
     /// invocation. Used for ExternalAuthorizer flows that produce a
     /// DynamicAuthorizer envelope (host-managed OAuth refresh, etc.).
     authorizer: Option<std::sync::Arc<dyn meerkat_core::HttpAuthorizer>>,
+    supports_image_input: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -431,19 +432,21 @@ fn project_openai_assistant_blocks(
     Ok(projected)
 }
 
+#[cfg(test)]
 fn project_openai_replay_messages(
     messages: &[Message],
     mode: OpenAiReplayProjectionMode,
 ) -> Result<Vec<Message>, LlmError> {
-    project_openai_replay_messages_for_capabilities(messages, mode, true)
+    project_openai_replay_messages_for_capabilities(messages, mode, true, true)
 }
 
 pub(crate) fn project_openai_replay_messages_for_capabilities(
     messages: &[Message],
     mode: OpenAiReplayProjectionMode,
+    image_input: bool,
     image_tool_results: bool,
 ) -> Result<Vec<Message>, LlmError> {
-    project_openai_replay_messages_for_target(messages, mode, true, image_tool_results)
+    project_openai_replay_messages_for_target(messages, mode, image_input, image_tool_results)
 }
 
 pub(crate) fn project_openai_replay_messages_for_target(
@@ -604,6 +607,7 @@ impl OpenAiClient {
             http,
             extra_headers: Vec::new(),
             authorizer: None,
+            supports_image_input: true,
         }
     }
 
@@ -645,6 +649,12 @@ impl OpenAiClient {
         authorizer: std::sync::Arc<dyn meerkat_core::HttpAuthorizer>,
     ) -> Self {
         self.authorizer = Some(authorizer);
+        self
+    }
+
+    #[must_use]
+    pub fn with_image_input_support(mut self, supports_image_input: bool) -> Self {
+        self.supports_image_input = supports_image_input;
         self
     }
 
@@ -2267,7 +2277,12 @@ fn ensure_additional_properties_false(value: &mut Value) {
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 impl LlmClient for OpenAiClient {
     fn project_replay_messages(&self, messages: &[Message]) -> Result<Vec<Message>, LlmError> {
-        project_openai_replay_messages(messages, OpenAiReplayProjectionMode::Responses)
+        project_openai_replay_messages_for_capabilities(
+            messages,
+            OpenAiReplayProjectionMode::Responses,
+            self.supports_image_input,
+            true,
+        )
     }
 
     fn request_pressure(
@@ -3540,6 +3555,30 @@ mod tests {
         assert_eq!(output[1]["type"], "input_image");
         assert_eq!(output[1]["image_url"], "data:image/png;base64,CCCC");
         assert!(matches!(projected[3], Message::SystemNotice(_)));
+        Ok(())
+    }
+
+    #[test]
+    fn non_vision_openai_replay_lowers_inline_images_to_text()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let client = OpenAiClient::new("test-key".to_string()).with_image_input_support(false);
+        let messages = vec![Message::User(UserMessage::with_blocks(vec![
+            ContentBlock::Image {
+                media_type: "image/png".to_string(),
+                data: ImageData::Inline {
+                    data: "AAAA".to_string(),
+                },
+            },
+        ]))];
+
+        let projected = client.project_replay_messages(&messages)?;
+        let Message::User(user) = &projected[0] else {
+            return Err("expected projected user message".into());
+        };
+        assert!(matches!(
+            user.content.as_slice(),
+            [ContentBlock::Text { .. }]
+        ));
         Ok(())
     }
 

--- a/meerkat-openai/src/client.rs
+++ b/meerkat-openai/src/client.rs
@@ -131,26 +131,45 @@ fn web_search_message_annotations(value: &Value) -> Option<Vec<Value>> {
     (!web_citations.is_empty()).then_some(web_citations)
 }
 
-fn project_openai_content_blocks(blocks: &[ContentBlock]) -> Vec<ContentBlock> {
+fn project_openai_content_blocks(
+    replay_application: &mut meerkat_core::ReplayApplication<'_>,
+    message: meerkat_core::ReplayMessageIndex,
+    blocks: &[ContentBlock],
+) -> Result<Vec<ContentBlock>, LlmError> {
     blocks
         .iter()
-        .map(|block| match block {
-            ContentBlock::Text { .. } => block.clone(),
-            ContentBlock::Image {
-                data: ImageData::Inline { .. },
-                ..
-            } => block.clone(),
-            ContentBlock::Image { .. } | ContentBlock::Video { .. } => ContentBlock::Text {
-                text: block.text_projection().into_owned(),
-            },
-            _ => ContentBlock::Text {
-                text: block.text_projection().into_owned(),
-            },
+        .enumerate()
+        .map(|(block_index, block)| {
+            let subject = meerkat_core::ReplaySubject::UserContent {
+                message,
+                block: meerkat_core::ReplayUserContentIndex(block_index),
+            };
+            let projected = match replay_application
+                .next(subject)
+                .map_err(|error| invalid_replay(error.to_string()))?
+            {
+                meerkat_core::ReplayDisposition::Preserve => block.clone(),
+                meerkat_core::ReplayDisposition::LowerToText => ContentBlock::Text {
+                    text: block.text_projection().into_owned(),
+                },
+                disposition => {
+                    return Err(invalid_replay(format!(
+                        "OpenAI replay cannot apply user-content disposition {disposition:?}"
+                    )));
+                }
+            };
+            replay_application
+                .record_content(subject, block, &projected)
+                .map_err(|error| invalid_replay(error.to_string()))?;
+            Ok(projected)
         })
         .collect()
 }
 
 fn project_openai_tool_result(
+    replay_application: &mut meerkat_core::ReplayApplication<'_>,
+    message: meerkat_core::ReplayMessageIndex,
+    result_index: meerkat_core::ReplayToolResultIndex,
     result: &ToolResult,
     image_tool_results: bool,
 ) -> Result<ToolResult, LlmError> {
@@ -160,15 +179,70 @@ fn project_openai_tool_result(
         ));
     }
     if !image_tool_results {
+        let mut projected_blocks = Vec::with_capacity(result.content.len());
+        for (block_index, block) in result.content.iter().enumerate() {
+            let subject = meerkat_core::ReplaySubject::ToolResultContent {
+                message,
+                result: result_index,
+                block: meerkat_core::ReplayToolResultContentIndex(block_index),
+            };
+            let projected = match replay_application
+                .next(subject)
+                .map_err(|error| invalid_replay(error.to_string()))?
+            {
+                meerkat_core::ReplayDisposition::Preserve => block.clone(),
+                meerkat_core::ReplayDisposition::LowerToText => ContentBlock::Text {
+                    text: block.text_projection().into_owned(),
+                },
+                disposition => {
+                    return Err(invalid_replay(format!(
+                        "OpenAI replay cannot apply tool-result disposition {disposition:?}"
+                    )));
+                }
+            };
+            replay_application
+                .record_content(subject, block, &projected)
+                .map_err(|error| invalid_replay(error.to_string()))?;
+            projected_blocks.push(projected);
+        }
         return Ok(ToolResult::new(
             result.tool_use_id.clone(),
-            result.text_content(),
+            meerkat_core::types::text_content(&projected_blocks),
             result.is_error,
         ));
     }
     Ok(ToolResult::with_blocks(
         result.tool_use_id.clone(),
-        project_openai_content_blocks(&result.content),
+        result
+            .content
+            .iter()
+            .enumerate()
+            .map(|(block_index, block)| {
+                let subject = meerkat_core::ReplaySubject::ToolResultContent {
+                    message,
+                    result: result_index,
+                    block: meerkat_core::ReplayToolResultContentIndex(block_index),
+                };
+                let projected = match replay_application
+                    .next(subject)
+                    .map_err(|error| invalid_replay(error.to_string()))?
+                {
+                    meerkat_core::ReplayDisposition::Preserve => block.clone(),
+                    meerkat_core::ReplayDisposition::LowerToText => ContentBlock::Text {
+                        text: block.text_projection().into_owned(),
+                    },
+                    disposition => {
+                        return Err(invalid_replay(format!(
+                            "OpenAI replay cannot apply tool-result disposition {disposition:?}"
+                        )));
+                    }
+                };
+                replay_application
+                    .record_content(subject, block, &projected)
+                    .map_err(|error| invalid_replay(error.to_string()))?;
+                Ok(projected)
+            })
+            .collect::<Result<Vec<_>, _>>()?,
         result.is_error,
     ))
 }
@@ -273,90 +347,91 @@ fn openai_continuation_plan(request: &LlmRequest) -> Option<OpenAiContinuationPl
 }
 
 fn project_openai_assistant_blocks(
+    replay_application: &mut meerkat_core::ReplayApplication<'_>,
+    message: meerkat_core::ReplayMessageIndex,
     mode: OpenAiReplayProjectionMode,
     blocks: &[AssistantBlock],
-) -> Vec<AssistantBlock> {
+) -> Result<Vec<AssistantBlock>, LlmError> {
     let mut projected = Vec::with_capacity(blocks.len());
-    let mut has_output_item = false;
+    let has_output_item = blocks.iter().any(|block| match block {
+        AssistantBlock::Text { text, .. } | AssistantBlock::Transcript { text, .. } => {
+            !text.is_empty()
+        }
+        AssistantBlock::ToolUse { .. } => true,
+        AssistantBlock::ServerToolContent { content, .. } => {
+            openai_server_tool_content_replayable(mode, content)
+        }
+        AssistantBlock::Reasoning { .. } | AssistantBlock::Image { .. } => false,
+        _ => false,
+    });
 
-    for block in blocks {
+    for (block_index, block) in blocks.iter().enumerate() {
         let projected_block = match block {
             AssistantBlock::Text { text, .. } if text.is_empty() => None,
             AssistantBlock::Text { .. } | AssistantBlock::ToolUse { .. } => {
-                has_output_item = true;
-                Some(block.clone())
+                Some(meerkat_core::ReplayWireFamily::OpenAi.strip_foreign_metadata(block.clone()))
             }
             // Spoken transcripts replay back to the provider as plain text;
             // OpenAI Responses API sees the assistant's visible output
             // regardless of capture lane.
             AssistantBlock::Transcript { text, .. } if text.is_empty() => None,
-            AssistantBlock::Transcript { text, .. } => {
-                has_output_item = true;
-                Some(AssistantBlock::Text {
-                    text: text.clone(),
-                    meta: None,
-                })
-            }
-            AssistantBlock::Reasoning { meta, .. } if openai_reasoning_replayable(mode, meta) => {
-                Some(block.clone())
+            AssistantBlock::Transcript { text, .. } => Some(AssistantBlock::Text {
+                text: text.clone(),
+                meta: None,
+            }),
+            AssistantBlock::Reasoning { meta, .. }
+                if has_output_item && openai_reasoning_replayable(mode, meta) =>
+            {
+                Some(meerkat_core::ReplayWireFamily::OpenAi.strip_foreign_metadata(block.clone()))
             }
             AssistantBlock::ServerToolContent { content, .. }
                 if openai_server_tool_content_replayable(mode, content) =>
             {
-                has_output_item = true;
-                Some(block.clone())
+                Some(meerkat_core::ReplayWireFamily::OpenAi.strip_foreign_metadata(block.clone()))
             }
             AssistantBlock::Reasoning { .. }
             | AssistantBlock::ServerToolContent { .. }
             | AssistantBlock::Image { .. } => None,
-            _ => None,
+            _ => {
+                return Err(invalid_replay(
+                    "OpenAI replay cannot project an unknown assistant block",
+                ));
+            }
         };
+        replay_application
+            .record_assistant(
+                meerkat_core::ReplaySubject::AssistantBlock {
+                    message,
+                    block: meerkat_core::ReplayAssistantBlockIndex(block_index),
+                },
+                block,
+                projected_block.as_ref(),
+            )
+            .map_err(|error| invalid_replay(error.to_string()))?;
+        let source_meta = meerkat_core::replay_provider_metadata(block);
+        if let Some(meta) = source_meta {
+            replay_application
+                .record_provider_metadata(
+                    meerkat_core::ReplaySubject::ProviderMetadata {
+                        message,
+                        block: meerkat_core::ReplayAssistantBlockIndex(block_index),
+                    },
+                    meta,
+                    block,
+                    projected_block.as_ref(),
+                )
+                .map_err(|error| invalid_replay(error.to_string()))?;
+        }
 
         if let Some(block) = projected_block {
             projected.push(block);
         }
     }
 
-    if has_output_item {
-        projected
-    } else {
-        Vec::new()
-    }
+    Ok(projected)
 }
 
-fn tool_ids_from_assistant(message: &Message) -> HashSet<String> {
-    match message {
-        Message::BlockAssistant(assistant) => assistant
-            .blocks
-            .iter()
-            .filter_map(|block| match block {
-                AssistantBlock::ToolUse { id, .. } => Some(id.clone()),
-                _ => None,
-            })
-            .collect(),
-        _ => HashSet::new(),
-    }
-}
-
-fn validate_tool_results(
-    provider: &str,
-    pending: HashSet<String>,
-    results: &[ToolResult],
-) -> Result<(), LlmError> {
-    let actual: HashSet<String> = results
-        .iter()
-        .map(|result| result.tool_use_id.clone())
-        .collect();
-    if actual == pending {
-        Ok(())
-    } else {
-        Err(invalid_replay(format!(
-            "{provider} replay projection found tool results that are not adjacent to matching tool uses"
-        )))
-    }
-}
-
-pub(crate) fn project_openai_replay_messages(
+fn project_openai_replay_messages(
     messages: &[Message],
     mode: OpenAiReplayProjectionMode,
 ) -> Result<Vec<Message>, LlmError> {
@@ -368,8 +443,16 @@ pub(crate) fn project_openai_replay_messages_for_capabilities(
     mode: OpenAiReplayProjectionMode,
     image_tool_results: bool,
 ) -> Result<Vec<Message>, LlmError> {
+    project_openai_replay_messages_for_target(messages, mode, true, image_tool_results)
+}
+
+pub(crate) fn project_openai_replay_messages_for_target(
+    messages: &[Message],
+    mode: OpenAiReplayProjectionMode,
+    image_input: bool,
+    image_tool_results: bool,
+) -> Result<Vec<Message>, LlmError> {
     let mut projected = Vec::with_capacity(messages.len());
-    let mut pending_tool_ids: Option<HashSet<String>> = None;
     // Responses can now accept image parts in `function_call_output.output`.
     // This projection intentionally preserves inline tool-result images across
     // the replayed history for capable models, matching Anthropic semantics.
@@ -377,22 +460,47 @@ pub(crate) fn project_openai_replay_messages_for_capabilities(
     // fresh-vs-historical projection policy instead of changing this default.
     let image_tool_results =
         matches!(mode, OpenAiReplayProjectionMode::Responses) && image_tool_results;
+    let replay_plan = meerkat_core::ReplayPlan::build(
+        messages,
+        meerkat_core::ReplayTarget::new(
+            meerkat_core::ReplayWireFamily::OpenAi,
+            image_input,
+            false,
+            image_tool_results,
+        ),
+    )
+    .map_err(|error| invalid_replay(error.to_string()))?;
+    let mut replay_application = replay_plan.application();
 
-    for message in messages {
+    for (message_index, message) in messages.iter().enumerate() {
+        let message_index = meerkat_core::ReplayMessageIndex(message_index);
+        replay_application
+            .record_message(
+                meerkat_core::ReplaySubject::Message(message_index),
+                message,
+                match message {
+                    Message::System(_) | Message::SystemNotice(_) => Some(message),
+                    _ => None,
+                },
+            )
+            .map_err(|error| invalid_replay(error.to_string()))?;
         if let Message::ToolResults {
             results,
             created_at,
         } = message
         {
-            let Some(pending) = pending_tool_ids.take() else {
-                return Err(invalid_replay(
-                    "OpenAI replay projection found tool results without preceding tool use",
-                ));
-            };
-            validate_tool_results("OpenAI", pending, results)?;
             let results = results
                 .iter()
-                .map(|result| project_openai_tool_result(result, image_tool_results))
+                .enumerate()
+                .map(|(result_index, result)| {
+                    project_openai_tool_result(
+                        &mut replay_application,
+                        message_index,
+                        meerkat_core::ReplayToolResultIndex(result_index),
+                        result,
+                        image_tool_results,
+                    )
+                })
                 .collect::<Result<Vec<_>, _>>()?;
             projected.push(Message::ToolResults {
                 results,
@@ -404,14 +512,23 @@ pub(crate) fn project_openai_replay_messages_for_capabilities(
         let next_message = match message {
             Message::System(_) | Message::SystemNotice(_) => Some(message.clone()),
             Message::User(user) => Some(Message::User(UserMessage {
-                content: project_openai_content_blocks(&user.content),
+                content: project_openai_content_blocks(
+                    &mut replay_application,
+                    message_index,
+                    &user.content,
+                )?,
                 render_metadata: user.render_metadata.clone(),
                 identity: user.identity.clone(),
                 transcript_role: user.transcript_role,
                 created_at: user.created_at,
             })),
             Message::BlockAssistant(assistant) => {
-                let blocks = project_openai_assistant_blocks(mode, &assistant.blocks);
+                let blocks = project_openai_assistant_blocks(
+                    &mut replay_application,
+                    message_index,
+                    mode,
+                    &assistant.blocks,
+                )?;
                 if blocks.is_empty() {
                     None
                 } else {
@@ -429,26 +546,12 @@ pub(crate) fn project_openai_replay_messages_for_capabilities(
         let Some(message) = next_message else {
             continue;
         };
-
-        if pending_tool_ids.is_some() {
-            return Err(invalid_replay(
-                "OpenAI replay projection found a tool use without adjacent tool results",
-            ));
-        }
-
-        let tool_ids = tool_ids_from_assistant(&message);
-        if !tool_ids.is_empty() {
-            pending_tool_ids = Some(tool_ids);
-        }
         projected.push(message);
     }
 
-    if pending_tool_ids.is_some() {
-        return Err(invalid_replay(
-            "OpenAI replay projection found a trailing tool use without tool results",
-        ));
-    }
-
+    replay_plan
+        .validate_projected(messages, &projected, replay_application)
+        .map_err(|error| invalid_replay(error.to_string()))?;
     Ok(projected)
 }
 
@@ -3269,6 +3372,12 @@ mod tests {
                             response_id: None,
                         })),
                     },
+                    AssistantBlock::Reasoning {
+                        text: "foreign reasoning".to_string(),
+                        meta: Some(Box::new(ProviderMeta::Anthropic {
+                            signature: "signature".to_string(),
+                        })),
+                    },
                     AssistantBlock::ServerToolContent {
                         id: Some("ws_status".to_string()),
                         kind: ServerToolKind::WebSearch,
@@ -3326,6 +3435,10 @@ mod tests {
                 ],
                 false,
             )]),
+            Message::SystemNotice(SystemNoticeMessage::new(
+                meerkat_core::SystemNoticeKind::Generic,
+                "control intent",
+            )),
         ];
 
         let projected = client.project_replay_messages(&messages)?;
@@ -3357,6 +3470,10 @@ mod tests {
                 .any(|block| matches!(block, AssistantBlock::Reasoning { .. })),
             "OpenAI Responses replay projection should keep OpenAI reasoning blocks"
         );
+        assert!(!assistant.blocks.iter().any(|block| matches!(
+            block,
+            AssistantBlock::Reasoning { text, .. } if text == "foreign reasoning"
+        )));
         assert!(assistant.blocks.iter().any(|block| matches!(
             block,
             AssistantBlock::ServerToolContent { content, .. }
@@ -3422,6 +3539,7 @@ mod tests {
         assert_eq!(output[0]["text"], "tool text");
         assert_eq!(output[1]["type"], "input_image");
         assert_eq!(output[1]["image_url"], "data:image/png;base64,CCCC");
+        assert!(matches!(projected[3], Message::SystemNotice(_)));
         Ok(())
     }
 
@@ -8104,5 +8222,93 @@ mod tests {
         let tools = body["tools"].as_array().expect("tools should be array");
         assert_eq!(tools.len(), 1, "should only have the regular tool");
         assert_eq!(tools[0]["type"], "function");
+    }
+
+    #[test]
+    fn replay_projection_rejects_duplicate_tool_use_ids() {
+        let client = OpenAiClient::new("test-key".to_string());
+        let args = serde_json::value::RawValue::from_string("{}".to_string())
+            .unwrap_or_else(|error| panic!("test args: {error}"));
+        let messages = [
+            Message::BlockAssistant(BlockAssistantMessage::new(
+                vec![
+                    AssistantBlock::ToolUse {
+                        id: "duplicate".to_string(),
+                        name: "a".to_string(),
+                        args: args.clone(),
+                        meta: None,
+                    },
+                    AssistantBlock::ToolUse {
+                        id: "duplicate".to_string(),
+                        name: "b".to_string(),
+                        args,
+                        meta: None,
+                    },
+                ],
+                StopReason::ToolUse,
+            )),
+            Message::tool_results(vec![ToolResult::new(
+                "duplicate".to_string(),
+                "result".to_string(),
+                false,
+            )]),
+        ];
+        assert!(matches!(
+            client.project_replay_messages(&messages),
+            Err(LlmError::InvalidRequest { .. })
+        ));
+    }
+
+    #[test]
+    fn replay_projection_rejects_duplicate_tool_result_ids() {
+        let client = OpenAiClient::new("test-key".to_string());
+        let args = serde_json::value::RawValue::from_string("{}".to_string())
+            .unwrap_or_else(|error| panic!("test args: {error}"));
+        let messages = [
+            Message::BlockAssistant(BlockAssistantMessage::new(
+                vec![AssistantBlock::ToolUse {
+                    id: "tool".to_string(),
+                    name: "a".to_string(),
+                    args,
+                    meta: None,
+                }],
+                StopReason::ToolUse,
+            )),
+            Message::tool_results(vec![
+                ToolResult::new("tool".to_string(), "first".to_string(), false),
+                ToolResult::new("tool".to_string(), "second".to_string(), false),
+            ]),
+        ];
+        assert!(matches!(
+            client.project_replay_messages(&messages),
+            Err(LlmError::InvalidRequest { .. })
+        ));
+    }
+
+    #[test]
+    fn replay_projection_rejects_mismatched_tool_result_id() {
+        let client = OpenAiClient::new("test-key".to_string());
+        let args = serde_json::value::RawValue::from_string("{}".to_string())
+            .unwrap_or_else(|error| panic!("test args: {error}"));
+        let messages = [
+            Message::BlockAssistant(BlockAssistantMessage::new(
+                vec![AssistantBlock::ToolUse {
+                    id: "tool".to_string(),
+                    name: "a".to_string(),
+                    args,
+                    meta: None,
+                }],
+                StopReason::ToolUse,
+            )),
+            Message::tool_results(vec![ToolResult::new(
+                "other".to_string(),
+                "result".to_string(),
+                false,
+            )]),
+        ];
+        assert!(matches!(
+            client.project_replay_messages(&messages),
+            Err(LlmError::InvalidRequest { .. })
+        ));
     }
 }

--- a/meerkat-openai/src/client.rs
+++ b/meerkat-openai/src/client.rs
@@ -172,80 +172,10 @@ fn project_openai_tool_result(
     message: meerkat_core::ReplayMessageIndex,
     result_index: meerkat_core::ReplayToolResultIndex,
     result: &ToolResult,
-    image_tool_results: bool,
 ) -> Result<ToolResult, LlmError> {
-    if result.has_video() {
-        return Err(invalid_replay(
-            "video blocks are not supported in OpenAI tool results",
-        ));
-    }
-    if !image_tool_results {
-        let mut projected_blocks = Vec::with_capacity(result.content.len());
-        for (block_index, block) in result.content.iter().enumerate() {
-            let subject = meerkat_core::ReplaySubject::ToolResultContent {
-                message,
-                result: result_index,
-                block: meerkat_core::ReplayToolResultContentIndex(block_index),
-            };
-            let projected = match replay_application
-                .next(subject)
-                .map_err(|error| invalid_replay(error.to_string()))?
-            {
-                meerkat_core::ReplayDisposition::Preserve => block.clone(),
-                meerkat_core::ReplayDisposition::LowerToText => ContentBlock::Text {
-                    text: block.text_projection().into_owned(),
-                },
-                disposition => {
-                    return Err(invalid_replay(format!(
-                        "OpenAI replay cannot apply tool-result disposition {disposition:?}"
-                    )));
-                }
-            };
-            replay_application
-                .record_content(subject, block, &projected)
-                .map_err(|error| invalid_replay(error.to_string()))?;
-            projected_blocks.push(projected);
-        }
-        return Ok(ToolResult::new(
-            result.tool_use_id.clone(),
-            meerkat_core::types::text_content(&projected_blocks),
-            result.is_error,
-        ));
-    }
-    Ok(ToolResult::with_blocks(
-        result.tool_use_id.clone(),
-        result
-            .content
-            .iter()
-            .enumerate()
-            .map(|(block_index, block)| {
-                let subject = meerkat_core::ReplaySubject::ToolResultContent {
-                    message,
-                    result: result_index,
-                    block: meerkat_core::ReplayToolResultContentIndex(block_index),
-                };
-                let projected = match replay_application
-                    .next(subject)
-                    .map_err(|error| invalid_replay(error.to_string()))?
-                {
-                    meerkat_core::ReplayDisposition::Preserve => block.clone(),
-                    meerkat_core::ReplayDisposition::LowerToText => ContentBlock::Text {
-                        text: block.text_projection().into_owned(),
-                    },
-                    disposition => {
-                        return Err(invalid_replay(format!(
-                            "OpenAI replay cannot apply tool-result disposition {disposition:?}"
-                        )));
-                    }
-                };
-                replay_application
-                    .record_content(subject, block, &projected)
-                    .map_err(|error| invalid_replay(error.to_string()))?;
-                Ok(projected)
-            })
-            .collect::<Result<Vec<_>, _>>()?,
-        result.is_error,
-    ))
+    replay_application
+        .project_tool_result(message, result_index, result)
+        .map_err(|error| invalid_replay(error.to_string()))
 }
 
 fn openai_reasoning_replayable(
@@ -470,6 +400,19 @@ pub(crate) fn project_openai_replay_messages_for_target(
             image_input,
             false,
             image_tool_results,
+            if image_tool_results {
+                meerkat_core::ReplayToolResultProjection::PreserveBlocks
+            } else {
+                meerkat_core::ReplayToolResultProjection::CollapseToText
+            },
+            match mode {
+                OpenAiReplayProjectionMode::Responses => {
+                    meerkat_core::ReplayReasoningProjection::ProviderNative
+                }
+                OpenAiReplayProjectionMode::ChatCompletions => {
+                    meerkat_core::ReplayReasoningProjection::Omit
+                }
+            },
         ),
     )
     .map_err(|error| invalid_replay(error.to_string()))?;
@@ -477,12 +420,19 @@ pub(crate) fn project_openai_replay_messages_for_target(
 
     for (message_index, message) in messages.iter().enumerate() {
         let message_index = meerkat_core::ReplayMessageIndex(message_index);
+        if let Message::SystemNotice(notice) = message {
+            let projected_notice = replay_application
+                .project_system_notice(message_index, notice)
+                .map_err(|error| invalid_replay(error.to_string()))?;
+            projected.push(Message::SystemNotice(projected_notice));
+            continue;
+        }
         replay_application
             .record_message(
                 meerkat_core::ReplaySubject::Message(message_index),
                 message,
                 match message {
-                    Message::System(_) | Message::SystemNotice(_) => Some(message),
+                    Message::System(_) => Some(message),
                     _ => None,
                 },
             )
@@ -501,7 +451,6 @@ pub(crate) fn project_openai_replay_messages_for_target(
                         message_index,
                         meerkat_core::ReplayToolResultIndex(result_index),
                         result,
-                        image_tool_results,
                     )
                 })
                 .collect::<Result<Vec<_>, _>>()?;
@@ -513,7 +462,8 @@ pub(crate) fn project_openai_replay_messages_for_target(
         }
 
         let next_message = match message {
-            Message::System(_) | Message::SystemNotice(_) => Some(message.clone()),
+            Message::System(_) => Some(message.clone()),
+            Message::SystemNotice(_) => unreachable!("handled above"),
             Message::User(user) => Some(Message::User(UserMessage {
                 content: project_openai_content_blocks(
                     &mut replay_application,
@@ -749,7 +699,7 @@ impl OpenAiClient {
     }
 
     /// Build request body for OpenAI Responses API
-    fn build_request_body(&self, request: &LlmRequest) -> Result<Value, LlmError> {
+    pub(crate) fn build_request_body(&self, request: &LlmRequest) -> Result<Value, LlmError> {
         let author_explicit_breakpoints = openai_tag(request).is_some_and(|tag| {
             tag.prompt_cache_enabled != Some(false)
                 && tag.prompt_cache_options.is_some_and(|options| {
@@ -8044,7 +7994,7 @@ mod tests {
         };
 
         let client = OpenAiClient::new("test-key".to_string());
-        let request = LlmRequest::new(
+        let mut request = LlmRequest::new(
             "gpt-5.4",
             vec![Message::SystemNotice(SystemNoticeMessage::with_block(
                 SystemNoticeKind::Comms,
@@ -8076,6 +8026,9 @@ mod tests {
                 },
             ))],
         );
+        request.messages = client
+            .project_replay_messages(&request.messages)
+            .expect("project system notice");
 
         let body = client.build_request_body(&request).expect("build request");
         let input = body["input"].as_array().expect("input array");

--- a/meerkat-openai/src/client.rs
+++ b/meerkat-openai/src/client.rs
@@ -8216,6 +8216,50 @@ mod tests {
         assert_eq!(tools[0]["type"], "function");
     }
 
+    #[tokio::test]
+    async fn stream_dispatch_applies_non_vision_replay_to_captured_request() {
+        let seen = Arc::new(Mutex::new(Vec::new()));
+        let payload = concat!(
+            "data: {\"type\":\"response.completed\",\"response\":{\"status\":\"completed\",\"output\":[],\"usage\":{\"input_tokens\":1,\"output_tokens\":1}}}\n\n",
+            "data: {\"type\":\"response.done\",\"response\":{\"status\":\"completed\",\"output\":[],\"usage\":{\"input_tokens\":1,\"output_tokens\":1}}}\n\n"
+        )
+        .to_string();
+        let (base_url, server) =
+            spawn_openai_stub_server_with_body(payload, Arc::clone(&seen)).await;
+        let client = OpenAiClient::new_with_base_url("test-key".to_string(), base_url)
+            .with_image_input_support(false);
+        let request = LlmRequest::new(
+            "gpt-5.4",
+            vec![Message::SystemNotice(SystemNoticeMessage::with_block(
+                meerkat_core::SystemNoticeKind::ExternalEvent,
+                None,
+                SystemNoticeBlock::ExternalEvent {
+                    source: "console".to_string(),
+                    event_type: "operator_message".to_string(),
+                    summary: None,
+                    body: Some("inspect this".to_string()),
+                    payload: None,
+                    content: vec![ContentBlock::Image {
+                        media_type: "image/png".to_string(),
+                        data: ImageData::Inline {
+                            data: "NESTED_IMAGE_BYTES".to_string(),
+                        },
+                    }],
+                },
+            ))],
+        );
+
+        let events = client.stream(&request).collect::<Vec<_>>().await;
+        assert!(events.iter().all(Result::is_ok));
+        let bodies = seen.lock().expect("request body capture lock");
+        assert_eq!(bodies.len(), 1);
+        let encoded = serde_json::to_string(&bodies[0]).expect("encode captured request");
+        assert!(!encoded.contains("NESTED_IMAGE_BYTES"));
+        assert!(!encoded.contains("input_image"));
+        assert!(encoded.contains("[image: image/png]"));
+        server.abort();
+    }
+
     #[test]
     fn replay_projection_rejects_duplicate_tool_use_ids() {
         let client = OpenAiClient::new("test-key".to_string());

--- a/meerkat-openai/src/client_compatible.rs
+++ b/meerkat-openai/src/client_compatible.rs
@@ -1774,8 +1774,16 @@ mod tests {
     fn chat_completions_system_notice_with_image_emits_typed_image_part() {
         use meerkat_core::{ContentBlock, ImageData, SystemNoticeKind, SystemNoticeMessage};
 
-        let messages = OpenAiCompatibleClient::convert_to_chat_messages(&[Message::SystemNotice(
-            SystemNoticeMessage::with_block(
+        let client = OpenAiCompatibleClient::new_with_options(
+            OpenAiCompatibleMode::ChatCompletions,
+            "remote-model".to_string(),
+            "https://example.test".to_string(),
+            None,
+            options(true, true, true, true),
+        )
+        .with_image_input_support(true);
+        let projected = client
+            .project_replay_messages(&[Message::SystemNotice(SystemNoticeMessage::with_block(
                 SystemNoticeKind::ExternalEvent,
                 None,
                 SystemNoticeBlock::ExternalEvent {
@@ -1791,9 +1799,10 @@ mod tests {
                         },
                     }],
                 },
-            ),
-        )])
-        .expect("convert chat messages");
+            ))])
+            .expect("project chat messages");
+        let messages =
+            OpenAiCompatibleClient::convert_to_chat_messages(&projected).expect("convert chat");
 
         assert_eq!(messages[0]["role"], "user");
         let content = messages[0]["content"].as_array().expect("content array");
@@ -3193,5 +3202,123 @@ mod tests {
             user.content.as_slice(),
             [ContentBlock::Text { .. }]
         ));
+    }
+
+    #[test]
+    fn non_vision_compatible_modes_strip_nested_notice_images_from_serialized_requests() {
+        use meerkat_core::{SystemNoticeKind, SystemNoticeMessage};
+
+        for mode in [
+            OpenAiCompatibleMode::Responses,
+            OpenAiCompatibleMode::ChatCompletions,
+        ] {
+            let client = OpenAiCompatibleClient::new_with_options(
+                mode,
+                "remote-model".to_string(),
+                "https://example.test".to_string(),
+                None,
+                options(true, true, true, true),
+            )
+            .with_image_input_support(false);
+            let mut request = LlmRequest::new(
+                "remote-model",
+                vec![Message::SystemNotice(SystemNoticeMessage::with_block(
+                    SystemNoticeKind::ExternalEvent,
+                    None,
+                    SystemNoticeBlock::ExternalEvent {
+                        source: "console".to_string(),
+                        event_type: "operator_message".to_string(),
+                        summary: None,
+                        body: Some("inspect this".to_string()),
+                        payload: None,
+                        content: vec![ContentBlock::Image {
+                            media_type: "image/png".to_string(),
+                            data: ImageData::Inline {
+                                data: "NESTED_IMAGE_BYTES".to_string(),
+                            },
+                        }],
+                    },
+                ))],
+            );
+            request.messages = client
+                .project_replay_messages(&request.messages)
+                .expect("project non-vision notice");
+
+            let body = match mode {
+                OpenAiCompatibleMode::Responses => client
+                    .responses_delegate
+                    .as_ref()
+                    .expect("responses delegate")
+                    .build_request_body(&client.request_with_remote_model(&request))
+                    .expect("build responses body"),
+                OpenAiCompatibleMode::ChatCompletions => client
+                    .build_chat_completions_body(&request)
+                    .expect("build chat body"),
+            };
+            let encoded = serde_json::to_string(&body).expect("encode request body");
+            assert!(!encoded.contains("NESTED_IMAGE_BYTES"));
+            assert!(!encoded.contains("input_image"));
+            assert!(!encoded.contains("image_url"));
+            assert!(encoded.contains("[image: image/png]"));
+        }
+    }
+
+    #[test]
+    fn compatible_modes_serialize_the_verified_collapsed_tool_result() {
+        for mode in [
+            OpenAiCompatibleMode::Responses,
+            OpenAiCompatibleMode::ChatCompletions,
+        ] {
+            let client = OpenAiCompatibleClient::new_with_options(
+                mode,
+                "remote-model".to_string(),
+                "https://example.test".to_string(),
+                None,
+                options(true, true, true, false),
+            );
+            let mut request = LlmRequest::new(
+                "remote-model",
+                vec![
+                    Message::BlockAssistant(BlockAssistantMessage::new(
+                        vec![AssistantBlock::ToolUse {
+                            id: "call-1".to_string(),
+                            name: "lookup".to_string(),
+                            args: serde_json::value::RawValue::from_string("{}".to_string())
+                                .expect("valid tool arguments"),
+                            meta: None,
+                        }],
+                        StopReason::ToolUse,
+                    )),
+                    Message::tool_results(vec![ToolResult::with_blocks(
+                        "call-1".to_string(),
+                        vec![
+                            ContentBlock::Text {
+                                text: "first".to_string(),
+                            },
+                            ContentBlock::Text {
+                                text: "second".to_string(),
+                            },
+                        ],
+                        false,
+                    )]),
+                ],
+            );
+            request.messages = client
+                .project_replay_messages(&request.messages)
+                .expect("project compatible tool result");
+            let body = match mode {
+                OpenAiCompatibleMode::Responses => client
+                    .responses_delegate
+                    .as_ref()
+                    .expect("responses delegate")
+                    .build_request_body(&client.request_with_remote_model(&request))
+                    .expect("build responses body"),
+                OpenAiCompatibleMode::ChatCompletions => client
+                    .build_chat_completions_body(&request)
+                    .expect("build chat body"),
+            };
+            let encoded = serde_json::to_string(&body).expect("encode request body");
+            assert!(encoded.contains("first\\nsecond"));
+        }
     }
 }

--- a/meerkat-openai/src/client_compatible.rs
+++ b/meerkat-openai/src/client_compatible.rs
@@ -1479,6 +1479,34 @@ mod tests {
         (format!("http://{addr}/v1"), handle)
     }
 
+    async fn spawn_compatible_replay_capture_server(
+        mode: OpenAiCompatibleMode,
+        payload: String,
+    ) -> (String, Arc<Mutex<Vec<Value>>>, tokio::task::JoinHandle<()>) {
+        let request_bodies = Arc::new(Mutex::new(Vec::new()));
+        let route = match mode {
+            OpenAiCompatibleMode::Responses => "/v1/responses",
+            OpenAiCompatibleMode::ChatCompletions => "/v1/chat/completions",
+        };
+        let app = Router::new()
+            .route(route, post(responses_sse))
+            .with_state(ResponsesStubState {
+                payload,
+                auth_headers: Arc::new(Mutex::new(Vec::new())),
+                request_bodies: Arc::clone(&request_bodies),
+            });
+        let listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind replay capture server");
+        let addr = listener.local_addr().expect("local addr");
+        let handle = tokio::spawn(async move {
+            axum::serve(listener, app)
+                .await
+                .expect("serve replay capture server");
+        });
+        (format!("http://{addr}/v1"), request_bodies, handle)
+    }
+
     #[derive(Clone)]
     struct ChatAuthRetryState {
         calls: Arc<std::sync::atomic::AtomicUsize>,
@@ -3204,79 +3232,101 @@ mod tests {
         ));
     }
 
-    #[test]
-    fn non_vision_compatible_modes_strip_nested_notice_images_from_serialized_requests() {
+    async fn assert_compatible_dispatch_strips_nested_image(mode: OpenAiCompatibleMode) {
         use meerkat_core::{SystemNoticeKind, SystemNoticeMessage};
 
-        for mode in [
-            OpenAiCompatibleMode::Responses,
-            OpenAiCompatibleMode::ChatCompletions,
-        ] {
-            let client = OpenAiCompatibleClient::new_with_options(
-                mode,
-                "remote-model".to_string(),
-                "https://example.test".to_string(),
-                None,
-                options(true, true, true, true),
-            )
-            .with_image_input_support(false);
-            let mut request = LlmRequest::new(
-                "remote-model",
-                vec![Message::SystemNotice(SystemNoticeMessage::with_block(
-                    SystemNoticeKind::ExternalEvent,
-                    None,
-                    SystemNoticeBlock::ExternalEvent {
-                        source: "console".to_string(),
-                        event_type: "operator_message".to_string(),
-                        summary: None,
-                        body: Some("inspect this".to_string()),
-                        payload: None,
-                        content: vec![ContentBlock::Image {
-                            media_type: "image/png".to_string(),
-                            data: ImageData::Inline {
-                                data: "NESTED_IMAGE_BYTES".to_string(),
-                            },
-                        }],
-                    },
-                ))],
-            );
-            request.messages = client
-                .project_replay_messages(&request.messages)
-                .expect("project non-vision notice");
-
-            let body = match mode {
-                OpenAiCompatibleMode::Responses => client
-                    .responses_delegate
-                    .as_ref()
-                    .expect("responses delegate")
-                    .build_request_body(&client.request_with_remote_model(&request))
-                    .expect("build responses body"),
-                OpenAiCompatibleMode::ChatCompletions => client
-                    .build_chat_completions_body(&request)
-                    .expect("build chat body"),
-            };
-            let encoded = serde_json::to_string(&body).expect("encode request body");
-            assert!(!encoded.contains("NESTED_IMAGE_BYTES"));
-            assert!(!encoded.contains("input_image"));
-            assert!(!encoded.contains("image_url"));
-            assert!(encoded.contains("[image: image/png]"));
+        let payload = match mode {
+            OpenAiCompatibleMode::Responses => concat!(
+                "data: {\"type\":\"response.completed\",\"response\":{\"status\":\"completed\",\"output\":[],\"usage\":{\"input_tokens\":1,\"output_tokens\":1}}}\n\n",
+                "data: {\"type\":\"response.done\",\"response\":{\"status\":\"completed\",\"output\":[],\"usage\":{\"input_tokens\":1,\"output_tokens\":1}}}\n\n"
+            ),
+            OpenAiCompatibleMode::ChatCompletions => concat!(
+                "data: {\"choices\":[{\"delta\":{},\"finish_reason\":\"stop\"}],\"usage\":{\"prompt_tokens\":1,\"completion_tokens\":1}}\n\n",
+                "data: [DONE]\n\n"
+            ),
         }
+        .to_string();
+        let (base_url, request_bodies, server) =
+            spawn_compatible_replay_capture_server(mode, payload).await;
+        let client = OpenAiCompatibleClient::new_with_options(
+            mode,
+            "remote-model".to_string(),
+            base_url,
+            None,
+            options(true, true, true, true),
+        )
+        .with_image_input_support(false);
+        let request = LlmRequest::new(
+            "remote-model",
+            vec![Message::SystemNotice(SystemNoticeMessage::with_block(
+                SystemNoticeKind::ExternalEvent,
+                None,
+                SystemNoticeBlock::ExternalEvent {
+                    source: "console".to_string(),
+                    event_type: "operator_message".to_string(),
+                    summary: None,
+                    body: Some("inspect this".to_string()),
+                    payload: None,
+                    content: vec![ContentBlock::Image {
+                        media_type: "image/png".to_string(),
+                        data: ImageData::Inline {
+                            data: "NESTED_IMAGE_BYTES".to_string(),
+                        },
+                    }],
+                },
+            ))],
+        );
+
+        let events = client.stream(&request).collect::<Vec<_>>().await;
+        assert!(events.iter().all(Result::is_ok));
+        let bodies = request_bodies.lock().expect("request body capture lock");
+        assert_eq!(bodies.len(), 1);
+        let encoded = serde_json::to_string(&bodies[0]).expect("encode request body");
+        assert!(!encoded.contains("NESTED_IMAGE_BYTES"));
+        assert!(!encoded.contains("input_image"));
+        assert!(!encoded.contains("image_url"));
+        assert!(encoded.contains("[image: image/png]"));
+        drop(bodies);
+        server.abort();
     }
 
-    #[test]
-    fn compatible_modes_serialize_the_verified_collapsed_tool_result() {
+    #[tokio::test]
+    async fn compatible_responses_dispatch_strips_nested_images_from_captured_request() {
+        assert_compatible_dispatch_strips_nested_image(OpenAiCompatibleMode::Responses).await;
+    }
+
+    #[tokio::test]
+    async fn compatible_chat_dispatch_strips_nested_images_from_captured_request() {
+        assert_compatible_dispatch_strips_nested_image(OpenAiCompatibleMode::ChatCompletions).await;
+    }
+
+    #[tokio::test]
+    async fn compatible_stream_dispatch_serializes_exact_collapsed_tool_result() {
         for mode in [
             OpenAiCompatibleMode::Responses,
             OpenAiCompatibleMode::ChatCompletions,
         ] {
+            let payload = match mode {
+                OpenAiCompatibleMode::Responses => concat!(
+                    "data: {\"type\":\"response.completed\",\"response\":{\"status\":\"completed\",\"output\":[],\"usage\":{\"input_tokens\":1,\"output_tokens\":1}}}\n\n",
+                    "data: {\"type\":\"response.done\",\"response\":{\"status\":\"completed\",\"output\":[],\"usage\":{\"input_tokens\":1,\"output_tokens\":1}}}\n\n"
+                ),
+                OpenAiCompatibleMode::ChatCompletions => concat!(
+                    "data: {\"choices\":[{\"delta\":{},\"finish_reason\":\"stop\"}],\"usage\":{\"prompt_tokens\":1,\"completion_tokens\":1}}\n\n",
+                    "data: [DONE]\n\n"
+                ),
+            }
+            .to_string();
+            let (base_url, request_bodies, server) =
+                spawn_compatible_replay_capture_server(mode, payload).await;
             let client = OpenAiCompatibleClient::new_with_options(
                 mode,
                 "remote-model".to_string(),
-                "https://example.test".to_string(),
+                base_url,
                 None,
                 options(true, true, true, false),
             );
-            let mut request = LlmRequest::new(
+            let request = LlmRequest::new(
                 "remote-model",
                 vec![
                     Message::BlockAssistant(BlockAssistantMessage::new(
@@ -3303,22 +3353,15 @@ mod tests {
                     )]),
                 ],
             );
-            request.messages = client
-                .project_replay_messages(&request.messages)
-                .expect("project compatible tool result");
-            let body = match mode {
-                OpenAiCompatibleMode::Responses => client
-                    .responses_delegate
-                    .as_ref()
-                    .expect("responses delegate")
-                    .build_request_body(&client.request_with_remote_model(&request))
-                    .expect("build responses body"),
-                OpenAiCompatibleMode::ChatCompletions => client
-                    .build_chat_completions_body(&request)
-                    .expect("build chat body"),
-            };
-            let encoded = serde_json::to_string(&body).expect("encode request body");
+
+            let events = client.stream(&request).collect::<Vec<_>>().await;
+            assert!(events.iter().all(Result::is_ok));
+            let bodies = request_bodies.lock().expect("request body capture lock");
+            assert_eq!(bodies.len(), 1);
+            let encoded = serde_json::to_string(&bodies[0]).expect("encode request body");
             assert!(encoded.contains("first\\nsecond"));
+            drop(bodies);
+            server.abort();
         }
     }
 }

--- a/meerkat-openai/src/client_compatible.rs
+++ b/meerkat-openai/src/client_compatible.rs
@@ -92,6 +92,7 @@ pub struct OpenAiCompatibleClient {
     supports_temperature: bool,
     supports_thinking: bool,
     supports_reasoning: bool,
+    supports_image_input: bool,
     supports_image_tool_results: bool,
     post_finish_trailer_window: Duration,
 }
@@ -147,6 +148,7 @@ impl OpenAiCompatibleClient {
             supports_temperature: options.supports_temperature,
             supports_thinking: options.supports_thinking,
             supports_reasoning: options.supports_reasoning,
+            supports_image_input: true,
             supports_image_tool_results: options.supports_image_tool_results,
             post_finish_trailer_window: DEFAULT_POST_FINISH_TRAILER_WINDOW,
         }
@@ -163,6 +165,12 @@ impl OpenAiCompatibleClient {
 
     pub fn with_provider(mut self, provider: Provider) -> Self {
         self.provider = provider;
+        self
+    }
+
+    #[must_use]
+    pub fn with_image_input_support(mut self, supports_image_input: bool) -> Self {
+        self.supports_image_input = supports_image_input;
         self
     }
 
@@ -676,6 +684,7 @@ impl LlmClient for OpenAiCompatibleClient {
         project_openai_replay_messages_for_capabilities(
             messages,
             mode,
+            self.supports_image_input,
             self.supports_image_tool_results,
         )
     }
@@ -3153,5 +3162,36 @@ mod tests {
             block,
             AssistantBlock::Reasoning { text, .. } if text == "anthropic" || text == "gemini"
         )));
+    }
+
+    #[test]
+    fn non_vision_self_hosted_replay_lowers_inline_images_to_text() {
+        let client = OpenAiCompatibleClient::new_with_options(
+            OpenAiCompatibleMode::Responses,
+            "remote-model".to_string(),
+            "https://example.test".to_string(),
+            None,
+            options(true, true, true, true),
+        )
+        .with_image_input_support(false);
+        let messages = vec![Message::User(UserMessage::with_blocks(vec![
+            ContentBlock::Image {
+                media_type: "image/png".to_string(),
+                data: ImageData::Inline {
+                    data: "AAAA".to_string(),
+                },
+            },
+        ]))];
+
+        let projected = client
+            .project_replay_messages(&messages)
+            .expect("non-vision SelfHosted replay should lower image history");
+        let Message::User(user) = &projected[0] else {
+            panic!("expected projected user message");
+        };
+        assert!(matches!(
+            user.content.as_slice(),
+            [ContentBlock::Text { .. }]
+        ));
     }
 }

--- a/meerkat-openai/src/client_compatible.rs
+++ b/meerkat-openai/src/client_compatible.rs
@@ -1350,7 +1350,7 @@ struct ChatPromptTokensDetails {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
+#[allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
 mod tests {
     use super::*;
     use axum::body::to_bytes;
@@ -3094,5 +3094,64 @@ mod tests {
             value["properties"]["outer"]["properties"]["inner"]["additionalProperties"],
             Value::Bool(false)
         );
+    }
+
+    #[test]
+    fn self_hosted_replay_uses_openai_wire_family_for_metadata() {
+        use meerkat_core::ProviderMeta;
+
+        let client = OpenAiCompatibleClient::new_with_options(
+            OpenAiCompatibleMode::Responses,
+            "remote-model".to_string(),
+            "https://example.test".to_string(),
+            None,
+            options(true, true, true, true),
+        );
+        assert_eq!(client.provider(), Provider::SelfHosted);
+        let messages = vec![Message::BlockAssistant(BlockAssistantMessage::new(
+            vec![
+                AssistantBlock::Text {
+                    text: "visible".to_string(),
+                    meta: None,
+                },
+                AssistantBlock::Reasoning {
+                    text: "openai".to_string(),
+                    meta: Some(Box::new(ProviderMeta::OpenAi {
+                        id: "rs_1".to_string(),
+                        encrypted_content: Some("ciphertext".to_string()),
+                        phase: Some("reasoning".to_string()),
+                        response_id: None,
+                    })),
+                },
+                AssistantBlock::Reasoning {
+                    text: "anthropic".to_string(),
+                    meta: Some(Box::new(ProviderMeta::Anthropic {
+                        signature: "foreign".to_string(),
+                    })),
+                },
+                AssistantBlock::Reasoning {
+                    text: "gemini".to_string(),
+                    meta: Some(Box::new(ProviderMeta::Gemini {
+                        thought_signature: "foreign".to_string(),
+                    })),
+                },
+            ],
+            StopReason::EndTurn,
+        ))];
+
+        let projected = client
+            .project_replay_messages(&messages)
+            .expect("SelfHosted OpenAI-family projection");
+        let Message::BlockAssistant(assistant) = &projected[0] else {
+            panic!("expected projected assistant message");
+        };
+        assert_eq!(assistant.blocks.len(), 2);
+        assert!(
+            matches!(assistant.blocks[1], AssistantBlock::Reasoning { meta: Some(ref meta), .. } if matches!(meta.as_ref(), ProviderMeta::OpenAi { .. }))
+        );
+        assert!(assistant.blocks.iter().all(|block| !matches!(
+            block,
+            AssistantBlock::Reasoning { text, .. } if text == "anthropic" || text == "gemini"
+        )));
     }
 }

--- a/meerkat-openai/src/runtime/mod.rs
+++ b/meerkat-openai/src/runtime/mod.rs
@@ -280,6 +280,83 @@ impl OpenAiProviderRuntime {
     }
 }
 
+fn build_openai_client(
+    connection: ResolvedConnection,
+    supports_image_input: bool,
+) -> Result<Arc<dyn LlmClient>, ProviderClientError> {
+    let backend_kind = match connection.backend {
+        NormalizedBackendKind::OpenAi(kind) => kind,
+        other => unreachable!(
+            "OpenAiProviderRuntime received non-OpenAi backend: {other:?} \
+             — registry dispatch invariant violated"
+        ),
+    };
+    #[cfg(not(target_arch = "wasm32"))]
+    if let Some(authorizer) = connection.resolved_authorizer() {
+        let base_url = match backend_kind {
+            OpenAiBackendKind::ChatGptBackend => {
+                chatgpt_backend_base_url(connection.backend_profile.base_url.as_deref())?
+            }
+            OpenAiBackendKind::AzureOpenAi => {
+                azure_openai_base_url(connection.backend_profile.base_url.as_deref())?
+            }
+            OpenAiBackendKind::OpenAiApi => connection
+                .backend_profile
+                .base_url
+                .clone()
+                .unwrap_or_else(|| backend_kind.default_base_url().into()),
+            OpenAiBackendKind::Copilot => {
+                return Err(ProviderClientError::MissingFeature("copilot-text-target"));
+            }
+        };
+        let mut client =
+            crate::OpenAiClient::new_with_optional_api_key_and_base_url(None, base_url)
+                .with_image_input_support(supports_image_input)
+                .with_authorizer(authorizer);
+        if matches!(backend_kind, OpenAiBackendKind::ChatGptBackend) {
+            client = client.with_chatgpt_backend_wire();
+        } else if matches!(backend_kind, OpenAiBackendKind::AzureOpenAi) {
+            client = client.with_azure_openai_wire(azure_openai_wire_config(&connection));
+        }
+        return Ok(Arc::new(client));
+    }
+    #[cfg(target_arch = "wasm32")]
+    let secret = connection
+        .resolved_secret()
+        .ok_or(ProviderClientError::MissingFeature(
+            "openai-authorizer-backed auth not available on wasm32",
+        ))?;
+    #[cfg(not(target_arch = "wasm32"))]
+    let secret = connection
+        .resolved_secret()
+        .ok_or(ProviderClientError::NoCredentialMaterial)?;
+    let client = match backend_kind {
+        OpenAiBackendKind::OpenAiApi => match &connection.backend_profile.base_url {
+            Some(url) => crate::OpenAiClient::new_with_base_url(secret, url.clone()),
+            None => crate::OpenAiClient::new(secret),
+        }
+        .with_image_input_support(supports_image_input),
+        OpenAiBackendKind::ChatGptBackend => {
+            let base_url =
+                chatgpt_backend_base_url(connection.backend_profile.base_url.as_deref())?;
+            crate::OpenAiClient::new_with_base_url(secret, base_url)
+                .with_image_input_support(supports_image_input)
+                .with_extra_headers(chatgpt_backend_extra_headers(&connection))
+                .with_chatgpt_backend_wire()
+        }
+        OpenAiBackendKind::AzureOpenAi => {
+            let base_url = azure_openai_base_url(connection.backend_profile.base_url.as_deref())?;
+            crate::OpenAiClient::new_with_base_url(secret, base_url)
+                .with_image_input_support(supports_image_input)
+                .with_azure_openai_wire(azure_openai_wire_config(&connection))
+        }
+        OpenAiBackendKind::Copilot => {
+            return Err(ProviderClientError::MissingFeature("copilot-text-target"));
+        }
+    };
+    Ok(Arc::new(client))
+}
+
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 impl ProviderRuntime for OpenAiProviderRuntime {
@@ -517,93 +594,10 @@ impl ProviderRuntime for OpenAiProviderRuntime {
         &self,
         connection: ResolvedConnection,
     ) -> Result<Arc<dyn LlmClient>, ProviderClientError> {
-        // ProviderRuntimeRegistry dispatches on Provider enum; non-OpenAI
-        // arms are unreachable at runtime.
-        let backend_kind = match connection.backend {
-            NormalizedBackendKind::OpenAi(k) => k,
-            other => unreachable!(
-                "OpenAiProviderRuntime received non-OpenAi backend: {other:?} \
-                 — registry dispatch invariant violated"
-            ),
-        };
-        // Authorizer-backed path (ExternalAuthorizer→DynamicAuthorizer
-        // envelope). Wire through OpenAiClient.with_authorizer so the
-        // request uses HttpAuthorizer::authorize for headers rather
+        // Authorizer-backed connections use HttpAuthorizer rather
         // than Authorization: Bearer <api_key>. Plan §6.11: read the
-        // authorizer from the auth lease directly instead of the
-        // (deleted side channel).
-        #[cfg(not(target_arch = "wasm32"))]
-        if let Some(authorizer) = connection.resolved_authorizer() {
-            let base_url = match backend_kind {
-                OpenAiBackendKind::ChatGptBackend => {
-                    chatgpt_backend_base_url(connection.backend_profile.base_url.as_deref())?
-                }
-                OpenAiBackendKind::AzureOpenAi => {
-                    azure_openai_base_url(connection.backend_profile.base_url.as_deref())?
-                }
-                OpenAiBackendKind::OpenAiApi => connection
-                    .backend_profile
-                    .base_url
-                    .clone()
-                    .unwrap_or_else(|| backend_kind.default_base_url().into()),
-                OpenAiBackendKind::Copilot => {
-                    return Err(ProviderClientError::MissingFeature("copilot-text-target"));
-                }
-            };
-            let mut client =
-                crate::OpenAiClient::new_with_optional_api_key_and_base_url(None, base_url)
-                    .with_authorizer(authorizer);
-            if matches!(backend_kind, OpenAiBackendKind::ChatGptBackend) {
-                client = client.with_chatgpt_backend_wire();
-            } else if matches!(backend_kind, OpenAiBackendKind::AzureOpenAi) {
-                client = client.with_azure_openai_wire(azure_openai_wire_config(&connection));
-            }
-            return Ok(Arc::new(client));
-        }
-        // No inline secret and no DynamicAuthorizer kind: the
-        // lease was constructed empty. Surface as missing credential
-        // material (or MissingFeature on wasm32 where authorizers
-        // don't compile) so surfaces get a typed error.
-        #[cfg(target_arch = "wasm32")]
-        let secret = connection
-            .resolved_secret()
-            .ok_or(ProviderClientError::MissingFeature(
-                "openai-authorizer-backed auth not available on wasm32",
-            ))?;
-        #[cfg(not(target_arch = "wasm32"))]
-        let secret = connection
-            .resolved_secret()
-            .ok_or(ProviderClientError::NoCredentialMaterial)?;
-        match backend_kind {
-            OpenAiBackendKind::OpenAiApi => {
-                // S1-verified: OpenAiClient::new returns Self (infallible).
-                let client = match &connection.backend_profile.base_url {
-                    Some(url) => crate::OpenAiClient::new_with_base_url(secret, url.clone()),
-                    None => crate::OpenAiClient::new(secret),
-                };
-                Ok(Arc::new(client))
-            }
-            OpenAiBackendKind::ChatGptBackend => {
-                // ChatGPT backend: emit account_id + fedramp wire
-                // headers per Codex bearer_auth_provider.rs:23-38.
-                let base_url =
-                    chatgpt_backend_base_url(connection.backend_profile.base_url.as_deref())?;
-                let client = crate::OpenAiClient::new_with_base_url(secret, base_url)
-                    .with_extra_headers(chatgpt_backend_extra_headers(&connection))
-                    .with_chatgpt_backend_wire();
-                Ok(Arc::new(client))
-            }
-            OpenAiBackendKind::AzureOpenAi => {
-                let base_url =
-                    azure_openai_base_url(connection.backend_profile.base_url.as_deref())?;
-                let client = crate::OpenAiClient::new_with_base_url(secret, base_url)
-                    .with_azure_openai_wire(azure_openai_wire_config(&connection));
-                Ok(Arc::new(client))
-            }
-            OpenAiBackendKind::Copilot => {
-                Err(ProviderClientError::MissingFeature("copilot-text-target"))
-            }
-        }
+        // authorizer directly from the auth lease.
+        build_openai_client(connection, true)
     }
 
     fn build_text_client(
@@ -614,8 +608,8 @@ impl ProviderRuntime for OpenAiProviderRuntime {
             target.connection().backend,
             NormalizedBackendKind::OpenAi(OpenAiBackendKind::Copilot)
         ) {
-            let (_, _, connection) = target.into_parts();
-            return self.build_client(connection);
+            let (_, profile, connection) = target.into_parts();
+            return build_openai_client(connection, profile.profile().image_input);
         }
         #[cfg(all(feature = "copilot", not(target_arch = "wasm32")))]
         {
@@ -855,8 +849,9 @@ mod tests {
         Json, Router, extract::State, http::HeaderMap, response::IntoResponse, routing::post,
     };
     use meerkat_core::{
-        AuthMetadata, AuthProfile, BackendProfile, BindingPolicy, ImageProviderTerminalObservation,
-        OpenAiAuthMetadata, ProviderAuthMetadata,
+        AuthMetadata, AuthProfile, BackendProfile, BindingPolicy, ContentBlock, ImageData,
+        ImageProviderTerminalObservation, Message, OpenAiAuthMetadata, ProviderAuthMetadata,
+        UserMessage,
     };
     use meerkat_llm_core::{
         ProviderImageGenerationRequest,
@@ -981,6 +976,27 @@ mod tests {
                 "openai:test",
             )),
         }
+    }
+
+    #[test]
+    fn profile_aware_openai_builder_disables_image_replay() {
+        let client = build_openai_client(resolved_openai_connection(), false)
+            .expect("profile-aware OpenAI client");
+        let projected = client
+            .project_replay_messages(&[Message::User(UserMessage::with_blocks(vec![
+                ContentBlock::Image {
+                    media_type: "image/png".to_string(),
+                    data: ImageData::Inline {
+                        data: "IMAGE_BYTES".to_string(),
+                    },
+                },
+            ]))])
+            .expect("non-vision replay projection");
+
+        assert!(matches!(
+            &projected[0],
+            Message::User(user) if matches!(user.content.as_slice(), [ContentBlock::Text { .. }])
+        ));
     }
 
     fn resolved_realtime_target(

--- a/meerkat-openai/src/runtime/mod.rs
+++ b/meerkat-openai/src/runtime/mod.rs
@@ -240,6 +240,7 @@ impl meerkat_copilot::CopilotChatCompletionsClientFactory
         &self,
         spec: meerkat_copilot::CopilotChatCompletionsClientSpec,
     ) -> Result<Arc<dyn LlmClient>, ProviderClientError> {
+        let supports_image_input = spec.supports_image_input();
         let (
             provider,
             model,
@@ -263,6 +264,7 @@ impl meerkat_copilot::CopilotChatCompletionsClientFactory
                     supports_image_tool_results,
                 },
             )
+            .with_image_input_support(supports_image_input)
             .with_authorizer(authorizer)
             .with_provider(provider),
         ))
@@ -625,6 +627,7 @@ impl ProviderRuntime for OpenAiProviderRuntime {
             let (identity, profile, connection) = target.into_parts();
             let model = identity.model.clone();
             let supports_temperature = profile.profile().supports_temperature;
+            let supports_image_input = profile.profile().image_input;
             let supports_image_tool_results = profile.profile().image_tool_results;
             let factory: meerkat_copilot::CopilotRouteClientFactory =
                 Arc::new(move |route, connection| {
@@ -660,6 +663,7 @@ impl ProviderRuntime for OpenAiProviderRuntime {
                                 None,
                                 route.api_base.clone(),
                             )
+                            .with_image_input_support(supports_image_input)
                             .with_authorizer(authorizer)
                             .with_responses_path("responses"),
                         )
@@ -677,6 +681,7 @@ impl ProviderRuntime for OpenAiProviderRuntime {
                                     supports_image_tool_results,
                                 },
                             )
+                            .with_image_input_support(supports_image_input)
                             .with_authorizer(authorizer)
                             .with_provider(Provider::OpenAI),
                         )

--- a/meerkat-openai/src/text_adapter.rs
+++ b/meerkat-openai/src/text_adapter.rs
@@ -27,8 +27,7 @@ use async_stream::try_stream;
 use async_trait::async_trait;
 use meerkat_core::schema::{CompiledSchema, SchemaError};
 use meerkat_core::{
-    AssistantBlock, BlockAssistantMessage, ContentBlock, ImageData, Message, OutputSchema,
-    StopReason, ToolResult, Usage, UserMessage,
+    AssistantBlock, ContentBlock, ImageData, Message, OutputSchema, StopReason, Usage,
 };
 use meerkat_llm_core::{LlmClient, LlmDoneOutcome, LlmError, LlmEvent, LlmRequest, LlmStream};
 
@@ -37,7 +36,6 @@ use oai_rt_rs::protocol::models::{
     SessionUpdate, SessionUpdateConfig, Temperature, Tool, Usage as OaiUsage,
 };
 use oai_rt_rs::{ClientEvent, RealtimeClient, ServerEvent};
-use std::collections::HashSet;
 
 /// OpenAI's Realtime API caps `response.max_output_tokens` at 4096 for
 /// integer values; larger values fail with `integer above maximum value`.
@@ -98,160 +96,13 @@ pub struct OpenAiRealtimeTextAdapter {
     api_key: String,
 }
 
-fn invalid_replay(message: impl Into<String>) -> LlmError {
-    LlmError::InvalidRequest {
-        message: message.into(),
-    }
-}
-
-fn project_realtime_content_blocks(blocks: &[ContentBlock]) -> Vec<ContentBlock> {
-    blocks
-        .iter()
-        .map(|block| match block {
-            ContentBlock::Text { .. } => block.clone(),
-            _ => ContentBlock::Text {
-                text: block.text_projection().into_owned(),
-            },
-        })
-        .collect()
-}
-
-fn project_realtime_tool_result(result: &ToolResult) -> Result<ToolResult, LlmError> {
-    if result.has_video() {
-        return Err(invalid_replay(
-            "video blocks are not supported in OpenAI realtime tool results",
-        ));
-    }
-    Ok(ToolResult::new(
-        result.tool_use_id.clone(),
-        result.text_content(),
-        result.is_error,
-    ))
-}
-
-fn project_realtime_assistant_blocks(blocks: &[AssistantBlock]) -> Vec<AssistantBlock> {
-    blocks
-        .iter()
-        .filter_map(|block| match block {
-            AssistantBlock::Text { text, .. } if text.is_empty() => None,
-            AssistantBlock::Text { .. } | AssistantBlock::ToolUse { .. } => Some(block.clone()),
-            // Spoken transcripts replay back as plain text; provider sees
-            // the assistant's visible output regardless of capture lane.
-            AssistantBlock::Transcript { text, .. } if text.is_empty() => None,
-            AssistantBlock::Transcript { text, .. } => Some(AssistantBlock::Text {
-                text: text.clone(),
-                meta: None,
-            }),
-            AssistantBlock::Reasoning { .. }
-            | AssistantBlock::ServerToolContent { .. }
-            | AssistantBlock::Image { .. } => None,
-            _ => None,
-        })
-        .collect()
-}
-
-fn tool_ids_from_assistant(message: &Message) -> HashSet<String> {
-    match message {
-        Message::BlockAssistant(assistant) => assistant
-            .blocks
-            .iter()
-            .filter_map(|block| match block {
-                AssistantBlock::ToolUse { id, .. } => Some(id.clone()),
-                _ => None,
-            })
-            .collect(),
-        _ => HashSet::new(),
-    }
-}
-
-fn validate_tool_results(pending: HashSet<String>, results: &[ToolResult]) -> Result<(), LlmError> {
-    let actual: HashSet<String> = results
-        .iter()
-        .map(|result| result.tool_use_id.clone())
-        .collect();
-    if actual == pending {
-        Ok(())
-    } else {
-        Err(invalid_replay(
-            "OpenAI realtime replay projection found tool results that are not adjacent to matching tool uses",
-        ))
-    }
-}
-
 fn project_realtime_replay_messages(messages: &[Message]) -> Result<Vec<Message>, LlmError> {
-    let mut projected = Vec::with_capacity(messages.len());
-    let mut pending_tool_ids: Option<HashSet<String>> = None;
-
-    for message in messages {
-        if let Message::ToolResults {
-            results,
-            created_at,
-        } = message
-        {
-            let Some(pending) = pending_tool_ids.take() else {
-                return Err(invalid_replay(
-                    "OpenAI realtime replay projection found tool results without preceding tool use",
-                ));
-            };
-            validate_tool_results(pending, results)?;
-            let results = results
-                .iter()
-                .map(project_realtime_tool_result)
-                .collect::<Result<Vec<_>, _>>()?;
-            projected.push(Message::ToolResults {
-                results,
-                created_at: *created_at,
-            });
-            continue;
-        }
-
-        if pending_tool_ids.is_some() {
-            return Err(invalid_replay(
-                "OpenAI realtime replay projection found a tool use without adjacent tool results",
-            ));
-        }
-
-        let next_message = match message {
-            Message::System(_) | Message::SystemNotice(_) => Some(message.clone()),
-            Message::User(user) => Some(Message::User(UserMessage {
-                content: project_realtime_content_blocks(&user.content),
-                render_metadata: user.render_metadata.clone(),
-                identity: user.identity.clone(),
-                transcript_role: user.transcript_role,
-                created_at: user.created_at,
-            })),
-            Message::BlockAssistant(assistant) => {
-                let blocks = project_realtime_assistant_blocks(&assistant.blocks);
-                if blocks.is_empty() {
-                    None
-                } else {
-                    Some(Message::BlockAssistant(BlockAssistantMessage {
-                        blocks,
-                        stop_reason: assistant.stop_reason,
-                        identity: assistant.identity.clone(),
-                        created_at: assistant.created_at,
-                    }))
-                }
-            }
-            Message::ToolResults { .. } => unreachable!("handled above"),
-        };
-
-        if let Some(message) = next_message {
-            let tool_ids = tool_ids_from_assistant(&message);
-            if !tool_ids.is_empty() {
-                pending_tool_ids = Some(tool_ids);
-            }
-            projected.push(message);
-        }
-    }
-
-    if pending_tool_ids.is_some() {
-        return Err(invalid_replay(
-            "OpenAI realtime replay projection found a trailing tool use without tool results",
-        ));
-    }
-
-    Ok(projected)
+    crate::client::project_openai_replay_messages_for_target(
+        messages,
+        crate::client::OpenAiReplayProjectionMode::ChatCompletions,
+        false,
+        false,
+    )
 }
 
 impl OpenAiRealtimeTextAdapter {
@@ -1199,5 +1050,93 @@ mod tests {
         let negative = resolve_realtime_temperature(Some(-1.0))
             .expect_err("a negative temperature must be a typed reject");
         assert!(matches!(negative, LlmError::InvalidRequest { .. }));
+    }
+
+    #[test]
+    fn replay_projection_rejects_duplicate_tool_use_ids() {
+        let client = OpenAiRealtimeTextAdapter::new("test-key");
+        let args = serde_json::value::RawValue::from_string("{}".to_string())
+            .unwrap_or_else(|error| panic!("test args: {error}"));
+        let messages = [
+            Message::BlockAssistant(BlockAssistantMessage::new(
+                vec![
+                    AssistantBlock::ToolUse {
+                        id: "duplicate".to_string(),
+                        name: "a".to_string(),
+                        args: args.clone(),
+                        meta: None,
+                    },
+                    AssistantBlock::ToolUse {
+                        id: "duplicate".to_string(),
+                        name: "b".to_string(),
+                        args,
+                        meta: None,
+                    },
+                ],
+                StopReason::ToolUse,
+            )),
+            Message::tool_results(vec![ToolResult::new(
+                "duplicate".to_string(),
+                "result".to_string(),
+                false,
+            )]),
+        ];
+        assert!(matches!(
+            client.project_replay_messages(&messages),
+            Err(LlmError::InvalidRequest { .. })
+        ));
+    }
+
+    #[test]
+    fn replay_projection_rejects_duplicate_tool_result_ids() {
+        let client = OpenAiRealtimeTextAdapter::new("test-key");
+        let args = serde_json::value::RawValue::from_string("{}".to_string())
+            .unwrap_or_else(|error| panic!("test args: {error}"));
+        let messages = [
+            Message::BlockAssistant(BlockAssistantMessage::new(
+                vec![AssistantBlock::ToolUse {
+                    id: "tool".to_string(),
+                    name: "a".to_string(),
+                    args,
+                    meta: None,
+                }],
+                StopReason::ToolUse,
+            )),
+            Message::tool_results(vec![
+                ToolResult::new("tool".to_string(), "first".to_string(), false),
+                ToolResult::new("tool".to_string(), "second".to_string(), false),
+            ]),
+        ];
+        assert!(matches!(
+            client.project_replay_messages(&messages),
+            Err(LlmError::InvalidRequest { .. })
+        ));
+    }
+
+    #[test]
+    fn replay_projection_rejects_mismatched_tool_result_id() {
+        let client = OpenAiRealtimeTextAdapter::new("test-key");
+        let args = serde_json::value::RawValue::from_string("{}".to_string())
+            .unwrap_or_else(|error| panic!("test args: {error}"));
+        let messages = [
+            Message::BlockAssistant(BlockAssistantMessage::new(
+                vec![AssistantBlock::ToolUse {
+                    id: "tool".to_string(),
+                    name: "a".to_string(),
+                    args,
+                    meta: None,
+                }],
+                StopReason::ToolUse,
+            )),
+            Message::tool_results(vec![ToolResult::new(
+                "other".to_string(),
+                "result".to_string(),
+                false,
+            )]),
+        ];
+        assert!(matches!(
+            client.project_replay_messages(&messages),
+            Err(LlmError::InvalidRequest { .. })
+        ));
     }
 }

--- a/meerkat/src/factory.rs
+++ b/meerkat/src/factory.rs
@@ -1722,6 +1722,7 @@ struct SelfHostedClientSpec {
     supports_temperature: bool,
     supports_thinking: bool,
     supports_reasoning: bool,
+    supports_image_input: bool,
     supports_image_tool_results: bool,
 }
 
@@ -4569,6 +4570,7 @@ impl AgentFactory {
             supports_temperature: profile.supports_temperature,
             supports_thinking: profile.supports_thinking,
             supports_reasoning: profile.supports_reasoning,
+            supports_image_input: profile.image_input,
             supports_image_tool_results: profile.image_tool_results,
         })
     }
@@ -4639,18 +4641,21 @@ impl AgentFactory {
                 .clone()
                 .unwrap_or(spec.base_url);
             Ok(SelfHostedClientBuild {
-                client: Arc::new(OpenAiCompatibleClient::new_with_options(
-                    spec.mode,
-                    spec.remote_model,
-                    base_url,
-                    bearer_token,
-                    OpenAiCompatibleClientOptions {
-                        supports_temperature: spec.supports_temperature,
-                        supports_thinking: spec.supports_thinking,
-                        supports_reasoning: spec.supports_reasoning,
-                        supports_image_tool_results: spec.supports_image_tool_results,
-                    },
-                )),
+                client: Arc::new(
+                    OpenAiCompatibleClient::new_with_options(
+                        spec.mode,
+                        spec.remote_model,
+                        base_url,
+                        bearer_token,
+                        OpenAiCompatibleClientOptions {
+                            supports_temperature: spec.supports_temperature,
+                            supports_thinking: spec.supports_thinking,
+                            supports_reasoning: spec.supports_reasoning,
+                            supports_image_tool_results: spec.supports_image_tool_results,
+                        },
+                    )
+                    .with_image_input_support(spec.supports_image_input),
+                ),
                 durable_auth_binding,
                 credential_identity: connection.credential_identity,
             })


### PR DESCRIPTION
Closes #360.

## Summary
- add canonical typed transcript replay projection and structural validation
- lower replay into actual Anthropic, Gemini, OpenAI Responses, OpenAI-compatible Responses, and compatible Chat dispatch paths
- preserve provider metadata, tool-result collapse, nested notice image handling, constructor compatibility, and profile-aware image capability

## Evidence
- real HTTP/stream captures for all five dispatch families; bypassing each projection makes its test fail
- compatible modes independently pin exact `first\nsecond` collapse bytes
- exact 13-file scope; no CHANGELOG/generated/schema changes
- focused captures, scoped Clippy, RMAT/effect-authority, final architecture/Rust/correctness reviews
- exact-tree normal pre-push: every hook passed, including workspace deterministic unit+integration+e2e

Validated base: `5aad28eb92ffbaa35746f2560ceee414a45c3dc4`
Head: `3ed312c93ac6f0cba4e29b16dc2187cd2c39c94d`
Tree: `362982fa2fbfbbd45ba4ecf24ac4cb35227fc52b`
Patch IDs: `923e02be`, `c2e07e10`, `e4c871b6`, `94a75133`, `eb70d4f6`