### PR TITLE
docs: publish MobKit v0.8.30

### DIFF
--- a/docs/mobkit/_source.json
+++ b/docs/mobkit/_source.json
@@ -1,10 +1,10 @@
 {
   "generated": true,
   "source_repository": "https://github.com/lukacf/meerkat-mobkit",
-  "source_ref": "v0.8.22",
-  "source_commit": "3d8a7ed658da7fa8188edbcc353cf28031cb2dc8",
-  "source_version": "0.8.22",
+  "source_ref": "v0.8.30",
+  "source_commit": "44f1c4ef3c6ae45079c54fac760bc703604d3f0b",
+  "source_version": "0.8.30",
   "source_docs_dirty": false,
   "public_pages": 26,
-  "content_sha256": "c633f0730bdc35c1a70f5fac4ed1b5ac35771656b2ffbad17cd3bc1923f8d018"
+  "content_sha256": "cf45263b1d801caebce20434285d1d184039a95c70a6f6385ff5adc8b2a5280b"
 }

--- a/docs/mobkit/api/rpc.mdx
+++ b/docs/mobkit/api/rpc.mdx
@@ -134,7 +134,7 @@ errors. SDKs surface it on `RpcError.data`.
 | `-32014` | `mobkit/init` fail-closed storage refusal: file-name twins the storage layout refuses to pick between, a session/runtime/blob/metadata/console store that failed to open (formerly a silent in-memory fallback), or an uncreatable state root. The message carries the remediation (the storage doctor, or the explicit ephemeral declaration). The gateway writes the error response and exits. | none |
 | `-32015` | `mobkit/bound_member_transcript` target session is live/running (transcript surgery only supports reject-while-active); quiesce the member first (retire or park it), then retry | none |
 | `-32016` | operator verb exists but its gateway wiring is absent (no compaction-floor registry / no concrete transcript-edit service threaded into the RPC context) | none |
-| `-32017` | a read-only console arm exhausted its deadline. The member's meerkat session task and the mob actor loop are strict sequential command loops, so a read issued while the member is mid-turn queues behind that turn instead of degrading; the arms that cross either loop (`identity/resolved_tools`, `member_status`, `list_members`, `get_member`, `find_members`, `flow_status`, `list_runs`) give up after the read budget and say so. The read is abandoned, never half-applied. Budget defaults to 30s, overridable with `MOBKIT_CONSOLE_READ_TIMEOUT_SECS` (clamped to 1..3600). | `{kind: "console_read_timeout", arm, awaiting, timeout_secs}` |
+| `-32017` | a read-only console arm exhausted its deadline. The member's meerkat session task and the mob actor loop are strict sequential command loops, so a read issued while the member is mid-turn queues behind that turn instead of degrading; the arms that cross either loop (`identity/resolved_tools`, `identity/routing_status`, `member_status`, `list_members`, `get_member`, `find_members`, `flow_status`, `list_runs`) give up after the read budget and say so. The read is abandoned, never half-applied. Budget defaults to 30s, overridable with `MOBKIT_CONSOLE_READ_TIMEOUT_SECS` (clamped to 1..3600). | `{kind: "console_read_timeout", arm, awaiting, timeout_secs}` |
 
 The `-32010` constant is exported from both SDKs as
 `MOB_EVENTS_STALE_CURSOR_CODE`. The Python and TypeScript SDKs auto-
@@ -579,6 +579,66 @@ Register a new route.
 ### `mobkit/routing/routes/delete`
 
 Remove a registered route.
+
+### `mobkit/identity/routing_status`
+
+Meerkat's typed model-routing status for the live session behind a MobKit
+identity. The result is meerkat's `SessionModelRoutingStatus` verbatim
+(`WireSessionModelRoutingStatus` is a type alias to it), flattened under
+`identity` and `session_id`. MobKit declares no mirror type, so this payload
+cannot drift from meerkat's contract.
+
+<Accordion title="Parameters">
+| Param | Type | Required | Description |
+|-------|------|----------|-------------|
+| `identity` | string | yes | Agent identity. `member_id` is accepted as an alias. |
+</Accordion>
+
+Result fields: `identity`, `session_id`, `baseline_model`, `effective_model`,
+and the optional `session_provider`, `active_turn_override`,
+`active_operation_override`, `pending_switch_turn`.
+
+`session_provider` is the typed provider of the session's current LLM identity.
+An absent `session_provider` means the runtime machine has no hydrated session
+LLM identity yet (pre-hydration). It is **not** a signal to re-derive a provider
+from `effective_model`: meerkat documents that re-derivation as silently wrong
+for models owned by a custom `ModelRegistry`, which is why the field is carried
+typed rather than inferred.
+
+**This method requires a resolved session.** Identity-first materializes an
+identity without activating it, so an identity that has been materialized but
+never addressed has no session and therefore no routing status. That is the
+expected state after a restart, not a defect. A fleet sweep should address an
+identity before reading, and label its coverage post-address rather than
+post-restart.
+
+Failures carry a machine-readable discriminator so a sweep can classify an
+identity rather than only fail it:
+
+| `reason` | Meaning |
+|----------|---------|
+| `runtime_unsupported` | The session service exposes no runtime adapter. Configuration, not state. |
+| `no_current_session` | The roster reports no current session. **Covers two cases this surface cannot distinguish:** an identity materialized but never addressed (the normal state at boot), and an identity that does not exist at all. A caller must not read this as proof the identity exists. |
+| `member_lookup_failed` | The mob could not resolve the member at all. A roster failure, not a session claim. |
+| `session_not_held` | A session resolved **and** meerkat answered `NotFound` for it. A real defect. |
+| `upstream_read_failed` | A session resolved and the upstream read failed some other way. Diagnoses nothing. |
+| `invalid_identity` | No usable identity was supplied. |
+
+Each reason is derived only from a fact MobKit observed. `session_not_held` is
+matched on `RuntimeDriverError::NotFound` structurally, never on message text;
+because that error is `#[non_exhaustive]`, every other upstream failure lands in
+`upstream_read_failed` rather than being asserted as a missing session.
+
+```json
+{"code": -32000,
+ "message": "routing_status unavailable: ...",
+ "data": {"kind": "routing_status_unavailable",
+          "reason": "no_current_session",
+          "identity": "domain:security"}}
+```
+
+SDKs: `handle.identity_routing_status(identity)` (Python),
+`handle.identityRoutingStatus(identity)` (TypeScript).
 
 ---
 

--- a/docs/mobkit/quickstart.mdx
+++ b/docs/mobkit/quickstart.mdx
@@ -10,7 +10,7 @@ icon: "rocket"
   <Tab title="Rust crate">
     ```toml Cargo.toml
     [dependencies]
-    meerkat-mobkit = "0.8.22"
+    meerkat-mobkit = "0.8.30"
     tokio = { version = "1", features = ["full"] }
     ```
   </Tab>

--- a/docs/mobkit/reference/configuration.mdx
+++ b/docs/mobkit/reference/configuration.mdx
@@ -109,9 +109,50 @@ The stock SDK gateway consumes the `runtime_options` object sent by Python and T
 | `control_grants_toml` | TOML string | Loads the closed `[control_grants]` table for `--control-listen`. Each caller public key is scoped to named control verbs and members, and the gateway binds every request signature to the local mob id as its audience. Omitting the field installs an empty deny-all table; an explicit value without `[control_grants]`, or with an unknown/invalid field, fails initialization. |
 | `event_log` | Object | Declares the operational event log. `storage = "memory"` (with optional `batch_size`, `flush_interval_ms`) keeps a bounded queryable in-process store so `mobkit/query_events` returns events instead of `no_event_log_configured`; `storage = "null"` declares that events are dropped. Both are declared-ephemeral choices; omitting the key means no ingestion at all, and any other storage kind fails initialization. Durable event-log backends are embedder-only (`UnifiedRuntimeBuilder` accepts any `EventLogStore`). |
 | `runtime_store` | Object | Declares the runtime store's durability. The store (`runtime.sqlite` — session resume, archive, retire) is persistent SQLite by default; the only accepted declaration is `{ "storage": "memory" }`, after which sessions do not survive gateway restart. A failed SQLite open without this declaration is a startup error (`-32014`), never a silent in-memory fallback. |
+| `declare_spec_update` | Object | One-shot canonical mob-definition compare-and-swap. `{ "expected_revision": N }` applies the `mob_config` supplied in the same `mobkit/init` request only when the durable definition is still at `N`. The launch must be authoritative and use persistent mob storage. Exact replay converges; stale revision or successor-content disagreement refuses initialization with typed storage error `-32014`. |
 | `compaction` | Object | Declares the host-level session-compaction policy for every agent the gateway builds: `auto_compact_threshold` (tokens, non-zero), `recent_turn_budget`, `max_summary_tokens`, `min_turns_between_compactions`. A compactor is always installed; this declares *when it fires*. **Omitting `auto_compact_threshold` inherits Meerkat's model-aware default — `context_window * 4 / 5`, i.e. ~840,000 tokens on a million-token model such as `gpt-5.6-sol`, which in practice never fires and resends the full transcript every turn.** Declaring the key pins it. A mob profile's own `auto_compact_threshold` still wins per member. Unknown keys and a zero threshold fail initialization. |
 
 Unsupported nested fields fail initialization with `-32602` instead of being silently ignored.
+
+### One-shot mob definition update
+
+Python hosts use the supported builder ceremony on the single activation
+authorized to change the durable definition:
+
+```python
+runtime = await (
+    MobKit.builder()
+    .mob("config/mob.toml")  # complete replacement definition
+    .persistent_state("/var/lib/homecore")
+    .declare_spec_update(expected_revision=1)
+    .gateway("/path/to/rpc_gateway")
+    .build()
+)
+```
+
+The builder sends the replacement TOML as top-level `mob_config` and emits:
+
+```json
+{
+  "runtime_options": {
+    "mob_composition": {"authority": "authoritative"},
+    "declare_spec_update": {"expected_revision": 1}
+  }
+}
+```
+
+The gateway delegates the mutation to Meerkat's canonical definition CAS. It
+does not append raw events, rewrite a projection independently, or treat the
+creation manifest as mutable authority. Remove `declare_spec_update(...)` from
+later ordinary restarts. A stale revision or different successor definition
+raises Python `StorageResolutionError`; an exact retry returns the already
+committed successor revision and converges its checked projection.
+
+This is a cold-activation ceremony, not a hot reload. Fully shut down the prior
+runtime before issuing the update: an already-running `MobHandle` keeps the
+definition it was constructed with. The CAS and verified-resume fence serialize
+the update with the next bootstrap, but they do not reconfigure an older live
+process.
 
 <Warning>
 `runtime_options.scheduling_files` was removed in contract 0.5.0 and is an

--- a/docs/mobkit/sdks/rust.mdx
+++ b/docs/mobkit/sdks/rust.mdx
@@ -10,7 +10,7 @@ The Rust crate `meerkat-mobkit` is the primary interface for MobKit. All other i
 
 ```toml Cargo.toml
 [dependencies]
-meerkat-mobkit = "0.8.22"
+meerkat-mobkit = "0.8.30"
 tokio = { version = "1", features = ["full"] }
 serde_json = "1"
 ```


### PR DESCRIPTION
Publishes the generated MobKit v0.8.30 documentation from verified release run 33719562463.

Generated by Meerkat docs workflow run 33723467819; branch contains only docs/mobkit projections.