### PR TITLE
fix(mob): reconcile exact projection-ahead residue

### DIFF
--- a/meerkat-mob/src/runtime/tests.rs
+++ b/meerkat-mob/src/runtime/tests.rs
@@ -9486,6 +9486,8 @@ async fn create_test_mob_with_run_store(
         events: Arc::new(InMemoryMobEventStore::new()),
         runs: run_store,
         specs: Arc::new(InMemoryMobSpecStore::new()),
+        definition_projection_composition:
+            crate::storage::DefinitionProjectionComposition::Independent,
         runtime_metadata: Arc::new(InMemoryMobRuntimeMetadataStore::new()),
         identity: Arc::new(InMemoryMobIdentityStore::new()),
         identity_member: None,
@@ -11924,6 +11926,8 @@ async fn test_mob_builder_persists_spec_and_resume_requires_consistency() {
         events: storage.events.clone(),
         runs: storage.runs.clone(),
         specs: storage.specs.clone(),
+        definition_projection_composition:
+            crate::storage::DefinitionProjectionComposition::Independent,
         runtime_metadata: storage.runtime_metadata.clone(),
         identity: storage.identity.clone(),
         identity_member: storage.identity_member.clone(),
@@ -12821,6 +12825,8 @@ async fn test_existing_member_adoption_tool_update_and_resume_keep_identity_and_
         events: events.clone(),
         runs: runs.clone(),
         specs: specs.clone(),
+        definition_projection_composition:
+            crate::storage::DefinitionProjectionComposition::Independent,
         runtime_metadata: runtime_metadata.clone(),
         identity: identity_store.clone(),
         identity_member: Some(identity_store.clone()),
@@ -13018,6 +13024,8 @@ async fn test_existing_member_adoption_tool_update_and_resume_keep_identity_and_
         events,
         runs,
         specs,
+        definition_projection_composition:
+            crate::storage::DefinitionProjectionComposition::Independent,
         runtime_metadata,
         identity: identity_store.clone(),
         identity_member: Some(identity_store.clone()),
@@ -13115,6 +13123,8 @@ async fn test_existing_member_adoption_preserves_prompt_sequence_without_spawn_p
         events: Arc::new(event_store),
         runs,
         specs,
+        definition_projection_composition:
+            crate::storage::DefinitionProjectionComposition::Independent,
         runtime_metadata,
         identity: identity_store.clone(),
         identity_member: Some(identity_store.clone()),
@@ -23530,6 +23540,8 @@ async fn test_cold_running_resume_reestablishes_autonomous_startup_ready_without
         events,
         runs,
         specs,
+        definition_projection_composition:
+            crate::storage::DefinitionProjectionComposition::Independent,
         runtime_metadata,
         identity,
         identity_member,
@@ -23686,6 +23698,8 @@ async fn assert_cold_running_local_resume_fails_closed(
         events: events.clone(),
         runs,
         specs,
+        definition_projection_composition:
+            crate::storage::DefinitionProjectionComposition::Independent,
         runtime_metadata,
         identity,
         identity_member,
@@ -45021,6 +45035,8 @@ async fn test_explicit_fail_step_routes_generated_supervisor_escalation_effect()
         events: event_store.clone(),
         runs: run_store.clone(),
         specs: Arc::new(InMemoryMobSpecStore::new()),
+        definition_projection_composition:
+            crate::storage::DefinitionProjectionComposition::Independent,
         runtime_metadata: Arc::new(InMemoryMobRuntimeMetadataStore::new()),
         identity: Arc::new(InMemoryMobIdentityStore::new()),
         identity_member: None,
@@ -45918,6 +45934,8 @@ async fn test_resume_from_events_restarts_autonomous_host_loops_from_runtime_mod
         events: storage.events.clone(),
         runs: storage.runs.clone(),
         specs: storage.specs.clone(),
+        definition_projection_composition:
+            crate::storage::DefinitionProjectionComposition::Independent,
         runtime_metadata: storage.runtime_metadata.clone(),
         identity: storage.identity.clone(),
         identity_member: storage.identity_member.clone(),
@@ -46033,6 +46051,8 @@ async fn test_explicit_resume_retains_wedged_attachment_retirement_for_level_tri
         events: storage.events.clone(),
         runs: storage.runs.clone(),
         specs: storage.specs.clone(),
+        definition_projection_composition:
+            crate::storage::DefinitionProjectionComposition::Independent,
         runtime_metadata: storage.runtime_metadata.clone(),
         identity: storage.identity.clone(),
         identity_member: storage.identity_member.clone(),
@@ -62997,6 +63017,8 @@ async fn create_test_mob_with_realm_store(
         events: Arc::new(InMemoryMobEventStore::new()),
         runs: Arc::new(InMemoryMobRunStore::new()),
         specs: Arc::new(InMemoryMobSpecStore::new()),
+        definition_projection_composition:
+            crate::storage::DefinitionProjectionComposition::Independent,
         runtime_metadata: Arc::new(InMemoryMobRuntimeMetadataStore::new()),
         identity: Arc::new(InMemoryMobIdentityStore::new()),
         identity_member: None,
@@ -63101,6 +63123,8 @@ async fn test_spawn_realm_ref_without_store_returns_error() {
         events: Arc::new(InMemoryMobEventStore::new()),
         runs: Arc::new(InMemoryMobRunStore::new()),
         specs: Arc::new(InMemoryMobSpecStore::new()),
+        definition_projection_composition:
+            crate::storage::DefinitionProjectionComposition::Independent,
         runtime_metadata: Arc::new(InMemoryMobRuntimeMetadataStore::new()),
         identity: Arc::new(InMemoryMobIdentityStore::new()),
         identity_member: None,

--- a/meerkat-mob/src/runtime/tests.rs
+++ b/meerkat-mob/src/runtime/tests.rs
@@ -11984,6 +11984,136 @@ async fn test_mob_builder_persists_spec_and_resume_requires_consistency() {
 }
 
 #[tokio::test]
+async fn durable_definition_update_adopts_exact_projection_ahead_residue_atomically() {
+    let service = Arc::new(MockSessionService::new());
+    let _ = service.enable_runtime_adapter();
+    let directory = tempfile::tempdir().expect("temporary mob directory");
+    let database = directory.path().join("mob.db");
+    let storage = MobStorage::persistent(&database).expect("open persistent mob storage");
+    let definition = sample_definition();
+    let mob_id = definition.id.clone();
+    let mut updated = definition.clone();
+    let added_profile = updated
+        .profiles
+        .get(&ProfileName::from("worker"))
+        .expect("worker profile exists")
+        .clone();
+    updated
+        .profiles
+        .insert(ProfileName::from("reviewer"), added_profile);
+
+    let handle = MobBuilder::new(definition, storage.clone())
+        .with_session_service(service)
+        .allow_ephemeral_sessions(true)
+        .create()
+        .await
+        .expect("create mob");
+    handle.shutdown().await.expect("stop process-local actor");
+    drop(handle);
+
+    let projection_revision = storage
+        .specs
+        .put_spec(&mob_id, &updated, Some(1))
+        .await
+        .expect("model released projection-only update");
+    assert_eq!(projection_revision, 2);
+
+    let receipt = storage
+        .update_definition(1, updated.clone())
+        .await
+        .expect("adopt exact projection residue through canonical authority");
+    assert_eq!(receipt.epoch, 2);
+    assert_eq!(receipt.projection_revision, 2);
+    assert!(matches!(
+        storage
+            .definition_projection_health()
+            .await
+            .expect("projection health"),
+        Some(crate::MobDefinitionProjectionHealth::Healthy {
+            authority_epoch: 2,
+            projection_revision: 2,
+        })
+    ));
+    let events = storage.events.replay_all().await.expect("replay events");
+    assert_eq!(
+        events
+            .iter()
+            .filter(|event| matches!(
+                &event.kind,
+                crate::MobEventKind::MobDefinitionUpdated {
+                    epoch: 2,
+                    definition,
+                } if definition.as_ref() == &updated
+            ))
+            .count(),
+        1
+    );
+}
+
+#[tokio::test]
+async fn durable_definition_update_refuses_different_projection_ahead_residue() {
+    let service = Arc::new(MockSessionService::new());
+    let _ = service.enable_runtime_adapter();
+    let directory = tempfile::tempdir().expect("temporary mob directory");
+    let database = directory.path().join("mob.db");
+    let storage = MobStorage::persistent(&database).expect("open persistent mob storage");
+    let definition = sample_definition();
+    let mob_id = definition.id.clone();
+    let mut declared = definition.clone();
+    declared
+        .profiles
+        .get_mut(&ProfileName::from("worker"))
+        .expect("worker profile exists")
+        .as_inline_mut()
+        .unwrap()
+        .peer_description = "declared update".to_string();
+    let mut residue = declared.clone();
+    residue
+        .profiles
+        .get_mut(&ProfileName::from("worker"))
+        .expect("worker profile exists")
+        .as_inline_mut()
+        .unwrap()
+        .peer_description = "different projection-only update".to_string();
+
+    let handle = MobBuilder::new(definition, storage.clone())
+        .with_session_service(service)
+        .allow_ephemeral_sessions(true)
+        .create()
+        .await
+        .expect("create mob");
+    handle.shutdown().await.expect("stop process-local actor");
+    drop(handle);
+    assert_eq!(
+        storage
+            .specs
+            .put_spec(&mob_id, &residue, Some(1))
+            .await
+            .expect("model released projection-only update"),
+        2
+    );
+
+    assert!(matches!(
+        storage.update_definition(1, declared).await,
+        Err(MobError::MobDefinitionProjectionMismatch {
+            authority_epoch: 1,
+            projection_revision: 2,
+            kind: crate::MobDefinitionProjectionMismatchKind::ProjectionAhead,
+            ..
+        })
+    ));
+    assert!(
+        storage
+            .events
+            .replay_all()
+            .await
+            .expect("replay events")
+            .iter()
+            .all(|event| !matches!(event.kind, crate::MobEventKind::MobDefinitionUpdated { .. }))
+    );
+}
+
+#[tokio::test]
 async fn durable_definition_update_adds_profile_and_resume_uses_latest_epoch() {
     let service = Arc::new(MockSessionService::new());
     let _ = service.enable_runtime_adapter();

--- a/meerkat-mob/src/storage.rs
+++ b/meerkat-mob/src/storage.rs
@@ -63,6 +63,12 @@ pub struct MobDefinitionSnapshot {
     event_cursor: u64,
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum DefinitionProjectionComposition {
+    Independent,
+    AtomicSqlite,
+}
+
 impl MobDefinitionSnapshot {
     #[must_use]
     pub fn definition(&self) -> &MobDefinition {
@@ -92,6 +98,8 @@ pub struct MobStorage {
     pub(crate) runs: Arc<dyn MobRunStore>,
     /// Flow spec persistence store.
     pub(crate) specs: Arc<dyn MobSpecStore>,
+    /// Proof that the event and spec stores share one built-in transaction boundary.
+    pub(crate) definition_projection_composition: DefinitionProjectionComposition,
     /// Runtime metadata store for supervisor authority and compatibility projections.
     pub(crate) runtime_metadata: Arc<dyn MobRuntimeMetadataStore>,
     /// Sole desired-state authority for identity intent, leases, and immutable custody.
@@ -129,6 +137,7 @@ impl MobStorage {
             events: Arc::new(events),
             runs,
             specs,
+            definition_projection_composition: DefinitionProjectionComposition::Independent,
             runtime_metadata: Arc::new(InMemoryMobRuntimeMetadataStore::new()),
             identity: Arc::new(identity),
             identity_member: Some(identity_member),
@@ -156,6 +165,7 @@ impl MobStorage {
             events,
             runs,
             specs,
+            definition_projection_composition: DefinitionProjectionComposition::Independent,
             runtime_metadata: Arc::new(InMemoryMobRuntimeMetadataStore::new()),
             identity: Arc::new(InMemoryMobIdentityStore::new()),
             identity_member: None,
@@ -179,6 +189,7 @@ impl MobStorage {
             events,
             runs,
             specs,
+            definition_projection_composition: DefinitionProjectionComposition::Independent,
             runtime_metadata,
             identity: Arc::new(InMemoryMobIdentityStore::new()),
             identity_member: None,
@@ -225,6 +236,7 @@ impl MobStorage {
             events,
             runs: authority_validating_mob_run_store(runs),
             specs,
+            definition_projection_composition: DefinitionProjectionComposition::Independent,
             runtime_metadata,
             identity,
             identity_member: None,
@@ -425,7 +437,8 @@ impl MobStorage {
                 kind: MobDefinitionProjectionMismatchKind::ProjectionAhead,
             }) if authority_epoch == current_epoch
                 && projection_revision == next_epoch
-                && self.events.supports_atomic_projection_ahead_epoch_repair()
+                && self.definition_projection_composition
+                    == DefinitionProjectionComposition::AtomicSqlite
         );
         if !projection_ahead_repair {
             self.converge_definition_projection(&current_definition, current_epoch)
@@ -559,6 +572,7 @@ impl MobStorage {
             events: Arc::new(stores.event_store()),
             runs: authority_validating_mob_run_store(Arc::new(stores.run_store())),
             specs: Arc::new(stores.spec_store()),
+            definition_projection_composition: DefinitionProjectionComposition::AtomicSqlite,
             runtime_metadata: Arc::new(stores.runtime_metadata_store()),
             identity: Arc::new(identity),
             identity_member: Some(identity_member),
@@ -1699,6 +1713,98 @@ mod tests {
             Some(definition),
             "projection-first state must not rewrite event authority"
         );
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    async fn assert_split_sqlite_projection_ahead_refused(projected_matches_declared: bool) {
+        let directory = tempfile::tempdir().unwrap();
+        let stores = SqliteMobStores::open(directory.path().join("mob.db")).unwrap();
+        let sqlite_events = stores.event_store();
+        let sqlite_specs = stores.spec_store();
+        let definition = valid_definition("definition-split-projection");
+        sqlite_events
+            .append(NewMobEvent {
+                mob_id: definition.id.clone(),
+                timestamp: None,
+                kind: MobEventKind::MobCreated {
+                    definition: Box::new(definition.clone()),
+                },
+            })
+            .await
+            .unwrap();
+        sqlite_specs
+            .put_spec(&definition.id, &definition, None)
+            .await
+            .unwrap();
+
+        let mut declared = definition.clone();
+        declared.image_generation_provider = Some(meerkat_core::Provider::OpenAI);
+        let mut projected = declared.clone();
+        if !projected_matches_declared {
+            projected.image_generation_provider = Some(meerkat_core::Provider::Gemini);
+        }
+        let external_specs = Arc::new(InMemoryMobSpecStore::new());
+        external_specs
+            .put_spec(&definition.id, &definition, None)
+            .await
+            .unwrap();
+        external_specs
+            .put_spec(&definition.id, &projected, Some(1))
+            .await
+            .unwrap();
+
+        let storage = MobStorage::custom(
+            Arc::new(sqlite_events),
+            Arc::new(InMemoryMobRunStore::new()),
+            external_specs.clone(),
+            Arc::new(InMemoryMobIdentityStore::new()),
+            Arc::new(InMemoryMobIdentityStatusStore::new()),
+        );
+        let cursor_before = storage.events.latest_cursor().await.unwrap();
+        let event_count_before = storage.events.replay_all().await.unwrap().len();
+
+        let error = storage
+            .update_definition(1, declared)
+            .await
+            .expect_err("split store composition must never adopt projection residue");
+        assert!(matches!(
+            error,
+            MobError::MobDefinitionProjectionMismatch {
+                authority_epoch: 1,
+                projection_revision: 2,
+                kind: MobDefinitionProjectionMismatchKind::ProjectionAhead,
+                ..
+            }
+        ));
+        assert_eq!(storage.events.latest_cursor().await.unwrap(), cursor_before);
+        assert_eq!(
+            storage.events.replay_all().await.unwrap().len(),
+            event_count_before
+        );
+        assert_eq!(
+            storage.created_definition().await.unwrap(),
+            Some(definition.clone())
+        );
+        assert_eq!(
+            sqlite_specs.get_spec(&definition.id).await.unwrap(),
+            Some((definition.clone(), 1))
+        );
+        assert_eq!(
+            external_specs.get_spec(&definition.id).await.unwrap(),
+            Some((projected, 2))
+        );
+    }
+
+    #[tokio::test]
+    #[cfg(not(target_arch = "wasm32"))]
+    async fn split_sqlite_event_and_custom_spec_refuses_exact_projection_ahead_residue() {
+        assert_split_sqlite_projection_ahead_refused(true).await;
+    }
+
+    #[tokio::test]
+    #[cfg(not(target_arch = "wasm32"))]
+    async fn split_sqlite_event_and_custom_spec_refuses_mismatched_projection_ahead_residue() {
+        assert_split_sqlite_projection_ahead_refused(false).await;
     }
 
     #[tokio::test]

--- a/meerkat-mob/src/storage.rs
+++ b/meerkat-mob/src/storage.rs
@@ -417,8 +417,20 @@ impl MobStorage {
                 actual: current_epoch,
             });
         }
-        self.converge_definition_projection(&current_definition, current_epoch)
-            .await?;
+        let projection_ahead_repair = matches!(
+            self.definition_projection_health().await?,
+            Some(MobDefinitionProjectionHealth::Diverged {
+                authority_epoch,
+                projection_revision,
+                kind: MobDefinitionProjectionMismatchKind::ProjectionAhead,
+            }) if authority_epoch == current_epoch
+                && projection_revision == next_epoch
+                && self.events.supports_atomic_projection_ahead_epoch_repair()
+        );
+        if !projection_ahead_repair {
+            self.converge_definition_projection(&current_definition, current_epoch)
+                .await?;
+        }
 
         let mut authority =
             crate::runtime::recover_definition_epoch_authority(&events, &current_definition)?;

--- a/meerkat-mob/src/store/mod.rs
+++ b/meerkat-mob/src/store/mod.rs
@@ -155,6 +155,10 @@ pub(crate) mod private {
     #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
     #[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
     pub trait MobEventStoreSealed: Send + Sync {
+        fn supports_atomic_projection_ahead_epoch_repair(&self) -> bool {
+            false
+        }
+
         fn definition_resume_gate(&self) -> Arc<tokio::sync::RwLock<()>> {
             static GATE: std::sync::OnceLock<Arc<tokio::sync::RwLock<()>>> =
                 std::sync::OnceLock::new();

--- a/meerkat-mob/src/store/mod.rs
+++ b/meerkat-mob/src/store/mod.rs
@@ -155,10 +155,6 @@ pub(crate) mod private {
     #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
     #[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
     pub trait MobEventStoreSealed: Send + Sync {
-        fn supports_atomic_projection_ahead_epoch_repair(&self) -> bool {
-            false
-        }
-
         fn definition_resume_gate(&self) -> Arc<tokio::sync::RwLock<()>> {
             static GATE: std::sync::OnceLock<Arc<tokio::sync::RwLock<()>>> =
                 std::sync::OnceLock::new();

--- a/meerkat-mob/src/store/sqlite.rs
+++ b/meerkat-mob/src/store/sqlite.rs
@@ -7159,6 +7159,10 @@ fn validate_initial_mob_created_sqlite(
 
 #[async_trait]
 impl private::MobEventStoreSealed for SqliteMobEventStore {
+    fn supports_atomic_projection_ahead_epoch_repair(&self) -> bool {
+        true
+    }
+
     fn definition_resume_gate(&self) -> Arc<tokio::sync::RwLock<()>> {
         Arc::clone(&self.event_bus.definition_resume_gate)
     }
@@ -7353,7 +7357,9 @@ impl private::MobEventStoreSealed for SqliteMobEventStore {
                     event.mob_id
                 )));
             };
-            if projected.revision > previous_epoch {
+            let exact_projection_ahead_residue =
+                projected.revision == epoch && projected.definition == proposed;
+            if projected.revision > previous_epoch && !exact_projection_ahead_residue {
                 return Err(MobStoreError::MobDefinitionProjectionMismatch {
                     mob_id: event.mob_id,
                     authority_epoch: previous_epoch,
@@ -7373,7 +7379,7 @@ impl private::MobEventStoreSealed for SqliteMobEventStore {
                     kind: crate::error::MobDefinitionProjectionMismatchKind::DefinitionMismatch,
                 });
             }
-            if projected.revision != previous_epoch {
+            if projected.revision != previous_epoch && !exact_projection_ahead_residue {
                 return Err(MobStoreError::CasConflict(format!(
                     "mob '{}' definition projection changed during epoch CAS",
                     event.mob_id

--- a/meerkat-mob/src/store/sqlite.rs
+++ b/meerkat-mob/src/store/sqlite.rs
@@ -7159,10 +7159,6 @@ fn validate_initial_mob_created_sqlite(
 
 #[async_trait]
 impl private::MobEventStoreSealed for SqliteMobEventStore {
-    fn supports_atomic_projection_ahead_epoch_repair(&self) -> bool {
-        true
-    }
-
     fn definition_resume_gate(&self) -> Arc<tokio::sync::RwLock<()>> {
         Arc::clone(&self.event_bus.definition_resume_gate)
     }


### PR DESCRIPTION
## Summary
- let the paired SQLite Mob store atomically append a missing definition epoch when an exact one-epoch-ahead spec projection already exists
- require full projected-definition equality with the declared update inside the same transaction
- bind repair eligibility to a bundle witness minted only by `MobStorage::persistent`; split/custom/in-memory stores refuse before mutation

## Validation
- focused built-in and split-store recovery tests: 5/5 passed
- `clippy -p meerkat-mob --all-features --all-targets -- -D warnings`
- definition authority owner review: PASS
- Meerkat Rust Zealot: PASS
- Rust Quality Gate: PASS
- MobKit preliminary consumer battery: 42/42 passed