### PR TITLE
chore: refresh machine posters

### DIFF
--- a/docs-internal/machine-posters/index.html
+++ b/docs-internal/machine-posters/index.html
@@ -75,12 +75,12 @@
         <a class="card" href="./meerkat_machine.html">
               <div class="eyebrow">Lifecycle / Transition / Visibility / Effect Architecture</div>
               <h2>MeerkatMachine</h2>
-              <p>40 inputs · 7 signals · 224 effects</p>
+              <p>44 inputs · 7 signals · 224 effects</p>
               <small>specs/machines/meerkat_machine/model.tla</small>
             </a><a class="card" href="./mob_machine.html">
               <div class="eyebrow">Identity / Runtime / Flow / Orchestration Architecture</div>
               <h2>MobMachine</h2>
-              <p>38 inputs · 73 signals · 141 effects</p>
+              <p>38 inputs · 73 signals · 142 effects</p>
               <small>specs/machines/mob_machine/model.tla</small>
             </a>
       </div>

--- a/docs-internal/machine-posters/meerkat_machine.html
+++ b/docs-internal/machine-posters/meerkat_machine.html
@@ -606,7 +606,7 @@
           <text x="70" y="22" fill="#f4efe5" font-size="11" font-weight="600" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">8</text>
           <rect x="124" y="0" width="54" height="28" rx="8" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.07)" />
           <text x="132" y="10" fill="#7d7a74" font-size="8" letter-spacing="1.4" font-family="Avenir Next, Helvetica Neue, Arial, sans-serif">INPUTS</text>
-          <text x="132" y="22" fill="#f4efe5" font-size="11" font-weight="600" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">40</text>
+          <text x="132" y="22" fill="#f4efe5" font-size="11" font-weight="600" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">44</text>
           <rect x="186" y="0" width="54" height="28" rx="8" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.07)" />
           <text x="194" y="10" fill="#7d7a74" font-size="8" letter-spacing="1.4" font-family="Avenir Next, Helvetica Neue, Arial, sans-serif">SIGNALS</text>
           <text x="194" y="22" fill="#f4efe5" font-size="11" font-weight="600" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">7</text>
@@ -618,7 +618,7 @@
           <text x="318" y="22" fill="#f4efe5" font-size="11" font-weight="600" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">49</text>
           <rect x="372" y="0" width="54" height="28" rx="8" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.07)" />
           <text x="380" y="10" fill="#7d7a74" font-size="8" letter-spacing="1.4" font-family="Avenir Next, Helvetica Neue, Arial, sans-serif">STATE</text>
-          <text x="380" y="22" fill="#f4efe5" font-size="11" font-weight="600" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">409</text>
+          <text x="380" y="22" fill="#f4efe5" font-size="11" font-weight="600" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">410</text>
   </g>
     <g transform="translate(24, 198)">
         <rect x="0" y="0" width="304" height="116" rx="12" fill="#141a1f" stroke="rgba(255,255,255,0.08)" />
@@ -637,7 +637,7 @@
         <text x="12" y="28" fill="#f4efe5" font-size="13" font-weight="600" font-family="Avenir Next, Helvetica Neue, Arial, sans-serif">Control Fabric</text>
 
       </g><g transform="translate(24, 420)">
-        <rect x="0" y="0" width="304" height="6950" rx="12" fill="#141a1f" stroke="rgba(255,255,255,0.08)" />
+        <rect x="0" y="0" width="304" height="6984" rx="12" fill="#141a1f" stroke="rgba(255,255,255,0.08)" />
         <text x="12" y="14" fill="#7d7a74" font-size="8" letter-spacing="1.5" font-family="Avenir Next, Helvetica Neue, Arial, sans-serif">SUBSYSTEM</text>
         <text x="12" y="28" fill="#f4efe5" font-size="13" font-weight="600" font-family="Avenir Next, Helvetica Neue, Arial, sans-serif">Residual Registers</text>
 
@@ -776,683 +776,685 @@
               <rect x="10" y="1162" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
               <text x="17" y="1178" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">model_routing_approval_parent_kind</text>
               <rect x="157" y="1162" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="1178" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">registration_phase</text>
+              <text x="164" y="1178" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">model_routing_handoff</text>
               <rect x="10" y="1196" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="1212" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">unregister_runtime_loop_drain_pending</text>
+              <text x="17" y="1212" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">registration_phase</text>
               <rect x="157" y="1196" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="1212" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">unregister_comms_drain_exit_pending</text>
+              <text x="164" y="1212" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">unregister_runtime_loop_drain_pending</text>
               <rect x="10" y="1230" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="1246" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">unregister_completion_waiter_drain_pending</text>
+              <text x="17" y="1246" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">unregister_comms_drain_exit_pending</text>
               <rect x="157" y="1230" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="1246" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">unregister_teardown_retains_snapshot</text>
+              <text x="164" y="1246" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">unregister_completion_waiter_drain_pending</text>
               <rect x="10" y="1264" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="1280" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">unregister_runtime_loop_forced_abort</text>
+              <text x="17" y="1280" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">unregister_teardown_retains_snapshot</text>
               <rect x="157" y="1264" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="1280" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">unregister_comms_drain_forced_abort</text>
+              <text x="164" y="1280" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">unregister_runtime_loop_forced_abort</text>
               <rect x="10" y="1298" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="1314" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">staged_session_phase</text>
+              <text x="17" y="1314" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">unregister_comms_drain_forced_abort</text>
               <rect x="157" y="1298" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="1314" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">staged_session_id</text>
+              <text x="164" y="1314" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">staged_session_phase</text>
               <rect x="10" y="1332" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="1348" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">staged_session_keep_alive</text>
+              <text x="17" y="1348" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">staged_session_id</text>
               <rect x="157" y="1332" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="1348" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">staged_session_llm_identity</text>
+              <text x="164" y="1348" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">staged_session_keep_alive</text>
               <rect x="10" y="1366" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="1382" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">staged_session_machine_archived_resume_authorized</text>
+              <text x="17" y="1382" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">staged_session_llm_identity</text>
               <rect x="157" y="1366" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="1382" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">current_session_llm_identity</text>
+              <text x="164" y="1382" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">staged_session_machine_archived_resume_authorized</text>
               <rect x="10" y="1400" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="1416" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">current_session_capability_surface</text>
+              <text x="17" y="1416" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">current_session_llm_identity</text>
               <rect x="157" y="1400" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="1416" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">current_session_capability_surface_status</text>
+              <text x="164" y="1416" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">current_session_capability_surface</text>
               <rect x="10" y="1434" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="1450" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">current_session_capability_base_filter</text>
+              <text x="17" y="1450" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">current_session_capability_surface_status</text>
               <rect x="157" y="1434" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="1450" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">session_llm_reconfigure_previous_capability_surface</text>
+              <text x="164" y="1450" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">current_session_capability_base_filter</text>
               <rect x="10" y="1468" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="1484" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">session_llm_reconfigure_current_capability_surface</text>
+              <text x="17" y="1484" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">session_llm_reconfigure_previous_capability_surface</text>
               <rect x="157" y="1468" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="1484" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">session_llm_reconfigure_capability_changed</text>
+              <text x="164" y="1484" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">session_llm_reconfigure_current_capability_surface</text>
               <rect x="10" y="1502" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="1518" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">session_llm_reconfigure_previous_capability_base_filter</text>
+              <text x="17" y="1518" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">session_llm_reconfigure_capability_changed</text>
               <rect x="157" y="1502" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="1518" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">session_llm_reconfigure_current_capability_base_filter</text>
+              <text x="164" y="1518" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">session_llm_reconfigure_previous_capability_base_filter</text>
               <rect x="10" y="1536" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="1552" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">session_llm_reconfigure_committed_visible_set_changed</text>
+              <text x="17" y="1552" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">session_llm_reconfigure_current_capability_base_filter</text>
               <rect x="157" y="1536" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="1552" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">session_llm_reconfigure_revision_bumped</text>
+              <text x="164" y="1552" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">session_llm_reconfigure_committed_visible_set_changed</text>
               <rect x="10" y="1570" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="1586" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">session_llm_reconfigure_active_visibility_revision</text>
+              <text x="17" y="1586" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">session_llm_reconfigure_revision_bumped</text>
               <rect x="157" y="1570" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="1586" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">mob_operator_authority_present</text>
+              <text x="164" y="1586" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">session_llm_reconfigure_active_visibility_revision</text>
               <rect x="10" y="1604" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="1620" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">mob_operator_principal_token</text>
+              <text x="17" y="1620" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">mob_operator_authority_present</text>
               <rect x="157" y="1604" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="1620" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">mob_operator_can_create_mobs</text>
+              <text x="164" y="1620" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">mob_operator_principal_token</text>
               <rect x="10" y="1638" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="1654" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">mob_operator_can_mutate_profiles</text>
+              <text x="17" y="1654" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">mob_operator_can_create_mobs</text>
               <rect x="157" y="1638" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="1654" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">mob_operator_managed_mob_scope</text>
+              <text x="164" y="1654" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">mob_operator_can_mutate_profiles</text>
               <rect x="10" y="1672" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="1688" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">mob_operator_spawn_profile_scope</text>
+              <text x="17" y="1688" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">mob_operator_managed_mob_scope</text>
               <rect x="157" y="1672" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="1688" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">mob_operator_caller_provenance</text>
+              <text x="164" y="1688" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">mob_operator_spawn_profile_scope</text>
               <rect x="10" y="1706" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="1722" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">mob_operator_audit_invocation_id</text>
+              <text x="17" y="1722" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">mob_operator_caller_provenance</text>
               <rect x="157" y="1706" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="1722" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">drain_phase</text>
+              <text x="164" y="1722" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">mob_operator_audit_invocation_id</text>
               <rect x="10" y="1740" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="1756" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">drain_mode</text>
+              <text x="17" y="1756" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">drain_phase</text>
               <rect x="157" y="1740" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="1756" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">next_staged_visibility_revision</text>
+              <text x="164" y="1756" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">drain_mode</text>
               <rect x="10" y="1774" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="1790" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">inherited_base_filter</text>
+              <text x="17" y="1790" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">next_staged_visibility_revision</text>
               <rect x="157" y="1774" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="1790" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">active_filter</text>
+              <text x="164" y="1790" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">inherited_base_filter</text>
               <rect x="10" y="1808" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="1824" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">staged_filter</text>
+              <text x="17" y="1824" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">active_filter</text>
               <rect x="157" y="1808" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="1824" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">active_visibility_revision</text>
+              <text x="164" y="1824" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">staged_filter</text>
               <rect x="10" y="1842" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="1858" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">staged_visibility_revision</text>
+              <text x="17" y="1858" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">active_visibility_revision</text>
               <rect x="157" y="1842" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="1858" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">active_deferred_names</text>
+              <text x="164" y="1858" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">staged_visibility_revision</text>
               <rect x="10" y="1876" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="1892" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">staged_deferred_names</text>
+              <text x="17" y="1892" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">active_deferred_names</text>
               <rect x="157" y="1876" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="1892" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">requested_visibility_witnesses</text>
+              <text x="164" y="1892" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">staged_deferred_names</text>
               <rect x="10" y="1910" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="1926" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">filter_visibility_witnesses</text>
+              <text x="17" y="1926" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">requested_visibility_witnesses</text>
               <rect x="157" y="1910" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="1926" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">active_deferred_authorities</text>
+              <text x="164" y="1926" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">filter_visibility_witnesses</text>
               <rect x="10" y="1944" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="1960" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">staged_deferred_authorities</text>
+              <text x="17" y="1960" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">active_deferred_authorities</text>
               <rect x="157" y="1944" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="1960" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">deferred_visibility_authority_catalog</text>
+              <text x="164" y="1960" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">staged_deferred_authorities</text>
               <rect x="10" y="1978" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="1994" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">filter_visibility_authority_catalog</text>
+              <text x="17" y="1994" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">deferred_visibility_authority_catalog</text>
               <rect x="157" y="1978" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="1994" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">turn_tool_overlay_allow_active</text>
+              <text x="164" y="1994" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">filter_visibility_authority_catalog</text>
               <rect x="10" y="2012" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="2028" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">turn_tool_overlay_allow_names</text>
+              <text x="17" y="2028" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">turn_tool_overlay_allow_active</text>
               <rect x="157" y="2012" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="2028" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">turn_tool_overlay_deny_names</text>
+              <text x="164" y="2028" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">turn_tool_overlay_allow_names</text>
               <rect x="10" y="2046" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="2062" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">input_phases</text>
+              <text x="17" y="2062" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">turn_tool_overlay_deny_names</text>
               <rect x="157" y="2046" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="2062" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">input_terminal_kind</text>
+              <text x="164" y="2062" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">input_phases</text>
               <rect x="10" y="2080" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="2096" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">input_superseded_by</text>
+              <text x="17" y="2096" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">input_terminal_kind</text>
               <rect x="157" y="2080" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="2096" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">input_aggregate_id</text>
+              <text x="164" y="2096" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">input_superseded_by</text>
               <rect x="10" y="2114" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="2130" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">input_abandon_reason</text>
+              <text x="17" y="2130" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">input_aggregate_id</text>
               <rect x="157" y="2114" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="2130" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">input_abandon_attempt_count</text>
+              <text x="164" y="2130" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">input_abandon_reason</text>
               <rect x="10" y="2148" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="2164" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">input_attempt_counts</text>
+              <text x="17" y="2164" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">input_abandon_attempt_count</text>
               <rect x="157" y="2148" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="2164" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">max_stage_attempts</text>
+              <text x="164" y="2164" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">input_attempt_counts</text>
               <rect x="10" y="2182" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="2198" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">input_run_associations</text>
+              <text x="17" y="2198" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">max_stage_attempts</text>
               <rect x="157" y="2182" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="2198" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">input_boundary_sequences</text>
+              <text x="164" y="2198" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">input_run_associations</text>
               <rect x="10" y="2216" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="2232" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_boundary_context_sequence_by_run</text>
+              <text x="17" y="2232" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">input_boundary_sequences</text>
               <rect x="157" y="2216" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="2232" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">next_admission_seq</text>
+              <text x="164" y="2232" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_boundary_context_sequence_by_run</text>
               <rect x="10" y="2250" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="2266" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">next_priority_admission_seq</text>
+              <text x="17" y="2266" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">next_admission_seq</text>
               <rect x="157" y="2250" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="2266" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">input_admission_seq</text>
+              <text x="164" y="2266" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">next_priority_admission_seq</text>
               <rect x="10" y="2284" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="2300" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">input_runtime_boundary</text>
+              <text x="17" y="2300" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">input_admission_seq</text>
               <rect x="157" y="2284" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="2300" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">input_runtime_execution_kind</text>
+              <text x="164" y="2300" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">input_runtime_boundary</text>
               <rect x="10" y="2318" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="2334" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">input_runtime_peer_response_terminal_apply_intent</text>
+              <text x="17" y="2334" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">input_runtime_execution_kind</text>
               <rect x="157" y="2318" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="2334" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">input_is_prompt</text>
+              <text x="164" y="2334" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">input_runtime_peer_response_terminal_apply_intent</text>
               <rect x="10" y="2352" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="2368" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">input_lane</text>
+              <text x="17" y="2368" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">input_is_prompt</text>
               <rect x="157" y="2352" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="2368" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">input_recovery_lanes</text>
+              <text x="164" y="2368" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">input_lane</text>
               <rect x="10" y="2386" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="2402" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">admission_authorized_lanes</text>
+              <text x="17" y="2402" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">input_recovery_lanes</text>
               <rect x="157" y="2386" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="2402" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">admission_authorized_plans</text>
+              <text x="164" y="2402" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">admission_authorized_lanes</text>
               <rect x="10" y="2420" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="2436" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">admission_authorized_existing_actions</text>
+              <text x="17" y="2436" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">admission_authorized_plans</text>
               <rect x="157" y="2420" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="2436" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">admission_authorized_existing_targets</text>
+              <text x="164" y="2436" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">admission_authorized_existing_actions</text>
               <rect x="10" y="2454" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="2470" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">admission_idempotency_inputs</text>
+              <text x="17" y="2470" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">admission_authorized_existing_targets</text>
               <rect x="157" y="2454" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="2470" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">input_idempotency_keys</text>
+              <text x="164" y="2470" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">admission_idempotency_inputs</text>
               <rect x="10" y="2488" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="2504" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">recovered_admitted_inputs</text>
+              <text x="17" y="2504" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">input_idempotency_keys</text>
               <rect x="157" y="2488" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="2504" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">recovered_admitted_lanes</text>
+              <text x="164" y="2504" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">recovered_admitted_inputs</text>
               <rect x="10" y="2522" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="2538" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">op_statuses</text>
+              <text x="17" y="2538" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">recovered_admitted_lanes</text>
               <rect x="157" y="2522" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="2538" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">op_completion_seq</text>
+              <text x="164" y="2538" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">op_statuses</text>
               <rect x="10" y="2556" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="2572" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">completion_sequence_claims</text>
+              <text x="17" y="2572" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">op_completion_seq</text>
               <rect x="157" y="2556" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="2572" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">completion_feed_sequences</text>
+              <text x="164" y="2572" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">completion_sequence_claims</text>
               <rect x="10" y="2590" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="2606" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">completion_feed_kinds</text>
+              <text x="17" y="2606" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">completion_feed_sequences</text>
               <rect x="157" y="2590" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="2606" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">completion_feed_terminal_outcomes</text>
+              <text x="164" y="2606" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">completion_feed_kinds</text>
               <rect x="10" y="2624" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="2640" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">completion_feed_terminal_payload</text>
+              <text x="17" y="2640" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">completion_feed_terminal_outcomes</text>
               <rect x="157" y="2624" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="2640" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">op_terminal_outcomes</text>
+              <text x="164" y="2640" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">completion_feed_terminal_payload</text>
               <rect x="10" y="2658" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="2674" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">op_terminal_payload</text>
+              <text x="17" y="2674" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">op_terminal_outcomes</text>
               <rect x="157" y="2658" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="2674" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">op_kinds</text>
+              <text x="164" y="2674" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">op_terminal_payload</text>
               <rect x="10" y="2692" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="2708" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">op_sources</text>
+              <text x="17" y="2708" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">op_kinds</text>
               <rect x="157" y="2692" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="2708" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">op_peer_ready</text>
+              <text x="164" y="2708" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">op_sources</text>
               <rect x="10" y="2726" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="2742" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">op_progress_counts</text>
+              <text x="17" y="2742" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">op_peer_ready</text>
               <rect x="157" y="2726" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="2742" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">active_op_count</text>
+              <text x="164" y="2742" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">op_progress_counts</text>
               <rect x="10" y="2760" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="2776" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">wait_active</text>
+              <text x="17" y="2776" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">active_op_count</text>
               <rect x="157" y="2760" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="2776" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">wait_request_id</text>
+              <text x="164" y="2776" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">wait_active</text>
               <rect x="10" y="2794" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="2810" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">wait_run_id</text>
+              <text x="17" y="2810" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">wait_request_id</text>
               <rect x="157" y="2794" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="2810" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">wait_operation_ids</text>
+              <text x="164" y="2810" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">wait_run_id</text>
               <rect x="10" y="2828" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="2844" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">wait_operation_id_tokens</text>
+              <text x="17" y="2844" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">wait_operation_ids</text>
               <rect x="157" y="2828" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="2844" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">next_completion_seq</text>
+              <text x="164" y="2844" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">wait_operation_id_tokens</text>
               <rect x="10" y="2862" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="2878" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">completion_agent_applied_cursor</text>
+              <text x="17" y="2878" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">next_completion_seq</text>
               <rect x="157" y="2862" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="2878" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">completion_runtime_observed_cursor</text>
+              <text x="164" y="2878" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">completion_agent_applied_cursor</text>
               <rect x="10" y="2896" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="2912" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">completion_runtime_injected_cursor</text>
+              <text x="17" y="2912" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">completion_runtime_observed_cursor</text>
               <rect x="157" y="2896" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="2912" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">surface_request_phases</text>
+              <text x="164" y="2912" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">completion_runtime_injected_cursor</text>
               <rect x="10" y="2930" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="2946" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">surface_request_terminal_policies</text>
+              <text x="17" y="2946" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">surface_request_phases</text>
               <rect x="157" y="2930" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="2946" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_open_admission_sequence</text>
+              <text x="164" y="2946" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">surface_request_terminal_policies</text>
               <rect x="10" y="2964" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="2980" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_active_channel_by_session</text>
+              <text x="17" y="2980" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_open_admission_sequence</text>
               <rect x="157" y="2964" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="2980" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_channel_session_by_channel</text>
+              <text x="164" y="2980" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_active_channel_by_session</text>
               <rect x="10" y="2998" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="3014" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_channel_identity_by_channel</text>
+              <text x="17" y="3014" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_channel_session_by_channel</text>
               <rect x="157" y="2998" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="3014" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_execution_runtime_id_by_channel</text>
+              <text x="164" y="3014" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_channel_identity_by_channel</text>
               <rect x="10" y="3032" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="3048" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_execution_fence_by_channel</text>
+              <text x="17" y="3048" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_execution_runtime_id_by_channel</text>
               <rect x="157" y="3032" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="3048" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_execution_generation_by_channel</text>
+              <text x="164" y="3048" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_execution_fence_by_channel</text>
               <rect x="10" y="3066" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="3082" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_execution_phase_by_channel</text>
+              <text x="17" y="3082" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_execution_generation_by_channel</text>
               <rect x="157" y="3066" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="3082" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_revoked_execution_channels</text>
+              <text x="164" y="3082" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_execution_phase_by_channel</text>
               <rect x="10" y="3100" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="3116" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_execution_profile_by_channel</text>
+              <text x="17" y="3116" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_revoked_execution_channels</text>
               <rect x="157" y="3100" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="3116" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_execution_mode_by_channel</text>
+              <text x="164" y="3116" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_execution_profile_by_channel</text>
               <rect x="10" y="3134" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="3150" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_function_bridge_capable_channels</text>
+              <text x="17" y="3150" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_execution_mode_by_channel</text>
               <rect x="157" y="3134" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="3150" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_client_context_capable_channels</text>
+              <text x="164" y="3150" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_function_bridge_capable_channels</text>
               <rect x="10" y="3168" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="3184" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_playback_owner_by_channel</text>
+              <text x="17" y="3184" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_client_context_capable_channels</text>
               <rect x="157" y="3168" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="3184" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_playback_readiness_by_channel</text>
+              <text x="164" y="3184" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_playback_owner_by_channel</text>
               <rect x="10" y="3202" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="3218" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_activation_receipt_by_channel</text>
+              <text x="17" y="3218" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_playback_readiness_by_channel</text>
               <rect x="157" y="3202" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="3218" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_active_control_operation_by_authority</text>
+              <text x="164" y="3218" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_activation_receipt_by_channel</text>
               <rect x="10" y="3236" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="3252" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_consumed_active_control_authorities</text>
+              <text x="17" y="3252" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_active_control_operation_by_authority</text>
               <rect x="157" y="3236" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="3252" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_experimental_staged_runtime_by_channel</text>
+              <text x="164" y="3252" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_consumed_active_control_authorities</text>
               <rect x="10" y="3270" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="3286" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_experimental_staged_fence_by_channel</text>
+              <text x="17" y="3286" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_experimental_staged_runtime_by_channel</text>
               <rect x="157" y="3270" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="3286" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_experimental_staged_generation_by_channel</text>
+              <text x="164" y="3286" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_experimental_staged_fence_by_channel</text>
               <rect x="10" y="3304" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="3320" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_experimental_staged_seed_cursor_by_channel</text>
+              <text x="17" y="3320" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_experimental_staged_generation_by_channel</text>
               <rect x="157" y="3304" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="3320" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_experimental_pending_receipt_by_channel</text>
+              <text x="164" y="3320" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_experimental_staged_seed_cursor_by_channel</text>
               <rect x="10" y="3338" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="3354" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_experimental_execution_channels</text>
+              <text x="17" y="3354" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_experimental_pending_receipt_by_channel</text>
               <rect x="157" y="3338" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="3354" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_interaction_channel_by_id</text>
+              <text x="164" y="3354" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_experimental_execution_channels</text>
               <rect x="10" y="3372" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="3388" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_active_interaction_by_channel</text>
+              <text x="17" y="3388" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_interaction_channel_by_id</text>
               <rect x="157" y="3372" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="3388" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_provider_turn_by_channel</text>
+              <text x="164" y="3388" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_active_interaction_by_channel</text>
               <rect x="10" y="3406" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="3422" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_provider_interaction_by_turn</text>
+              <text x="17" y="3422" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_provider_turn_by_channel</text>
               <rect x="157" y="3406" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="3422" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_provider_turn_channel_by_ref</text>
+              <text x="164" y="3422" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_provider_interaction_by_turn</text>
               <rect x="10" y="3440" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="3456" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_awaiting_assistant_interaction_by_channel</text>
+              <text x="17" y="3456" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_provider_turn_channel_by_ref</text>
               <rect x="157" y="3440" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="3456" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_assistant_interaction_by_turn</text>
+              <text x="164" y="3456" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_awaiting_assistant_interaction_by_channel</text>
               <rect x="10" y="3474" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="3490" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_assistant_turn_channel_by_ref</text>
+              <text x="17" y="3490" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_assistant_interaction_by_turn</text>
               <rect x="157" y="3474" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="3490" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_abandoned_interactions</text>
+              <text x="164" y="3490" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_assistant_turn_channel_by_ref</text>
               <rect x="10" y="3508" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="3524" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_delegation_interaction_by_channel</text>
+              <text x="17" y="3524" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_abandoned_interactions</text>
               <rect x="157" y="3508" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="3524" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_delegation_operation_by_channel</text>
+              <text x="164" y="3524" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_delegation_interaction_by_channel</text>
               <rect x="10" y="3542" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="3558" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_delegation_provider_turn_by_channel</text>
+              <text x="17" y="3558" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_delegation_operation_by_channel</text>
               <rect x="157" y="3542" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="3558" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_delegation_interaction_by_operation</text>
+              <text x="164" y="3558" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_delegation_provider_turn_by_channel</text>
               <rect x="10" y="3576" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="3592" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_delegation_provider_turn_by_operation</text>
+              <text x="17" y="3592" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_delegation_interaction_by_operation</text>
               <rect x="157" y="3576" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="3592" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_delegation_reconciliation_by_operation</text>
+              <text x="164" y="3592" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_delegation_provider_turn_by_operation</text>
               <rect x="10" y="3610" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="3626" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_delegation_worker_identity_by_operation</text>
+              <text x="17" y="3626" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_delegation_reconciliation_by_operation</text>
               <rect x="157" y="3610" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="3626" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_delegation_worker_phase_by_operation</text>
+              <text x="164" y="3626" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_delegation_worker_identity_by_operation</text>
               <rect x="10" y="3644" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="3660" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_delegation_cancellation_reason_by_operation</text>
+              <text x="17" y="3660" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_delegation_worker_phase_by_operation</text>
               <rect x="157" y="3644" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="3660" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_delegation_worker_terminal_by_operation</text>
+              <text x="164" y="3660" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_delegation_cancellation_reason_by_operation</text>
               <rect x="10" y="3678" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="3694" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_delegation_result_eligible_operations</text>
+              <text x="17" y="3694" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_delegation_worker_terminal_by_operation</text>
               <rect x="157" y="3678" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="3694" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_delegation_late_terminal_operations</text>
+              <text x="164" y="3694" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_delegation_result_eligible_operations</text>
               <rect x="10" y="3712" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="3728" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_consequential_effect_operation_by_authority</text>
+              <text x="17" y="3728" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_delegation_late_terminal_operations</text>
               <rect x="157" y="3712" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="3728" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_result_released_operations</text>
+              <text x="164" y="3728" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_consequential_effect_operation_by_authority</text>
               <rect x="10" y="3746" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="3762" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_result_release_disposition_by_operation</text>
+              <text x="17" y="3762" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_result_released_operations</text>
               <rect x="157" y="3746" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="3762" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_result_delivery_channel_by_operation</text>
+              <text x="164" y="3762" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_result_release_disposition_by_operation</text>
               <rect x="10" y="3780" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="3796" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_result_delivery_operation_by_channel</text>
+              <text x="17" y="3796" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_result_delivery_channel_by_operation</text>
               <rect x="157" y="3780" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="3796" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_result_delivery_digest_by_operation</text>
+              <text x="164" y="3796" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_result_delivery_operation_by_channel</text>
               <rect x="10" y="3814" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="3830" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_result_delivery_observation_by_operation</text>
+              <text x="17" y="3830" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_result_delivery_digest_by_operation</text>
               <rect x="157" y="3814" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="3830" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_result_speech_suppressed_operations</text>
+              <text x="164" y="3830" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_result_delivery_observation_by_operation</text>
               <rect x="10" y="3848" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="3864" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_result_recovery_replacement_by_channel</text>
+              <text x="17" y="3864" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_result_speech_suppressed_operations</text>
               <rect x="157" y="3848" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="3864" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_result_recovery_source_by_replacement</text>
+              <text x="164" y="3864" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_result_recovery_replacement_by_channel</text>
               <rect x="10" y="3882" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="3898" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_result_recovery_session_by_channel</text>
+              <text x="17" y="3898" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_result_recovery_source_by_replacement</text>
               <rect x="157" y="3882" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="3898" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_result_recovery_operation_by_channel</text>
+              <text x="164" y="3898" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_result_recovery_session_by_channel</text>
               <rect x="10" y="3916" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="3932" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_result_recovery_digest_by_channel</text>
+              <text x="17" y="3932" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_result_recovery_operation_by_channel</text>
               <rect x="157" y="3916" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="3932" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_result_recovery_seed_cursor_by_channel</text>
+              <text x="164" y="3932" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_result_recovery_digest_by_channel</text>
               <rect x="10" y="3950" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="3966" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_result_recovery_identity_by_channel</text>
+              <text x="17" y="3966" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_result_recovery_seed_cursor_by_channel</text>
               <rect x="157" y="3950" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="3966" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_result_recovery_runtime_id_by_channel</text>
+              <text x="164" y="3966" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_result_recovery_identity_by_channel</text>
               <rect x="10" y="3984" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="4000" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_result_recovery_fence_by_channel</text>
+              <text x="17" y="4000" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_result_recovery_runtime_id_by_channel</text>
               <rect x="157" y="3984" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="4000" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_result_recovery_generation_by_channel</text>
+              <text x="164" y="4000" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_result_recovery_fence_by_channel</text>
               <rect x="10" y="4018" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="4034" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_bridge_operation_by_channel</text>
+              <text x="17" y="4034" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_result_recovery_generation_by_channel</text>
               <rect x="157" y="4018" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="4034" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_bridge_channel_by_operation</text>
+              <text x="164" y="4034" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_bridge_operation_by_channel</text>
               <rect x="10" y="4052" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="4068" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_bridge_interaction_by_operation</text>
+              <text x="17" y="4068" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_bridge_channel_by_operation</text>
               <rect x="157" y="4052" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="4068" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_bridge_provider_turn_by_operation</text>
+              <text x="164" y="4068" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_bridge_interaction_by_operation</text>
               <rect x="10" y="4086" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="4102" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_bridge_provider_delegation_by_operation</text>
+              <text x="17" y="4102" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_bridge_provider_turn_by_operation</text>
               <rect x="157" y="4086" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="4102" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_bridge_provider_call_by_operation</text>
+              <text x="164" y="4102" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_bridge_provider_delegation_by_operation</text>
               <rect x="10" y="4120" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="4136" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_bridge_agent_identity_by_operation</text>
+              <text x="17" y="4136" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_bridge_provider_call_by_operation</text>
               <rect x="157" y="4120" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="4136" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_bridge_context_revision_by_operation</text>
+              <text x="164" y="4136" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_bridge_agent_identity_by_operation</text>
               <rect x="10" y="4154" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="4170" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_bridge_request_digest_by_operation</text>
+              <text x="17" y="4170" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_bridge_context_revision_by_operation</text>
               <rect x="157" y="4154" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="4170" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_bridge_phase_by_operation</text>
+              <text x="164" y="4170" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_bridge_request_digest_by_operation</text>
               <rect x="10" y="4188" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="4204" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_bridge_effect_operation_by_authority</text>
+              <text x="17" y="4204" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_bridge_phase_by_operation</text>
               <rect x="157" y="4188" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="4204" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_bridge_effect_kind_by_authority</text>
+              <text x="164" y="4204" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_bridge_effect_operation_by_authority</text>
               <rect x="10" y="4222" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="4238" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_bridge_consumed_effect_authorities</text>
+              <text x="17" y="4238" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_bridge_effect_kind_by_authority</text>
               <rect x="157" y="4222" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="4238" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_bridge_in_flight_effect_authorities</text>
+              <text x="164" y="4238" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_bridge_consumed_effect_authorities</text>
               <rect x="10" y="4256" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="4272" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_bridge_effect_outcome_by_authority</text>
+              <text x="17" y="4272" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_bridge_in_flight_effect_authorities</text>
               <rect x="157" y="4256" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="4272" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_bridge_model_computation_authorized_operations</text>
+              <text x="164" y="4272" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_bridge_effect_outcome_by_authority</text>
               <rect x="10" y="4290" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="4306" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_bridge_read_snapshot_authorized_operations</text>
+              <text x="17" y="4306" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_bridge_model_computation_authorized_operations</text>
               <rect x="157" y="4290" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="4306" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_bridge_execution_started_operations</text>
+              <text x="164" y="4306" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_bridge_read_snapshot_authorized_operations</text>
               <rect x="10" y="4324" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="4340" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_bridge_outcome_receipt_required_operations</text>
+              <text x="17" y="4340" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_bridge_execution_started_operations</text>
               <rect x="157" y="4324" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="4340" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_bridge_outcome_receipt_operations</text>
+              <text x="164" y="4340" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_bridge_outcome_receipt_required_operations</text>
               <rect x="10" y="4358" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="4374" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_bridge_execution_terminal_by_operation</text>
+              <text x="17" y="4374" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_bridge_outcome_receipt_operations</text>
               <rect x="157" y="4358" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="4374" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_bridge_execution_result_digest_by_operation</text>
+              <text x="164" y="4374" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_bridge_execution_terminal_by_operation</text>
               <rect x="10" y="4392" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="4408" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_bridge_cancellation_reason_by_operation</text>
+              <text x="17" y="4408" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_bridge_execution_result_digest_by_operation</text>
               <rect x="157" y="4392" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="4408" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_bridge_submission_output_kind_by_operation</text>
+              <text x="164" y="4408" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_bridge_cancellation_reason_by_operation</text>
               <rect x="10" y="4426" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="4442" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_bridge_submission_digest_by_operation</text>
+              <text x="17" y="4442" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_bridge_submission_output_kind_by_operation</text>
               <rect x="157" y="4426" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="4442" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_bridge_submission_state_by_operation</text>
+              <text x="164" y="4442" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_bridge_submission_digest_by_operation</text>
               <rect x="10" y="4460" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="4476" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_context_cursor_by_channel</text>
+              <text x="17" y="4476" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_bridge_submission_state_by_operation</text>
               <rect x="157" y="4460" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="4476" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_context_queued_session_by_append</text>
+              <text x="164" y="4476" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_context_cursor_by_channel</text>
               <rect x="10" y="4494" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="4510" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_context_queued_cursor_by_append</text>
+              <text x="17" y="4510" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_context_queued_session_by_append</text>
               <rect x="157" y="4494" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="4510" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_context_queued_digest_by_append</text>
+              <text x="164" y="4510" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_context_queued_cursor_by_append</text>
               <rect x="10" y="4528" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="4544" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_context_queued_commit_token_by_append</text>
+              <text x="17" y="4544" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_context_queued_digest_by_append</text>
               <rect x="157" y="4528" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="4544" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_context_queued_disposition_by_append</text>
+              <text x="164" y="4544" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_context_queued_commit_token_by_append</text>
               <rect x="10" y="4562" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="4578" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_context_queued_append_by_cursor</text>
+              <text x="17" y="4578" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_context_queued_disposition_by_append</text>
               <rect x="157" y="4562" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="4578" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_context_pending_append_by_channel</text>
+              <text x="164" y="4578" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_context_queued_append_by_cursor</text>
               <rect x="10" y="4596" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="4612" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_context_pending_channel_by_append</text>
+              <text x="17" y="4612" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_context_pending_append_by_channel</text>
               <rect x="157" y="4596" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="4612" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_context_pending_previous_cursor_by_append</text>
+              <text x="164" y="4612" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_context_pending_channel_by_append</text>
               <rect x="10" y="4630" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="4646" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_context_pending_next_cursor_by_append</text>
+              <text x="17" y="4646" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_context_pending_previous_cursor_by_append</text>
               <rect x="157" y="4630" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="4646" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_context_delivered_append_ids</text>
+              <text x="164" y="4646" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_context_pending_next_cursor_by_append</text>
               <rect x="10" y="4664" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="4680" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_context_ambiguous_no_retry</text>
+              <text x="17" y="4680" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_context_delivered_append_ids</text>
               <rect x="157" y="4664" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="4680" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_context_recovery_replacement_by_channel</text>
+              <text x="164" y="4680" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_context_ambiguous_no_retry</text>
               <rect x="10" y="4698" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="4714" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_context_recovery_source_by_replacement</text>
+              <text x="17" y="4714" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_context_recovery_replacement_by_channel</text>
               <rect x="157" y="4698" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="4714" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_context_recovery_session_by_channel</text>
+              <text x="164" y="4714" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_context_recovery_source_by_replacement</text>
               <rect x="10" y="4732" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="4748" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_context_recovery_append_by_channel</text>
+              <text x="17" y="4748" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_context_recovery_session_by_channel</text>
               <rect x="157" y="4732" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="4748" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_context_recovery_seed_cursor_by_channel</text>
+              <text x="164" y="4748" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_context_recovery_append_by_channel</text>
               <rect x="10" y="4766" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="4782" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_context_recovery_identity_by_channel</text>
+              <text x="17" y="4782" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_context_recovery_seed_cursor_by_channel</text>
               <rect x="157" y="4766" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="4782" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_context_recovery_runtime_id_by_channel</text>
+              <text x="164" y="4782" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_context_recovery_identity_by_channel</text>
               <rect x="10" y="4800" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="4816" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_context_recovery_fence_by_channel</text>
+              <text x="17" y="4816" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_context_recovery_runtime_id_by_channel</text>
               <rect x="157" y="4800" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="4816" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_context_recovery_generation_by_channel</text>
+              <text x="164" y="4816" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_context_recovery_fence_by_channel</text>
               <rect x="10" y="4834" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="4850" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_refresh_result_sequence</text>
+              <text x="17" y="4850" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_context_recovery_generation_by_channel</text>
               <rect x="157" y="4834" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="4850" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_refresh_queue_acceptance_sequence_by_channel</text>
+              <text x="164" y="4850" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_refresh_result_sequence</text>
               <rect x="10" y="4868" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="4884" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_refresh_status_by_channel</text>
+              <text x="17" y="4884" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_refresh_queue_acceptance_sequence_by_channel</text>
               <rect x="157" y="4868" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="4884" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_close_result_sequence</text>
+              <text x="164" y="4884" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_refresh_status_by_channel</text>
               <rect x="10" y="4902" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="4918" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_close_observation_sequence_by_channel</text>
+              <text x="17" y="4918" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_close_result_sequence</text>
               <rect x="157" y="4902" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="4918" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_close_status_by_channel</text>
+              <text x="164" y="4918" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_close_observation_sequence_by_channel</text>
               <rect x="10" y="4936" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="4952" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_command_result_sequence</text>
+              <text x="17" y="4952" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_close_status_by_channel</text>
               <rect x="157" y="4936" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="4952" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_command_acceptance_sequence_by_channel</text>
+              <text x="164" y="4952" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_command_result_sequence</text>
               <rect x="10" y="4970" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="4986" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_command_kind_by_channel</text>
+              <text x="17" y="4986" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_command_acceptance_sequence_by_channel</text>
               <rect x="157" y="4970" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="4986" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_command_rejection_sequence</text>
+              <text x="164" y="4986" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_command_kind_by_channel</text>
               <rect x="10" y="5004" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="5020" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_command_rejection_reason_by_channel</text>
+              <text x="17" y="5020" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_command_rejection_sequence</text>
               <rect x="157" y="5004" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="5020" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_command_rejection_public_error_class_by_channel</text>
+              <text x="164" y="5020" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_command_rejection_reason_by_channel</text>
               <rect x="10" y="5038" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="5054" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_channel_request_rejection_sequence</text>
+              <text x="17" y="5054" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_command_rejection_public_error_class_by_channel</text>
               <rect x="157" y="5038" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="5054" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_channel_request_rejection_reason_by_channel</text>
+              <text x="164" y="5054" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_channel_request_rejection_sequence</text>
               <rect x="10" y="5072" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="5088" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_channel_request_rejection_public_error_class_by_channel</text>
+              <text x="17" y="5088" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_channel_request_rejection_reason_by_channel</text>
               <rect x="157" y="5072" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="5088" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_webrtc_token_issue_sequence</text>
+              <text x="164" y="5088" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_channel_request_rejection_public_error_class_by_channel</text>
               <rect x="10" y="5106" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="5122" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_webrtc_token_channel_by_token</text>
+              <text x="17" y="5122" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_webrtc_token_issue_sequence</text>
               <rect x="157" y="5106" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="5122" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_webrtc_token_expires_at_ms_by_token</text>
+              <text x="164" y="5122" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_webrtc_token_channel_by_token</text>
               <rect x="10" y="5140" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="5156" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_webrtc_consumed_tokens</text>
+              <text x="17" y="5156" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_webrtc_token_expires_at_ms_by_token</text>
               <rect x="157" y="5140" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="5156" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_webrtc_answer_admission_sequence</text>
+              <text x="164" y="5156" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_webrtc_consumed_tokens</text>
               <rect x="10" y="5174" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="5190" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_webrtc_answer_result_sequence</text>
+              <text x="17" y="5190" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_webrtc_answer_admission_sequence</text>
               <rect x="157" y="5174" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="5190" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_webrtc_answer_observation_sequence_by_channel</text>
+              <text x="164" y="5190" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_webrtc_answer_result_sequence</text>
               <rect x="10" y="5208" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="5224" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_webrtc_answer_status_by_channel</text>
+              <text x="17" y="5224" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_webrtc_answer_observation_sequence_by_channel</text>
               <rect x="157" y="5208" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="5224" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_websocket_token_issue_sequence</text>
+              <text x="164" y="5224" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_webrtc_answer_status_by_channel</text>
               <rect x="10" y="5242" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="5258" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_websocket_token_channel_by_token</text>
+              <text x="17" y="5258" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_websocket_token_issue_sequence</text>
               <rect x="157" y="5242" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="5258" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_websocket_token_expires_at_ms_by_token</text>
+              <text x="164" y="5258" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_websocket_token_channel_by_token</text>
               <rect x="10" y="5276" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="5292" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_websocket_consumed_tokens</text>
+              <text x="17" y="5292" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_websocket_token_expires_at_ms_by_token</text>
               <rect x="157" y="5276" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="5292" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_websocket_token_admission_sequence</text>
+              <text x="164" y="5292" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_websocket_consumed_tokens</text>
               <rect x="10" y="5310" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="5326" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_channel_status_result_sequence</text>
+              <text x="17" y="5326" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_websocket_token_admission_sequence</text>
               <rect x="157" y="5310" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="5326" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_channel_status_observation_sequence_by_channel</text>
+              <text x="164" y="5326" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_channel_status_result_sequence</text>
               <rect x="10" y="5344" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="5360" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_channel_status_by_channel</text>
+              <text x="17" y="5360" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_channel_status_observation_sequence_by_channel</text>
               <rect x="157" y="5344" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="5360" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">session_event_stream_open_result_sequence</text>
+              <text x="164" y="5360" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_channel_status_by_channel</text>
               <rect x="10" y="5378" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="5394" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">session_event_stream_close_result_sequence</text>
+              <text x="17" y="5394" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">session_event_stream_open_result_sequence</text>
               <rect x="157" y="5378" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="5394" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">session_event_stream_terminal_sequence</text>
+              <text x="164" y="5394" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">session_event_stream_close_result_sequence</text>
               <rect x="10" y="5412" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="5428" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">active_session_event_streams</text>
+              <text x="17" y="5428" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">session_event_stream_terminal_sequence</text>
               <rect x="157" y="5412" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="5428" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">closed_session_event_streams</text>
+              <text x="164" y="5428" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">active_session_event_streams</text>
               <rect x="10" y="5446" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="5462" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">session_event_stream_session_ids</text>
+              <text x="17" y="5462" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">closed_session_event_streams</text>
               <rect x="157" y="5446" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="5462" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">mob_event_stream_open_result_sequence</text>
+              <text x="164" y="5462" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">session_event_stream_session_ids</text>
               <rect x="10" y="5480" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="5496" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">mob_event_stream_close_result_sequence</text>
+              <text x="17" y="5496" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">mob_event_stream_open_result_sequence</text>
               <rect x="157" y="5480" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="5496" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">mob_event_stream_terminal_sequence</text>
+              <text x="164" y="5496" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">mob_event_stream_close_result_sequence</text>
               <rect x="10" y="5514" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="5530" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">active_mob_event_streams</text>
+              <text x="17" y="5530" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">mob_event_stream_terminal_sequence</text>
               <rect x="157" y="5514" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="5530" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">closed_mob_event_streams</text>
+              <text x="164" y="5530" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">active_mob_event_streams</text>
               <rect x="10" y="5548" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="5564" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">known_surfaces</text>
+              <text x="17" y="5564" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">closed_mob_event_streams</text>
               <rect x="157" y="5548" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="5564" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">active_surfaces</text>
+              <text x="164" y="5564" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">known_surfaces</text>
               <rect x="10" y="5582" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="5598" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">visible_surfaces</text>
+              <text x="17" y="5598" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">active_surfaces</text>
               <rect x="157" y="5582" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="5598" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">surface_base_state</text>
+              <text x="164" y="5598" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">visible_surfaces</text>
               <rect x="10" y="5616" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="5632" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">surface_pending_op</text>
+              <text x="17" y="5632" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">surface_base_state</text>
               <rect x="157" y="5616" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="5632" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">surface_staged_op</text>
+              <text x="164" y="5632" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">surface_pending_op</text>
               <rect x="10" y="5650" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="5666" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">reload_staged_surfaces</text>
+              <text x="17" y="5666" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">surface_staged_op</text>
               <rect x="157" y="5650" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="5666" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">surface_staged_intent_sequence</text>
+              <text x="164" y="5666" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">reload_staged_surfaces</text>
               <rect x="10" y="5684" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="5700" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">next_staged_intent_sequence</text>
+              <text x="17" y="5700" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">surface_staged_intent_sequence</text>
               <rect x="157" y="5684" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="5700" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">surface_pending_task_sequence</text>
+              <text x="164" y="5700" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">next_staged_intent_sequence</text>
               <rect x="10" y="5718" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="5734" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">next_pending_task_sequence</text>
+              <text x="17" y="5734" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">surface_pending_task_sequence</text>
               <rect x="157" y="5718" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="5734" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">surface_pending_lineage_sequence</text>
+              <text x="164" y="5734" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">next_pending_task_sequence</text>
               <rect x="10" y="5752" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="5768" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">surface_inflight_calls</text>
+              <text x="17" y="5768" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">surface_pending_lineage_sequence</text>
               <rect x="157" y="5752" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="5768" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">surface_last_delta_operation</text>
+              <text x="164" y="5768" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">surface_inflight_calls</text>
               <rect x="10" y="5786" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="5802" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">surface_last_delta_phase</text>
+              <text x="17" y="5802" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">surface_last_delta_operation</text>
               <rect x="157" y="5786" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="5802" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">snapshot_epoch</text>
+              <text x="164" y="5802" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">surface_last_delta_phase</text>
               <rect x="10" y="5820" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="5836" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">snapshot_aligned_epoch</text>
+              <text x="17" y="5836" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">snapshot_epoch</text>
               <rect x="157" y="5820" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="5836" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">surface_draining_since_ms</text>
+              <text x="164" y="5836" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">snapshot_aligned_epoch</text>
               <rect x="10" y="5854" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="5870" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">surface_removal_timeout_at_ms</text>
+              <text x="17" y="5870" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">surface_draining_since_ms</text>
               <rect x="157" y="5854" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="5870" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">surface_removal_applied_at_turn</text>
+              <text x="164" y="5870" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">surface_removal_timeout_at_ms</text>
               <rect x="10" y="5888" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="5904" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">surface_phase</text>
+              <text x="17" y="5904" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">surface_removal_applied_at_turn</text>
               <rect x="157" y="5888" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="5904" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">removal_timeout_ms</text>
+              <text x="164" y="5904" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">surface_phase</text>
               <rect x="10" y="5922" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="5938" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">mcp_server_states</text>
+              <text x="17" y="5938" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">removal_timeout_ms</text>
               <rect x="157" y="5922" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="5938" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">pending_peer_requests</text>
+              <text x="164" y="5938" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">mcp_server_states</text>
               <rect x="10" y="5956" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="5972" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">inbound_peer_requests</text>
+              <text x="17" y="5972" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">pending_peer_requests</text>
               <rect x="157" y="5956" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="5972" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">inbound_peer_request_lanes</text>
+              <text x="164" y="5972" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">inbound_peer_requests</text>
               <rect x="10" y="5990" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="6006" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">last_session_context_updated_at_ms</text>
+              <text x="17" y="6006" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">inbound_peer_request_lanes</text>
               <rect x="157" y="5990" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="6006" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">reserved_interaction_streams</text>
+              <text x="164" y="6006" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">last_session_context_updated_at_ms</text>
               <rect x="10" y="6024" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="6040" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">attached_interaction_streams</text>
+              <text x="17" y="6040" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">reserved_interaction_streams</text>
               <rect x="157" y="6024" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="6040" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">peer_ingress_owner_kind</text>
+              <text x="164" y="6040" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">attached_interaction_streams</text>
               <rect x="10" y="6058" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="6074" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">peer_ingress_comms_runtime_id</text>
+              <text x="17" y="6074" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">peer_ingress_owner_kind</text>
               <rect x="157" y="6058" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="6074" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">peer_ingress_mob_id</text>
+              <text x="164" y="6074" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">peer_ingress_comms_runtime_id</text>
               <rect x="10" y="6092" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="6108" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">peer_ingress_authority_phase</text>
+              <text x="17" y="6108" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">peer_ingress_mob_id</text>
               <rect x="157" y="6092" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="6108" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">supervisor_binding_kind</text>
+              <text x="164" y="6108" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">peer_ingress_authority_phase</text>
               <rect x="10" y="6126" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="6142" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">supervisor_bound_name</text>
+              <text x="17" y="6142" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">supervisor_binding_kind</text>
               <rect x="157" y="6126" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="6142" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">supervisor_bound_peer_id</text>
+              <text x="164" y="6142" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">supervisor_bound_name</text>
               <rect x="10" y="6160" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="6176" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">supervisor_bound_address</text>
+              <text x="17" y="6176" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">supervisor_bound_peer_id</text>
               <rect x="157" y="6160" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="6176" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">supervisor_bound_signing_public_key</text>
+              <text x="164" y="6176" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">supervisor_bound_address</text>
               <rect x="10" y="6194" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="6210" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">supervisor_bound_epoch</text>
+              <text x="17" y="6210" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">supervisor_bound_signing_public_key</text>
               <rect x="157" y="6194" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="6210" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">supervisor_publish_pending_name</text>
+              <text x="164" y="6210" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">supervisor_bound_epoch</text>
               <rect x="10" y="6228" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="6244" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">supervisor_publish_pending_peer_id</text>
+              <text x="17" y="6244" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">supervisor_publish_pending_name</text>
               <rect x="157" y="6228" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="6244" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">supervisor_publish_pending_address</text>
+              <text x="164" y="6244" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">supervisor_publish_pending_peer_id</text>
               <rect x="10" y="6262" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="6278" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">supervisor_publish_pending_signing_public_key</text>
+              <text x="17" y="6278" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">supervisor_publish_pending_address</text>
               <rect x="157" y="6262" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="6278" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">supervisor_publish_pending_epoch</text>
+              <text x="164" y="6278" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">supervisor_publish_pending_signing_public_key</text>
               <rect x="10" y="6296" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="6312" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">supervisor_revoke_pending_name</text>
+              <text x="17" y="6312" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">supervisor_publish_pending_epoch</text>
               <rect x="157" y="6296" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="6312" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">supervisor_revoke_pending_peer_id</text>
+              <text x="164" y="6312" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">supervisor_revoke_pending_name</text>
               <rect x="10" y="6330" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="6346" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">supervisor_revoke_pending_address</text>
+              <text x="17" y="6346" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">supervisor_revoke_pending_peer_id</text>
               <rect x="157" y="6330" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="6346" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">supervisor_revoke_pending_signing_public_key</text>
+              <text x="164" y="6346" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">supervisor_revoke_pending_address</text>
               <rect x="10" y="6364" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="6380" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">supervisor_revoke_pending_epoch</text>
+              <text x="17" y="6380" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">supervisor_revoke_pending_signing_public_key</text>
               <rect x="157" y="6364" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="6380" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">supervisor_revoked_peer_id</text>
+              <text x="164" y="6380" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">supervisor_revoke_pending_epoch</text>
               <rect x="10" y="6398" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="6414" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">supervisor_revoked_signing_public_key</text>
+              <text x="17" y="6414" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">supervisor_revoked_peer_id</text>
               <rect x="157" y="6398" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="6414" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">supervisor_revoked_epoch</text>
+              <text x="164" y="6414" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">supervisor_revoked_signing_public_key</text>
               <rect x="10" y="6432" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="6448" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">supervisor_rotation_operation_id</text>
+              <text x="17" y="6448" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">supervisor_revoked_epoch</text>
               <rect x="157" y="6432" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="6448" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">supervisor_rotation_phase</text>
+              <text x="164" y="6448" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">supervisor_rotation_operation_id</text>
               <rect x="10" y="6466" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="6482" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">supervisor_rotation_rejection</text>
+              <text x="17" y="6482" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">supervisor_rotation_phase</text>
               <rect x="157" y="6466" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="6482" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">supervisor_rotation_previous_name</text>
+              <text x="164" y="6482" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">supervisor_rotation_rejection</text>
               <rect x="10" y="6500" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="6516" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">supervisor_rotation_previous_peer_id</text>
+              <text x="17" y="6516" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">supervisor_rotation_previous_name</text>
               <rect x="157" y="6500" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="6516" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">supervisor_rotation_previous_address</text>
+              <text x="164" y="6516" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">supervisor_rotation_previous_peer_id</text>
               <rect x="10" y="6534" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="6550" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">supervisor_rotation_previous_signing_public_key</text>
+              <text x="17" y="6550" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">supervisor_rotation_previous_address</text>
               <rect x="157" y="6534" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="6550" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">supervisor_rotation_previous_epoch</text>
+              <text x="164" y="6550" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">supervisor_rotation_previous_signing_public_key</text>
               <rect x="10" y="6568" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="6584" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">supervisor_rotation_next_name</text>
+              <text x="17" y="6584" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">supervisor_rotation_previous_epoch</text>
               <rect x="157" y="6568" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="6584" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">supervisor_rotation_next_peer_id</text>
+              <text x="164" y="6584" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">supervisor_rotation_next_name</text>
               <rect x="10" y="6602" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="6618" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">supervisor_rotation_next_address</text>
+              <text x="17" y="6618" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">supervisor_rotation_next_peer_id</text>
               <rect x="157" y="6602" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="6618" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">supervisor_rotation_next_signing_public_key</text>
+              <text x="164" y="6618" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">supervisor_rotation_next_address</text>
               <rect x="10" y="6636" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="6652" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">supervisor_rotation_next_epoch</text>
+              <text x="17" y="6652" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">supervisor_rotation_next_signing_public_key</text>
               <rect x="157" y="6636" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="6652" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">supervisor_rotation_terminal_phases</text>
+              <text x="164" y="6652" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">supervisor_rotation_next_epoch</text>
               <rect x="10" y="6670" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="6686" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">supervisor_rotation_terminal_rejections</text>
+              <text x="17" y="6686" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">supervisor_rotation_terminal_phases</text>
               <rect x="157" y="6670" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="6686" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">supervisor_rotation_terminal_previous_names</text>
+              <text x="164" y="6686" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">supervisor_rotation_terminal_rejections</text>
               <rect x="10" y="6704" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="6720" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">supervisor_rotation_terminal_previous_peer_ids</text>
+              <text x="17" y="6720" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">supervisor_rotation_terminal_previous_names</text>
               <rect x="157" y="6704" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="6720" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">supervisor_rotation_terminal_previous_addresses</text>
+              <text x="164" y="6720" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">supervisor_rotation_terminal_previous_peer_ids</text>
               <rect x="10" y="6738" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="6754" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">supervisor_rotation_terminal_previous_signing_public_keys</text>
+              <text x="17" y="6754" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">supervisor_rotation_terminal_previous_addresses</text>
               <rect x="157" y="6738" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="6754" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">supervisor_rotation_terminal_previous_epochs</text>
+              <text x="164" y="6754" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">supervisor_rotation_terminal_previous_signing_public_keys</text>
               <rect x="10" y="6772" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="6788" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">supervisor_rotation_terminal_next_names</text>
+              <text x="17" y="6788" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">supervisor_rotation_terminal_previous_epochs</text>
               <rect x="157" y="6772" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="6788" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">supervisor_rotation_terminal_next_peer_ids</text>
+              <text x="164" y="6788" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">supervisor_rotation_terminal_next_names</text>
               <rect x="10" y="6806" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="6822" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">supervisor_rotation_terminal_next_addresses</text>
+              <text x="17" y="6822" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">supervisor_rotation_terminal_next_peer_ids</text>
               <rect x="157" y="6806" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="6822" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">supervisor_rotation_terminal_next_signing_public_keys</text>
+              <text x="164" y="6822" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">supervisor_rotation_terminal_next_addresses</text>
               <rect x="10" y="6840" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="6856" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">supervisor_rotation_terminal_next_epochs</text>
+              <text x="17" y="6856" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">supervisor_rotation_terminal_next_signing_public_keys</text>
               <rect x="157" y="6840" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="6856" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">local_endpoint</text>
+              <text x="164" y="6856" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">supervisor_rotation_terminal_next_epochs</text>
               <rect x="10" y="6874" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="6890" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">direct_peer_endpoints</text>
+              <text x="17" y="6890" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">local_endpoint</text>
               <rect x="157" y="6874" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="6890" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">mob_overlay_peer_endpoints</text>
+              <text x="164" y="6890" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">direct_peer_endpoints</text>
               <rect x="10" y="6908" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="6924" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">peer_projection_epoch</text>
+              <text x="17" y="6924" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">mob_overlay_peer_endpoints</text>
               <rect x="157" y="6908" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="6924" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">mob_overlay_epoch</text>
+              <text x="164" y="6924" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">peer_projection_epoch</text>
+              <rect x="10" y="6942" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
+              <text x="17" y="6958" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">mob_overlay_epoch</text>
       </g>
     <g transform="translate(2344, 198)">
         <rect x="0" y="0" width="316" height="150" rx="12" fill="#141a1f" stroke="rgba(255,255,255,0.08)" />
@@ -1475,7 +1477,7 @@
         <text x="12" y="28" fill="#f4efe5" font-size="13" font-weight="600" font-family="Avenir Next, Helvetica Neue, Arial, sans-serif">Peer Reachability Fabric</text>
 
       </g><g transform="translate(2344, 454)">
-        <rect x="0" y="0" width="316" height="6916" rx="12" fill="#141a1f" stroke="rgba(255,255,255,0.08)" />
+        <rect x="0" y="0" width="316" height="6950" rx="12" fill="#141a1f" stroke="rgba(255,255,255,0.08)" />
         <text x="12" y="14" fill="#7d7a74" font-size="8" letter-spacing="1.5" font-family="Avenir Next, Helvetica Neue, Arial, sans-serif">SUBSYSTEM</text>
         <text x="12" y="28" fill="#f4efe5" font-size="13" font-weight="600" font-family="Avenir Next, Helvetica Neue, Arial, sans-serif">Residual Registers</text>
 
@@ -1620,673 +1622,675 @@
               <rect x="163" y="1196" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
               <text x="170" y="1212" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">model_routing_approval_parent_kind</text>
               <rect x="10" y="1230" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="1246" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">registration_phase</text>
+              <text x="17" y="1246" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">model_routing_handoff</text>
               <rect x="163" y="1230" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="1246" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">unregister_runtime_loop_drain_pending</text>
+              <text x="170" y="1246" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">registration_phase</text>
               <rect x="10" y="1264" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="1280" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">unregister_comms_drain_exit_pending</text>
+              <text x="17" y="1280" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">unregister_runtime_loop_drain_pending</text>
               <rect x="163" y="1264" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="1280" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">unregister_completion_waiter_drain_pending</text>
+              <text x="170" y="1280" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">unregister_comms_drain_exit_pending</text>
               <rect x="10" y="1298" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="1314" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">unregister_teardown_retains_snapshot</text>
+              <text x="17" y="1314" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">unregister_completion_waiter_drain_pending</text>
               <rect x="163" y="1298" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="1314" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">unregister_runtime_loop_forced_abort</text>
+              <text x="170" y="1314" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">unregister_teardown_retains_snapshot</text>
               <rect x="10" y="1332" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="1348" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">unregister_comms_drain_forced_abort</text>
+              <text x="17" y="1348" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">unregister_runtime_loop_forced_abort</text>
               <rect x="163" y="1332" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="1348" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">staged_session_phase</text>
+              <text x="170" y="1348" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">unregister_comms_drain_forced_abort</text>
               <rect x="10" y="1366" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="1382" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">staged_session_id</text>
+              <text x="17" y="1382" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">staged_session_phase</text>
               <rect x="163" y="1366" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="1382" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">staged_session_keep_alive</text>
+              <text x="170" y="1382" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">staged_session_id</text>
               <rect x="10" y="1400" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="1416" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">staged_session_llm_identity</text>
+              <text x="17" y="1416" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">staged_session_keep_alive</text>
               <rect x="163" y="1400" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="1416" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">staged_session_machine_archived_resume_authorized</text>
+              <text x="170" y="1416" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">staged_session_llm_identity</text>
               <rect x="10" y="1434" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="1450" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">current_session_llm_identity</text>
+              <text x="17" y="1450" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">staged_session_machine_archived_resume_authorized</text>
               <rect x="163" y="1434" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="1450" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">current_session_capability_surface</text>
+              <text x="170" y="1450" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">current_session_llm_identity</text>
               <rect x="10" y="1468" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="1484" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">current_session_capability_surface_status</text>
+              <text x="17" y="1484" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">current_session_capability_surface</text>
               <rect x="163" y="1468" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="1484" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">current_session_capability_base_filter</text>
+              <text x="170" y="1484" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">current_session_capability_surface_status</text>
               <rect x="10" y="1502" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="1518" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">session_llm_reconfigure_previous_capability_surface</text>
+              <text x="17" y="1518" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">current_session_capability_base_filter</text>
               <rect x="163" y="1502" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="1518" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">session_llm_reconfigure_current_capability_surface</text>
+              <text x="170" y="1518" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">session_llm_reconfigure_previous_capability_surface</text>
               <rect x="10" y="1536" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="1552" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">session_llm_reconfigure_capability_changed</text>
+              <text x="17" y="1552" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">session_llm_reconfigure_current_capability_surface</text>
               <rect x="163" y="1536" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="1552" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">session_llm_reconfigure_previous_capability_base_filter</text>
+              <text x="170" y="1552" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">session_llm_reconfigure_capability_changed</text>
               <rect x="10" y="1570" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="1586" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">session_llm_reconfigure_current_capability_base_filter</text>
+              <text x="17" y="1586" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">session_llm_reconfigure_previous_capability_base_filter</text>
               <rect x="163" y="1570" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="1586" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">session_llm_reconfigure_committed_visible_set_changed</text>
+              <text x="170" y="1586" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">session_llm_reconfigure_current_capability_base_filter</text>
               <rect x="10" y="1604" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="1620" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">session_llm_reconfigure_revision_bumped</text>
+              <text x="17" y="1620" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">session_llm_reconfigure_committed_visible_set_changed</text>
               <rect x="163" y="1604" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="1620" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">session_llm_reconfigure_active_visibility_revision</text>
+              <text x="170" y="1620" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">session_llm_reconfigure_revision_bumped</text>
               <rect x="10" y="1638" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="1654" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">mob_operator_authority_present</text>
+              <text x="17" y="1654" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">session_llm_reconfigure_active_visibility_revision</text>
               <rect x="163" y="1638" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="1654" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">mob_operator_principal_token</text>
+              <text x="170" y="1654" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">mob_operator_authority_present</text>
               <rect x="10" y="1672" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="1688" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">mob_operator_can_create_mobs</text>
+              <text x="17" y="1688" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">mob_operator_principal_token</text>
               <rect x="163" y="1672" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="1688" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">mob_operator_can_mutate_profiles</text>
+              <text x="170" y="1688" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">mob_operator_can_create_mobs</text>
               <rect x="10" y="1706" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="1722" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">mob_operator_managed_mob_scope</text>
+              <text x="17" y="1722" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">mob_operator_can_mutate_profiles</text>
               <rect x="163" y="1706" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="1722" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">mob_operator_spawn_profile_scope</text>
+              <text x="170" y="1722" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">mob_operator_managed_mob_scope</text>
               <rect x="10" y="1740" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="1756" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">mob_operator_caller_provenance</text>
+              <text x="17" y="1756" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">mob_operator_spawn_profile_scope</text>
               <rect x="163" y="1740" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="1756" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">mob_operator_audit_invocation_id</text>
+              <text x="170" y="1756" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">mob_operator_caller_provenance</text>
               <rect x="10" y="1774" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="1790" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">drain_phase</text>
+              <text x="17" y="1790" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">mob_operator_audit_invocation_id</text>
               <rect x="163" y="1774" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="1790" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">drain_mode</text>
+              <text x="170" y="1790" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">drain_phase</text>
               <rect x="10" y="1808" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="1824" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">next_staged_visibility_revision</text>
+              <text x="17" y="1824" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">drain_mode</text>
               <rect x="163" y="1808" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="1824" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">active_deferred_names</text>
+              <text x="170" y="1824" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">next_staged_visibility_revision</text>
               <rect x="10" y="1842" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="1858" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">staged_deferred_names</text>
+              <text x="17" y="1858" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">active_deferred_names</text>
               <rect x="163" y="1842" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="1858" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">requested_visibility_witnesses</text>
+              <text x="170" y="1858" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">staged_deferred_names</text>
               <rect x="10" y="1876" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="1892" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">filter_visibility_witnesses</text>
+              <text x="17" y="1892" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">requested_visibility_witnesses</text>
               <rect x="163" y="1876" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="1892" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">active_deferred_authorities</text>
+              <text x="170" y="1892" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">filter_visibility_witnesses</text>
               <rect x="10" y="1910" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="1926" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">staged_deferred_authorities</text>
+              <text x="17" y="1926" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">active_deferred_authorities</text>
               <rect x="163" y="1910" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="1926" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">deferred_visibility_authority_catalog</text>
+              <text x="170" y="1926" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">staged_deferred_authorities</text>
               <rect x="10" y="1944" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="1960" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">filter_visibility_authority_catalog</text>
+              <text x="17" y="1960" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">deferred_visibility_authority_catalog</text>
               <rect x="163" y="1944" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="1960" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">turn_tool_overlay_allow_active</text>
+              <text x="170" y="1960" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">filter_visibility_authority_catalog</text>
               <rect x="10" y="1978" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="1994" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">turn_tool_overlay_allow_names</text>
+              <text x="17" y="1994" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">turn_tool_overlay_allow_active</text>
               <rect x="163" y="1978" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="1994" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">turn_tool_overlay_deny_names</text>
+              <text x="170" y="1994" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">turn_tool_overlay_allow_names</text>
               <rect x="10" y="2012" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="2028" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">input_phases</text>
+              <text x="17" y="2028" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">turn_tool_overlay_deny_names</text>
               <rect x="163" y="2012" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="2028" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">input_terminal_kind</text>
+              <text x="170" y="2028" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">input_phases</text>
               <rect x="10" y="2046" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="2062" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">input_superseded_by</text>
+              <text x="17" y="2062" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">input_terminal_kind</text>
               <rect x="163" y="2046" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="2062" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">input_aggregate_id</text>
+              <text x="170" y="2062" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">input_superseded_by</text>
               <rect x="10" y="2080" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="2096" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">input_abandon_reason</text>
+              <text x="17" y="2096" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">input_aggregate_id</text>
               <rect x="163" y="2080" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="2096" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">input_abandon_attempt_count</text>
+              <text x="170" y="2096" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">input_abandon_reason</text>
               <rect x="10" y="2114" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="2130" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">input_attempt_counts</text>
+              <text x="17" y="2130" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">input_abandon_attempt_count</text>
               <rect x="163" y="2114" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="2130" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">max_stage_attempts</text>
+              <text x="170" y="2130" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">input_attempt_counts</text>
               <rect x="10" y="2148" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="2164" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">input_run_associations</text>
+              <text x="17" y="2164" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">max_stage_attempts</text>
               <rect x="163" y="2148" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="2164" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">input_boundary_sequences</text>
+              <text x="170" y="2164" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">input_run_associations</text>
               <rect x="10" y="2182" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="2198" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_boundary_context_sequence_by_run</text>
+              <text x="17" y="2198" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">input_boundary_sequences</text>
               <rect x="163" y="2182" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="2198" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">next_admission_seq</text>
+              <text x="170" y="2198" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_boundary_context_sequence_by_run</text>
               <rect x="10" y="2216" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="2232" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">next_priority_admission_seq</text>
+              <text x="17" y="2232" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">next_admission_seq</text>
               <rect x="163" y="2216" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="2232" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">input_admission_seq</text>
+              <text x="170" y="2232" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">next_priority_admission_seq</text>
               <rect x="10" y="2250" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="2266" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">input_runtime_boundary</text>
+              <text x="17" y="2266" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">input_admission_seq</text>
               <rect x="163" y="2250" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="2266" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">input_runtime_execution_kind</text>
+              <text x="170" y="2266" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">input_runtime_boundary</text>
               <rect x="10" y="2284" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="2300" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">input_runtime_peer_response_terminal_apply_intent</text>
+              <text x="17" y="2300" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">input_runtime_execution_kind</text>
               <rect x="163" y="2284" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="2300" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">input_is_prompt</text>
+              <text x="170" y="2300" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">input_runtime_peer_response_terminal_apply_intent</text>
               <rect x="10" y="2318" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="2334" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">input_lane</text>
+              <text x="17" y="2334" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">input_is_prompt</text>
               <rect x="163" y="2318" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="2334" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">input_recovery_lanes</text>
+              <text x="170" y="2334" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">input_lane</text>
               <rect x="10" y="2352" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="2368" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">admission_authorized_lanes</text>
+              <text x="17" y="2368" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">input_recovery_lanes</text>
               <rect x="163" y="2352" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="2368" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">admission_authorized_plans</text>
+              <text x="170" y="2368" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">admission_authorized_lanes</text>
               <rect x="10" y="2386" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="2402" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">admission_authorized_existing_actions</text>
+              <text x="17" y="2402" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">admission_authorized_plans</text>
               <rect x="163" y="2386" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="2402" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">admission_authorized_existing_targets</text>
+              <text x="170" y="2402" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">admission_authorized_existing_actions</text>
               <rect x="10" y="2420" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="2436" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">admission_idempotency_inputs</text>
+              <text x="17" y="2436" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">admission_authorized_existing_targets</text>
               <rect x="163" y="2420" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="2436" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">input_idempotency_keys</text>
+              <text x="170" y="2436" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">admission_idempotency_inputs</text>
               <rect x="10" y="2454" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="2470" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">recovered_admitted_inputs</text>
+              <text x="17" y="2470" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">input_idempotency_keys</text>
               <rect x="163" y="2454" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="2470" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">recovered_admitted_lanes</text>
+              <text x="170" y="2470" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">recovered_admitted_inputs</text>
               <rect x="10" y="2488" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="2504" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">op_statuses</text>
+              <text x="17" y="2504" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">recovered_admitted_lanes</text>
               <rect x="163" y="2488" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="2504" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">op_completion_seq</text>
+              <text x="170" y="2504" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">op_statuses</text>
               <rect x="10" y="2522" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="2538" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">completion_sequence_claims</text>
+              <text x="17" y="2538" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">op_completion_seq</text>
               <rect x="163" y="2522" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="2538" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">completion_feed_sequences</text>
+              <text x="170" y="2538" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">completion_sequence_claims</text>
               <rect x="10" y="2556" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="2572" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">completion_feed_kinds</text>
+              <text x="17" y="2572" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">completion_feed_sequences</text>
               <rect x="163" y="2556" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="2572" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">completion_feed_terminal_outcomes</text>
+              <text x="170" y="2572" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">completion_feed_kinds</text>
               <rect x="10" y="2590" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="2606" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">completion_feed_terminal_payload</text>
+              <text x="17" y="2606" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">completion_feed_terminal_outcomes</text>
               <rect x="163" y="2590" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="2606" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">op_terminal_outcomes</text>
+              <text x="170" y="2606" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">completion_feed_terminal_payload</text>
               <rect x="10" y="2624" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="2640" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">op_terminal_payload</text>
+              <text x="17" y="2640" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">op_terminal_outcomes</text>
               <rect x="163" y="2624" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="2640" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">op_kinds</text>
+              <text x="170" y="2640" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">op_terminal_payload</text>
               <rect x="10" y="2658" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="2674" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">op_sources</text>
+              <text x="17" y="2674" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">op_kinds</text>
               <rect x="163" y="2658" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="2674" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">op_peer_ready</text>
+              <text x="170" y="2674" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">op_sources</text>
               <rect x="10" y="2692" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="2708" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">op_progress_counts</text>
+              <text x="17" y="2708" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">op_peer_ready</text>
               <rect x="163" y="2692" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="2708" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">active_op_count</text>
+              <text x="170" y="2708" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">op_progress_counts</text>
               <rect x="10" y="2726" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="2742" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">wait_active</text>
+              <text x="17" y="2742" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">active_op_count</text>
               <rect x="163" y="2726" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="2742" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">wait_request_id</text>
+              <text x="170" y="2742" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">wait_active</text>
               <rect x="10" y="2760" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="2776" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">wait_run_id</text>
+              <text x="17" y="2776" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">wait_request_id</text>
               <rect x="163" y="2760" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="2776" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">wait_operation_ids</text>
+              <text x="170" y="2776" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">wait_run_id</text>
               <rect x="10" y="2794" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="2810" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">wait_operation_id_tokens</text>
+              <text x="17" y="2810" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">wait_operation_ids</text>
               <rect x="163" y="2794" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="2810" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">next_completion_seq</text>
+              <text x="170" y="2810" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">wait_operation_id_tokens</text>
               <rect x="10" y="2828" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="2844" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">completion_agent_applied_cursor</text>
+              <text x="17" y="2844" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">next_completion_seq</text>
               <rect x="163" y="2828" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="2844" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">completion_runtime_observed_cursor</text>
+              <text x="170" y="2844" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">completion_agent_applied_cursor</text>
               <rect x="10" y="2862" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="2878" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">completion_runtime_injected_cursor</text>
+              <text x="17" y="2878" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">completion_runtime_observed_cursor</text>
               <rect x="163" y="2862" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="2878" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">surface_request_phases</text>
+              <text x="170" y="2878" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">completion_runtime_injected_cursor</text>
               <rect x="10" y="2896" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="2912" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">surface_request_terminal_policies</text>
+              <text x="17" y="2912" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">surface_request_phases</text>
               <rect x="163" y="2896" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="2912" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_open_admission_sequence</text>
+              <text x="170" y="2912" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">surface_request_terminal_policies</text>
               <rect x="10" y="2930" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="2946" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_active_channel_by_session</text>
+              <text x="17" y="2946" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_open_admission_sequence</text>
               <rect x="163" y="2930" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="2946" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_channel_session_by_channel</text>
+              <text x="170" y="2946" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_active_channel_by_session</text>
               <rect x="10" y="2964" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="2980" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_channel_identity_by_channel</text>
+              <text x="17" y="2980" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_channel_session_by_channel</text>
               <rect x="163" y="2964" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="2980" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_execution_runtime_id_by_channel</text>
+              <text x="170" y="2980" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_channel_identity_by_channel</text>
               <rect x="10" y="2998" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="3014" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_execution_fence_by_channel</text>
+              <text x="17" y="3014" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_execution_runtime_id_by_channel</text>
               <rect x="163" y="2998" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="3014" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_execution_generation_by_channel</text>
+              <text x="170" y="3014" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_execution_fence_by_channel</text>
               <rect x="10" y="3032" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="3048" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_execution_phase_by_channel</text>
+              <text x="17" y="3048" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_execution_generation_by_channel</text>
               <rect x="163" y="3032" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="3048" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_revoked_execution_channels</text>
+              <text x="170" y="3048" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_execution_phase_by_channel</text>
               <rect x="10" y="3066" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="3082" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_execution_profile_by_channel</text>
+              <text x="17" y="3082" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_revoked_execution_channels</text>
               <rect x="163" y="3066" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="3082" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_execution_mode_by_channel</text>
+              <text x="170" y="3082" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_execution_profile_by_channel</text>
               <rect x="10" y="3100" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="3116" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_function_bridge_capable_channels</text>
+              <text x="17" y="3116" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_execution_mode_by_channel</text>
               <rect x="163" y="3100" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="3116" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_client_context_capable_channels</text>
+              <text x="170" y="3116" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_function_bridge_capable_channels</text>
               <rect x="10" y="3134" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="3150" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_playback_owner_by_channel</text>
+              <text x="17" y="3150" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_client_context_capable_channels</text>
               <rect x="163" y="3134" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="3150" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_playback_readiness_by_channel</text>
+              <text x="170" y="3150" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_playback_owner_by_channel</text>
               <rect x="10" y="3168" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="3184" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_activation_receipt_by_channel</text>
+              <text x="17" y="3184" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_playback_readiness_by_channel</text>
               <rect x="163" y="3168" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="3184" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_active_control_operation_by_authority</text>
+              <text x="170" y="3184" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_activation_receipt_by_channel</text>
               <rect x="10" y="3202" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="3218" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_consumed_active_control_authorities</text>
+              <text x="17" y="3218" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_active_control_operation_by_authority</text>
               <rect x="163" y="3202" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="3218" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_experimental_staged_runtime_by_channel</text>
+              <text x="170" y="3218" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_consumed_active_control_authorities</text>
               <rect x="10" y="3236" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="3252" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_experimental_staged_fence_by_channel</text>
+              <text x="17" y="3252" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_experimental_staged_runtime_by_channel</text>
               <rect x="163" y="3236" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="3252" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_experimental_staged_generation_by_channel</text>
+              <text x="170" y="3252" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_experimental_staged_fence_by_channel</text>
               <rect x="10" y="3270" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="3286" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_experimental_staged_seed_cursor_by_channel</text>
+              <text x="17" y="3286" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_experimental_staged_generation_by_channel</text>
               <rect x="163" y="3270" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="3286" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_experimental_pending_receipt_by_channel</text>
+              <text x="170" y="3286" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_experimental_staged_seed_cursor_by_channel</text>
               <rect x="10" y="3304" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="3320" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_experimental_execution_channels</text>
+              <text x="17" y="3320" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_experimental_pending_receipt_by_channel</text>
               <rect x="163" y="3304" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="3320" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_interaction_channel_by_id</text>
+              <text x="170" y="3320" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_experimental_execution_channels</text>
               <rect x="10" y="3338" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="3354" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_active_interaction_by_channel</text>
+              <text x="17" y="3354" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_interaction_channel_by_id</text>
               <rect x="163" y="3338" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="3354" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_provider_turn_by_channel</text>
+              <text x="170" y="3354" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_active_interaction_by_channel</text>
               <rect x="10" y="3372" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="3388" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_provider_interaction_by_turn</text>
+              <text x="17" y="3388" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_provider_turn_by_channel</text>
               <rect x="163" y="3372" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="3388" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_provider_turn_channel_by_ref</text>
+              <text x="170" y="3388" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_provider_interaction_by_turn</text>
               <rect x="10" y="3406" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="3422" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_awaiting_assistant_interaction_by_channel</text>
+              <text x="17" y="3422" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_provider_turn_channel_by_ref</text>
               <rect x="163" y="3406" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="3422" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_assistant_interaction_by_turn</text>
+              <text x="170" y="3422" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_awaiting_assistant_interaction_by_channel</text>
               <rect x="10" y="3440" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="3456" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_assistant_turn_channel_by_ref</text>
+              <text x="17" y="3456" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_assistant_interaction_by_turn</text>
               <rect x="163" y="3440" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="3456" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_abandoned_interactions</text>
+              <text x="170" y="3456" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_assistant_turn_channel_by_ref</text>
               <rect x="10" y="3474" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="3490" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_delegation_interaction_by_channel</text>
+              <text x="17" y="3490" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_abandoned_interactions</text>
               <rect x="163" y="3474" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="3490" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_delegation_operation_by_channel</text>
+              <text x="170" y="3490" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_delegation_interaction_by_channel</text>
               <rect x="10" y="3508" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="3524" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_delegation_provider_turn_by_channel</text>
+              <text x="17" y="3524" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_delegation_operation_by_channel</text>
               <rect x="163" y="3508" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="3524" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_delegation_interaction_by_operation</text>
+              <text x="170" y="3524" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_delegation_provider_turn_by_channel</text>
               <rect x="10" y="3542" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="3558" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_delegation_provider_turn_by_operation</text>
+              <text x="17" y="3558" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_delegation_interaction_by_operation</text>
               <rect x="163" y="3542" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="3558" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_delegation_reconciliation_by_operation</text>
+              <text x="170" y="3558" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_delegation_provider_turn_by_operation</text>
               <rect x="10" y="3576" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="3592" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_delegation_worker_identity_by_operation</text>
+              <text x="17" y="3592" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_delegation_reconciliation_by_operation</text>
               <rect x="163" y="3576" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="3592" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_delegation_worker_phase_by_operation</text>
+              <text x="170" y="3592" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_delegation_worker_identity_by_operation</text>
               <rect x="10" y="3610" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="3626" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_delegation_cancellation_reason_by_operation</text>
+              <text x="17" y="3626" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_delegation_worker_phase_by_operation</text>
               <rect x="163" y="3610" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="3626" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_delegation_worker_terminal_by_operation</text>
+              <text x="170" y="3626" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_delegation_cancellation_reason_by_operation</text>
               <rect x="10" y="3644" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="3660" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_delegation_result_eligible_operations</text>
+              <text x="17" y="3660" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_delegation_worker_terminal_by_operation</text>
               <rect x="163" y="3644" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="3660" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_delegation_late_terminal_operations</text>
+              <text x="170" y="3660" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_delegation_result_eligible_operations</text>
               <rect x="10" y="3678" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="3694" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_consequential_effect_operation_by_authority</text>
+              <text x="17" y="3694" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_delegation_late_terminal_operations</text>
               <rect x="163" y="3678" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="3694" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_result_released_operations</text>
+              <text x="170" y="3694" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_consequential_effect_operation_by_authority</text>
               <rect x="10" y="3712" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="3728" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_result_release_disposition_by_operation</text>
+              <text x="17" y="3728" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_result_released_operations</text>
               <rect x="163" y="3712" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="3728" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_result_delivery_channel_by_operation</text>
+              <text x="170" y="3728" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_result_release_disposition_by_operation</text>
               <rect x="10" y="3746" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="3762" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_result_delivery_operation_by_channel</text>
+              <text x="17" y="3762" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_result_delivery_channel_by_operation</text>
               <rect x="163" y="3746" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="3762" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_result_delivery_digest_by_operation</text>
+              <text x="170" y="3762" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_result_delivery_operation_by_channel</text>
               <rect x="10" y="3780" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="3796" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_result_delivery_observation_by_operation</text>
+              <text x="17" y="3796" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_result_delivery_digest_by_operation</text>
               <rect x="163" y="3780" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="3796" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_result_speech_suppressed_operations</text>
+              <text x="170" y="3796" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_result_delivery_observation_by_operation</text>
               <rect x="10" y="3814" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="3830" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_result_recovery_replacement_by_channel</text>
+              <text x="17" y="3830" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_result_speech_suppressed_operations</text>
               <rect x="163" y="3814" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="3830" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_result_recovery_source_by_replacement</text>
+              <text x="170" y="3830" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_result_recovery_replacement_by_channel</text>
               <rect x="10" y="3848" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="3864" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_result_recovery_session_by_channel</text>
+              <text x="17" y="3864" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_result_recovery_source_by_replacement</text>
               <rect x="163" y="3848" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="3864" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_result_recovery_operation_by_channel</text>
+              <text x="170" y="3864" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_result_recovery_session_by_channel</text>
               <rect x="10" y="3882" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="3898" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_result_recovery_digest_by_channel</text>
+              <text x="17" y="3898" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_result_recovery_operation_by_channel</text>
               <rect x="163" y="3882" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="3898" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_result_recovery_seed_cursor_by_channel</text>
+              <text x="170" y="3898" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_result_recovery_digest_by_channel</text>
               <rect x="10" y="3916" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="3932" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_result_recovery_identity_by_channel</text>
+              <text x="17" y="3932" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_result_recovery_seed_cursor_by_channel</text>
               <rect x="163" y="3916" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="3932" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_result_recovery_runtime_id_by_channel</text>
+              <text x="170" y="3932" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_result_recovery_identity_by_channel</text>
               <rect x="10" y="3950" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="3966" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_result_recovery_fence_by_channel</text>
+              <text x="17" y="3966" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_result_recovery_runtime_id_by_channel</text>
               <rect x="163" y="3950" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="3966" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_result_recovery_generation_by_channel</text>
+              <text x="170" y="3966" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_result_recovery_fence_by_channel</text>
               <rect x="10" y="3984" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="4000" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_bridge_operation_by_channel</text>
+              <text x="17" y="4000" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_result_recovery_generation_by_channel</text>
               <rect x="163" y="3984" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="4000" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_bridge_channel_by_operation</text>
+              <text x="170" y="4000" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_bridge_operation_by_channel</text>
               <rect x="10" y="4018" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="4034" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_bridge_interaction_by_operation</text>
+              <text x="17" y="4034" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_bridge_channel_by_operation</text>
               <rect x="163" y="4018" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="4034" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_bridge_provider_turn_by_operation</text>
+              <text x="170" y="4034" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_bridge_interaction_by_operation</text>
               <rect x="10" y="4052" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="4068" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_bridge_provider_delegation_by_operation</text>
+              <text x="17" y="4068" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_bridge_provider_turn_by_operation</text>
               <rect x="163" y="4052" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="4068" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_bridge_provider_call_by_operation</text>
+              <text x="170" y="4068" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_bridge_provider_delegation_by_operation</text>
               <rect x="10" y="4086" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="4102" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_bridge_agent_identity_by_operation</text>
+              <text x="17" y="4102" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_bridge_provider_call_by_operation</text>
               <rect x="163" y="4086" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="4102" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_bridge_context_revision_by_operation</text>
+              <text x="170" y="4102" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_bridge_agent_identity_by_operation</text>
               <rect x="10" y="4120" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="4136" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_bridge_request_digest_by_operation</text>
+              <text x="17" y="4136" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_bridge_context_revision_by_operation</text>
               <rect x="163" y="4120" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="4136" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_bridge_phase_by_operation</text>
+              <text x="170" y="4136" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_bridge_request_digest_by_operation</text>
               <rect x="10" y="4154" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="4170" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_bridge_effect_operation_by_authority</text>
+              <text x="17" y="4170" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_bridge_phase_by_operation</text>
               <rect x="163" y="4154" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="4170" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_bridge_effect_kind_by_authority</text>
+              <text x="170" y="4170" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_bridge_effect_operation_by_authority</text>
               <rect x="10" y="4188" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="4204" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_bridge_consumed_effect_authorities</text>
+              <text x="17" y="4204" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_bridge_effect_kind_by_authority</text>
               <rect x="163" y="4188" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="4204" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_bridge_in_flight_effect_authorities</text>
+              <text x="170" y="4204" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_bridge_consumed_effect_authorities</text>
               <rect x="10" y="4222" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="4238" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_bridge_effect_outcome_by_authority</text>
+              <text x="17" y="4238" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_bridge_in_flight_effect_authorities</text>
               <rect x="163" y="4222" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="4238" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_bridge_model_computation_authorized_operations</text>
+              <text x="170" y="4238" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_bridge_effect_outcome_by_authority</text>
               <rect x="10" y="4256" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="4272" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_bridge_read_snapshot_authorized_operations</text>
+              <text x="17" y="4272" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_bridge_model_computation_authorized_operations</text>
               <rect x="163" y="4256" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="4272" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_bridge_execution_started_operations</text>
+              <text x="170" y="4272" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_bridge_read_snapshot_authorized_operations</text>
               <rect x="10" y="4290" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="4306" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_bridge_outcome_receipt_required_operations</text>
+              <text x="17" y="4306" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_bridge_execution_started_operations</text>
               <rect x="163" y="4290" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="4306" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_bridge_outcome_receipt_operations</text>
+              <text x="170" y="4306" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_bridge_outcome_receipt_required_operations</text>
               <rect x="10" y="4324" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="4340" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_bridge_execution_terminal_by_operation</text>
+              <text x="17" y="4340" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_bridge_outcome_receipt_operations</text>
               <rect x="163" y="4324" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="4340" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_bridge_execution_result_digest_by_operation</text>
+              <text x="170" y="4340" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_bridge_execution_terminal_by_operation</text>
               <rect x="10" y="4358" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="4374" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_bridge_cancellation_reason_by_operation</text>
+              <text x="17" y="4374" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_bridge_execution_result_digest_by_operation</text>
               <rect x="163" y="4358" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="4374" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_bridge_submission_output_kind_by_operation</text>
+              <text x="170" y="4374" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_bridge_cancellation_reason_by_operation</text>
               <rect x="10" y="4392" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="4408" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_bridge_submission_digest_by_operation</text>
+              <text x="17" y="4408" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_bridge_submission_output_kind_by_operation</text>
               <rect x="163" y="4392" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="4408" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_bridge_submission_state_by_operation</text>
+              <text x="170" y="4408" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_bridge_submission_digest_by_operation</text>
               <rect x="10" y="4426" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="4442" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_context_cursor_by_channel</text>
+              <text x="17" y="4442" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_bridge_submission_state_by_operation</text>
               <rect x="163" y="4426" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="4442" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_context_queued_session_by_append</text>
+              <text x="170" y="4442" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_context_cursor_by_channel</text>
               <rect x="10" y="4460" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="4476" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_context_queued_cursor_by_append</text>
+              <text x="17" y="4476" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_context_queued_session_by_append</text>
               <rect x="163" y="4460" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="4476" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_context_queued_digest_by_append</text>
+              <text x="170" y="4476" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_context_queued_cursor_by_append</text>
               <rect x="10" y="4494" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="4510" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_context_queued_commit_token_by_append</text>
+              <text x="17" y="4510" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_context_queued_digest_by_append</text>
               <rect x="163" y="4494" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="4510" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_context_queued_disposition_by_append</text>
+              <text x="170" y="4510" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_context_queued_commit_token_by_append</text>
               <rect x="10" y="4528" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="4544" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_context_queued_append_by_cursor</text>
+              <text x="17" y="4544" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_context_queued_disposition_by_append</text>
               <rect x="163" y="4528" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="4544" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_context_pending_append_by_channel</text>
+              <text x="170" y="4544" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_context_queued_append_by_cursor</text>
               <rect x="10" y="4562" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="4578" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_context_pending_channel_by_append</text>
+              <text x="17" y="4578" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_context_pending_append_by_channel</text>
               <rect x="163" y="4562" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="4578" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_context_pending_previous_cursor_by_append</text>
+              <text x="170" y="4578" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_context_pending_channel_by_append</text>
               <rect x="10" y="4596" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="4612" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_context_pending_next_cursor_by_append</text>
+              <text x="17" y="4612" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_context_pending_previous_cursor_by_append</text>
               <rect x="163" y="4596" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="4612" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_context_delivered_append_ids</text>
+              <text x="170" y="4612" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_context_pending_next_cursor_by_append</text>
               <rect x="10" y="4630" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="4646" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_context_ambiguous_no_retry</text>
+              <text x="17" y="4646" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_context_delivered_append_ids</text>
               <rect x="163" y="4630" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="4646" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_context_recovery_replacement_by_channel</text>
+              <text x="170" y="4646" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_context_ambiguous_no_retry</text>
               <rect x="10" y="4664" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="4680" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_context_recovery_source_by_replacement</text>
+              <text x="17" y="4680" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_context_recovery_replacement_by_channel</text>
               <rect x="163" y="4664" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="4680" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_context_recovery_session_by_channel</text>
+              <text x="170" y="4680" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_context_recovery_source_by_replacement</text>
               <rect x="10" y="4698" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="4714" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_context_recovery_append_by_channel</text>
+              <text x="17" y="4714" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_context_recovery_session_by_channel</text>
               <rect x="163" y="4698" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="4714" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_context_recovery_seed_cursor_by_channel</text>
+              <text x="170" y="4714" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_context_recovery_append_by_channel</text>
               <rect x="10" y="4732" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="4748" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_context_recovery_identity_by_channel</text>
+              <text x="17" y="4748" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_context_recovery_seed_cursor_by_channel</text>
               <rect x="163" y="4732" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="4748" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_context_recovery_runtime_id_by_channel</text>
+              <text x="170" y="4748" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_context_recovery_identity_by_channel</text>
               <rect x="10" y="4766" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="4782" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_context_recovery_fence_by_channel</text>
+              <text x="17" y="4782" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_context_recovery_runtime_id_by_channel</text>
               <rect x="163" y="4766" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="4782" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_context_recovery_generation_by_channel</text>
+              <text x="170" y="4782" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_context_recovery_fence_by_channel</text>
               <rect x="10" y="4800" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="4816" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_refresh_result_sequence</text>
+              <text x="17" y="4816" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_context_recovery_generation_by_channel</text>
               <rect x="163" y="4800" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="4816" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_refresh_queue_acceptance_sequence_by_channel</text>
+              <text x="170" y="4816" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_refresh_result_sequence</text>
               <rect x="10" y="4834" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="4850" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_refresh_status_by_channel</text>
+              <text x="17" y="4850" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_refresh_queue_acceptance_sequence_by_channel</text>
               <rect x="163" y="4834" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="4850" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_close_result_sequence</text>
+              <text x="170" y="4850" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_refresh_status_by_channel</text>
               <rect x="10" y="4868" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="4884" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_close_observation_sequence_by_channel</text>
+              <text x="17" y="4884" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_close_result_sequence</text>
               <rect x="163" y="4868" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="4884" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_close_status_by_channel</text>
+              <text x="170" y="4884" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_close_observation_sequence_by_channel</text>
               <rect x="10" y="4902" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="4918" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_command_result_sequence</text>
+              <text x="17" y="4918" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_close_status_by_channel</text>
               <rect x="163" y="4902" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="4918" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_command_acceptance_sequence_by_channel</text>
+              <text x="170" y="4918" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_command_result_sequence</text>
               <rect x="10" y="4936" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="4952" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_command_kind_by_channel</text>
+              <text x="17" y="4952" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_command_acceptance_sequence_by_channel</text>
               <rect x="163" y="4936" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="4952" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_command_rejection_sequence</text>
+              <text x="170" y="4952" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_command_kind_by_channel</text>
               <rect x="10" y="4970" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="4986" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_command_rejection_reason_by_channel</text>
+              <text x="17" y="4986" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_command_rejection_sequence</text>
               <rect x="163" y="4970" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="4986" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_command_rejection_public_error_class_by_channel</text>
+              <text x="170" y="4986" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_command_rejection_reason_by_channel</text>
               <rect x="10" y="5004" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="5020" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_channel_request_rejection_sequence</text>
+              <text x="17" y="5020" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_command_rejection_public_error_class_by_channel</text>
               <rect x="163" y="5004" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="5020" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_channel_request_rejection_reason_by_channel</text>
+              <text x="170" y="5020" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_channel_request_rejection_sequence</text>
               <rect x="10" y="5038" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="5054" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_channel_request_rejection_public_error_class_by_channel</text>
+              <text x="17" y="5054" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_channel_request_rejection_reason_by_channel</text>
               <rect x="163" y="5038" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="5054" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_webrtc_token_issue_sequence</text>
+              <text x="170" y="5054" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_channel_request_rejection_public_error_class_by_channel</text>
               <rect x="10" y="5072" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="5088" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_webrtc_token_channel_by_token</text>
+              <text x="17" y="5088" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_webrtc_token_issue_sequence</text>
               <rect x="163" y="5072" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="5088" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_webrtc_token_expires_at_ms_by_token</text>
+              <text x="170" y="5088" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_webrtc_token_channel_by_token</text>
               <rect x="10" y="5106" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="5122" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_webrtc_consumed_tokens</text>
+              <text x="17" y="5122" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_webrtc_token_expires_at_ms_by_token</text>
               <rect x="163" y="5106" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="5122" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_webrtc_answer_admission_sequence</text>
+              <text x="170" y="5122" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_webrtc_consumed_tokens</text>
               <rect x="10" y="5140" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="5156" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_webrtc_answer_result_sequence</text>
+              <text x="17" y="5156" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_webrtc_answer_admission_sequence</text>
               <rect x="163" y="5140" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="5156" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_webrtc_answer_observation_sequence_by_channel</text>
+              <text x="170" y="5156" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_webrtc_answer_result_sequence</text>
               <rect x="10" y="5174" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="5190" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_webrtc_answer_status_by_channel</text>
+              <text x="17" y="5190" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_webrtc_answer_observation_sequence_by_channel</text>
               <rect x="163" y="5174" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="5190" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_websocket_token_issue_sequence</text>
+              <text x="170" y="5190" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_webrtc_answer_status_by_channel</text>
               <rect x="10" y="5208" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="5224" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_websocket_token_channel_by_token</text>
+              <text x="17" y="5224" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_websocket_token_issue_sequence</text>
               <rect x="163" y="5208" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="5224" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_websocket_token_expires_at_ms_by_token</text>
+              <text x="170" y="5224" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_websocket_token_channel_by_token</text>
               <rect x="10" y="5242" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="5258" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_websocket_consumed_tokens</text>
+              <text x="17" y="5258" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_websocket_token_expires_at_ms_by_token</text>
               <rect x="163" y="5242" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="5258" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_websocket_token_admission_sequence</text>
+              <text x="170" y="5258" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_websocket_consumed_tokens</text>
               <rect x="10" y="5276" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="5292" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_channel_status_result_sequence</text>
+              <text x="17" y="5292" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_websocket_token_admission_sequence</text>
               <rect x="163" y="5276" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="5292" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_channel_status_observation_sequence_by_channel</text>
+              <text x="170" y="5292" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_channel_status_result_sequence</text>
               <rect x="10" y="5310" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="5326" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_channel_status_by_channel</text>
+              <text x="17" y="5326" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_channel_status_observation_sequence_by_channel</text>
               <rect x="163" y="5310" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="5326" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">session_event_stream_open_result_sequence</text>
+              <text x="170" y="5326" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_channel_status_by_channel</text>
               <rect x="10" y="5344" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="5360" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">session_event_stream_close_result_sequence</text>
+              <text x="17" y="5360" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">session_event_stream_open_result_sequence</text>
               <rect x="163" y="5344" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="5360" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">session_event_stream_terminal_sequence</text>
+              <text x="170" y="5360" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">session_event_stream_close_result_sequence</text>
               <rect x="10" y="5378" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="5394" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">active_session_event_streams</text>
+              <text x="17" y="5394" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">session_event_stream_terminal_sequence</text>
               <rect x="163" y="5378" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="5394" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">closed_session_event_streams</text>
+              <text x="170" y="5394" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">active_session_event_streams</text>
               <rect x="10" y="5412" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="5428" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">session_event_stream_session_ids</text>
+              <text x="17" y="5428" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">closed_session_event_streams</text>
               <rect x="163" y="5412" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="5428" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">mob_event_stream_open_result_sequence</text>
+              <text x="170" y="5428" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">session_event_stream_session_ids</text>
               <rect x="10" y="5446" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="5462" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">mob_event_stream_close_result_sequence</text>
+              <text x="17" y="5462" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">mob_event_stream_open_result_sequence</text>
               <rect x="163" y="5446" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="5462" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">mob_event_stream_terminal_sequence</text>
+              <text x="170" y="5462" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">mob_event_stream_close_result_sequence</text>
               <rect x="10" y="5480" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="5496" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">active_mob_event_streams</text>
+              <text x="17" y="5496" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">mob_event_stream_terminal_sequence</text>
               <rect x="163" y="5480" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="5496" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">closed_mob_event_streams</text>
+              <text x="170" y="5496" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">active_mob_event_streams</text>
               <rect x="10" y="5514" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="5530" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">known_surfaces</text>
+              <text x="17" y="5530" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">closed_mob_event_streams</text>
               <rect x="163" y="5514" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="5530" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">active_surfaces</text>
+              <text x="170" y="5530" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">known_surfaces</text>
               <rect x="10" y="5548" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="5564" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">visible_surfaces</text>
+              <text x="17" y="5564" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">active_surfaces</text>
               <rect x="163" y="5548" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="5564" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">surface_base_state</text>
+              <text x="170" y="5564" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">visible_surfaces</text>
               <rect x="10" y="5582" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="5598" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">surface_pending_op</text>
+              <text x="17" y="5598" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">surface_base_state</text>
               <rect x="163" y="5582" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="5598" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">surface_staged_op</text>
+              <text x="170" y="5598" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">surface_pending_op</text>
               <rect x="10" y="5616" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="5632" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">reload_staged_surfaces</text>
+              <text x="17" y="5632" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">surface_staged_op</text>
               <rect x="163" y="5616" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="5632" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">surface_staged_intent_sequence</text>
+              <text x="170" y="5632" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">reload_staged_surfaces</text>
               <rect x="10" y="5650" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="5666" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">next_staged_intent_sequence</text>
+              <text x="17" y="5666" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">surface_staged_intent_sequence</text>
               <rect x="163" y="5650" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="5666" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">surface_pending_task_sequence</text>
+              <text x="170" y="5666" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">next_staged_intent_sequence</text>
               <rect x="10" y="5684" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="5700" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">next_pending_task_sequence</text>
+              <text x="17" y="5700" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">surface_pending_task_sequence</text>
               <rect x="163" y="5684" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="5700" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">surface_pending_lineage_sequence</text>
+              <text x="170" y="5700" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">next_pending_task_sequence</text>
               <rect x="10" y="5718" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="5734" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">surface_inflight_calls</text>
+              <text x="17" y="5734" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">surface_pending_lineage_sequence</text>
               <rect x="163" y="5718" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="5734" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">surface_last_delta_operation</text>
+              <text x="170" y="5734" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">surface_inflight_calls</text>
               <rect x="10" y="5752" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="5768" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">surface_last_delta_phase</text>
+              <text x="17" y="5768" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">surface_last_delta_operation</text>
               <rect x="163" y="5752" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="5768" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">snapshot_epoch</text>
+              <text x="170" y="5768" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">surface_last_delta_phase</text>
               <rect x="10" y="5786" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="5802" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">snapshot_aligned_epoch</text>
+              <text x="17" y="5802" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">snapshot_epoch</text>
               <rect x="163" y="5786" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="5802" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">surface_draining_since_ms</text>
+              <text x="170" y="5802" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">snapshot_aligned_epoch</text>
               <rect x="10" y="5820" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="5836" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">surface_removal_timeout_at_ms</text>
+              <text x="17" y="5836" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">surface_draining_since_ms</text>
               <rect x="163" y="5820" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="5836" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">surface_removal_applied_at_turn</text>
+              <text x="170" y="5836" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">surface_removal_timeout_at_ms</text>
               <rect x="10" y="5854" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="5870" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">surface_phase</text>
+              <text x="17" y="5870" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">surface_removal_applied_at_turn</text>
               <rect x="163" y="5854" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="5870" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">removal_timeout_ms</text>
+              <text x="170" y="5870" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">surface_phase</text>
               <rect x="10" y="5888" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="5904" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">mcp_server_states</text>
+              <text x="17" y="5904" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">removal_timeout_ms</text>
               <rect x="163" y="5888" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="5904" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">pending_peer_requests</text>
+              <text x="170" y="5904" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">mcp_server_states</text>
               <rect x="10" y="5922" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="5938" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">inbound_peer_requests</text>
+              <text x="17" y="5938" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">pending_peer_requests</text>
               <rect x="163" y="5922" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="5938" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">inbound_peer_request_lanes</text>
+              <text x="170" y="5938" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">inbound_peer_requests</text>
               <rect x="10" y="5956" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="5972" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">last_session_context_updated_at_ms</text>
+              <text x="17" y="5972" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">inbound_peer_request_lanes</text>
               <rect x="163" y="5956" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="5972" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">reserved_interaction_streams</text>
+              <text x="170" y="5972" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">last_session_context_updated_at_ms</text>
               <rect x="10" y="5990" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="6006" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">attached_interaction_streams</text>
+              <text x="17" y="6006" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">reserved_interaction_streams</text>
               <rect x="163" y="5990" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="6006" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">peer_ingress_owner_kind</text>
+              <text x="170" y="6006" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">attached_interaction_streams</text>
               <rect x="10" y="6024" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="6040" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">peer_ingress_comms_runtime_id</text>
+              <text x="17" y="6040" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">peer_ingress_owner_kind</text>
               <rect x="163" y="6024" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="6040" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">peer_ingress_mob_id</text>
+              <text x="170" y="6040" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">peer_ingress_comms_runtime_id</text>
               <rect x="10" y="6058" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="6074" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">peer_ingress_authority_phase</text>
+              <text x="17" y="6074" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">peer_ingress_mob_id</text>
               <rect x="163" y="6058" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="6074" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">supervisor_binding_kind</text>
+              <text x="170" y="6074" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">peer_ingress_authority_phase</text>
               <rect x="10" y="6092" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="6108" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">supervisor_bound_name</text>
+              <text x="17" y="6108" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">supervisor_binding_kind</text>
               <rect x="163" y="6092" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="6108" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">supervisor_bound_peer_id</text>
+              <text x="170" y="6108" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">supervisor_bound_name</text>
               <rect x="10" y="6126" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="6142" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">supervisor_bound_address</text>
+              <text x="17" y="6142" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">supervisor_bound_peer_id</text>
               <rect x="163" y="6126" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="6142" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">supervisor_bound_signing_public_key</text>
+              <text x="170" y="6142" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">supervisor_bound_address</text>
               <rect x="10" y="6160" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="6176" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">supervisor_bound_epoch</text>
+              <text x="17" y="6176" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">supervisor_bound_signing_public_key</text>
               <rect x="163" y="6160" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="6176" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">supervisor_publish_pending_name</text>
+              <text x="170" y="6176" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">supervisor_bound_epoch</text>
               <rect x="10" y="6194" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="6210" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">supervisor_publish_pending_peer_id</text>
+              <text x="17" y="6210" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">supervisor_publish_pending_name</text>
               <rect x="163" y="6194" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="6210" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">supervisor_publish_pending_address</text>
+              <text x="170" y="6210" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">supervisor_publish_pending_peer_id</text>
               <rect x="10" y="6228" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="6244" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">supervisor_publish_pending_signing_public_key</text>
+              <text x="17" y="6244" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">supervisor_publish_pending_address</text>
               <rect x="163" y="6228" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="6244" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">supervisor_publish_pending_epoch</text>
+              <text x="170" y="6244" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">supervisor_publish_pending_signing_public_key</text>
               <rect x="10" y="6262" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="6278" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">supervisor_revoke_pending_name</text>
+              <text x="17" y="6278" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">supervisor_publish_pending_epoch</text>
               <rect x="163" y="6262" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="6278" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">supervisor_revoke_pending_peer_id</text>
+              <text x="170" y="6278" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">supervisor_revoke_pending_name</text>
               <rect x="10" y="6296" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="6312" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">supervisor_revoke_pending_address</text>
+              <text x="17" y="6312" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">supervisor_revoke_pending_peer_id</text>
               <rect x="163" y="6296" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="6312" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">supervisor_revoke_pending_signing_public_key</text>
+              <text x="170" y="6312" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">supervisor_revoke_pending_address</text>
               <rect x="10" y="6330" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="6346" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">supervisor_revoke_pending_epoch</text>
+              <text x="17" y="6346" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">supervisor_revoke_pending_signing_public_key</text>
               <rect x="163" y="6330" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="6346" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">supervisor_revoked_peer_id</text>
+              <text x="170" y="6346" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">supervisor_revoke_pending_epoch</text>
               <rect x="10" y="6364" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="6380" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">supervisor_revoked_signing_public_key</text>
+              <text x="17" y="6380" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">supervisor_revoked_peer_id</text>
               <rect x="163" y="6364" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="6380" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">supervisor_revoked_epoch</text>
+              <text x="170" y="6380" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">supervisor_revoked_signing_public_key</text>
               <rect x="10" y="6398" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="6414" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">supervisor_rotation_operation_id</text>
+              <text x="17" y="6414" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">supervisor_revoked_epoch</text>
               <rect x="163" y="6398" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="6414" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">supervisor_rotation_phase</text>
+              <text x="170" y="6414" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">supervisor_rotation_operation_id</text>
               <rect x="10" y="6432" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="6448" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">supervisor_rotation_rejection</text>
+              <text x="17" y="6448" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">supervisor_rotation_phase</text>
               <rect x="163" y="6432" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="6448" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">supervisor_rotation_previous_name</text>
+              <text x="170" y="6448" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">supervisor_rotation_rejection</text>
               <rect x="10" y="6466" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="6482" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">supervisor_rotation_previous_peer_id</text>
+              <text x="17" y="6482" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">supervisor_rotation_previous_name</text>
               <rect x="163" y="6466" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="6482" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">supervisor_rotation_previous_address</text>
+              <text x="170" y="6482" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">supervisor_rotation_previous_peer_id</text>
               <rect x="10" y="6500" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="6516" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">supervisor_rotation_previous_signing_public_key</text>
+              <text x="17" y="6516" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">supervisor_rotation_previous_address</text>
               <rect x="163" y="6500" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="6516" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">supervisor_rotation_previous_epoch</text>
+              <text x="170" y="6516" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">supervisor_rotation_previous_signing_public_key</text>
               <rect x="10" y="6534" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="6550" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">supervisor_rotation_next_name</text>
+              <text x="17" y="6550" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">supervisor_rotation_previous_epoch</text>
               <rect x="163" y="6534" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="6550" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">supervisor_rotation_next_peer_id</text>
+              <text x="170" y="6550" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">supervisor_rotation_next_name</text>
               <rect x="10" y="6568" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="6584" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">supervisor_rotation_next_address</text>
+              <text x="17" y="6584" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">supervisor_rotation_next_peer_id</text>
               <rect x="163" y="6568" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="6584" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">supervisor_rotation_next_signing_public_key</text>
+              <text x="170" y="6584" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">supervisor_rotation_next_address</text>
               <rect x="10" y="6602" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="6618" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">supervisor_rotation_next_epoch</text>
+              <text x="17" y="6618" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">supervisor_rotation_next_signing_public_key</text>
               <rect x="163" y="6602" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="6618" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">supervisor_rotation_terminal_phases</text>
+              <text x="170" y="6618" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">supervisor_rotation_next_epoch</text>
               <rect x="10" y="6636" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="6652" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">supervisor_rotation_terminal_rejections</text>
+              <text x="17" y="6652" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">supervisor_rotation_terminal_phases</text>
               <rect x="163" y="6636" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="6652" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">supervisor_rotation_terminal_previous_names</text>
+              <text x="170" y="6652" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">supervisor_rotation_terminal_rejections</text>
               <rect x="10" y="6670" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="6686" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">supervisor_rotation_terminal_previous_peer_ids</text>
+              <text x="17" y="6686" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">supervisor_rotation_terminal_previous_names</text>
               <rect x="163" y="6670" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="6686" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">supervisor_rotation_terminal_previous_addresses</text>
+              <text x="170" y="6686" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">supervisor_rotation_terminal_previous_peer_ids</text>
               <rect x="10" y="6704" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="6720" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">supervisor_rotation_terminal_previous_signing_public_keys</text>
+              <text x="17" y="6720" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">supervisor_rotation_terminal_previous_addresses</text>
               <rect x="163" y="6704" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="6720" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">supervisor_rotation_terminal_previous_epochs</text>
+              <text x="170" y="6720" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">supervisor_rotation_terminal_previous_signing_public_keys</text>
               <rect x="10" y="6738" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="6754" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">supervisor_rotation_terminal_next_names</text>
+              <text x="17" y="6754" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">supervisor_rotation_terminal_previous_epochs</text>
               <rect x="163" y="6738" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="6754" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">supervisor_rotation_terminal_next_peer_ids</text>
+              <text x="170" y="6754" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">supervisor_rotation_terminal_next_names</text>
               <rect x="10" y="6772" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="6788" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">supervisor_rotation_terminal_next_addresses</text>
+              <text x="17" y="6788" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">supervisor_rotation_terminal_next_peer_ids</text>
               <rect x="163" y="6772" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="6788" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">supervisor_rotation_terminal_next_signing_public_keys</text>
+              <text x="170" y="6788" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">supervisor_rotation_terminal_next_addresses</text>
               <rect x="10" y="6806" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="6822" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">supervisor_rotation_terminal_next_epochs</text>
+              <text x="17" y="6822" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">supervisor_rotation_terminal_next_signing_public_keys</text>
               <rect x="163" y="6806" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="6822" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">local_endpoint</text>
+              <text x="170" y="6822" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">supervisor_rotation_terminal_next_epochs</text>
               <rect x="10" y="6840" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="6856" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">direct_peer_endpoints</text>
+              <text x="17" y="6856" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">local_endpoint</text>
               <rect x="163" y="6840" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="6856" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">mob_overlay_peer_endpoints</text>
+              <text x="170" y="6856" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">direct_peer_endpoints</text>
               <rect x="10" y="6874" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="6890" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">peer_projection_epoch</text>
+              <text x="17" y="6890" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">mob_overlay_peer_endpoints</text>
               <rect x="163" y="6874" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="6890" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">mob_overlay_epoch</text>
+              <text x="170" y="6890" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">peer_projection_epoch</text>
+              <rect x="10" y="6908" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
+              <text x="17" y="6924" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">mob_overlay_epoch</text>
       </g>
     <g transform="translate(346, 172)">
       <defs>
@@ -2308,25 +2312,25 @@
           <rect x="0" y="0" width="280" height="94" rx="14" fill="rgba(132,191,215,0.08)" stroke="rgba(255,255,255,0.12)" />
           <text x="16" y="16" fill="#7d7a74" font-size="8" letter-spacing="1.8" font-family="Avenir Next, Helvetica Neue, Arial, sans-serif">PHASE</text>
           <text x="16" y="42" fill="#f4efe5" font-size="24" font-weight="600" letter-spacing="-1.5" font-family="Avenir Next, Helvetica Neue, Arial, sans-serif">Idle</text>
-          <text x="16" y="72" fill="#b6aea0" font-size="9" letter-spacing="1" font-family="Avenir Next, Helvetica Neue, Arial, sans-serif">L:559 E:9 I:11</text>
+          <text x="16" y="72" fill="#b6aea0" font-size="9" letter-spacing="1" font-family="Avenir Next, Helvetica Neue, Arial, sans-serif">L:568 E:9 I:11</text>
         </g>
         <g transform="translate(520, 248)">
           <rect x="0" y="0" width="320" height="116" rx="14" fill="rgba(132,191,215,0.08)" stroke="rgba(255,255,255,0.12)" />
           <text x="16" y="16" fill="#7d7a74" font-size="8" letter-spacing="1.8" font-family="Avenir Next, Helvetica Neue, Arial, sans-serif">PHASE</text>
           <text x="16" y="42" fill="#f4efe5" font-size="24" font-weight="600" letter-spacing="-1.5" font-family="Avenir Next, Helvetica Neue, Arial, sans-serif">Attached</text>
-          <text x="16" y="94" fill="#b6aea0" font-size="9" letter-spacing="1" font-family="Avenir Next, Helvetica Neue, Arial, sans-serif">L:466 E:10 I:8</text>
+          <text x="16" y="94" fill="#b6aea0" font-size="9" letter-spacing="1" font-family="Avenir Next, Helvetica Neue, Arial, sans-serif">L:475 E:10 I:8</text>
         </g>
         <g transform="translate(830, 392)">
           <rect x="0" y="0" width="410" height="188" rx="14" fill="rgba(201,109,84,0.18)" stroke="rgba(201,109,84,0.42)" />
           <text x="16" y="16" fill="#7d7a74" font-size="8" letter-spacing="1.8" font-family="Avenir Next, Helvetica Neue, Arial, sans-serif">PHASE</text>
           <text x="16" y="42" fill="#f4efe5" font-size="32" font-weight="600" letter-spacing="-1.5" font-family="Avenir Next, Helvetica Neue, Arial, sans-serif">Running</text>
-          <text x="16" y="166" fill="#b6aea0" font-size="9" letter-spacing="1" font-family="Avenir Next, Helvetica Neue, Arial, sans-serif">L:511 E:18 I:11</text>
+          <text x="16" y="166" fill="#b6aea0" font-size="9" letter-spacing="1" font-family="Avenir Next, Helvetica Neue, Arial, sans-serif">L:520 E:18 I:11</text>
         </g>
         <g transform="translate(1390, 430)">
           <rect x="0" y="0" width="280" height="96" rx="14" fill="rgba(132,191,215,0.08)" stroke="rgba(255,255,255,0.12)" />
           <text x="16" y="16" fill="#7d7a74" font-size="8" letter-spacing="1.8" font-family="Avenir Next, Helvetica Neue, Arial, sans-serif">PHASE</text>
           <text x="16" y="42" fill="#f4efe5" font-size="24" font-weight="600" letter-spacing="-1.5" font-family="Avenir Next, Helvetica Neue, Arial, sans-serif">Retired</text>
-          <text x="16" y="74" fill="#b6aea0" font-size="9" letter-spacing="1" font-family="Avenir Next, Helvetica Neue, Arial, sans-serif">L:294 E:5 I:7</text>
+          <text x="16" y="74" fill="#b6aea0" font-size="9" letter-spacing="1" font-family="Avenir Next, Helvetica Neue, Arial, sans-serif">L:298 E:5 I:7</text>
         </g>
         <g transform="translate(1300, 790)">
           <rect x="0" y="0" width="300" height="94" rx="14" fill="rgba(132,191,215,0.08)" stroke="rgba(255,255,255,0.12)" />
@@ -2656,10 +2660,10 @@
           <rect x="18" y="260" width="6" height="6" rx="1" fill="#d8aa57" />
           <text x="30" y="266.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ClassifyPlainEvent</text>
   </g><g transform="translate(40, 1120)">
-    <rect x="0" y="0" width="520" height="4718" rx="14" fill="rgba(20,26,31,0.82)" stroke="rgba(201,109,84,0.28)" stroke-opacity="0.28" />
+    <rect x="0" y="0" width="520" height="4820" rx="14" fill="rgba(20,26,31,0.82)" stroke="rgba(201,109,84,0.28)" stroke-opacity="0.28" />
     <text x="14" y="15" fill="#7d7a74" font-size="8" letter-spacing="1.8" font-family="Avenir Next, Helvetica Neue, Arial, sans-serif">CONTROL DOMAIN</text>
     <text x="14" y="30" fill="#f4efe5" font-size="13" font-weight="600" font-family="Avenir Next, Helvetica Neue, Arial, sans-serif">Emergent / Unassigned Surfaces</text>
-    <text x="506" y="15" text-anchor="end" fill="#7d7a74" font-size="8" letter-spacing="1.5" font-family="Avenir Next, Helvetica Neue, Arial, sans-serif">266 TRIGGERS</text>
+    <text x="506" y="15" text-anchor="end" fill="#7d7a74" font-size="8" letter-spacing="1.5" font-family="Avenir Next, Helvetica Neue, Arial, sans-serif">271 TRIGGERS</text>
 
           <rect x="12" y="34" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="18" y="40" width="6" height="6" rx="1" fill="#d8aa57" />
@@ -2723,742 +2727,757 @@
           <text x="281" y="244.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ArchiveTerminalInput</text>
           <rect x="12" y="254" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="18" y="260" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="30" y="266.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">AttachMobIngress</text>
+          <text x="30" y="266.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ArchiveUnresolvedModelRoutingHandoff</text>
           <rect x="263" y="254" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="269" y="260" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="281" y="266.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">AttachSessionIngress</text>
+          <text x="281" y="266.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">AttachMobIngress</text>
           <rect x="12" y="276" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="18" y="282" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="30" y="288.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">AuthorizeDeferredSessionMachineArchivedResume</text>
+          <text x="30" y="288.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">AttachSessionIngress</text>
           <rect x="263" y="276" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="269" y="282" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="281" y="288.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">AuthorizeDurableTailRecovery</text>
+          <text x="281" y="288.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">AuthorizeDeferredSessionMachineArchivedResume</text>
           <rect x="12" y="298" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="18" y="304" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="30" y="310.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">AuthorizeInteractionTerminalOutboxAdoption</text>
+          <text x="30" y="310.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">AuthorizeDurableTailRecovery</text>
           <rect x="263" y="298" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="269" y="304" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="281" y="310.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">AuthorizeLiveActiveChannelControl</text>
+          <text x="281" y="310.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">AuthorizeInteractionTerminalOutboxAdoption</text>
           <rect x="12" y="320" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="18" y="326" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="30" y="332.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">AuthorizeLiveBridgeEffect</text>
+          <text x="30" y="332.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">AuthorizeLiveActiveChannelControl</text>
           <rect x="263" y="320" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="269" y="326" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="281" y="332.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">AuthorizeLiveBridgeExecutionStart</text>
+          <text x="281" y="332.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">AuthorizeLiveBridgeEffect</text>
           <rect x="12" y="342" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="18" y="348" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="30" y="354.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">AuthorizeLiveBridgeSubmission</text>
+          <text x="30" y="354.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">AuthorizeLiveBridgeExecutionStart</text>
           <rect x="263" y="342" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="269" y="348" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="281" y="354.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">AuthorizeLiveConsequentialEffect</text>
+          <text x="281" y="354.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">AuthorizeLiveBridgeSubmission</text>
           <rect x="12" y="364" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="18" y="370" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="30" y="376.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">AuthorizeLiveContextAppend</text>
+          <text x="30" y="376.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">AuthorizeLiveConsequentialEffect</text>
           <rect x="263" y="364" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="269" y="370" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="281" y="376.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">AuthorizeLiveDelegationResultDelivery</text>
+          <text x="281" y="376.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">AuthorizeLiveContextAppend</text>
           <rect x="12" y="386" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="18" y="392" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="30" y="398.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">AuthorizeLiveDelegationResultRelease</text>
+          <text x="30" y="398.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">AuthorizeLiveDelegationResultDelivery</text>
           <rect x="263" y="386" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="269" y="392" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="281" y="398.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">AuthorizeLiveDelegationTranscriptTerminalCancellation</text>
+          <text x="281" y="398.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">AuthorizeLiveDelegationResultRelease</text>
           <rect x="12" y="408" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="18" y="414" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="30" y="420.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">AuthorizeLiveDelegationWorkerRetirement</text>
+          <text x="30" y="420.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">AuthorizeLiveDelegationTranscriptTerminalCancellation</text>
           <rect x="263" y="408" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="269" y="414" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="281" y="420.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">AuthorizeLiveDelegationWorkerStart</text>
+          <text x="281" y="420.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">AuthorizeLiveDelegationWorkerRetirement</text>
           <rect x="12" y="430" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="18" y="436" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="30" y="442.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">AuthorizeStoredInputStateSeed</text>
+          <text x="30" y="442.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">AuthorizeLiveDelegationWorkerStart</text>
           <rect x="263" y="430" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="269" y="436" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="281" y="442.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">AuthorizeSupervisor</text>
+          <text x="281" y="442.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">AuthorizeStoredInputStateSeed</text>
           <rect x="12" y="452" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="18" y="458" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="30" y="464.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">AuthorizeSupervisorMobPeerOverlay</text>
+          <text x="30" y="464.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">AuthorizeSupervisor</text>
           <rect x="263" y="452" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="269" y="458" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="281" y="464.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">BeginDeferredSessionArchive</text>
+          <text x="281" y="464.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">AuthorizeSupervisorMobPeerOverlay</text>
           <rect x="12" y="474" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="18" y="480" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="30" y="486.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">BeginDeferredSessionPromotion</text>
+          <text x="30" y="486.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">BeginDeferredSessionArchive</text>
           <rect x="263" y="474" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
-          <rect x="269" y="480" width="6" height="6" rx="1" fill="#84bfd7" />
-          <text x="281" y="486.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">BeginImageOperation</text>
+          <rect x="269" y="480" width="6" height="6" rx="1" fill="#d8aa57" />
+          <text x="281" y="486.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">BeginDeferredSessionPromotion</text>
           <rect x="12" y="496" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
-          <rect x="18" y="502" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="30" y="508.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">BeginUnregisterSession</text>
+          <rect x="18" y="502" width="6" height="6" rx="1" fill="#84bfd7" />
+          <text x="30" y="508.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">BeginImageOperation</text>
           <rect x="263" y="496" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="269" y="502" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="281" y="508.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">BeginUnregisterUnservedAttachment</text>
+          <text x="281" y="508.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">BeginUnregisterSession</text>
           <rect x="12" y="518" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="18" y="524" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="30" y="530.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">BindLiveContextRecoveryChannel</text>
+          <text x="30" y="530.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">BeginUnregisterUnservedAttachment</text>
           <rect x="263" y="518" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="269" y="524" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="281" y="530.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">BindLiveDelegationResultRecoveryChannel</text>
+          <text x="281" y="530.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">BindLiveContextRecoveryChannel</text>
           <rect x="12" y="540" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="18" y="546" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="30" y="552.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">BindLiveExecutionChannel</text>
+          <text x="30" y="552.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">BindLiveDelegationResultRecoveryChannel</text>
           <rect x="263" y="540" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="269" y="546" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="281" y="552.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">BindSupervisor</text>
+          <text x="281" y="552.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">BindLiveExecutionChannel</text>
           <rect x="12" y="562" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="18" y="568" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="30" y="574.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">CallbackPending</text>
+          <text x="30" y="574.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">BindSupervisor</text>
           <rect x="263" y="562" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="269" y="568" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="281" y="574.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">CancelAfterBoundaryForRun</text>
+          <text x="281" y="574.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">CallbackPending</text>
           <rect x="12" y="584" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="18" y="590" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="30" y="596.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">CancelLiveBridgeOperation</text>
+          <text x="30" y="596.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">CancelAfterBoundaryForRun</text>
           <rect x="263" y="584" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="269" y="590" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="281" y="596.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">CancelRun</text>
+          <text x="281" y="596.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">CancelLiveBridgeOperation</text>
           <rect x="12" y="606" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="18" y="612" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="30" y="618.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">CancelSurfaceRequest</text>
+          <text x="30" y="618.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">CancelRun</text>
           <rect x="263" y="606" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="269" y="612" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="281" y="618.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ChangeLane</text>
+          <text x="281" y="618.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">CancelSurfaceRequest</text>
           <rect x="12" y="628" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="18" y="634" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="30" y="640.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ClaimLiveBridgeSubmissionAttempt</text>
+          <text x="30" y="640.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ChangeLane</text>
           <rect x="263" y="628" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="269" y="634" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="281" y="640.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ClassifyAssistantOutput</text>
+          <text x="281" y="640.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ClaimLiveBridgeSubmissionAttempt</text>
           <rect x="12" y="650" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
-          <rect x="18" y="656" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="30" y="662.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ClassifyCallTimeout</text>
+          <rect x="18" y="656" width="6" height="6" rx="1" fill="#84bfd7" />
+          <text x="30" y="662.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ClaimModelRoutingHandoff</text>
           <rect x="263" y="650" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
-          <rect x="269" y="656" width="6" height="6" rx="1" fill="#84bfd7" />
-          <text x="281" y="662.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ClassifyImageOperationTerminal</text>
+          <rect x="269" y="656" width="6" height="6" rx="1" fill="#d8aa57" />
+          <text x="281" y="662.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ClassifyAssistantOutput</text>
           <rect x="12" y="672" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="18" y="678" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="30" y="684.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ClassifyInputTerminality</text>
+          <text x="30" y="684.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ClassifyCallTimeout</text>
           <rect x="263" y="672" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
-          <rect x="269" y="678" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="281" y="684.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ClassifyLlmFailureRecovery</text>
+          <rect x="269" y="678" width="6" height="6" rx="1" fill="#84bfd7" />
+          <text x="281" y="684.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ClassifyImageOperationTerminal</text>
           <rect x="12" y="694" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="18" y="700" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="30" y="706.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ClassifyOperationCompletionFeed</text>
+          <text x="30" y="706.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ClassifyInputTerminality</text>
           <rect x="263" y="694" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="269" y="700" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="281" y="706.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ClassifyOperationCompletionWake</text>
+          <text x="281" y="706.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ClassifyLlmFailureRecovery</text>
           <rect x="12" y="716" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="18" y="722" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="30" y="728.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ClassifyOperationDurability</text>
+          <text x="30" y="728.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ClassifyOperationCompletionFeed</text>
           <rect x="263" y="716" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="269" y="722" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="281" y="728.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ClassifyOperationPublicResult</text>
+          <text x="281" y="728.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ClassifyOperationCompletionWake</text>
           <rect x="12" y="738" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="18" y="744" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="30" y="750.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ClassifyOperationTerminality</text>
+          <text x="30" y="750.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ClassifyOperationDurability</text>
           <rect x="263" y="738" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="269" y="744" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="281" y="750.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ClassifyOperationTransitionIdempotence</text>
+          <text x="281" y="750.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ClassifyOperationPublicResult</text>
           <rect x="12" y="760" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="18" y="766" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="30" y="772.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ClassifyPeerResponseReply</text>
+          <text x="30" y="772.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ClassifyOperationTerminality</text>
           <rect x="263" y="760" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="269" y="766" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="281" y="772.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ClassifyRecoveredInputDurability</text>
+          <text x="281" y="772.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ClassifyOperationTransitionIdempotence</text>
           <rect x="12" y="782" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="18" y="788" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="30" y="794.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ClassifyRecoveredOperationRecord</text>
+          <text x="30" y="794.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ClassifyPeerResponseReply</text>
           <rect x="263" y="782" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="269" y="788" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="281" y="794.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ClassifyRecoveredTerminalCompletionBatch</text>
+          <text x="281" y="794.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ClassifyRecoveredInputDurability</text>
           <rect x="12" y="804" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="18" y="810" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="30" y="816.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ClassifyRuntimeAuthorityReconciliation</text>
+          <text x="30" y="816.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ClassifyRecoveredOperationRecord</text>
           <rect x="263" y="804" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="269" y="810" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="281" y="816.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ClassifyRuntimeLifecycleDurability</text>
+          <text x="281" y="816.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ClassifyRecoveredTerminalCompletionBatch</text>
           <rect x="12" y="826" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="18" y="832" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="30" y="838.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ClassifyRuntimeLifecycleState</text>
+          <text x="30" y="838.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ClassifyRuntimeAuthorityReconciliation</text>
           <rect x="263" y="826" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="269" y="832" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="281" y="838.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ClassifyRuntimeLoopQueueAdmission</text>
+          <text x="281" y="838.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ClassifyRuntimeLifecycleDurability</text>
           <rect x="12" y="848" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="18" y="854" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="30" y="860.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ClassifySurfaceRequestTerminal</text>
+          <text x="30" y="860.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ClassifyRuntimeLifecycleState</text>
           <rect x="263" y="848" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="269" y="854" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="281" y="860.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ClassifyTurnTerminalCauseClass</text>
+          <text x="281" y="860.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ClassifyRuntimeLoopQueueAdmission</text>
           <rect x="12" y="870" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="18" y="876" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="30" y="882.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ClassifyTurnTerminality</text>
+          <text x="30" y="882.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ClassifySurfaceRequestTerminal</text>
           <rect x="263" y="870" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="269" y="876" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="281" y="882.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ClearLocalEndpoint</text>
+          <text x="281" y="882.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ClassifyTurnTerminalCauseClass</text>
           <rect x="12" y="892" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="18" y="898" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="30" y="904.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ClearSessionLlmState</text>
+          <text x="30" y="904.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ClassifyTurnTerminality</text>
           <rect x="263" y="892" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="269" y="898" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="281" y="904.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ClearTurnToolOverlay</text>
+          <text x="281" y="904.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ClearLocalEndpoint</text>
           <rect x="12" y="914" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="18" y="920" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="30" y="926.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">CommitDeferredNames</text>
+          <text x="30" y="926.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ClearSessionLlmState</text>
           <rect x="263" y="914" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="269" y="920" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="281" y="926.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">CommitStickyModelFallback</text>
+          <text x="281" y="926.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ClearTurnToolOverlay</text>
           <rect x="12" y="936" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="18" y="942" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="30" y="948.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">CommitTerminalBoundarySequence</text>
+          <text x="30" y="948.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">CommitDeferredNames</text>
           <rect x="263" y="936" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="269" y="942" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="281" y="948.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">CommitVisibilityFilter</text>
+          <text x="281" y="948.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">CommitStickyModelFallback</text>
           <rect x="12" y="958" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="18" y="964" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="30" y="970.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">CommsDrainExitedForUnregister</text>
+          <text x="30" y="970.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">CommitTerminalBoundarySequence</text>
           <rect x="263" y="958" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
-          <rect x="269" y="964" width="6" height="6" rx="1" fill="#84bfd7" />
-          <text x="281" y="970.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">CompleteImageOperation</text>
+          <rect x="269" y="964" width="6" height="6" rx="1" fill="#d8aa57" />
+          <text x="281" y="970.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">CommitVisibilityFilter</text>
           <rect x="12" y="980" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="18" y="986" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="30" y="992.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">CompleteLiveInteraction</text>
+          <text x="30" y="992.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">CommsDrainExitedForUnregister</text>
           <rect x="263" y="980" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
-          <rect x="269" y="986" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="281" y="992.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">CompleteUntilChangedSwitchTurnReconfigure</text>
+          <rect x="269" y="986" width="6" height="6" rx="1" fill="#84bfd7" />
+          <text x="281" y="992.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">CompleteImageOperation</text>
           <rect x="12" y="1002" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="18" y="1008" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="30" y="1014.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">CompletionWaitersResolvedForUnregister</text>
+          <text x="30" y="1014.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">CompleteLiveInteraction</text>
           <rect x="263" y="1002" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="269" y="1008" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="281" y="1014.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ConfirmLiveBridgeFinalInput</text>
+          <text x="281" y="1014.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">CompleteUntilChangedSwitchTurnReconfigure</text>
           <rect x="12" y="1024" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="18" y="1030" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="30" y="1036.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ConsumeInput</text>
+          <text x="30" y="1036.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">CompletionWaitersResolvedForUnregister</text>
           <rect x="263" y="1024" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="269" y="1030" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="281" y="1036.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ConsumeLiveActiveChannelControl</text>
+          <text x="281" y="1036.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ConfirmLiveBridgeFinalInput</text>
           <rect x="12" y="1046" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="18" y="1052" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="30" y="1058.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ConsumeLiveBridgeEffectAuthority</text>
+          <text x="30" y="1058.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ConsumeInput</text>
           <rect x="263" y="1046" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="269" y="1052" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="281" y="1058.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">DeclareRecoveredTerminalCompletionUnrecoverable</text>
+          <text x="281" y="1058.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ConsumeLiveActiveChannelControl</text>
           <rect x="12" y="1068" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="18" y="1074" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="30" y="1080.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">DeferInputBehindBacklog</text>
+          <text x="30" y="1080.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ConsumeLiveBridgeEffectAuthority</text>
           <rect x="263" y="1068" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
-          <rect x="269" y="1074" width="6" height="6" rx="1" fill="#84bfd7" />
-          <text x="281" y="1080.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">DenyImageOperationPlan</text>
+          <rect x="269" y="1074" width="6" height="6" rx="1" fill="#d8aa57" />
+          <text x="281" y="1080.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">DeclareRecoveredTerminalCompletionUnrecoverable</text>
           <rect x="12" y="1090" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="18" y="1096" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="30" y="1102.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">DetachIngress</text>
+          <text x="30" y="1102.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">DeferInputBehindBacklog</text>
           <rect x="263" y="1090" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
-          <rect x="269" y="1096" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="281" y="1102.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">DrainQueuedRun</text>
+          <rect x="269" y="1096" width="6" height="6" rx="1" fill="#84bfd7" />
+          <text x="281" y="1102.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">DenyImageOperationPlan</text>
           <rect x="12" y="1112" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
-          <rect x="18" y="1118" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="30" y="1124.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">DropDeferredSession</text>
+          <rect x="18" y="1118" width="6" height="6" rx="1" fill="#84bfd7" />
+          <text x="30" y="1124.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">DenyModelRoutingHandoff</text>
           <rect x="263" y="1112" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="269" y="1118" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="281" y="1124.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">EnqueueLiveContextRow</text>
+          <text x="281" y="1124.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">DetachIngress</text>
           <rect x="12" y="1134" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="18" y="1140" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="30" y="1146.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">EvictCompletedOp</text>
+          <text x="30" y="1146.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">DrainQueuedRun</text>
           <rect x="263" y="1134" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="269" y="1140" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="281" y="1146.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ExtractionFailed</text>
+          <text x="281" y="1146.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">DropDeferredSession</text>
           <rect x="12" y="1156" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="18" y="1162" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="30" y="1168.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">FenceRestoredLiveBridgeOperationForRestart</text>
+          <text x="30" y="1168.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">EnqueueLiveContextRow</text>
           <rect x="263" y="1156" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="269" y="1162" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="281" y="1168.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">FinishDeferredSessionArchive</text>
+          <text x="281" y="1168.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">EvictCompletedOp</text>
           <rect x="12" y="1178" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="18" y="1184" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="30" y="1190.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">FinishDeferredSessionPromotion</text>
+          <text x="30" y="1190.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ExtractionFailed</text>
           <rect x="263" y="1178" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="269" y="1184" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="281" y="1190.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">FinishSurfaceRequestUnpublished</text>
+          <text x="281" y="1190.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">FenceRestoredLiveBridgeOperationForRestart</text>
           <rect x="12" y="1200" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="18" y="1206" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="30" y="1212.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">GrantMobOperatorManageMob</text>
+          <text x="30" y="1212.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">FinishDeferredSessionArchive</text>
           <rect x="263" y="1200" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="269" y="1206" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="281" y="1212.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">HydrateSessionLlmState</text>
+          <text x="281" y="1212.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">FinishDeferredSessionPromotion</text>
           <rect x="12" y="1222" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="18" y="1228" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="30" y="1234.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">IncrementAttemptCount</text>
+          <text x="30" y="1234.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">FinishSurfaceRequestUnpublished</text>
           <rect x="263" y="1222" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="269" y="1228" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="281" y="1234.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">InteractionStreamAbandoned</text>
+          <text x="281" y="1234.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">GrantMobOperatorManageMob</text>
           <rect x="12" y="1244" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="18" y="1250" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="30" y="1256.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">InteractionStreamAttached</text>
+          <text x="30" y="1256.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">HydrateSessionLlmState</text>
           <rect x="263" y="1244" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
-          <rect x="269" y="1250" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="281" y="1256.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">InteractionStreamClosedEarly</text>
+          <rect x="269" y="1250" width="6" height="6" rx="1" fill="#84bfd7" />
+          <text x="281" y="1256.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ImportCommittedModelRoutingHandoff</text>
           <rect x="12" y="1266" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="18" y="1272" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="30" y="1278.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">InteractionStreamCompleted</text>
+          <text x="30" y="1278.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">IncrementAttemptCount</text>
           <rect x="263" y="1266" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="269" y="1272" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="281" y="1278.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">InteractionStreamExpired</text>
+          <text x="281" y="1278.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">InteractionStreamAbandoned</text>
           <rect x="12" y="1288" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="18" y="1294" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="30" y="1300.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">InteractionStreamReserved</text>
+          <text x="30" y="1300.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">InteractionStreamAttached</text>
           <rect x="263" y="1288" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="269" y="1294" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="281" y="1300.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">InterruptCurrentRunForRun</text>
+          <text x="281" y="1300.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">InteractionStreamClosedEarly</text>
           <rect x="12" y="1310" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="18" y="1316" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="30" y="1322.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">LiveBoundaryUnavailable</text>
+          <text x="30" y="1322.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">InteractionStreamCompleted</text>
           <rect x="263" y="1310" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="269" y="1316" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="281" y="1322.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">MarkApplied</text>
+          <text x="281" y="1322.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">InteractionStreamExpired</text>
           <rect x="12" y="1332" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="18" y="1338" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="30" y="1344.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">MarkAppliedPendingConsumption</text>
+          <text x="30" y="1344.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">InteractionStreamReserved</text>
           <rect x="263" y="1332" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="269" y="1338" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="281" y="1344.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">McpServerConnected</text>
+          <text x="281" y="1344.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">InterruptCurrentRunForRun</text>
           <rect x="12" y="1354" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="18" y="1360" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="30" y="1366.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">McpServerConnectPending</text>
+          <text x="30" y="1366.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">LiveBoundaryUnavailable</text>
           <rect x="263" y="1354" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="269" y="1360" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="281" y="1366.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">McpServerDisconnected</text>
+          <text x="281" y="1366.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">MarkApplied</text>
           <rect x="12" y="1376" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="18" y="1382" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="30" y="1388.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">McpServerFailed</text>
+          <text x="30" y="1388.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">MarkAppliedPendingConsumption</text>
           <rect x="263" y="1376" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="269" y="1382" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="281" y="1388.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">McpServerReload</text>
+          <text x="281" y="1388.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">McpServerConnected</text>
           <rect x="12" y="1398" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="18" y="1404" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="30" y="1410.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">NormalizeRecoveredInputLifecycle</text>
+          <text x="30" y="1410.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">McpServerConnectPending</text>
           <rect x="263" y="1398" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="269" y="1404" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="281" y="1410.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ObserveLiveAssistantTurnStarted</text>
+          <text x="281" y="1410.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">McpServerDisconnected</text>
           <rect x="12" y="1420" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="18" y="1426" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="30" y="1432.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ObserveLiveProviderTurnStarted</text>
+          <text x="30" y="1432.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">McpServerFailed</text>
           <rect x="263" y="1420" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="269" y="1426" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="281" y="1432.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ObserveSupervisorRotation</text>
+          <text x="281" y="1432.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">McpServerReload</text>
           <rect x="12" y="1442" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="18" y="1448" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="30" y="1454.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">PeerRequestReceived</text>
+          <text x="30" y="1454.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">NormalizeRecoveredInputLifecycle</text>
           <rect x="263" y="1442" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="269" y="1448" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="281" y="1454.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">PeerRequestTimedOut</text>
+          <text x="281" y="1454.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ObserveLiveAssistantTurnStarted</text>
           <rect x="12" y="1464" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="18" y="1470" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="30" y="1476.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">PeerResponseProgressArrived</text>
+          <text x="30" y="1476.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ObserveLiveProviderTurnStarted</text>
           <rect x="263" y="1464" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="269" y="1470" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="281" y="1476.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">PeerResponseRejected</text>
+          <text x="281" y="1476.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ObserveSupervisorRotation</text>
           <rect x="12" y="1486" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="18" y="1492" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="30" y="1498.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">PeerResponseReplied</text>
+          <text x="30" y="1498.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">PeerRequestReceived</text>
           <rect x="263" y="1486" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="269" y="1492" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="281" y="1498.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">PeerResponseTerminalArrived</text>
+          <text x="281" y="1498.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">PeerRequestTimedOut</text>
           <rect x="12" y="1508" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="18" y="1514" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="30" y="1520.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">PrepareTerminalSupervisorCleanupBindings</text>
+          <text x="30" y="1520.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">PeerResponseProgressArrived</text>
           <rect x="263" y="1508" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="269" y="1514" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="281" y="1520.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">PrioritizeInput</text>
+          <text x="281" y="1520.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">PeerResponseRejected</text>
           <rect x="12" y="1530" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="18" y="1536" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="30" y="1542.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">PublishLocalEndpoint</text>
+          <text x="30" y="1542.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">PeerResponseReplied</text>
           <rect x="263" y="1530" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="269" y="1536" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="281" y="1542.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">PublishOrCancelSurfaceRequest</text>
+          <text x="281" y="1542.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">PeerResponseTerminalArrived</text>
           <rect x="12" y="1552" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="18" y="1558" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="30" y="1564.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">PublishSurfaceRequest</text>
+          <text x="30" y="1564.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">PrepareTerminalSupervisorCleanupBindings</text>
           <rect x="263" y="1552" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="269" y="1558" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="281" y="1564.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ReconcileLiveDelegationTranscript</text>
+          <text x="281" y="1564.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">PrioritizeInput</text>
           <rect x="12" y="1574" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="18" y="1580" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="30" y="1586.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ReconcileRevokedLiveBridgeExecutionTerminal</text>
+          <text x="30" y="1586.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">PublishLocalEndpoint</text>
           <rect x="263" y="1574" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="269" y="1580" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="281" y="1586.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ReconcileRevokedLiveDelegationWorkerAfterRestart</text>
+          <text x="281" y="1586.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">PublishOrCancelSurfaceRequest</text>
           <rect x="12" y="1596" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
-          <rect x="18" y="1602" width="6" height="6" rx="1" fill="#84bfd7" />
-          <text x="30" y="1608.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ReconfigureSessionLlmIdentity</text>
+          <rect x="18" y="1602" width="6" height="6" rx="1" fill="#d8aa57" />
+          <text x="30" y="1608.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">PublishSurfaceRequest</text>
           <rect x="263" y="1596" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
-          <rect x="269" y="1602" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="281" y="1608.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RecordBoundarySeq</text>
+          <rect x="269" y="1602" width="6" height="6" rx="1" fill="#84bfd7" />
+          <text x="281" y="1608.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RealizeModelRoutingHandoff</text>
           <rect x="12" y="1618" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="18" y="1624" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="30" y="1630.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RecordLiveBridgeEffectOutcome</text>
+          <text x="30" y="1630.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ReconcileLiveDelegationTranscript</text>
           <rect x="263" y="1618" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="269" y="1624" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="281" y="1630.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RecordLiveBridgeExecutionTerminal</text>
+          <text x="281" y="1630.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ReconcileRevokedLiveBridgeExecutionTerminal</text>
           <rect x="12" y="1640" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="18" y="1646" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="30" y="1652.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RecordLiveBridgeOutcomeReceipt</text>
+          <text x="30" y="1652.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ReconcileRevokedLiveDelegationWorkerAfterRestart</text>
           <rect x="263" y="1640" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
-          <rect x="269" y="1646" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="281" y="1652.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RecordLiveBridgeSubmissionLocalWrite</text>
+          <rect x="269" y="1646" width="6" height="6" rx="1" fill="#84bfd7" />
+          <text x="281" y="1652.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ReconfigureSessionLlmIdentity</text>
           <rect x="12" y="1662" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="18" y="1668" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="30" y="1674.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RecordLiveChannelRequestRejected</text>
+          <text x="30" y="1674.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RecordBoundarySeq</text>
           <rect x="263" y="1662" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="269" y="1668" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="281" y="1674.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RecordLiveChannelStatus</text>
+          <text x="281" y="1674.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RecordLiveBridgeEffectOutcome</text>
           <rect x="12" y="1684" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="18" y="1690" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="30" y="1696.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RecordLiveCloseClosed</text>
+          <text x="30" y="1696.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RecordLiveBridgeExecutionTerminal</text>
           <rect x="263" y="1684" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="269" y="1690" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="281" y="1696.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RecordLiveCommandAccepted</text>
+          <text x="281" y="1696.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RecordLiveBridgeOutcomeReceipt</text>
           <rect x="12" y="1706" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="18" y="1712" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="30" y="1718.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RecordLiveCommandRejected</text>
+          <text x="30" y="1718.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RecordLiveBridgeSubmissionLocalWrite</text>
           <rect x="263" y="1706" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="269" y="1712" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="281" y="1718.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RecordLiveDelegationWorkerTerminal</text>
+          <text x="281" y="1718.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RecordLiveChannelRequestRejected</text>
           <rect x="12" y="1728" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="18" y="1734" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="30" y="1740.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RecordLiveRefreshQueued</text>
+          <text x="30" y="1740.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RecordLiveChannelStatus</text>
           <rect x="263" y="1728" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="269" y="1734" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="281" y="1740.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RecordLiveWebrtcAnswerAccepted</text>
+          <text x="281" y="1740.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RecordLiveCloseClosed</text>
           <rect x="12" y="1750" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="18" y="1756" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="30" y="1762.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RecordLiveWebrtcAnswerAcceptedAndBindExecution</text>
+          <text x="30" y="1762.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RecordLiveCommandAccepted</text>
           <rect x="263" y="1750" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="269" y="1756" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="281" y="1762.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RecordLiveWebrtcTokenIssued</text>
+          <text x="281" y="1762.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RecordLiveCommandRejected</text>
           <rect x="12" y="1772" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="18" y="1778" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="30" y="1784.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RecordLiveWebsocketTokenIssued</text>
+          <text x="30" y="1784.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RecordLiveDelegationWorkerTerminal</text>
           <rect x="263" y="1772" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="269" y="1778" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="281" y="1784.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RecordMobEventStreamOpened</text>
+          <text x="281" y="1784.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RecordLiveRefreshQueued</text>
           <rect x="12" y="1794" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="18" y="1800" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="30" y="1806.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RecordMobEventStreamTerminated</text>
+          <text x="30" y="1806.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RecordLiveWebrtcAnswerAccepted</text>
           <rect x="263" y="1794" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="269" y="1800" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="281" y="1806.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RecordSessionEventStreamOpened</text>
+          <text x="281" y="1806.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RecordLiveWebrtcAnswerAcceptedAndBindExecution</text>
           <rect x="12" y="1816" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="18" y="1822" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="30" y="1828.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RecordSessionEventStreamTerminated</text>
+          <text x="30" y="1828.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RecordLiveWebrtcTokenIssued</text>
           <rect x="263" y="1816" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="269" y="1822" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="281" y="1828.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RecoverAdmittedInput</text>
+          <text x="281" y="1828.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RecordLiveWebsocketTokenIssued</text>
           <rect x="12" y="1838" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="18" y="1844" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="30" y="1850.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RecoverCompletionConsumerCursors</text>
+          <text x="30" y="1850.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RecordMobEventStreamOpened</text>
           <rect x="263" y="1838" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="269" y="1844" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="281" y="1850.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RecoverCompletionFeedEntry</text>
+          <text x="281" y="1850.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RecordMobEventStreamTerminated</text>
           <rect x="12" y="1860" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="18" y="1866" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="30" y="1872.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RecoverInputLifecycle</text>
+          <text x="30" y="1872.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RecordSessionEventStreamOpened</text>
           <rect x="263" y="1860" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="269" y="1866" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="281" y="1872.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RecoverLiveBridgeSubmission</text>
+          <text x="281" y="1872.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RecordSessionEventStreamTerminated</text>
           <rect x="12" y="1882" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="18" y="1888" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="30" y="1894.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RecoverOpRecord</text>
+          <text x="30" y="1894.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RecoverAdmittedInput</text>
           <rect x="263" y="1882" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="269" y="1888" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="281" y="1894.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RecoverOpsCompletionCursor</text>
+          <text x="281" y="1894.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RecoverCompletionConsumerCursors</text>
           <rect x="12" y="1904" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="18" y="1910" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="30" y="1916.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RecoverRevokedSupervisorReceipt</text>
+          <text x="30" y="1916.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RecoverCompletionFeedEntry</text>
           <rect x="263" y="1904" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="269" y="1910" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="281" y="1916.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RecoverRuntimeCompletionResultCorrelation</text>
+          <text x="281" y="1916.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RecoverInputLifecycle</text>
           <rect x="12" y="1926" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="18" y="1932" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="30" y="1938.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RecoverSupervisorBinding</text>
+          <text x="30" y="1938.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RecoverLiveBridgeSubmission</text>
           <rect x="263" y="1926" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="269" y="1932" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="281" y="1938.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RecoverSupervisorRevocationPending</text>
+          <text x="281" y="1938.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RecoverOpRecord</text>
           <rect x="12" y="1948" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="18" y="1954" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="30" y="1960.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RecoverSupervisorRotationOperation</text>
+          <text x="30" y="1960.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RecoverOpsCompletionCursor</text>
           <rect x="263" y="1948" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="269" y="1954" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="281" y="1960.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RecoverSupervisorRotationTerminalReceipt</text>
+          <text x="281" y="1960.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RecoverRevokedSupervisorReceipt</text>
           <rect x="12" y="1970" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="18" y="1976" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="30" y="1982.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RefreshSupervisorBindingRoute</text>
+          <text x="30" y="1982.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RecoverRuntimeCompletionResultCorrelation</text>
           <rect x="263" y="1970" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="269" y="1976" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="281" y="1982.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RegisterAcceptedIdempotency</text>
+          <text x="281" y="1982.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RecoverSupervisorBinding</text>
           <rect x="12" y="1992" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="18" y="1998" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="30" y="2004.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RegisterLivePlaybackOwner</text>
+          <text x="30" y="2004.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RecoverSupervisorRevocationPending</text>
           <rect x="263" y="1992" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="269" y="1998" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="281" y="2004.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RemoveDirectPeerEndpoint</text>
+          <text x="281" y="2004.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RecoverSupervisorRotationOperation</text>
           <rect x="12" y="2014" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="18" y="2020" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="30" y="2026.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ReplaceDeferredToolAuthorityCatalog</text>
+          <text x="30" y="2026.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RecoverSupervisorRotationTerminalReceipt</text>
           <rect x="263" y="2014" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="269" y="2020" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="281" y="2026.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ReplaceFilterToolAuthorityCatalog</text>
+          <text x="281" y="2026.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RefreshSupervisorBindingRoute</text>
           <rect x="12" y="2036" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="18" y="2042" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="30" y="2048.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ReplaceVisibilityState</text>
+          <text x="30" y="2048.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RegisterAcceptedIdempotency</text>
           <rect x="263" y="2036" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="269" y="2042" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="281" y="2048.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RequestCancelAfterBoundary</text>
+          <text x="281" y="2048.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RegisterLivePlaybackOwner</text>
           <rect x="12" y="2058" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="18" y="2064" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="30" y="2070.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RequestFiniteSwitchTurn</text>
+          <text x="30" y="2070.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RemoveDirectPeerEndpoint</text>
           <rect x="263" y="2058" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="269" y="2064" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="281" y="2070.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RequestSupervisorTrustPublish</text>
+          <text x="281" y="2070.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ReplaceDeferredToolAuthorityCatalog</text>
           <rect x="12" y="2080" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="18" y="2086" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="30" y="2092.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RequestUntilChangedSwitchTurn</text>
+          <text x="30" y="2092.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ReplaceFilterToolAuthorityCatalog</text>
           <rect x="263" y="2080" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="269" y="2086" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="281" y="2092.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ResolveAdmissionIdempotency</text>
+          <text x="281" y="2092.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ReplaceVisibilityState</text>
           <rect x="12" y="2102" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="18" y="2108" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="30" y="2114.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ResolveAdmissionPlan</text>
+          <text x="30" y="2114.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RequestCancelAfterBoundary</text>
           <rect x="263" y="2102" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="269" y="2108" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="281" y="2114.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ResolveAdmissionValidation</text>
+          <text x="281" y="2114.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RequestFiniteSwitchTurn</text>
           <rect x="12" y="2124" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="18" y="2130" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="30" y="2136.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ResolveInputPublicLifecycle</text>
+          <text x="30" y="2136.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RequestSupervisorTrustPublish</text>
           <rect x="263" y="2124" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="269" y="2130" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="281" y="2136.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ResolveInputPublicTerminalOutcome</text>
+          <text x="281" y="2136.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RequestUntilChangedSwitchTurn</text>
           <rect x="12" y="2146" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="18" y="2152" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="30" y="2158.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ResolveLiveBoundaryContextReceipt</text>
+          <text x="30" y="2158.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ResolveAdmissionIdempotency</text>
           <rect x="263" y="2146" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="269" y="2152" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="281" y="2158.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ResolveLiveBridgeSubmission</text>
+          <text x="281" y="2158.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ResolveAdmissionPlan</text>
           <rect x="12" y="2168" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="18" y="2174" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="30" y="2180.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ResolveLiveContextAppend</text>
+          <text x="30" y="2180.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ResolveAdmissionValidation</text>
           <rect x="263" y="2168" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="269" y="2174" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="281" y="2180.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ResolveLiveDelegationCancellation</text>
+          <text x="281" y="2180.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ResolveInputPublicLifecycle</text>
           <rect x="12" y="2190" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="18" y="2196" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="30" y="2202.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ResolveLiveDelegationResultDelivery</text>
+          <text x="30" y="2202.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ResolveInputPublicTerminalOutcome</text>
           <rect x="263" y="2190" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="269" y="2196" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="281" y="2202.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ResolveLiveDelegationWorkerRetirement</text>
+          <text x="281" y="2202.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ResolveLiveBoundaryContextReceipt</text>
           <rect x="12" y="2212" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="18" y="2218" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="30" y="2224.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ResolveLiveDelegationWorkerStart</text>
+          <text x="30" y="2224.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ResolveLiveBridgeSubmission</text>
           <rect x="263" y="2212" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="269" y="2218" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="281" y="2224.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ResolveLiveExecutionModeAdmission</text>
+          <text x="281" y="2224.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ResolveLiveContextAppend</text>
           <rect x="12" y="2234" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="18" y="2240" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="30" y="2246.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ResolveLiveOpenAdmission</text>
+          <text x="30" y="2246.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ResolveLiveDelegationCancellation</text>
           <rect x="263" y="2234" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="269" y="2240" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="281" y="2246.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ResolveLiveWebrtcAnswerAdmission</text>
+          <text x="281" y="2246.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ResolveLiveDelegationResultDelivery</text>
           <rect x="12" y="2256" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="18" y="2262" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="30" y="2268.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ResolveLiveWebsocketTokenAdmission</text>
+          <text x="30" y="2268.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ResolveLiveDelegationWorkerRetirement</text>
           <rect x="263" y="2256" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="269" y="2262" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="281" y="2268.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ResolveMobEventStreamClose</text>
+          <text x="281" y="2268.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ResolveLiveDelegationWorkerStart</text>
           <rect x="12" y="2278" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="18" y="2284" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="30" y="2290.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ResolveMobOperatorCreateAuthority</text>
+          <text x="30" y="2290.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ResolveLiveExecutionModeAdmission</text>
           <rect x="263" y="2278" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="269" y="2284" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="281" y="2290.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ResolveOpLifecycleTransitionRejection</text>
+          <text x="281" y="2290.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ResolveLiveOpenAdmission</text>
           <rect x="12" y="2300" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="18" y="2306" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="30" y="2312.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ResolvePeerIngressDequeue</text>
+          <text x="30" y="2312.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ResolveLiveWebrtcAnswerAdmission</text>
           <rect x="263" y="2300" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="269" y="2306" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="281" y="2312.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ResolvePeerIngressReceive</text>
+          <text x="281" y="2312.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ResolveLiveWebsocketTokenAdmission</text>
           <rect x="12" y="2322" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="18" y="2328" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="30" y="2334.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ResolveRuntimeCompletionCleanup</text>
+          <text x="30" y="2334.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ResolveMobEventStreamClose</text>
           <rect x="263" y="2322" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="269" y="2328" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="281" y="2334.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ResolveRuntimeCompletionResult</text>
+          <text x="281" y="2334.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ResolveMobOperatorCreateAuthority</text>
           <rect x="12" y="2344" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="18" y="2350" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="30" y="2356.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ResolveRuntimeCompletionWaitFailure</text>
+          <text x="30" y="2356.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ResolveOpLifecycleTransitionRejection</text>
           <rect x="263" y="2344" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="269" y="2350" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="281" y="2356.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ResolveRuntimeOpsLifecycleDurability</text>
+          <text x="281" y="2356.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ResolvePeerIngressDequeue</text>
           <rect x="12" y="2366" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="18" y="2372" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="30" y="2378.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ResolveSessionEventStreamClose</text>
+          <text x="30" y="2378.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ResolvePeerIngressReceive</text>
           <rect x="263" y="2366" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="269" y="2372" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="281" y="2378.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ResolveStagedRollback</text>
+          <text x="281" y="2378.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ResolveRuntimeCompletionCleanup</text>
           <rect x="12" y="2388" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="18" y="2394" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="30" y="2400.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ResolveSupervisorAuthorizeAdmission</text>
+          <text x="30" y="2400.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ResolveRuntimeCompletionResult</text>
           <rect x="263" y="2388" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="269" y="2394" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="281" y="2400.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ResolveSupervisorBindAdmission</text>
+          <text x="281" y="2400.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ResolveRuntimeCompletionWaitFailure</text>
           <rect x="12" y="2410" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="18" y="2416" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="30" y="2422.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ResolveSupervisorBindMaterialAdmission</text>
+          <text x="30" y="2422.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ResolveRuntimeOpsLifecycleDurability</text>
           <rect x="263" y="2410" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="269" y="2416" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="281" y="2422.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ResolveSupervisorBridgeCommandAdmission</text>
+          <text x="281" y="2422.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ResolveSessionEventStreamClose</text>
           <rect x="12" y="2432" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="18" y="2438" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="30" y="2444.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ResolveSupervisorCleanupCommandAdmission</text>
+          <text x="30" y="2444.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ResolveStagedRollback</text>
           <rect x="263" y="2432" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="269" y="2438" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="281" y="2444.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ResolveTranscriptEditAdmission</text>
+          <text x="281" y="2444.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ResolveSupervisorAuthorizeAdmission</text>
           <rect x="12" y="2454" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="18" y="2460" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="30" y="2466.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ResolveTurnSurfaceResult</text>
+          <text x="30" y="2466.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ResolveSupervisorBindAdmission</text>
           <rect x="263" y="2454" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="269" y="2460" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="281" y="2466.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ResolveUnstageableQueuedInput</text>
+          <text x="281" y="2466.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ResolveSupervisorBindMaterialAdmission</text>
           <rect x="12" y="2476" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="18" y="2482" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="30" y="2488.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ResolveUserInterruptPublicResult</text>
+          <text x="30" y="2488.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ResolveSupervisorBridgeCommandAdmission</text>
           <rect x="263" y="2476" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="269" y="2482" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="281" y="2488.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ResolveVisibleRuntimePhase</text>
+          <text x="281" y="2488.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ResolveSupervisorCleanupCommandAdmission</text>
           <rect x="12" y="2498" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="18" y="2504" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="30" y="2510.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ResolveWaitAllAdmission</text>
+          <text x="30" y="2510.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ResolveTranscriptEditAdmission</text>
           <rect x="263" y="2498" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="269" y="2504" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="281" y="2510.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RestoreDeferredSessionArchive</text>
+          <text x="281" y="2510.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ResolveTurnSurfaceResult</text>
           <rect x="12" y="2520" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
-          <rect x="18" y="2526" width="6" height="6" rx="1" fill="#84bfd7" />
-          <text x="30" y="2532.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RestoreImageOperationOverride</text>
+          <rect x="18" y="2526" width="6" height="6" rx="1" fill="#d8aa57" />
+          <text x="30" y="2532.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ResolveUnstageableQueuedInput</text>
           <rect x="263" y="2520" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="269" y="2526" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="281" y="2532.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RestoreMobOperatorAuthority</text>
+          <text x="281" y="2532.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ResolveUserInterruptPublicResult</text>
           <rect x="12" y="2542" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="18" y="2548" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="30" y="2554.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ResumeSupervisorRotation</text>
+          <text x="30" y="2554.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ResolveVisibleRuntimePhase</text>
           <rect x="263" y="2542" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="269" y="2548" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="281" y="2554.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RetireSettledLiveBridgeOperation</text>
+          <text x="281" y="2554.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ResolveWaitAllAdmission</text>
           <rect x="12" y="2564" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="18" y="2570" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="30" y="2576.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RevokeLiveChannelCloseCustody</text>
+          <text x="30" y="2576.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RestoreDeferredSessionArchive</text>
           <rect x="263" y="2564" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
-          <rect x="269" y="2570" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="281" y="2576.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RevokeLivePlaybackOwner</text>
+          <rect x="269" y="2570" width="6" height="6" rx="1" fill="#84bfd7" />
+          <text x="281" y="2576.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RestoreImageOperationOverride</text>
           <rect x="12" y="2586" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="18" y="2592" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="30" y="2598.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RevokeSupervisor</text>
+          <text x="30" y="2598.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RestoreMobOperatorAuthority</text>
           <rect x="263" y="2586" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="269" y="2592" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="281" y="2598.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RollbackRun</text>
+          <text x="281" y="2598.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ResumeSupervisorRotation</text>
           <rect x="12" y="2608" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="18" y="2614" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="30" y="2620.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RollbackStaged</text>
+          <text x="30" y="2620.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RetireSettledLiveBridgeOperation</text>
           <rect x="263" y="2608" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="269" y="2614" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="281" y="2620.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RollbackUnreturnedOp</text>
+          <text x="281" y="2620.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RevokeLiveChannelCloseCustody</text>
           <rect x="12" y="2630" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="18" y="2636" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="30" y="2642.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RuntimeExecutorExited</text>
+          <text x="30" y="2642.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RevokeLivePlaybackOwner</text>
           <rect x="263" y="2630" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="269" y="2636" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="281" y="2642.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RuntimeLoopStoppedForUnregister</text>
+          <text x="281" y="2642.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RevokeSupervisor</text>
           <rect x="12" y="2652" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="18" y="2658" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="30" y="2664.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">SatisfyWaitAll</text>
+          <text x="30" y="2664.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RollbackRun</text>
           <rect x="263" y="2652" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="269" y="2658" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="281" y="2664.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ServiceTurnCommitted</text>
+          <text x="281" y="2664.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RollbackStaged</text>
           <rect x="12" y="2674" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="18" y="2680" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="30" y="2686.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">SetMobOperatorCreateAuthority</text>
+          <text x="30" y="2686.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RollbackUnreturnedOp</text>
           <rect x="263" y="2674" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="269" y="2680" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="281" y="2686.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">SetMobOperatorProfileMutation</text>
+          <text x="281" y="2686.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RuntimeExecutorExited</text>
           <rect x="12" y="2696" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="18" y="2702" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="30" y="2708.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">SetMobOperatorSpawnProfilesInMob</text>
+          <text x="30" y="2708.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RuntimeLoopStoppedForUnregister</text>
           <rect x="263" y="2696" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="269" y="2702" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="281" y="2708.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">SetModelRoutingBaseline</text>
+          <text x="281" y="2708.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">SatisfyWaitAll</text>
           <rect x="12" y="2718" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="18" y="2724" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="30" y="2730.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">SetTurnToolOverlay</text>
+          <text x="30" y="2730.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ServiceTurnCommitted</text>
           <rect x="263" y="2718" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="269" y="2724" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="281" y="2730.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">SpawnDrain</text>
+          <text x="281" y="2730.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">SetMobOperatorCreateAuthority</text>
           <rect x="12" y="2740" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="18" y="2746" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="30" y="2752.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">StageDeferredNames</text>
+          <text x="30" y="2752.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">SetMobOperatorProfileMutation</text>
           <rect x="263" y="2740" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="269" y="2746" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="281" y="2752.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">StageDeferredSession</text>
+          <text x="281" y="2752.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">SetMobOperatorSpawnProfilesInMob</text>
           <rect x="12" y="2762" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="18" y="2768" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="30" y="2774.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">StageExperimentalLiveExecution</text>
+          <text x="30" y="2774.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">SetModelRoutingBaseline</text>
           <rect x="263" y="2762" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="269" y="2768" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="281" y="2774.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">StageForRun</text>
+          <text x="281" y="2774.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">SetTurnToolOverlay</text>
           <rect x="12" y="2784" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="18" y="2790" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="30" y="2796.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">StageVisibilityFilter</text>
+          <text x="30" y="2796.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">SpawnDrain</text>
           <rect x="263" y="2784" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="269" y="2790" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="281" y="2796.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">SteerAccepted</text>
+          <text x="281" y="2796.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">StageDeferredNames</text>
           <rect x="12" y="2806" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="18" y="2812" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="30" y="2818.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">StopDrain</text>
+          <text x="30" y="2818.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">StageDeferredSession</text>
           <rect x="263" y="2806" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="269" y="2812" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="281" y="2818.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">SubmitSupervisorRotation</text>
+          <text x="281" y="2818.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">StageExperimentalLiveExecution</text>
           <rect x="12" y="2828" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="18" y="2834" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="30" y="2840.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">SupersedeLiveInteraction</text>
+          <text x="30" y="2840.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">StageForRun</text>
           <rect x="263" y="2828" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="269" y="2834" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="281" y="2840.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">SupervisorRotationNextPublished</text>
+          <text x="281" y="2840.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">StageVisibilityFilter</text>
           <rect x="12" y="2850" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="18" y="2856" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="30" y="2862.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">SupervisorRotationPreviousRevoked</text>
+          <text x="30" y="2862.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">SteerAccepted</text>
           <rect x="263" y="2850" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="269" y="2856" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="281" y="2862.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">SupervisorTrustEdgePublished</text>
+          <text x="281" y="2862.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">StopDrain</text>
           <rect x="12" y="2872" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="18" y="2878" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="30" y="2884.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">SupervisorTrustEdgePublishFailed</text>
+          <text x="30" y="2884.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">SubmitSupervisorRotation</text>
           <rect x="263" y="2872" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="269" y="2878" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="281" y="2884.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">SupervisorTrustEdgeRevoked</text>
+          <text x="281" y="2884.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">SupersedeLiveInteraction</text>
           <rect x="12" y="2894" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="18" y="2900" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="30" y="2906.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">SupervisorTrustEdgeRevokeFailed</text>
+          <text x="30" y="2906.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">SupervisorRotationNextPublished</text>
           <rect x="263" y="2894" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="269" y="2900" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="281" y="2906.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">SurfaceRegister</text>
+          <text x="281" y="2906.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">SupervisorRotationPreviousRevoked</text>
           <rect x="12" y="2916" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="18" y="2922" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="30" y="2928.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">SurfaceSetRemovalTimeout</text>
+          <text x="30" y="2928.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">SupervisorTrustEdgePublished</text>
           <rect x="263" y="2916" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="269" y="2922" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="281" y="2928.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">TerminateOp</text>
+          <text x="281" y="2928.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">SupervisorTrustEdgePublishFailed</text>
           <rect x="12" y="2938" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="18" y="2944" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="30" y="2950.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">UpdateDeferredSessionKeepAlive</text>
+          <text x="30" y="2950.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">SupervisorTrustEdgeRevoked</text>
           <rect x="263" y="2938" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="269" y="2944" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="281" y="2950.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">UpdateDeferredSessionLlmIdentity</text>
+          <text x="281" y="2950.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">SupervisorTrustEdgeRevokeFailed</text>
+          <rect x="12" y="2960" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
+          <rect x="18" y="2966" width="6" height="6" rx="1" fill="#d8aa57" />
+          <text x="30" y="2972.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">SurfaceRegister</text>
+          <rect x="263" y="2960" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
+          <rect x="269" y="2966" width="6" height="6" rx="1" fill="#d8aa57" />
+          <text x="281" y="2972.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">SurfaceSetRemovalTimeout</text>
+          <rect x="12" y="2982" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
+          <rect x="18" y="2988" width="6" height="6" rx="1" fill="#d8aa57" />
+          <text x="30" y="2994.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">TerminateOp</text>
+          <rect x="263" y="2982" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
+          <rect x="269" y="2988" width="6" height="6" rx="1" fill="#d8aa57" />
+          <text x="281" y="2994.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">UpdateDeferredSessionKeepAlive</text>
+          <rect x="12" y="3004" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
+          <rect x="18" y="3010" width="6" height="6" rx="1" fill="#d8aa57" />
+          <text x="30" y="3016.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">UpdateDeferredSessionLlmIdentity</text>
   </g>
     </g>
     <g transform="translate(24, 1458)">

--- a/docs-internal/machine-posters/mob_machine.html
+++ b/docs-internal/machine-posters/mob_machine.html
@@ -612,13 +612,13 @@
           <text x="194" y="22" fill="#f4efe5" font-size="11" font-weight="600" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">73</text>
           <rect x="248" y="0" width="54" height="28" rx="8" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.07)" />
           <text x="256" y="10" fill="#7d7a74" font-size="8" letter-spacing="1.4" font-family="Avenir Next, Helvetica Neue, Arial, sans-serif">EFFECTS</text>
-          <text x="256" y="22" fill="#f4efe5" font-size="11" font-weight="600" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">141</text>
+          <text x="256" y="22" fill="#f4efe5" font-size="11" font-weight="600" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">142</text>
           <rect x="310" y="0" width="54" height="28" rx="8" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.07)" />
           <text x="318" y="10" fill="#7d7a74" font-size="8" letter-spacing="1.4" font-family="Avenir Next, Helvetica Neue, Arial, sans-serif">INVARIANTS</text>
           <text x="318" y="22" fill="#f4efe5" font-size="11" font-weight="600" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">51</text>
           <rect x="372" y="0" width="54" height="28" rx="8" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.07)" />
           <text x="380" y="10" fill="#7d7a74" font-size="8" letter-spacing="1.4" font-family="Avenir Next, Helvetica Neue, Arial, sans-serif">STATE</text>
-          <text x="380" y="22" fill="#f4efe5" font-size="11" font-weight="600" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">269</text>
+          <text x="380" y="22" fill="#f4efe5" font-size="11" font-weight="600" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">270</text>
   </g>
     <g transform="translate(24, 198)">
         <rect x="0" y="0" width="304" height="82" rx="12" fill="#141a1f" stroke="rgba(255,255,255,0.08)" />
@@ -640,539 +640,541 @@
         <text x="12" y="28" fill="#f4efe5" font-size="13" font-weight="600" font-family="Avenir Next, Helvetica Neue, Arial, sans-serif">Residual Registers</text>
 
               <rect x="10" y="40" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="56" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">destroy_admitted</text>
+              <text x="17" y="56" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">definition_epoch</text>
               <rect x="157" y="40" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="56" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_runtime_ids</text>
+              <text x="164" y="56" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">destroy_admitted</text>
               <rect x="10" y="74" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="90" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">externally_addressable_runtime_ids</text>
+              <text x="17" y="90" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_runtime_ids</text>
               <rect x="157" y="74" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="90" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">runtime_fence_tokens</text>
+              <text x="164" y="90" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">externally_addressable_runtime_ids</text>
               <rect x="10" y="108" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="124" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">identity_runtime_generations</text>
+              <text x="17" y="124" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">runtime_fence_tokens</text>
               <rect x="157" y="108" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="124" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">identity_runtime_fence_tokens</text>
+              <text x="164" y="124" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">identity_runtime_generations</text>
               <rect x="10" y="142" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="158" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">active_run_count</text>
+              <text x="17" y="158" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">identity_runtime_fence_tokens</text>
               <rect x="157" y="142" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="158" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">flow_authority_schema_version</text>
+              <text x="164" y="158" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">active_run_count</text>
               <rect x="10" y="176" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="192" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">run_status</text>
+              <text x="17" y="192" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">flow_authority_schema_version</text>
               <rect x="157" y="176" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="192" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">run_ordered_steps</text>
+              <text x="164" y="192" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">run_status</text>
               <rect x="10" y="210" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="226" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">run_tracked_steps</text>
+              <text x="17" y="226" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">run_ordered_steps</text>
               <rect x="157" y="210" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="226" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">run_step_status</text>
+              <text x="164" y="226" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">run_tracked_steps</text>
               <rect x="10" y="244" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="260" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">run_output_recorded</text>
+              <text x="17" y="260" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">run_step_status</text>
               <rect x="157" y="244" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="260" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">run_step_condition_results</text>
+              <text x="164" y="260" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">run_output_recorded</text>
               <rect x="10" y="278" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="294" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">run_step_has_conditions</text>
+              <text x="17" y="294" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">run_step_condition_results</text>
               <rect x="157" y="278" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="294" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">run_step_dependencies</text>
+              <text x="164" y="294" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">run_step_has_conditions</text>
               <rect x="10" y="312" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="328" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">run_step_dependency_modes</text>
+              <text x="17" y="328" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">run_step_dependencies</text>
               <rect x="157" y="312" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="328" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">run_step_branches</text>
+              <text x="164" y="328" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">run_step_dependency_modes</text>
               <rect x="10" y="346" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="362" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">run_step_collection_policies</text>
+              <text x="17" y="362" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">run_step_branches</text>
               <rect x="157" y="346" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="362" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">run_step_quorum_thresholds</text>
+              <text x="164" y="362" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">run_step_collection_policies</text>
               <rect x="10" y="380" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="396" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">run_step_target_counts</text>
+              <text x="17" y="396" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">run_step_quorum_thresholds</text>
               <rect x="157" y="380" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="396" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">run_step_target_success_counts</text>
+              <text x="164" y="396" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">run_step_target_counts</text>
               <rect x="10" y="414" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="430" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">run_step_target_terminal_failure_counts</text>
+              <text x="17" y="430" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">run_step_target_success_counts</text>
               <rect x="157" y="414" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="430" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">run_target_retry_counts</text>
+              <text x="164" y="430" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">run_step_target_terminal_failure_counts</text>
               <rect x="10" y="448" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="464" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">run_failure_count</text>
+              <text x="17" y="464" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">run_target_retry_counts</text>
               <rect x="157" y="448" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="464" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">run_consecutive_failure_count</text>
+              <text x="164" y="464" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">run_failure_count</text>
               <rect x="10" y="482" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="498" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">run_escalation_threshold</text>
+              <text x="17" y="498" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">run_consecutive_failure_count</text>
               <rect x="157" y="482" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="498" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">run_max_step_retries</text>
+              <text x="164" y="498" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">run_escalation_threshold</text>
               <rect x="10" y="516" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="532" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">run_ready_frames</text>
+              <text x="17" y="532" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">run_max_step_retries</text>
               <rect x="157" y="516" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="532" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">run_ready_frame_membership</text>
+              <text x="164" y="532" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">run_ready_frames</text>
               <rect x="10" y="550" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="566" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">run_ready_frame_membership_flat</text>
+              <text x="17" y="566" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">run_ready_frame_membership</text>
               <rect x="157" y="550" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="566" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">run_pending_body_frame_loops</text>
+              <text x="164" y="566" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">run_ready_frame_membership_flat</text>
               <rect x="10" y="584" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="600" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">run_pending_body_frame_loop_membership</text>
+              <text x="17" y="600" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">run_pending_body_frame_loops</text>
               <rect x="157" y="584" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="600" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">run_pending_body_frame_loop_membership_flat</text>
+              <text x="164" y="600" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">run_pending_body_frame_loop_membership</text>
               <rect x="10" y="618" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="634" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">run_active_node_count</text>
+              <text x="17" y="634" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">run_pending_body_frame_loop_membership_flat</text>
               <rect x="157" y="618" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="634" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">run_active_frame_count</text>
+              <text x="164" y="634" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">run_active_node_count</text>
               <rect x="10" y="652" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="668" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">run_last_granted_frame</text>
+              <text x="17" y="668" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">run_active_frame_count</text>
               <rect x="157" y="652" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="668" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">run_last_granted_loop</text>
+              <text x="164" y="668" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">run_last_granted_frame</text>
               <rect x="10" y="686" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="702" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">run_max_active_nodes</text>
+              <text x="17" y="702" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">run_last_granted_loop</text>
               <rect x="157" y="686" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="702" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">run_max_active_frames</text>
+              <text x="164" y="702" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">run_max_active_nodes</text>
               <rect x="10" y="720" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="736" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">run_max_frame_depth</text>
+              <text x="17" y="736" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">run_max_active_frames</text>
               <rect x="157" y="720" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="736" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">frame_scope</text>
+              <text x="164" y="736" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">run_max_frame_depth</text>
               <rect x="10" y="754" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="770" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">frame_phase</text>
+              <text x="17" y="770" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">frame_scope</text>
               <rect x="157" y="754" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="770" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">frame_run</text>
+              <text x="164" y="770" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">frame_phase</text>
               <rect x="10" y="788" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="804" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">frame_parent_loop</text>
+              <text x="17" y="804" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">frame_run</text>
               <rect x="157" y="788" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="804" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">frame_iteration</text>
+              <text x="164" y="804" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">frame_parent_loop</text>
               <rect x="10" y="822" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="838" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">frame_tracked_nodes</text>
+              <text x="17" y="838" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">frame_iteration</text>
               <rect x="157" y="822" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="838" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">frame_ordered_nodes</text>
+              <text x="164" y="838" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">frame_tracked_nodes</text>
               <rect x="10" y="856" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="872" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">frame_node_kind</text>
+              <text x="17" y="872" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">frame_ordered_nodes</text>
               <rect x="157" y="856" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="872" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">frame_node_dependencies</text>
+              <text x="164" y="872" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">frame_node_kind</text>
               <rect x="10" y="890" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="906" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">frame_node_dependency_modes</text>
+              <text x="17" y="906" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">frame_node_dependencies</text>
               <rect x="157" y="890" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="906" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">frame_node_step_ids</text>
+              <text x="164" y="906" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">frame_node_dependency_modes</text>
               <rect x="10" y="924" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="940" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">frame_node_loop_ids</text>
+              <text x="17" y="940" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">frame_node_step_ids</text>
               <rect x="157" y="924" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="940" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">frame_node_status</text>
+              <text x="164" y="940" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">frame_node_loop_ids</text>
               <rect x="10" y="958" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="974" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">frame_node_failure_policy</text>
+              <text x="17" y="974" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">frame_node_status</text>
               <rect x="157" y="958" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="974" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">frame_ready_queue</text>
+              <text x="164" y="974" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">frame_node_failure_policy</text>
               <rect x="10" y="992" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="1008" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">frame_output_recorded</text>
+              <text x="17" y="1008" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">frame_ready_queue</text>
               <rect x="157" y="992" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="1008" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">frame_last_admitted_node</text>
+              <text x="164" y="1008" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">frame_output_recorded</text>
               <rect x="10" y="1026" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="1042" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">frame_node_condition_results</text>
+              <text x="17" y="1042" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">frame_last_admitted_node</text>
               <rect x="157" y="1026" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="1042" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">frame_node_branches</text>
+              <text x="164" y="1042" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">frame_node_condition_results</text>
               <rect x="10" y="1060" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="1076" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">loop_phase</text>
+              <text x="17" y="1076" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">frame_node_branches</text>
               <rect x="157" y="1060" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="1076" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">loop_parent_frame</text>
+              <text x="164" y="1076" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">loop_phase</text>
               <rect x="10" y="1094" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="1110" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">loop_parent_node</text>
+              <text x="17" y="1110" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">loop_parent_frame</text>
               <rect x="157" y="1094" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="1110" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">loop_definition</text>
+              <text x="164" y="1110" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">loop_parent_node</text>
               <rect x="10" y="1128" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="1144" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">loop_depth</text>
+              <text x="17" y="1144" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">loop_definition</text>
               <rect x="157" y="1128" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="1144" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">loop_stage</text>
+              <text x="164" y="1144" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">loop_depth</text>
               <rect x="10" y="1162" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="1178" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">loop_current_iteration</text>
+              <text x="17" y="1178" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">loop_stage</text>
               <rect x="157" y="1162" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="1178" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">loop_last_completed_iteration</text>
+              <text x="164" y="1178" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">loop_current_iteration</text>
               <rect x="10" y="1196" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="1212" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">loop_max_iterations</text>
+              <text x="17" y="1212" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">loop_last_completed_iteration</text>
               <rect x="157" y="1196" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="1212" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">loop_active_body_frame</text>
+              <text x="164" y="1212" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">loop_max_iterations</text>
               <rect x="10" y="1230" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="1246" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">pending_spawn_sessions</text>
+              <text x="17" y="1246" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">loop_active_body_frame</text>
               <rect x="157" y="1230" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="1246" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">member_startup_binding_requested</text>
+              <text x="164" y="1246" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">pending_spawn_sessions</text>
               <rect x="10" y="1264" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="1280" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">member_startup_runtime_ready</text>
+              <text x="17" y="1280" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">member_startup_binding_requested</text>
               <rect x="157" y="1264" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="1280" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">member_startup_ready</text>
+              <text x="164" y="1280" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">member_startup_runtime_ready</text>
               <rect x="10" y="1298" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="1314" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">member_kickoff_pending</text>
+              <text x="17" y="1314" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">member_startup_ready</text>
               <rect x="157" y="1298" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="1314" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">member_kickoff_starting</text>
+              <text x="164" y="1314" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">member_kickoff_pending</text>
               <rect x="10" y="1332" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="1348" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">member_kickoff_callback_pending</text>
+              <text x="17" y="1348" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">member_kickoff_starting</text>
               <rect x="157" y="1332" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="1348" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">member_kickoff_started</text>
+              <text x="164" y="1348" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">member_kickoff_callback_pending</text>
               <rect x="10" y="1366" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="1382" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">member_kickoff_failed</text>
+              <text x="17" y="1382" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">member_kickoff_started</text>
               <rect x="157" y="1366" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="1382" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">member_kickoff_cancelled</text>
+              <text x="164" y="1382" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">member_kickoff_failed</text>
               <rect x="10" y="1400" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="1416" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">member_kickoff_error</text>
+              <text x="17" y="1416" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">member_kickoff_cancelled</text>
               <rect x="157" y="1400" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="1416" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">member_kickoff_objective_ids</text>
+              <text x="164" y="1416" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">member_kickoff_error</text>
               <rect x="10" y="1434" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="1450" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">member_kickoff_input_ids</text>
+              <text x="17" y="1450" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">member_kickoff_objective_ids</text>
               <rect x="157" y="1434" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="1450" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">retained_placed_kickoff_obligations</text>
+              <text x="164" y="1450" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">member_kickoff_input_ids</text>
               <rect x="10" y="1468" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="1484" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">member_placed_kickoff_outcome_kinds</text>
+              <text x="17" y="1484" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">retained_placed_kickoff_obligations</text>
               <rect x="157" y="1468" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="1484" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">member_placed_kickoff_outcome_errors</text>
+              <text x="164" y="1484" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">member_placed_kickoff_outcome_kinds</text>
               <rect x="10" y="1502" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="1518" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">member_placed_kickoff_closure_kinds</text>
+              <text x="17" y="1518" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">member_placed_kickoff_outcome_errors</text>
               <rect x="157" y="1502" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="1518" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">pending_placed_kickoff_outcomes</text>
+              <text x="164" y="1518" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">member_placed_kickoff_closure_kinds</text>
               <rect x="10" y="1536" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="1552" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">resolved_placed_kickoff_outcomes</text>
+              <text x="17" y="1552" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">pending_placed_kickoff_outcomes</text>
               <rect x="157" y="1536" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="1552" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">objective_owner_ids</text>
+              <text x="164" y="1552" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">resolved_placed_kickoff_outcomes</text>
               <rect x="10" y="1570" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="1586" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">objective_outcomes</text>
+              <text x="17" y="1586" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">objective_owner_ids</text>
               <rect x="157" y="1570" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="1586" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">concluded_objective_ids</text>
+              <text x="164" y="1586" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">objective_outcomes</text>
               <rect x="10" y="1604" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="1620" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">member_restore_failures</text>
+              <text x="17" y="1620" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">concluded_objective_ids</text>
               <rect x="157" y="1604" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="1620" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">member_restore_failure_codes</text>
+              <text x="164" y="1620" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">member_restore_failures</text>
               <rect x="10" y="1638" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="1654" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">runtime_retire_refusal_codes</text>
+              <text x="17" y="1654" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">member_restore_failure_codes</text>
               <rect x="157" y="1638" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="1654" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">runtime_retire_refusal_reasons</text>
+              <text x="164" y="1654" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">runtime_retire_refusal_codes</text>
               <rect x="10" y="1672" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="1688" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">runtime_retire_pending_sessions</text>
+              <text x="17" y="1688" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">runtime_retire_refusal_reasons</text>
               <rect x="157" y="1672" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="1688" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">remote_runtime_retired_ids</text>
+              <text x="164" y="1688" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">runtime_retire_pending_sessions</text>
               <rect x="10" y="1706" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="1722" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">remote_supervisor_revoked_ids</text>
+              <text x="17" y="1722" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">remote_runtime_retired_ids</text>
               <rect x="157" y="1706" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="1722" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">member_revival_pending</text>
+              <text x="164" y="1722" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">remote_supervisor_revoked_ids</text>
               <rect x="10" y="1740" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="1756" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">member_run_open</text>
+              <text x="17" y="1756" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">member_revival_pending</text>
               <rect x="157" y="1740" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="1756" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">member_in_flight_work</text>
+              <text x="164" y="1756" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">member_run_open</text>
               <rect x="10" y="1774" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="1790" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">member_progress_tokens</text>
+              <text x="17" y="1790" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">member_in_flight_work</text>
               <rect x="157" y="1774" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="1790" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">member_last_observed_at_ms</text>
+              <text x="164" y="1790" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">member_progress_tokens</text>
               <rect x="10" y="1808" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="1824" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">member_last_progress_at_ms</text>
+              <text x="17" y="1824" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">member_last_observed_at_ms</text>
               <rect x="157" y="1808" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="1824" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">member_last_progress_event</text>
+              <text x="164" y="1824" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">member_last_progress_at_ms</text>
               <rect x="10" y="1842" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="1858" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">member_health_class</text>
+              <text x="17" y="1858" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">member_last_progress_event</text>
               <rect x="157" y="1842" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="1858" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">spawn_exec_phase</text>
+              <text x="164" y="1858" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">member_health_class</text>
               <rect x="10" y="1876" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="1892" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">member_state_markers</text>
+              <text x="17" y="1892" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">spawn_exec_phase</text>
               <rect x="157" y="1876" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="1892" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">wiring_edges</text>
+              <text x="164" y="1892" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">member_state_markers</text>
               <rect x="10" y="1910" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="1926" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">pending_respawn_topology</text>
+              <text x="17" y="1926" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">wiring_edges</text>
               <rect x="157" y="1910" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="1926" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">abandoned_respawn_topology</text>
+              <text x="164" y="1926" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">pending_respawn_topology</text>
               <rect x="10" y="1944" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="1960" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">external_peer_edges</text>
+              <text x="17" y="1960" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">abandoned_respawn_topology</text>
               <rect x="157" y="1944" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="1960" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">external_peer_edges_by_key</text>
+              <text x="164" y="1960" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">external_peer_edges</text>
               <rect x="10" y="1978" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="1994" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">supervisor_authority_peer_id</text>
+              <text x="17" y="1994" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">external_peer_edges_by_key</text>
               <rect x="157" y="1978" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="1994" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">supervisor_authority_signing_key</text>
+              <text x="164" y="1994" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">supervisor_authority_peer_id</text>
               <rect x="10" y="2012" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="2028" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">supervisor_authority_epoch</text>
+              <text x="17" y="2028" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">supervisor_authority_signing_key</text>
               <rect x="157" y="2012" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="2028" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">supervisor_authority_protocol_version</text>
+              <text x="164" y="2028" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">supervisor_authority_epoch</text>
               <rect x="10" y="2046" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="2062" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">supervisor_pending_authority_peer_id</text>
+              <text x="17" y="2062" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">supervisor_authority_protocol_version</text>
               <rect x="157" y="2046" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="2062" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">supervisor_pending_authority_signing_key</text>
+              <text x="164" y="2062" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">supervisor_pending_authority_peer_id</text>
               <rect x="10" y="2080" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="2096" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">supervisor_pending_authority_epoch</text>
+              <text x="17" y="2096" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">supervisor_pending_authority_signing_key</text>
               <rect x="157" y="2080" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="2096" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">supervisor_pending_authority_protocol_version</text>
+              <text x="164" y="2096" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">supervisor_pending_authority_epoch</text>
               <rect x="10" y="2114" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="2130" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">supervisor_pending_authority_operation_id</text>
+              <text x="17" y="2130" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">supervisor_pending_authority_protocol_version</text>
               <rect x="157" y="2114" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="2130" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">supervisor_pending_authority_accepted_peer_ids</text>
+              <text x="164" y="2130" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">supervisor_pending_authority_operation_id</text>
               <rect x="10" y="2148" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="2164" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">supervisor_pending_authority_member_target_names</text>
+              <text x="17" y="2164" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">supervisor_pending_authority_accepted_peer_ids</text>
               <rect x="157" y="2148" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="2164" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">supervisor_pending_authority_member_target_addresses</text>
+              <text x="164" y="2164" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">supervisor_pending_authority_member_target_names</text>
               <rect x="10" y="2182" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="2198" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">pending_recipient_trust</text>
+              <text x="17" y="2198" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">supervisor_pending_authority_member_target_addresses</text>
               <rect x="157" y="2182" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="2198" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">owner_bridge_session_id</text>
+              <text x="164" y="2198" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">pending_recipient_trust</text>
               <rect x="10" y="2216" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="2232" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">owner_bridge_destroy_on_archive</text>
+              <text x="17" y="2232" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">owner_bridge_session_id</text>
               <rect x="157" y="2216" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="2232" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">implicit_delegation_mob</text>
+              <text x="164" y="2232" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">owner_bridge_destroy_on_archive</text>
               <rect x="10" y="2250" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="2266" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">identity_to_runtime</text>
+              <text x="17" y="2266" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">implicit_delegation_mob</text>
               <rect x="157" y="2250" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="2266" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">member_session_bindings</text>
+              <text x="164" y="2266" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">identity_to_runtime</text>
               <rect x="10" y="2284" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="2300" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">member_profile_names</text>
+              <text x="17" y="2300" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">member_session_bindings</text>
               <rect x="157" y="2284" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="2300" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">member_runtime_modes</text>
+              <text x="164" y="2300" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">member_profile_names</text>
               <rect x="10" y="2318" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="2334" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">member_peer_ids</text>
+              <text x="17" y="2334" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">member_runtime_modes</text>
               <rect x="157" y="2318" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="2334" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">member_peer_endpoints</text>
+              <text x="164" y="2334" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">member_peer_ids</text>
               <rect x="10" y="2352" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="2368" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">member_prior_peer_endpoints</text>
+              <text x="17" y="2368" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">member_peer_endpoints</text>
               <rect x="157" y="2352" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="2368" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">pending_session_ingress_detach_runtime_ids</text>
+              <text x="164" y="2368" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">member_prior_peer_endpoints</text>
               <rect x="10" y="2386" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="2402" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">spawn_policy_enabled</text>
+              <text x="17" y="2402" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">pending_session_ingress_detach_runtime_ids</text>
               <rect x="157" y="2386" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="2402" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">spawn_policy_revision</text>
+              <text x="164" y="2402" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">spawn_policy_enabled</text>
               <rect x="10" y="2420" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="2436" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">spawn_policy_resolution_revision</text>
+              <text x="17" y="2436" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">spawn_policy_revision</text>
               <rect x="157" y="2420" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="2436" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">spawn_policy_resolution_profiles</text>
+              <text x="164" y="2436" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">spawn_policy_resolution_revision</text>
               <rect x="10" y="2454" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="2470" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">spawn_policy_resolution_runtime_modes</text>
+              <text x="17" y="2470" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">spawn_policy_resolution_profiles</text>
               <rect x="157" y="2454" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="2470" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">spawn_policy_resolution_absent</text>
+              <text x="164" y="2470" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">spawn_policy_resolution_runtime_modes</text>
               <rect x="10" y="2488" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="2504" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">spawn_profile_authority_profile_names</text>
+              <text x="17" y="2504" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">spawn_policy_resolution_absent</text>
               <rect x="157" y="2488" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="2504" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">spawn_profile_authority_models</text>
+              <text x="164" y="2504" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">spawn_profile_authority_profile_names</text>
               <rect x="10" y="2522" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="2538" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">spawn_profile_authority_material_digests</text>
+              <text x="17" y="2538" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">spawn_profile_authority_models</text>
               <rect x="157" y="2522" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="2538" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">spawn_profile_authority_tool_config_digests</text>
+              <text x="164" y="2538" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">spawn_profile_authority_material_digests</text>
               <rect x="10" y="2556" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="2572" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">spawn_profile_authority_skills_digests</text>
+              <text x="17" y="2572" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">spawn_profile_authority_tool_config_digests</text>
               <rect x="157" y="2556" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="2572" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">spawn_profile_authority_provider_params_digests</text>
+              <text x="164" y="2572" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">spawn_profile_authority_skills_digests</text>
               <rect x="10" y="2590" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="2606" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">spawn_profile_authority_output_schema_digests</text>
+              <text x="17" y="2606" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">spawn_profile_authority_provider_params_digests</text>
               <rect x="157" y="2590" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="2606" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">spawn_profile_authority_external_addressable</text>
+              <text x="164" y="2606" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">spawn_profile_authority_output_schema_digests</text>
               <rect x="10" y="2624" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="2640" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">topology_epoch</text>
+              <text x="17" y="2640" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">spawn_profile_authority_external_addressable</text>
               <rect x="157" y="2624" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="2640" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">work_intent_status</text>
+              <text x="164" y="2640" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">topology_epoch</text>
               <rect x="10" y="2658" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="2674" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">work_intent_revision</text>
+              <text x="17" y="2674" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">work_intent_status</text>
               <rect x="157" y="2658" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="2674" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">work_intent_resources</text>
+              <text x="164" y="2674" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">work_intent_revision</text>
               <rect x="10" y="2692" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="2708" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">work_intent_owner_present</text>
+              <text x="17" y="2708" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">work_intent_resources</text>
               <rect x="157" y="2692" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="2708" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">work_intent_expires_at_ms</text>
+              <text x="164" y="2708" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">work_intent_owner_present</text>
               <rect x="10" y="2726" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="2742" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">resource_claim_status</text>
+              <text x="17" y="2742" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">work_intent_expires_at_ms</text>
               <rect x="157" y="2726" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="2742" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">resource_claim_kind</text>
+              <text x="164" y="2742" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">resource_claim_status</text>
               <rect x="10" y="2760" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="2776" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">resource_claim_revision</text>
+              <text x="17" y="2776" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">resource_claim_kind</text>
               <rect x="157" y="2760" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="2776" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">resource_claim_resources</text>
+              <text x="164" y="2776" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">resource_claim_revision</text>
               <rect x="10" y="2794" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="2810" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">resource_claim_owner_present</text>
+              <text x="17" y="2810" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">resource_claim_resources</text>
               <rect x="157" y="2794" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="2810" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">resource_claim_expires_at_ms</text>
+              <text x="164" y="2810" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">resource_claim_owner_present</text>
               <rect x="10" y="2828" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="2844" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">coordination_event_next_sequence</text>
+              <text x="17" y="2844" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">resource_claim_expires_at_ms</text>
               <rect x="157" y="2828" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="2844" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">topology_default_policy</text>
+              <text x="164" y="2844" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">coordination_event_next_sequence</text>
               <rect x="10" y="2862" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="2878" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">external_member_rebind_capability</text>
+              <text x="17" y="2878" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">topology_default_policy</text>
               <rect x="157" y="2862" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="2878" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">orphan_budget</text>
+              <text x="164" y="2878" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">external_member_rebind_capability</text>
               <rect x="10" y="2896" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="2912" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">desired_members</text>
+              <text x="17" y="2912" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">orphan_budget</text>
               <rect x="157" y="2896" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="2912" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">members_to_spawn</text>
+              <text x="164" y="2912" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">desired_members</text>
               <rect x="10" y="2930" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="2946" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">members_to_retire</text>
+              <text x="17" y="2946" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">members_to_spawn</text>
               <rect x="157" y="2930" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="2946" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">adaptive_active_run</text>
+              <text x="164" y="2946" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">members_to_retire</text>
               <rect x="10" y="2964" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="2980" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">adaptive_run_phase</text>
+              <text x="17" y="2980" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">adaptive_active_run</text>
               <rect x="157" y="2964" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="2980" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">adaptive_stop_reason</text>
+              <text x="164" y="2980" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">adaptive_run_phase</text>
               <rect x="10" y="2998" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="3014" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">adaptive_limit_max_depth</text>
+              <text x="17" y="3014" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">adaptive_stop_reason</text>
               <rect x="157" y="2998" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="3014" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">adaptive_limit_max_total_decisions</text>
+              <text x="164" y="3014" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">adaptive_limit_max_depth</text>
               <rect x="10" y="3032" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="3048" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">adaptive_limit_max_repair_attempts</text>
+              <text x="17" y="3048" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">adaptive_limit_max_total_decisions</text>
               <rect x="157" y="3032" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="3048" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">adaptive_limit_max_layer_failures</text>
+              <text x="164" y="3048" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">adaptive_limit_max_repair_attempts</text>
               <rect x="10" y="3066" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="3082" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">adaptive_limit_max_attempts_per_layer</text>
+              <text x="17" y="3082" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">adaptive_limit_max_layer_failures</text>
               <rect x="157" y="3066" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="3082" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">adaptive_limit_max_members_per_layer</text>
+              <text x="164" y="3082" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">adaptive_limit_max_attempts_per_layer</text>
               <rect x="10" y="3100" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="3116" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">adaptive_limit_max_total_spawned_members</text>
+              <text x="17" y="3116" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">adaptive_limit_max_members_per_layer</text>
               <rect x="157" y="3100" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="3116" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">adaptive_limit_max_active_members</text>
+              <text x="164" y="3116" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">adaptive_limit_max_total_spawned_members</text>
               <rect x="10" y="3134" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="3150" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">adaptive_limit_max_retained_layer_mobs</text>
+              <text x="17" y="3150" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">adaptive_limit_max_active_members</text>
               <rect x="157" y="3134" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="3150" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">adaptive_limit_max_aggregate_tokens</text>
+              <text x="164" y="3150" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">adaptive_limit_max_retained_layer_mobs</text>
               <rect x="10" y="3168" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="3184" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">adaptive_limit_max_aggregate_tool_calls</text>
+              <text x="17" y="3184" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">adaptive_limit_max_aggregate_tokens</text>
               <rect x="157" y="3168" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="3184" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">adaptive_limit_allowed_model_classes</text>
+              <text x="164" y="3184" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">adaptive_limit_max_aggregate_tool_calls</text>
               <rect x="10" y="3202" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="3218" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">adaptive_limit_allowed_tool_classes</text>
+              <text x="17" y="3218" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">adaptive_limit_allowed_model_classes</text>
               <rect x="157" y="3202" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="3218" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">adaptive_limit_allowed_skill_identities</text>
+              <text x="164" y="3218" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">adaptive_limit_allowed_tool_classes</text>
               <rect x="10" y="3236" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="3252" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">adaptive_limit_allowed_auth_binding_refs</text>
+              <text x="17" y="3252" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">adaptive_limit_allowed_skill_identities</text>
               <rect x="157" y="3236" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="3252" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">adaptive_deadline_ms</text>
+              <text x="164" y="3252" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">adaptive_limit_allowed_auth_binding_refs</text>
               <rect x="10" y="3270" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="3286" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">adaptive_depth</text>
+              <text x="17" y="3286" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">adaptive_deadline_ms</text>
               <rect x="157" y="3270" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="3286" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">adaptive_total_decisions</text>
+              <text x="164" y="3286" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">adaptive_depth</text>
               <rect x="10" y="3304" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="3320" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">adaptive_repair_attempts</text>
+              <text x="17" y="3320" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">adaptive_total_decisions</text>
               <rect x="157" y="3304" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="3320" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">adaptive_layer_failures</text>
+              <text x="164" y="3320" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">adaptive_repair_attempts</text>
               <rect x="10" y="3338" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="3354" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">adaptive_total_spawned_members</text>
+              <text x="17" y="3354" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">adaptive_layer_failures</text>
               <rect x="157" y="3338" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="3354" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">adaptive_active_members</text>
+              <text x="164" y="3354" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">adaptive_total_spawned_members</text>
               <rect x="10" y="3372" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="3388" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">adaptive_retained_layer_mobs</text>
+              <text x="17" y="3388" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">adaptive_active_members</text>
               <rect x="157" y="3372" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="3388" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">adaptive_aggregate_token_reserved</text>
+              <text x="164" y="3388" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">adaptive_retained_layer_mobs</text>
               <rect x="10" y="3406" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="3422" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">adaptive_aggregate_token_actual</text>
+              <text x="17" y="3422" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">adaptive_aggregate_token_reserved</text>
               <rect x="157" y="3406" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="3422" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">adaptive_aggregate_tool_call_reserved</text>
+              <text x="164" y="3422" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">adaptive_aggregate_token_actual</text>
               <rect x="10" y="3440" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="3456" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">adaptive_aggregate_tool_call_actual</text>
+              <text x="17" y="3456" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">adaptive_aggregate_tool_call_reserved</text>
               <rect x="157" y="3440" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="3456" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">adaptive_active_layer</text>
+              <text x="164" y="3456" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">adaptive_aggregate_tool_call_actual</text>
               <rect x="10" y="3474" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="3490" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">adaptive_layer_adaptive_run</text>
+              <text x="17" y="3490" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">adaptive_active_layer</text>
               <rect x="157" y="3474" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="3490" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">adaptive_layer_phase</text>
+              <text x="164" y="3490" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">adaptive_layer_adaptive_run</text>
               <rect x="10" y="3508" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="3524" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">adaptive_layer_attempt</text>
+              <text x="17" y="3524" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">adaptive_layer_phase</text>
               <rect x="157" y="3508" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="3524" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">adaptive_layer_member_count</text>
+              <text x="164" y="3524" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">adaptive_layer_attempt</text>
               <rect x="10" y="3542" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="3558" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">adaptive_layer_plan_digest</text>
+              <text x="17" y="3558" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">adaptive_layer_member_count</text>
               <rect x="157" y="3542" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="3558" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">adaptive_layer_child_mob_id</text>
+              <text x="164" y="3558" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">adaptive_layer_plan_digest</text>
               <rect x="10" y="3576" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="3592" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">adaptive_layer_token_reservation</text>
+              <text x="17" y="3592" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">adaptive_layer_child_mob_id</text>
               <rect x="157" y="3576" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="3592" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">adaptive_layer_tool_call_reservation</text>
+              <text x="164" y="3592" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">adaptive_layer_token_reservation</text>
               <rect x="10" y="3610" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="3626" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">adaptive_layer_run_id</text>
+              <text x="17" y="3626" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">adaptive_layer_tool_call_reservation</text>
               <rect x="157" y="3610" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="3626" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">adaptive_layer_result_digest</text>
+              <text x="164" y="3626" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">adaptive_layer_run_id</text>
               <rect x="10" y="3644" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="3660" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">adaptive_layer_fault</text>
+              <text x="17" y="3660" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">adaptive_layer_result_digest</text>
               <rect x="157" y="3644" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="3660" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">adaptive_layer_disposition</text>
+              <text x="164" y="3660" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">adaptive_layer_fault</text>
               <rect x="10" y="3678" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="3694" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">adaptive_missing_body_digest</text>
+              <text x="17" y="3694" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">adaptive_layer_disposition</text>
               <rect x="157" y="3678" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="3694" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">mob_hosts</text>
+              <text x="164" y="3694" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">adaptive_missing_body_digest</text>
               <rect x="10" y="3712" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="3728" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">host_public_keys</text>
+              <text x="17" y="3728" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">mob_hosts</text>
               <rect x="157" y="3712" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="3728" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">host_endpoints</text>
+              <text x="164" y="3728" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">host_public_keys</text>
               <rect x="10" y="3746" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="3762" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">host_authority_epochs</text>
+              <text x="17" y="3762" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">host_endpoints</text>
               <rect x="157" y="3746" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="3762" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">host_binding_generations</text>
+              <text x="164" y="3762" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">host_authority_epochs</text>
               <rect x="10" y="3780" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="3796" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">host_binding_generation_highwater</text>
+              <text x="17" y="3796" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">host_binding_generations</text>
               <rect x="157" y="3780" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="3796" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">confirmed_host_binding_revocations</text>
+              <text x="164" y="3796" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">host_binding_generation_highwater</text>
               <rect x="10" y="3814" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="3830" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">replacement_host_bind_endpoints</text>
+              <text x="17" y="3830" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">confirmed_host_binding_revocations</text>
               <rect x="157" y="3814" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="3830" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">replacement_host_binding_generations</text>
+              <text x="164" y="3830" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">replacement_host_bind_endpoints</text>
               <rect x="10" y="3848" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="3864" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">host_bind_phase</text>
+              <text x="17" y="3864" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">replacement_host_binding_generations</text>
               <rect x="157" y="3848" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="3864" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">host_protocol_min</text>
+              <text x="164" y="3864" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">host_bind_phase</text>
               <rect x="10" y="3882" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="3898" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">host_protocol_max</text>
+              <text x="17" y="3898" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">host_protocol_min</text>
               <rect x="157" y="3882" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="3898" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">host_engine_versions</text>
+              <text x="164" y="3898" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">host_protocol_max</text>
               <rect x="10" y="3916" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="3932" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">host_durable_sessions</text>
+              <text x="17" y="3932" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">host_engine_versions</text>
               <rect x="157" y="3916" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="3932" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">host_autonomous_members</text>
+              <text x="164" y="3932" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">host_durable_sessions</text>
               <rect x="10" y="3950" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="3966" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">host_hard_cancel_member</text>
+              <text x="17" y="3966" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">host_autonomous_members</text>
               <rect x="157" y="3950" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="3966" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">host_tracked_input_cancel</text>
+              <text x="164" y="3966" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">host_hard_cancel_member</text>
               <rect x="10" y="3984" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="4000" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">host_memory_store</text>
+              <text x="17" y="4000" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">host_tracked_input_cancel</text>
               <rect x="157" y="3984" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="4000" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">host_mcp</text>
+              <text x="164" y="4000" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">host_memory_store</text>
               <rect x="10" y="4018" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="4034" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">host_resolvable_providers</text>
+              <text x="17" y="4034" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">host_mcp</text>
               <rect x="157" y="4018" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="4034" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">host_approval_forwarding</text>
+              <text x="164" y="4034" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">host_resolvable_providers</text>
               <rect x="10" y="4052" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="4068" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">host_live_endpoints</text>
+              <text x="17" y="4068" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">host_approval_forwarding</text>
               <rect x="157" y="4052" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="4068" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">member_placement</text>
+              <text x="164" y="4068" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">host_live_endpoints</text>
               <rect x="10" y="4086" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="4102" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">pending_placed_spawn_ids</text>
+              <text x="17" y="4102" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">member_placement</text>
               <rect x="157" y="4086" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="4102" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">pending_placed_spawn_generations</text>
+              <text x="164" y="4102" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">pending_placed_spawn_ids</text>
               <rect x="10" y="4120" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="4136" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">pending_placed_spawn_fence_tokens</text>
+              <text x="17" y="4136" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">pending_placed_spawn_generations</text>
               <rect x="157" y="4120" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="4136" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">pending_placed_spawn_hosts</text>
+              <text x="164" y="4136" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">pending_placed_spawn_fence_tokens</text>
               <rect x="10" y="4154" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="4170" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">pending_autonomous_placed_spawns</text>
+              <text x="17" y="4170" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">pending_placed_spawn_hosts</text>
               <rect x="157" y="4154" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="4170" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">pending_placed_spawn_host_binding_generations</text>
+              <text x="164" y="4170" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">pending_autonomous_placed_spawns</text>
               <rect x="10" y="4188" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="4204" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">pending_placed_spawn_spec_digests</text>
+              <text x="17" y="4204" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">pending_placed_spawn_host_binding_generations</text>
               <rect x="157" y="4188" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="4204" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">pending_placed_spawn_provision_operation_ids</text>
+              <text x="164" y="4204" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">pending_placed_spawn_spec_digests</text>
               <rect x="10" y="4222" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="4238" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">pending_placed_spawn_operation_owner_session_ids</text>
+              <text x="17" y="4238" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">pending_placed_spawn_provision_operation_ids</text>
               <rect x="157" y="4222" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="4238" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">current_placed_spawn_ids</text>
+              <text x="164" y="4238" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">pending_placed_spawn_operation_owner_session_ids</text>
               <rect x="10" y="4256" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="4272" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">current_placed_spawn_host_binding_generations</text>
+              <text x="17" y="4272" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">current_placed_spawn_ids</text>
               <rect x="157" y="4256" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="4272" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">current_placed_spawn_provision_operation_ids</text>
+              <text x="164" y="4272" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">current_placed_spawn_host_binding_generations</text>
               <rect x="10" y="4290" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="4306" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">current_placed_spawn_operation_owner_session_ids</text>
+              <text x="17" y="4306" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">current_placed_spawn_provision_operation_ids</text>
               <rect x="157" y="4290" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="4306" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">pending_placed_carrier_cleanup</text>
+              <text x="164" y="4306" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">current_placed_spawn_operation_owner_session_ids</text>
               <rect x="10" y="4324" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="4340" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">member_materialization_failures</text>
+              <text x="17" y="4340" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">pending_placed_carrier_cleanup</text>
               <rect x="157" y="4324" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="4340" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">remote_turn_dispatch_sequence</text>
+              <text x="164" y="4340" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">member_materialization_failures</text>
               <rect x="10" y="4358" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="4374" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">pending_remote_turn_outcomes</text>
+              <text x="17" y="4374" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">remote_turn_dispatch_sequence</text>
               <rect x="157" y="4358" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="4374" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">committed_remote_turn_outcomes</text>
+              <text x="164" y="4374" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">pending_remote_turn_outcomes</text>
               <rect x="10" y="4392" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="4408" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">resolved_remote_turn_outcomes</text>
+              <text x="17" y="4408" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">committed_remote_turn_outcomes</text>
               <rect x="157" y="4392" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="4408" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">placed_completion_dispatch_sequence</text>
+              <text x="164" y="4408" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">resolved_remote_turn_outcomes</text>
               <rect x="10" y="4426" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="4442" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">placed_completion_lifecycle_quiescing</text>
+              <text x="17" y="4442" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">placed_completion_dispatch_sequence</text>
               <rect x="157" y="4426" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="4442" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">placed_completion_lifecycle_intent</text>
+              <text x="164" y="4442" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">placed_completion_lifecycle_quiescing</text>
               <rect x="10" y="4460" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="4476" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">pending_placed_completion_outcomes</text>
+              <text x="17" y="4476" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">placed_completion_lifecycle_intent</text>
               <rect x="157" y="4460" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="4476" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">cancel_requested_placed_completion_outcomes</text>
+              <text x="164" y="4476" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">pending_placed_completion_outcomes</text>
               <rect x="10" y="4494" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="4510" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">resolved_placed_completion_outcomes</text>
+              <text x="17" y="4510" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">cancel_requested_placed_completion_outcomes</text>
               <rect x="157" y="4494" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="4510" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">pending_route_installs</text>
+              <text x="164" y="4510" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">resolved_placed_completion_outcomes</text>
               <rect x="10" y="4528" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="4544" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">operator_grant_scopes</text>
+              <text x="17" y="4544" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">pending_route_installs</text>
               <rect x="157" y="4528" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="164" y="4544" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">operator_grant_expiries</text>
+              <text x="164" y="4544" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">operator_grant_scopes</text>
               <rect x="10" y="4562" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="4578" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">spawn_profile_authority_resolved_spec_digests</text>
+              <text x="17" y="4578" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">operator_grant_expiries</text>
+              <rect x="157" y="4562" width="139" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
+              <text x="164" y="4578" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">spawn_profile_authority_resolved_spec_digests</text>
       </g>
     <g transform="translate(2244, 198)">
         <rect x="0" y="0" width="316" height="82" rx="12" fill="#141a1f" stroke="rgba(255,255,255,0.08)" />
@@ -1187,546 +1189,548 @@
         <text x="12" y="28" fill="#f4efe5" font-size="13" font-weight="600" font-family="Avenir Next, Helvetica Neue, Arial, sans-serif">Task + Event Surface</text>
 
       </g><g transform="translate(2244, 386)">
-        <rect x="0" y="0" width="316" height="4604" rx="12" fill="#141a1f" stroke="rgba(255,255,255,0.08)" />
+        <rect x="0" y="0" width="316" height="4638" rx="12" fill="#141a1f" stroke="rgba(255,255,255,0.08)" />
         <text x="12" y="14" fill="#7d7a74" font-size="8" letter-spacing="1.5" font-family="Avenir Next, Helvetica Neue, Arial, sans-serif">SUBSYSTEM</text>
         <text x="12" y="28" fill="#f4efe5" font-size="13" font-weight="600" font-family="Avenir Next, Helvetica Neue, Arial, sans-serif">Residual Registers</text>
 
               <rect x="10" y="40" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="56" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">destroy_admitted</text>
+              <text x="17" y="56" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">definition_epoch</text>
               <rect x="163" y="40" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="56" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_runtime_ids</text>
+              <text x="170" y="56" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">destroy_admitted</text>
               <rect x="10" y="74" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="90" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">externally_addressable_runtime_ids</text>
+              <text x="17" y="90" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">live_runtime_ids</text>
               <rect x="163" y="74" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="90" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">runtime_fence_tokens</text>
+              <text x="170" y="90" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">externally_addressable_runtime_ids</text>
               <rect x="10" y="108" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="124" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">identity_runtime_generations</text>
+              <text x="17" y="124" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">runtime_fence_tokens</text>
               <rect x="163" y="108" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="124" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">identity_runtime_fence_tokens</text>
+              <text x="170" y="124" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">identity_runtime_generations</text>
               <rect x="10" y="142" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="158" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">flow_authority_schema_version</text>
+              <text x="17" y="158" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">identity_runtime_fence_tokens</text>
               <rect x="163" y="142" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="158" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">run_status</text>
+              <text x="170" y="158" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">flow_authority_schema_version</text>
               <rect x="10" y="176" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="192" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">run_ordered_steps</text>
+              <text x="17" y="192" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">run_status</text>
               <rect x="163" y="176" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="192" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">run_tracked_steps</text>
+              <text x="170" y="192" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">run_ordered_steps</text>
               <rect x="10" y="210" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="226" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">run_step_status</text>
+              <text x="17" y="226" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">run_tracked_steps</text>
               <rect x="163" y="210" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="226" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">run_output_recorded</text>
+              <text x="170" y="226" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">run_step_status</text>
               <rect x="10" y="244" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="260" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">run_step_condition_results</text>
+              <text x="17" y="260" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">run_output_recorded</text>
               <rect x="163" y="244" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="260" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">run_step_has_conditions</text>
+              <text x="170" y="260" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">run_step_condition_results</text>
               <rect x="10" y="278" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="294" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">run_step_dependencies</text>
+              <text x="17" y="294" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">run_step_has_conditions</text>
               <rect x="163" y="278" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="294" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">run_step_dependency_modes</text>
+              <text x="170" y="294" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">run_step_dependencies</text>
               <rect x="10" y="312" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="328" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">run_step_branches</text>
+              <text x="17" y="328" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">run_step_dependency_modes</text>
               <rect x="163" y="312" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="328" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">run_step_collection_policies</text>
+              <text x="170" y="328" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">run_step_branches</text>
               <rect x="10" y="346" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="362" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">run_step_quorum_thresholds</text>
+              <text x="17" y="362" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">run_step_collection_policies</text>
               <rect x="163" y="346" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="362" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">run_step_target_counts</text>
+              <text x="170" y="362" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">run_step_quorum_thresholds</text>
               <rect x="10" y="380" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="396" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">run_step_target_success_counts</text>
+              <text x="17" y="396" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">run_step_target_counts</text>
               <rect x="163" y="380" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="396" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">run_step_target_terminal_failure_counts</text>
+              <text x="170" y="396" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">run_step_target_success_counts</text>
               <rect x="10" y="414" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="430" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">run_target_retry_counts</text>
+              <text x="17" y="430" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">run_step_target_terminal_failure_counts</text>
               <rect x="163" y="414" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="430" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">run_failure_count</text>
+              <text x="170" y="430" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">run_target_retry_counts</text>
               <rect x="10" y="448" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="464" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">run_consecutive_failure_count</text>
+              <text x="17" y="464" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">run_failure_count</text>
               <rect x="163" y="448" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="464" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">run_escalation_threshold</text>
+              <text x="170" y="464" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">run_consecutive_failure_count</text>
               <rect x="10" y="482" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="498" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">run_max_step_retries</text>
+              <text x="17" y="498" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">run_escalation_threshold</text>
               <rect x="163" y="482" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="498" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">run_ready_frames</text>
+              <text x="170" y="498" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">run_max_step_retries</text>
               <rect x="10" y="516" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="532" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">run_ready_frame_membership</text>
+              <text x="17" y="532" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">run_ready_frames</text>
               <rect x="163" y="516" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="532" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">run_ready_frame_membership_flat</text>
+              <text x="170" y="532" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">run_ready_frame_membership</text>
               <rect x="10" y="550" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="566" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">run_pending_body_frame_loops</text>
+              <text x="17" y="566" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">run_ready_frame_membership_flat</text>
               <rect x="163" y="550" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="566" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">run_pending_body_frame_loop_membership</text>
+              <text x="170" y="566" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">run_pending_body_frame_loops</text>
               <rect x="10" y="584" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="600" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">run_pending_body_frame_loop_membership_flat</text>
+              <text x="17" y="600" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">run_pending_body_frame_loop_membership</text>
               <rect x="163" y="584" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="600" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">run_active_node_count</text>
+              <text x="170" y="600" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">run_pending_body_frame_loop_membership_flat</text>
               <rect x="10" y="618" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="634" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">run_active_frame_count</text>
+              <text x="17" y="634" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">run_active_node_count</text>
               <rect x="163" y="618" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="634" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">run_last_granted_frame</text>
+              <text x="170" y="634" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">run_active_frame_count</text>
               <rect x="10" y="652" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="668" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">run_last_granted_loop</text>
+              <text x="17" y="668" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">run_last_granted_frame</text>
               <rect x="163" y="652" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="668" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">run_max_active_nodes</text>
+              <text x="170" y="668" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">run_last_granted_loop</text>
               <rect x="10" y="686" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="702" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">run_max_active_frames</text>
+              <text x="17" y="702" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">run_max_active_nodes</text>
               <rect x="163" y="686" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="702" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">run_max_frame_depth</text>
+              <text x="170" y="702" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">run_max_active_frames</text>
               <rect x="10" y="720" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="736" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">frame_scope</text>
+              <text x="17" y="736" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">run_max_frame_depth</text>
               <rect x="163" y="720" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="736" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">frame_phase</text>
+              <text x="170" y="736" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">frame_scope</text>
               <rect x="10" y="754" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="770" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">frame_run</text>
+              <text x="17" y="770" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">frame_phase</text>
               <rect x="163" y="754" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="770" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">frame_parent_loop</text>
+              <text x="170" y="770" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">frame_run</text>
               <rect x="10" y="788" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="804" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">frame_iteration</text>
+              <text x="17" y="804" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">frame_parent_loop</text>
               <rect x="163" y="788" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="804" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">frame_tracked_nodes</text>
+              <text x="170" y="804" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">frame_iteration</text>
               <rect x="10" y="822" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="838" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">frame_ordered_nodes</text>
+              <text x="17" y="838" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">frame_tracked_nodes</text>
               <rect x="163" y="822" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="838" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">frame_node_kind</text>
+              <text x="170" y="838" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">frame_ordered_nodes</text>
               <rect x="10" y="856" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="872" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">frame_node_dependencies</text>
+              <text x="17" y="872" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">frame_node_kind</text>
               <rect x="163" y="856" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="872" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">frame_node_dependency_modes</text>
+              <text x="170" y="872" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">frame_node_dependencies</text>
               <rect x="10" y="890" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="906" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">frame_node_step_ids</text>
+              <text x="17" y="906" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">frame_node_dependency_modes</text>
               <rect x="163" y="890" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="906" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">frame_node_loop_ids</text>
+              <text x="170" y="906" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">frame_node_step_ids</text>
               <rect x="10" y="924" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="940" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">frame_node_status</text>
+              <text x="17" y="940" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">frame_node_loop_ids</text>
               <rect x="163" y="924" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="940" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">frame_node_failure_policy</text>
+              <text x="170" y="940" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">frame_node_status</text>
               <rect x="10" y="958" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="974" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">frame_ready_queue</text>
+              <text x="17" y="974" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">frame_node_failure_policy</text>
               <rect x="163" y="958" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="974" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">frame_output_recorded</text>
+              <text x="170" y="974" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">frame_ready_queue</text>
               <rect x="10" y="992" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="1008" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">frame_last_admitted_node</text>
+              <text x="17" y="1008" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">frame_output_recorded</text>
               <rect x="163" y="992" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="1008" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">frame_node_condition_results</text>
+              <text x="170" y="1008" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">frame_last_admitted_node</text>
               <rect x="10" y="1026" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="1042" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">frame_node_branches</text>
+              <text x="17" y="1042" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">frame_node_condition_results</text>
               <rect x="163" y="1026" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="1042" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">loop_phase</text>
+              <text x="170" y="1042" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">frame_node_branches</text>
               <rect x="10" y="1060" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="1076" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">loop_parent_frame</text>
+              <text x="17" y="1076" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">loop_phase</text>
               <rect x="163" y="1060" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="1076" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">loop_parent_node</text>
+              <text x="170" y="1076" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">loop_parent_frame</text>
               <rect x="10" y="1094" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="1110" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">loop_definition</text>
+              <text x="17" y="1110" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">loop_parent_node</text>
               <rect x="163" y="1094" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="1110" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">loop_depth</text>
+              <text x="170" y="1110" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">loop_definition</text>
               <rect x="10" y="1128" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="1144" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">loop_stage</text>
+              <text x="17" y="1144" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">loop_depth</text>
               <rect x="163" y="1128" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="1144" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">loop_current_iteration</text>
+              <text x="170" y="1144" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">loop_stage</text>
               <rect x="10" y="1162" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="1178" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">loop_last_completed_iteration</text>
+              <text x="17" y="1178" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">loop_current_iteration</text>
               <rect x="163" y="1162" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="1178" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">loop_max_iterations</text>
+              <text x="170" y="1178" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">loop_last_completed_iteration</text>
               <rect x="10" y="1196" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="1212" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">loop_active_body_frame</text>
+              <text x="17" y="1212" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">loop_max_iterations</text>
               <rect x="163" y="1196" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="1212" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">pending_spawn_count</text>
+              <text x="170" y="1212" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">loop_active_body_frame</text>
               <rect x="10" y="1230" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="1246" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">pending_spawn_sessions</text>
+              <text x="17" y="1246" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">pending_spawn_count</text>
               <rect x="163" y="1230" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="1246" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">coordinator_bound</text>
+              <text x="170" y="1246" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">pending_spawn_sessions</text>
               <rect x="10" y="1264" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="1280" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">member_startup_binding_requested</text>
+              <text x="17" y="1280" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">coordinator_bound</text>
               <rect x="163" y="1264" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="1280" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">member_startup_runtime_ready</text>
+              <text x="170" y="1280" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">member_startup_binding_requested</text>
               <rect x="10" y="1298" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="1314" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">member_startup_ready</text>
+              <text x="17" y="1314" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">member_startup_runtime_ready</text>
               <rect x="163" y="1298" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="1314" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">member_kickoff_pending</text>
+              <text x="170" y="1314" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">member_startup_ready</text>
               <rect x="10" y="1332" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="1348" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">member_kickoff_starting</text>
+              <text x="17" y="1348" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">member_kickoff_pending</text>
               <rect x="163" y="1332" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="1348" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">member_kickoff_callback_pending</text>
+              <text x="170" y="1348" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">member_kickoff_starting</text>
               <rect x="10" y="1366" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="1382" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">member_kickoff_started</text>
+              <text x="17" y="1382" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">member_kickoff_callback_pending</text>
               <rect x="163" y="1366" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="1382" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">member_kickoff_failed</text>
+              <text x="170" y="1382" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">member_kickoff_started</text>
               <rect x="10" y="1400" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="1416" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">member_kickoff_cancelled</text>
+              <text x="17" y="1416" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">member_kickoff_failed</text>
               <rect x="163" y="1400" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="1416" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">member_kickoff_error</text>
+              <text x="170" y="1416" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">member_kickoff_cancelled</text>
               <rect x="10" y="1434" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="1450" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">member_kickoff_objective_ids</text>
+              <text x="17" y="1450" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">member_kickoff_error</text>
               <rect x="163" y="1434" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="1450" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">member_kickoff_input_ids</text>
+              <text x="170" y="1450" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">member_kickoff_objective_ids</text>
               <rect x="10" y="1468" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="1484" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">retained_placed_kickoff_obligations</text>
+              <text x="17" y="1484" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">member_kickoff_input_ids</text>
               <rect x="163" y="1468" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="1484" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">member_placed_kickoff_outcome_kinds</text>
+              <text x="170" y="1484" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">retained_placed_kickoff_obligations</text>
               <rect x="10" y="1502" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="1518" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">member_placed_kickoff_outcome_errors</text>
+              <text x="17" y="1518" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">member_placed_kickoff_outcome_kinds</text>
               <rect x="163" y="1502" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="1518" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">member_placed_kickoff_closure_kinds</text>
+              <text x="170" y="1518" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">member_placed_kickoff_outcome_errors</text>
               <rect x="10" y="1536" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="1552" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">pending_placed_kickoff_outcomes</text>
+              <text x="17" y="1552" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">member_placed_kickoff_closure_kinds</text>
               <rect x="163" y="1536" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="1552" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">resolved_placed_kickoff_outcomes</text>
+              <text x="170" y="1552" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">pending_placed_kickoff_outcomes</text>
               <rect x="10" y="1570" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="1586" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">objective_owner_ids</text>
+              <text x="17" y="1586" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">resolved_placed_kickoff_outcomes</text>
               <rect x="163" y="1570" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="1586" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">objective_outcomes</text>
+              <text x="170" y="1586" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">objective_owner_ids</text>
               <rect x="10" y="1604" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="1620" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">concluded_objective_ids</text>
+              <text x="17" y="1620" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">objective_outcomes</text>
               <rect x="163" y="1604" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="1620" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">member_restore_failures</text>
+              <text x="170" y="1620" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">concluded_objective_ids</text>
               <rect x="10" y="1638" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="1654" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">member_restore_failure_codes</text>
+              <text x="17" y="1654" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">member_restore_failures</text>
               <rect x="163" y="1638" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="1654" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">runtime_retire_refusal_codes</text>
+              <text x="170" y="1654" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">member_restore_failure_codes</text>
               <rect x="10" y="1672" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="1688" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">runtime_retire_refusal_reasons</text>
+              <text x="17" y="1688" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">runtime_retire_refusal_codes</text>
               <rect x="163" y="1672" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="1688" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">runtime_retire_pending_sessions</text>
+              <text x="170" y="1688" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">runtime_retire_refusal_reasons</text>
               <rect x="10" y="1706" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="1722" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">remote_runtime_retired_ids</text>
+              <text x="17" y="1722" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">runtime_retire_pending_sessions</text>
               <rect x="163" y="1706" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="1722" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">remote_supervisor_revoked_ids</text>
+              <text x="170" y="1722" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">remote_runtime_retired_ids</text>
               <rect x="10" y="1740" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="1756" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">member_revival_pending</text>
+              <text x="17" y="1756" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">remote_supervisor_revoked_ids</text>
               <rect x="163" y="1740" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="1756" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">member_run_open</text>
+              <text x="170" y="1756" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">member_revival_pending</text>
               <rect x="10" y="1774" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="1790" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">member_in_flight_work</text>
+              <text x="17" y="1790" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">member_run_open</text>
               <rect x="163" y="1774" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="1790" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">member_progress_tokens</text>
+              <text x="170" y="1790" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">member_in_flight_work</text>
               <rect x="10" y="1808" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="1824" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">member_last_observed_at_ms</text>
+              <text x="17" y="1824" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">member_progress_tokens</text>
               <rect x="163" y="1808" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="1824" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">member_last_progress_at_ms</text>
+              <text x="170" y="1824" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">member_last_observed_at_ms</text>
               <rect x="10" y="1842" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="1858" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">member_last_progress_event</text>
+              <text x="17" y="1858" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">member_last_progress_at_ms</text>
               <rect x="163" y="1842" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="1858" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">member_health_class</text>
+              <text x="170" y="1858" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">member_last_progress_event</text>
               <rect x="10" y="1876" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="1892" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">spawn_exec_phase</text>
+              <text x="17" y="1892" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">member_health_class</text>
               <rect x="163" y="1876" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="1892" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">member_state_markers</text>
+              <text x="170" y="1892" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">spawn_exec_phase</text>
               <rect x="10" y="1910" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="1926" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">wiring_edges</text>
+              <text x="17" y="1926" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">member_state_markers</text>
               <rect x="163" y="1910" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="1926" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">pending_respawn_topology</text>
+              <text x="170" y="1926" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">wiring_edges</text>
               <rect x="10" y="1944" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="1960" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">abandoned_respawn_topology</text>
+              <text x="17" y="1960" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">pending_respawn_topology</text>
               <rect x="163" y="1944" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="1960" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">external_peer_edges</text>
+              <text x="170" y="1960" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">abandoned_respawn_topology</text>
               <rect x="10" y="1978" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="1994" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">external_peer_edges_by_key</text>
+              <text x="17" y="1994" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">external_peer_edges</text>
               <rect x="163" y="1978" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="1994" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">supervisor_authority_peer_id</text>
+              <text x="170" y="1994" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">external_peer_edges_by_key</text>
               <rect x="10" y="2012" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="2028" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">supervisor_authority_signing_key</text>
+              <text x="17" y="2028" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">supervisor_authority_peer_id</text>
               <rect x="163" y="2012" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="2028" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">supervisor_authority_epoch</text>
+              <text x="170" y="2028" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">supervisor_authority_signing_key</text>
               <rect x="10" y="2046" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="2062" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">supervisor_authority_protocol_version</text>
+              <text x="17" y="2062" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">supervisor_authority_epoch</text>
               <rect x="163" y="2046" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="2062" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">supervisor_pending_authority_peer_id</text>
+              <text x="170" y="2062" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">supervisor_authority_protocol_version</text>
               <rect x="10" y="2080" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="2096" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">supervisor_pending_authority_signing_key</text>
+              <text x="17" y="2096" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">supervisor_pending_authority_peer_id</text>
               <rect x="163" y="2080" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="2096" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">supervisor_pending_authority_epoch</text>
+              <text x="170" y="2096" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">supervisor_pending_authority_signing_key</text>
               <rect x="10" y="2114" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="2130" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">supervisor_pending_authority_protocol_version</text>
+              <text x="17" y="2130" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">supervisor_pending_authority_epoch</text>
               <rect x="163" y="2114" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="2130" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">supervisor_pending_authority_operation_id</text>
+              <text x="170" y="2130" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">supervisor_pending_authority_protocol_version</text>
               <rect x="10" y="2148" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="2164" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">supervisor_pending_authority_accepted_peer_ids</text>
+              <text x="17" y="2164" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">supervisor_pending_authority_operation_id</text>
               <rect x="163" y="2148" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="2164" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">supervisor_pending_authority_member_target_names</text>
+              <text x="170" y="2164" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">supervisor_pending_authority_accepted_peer_ids</text>
               <rect x="10" y="2182" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="2198" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">supervisor_pending_authority_member_target_addresses</text>
+              <text x="17" y="2198" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">supervisor_pending_authority_member_target_names</text>
               <rect x="163" y="2182" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="2198" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">pending_recipient_trust</text>
+              <text x="170" y="2198" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">supervisor_pending_authority_member_target_addresses</text>
               <rect x="10" y="2216" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="2232" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">owner_bridge_session_id</text>
+              <text x="17" y="2232" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">pending_recipient_trust</text>
               <rect x="163" y="2216" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="2232" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">owner_bridge_destroy_on_archive</text>
+              <text x="170" y="2232" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">owner_bridge_session_id</text>
               <rect x="10" y="2250" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="2266" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">implicit_delegation_mob</text>
+              <text x="17" y="2266" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">owner_bridge_destroy_on_archive</text>
               <rect x="163" y="2250" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="2266" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">identity_to_runtime</text>
+              <text x="170" y="2266" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">implicit_delegation_mob</text>
               <rect x="10" y="2284" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="2300" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">member_session_bindings</text>
+              <text x="17" y="2300" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">identity_to_runtime</text>
               <rect x="163" y="2284" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="2300" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">member_profile_names</text>
+              <text x="170" y="2300" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">member_session_bindings</text>
               <rect x="10" y="2318" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="2334" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">member_runtime_modes</text>
+              <text x="17" y="2334" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">member_profile_names</text>
               <rect x="163" y="2318" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="2334" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">member_peer_ids</text>
+              <text x="170" y="2334" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">member_runtime_modes</text>
               <rect x="10" y="2352" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="2368" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">member_peer_endpoints</text>
+              <text x="17" y="2368" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">member_peer_ids</text>
               <rect x="163" y="2352" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="2368" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">member_prior_peer_endpoints</text>
+              <text x="170" y="2368" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">member_peer_endpoints</text>
               <rect x="10" y="2386" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="2402" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">pending_session_ingress_detach_runtime_ids</text>
+              <text x="17" y="2402" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">member_prior_peer_endpoints</text>
               <rect x="163" y="2386" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="2402" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">spawn_policy_enabled</text>
+              <text x="170" y="2402" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">pending_session_ingress_detach_runtime_ids</text>
               <rect x="10" y="2420" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="2436" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">spawn_policy_revision</text>
+              <text x="17" y="2436" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">spawn_policy_enabled</text>
               <rect x="163" y="2420" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="2436" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">spawn_policy_resolution_revision</text>
+              <text x="170" y="2436" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">spawn_policy_revision</text>
               <rect x="10" y="2454" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="2470" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">spawn_policy_resolution_profiles</text>
+              <text x="17" y="2470" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">spawn_policy_resolution_revision</text>
               <rect x="163" y="2454" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="2470" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">spawn_policy_resolution_runtime_modes</text>
+              <text x="170" y="2470" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">spawn_policy_resolution_profiles</text>
               <rect x="10" y="2488" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="2504" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">spawn_policy_resolution_absent</text>
+              <text x="17" y="2504" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">spawn_policy_resolution_runtime_modes</text>
               <rect x="163" y="2488" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="2504" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">spawn_profile_authority_profile_names</text>
+              <text x="170" y="2504" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">spawn_policy_resolution_absent</text>
               <rect x="10" y="2522" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="2538" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">spawn_profile_authority_models</text>
+              <text x="17" y="2538" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">spawn_profile_authority_profile_names</text>
               <rect x="163" y="2522" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="2538" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">spawn_profile_authority_material_digests</text>
+              <text x="170" y="2538" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">spawn_profile_authority_models</text>
               <rect x="10" y="2556" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="2572" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">spawn_profile_authority_tool_config_digests</text>
+              <text x="17" y="2572" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">spawn_profile_authority_material_digests</text>
               <rect x="163" y="2556" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="2572" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">spawn_profile_authority_skills_digests</text>
+              <text x="170" y="2572" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">spawn_profile_authority_tool_config_digests</text>
               <rect x="10" y="2590" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="2606" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">spawn_profile_authority_provider_params_digests</text>
+              <text x="17" y="2606" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">spawn_profile_authority_skills_digests</text>
               <rect x="163" y="2590" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="2606" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">spawn_profile_authority_output_schema_digests</text>
+              <text x="170" y="2606" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">spawn_profile_authority_provider_params_digests</text>
               <rect x="10" y="2624" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="2640" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">spawn_profile_authority_external_addressable</text>
+              <text x="17" y="2640" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">spawn_profile_authority_output_schema_digests</text>
               <rect x="163" y="2624" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="2640" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">topology_epoch</text>
+              <text x="170" y="2640" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">spawn_profile_authority_external_addressable</text>
               <rect x="10" y="2658" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="2674" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">work_intent_status</text>
+              <text x="17" y="2674" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">topology_epoch</text>
               <rect x="163" y="2658" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="2674" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">work_intent_revision</text>
+              <text x="170" y="2674" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">work_intent_status</text>
               <rect x="10" y="2692" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="2708" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">work_intent_resources</text>
+              <text x="17" y="2708" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">work_intent_revision</text>
               <rect x="163" y="2692" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="2708" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">work_intent_owner_present</text>
+              <text x="170" y="2708" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">work_intent_resources</text>
               <rect x="10" y="2726" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="2742" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">work_intent_expires_at_ms</text>
+              <text x="17" y="2742" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">work_intent_owner_present</text>
               <rect x="163" y="2726" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="2742" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">resource_claim_status</text>
+              <text x="170" y="2742" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">work_intent_expires_at_ms</text>
               <rect x="10" y="2760" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="2776" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">resource_claim_kind</text>
+              <text x="17" y="2776" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">resource_claim_status</text>
               <rect x="163" y="2760" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="2776" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">resource_claim_revision</text>
+              <text x="170" y="2776" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">resource_claim_kind</text>
               <rect x="10" y="2794" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="2810" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">resource_claim_resources</text>
+              <text x="17" y="2810" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">resource_claim_revision</text>
               <rect x="163" y="2794" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="2810" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">resource_claim_owner_present</text>
+              <text x="170" y="2810" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">resource_claim_resources</text>
               <rect x="10" y="2828" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="2844" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">resource_claim_expires_at_ms</text>
+              <text x="17" y="2844" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">resource_claim_owner_present</text>
               <rect x="163" y="2828" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="2844" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">coordination_event_next_sequence</text>
+              <text x="170" y="2844" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">resource_claim_expires_at_ms</text>
               <rect x="10" y="2862" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="2878" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">topology_default_policy</text>
+              <text x="17" y="2878" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">coordination_event_next_sequence</text>
               <rect x="163" y="2862" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="2878" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">external_member_rebind_capability</text>
+              <text x="170" y="2878" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">topology_default_policy</text>
               <rect x="10" y="2896" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="2912" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">orphan_budget</text>
+              <text x="17" y="2912" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">external_member_rebind_capability</text>
               <rect x="163" y="2896" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="2912" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">desired_members</text>
+              <text x="170" y="2912" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">orphan_budget</text>
               <rect x="10" y="2930" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="2946" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">members_to_spawn</text>
+              <text x="17" y="2946" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">desired_members</text>
               <rect x="163" y="2930" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="2946" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">members_to_retire</text>
+              <text x="170" y="2946" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">members_to_spawn</text>
               <rect x="10" y="2964" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="2980" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">adaptive_active_run</text>
+              <text x="17" y="2980" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">members_to_retire</text>
               <rect x="163" y="2964" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="2980" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">adaptive_run_phase</text>
+              <text x="170" y="2980" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">adaptive_active_run</text>
               <rect x="10" y="2998" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="3014" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">adaptive_stop_reason</text>
+              <text x="17" y="3014" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">adaptive_run_phase</text>
               <rect x="163" y="2998" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="3014" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">adaptive_limit_max_depth</text>
+              <text x="170" y="3014" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">adaptive_stop_reason</text>
               <rect x="10" y="3032" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="3048" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">adaptive_limit_max_total_decisions</text>
+              <text x="17" y="3048" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">adaptive_limit_max_depth</text>
               <rect x="163" y="3032" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="3048" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">adaptive_limit_max_repair_attempts</text>
+              <text x="170" y="3048" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">adaptive_limit_max_total_decisions</text>
               <rect x="10" y="3066" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="3082" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">adaptive_limit_max_layer_failures</text>
+              <text x="17" y="3082" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">adaptive_limit_max_repair_attempts</text>
               <rect x="163" y="3066" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="3082" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">adaptive_limit_max_attempts_per_layer</text>
+              <text x="170" y="3082" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">adaptive_limit_max_layer_failures</text>
               <rect x="10" y="3100" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="3116" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">adaptive_limit_max_members_per_layer</text>
+              <text x="17" y="3116" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">adaptive_limit_max_attempts_per_layer</text>
               <rect x="163" y="3100" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="3116" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">adaptive_limit_max_total_spawned_members</text>
+              <text x="170" y="3116" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">adaptive_limit_max_members_per_layer</text>
               <rect x="10" y="3134" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="3150" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">adaptive_limit_max_active_members</text>
+              <text x="17" y="3150" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">adaptive_limit_max_total_spawned_members</text>
               <rect x="163" y="3134" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="3150" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">adaptive_limit_max_retained_layer_mobs</text>
+              <text x="170" y="3150" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">adaptive_limit_max_active_members</text>
               <rect x="10" y="3168" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="3184" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">adaptive_limit_max_aggregate_tokens</text>
+              <text x="17" y="3184" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">adaptive_limit_max_retained_layer_mobs</text>
               <rect x="163" y="3168" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="3184" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">adaptive_limit_max_aggregate_tool_calls</text>
+              <text x="170" y="3184" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">adaptive_limit_max_aggregate_tokens</text>
               <rect x="10" y="3202" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="3218" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">adaptive_limit_allowed_model_classes</text>
+              <text x="17" y="3218" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">adaptive_limit_max_aggregate_tool_calls</text>
               <rect x="163" y="3202" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="3218" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">adaptive_limit_allowed_tool_classes</text>
+              <text x="170" y="3218" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">adaptive_limit_allowed_model_classes</text>
               <rect x="10" y="3236" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="3252" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">adaptive_limit_allowed_skill_identities</text>
+              <text x="17" y="3252" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">adaptive_limit_allowed_tool_classes</text>
               <rect x="163" y="3236" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="3252" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">adaptive_limit_allowed_auth_binding_refs</text>
+              <text x="170" y="3252" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">adaptive_limit_allowed_skill_identities</text>
               <rect x="10" y="3270" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="3286" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">adaptive_deadline_ms</text>
+              <text x="17" y="3286" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">adaptive_limit_allowed_auth_binding_refs</text>
               <rect x="163" y="3270" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="3286" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">adaptive_depth</text>
+              <text x="170" y="3286" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">adaptive_deadline_ms</text>
               <rect x="10" y="3304" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="3320" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">adaptive_total_decisions</text>
+              <text x="17" y="3320" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">adaptive_depth</text>
               <rect x="163" y="3304" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="3320" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">adaptive_repair_attempts</text>
+              <text x="170" y="3320" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">adaptive_total_decisions</text>
               <rect x="10" y="3338" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="3354" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">adaptive_layer_failures</text>
+              <text x="17" y="3354" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">adaptive_repair_attempts</text>
               <rect x="163" y="3338" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="3354" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">adaptive_total_spawned_members</text>
+              <text x="170" y="3354" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">adaptive_layer_failures</text>
               <rect x="10" y="3372" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="3388" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">adaptive_active_members</text>
+              <text x="17" y="3388" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">adaptive_total_spawned_members</text>
               <rect x="163" y="3372" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="3388" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">adaptive_retained_layer_mobs</text>
+              <text x="170" y="3388" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">adaptive_active_members</text>
               <rect x="10" y="3406" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="3422" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">adaptive_aggregate_token_reserved</text>
+              <text x="17" y="3422" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">adaptive_retained_layer_mobs</text>
               <rect x="163" y="3406" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="3422" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">adaptive_aggregate_token_actual</text>
+              <text x="170" y="3422" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">adaptive_aggregate_token_reserved</text>
               <rect x="10" y="3440" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="3456" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">adaptive_aggregate_tool_call_reserved</text>
+              <text x="17" y="3456" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">adaptive_aggregate_token_actual</text>
               <rect x="163" y="3440" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="3456" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">adaptive_aggregate_tool_call_actual</text>
+              <text x="170" y="3456" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">adaptive_aggregate_tool_call_reserved</text>
               <rect x="10" y="3474" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="3490" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">adaptive_active_layer</text>
+              <text x="17" y="3490" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">adaptive_aggregate_tool_call_actual</text>
               <rect x="163" y="3474" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="3490" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">adaptive_layer_adaptive_run</text>
+              <text x="170" y="3490" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">adaptive_active_layer</text>
               <rect x="10" y="3508" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="3524" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">adaptive_layer_phase</text>
+              <text x="17" y="3524" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">adaptive_layer_adaptive_run</text>
               <rect x="163" y="3508" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="3524" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">adaptive_layer_attempt</text>
+              <text x="170" y="3524" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">adaptive_layer_phase</text>
               <rect x="10" y="3542" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="3558" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">adaptive_layer_member_count</text>
+              <text x="17" y="3558" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">adaptive_layer_attempt</text>
               <rect x="163" y="3542" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="3558" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">adaptive_layer_plan_digest</text>
+              <text x="170" y="3558" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">adaptive_layer_member_count</text>
               <rect x="10" y="3576" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="3592" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">adaptive_layer_child_mob_id</text>
+              <text x="17" y="3592" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">adaptive_layer_plan_digest</text>
               <rect x="163" y="3576" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="3592" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">adaptive_layer_token_reservation</text>
+              <text x="170" y="3592" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">adaptive_layer_child_mob_id</text>
               <rect x="10" y="3610" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="3626" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">adaptive_layer_tool_call_reservation</text>
+              <text x="17" y="3626" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">adaptive_layer_token_reservation</text>
               <rect x="163" y="3610" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="3626" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">adaptive_layer_run_id</text>
+              <text x="170" y="3626" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">adaptive_layer_tool_call_reservation</text>
               <rect x="10" y="3644" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="3660" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">adaptive_layer_result_digest</text>
+              <text x="17" y="3660" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">adaptive_layer_run_id</text>
               <rect x="163" y="3644" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="3660" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">adaptive_layer_fault</text>
+              <text x="170" y="3660" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">adaptive_layer_result_digest</text>
               <rect x="10" y="3678" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="3694" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">adaptive_layer_disposition</text>
+              <text x="17" y="3694" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">adaptive_layer_fault</text>
               <rect x="163" y="3678" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="3694" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">adaptive_missing_body_digest</text>
+              <text x="170" y="3694" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">adaptive_layer_disposition</text>
               <rect x="10" y="3712" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="3728" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">mob_hosts</text>
+              <text x="17" y="3728" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">adaptive_missing_body_digest</text>
               <rect x="163" y="3712" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="3728" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">host_public_keys</text>
+              <text x="170" y="3728" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">mob_hosts</text>
               <rect x="10" y="3746" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="3762" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">host_endpoints</text>
+              <text x="17" y="3762" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">host_public_keys</text>
               <rect x="163" y="3746" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="3762" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">host_authority_epochs</text>
+              <text x="170" y="3762" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">host_endpoints</text>
               <rect x="10" y="3780" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="3796" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">host_binding_generations</text>
+              <text x="17" y="3796" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">host_authority_epochs</text>
               <rect x="163" y="3780" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="3796" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">host_binding_generation_highwater</text>
+              <text x="170" y="3796" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">host_binding_generations</text>
               <rect x="10" y="3814" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="3830" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">confirmed_host_binding_revocations</text>
+              <text x="17" y="3830" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">host_binding_generation_highwater</text>
               <rect x="163" y="3814" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="3830" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">replacement_host_bind_endpoints</text>
+              <text x="170" y="3830" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">confirmed_host_binding_revocations</text>
               <rect x="10" y="3848" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="3864" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">replacement_host_binding_generations</text>
+              <text x="17" y="3864" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">replacement_host_bind_endpoints</text>
               <rect x="163" y="3848" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="3864" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">host_bind_phase</text>
+              <text x="170" y="3864" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">replacement_host_binding_generations</text>
               <rect x="10" y="3882" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="3898" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">host_protocol_min</text>
+              <text x="17" y="3898" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">host_bind_phase</text>
               <rect x="163" y="3882" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="3898" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">host_protocol_max</text>
+              <text x="170" y="3898" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">host_protocol_min</text>
               <rect x="10" y="3916" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="3932" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">host_engine_versions</text>
+              <text x="17" y="3932" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">host_protocol_max</text>
               <rect x="163" y="3916" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="3932" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">host_durable_sessions</text>
+              <text x="170" y="3932" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">host_engine_versions</text>
               <rect x="10" y="3950" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="3966" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">host_autonomous_members</text>
+              <text x="17" y="3966" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">host_durable_sessions</text>
               <rect x="163" y="3950" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="3966" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">host_hard_cancel_member</text>
+              <text x="170" y="3966" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">host_autonomous_members</text>
               <rect x="10" y="3984" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="4000" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">host_tracked_input_cancel</text>
+              <text x="17" y="4000" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">host_hard_cancel_member</text>
               <rect x="163" y="3984" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="4000" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">host_memory_store</text>
+              <text x="170" y="4000" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">host_tracked_input_cancel</text>
               <rect x="10" y="4018" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="4034" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">host_mcp</text>
+              <text x="17" y="4034" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">host_memory_store</text>
               <rect x="163" y="4018" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="4034" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">host_resolvable_providers</text>
+              <text x="170" y="4034" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">host_mcp</text>
               <rect x="10" y="4052" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="4068" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">host_approval_forwarding</text>
+              <text x="17" y="4068" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">host_resolvable_providers</text>
               <rect x="163" y="4052" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="4068" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">host_live_endpoints</text>
+              <text x="170" y="4068" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">host_approval_forwarding</text>
               <rect x="10" y="4086" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="4102" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">member_placement</text>
+              <text x="17" y="4102" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">host_live_endpoints</text>
               <rect x="163" y="4086" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="4102" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">pending_placed_spawn_ids</text>
+              <text x="170" y="4102" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">member_placement</text>
               <rect x="10" y="4120" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="4136" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">pending_placed_spawn_generations</text>
+              <text x="17" y="4136" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">pending_placed_spawn_ids</text>
               <rect x="163" y="4120" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="4136" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">pending_placed_spawn_fence_tokens</text>
+              <text x="170" y="4136" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">pending_placed_spawn_generations</text>
               <rect x="10" y="4154" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="4170" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">pending_placed_spawn_hosts</text>
+              <text x="17" y="4170" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">pending_placed_spawn_fence_tokens</text>
               <rect x="163" y="4154" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="4170" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">pending_autonomous_placed_spawns</text>
+              <text x="170" y="4170" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">pending_placed_spawn_hosts</text>
               <rect x="10" y="4188" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="4204" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">pending_placed_spawn_host_binding_generations</text>
+              <text x="17" y="4204" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">pending_autonomous_placed_spawns</text>
               <rect x="163" y="4188" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="4204" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">pending_placed_spawn_spec_digests</text>
+              <text x="170" y="4204" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">pending_placed_spawn_host_binding_generations</text>
               <rect x="10" y="4222" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="4238" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">pending_placed_spawn_provision_operation_ids</text>
+              <text x="17" y="4238" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">pending_placed_spawn_spec_digests</text>
               <rect x="163" y="4222" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="4238" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">pending_placed_spawn_operation_owner_session_ids</text>
+              <text x="170" y="4238" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">pending_placed_spawn_provision_operation_ids</text>
               <rect x="10" y="4256" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="4272" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">current_placed_spawn_ids</text>
+              <text x="17" y="4272" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">pending_placed_spawn_operation_owner_session_ids</text>
               <rect x="163" y="4256" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="4272" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">current_placed_spawn_host_binding_generations</text>
+              <text x="170" y="4272" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">current_placed_spawn_ids</text>
               <rect x="10" y="4290" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="4306" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">current_placed_spawn_provision_operation_ids</text>
+              <text x="17" y="4306" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">current_placed_spawn_host_binding_generations</text>
               <rect x="163" y="4290" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="4306" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">current_placed_spawn_operation_owner_session_ids</text>
+              <text x="170" y="4306" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">current_placed_spawn_provision_operation_ids</text>
               <rect x="10" y="4324" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="4340" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">pending_placed_carrier_cleanup</text>
+              <text x="17" y="4340" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">current_placed_spawn_operation_owner_session_ids</text>
               <rect x="163" y="4324" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="4340" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">member_materialization_failures</text>
+              <text x="170" y="4340" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">pending_placed_carrier_cleanup</text>
               <rect x="10" y="4358" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="4374" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">remote_turn_dispatch_sequence</text>
+              <text x="17" y="4374" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">member_materialization_failures</text>
               <rect x="163" y="4358" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="4374" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">pending_remote_turn_outcomes</text>
+              <text x="170" y="4374" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">remote_turn_dispatch_sequence</text>
               <rect x="10" y="4392" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="4408" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">committed_remote_turn_outcomes</text>
+              <text x="17" y="4408" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">pending_remote_turn_outcomes</text>
               <rect x="163" y="4392" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="4408" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">resolved_remote_turn_outcomes</text>
+              <text x="170" y="4408" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">committed_remote_turn_outcomes</text>
               <rect x="10" y="4426" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="4442" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">placed_completion_dispatch_sequence</text>
+              <text x="17" y="4442" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">resolved_remote_turn_outcomes</text>
               <rect x="163" y="4426" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="4442" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">placed_completion_lifecycle_quiescing</text>
+              <text x="170" y="4442" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">placed_completion_dispatch_sequence</text>
               <rect x="10" y="4460" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="4476" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">placed_completion_lifecycle_intent</text>
+              <text x="17" y="4476" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">placed_completion_lifecycle_quiescing</text>
               <rect x="163" y="4460" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="4476" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">pending_placed_completion_outcomes</text>
+              <text x="170" y="4476" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">placed_completion_lifecycle_intent</text>
               <rect x="10" y="4494" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="4510" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">cancel_requested_placed_completion_outcomes</text>
+              <text x="17" y="4510" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">pending_placed_completion_outcomes</text>
               <rect x="163" y="4494" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="4510" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">resolved_placed_completion_outcomes</text>
+              <text x="170" y="4510" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">cancel_requested_placed_completion_outcomes</text>
               <rect x="10" y="4528" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="4544" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">pending_route_installs</text>
+              <text x="17" y="4544" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">resolved_placed_completion_outcomes</text>
               <rect x="163" y="4528" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="4544" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">operator_grant_scopes</text>
+              <text x="170" y="4544" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">pending_route_installs</text>
               <rect x="10" y="4562" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="17" y="4578" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">operator_grant_expiries</text>
+              <text x="17" y="4578" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">operator_grant_scopes</text>
               <rect x="163" y="4562" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
-              <text x="170" y="4578" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">spawn_profile_authority_resolved_spec_digests</text>
+              <text x="170" y="4578" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">operator_grant_expiries</text>
+              <rect x="10" y="4596" width="145" height="26" rx="7" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.05)" />
+              <text x="17" y="4612" fill="#f4efe5" font-size="9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">spawn_profile_authority_resolved_spec_digests</text>
       </g>
     <g transform="translate(346, 172)">
       <defs>
@@ -1742,7 +1746,7 @@
           <rect x="0" y="0" width="420" height="190" rx="14" fill="rgba(201,109,84,0.18)" stroke="rgba(201,109,84,0.42)" />
           <text x="16" y="16" fill="#7d7a74" font-size="8" letter-spacing="1.8" font-family="Avenir Next, Helvetica Neue, Arial, sans-serif">PHASE</text>
           <text x="16" y="42" fill="#f4efe5" font-size="32" font-weight="600" letter-spacing="-1.5" font-family="Avenir Next, Helvetica Neue, Arial, sans-serif">Running</text>
-          <text x="16" y="168" fill="#b6aea0" font-size="9" letter-spacing="1" font-family="Avenir Next, Helvetica Neue, Arial, sans-serif">L:577 E:8 I:1</text>
+          <text x="16" y="168" fill="#b6aea0" font-size="9" letter-spacing="1" font-family="Avenir Next, Helvetica Neue, Arial, sans-serif">L:578 E:8 I:1</text>
         </g>
         <g transform="translate(1210, 790)">
           <rect x="0" y="0" width="300" height="92" rx="14" fill="rgba(132,191,215,0.08)" stroke="rgba(255,255,255,0.12)" />
@@ -2027,7 +2031,7 @@
     <rect x="0" y="0" width="520" height="3392" rx="14" fill="rgba(20,26,31,0.82)" stroke="rgba(201,109,84,0.28)" stroke-opacity="0.28" />
     <text x="14" y="15" fill="#7d7a74" font-size="8" letter-spacing="1.8" font-family="Avenir Next, Helvetica Neue, Arial, sans-serif">CONTROL DOMAIN</text>
     <text x="14" y="30" fill="#f4efe5" font-size="13" font-weight="600" font-family="Avenir Next, Helvetica Neue, Arial, sans-serif">Emergent / Unassigned Surfaces</text>
-    <text x="506" y="15" text-anchor="end" fill="#7d7a74" font-size="8" letter-spacing="1.5" font-family="Avenir Next, Helvetica Neue, Arial, sans-serif">187 TRIGGERS</text>
+    <text x="506" y="15" text-anchor="end" fill="#7d7a74" font-size="8" letter-spacing="1.5" font-family="Avenir Next, Helvetica Neue, Arial, sans-serif">188 TRIGGERS</text>
 
           <rect x="12" y="34" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="18" y="40" width="6" height="6" rx="1" fill="#d8aa57" />
@@ -2055,541 +2059,544 @@
           <text x="281" y="112.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">AdmitSupervisorRotation</text>
           <rect x="12" y="122" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="18" y="128" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="30" y="134.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">AuthorizeExternalPeerReciprocalTrust</text>
+          <text x="30" y="134.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">AdvanceDefinitionEpoch</text>
           <rect x="263" y="122" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="269" y="128" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="281" y="134.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">AuthorizeMemberEndpointMigrationTrustCleanup</text>
+          <text x="281" y="134.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">AuthorizeExternalPeerReciprocalTrust</text>
           <rect x="12" y="144" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="18" y="150" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="30" y="156.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">AuthorizeMemberPeerOverlay</text>
+          <text x="30" y="156.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">AuthorizeMemberEndpointMigrationTrustCleanup</text>
           <rect x="263" y="144" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="269" y="150" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="281" y="156.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">AuthorizeMemberPeerRebind</text>
+          <text x="281" y="156.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">AuthorizeMemberPeerOverlay</text>
           <rect x="12" y="166" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="18" y="172" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="30" y="178.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">AuthorizeMemberTrustCleanup</text>
+          <text x="30" y="178.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">AuthorizeMemberPeerRebind</text>
           <rect x="263" y="166" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="269" y="172" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="281" y="178.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">AuthorizeMemberTrustCleanupObserved</text>
+          <text x="281" y="178.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">AuthorizeMemberTrustCleanup</text>
           <rect x="12" y="188" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="18" y="194" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="30" y="200.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">AuthorizeMemberTrustUnwiring</text>
+          <text x="30" y="200.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">AuthorizeMemberTrustCleanupObserved</text>
           <rect x="263" y="188" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="269" y="194" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="281" y="200.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">AuthorizeMemberTrustWiring</text>
+          <text x="281" y="200.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">AuthorizeMemberTrustUnwiring</text>
           <rect x="12" y="210" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="18" y="216" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="30" y="222.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">AuthorizeMobEventRouterMemberRemoval</text>
+          <text x="30" y="222.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">AuthorizeMemberTrustWiring</text>
           <rect x="263" y="210" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="269" y="216" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="281" y="222.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">AuthorizeMobEventRouterMemberSubscription</text>
+          <text x="281" y="222.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">AuthorizeMobEventRouterMemberRemoval</text>
           <rect x="12" y="232" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="18" y="238" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="30" y="244.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">AuthorizePlacedCarrierCleanup</text>
+          <text x="30" y="244.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">AuthorizeMobEventRouterMemberSubscription</text>
           <rect x="263" y="232" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="269" y="238" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="281" y="244.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">AuthorizeRetiringMemberPeerOverlayCleanup</text>
+          <text x="281" y="244.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">AuthorizePlacedCarrierCleanup</text>
           <rect x="12" y="254" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="18" y="260" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="30" y="266.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">AuthorizeRetiringMemberTrustCleanupObserved</text>
+          <text x="30" y="266.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">AuthorizeRetiringMemberPeerOverlayCleanup</text>
           <rect x="263" y="254" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="269" y="260" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="281" y="266.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">AuthorizeRouteRemovalBeforeUnwire</text>
+          <text x="281" y="266.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">AuthorizeRetiringMemberTrustCleanupObserved</text>
           <rect x="12" y="276" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="18" y="282" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="30" y="288.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">AuthorizeSpawnProfile</text>
+          <text x="30" y="288.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">AuthorizeRouteRemovalBeforeUnwire</text>
           <rect x="263" y="276" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="269" y="282" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="281" y="288.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">BeginHostBind</text>
+          <text x="281" y="288.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">AuthorizeSpawnProfile</text>
           <rect x="12" y="298" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="18" y="304" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="30" y="310.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">BeginPlacedCompletionLifecycleQuiesce</text>
+          <text x="30" y="310.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">BeginHostBind</text>
           <rect x="263" y="298" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="269" y="304" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="281" y="310.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">BindObjectiveOwner</text>
+          <text x="281" y="310.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">BeginPlacedCompletionLifecycleQuiesce</text>
           <rect x="12" y="320" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="18" y="326" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="30" y="332.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">BindOwnerBridgeSession</text>
+          <text x="30" y="332.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">BindObjectiveOwner</text>
           <rect x="263" y="320" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="269" y="326" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="281" y="332.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">CancelPendingSpawn</text>
+          <text x="281" y="332.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">BindOwnerBridgeSession</text>
           <rect x="12" y="342" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="18" y="348" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="30" y="354.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ClassifyBridgeRejectionRecovery</text>
+          <text x="30" y="354.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">CancelPendingSpawn</text>
           <rect x="263" y="342" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="269" y="348" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="281" y="354.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ClassifyFlowStepDispatch</text>
+          <text x="281" y="354.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ClassifyBridgeRejectionRecovery</text>
           <rect x="12" y="364" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="18" y="370" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="30" y="376.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ClassifyIdentityReconciliation</text>
+          <text x="30" y="376.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ClassifyFlowStepDispatch</text>
           <rect x="263" y="364" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="269" y="370" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="281" y="376.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ClassifyMemberLiveMaterialization</text>
+          <text x="281" y="376.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ClassifyIdentityReconciliation</text>
           <rect x="12" y="386" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="18" y="392" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="30" y="398.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ClassifyMemberOperationEligibility</text>
+          <text x="30" y="398.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ClassifyMemberLiveMaterialization</text>
           <rect x="263" y="386" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="269" y="392" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="281" y="398.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ClassifyMemberWait</text>
+          <text x="281" y="398.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ClassifyMemberOperationEligibility</text>
           <rect x="12" y="408" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="18" y="414" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="30" y="420.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ClassifyPendingSupervisorAcceptance</text>
+          <text x="30" y="420.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ClassifyMemberWait</text>
           <rect x="263" y="408" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="269" y="414" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="281" y="420.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ClassifyRemoteMemberRuntimeObservation</text>
+          <text x="281" y="420.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ClassifyPendingSupervisorAcceptance</text>
           <rect x="12" y="430" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="18" y="436" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="30" y="442.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ClassifyRetirePendingSpawnDisposition</text>
+          <text x="30" y="442.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ClassifyRemoteMemberRuntimeObservation</text>
           <rect x="263" y="430" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="269" y="436" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="281" y="442.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ClassifySpawnManyFailure</text>
+          <text x="281" y="442.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ClassifyRetirePendingSpawnDisposition</text>
           <rect x="12" y="452" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="18" y="458" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="30" y="464.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ClassifyTurnTimeoutDisposition</text>
+          <text x="30" y="464.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ClassifySpawnManyFailure</text>
           <rect x="263" y="452" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="269" y="458" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="281" y="464.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">CleanupRetiringExternalPeer</text>
+          <text x="281" y="464.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ClassifyTurnTimeoutDisposition</text>
           <rect x="12" y="474" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="18" y="480" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="30" y="486.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">CleanupRetiringExternalPeerObservedAbsent</text>
+          <text x="30" y="486.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">CleanupRetiringExternalPeer</text>
           <rect x="263" y="474" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="269" y="480" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="281" y="486.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">CleanupRetiringMemberWiring</text>
+          <text x="281" y="486.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">CleanupRetiringExternalPeerObservedAbsent</text>
           <rect x="12" y="496" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="18" y="502" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="30" y="508.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ClearSupervisorAuthorityForDestroy</text>
+          <text x="30" y="508.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">CleanupRetiringMemberWiring</text>
           <rect x="263" y="496" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="269" y="502" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="281" y="508.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ClosePlacedCompletionOutcome</text>
+          <text x="281" y="508.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ClearSupervisorAuthorityForDestroy</text>
           <rect x="12" y="518" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="18" y="524" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="30" y="530.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">CommitHostBind</text>
+          <text x="30" y="530.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ClosePlacedCompletionOutcome</text>
           <rect x="263" y="518" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="269" y="524" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="281" y="530.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">CommitRemoteTurnOutcome</text>
+          <text x="281" y="530.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">CommitHostBind</text>
           <rect x="12" y="540" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="18" y="546" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="30" y="552.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">CommitSpawnActivation</text>
+          <text x="30" y="552.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">CommitRemoteTurnOutcome</text>
           <rect x="263" y="540" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
-          <rect x="269" y="546" width="6" height="6" rx="1" fill="#84bfd7" />
-          <text x="281" y="552.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">CommitSpawnMembership</text>
+          <rect x="269" y="546" width="6" height="6" rx="1" fill="#d8aa57" />
+          <text x="281" y="552.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">CommitSpawnActivation</text>
           <rect x="12" y="562" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
-          <rect x="18" y="568" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="30" y="574.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">CommitSupervisorRotation</text>
+          <rect x="18" y="568" width="6" height="6" rx="1" fill="#84bfd7" />
+          <text x="30" y="574.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">CommitSpawnMembership</text>
           <rect x="263" y="562" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="269" y="568" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="281" y="574.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ComputeRespawnGeneration</text>
+          <text x="281" y="574.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">CommitSupervisorRotation</text>
           <rect x="12" y="584" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
-          <rect x="18" y="590" width="6" height="6" rx="1" fill="#84bfd7" />
-          <text x="30" y="596.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ConcludeObjective</text>
+          <rect x="18" y="590" width="6" height="6" rx="1" fill="#d8aa57" />
+          <text x="30" y="596.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ComputeRespawnGeneration</text>
           <rect x="263" y="584" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
-          <rect x="269" y="590" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="281" y="596.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ConvergeRecoveredRespawnTopology</text>
+          <rect x="269" y="590" width="6" height="6" rx="1" fill="#84bfd7" />
+          <text x="281" y="596.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ConcludeObjective</text>
           <rect x="12" y="606" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="18" y="612" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="30" y="618.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ConvergeRecoveredRosterTopology</text>
+          <text x="30" y="618.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ConvergeRecoveredRespawnTopology</text>
           <rect x="263" y="606" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="269" y="612" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="281" y="618.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">DisposePlacedCompletionOutcome</text>
+          <text x="281" y="618.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ConvergeRecoveredRosterTopology</text>
           <rect x="12" y="628" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="18" y="634" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="30" y="640.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">DisposePlacedKickoffObligation</text>
+          <text x="30" y="640.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">DisposePlacedCompletionOutcome</text>
           <rect x="263" y="628" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="269" y="634" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="281" y="640.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">DisposeRemoteTurnObligation</text>
+          <text x="281" y="640.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">DisposePlacedKickoffObligation</text>
           <rect x="12" y="650" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="18" y="656" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="30" y="662.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">EndPlacedCompletionLifecycleQuiesce</text>
+          <text x="30" y="662.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">DisposeRemoteTurnObligation</text>
           <rect x="263" y="650" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
-          <rect x="269" y="656" width="6" height="6" rx="1" fill="#84bfd7" />
-          <text x="281" y="662.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">EnsureMember</text>
+          <rect x="269" y="656" width="6" height="6" rx="1" fill="#d8aa57" />
+          <text x="281" y="662.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">EndPlacedCompletionLifecycleQuiesce</text>
           <rect x="12" y="672" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
-          <rect x="18" y="678" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="30" y="684.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">EscalateToSupervisor</text>
+          <rect x="18" y="678" width="6" height="6" rx="1" fill="#84bfd7" />
+          <text x="30" y="684.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">EnsureMember</text>
           <rect x="263" y="672" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="269" y="678" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="281" y="684.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">EscalateToSupervisorNoEligibleTarget</text>
+          <text x="281" y="684.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">EscalateToSupervisor</text>
           <rect x="12" y="694" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="18" y="700" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="30" y="706.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">EvaluateTopologyEdge</text>
+          <text x="30" y="706.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">EscalateToSupervisorNoEligibleTarget</text>
           <rect x="263" y="694" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="269" y="700" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="281" y="706.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">GrantOperatorScopes</text>
+          <text x="281" y="706.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">EvaluateTopologyEdge</text>
           <rect x="12" y="716" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="18" y="722" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="30" y="728.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">HostRebound</text>
+          <text x="30" y="728.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">GrantOperatorScopes</text>
           <rect x="263" y="716" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="269" y="722" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="281" y="728.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">IngestLayerTerminal</text>
+          <text x="281" y="728.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">HostRebound</text>
           <rect x="12" y="738" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="18" y="744" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="30" y="750.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">InitializeAdaptiveRun</text>
+          <text x="30" y="750.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">IngestLayerTerminal</text>
           <rect x="263" y="738" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="269" y="744" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="281" y="750.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">KickoffQuiesced</text>
+          <text x="281" y="750.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">InitializeAdaptiveRun</text>
           <rect x="12" y="760" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="18" y="766" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="30" y="772.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ObserveCoordinationResourceClaimOverlap</text>
+          <text x="30" y="772.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">KickoffQuiesced</text>
           <rect x="263" y="760" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="269" y="766" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="281" y="772.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ObserveDestroyMemberRetirementArchived</text>
+          <text x="281" y="772.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ObserveCoordinationResourceClaimOverlap</text>
           <rect x="12" y="782" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="18" y="788" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="30" y="794.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ObserveMemberProgress</text>
+          <text x="30" y="794.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ObserveDestroyMemberRetirementArchived</text>
           <rect x="263" y="782" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="269" y="788" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="281" y="794.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ObserveMemberRetirementArchived</text>
+          <text x="281" y="794.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ObserveMemberProgress</text>
           <rect x="12" y="804" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="18" y="810" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="30" y="816.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ObserveRemoteMemberRetirementArchivedAndSupervisorRevoked</text>
+          <text x="30" y="816.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ObserveMemberRetirementArchived</text>
           <rect x="263" y="804" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="269" y="810" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="281" y="816.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ObserveRespawnTopologyAbandoned</text>
+          <text x="281" y="816.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ObserveRemoteMemberRetirementArchivedAndSupervisorRevoked</text>
           <rect x="12" y="826" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="18" y="832" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="30" y="838.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ObserveRespawnTopologyPreservationStarted</text>
+          <text x="30" y="838.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ObserveRespawnTopologyAbandoned</text>
           <rect x="263" y="826" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="269" y="832" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="281" y="838.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">PollEventsStrict</text>
+          <text x="281" y="838.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ObserveRespawnTopologyPreservationStarted</text>
           <rect x="12" y="848" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="18" y="854" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="30" y="860.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ProbeMemberAdmission</text>
+          <text x="30" y="860.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">PollEventsStrict</text>
           <rect x="263" y="848" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="269" y="854" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="281" y="860.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">PromoteCommittedPlacedSpawnCarrierBinding</text>
+          <text x="281" y="860.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ProbeMemberAdmission</text>
           <rect x="12" y="870" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="18" y="876" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="30" y="882.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ProvisionSupervisorAuthority</text>
+          <text x="30" y="882.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">PromoteCommittedPlacedSpawnCarrierBinding</text>
           <rect x="263" y="870" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
-          <rect x="269" y="876" width="6" height="6" rx="1" fill="#84bfd7" />
-          <text x="281" y="882.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">Reconcile</text>
+          <rect x="269" y="876" width="6" height="6" rx="1" fill="#d8aa57" />
+          <text x="281" y="882.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ProvisionSupervisorAuthority</text>
           <rect x="12" y="892" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
-          <rect x="18" y="898" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="30" y="904.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RecordBodyEvidenceMissing</text>
+          <rect x="18" y="898" width="6" height="6" rx="1" fill="#84bfd7" />
+          <text x="30" y="904.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">Reconcile</text>
           <rect x="263" y="892" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="269" y="898" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="281" y="904.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RecordCleanupResolved</text>
+          <text x="281" y="904.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RecordBodyEvidenceMissing</text>
           <rect x="12" y="914" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="18" y="920" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="30" y="926.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RecordCoordinationResourceClaim</text>
+          <text x="30" y="926.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RecordCleanupResolved</text>
           <rect x="263" y="914" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="269" y="920" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="281" y="926.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RecordCoordinationWorkIntent</text>
+          <text x="281" y="926.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RecordCoordinationResourceClaim</text>
           <rect x="12" y="936" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="18" y="942" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="30" y="948.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RecordDeadlineObserved</text>
+          <text x="30" y="948.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RecordCoordinationWorkIntent</text>
           <rect x="263" y="936" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="269" y="942" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="281" y="948.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RecordLayerInterrupted</text>
+          <text x="281" y="948.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RecordDeadlineObserved</text>
           <rect x="12" y="958" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="18" y="964" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="30" y="970.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RecordLayerMobDestroyed</text>
+          <text x="30" y="970.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RecordLayerInterrupted</text>
           <rect x="263" y="958" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="269" y="964" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="281" y="970.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RecordLayerMobRetained</text>
+          <text x="281" y="970.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RecordLayerMobDestroyed</text>
           <rect x="12" y="980" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="18" y="986" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="30" y="992.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RecordLayerProvisioned</text>
+          <text x="30" y="992.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RecordLayerMobRetained</text>
           <rect x="263" y="980" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="269" y="986" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="281" y="992.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RecordLayerResultInvalid</text>
+          <text x="281" y="992.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RecordLayerProvisioned</text>
           <rect x="12" y="1002" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="18" y="1008" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="30" y="1014.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RecordLayerResultValidated</text>
+          <text x="30" y="1014.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RecordLayerResultInvalid</text>
           <rect x="263" y="1002" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="269" y="1008" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="281" y="1014.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RecordLayerRunStarted</text>
+          <text x="281" y="1014.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RecordLayerResultValidated</text>
           <rect x="12" y="1024" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="18" y="1030" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="30" y="1036.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RecordLayerSetupFault</text>
+          <text x="30" y="1036.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RecordLayerRunStarted</text>
           <rect x="263" y="1024" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="269" y="1030" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="281" y="1036.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RecordMemberMaterializationFailure</text>
+          <text x="281" y="1036.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RecordLayerSetupFault</text>
           <rect x="12" y="1046" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="18" y="1052" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="30" y="1058.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RecordPendingRecipientTrust</text>
+          <text x="30" y="1058.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RecordMemberMaterializationFailure</text>
           <rect x="263" y="1046" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="269" y="1052" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="281" y="1058.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RecordPlacedCompletionObligation</text>
+          <text x="281" y="1058.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RecordPendingRecipientTrust</text>
           <rect x="12" y="1068" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="18" y="1074" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="30" y="1080.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RecordPlanningDecision</text>
+          <text x="30" y="1080.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RecordPlacedCompletionObligation</text>
           <rect x="263" y="1068" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="269" y="1074" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="281" y="1080.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RecordPlanRejected</text>
+          <text x="281" y="1080.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RecordPlanningDecision</text>
           <rect x="12" y="1090" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="18" y="1096" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="30" y="1102.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RecordRemoteMemberRuntimeRetired</text>
+          <text x="30" y="1102.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RecordPlanRejected</text>
           <rect x="263" y="1090" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="269" y="1096" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="281" y="1102.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RecordRemoteMemberSupervisorRevoked</text>
+          <text x="281" y="1102.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RecordRemoteMemberRuntimeRetired</text>
           <rect x="12" y="1112" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="18" y="1118" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="30" y="1124.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RecordRemoteTurnObligation</text>
+          <text x="30" y="1124.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RecordRemoteMemberSupervisorRevoked</text>
           <rect x="263" y="1112" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="269" y="1118" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="281" y="1124.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RecordRouteInstall</text>
+          <text x="281" y="1124.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RecordRemoteTurnObligation</text>
           <rect x="12" y="1134" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="18" y="1140" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="30" y="1146.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RecordSupervisorPendingRotation</text>
+          <text x="30" y="1146.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RecordRouteInstall</text>
           <rect x="263" y="1134" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="269" y="1140" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="281" y="1146.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RecoverCommittedPlacedSpawn</text>
+          <text x="281" y="1146.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RecordSupervisorPendingRotation</text>
           <rect x="12" y="1156" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="18" y="1162" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="30" y="1168.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RecoverCompletedWithCleanupCustody</text>
+          <text x="30" y="1168.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RecoverCommittedPlacedSpawn</text>
           <rect x="263" y="1156" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="269" y="1162" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="281" y="1168.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RecoverConfirmedHostBindingRevocation</text>
+          <text x="281" y="1168.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RecoverCompletedWithCleanupCustody</text>
           <rect x="12" y="1178" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="18" y="1184" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="30" y="1190.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RecoverExternalPeerUnwire</text>
+          <text x="30" y="1190.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RecoverConfirmedHostBindingRevocation</text>
           <rect x="263" y="1178" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="269" y="1184" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="281" y="1190.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RecoverExternalPeerWiring</text>
+          <text x="281" y="1190.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RecoverExternalPeerUnwire</text>
           <rect x="12" y="1200" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="18" y="1206" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="30" y="1212.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RecoverFinalizedPlacedKickoff</text>
+          <text x="30" y="1212.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RecoverExternalPeerWiring</text>
           <rect x="263" y="1200" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="269" y="1206" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="281" y="1212.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RecoverHostBinding</text>
+          <text x="281" y="1212.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RecoverFinalizedPlacedKickoff</text>
           <rect x="12" y="1222" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="18" y="1228" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="30" y="1234.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RecoverHostBindingGenerationHighwater</text>
+          <text x="30" y="1234.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RecoverHostBinding</text>
           <rect x="263" y="1222" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="269" y="1228" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="281" y="1234.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RecoverHostBindRequest</text>
+          <text x="281" y="1234.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RecoverHostBindingGenerationHighwater</text>
           <rect x="12" y="1244" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="18" y="1250" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="30" y="1256.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RecoverMemberKickoff</text>
+          <text x="30" y="1256.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RecoverHostBindRequest</text>
           <rect x="263" y="1244" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="269" y="1250" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="281" y="1256.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RecoverMemberPeerEndpoint</text>
+          <text x="281" y="1256.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RecoverMemberKickoff</text>
           <rect x="12" y="1266" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="18" y="1272" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="30" y="1278.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RecoverMemberRestoreFailure</text>
+          <text x="30" y="1278.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RecoverMemberPeerEndpoint</text>
           <rect x="263" y="1266" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="269" y="1272" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="281" y="1278.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RecoverMemberSessionBinding</text>
+          <text x="281" y="1278.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RecoverMemberRestoreFailure</text>
           <rect x="12" y="1288" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="18" y="1294" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="30" y="1300.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RecoverObjectiveBinding</text>
+          <text x="30" y="1300.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RecoverMemberSessionBinding</text>
           <rect x="263" y="1288" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="269" y="1294" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="281" y="1300.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RecoverObjectiveConclusion</text>
+          <text x="281" y="1300.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RecoverObjectiveBinding</text>
           <rect x="12" y="1310" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="18" y="1316" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="30" y="1322.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RecoverOwnerBridgeSession</text>
+          <text x="30" y="1322.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RecoverObjectiveConclusion</text>
           <rect x="263" y="1310" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="269" y="1316" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="281" y="1322.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RecoverPendingPlacedCompletion</text>
+          <text x="281" y="1322.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RecoverOwnerBridgeSession</text>
           <rect x="12" y="1332" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="18" y="1338" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="30" y="1344.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RecoverPendingPlacedSpawn</text>
+          <text x="30" y="1344.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RecoverPendingPlacedCompletion</text>
           <rect x="263" y="1332" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="269" y="1338" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="281" y="1344.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RecoverPlacedCarrierCleanup</text>
+          <text x="281" y="1344.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RecoverPendingPlacedSpawn</text>
           <rect x="12" y="1354" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="18" y="1360" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="30" y="1366.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RecoverPlacedCompletionDispatchSequence</text>
+          <text x="30" y="1366.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RecoverPlacedCarrierCleanup</text>
           <rect x="263" y="1354" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="269" y="1360" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="281" y="1366.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RecoverRemoteMemberRuntimeRetired</text>
+          <text x="281" y="1366.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RecoverPlacedCompletionDispatchSequence</text>
           <rect x="12" y="1376" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="18" y="1382" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="30" y="1388.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RecoverRemoteMemberSupervisorRevoked</text>
+          <text x="30" y="1388.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RecoverRemoteMemberRuntimeRetired</text>
           <rect x="263" y="1376" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="269" y="1382" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="281" y="1388.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RecoverRemoteTurnDispatchSequence</text>
+          <text x="281" y="1388.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RecoverRemoteMemberSupervisorRevoked</text>
           <rect x="12" y="1398" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="18" y="1404" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="30" y="1410.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RecoverResolvedPlacedCompletion</text>
+          <text x="30" y="1410.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RecoverRemoteTurnDispatchSequence</text>
           <rect x="263" y="1398" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="269" y="1404" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="281" y="1410.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RecoverRosterMember</text>
+          <text x="281" y="1410.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RecoverResolvedPlacedCompletion</text>
           <rect x="12" y="1420" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="18" y="1426" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="30" y="1432.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RecoverRosterMemberReset</text>
+          <text x="30" y="1432.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RecoverRosterMember</text>
           <rect x="263" y="1420" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="269" y="1426" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="281" y="1432.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RecoverRosterMemberRetired</text>
+          <text x="281" y="1432.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RecoverRosterMemberReset</text>
           <rect x="12" y="1442" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="18" y="1448" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="30" y="1454.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RecoverRosterMemberRetirementStarted</text>
+          <text x="30" y="1454.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RecoverRosterMemberRetired</text>
           <rect x="263" y="1442" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="269" y="1448" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="281" y="1454.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RecoverRosterMemberRetiring</text>
+          <text x="281" y="1454.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RecoverRosterMemberRetirementStarted</text>
           <rect x="12" y="1464" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="18" y="1470" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="30" y="1476.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RecoverRosterUnwire</text>
+          <text x="30" y="1476.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RecoverRosterMemberRetiring</text>
           <rect x="263" y="1464" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="269" y="1470" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="281" y="1476.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RecoverRosterWiring</text>
+          <text x="281" y="1476.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RecoverRosterUnwire</text>
           <rect x="12" y="1486" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="18" y="1492" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="30" y="1498.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RecoverSpawnedMemberPeerEndpoint</text>
+          <text x="30" y="1498.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RecoverRosterWiring</text>
           <rect x="263" y="1486" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="269" y="1492" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="281" y="1498.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RecoverSupervisorAuthority</text>
+          <text x="281" y="1498.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RecoverSpawnedMemberPeerEndpoint</text>
           <rect x="12" y="1508" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="18" y="1514" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="30" y="1520.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RefreshHostCapabilities</text>
+          <text x="30" y="1520.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RecoverSupervisorAuthority</text>
           <rect x="263" y="1508" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="269" y="1514" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="281" y="1520.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RegisterMemberPeer</text>
+          <text x="281" y="1520.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RefreshHostCapabilities</text>
           <rect x="12" y="1530" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="18" y="1536" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="30" y="1542.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RejectPlacedKickoffBeforeAdmission</text>
+          <text x="30" y="1542.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RegisterMemberPeer</text>
           <rect x="263" y="1530" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="269" y="1536" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="281" y="1542.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RequestAdaptiveCancel</text>
+          <text x="281" y="1542.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RejectPlacedKickoffBeforeAdmission</text>
           <rect x="12" y="1552" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="18" y="1558" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="30" y="1564.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RequestPendingSessionIngressDetachForMobDestroy</text>
+          <text x="30" y="1564.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RequestAdaptiveCancel</text>
           <rect x="263" y="1552" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="269" y="1558" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="281" y="1564.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RequestPlacedCompletionCancellation</text>
+          <text x="281" y="1564.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RequestPendingSessionIngressDetachForMobDestroy</text>
           <rect x="12" y="1574" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="18" y="1580" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="30" y="1586.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ResolveAdaptiveFinish</text>
+          <text x="30" y="1586.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RequestPlacedCompletionCancellation</text>
           <rect x="263" y="1574" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="269" y="1580" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="281" y="1586.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ResolveAutonomousShutdownMemberAction</text>
+          <text x="281" y="1586.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ResolveAdaptiveFinish</text>
           <rect x="12" y="1596" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="18" y="1602" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="30" y="1608.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ResolveCancelAllWorkRejection</text>
+          <text x="30" y="1608.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ResolveAutonomousShutdownMemberAction</text>
           <rect x="263" y="1596" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="269" y="1602" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="281" y="1608.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ResolveCreateMobAdmission</text>
+          <text x="281" y="1608.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ResolveCancelAllWorkRejection</text>
           <rect x="12" y="1618" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="18" y="1624" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="30" y="1630.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ResolveCurrentMobAdmission</text>
+          <text x="30" y="1630.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ResolveCreateMobAdmission</text>
           <rect x="263" y="1618" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="269" y="1624" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="281" y="1630.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ResolveLayerAdmission</text>
+          <text x="281" y="1630.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ResolveCurrentMobAdmission</text>
           <rect x="12" y="1640" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="18" y="1646" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="30" y="1652.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ResolveMemberOperatorAdmission</text>
+          <text x="30" y="1652.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ResolveLayerAdmission</text>
           <rect x="263" y="1640" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="269" y="1646" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="281" y="1652.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ResolveMemberRevivalFailed</text>
+          <text x="281" y="1652.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ResolveMemberOperatorAdmission</text>
           <rect x="12" y="1662" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="18" y="1668" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="30" y="1674.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ResolveMemberRevivalSucceeded</text>
+          <text x="30" y="1674.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ResolveMemberRevivalFailed</text>
           <rect x="263" y="1662" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="269" y="1668" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="281" y="1674.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ResolvePendingRecipientTrust</text>
+          <text x="281" y="1674.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ResolveMemberRevivalSucceeded</text>
           <rect x="12" y="1684" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="18" y="1690" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="30" y="1696.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ResolvePlacedCarrierCleanup</text>
+          <text x="30" y="1696.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ResolvePendingRecipientTrust</text>
           <rect x="263" y="1684" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="269" y="1690" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="281" y="1696.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ResolvePlacedCompletionOutcome</text>
+          <text x="281" y="1696.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ResolvePlacedCarrierCleanup</text>
           <rect x="12" y="1706" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="18" y="1712" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="30" y="1718.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ResolvePlacedKickoffCallbackPending</text>
+          <text x="30" y="1718.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ResolvePlacedCompletionOutcome</text>
           <rect x="263" y="1706" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="269" y="1712" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="281" y="1718.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ResolvePlacedKickoffCancelled</text>
+          <text x="281" y="1718.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ResolvePlacedKickoffCallbackPending</text>
           <rect x="12" y="1728" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="18" y="1734" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="30" y="1740.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ResolvePlacedKickoffFailed</text>
+          <text x="30" y="1740.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ResolvePlacedKickoffCancelled</text>
           <rect x="263" y="1728" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="269" y="1734" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="281" y="1740.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ResolvePlacedKickoffStarted</text>
+          <text x="281" y="1740.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ResolvePlacedKickoffFailed</text>
           <rect x="12" y="1750" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="18" y="1756" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="30" y="1762.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ResolveProfileMutationAdmission</text>
+          <text x="30" y="1762.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ResolvePlacedKickoffStarted</text>
           <rect x="263" y="1750" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="269" y="1756" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="281" y="1762.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ResolveRemoteTurnObligation</text>
+          <text x="281" y="1762.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ResolveProfileMutationAdmission</text>
           <rect x="12" y="1772" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="18" y="1778" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="30" y="1784.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ResolveRespawnTopologyRestore</text>
+          <text x="30" y="1784.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ResolveRemoteTurnObligation</text>
           <rect x="263" y="1772" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="269" y="1778" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="281" y="1784.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ResolveRouteInstall</text>
+          <text x="281" y="1784.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ResolveRespawnTopologyRestore</text>
           <rect x="12" y="1794" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="18" y="1800" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="30" y="1806.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ResolveRuntimeBindingRefusal</text>
+          <text x="30" y="1806.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ResolveRouteInstall</text>
           <rect x="263" y="1794" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="269" y="1800" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="281" y="1806.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ResolveRuntimeIngressRefusal</text>
+          <text x="281" y="1806.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ResolveRuntimeBindingRefusal</text>
           <rect x="12" y="1816" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="18" y="1822" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="30" y="1828.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ResolveRuntimeRetireRefusal</text>
+          <text x="30" y="1828.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ResolveRuntimeIngressRefusal</text>
           <rect x="263" y="1816" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="269" y="1822" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="281" y="1828.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ResolveSpawnMemberAdmission</text>
+          <text x="281" y="1828.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ResolveRuntimeRetireRefusal</text>
           <rect x="12" y="1838" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="18" y="1844" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="30" y="1850.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ResolveSpawnPolicy</text>
+          <text x="30" y="1850.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ResolveSpawnMemberAdmission</text>
           <rect x="263" y="1838" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="269" y="1844" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="281" y="1850.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ResolveSpawnToolAdmission</text>
+          <text x="281" y="1850.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ResolveSpawnPolicy</text>
           <rect x="12" y="1860" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="18" y="1866" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="30" y="1872.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ResolveSubmitWorkRejection</text>
+          <text x="30" y="1872.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ResolveSpawnToolAdmission</text>
           <rect x="263" y="1860" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="269" y="1866" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="281" y="1872.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RestoreRetiringExternalPeer</text>
+          <text x="281" y="1872.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ResolveSubmitWorkRejection</text>
           <rect x="12" y="1882" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="18" y="1888" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="30" y="1894.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RestoreRetiringExternalPeerObservedAbsent</text>
+          <text x="30" y="1894.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RestoreRetiringExternalPeer</text>
           <rect x="263" y="1882" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="269" y="1888" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="281" y="1894.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RestoreRetiringMemberWiring</text>
+          <text x="281" y="1894.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RestoreRetiringExternalPeerObservedAbsent</text>
           <rect x="12" y="1904" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="18" y="1910" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="30" y="1916.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RestoreSupervisorAuthorityAfterDestroyRollback</text>
+          <text x="30" y="1916.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RestoreRetiringMemberWiring</text>
           <rect x="263" y="1904" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="269" y="1910" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="281" y="1916.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RetireAbsent</text>
+          <text x="281" y="1916.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RestoreSupervisorAuthorityAfterDestroyRollback</text>
           <rect x="12" y="1926" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="18" y="1932" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="30" y="1938.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RetireMember</text>
+          <text x="30" y="1938.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RetireAbsent</text>
           <rect x="263" y="1926" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="269" y="1932" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="281" y="1938.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RetryRuntimeRetire</text>
+          <text x="281" y="1938.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RetireMember</text>
           <rect x="12" y="1948" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="18" y="1954" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="30" y="1960.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RevokeHost</text>
+          <text x="30" y="1960.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RetryRuntimeRetire</text>
           <rect x="263" y="1948" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="269" y="1954" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="281" y="1960.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RevokeOperatorScopes</text>
+          <text x="281" y="1960.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RevokeHost</text>
           <rect x="12" y="1970" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="18" y="1976" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="30" y="1982.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RollbackPendingRecipientTrust</text>
+          <text x="30" y="1982.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RevokeOperatorScopes</text>
           <rect x="263" y="1970" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="269" y="1976" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="281" y="1982.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RollbackRouteInstall</text>
+          <text x="281" y="1982.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RollbackPendingRecipientTrust</text>
           <rect x="12" y="1992" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="18" y="1998" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="30" y="2004.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">SeedOrphanBudget</text>
+          <text x="30" y="2004.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">RollbackRouteInstall</text>
           <rect x="263" y="1992" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="269" y="1998" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="281" y="2004.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">SessionIngressDetachedForMobDestroy</text>
+          <text x="281" y="2004.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">SeedOrphanBudget</text>
           <rect x="12" y="2014" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="18" y="2020" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="30" y="2026.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">SessionIngressDetachFailedForMobDestroy</text>
+          <text x="30" y="2026.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">SessionIngressDetachedForMobDestroy</text>
           <rect x="263" y="2014" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="269" y="2020" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="281" y="2026.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">SetExternalMemberRebindCapability</text>
+          <text x="281" y="2026.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">SessionIngressDetachFailedForMobDestroy</text>
           <rect x="12" y="2036" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="18" y="2042" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="30" y="2048.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">StartPlacedKickoff</text>
+          <text x="30" y="2048.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">SetExternalMemberRebindCapability</text>
           <rect x="263" y="2036" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="269" y="2042" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="281" y="2048.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">StartupMarkReady</text>
+          <text x="281" y="2048.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">StartPlacedKickoff</text>
           <rect x="12" y="2058" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="18" y="2064" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="30" y="2070.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">SubscribeStructuralEvents</text>
+          <text x="30" y="2070.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">StartupMarkReady</text>
           <rect x="263" y="2058" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="269" y="2064" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="281" y="2070.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">UpdateCoordinationResourceClaimStatus</text>
+          <text x="281" y="2070.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">SubscribeStructuralEvents</text>
           <rect x="12" y="2080" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
           <rect x="18" y="2086" width="6" height="6" rx="1" fill="#d8aa57" />
-          <text x="30" y="2092.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">UpdateCoordinationWorkIntentStatus</text>
+          <text x="30" y="2092.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">UpdateCoordinationResourceClaimStatus</text>
+          <rect x="263" y="2080" width="245" height="18" rx="5" fill="rgba(255,255,255,0.018)" stroke="rgba(255,255,255,0.05)" />
+          <rect x="269" y="2086" width="6" height="6" rx="1" fill="#d8aa57" />
+          <text x="281" y="2092.5" fill="#f4efe5" font-size="8.6" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">UpdateCoordinationWorkIntentStatus</text>
   </g>
     </g>
     <g transform="translate(24, 1418)">


### PR DESCRIPTION
## Summary

- regenerate the MeerkatMachine and MobMachine HTML posters after the integrated definition-epoch and brain-swap changes
- refresh the poster index metadata

## Validation

- `make verify-machine-poster-coverage`
- `git diff --check`

Generated artifacts only; no source, version, or release changes.
