### PR TITLE
fix(cli): restore persistence tools on resume

### DIFF
--- a/meerkat-cli/src/main.rs
+++ b/meerkat-cli/src/main.rs
@@ -11997,13 +11997,20 @@ async fn resume_session_with_llm_override(
         // resumed session would accept the call, commit the request, and never
         // realize it. Routing through the shared CLI builder is what keeps
         // resume identical to a fresh run.
+        let schedule_service = ScheduleService::new(persistence.schedule_store());
+        let default_schedule_tools =
+            Some(Arc::new(ScheduleToolDispatcher::new(schedule_service))
+                as Arc<dyn AgentToolDispatcher>);
+        let default_workgraph_tools = Some(Arc::new(meerkat::WorkGraphToolSurface::new(
+            scoped_workgraph_service(scope, &persistence),
+        )) as Arc<dyn AgentToolDispatcher>);
         let (service, resume_adapter) = build_cli_runtime_backed_service_with_defaults(
             factory,
             config.clone(),
             persistence.clone(),
             config_base_dir.join("config_state.json"),
-            None,
-            None,
+            default_schedule_tools,
+            default_workgraph_tools,
         );
 
         log_stage("compose_external_tool_dispatchers");


### PR DESCRIPTION
## Summary
- wire the persistence-backed WorkGraph dispatcher into `run --resume`, allowing the existing builder to inject its paired realm namespace grant
- restore schedule dispatcher parity with fresh-run CLI construction
- preserve the factory's fail-closed WorkGraph authority check

## Validation
- `./scripts/repo-cargo fmt --all -- --check`
- `./scripts/repo-cargo check -p rkat --features integration-real-tests,memory-store-session`
- `./scripts/repo-cargo test -p rkat --features integration-real-tests,memory-store-session --test system_cli_resume integration_real_cli_resume_tools -- --ignored --nocapture`
- `./scripts/repo-cargo test -p rkat --features integration-real-tests --test system_cli_mcp_pending integration_real_cli_mcp_pending_resume_journey -- --ignored --nocapture`
- `./scripts/repo-cargo clippy -p rkat --all-targets --features integration-real-tests,memory-store-session -- -D warnings`
- `meerkat-rust-zealot`: approved
- `rust-quality-gate`: passed