### PR TITLE
fix(build): follow configurable agent gate in doctor

### DIFF
--- a/scripts/buildbuddy-doctor
+++ b/scripts/buildbuddy-doctor
@@ -408,7 +408,7 @@ if grep -Fq 'MEERKAT_GCP_BUILDBUDDY_CI_MAX_SECONDS' .github/workflows/buildbuddy
   grep -Fq '. ./scripts/build-backend-env' Makefile &&
   grep -Fq 'CARGO="${CARGO:-$ROOT/scripts/repo-cargo}"' scripts/pre-push-unit.sh &&
   grep -Fq 'scripts/agent-gate" --staged' scripts/test-changed-crates.sh &&
-  grep -Fq 'scripts/agent-gate" --committed --clippy-only' scripts/pre-push-clippy.sh; then
+  grep -Fq 'exec "$AGENT_GATE" --committed --clippy-only' scripts/pre-push-clippy.sh; then
   pass "CI and local BuildBuddy opt-in switches are wired consistently"
 else
   bad "CI or BuildBuddy opt-in switch is not wired consistently"


### PR DESCRIPTION
## Summary

- update BuildBuddy doctor to validate the configurable `AGENT_GATE` invocation used by `pre-push-clippy.sh`
- remove the stale hardcoded `scripts/agent-gate` text expectation

## Validation

- `make buildbuddy-doctor`: 43 pass, 1 warning, 0 failures
- `make buildbuddy-check`: passed (BuildBuddy invocation `ca3cf8d1-e13e-43e8-b554-ee330e71005f`)
- `make buildbuddy-e2e-fast`: 1/1 passed (BuildBuddy invocation `1fad8f04-0f68-4af7-a13e-060f6239139b`)
- `make buildbuddy-e2e-smoke-turbo-s`: all 63 remote shards executed; 14 passed and 49 live shards failed because Anthropic/OpenAI credentials were absent from the remote environment

No runtime, dependency, version, or release behavior changes.
