### PR TITLE
fix(buildbuddy): import login shell credentials

### DIFF
--- a/scripts/build-backend-env
+++ b/scripts/build-backend-env
@@ -64,33 +64,93 @@ meerkat_secret_env_key_allowed() {
   esac
 }
 
-meerkat_load_local_secrets_env() {
-  local root secrets_env loaded_env line key value
-  root="${1:-}"
-  secrets_env="$(meerkat_discover_local_secrets_env "${root}")"
-  if [[ -z "${secrets_env}" ]]; then
-    return 0
-  fi
+meerkat_exported_env_key_is_set() {
+  local exported_key
+  while IFS= read -r exported_key; do
+    if [[ "${exported_key}" == "$1" ]]; then
+      return 0
+    fi
+  done < <(compgen -e)
+  return 1
+}
 
-  if ! loaded_env="$(
-    set +u
-    set -a
-    # shellcheck disable=SC1090
-    source "${secrets_env}" >/dev/null
-    env
-  )"; then
-    echo "warning: failed to load local secrets env from ${secrets_env}" >&2
-    return 0
-  fi
-
-  while IFS= read -r line; do
-    key="${line%%=*}"
-    value="${line#*=}"
-    if [[ "${key}" == "${line}" ]]; then
+meerkat_import_allowed_env() {
+  local record key value import_status index
+  local keys=()
+  local values=()
+  import_status=1
+  while IFS= read -r -d '' record; do
+    key="${record%%=*}"
+    value="${record#*=}"
+    if [[ "${key}" == "__MEERKAT_ENV_IMPORT_STATUS" ]]; then
+      import_status="${value}"
       continue
     fi
-    if meerkat_secret_env_key_allowed "${key}" && [[ -z "${!key:-}" ]]; then
-      export "${key}=${value}"
+    if [[ "${key}" == "${record}" || ! "${key}" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]]; then
+      continue
     fi
-  done <<< "${loaded_env}"
+    if meerkat_secret_env_key_allowed "${key}" && ! meerkat_exported_env_key_is_set "${key}"; then
+      keys[${#keys[@]}]="${key}"
+      values[${#values[@]}]="${value}"
+    fi
+  done
+  if [[ "${import_status}" != "0" ]]; then
+    return 1
+  fi
+  for ((index = 0; index < ${#keys[@]}; index++)); do
+    export "${keys[index]}=${values[index]}"
+  done
+}
+
+meerkat_login_zsh_env_enabled() {
+  case "${MEERKAT_IMPORT_LOGIN_ZSH_ENV:-1}" in
+    0|false|FALSE|no|NO|off|OFF)
+      return 1
+      ;;
+    *)
+      return 0
+      ;;
+  esac
+}
+
+meerkat_load_local_secrets_env() {
+  local root secrets_env restore_xtrace
+  root="${1:-}"
+  secrets_env="$(meerkat_discover_local_secrets_env "${root}")"
+  restore_xtrace=0
+  if [[ "$-" == *x* ]]; then
+    restore_xtrace=1
+    set +x
+  fi
+
+  if [[ -n "${secrets_env}" ]]; then
+    if ! meerkat_import_allowed_env < <(
+      set +u
+      set -a
+      # shellcheck disable=SC1090
+      if source "${secrets_env}" >/dev/null 2>&1 && /usr/bin/env -0; then
+        printf '__MEERKAT_ENV_IMPORT_STATUS=0\0'
+      else
+        printf '__MEERKAT_ENV_IMPORT_STATUS=1\0'
+      fi
+    ); then
+      echo "warning: failed to load local secrets env from ${secrets_env}" >&2
+    fi
+  fi
+
+  # Live lanes may start from a non-login agent process. Import only the
+  # established secret allowlist; set MEERKAT_IMPORT_LOGIN_ZSH_ENV=0 to opt out.
+  if meerkat_login_zsh_env_enabled && command -v zsh >/dev/null 2>&1; then
+    meerkat_import_allowed_env < <(
+      if zsh -lic '/usr/bin/env -0 >&3' 3>&1 >/dev/null 2>&1; then
+        printf '__MEERKAT_ENV_IMPORT_STATUS=0\0'
+      else
+        printf '__MEERKAT_ENV_IMPORT_STATUS=1\0'
+      fi
+    ) || true
+  fi
+
+  if [[ "${restore_xtrace}" == "1" ]]; then
+    set -x
+  fi
 }

--- a/scripts/buildbuddy-doctor
+++ b/scripts/buildbuddy-doctor
@@ -61,6 +61,12 @@ else
   bad "BuildBuddy API key is not configured; set BUILDBUDDY_API_KEY or add it to ~/.zshrc"
 fi
 
+if scripts/test-build-backend-env.sh >/dev/null 2>&1; then
+  pass "Build backend imports only allowlisted login-shell secrets"
+else
+  bad "Build backend login-shell secret import contract failed"
+fi
+
 bb_bin=""
 if [[ -n "${BUILDBUDDY_BB:-}" && -x "${BUILDBUDDY_BB}" ]]; then
   bb_bin="${BUILDBUDDY_BB}"

--- a/scripts/test-build-backend-env.sh
+++ b/scripts/test-build-backend-env.sh
@@ -1,0 +1,158 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2030,SC2031
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+TEST_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/meerkat-build-backend-env.XXXXXX")"
+trap 'rm -rf "$TEST_ROOT"' EXIT
+
+FAKE_HOME="${TEST_ROOT}/home"
+FAKE_BIN="${TEST_ROOT}/bin"
+mkdir -p "${FAKE_HOME}" "${FAKE_BIN}"
+
+cat > "${FAKE_HOME}/.zshrc" <<'EOF'
+export OPENAI_API_KEY=login-openai
+export ANTHROPIC_API_KEY=login-anthropic
+export GEMINI_API_KEY=login-gemini
+export GOOGLE_API_KEY=login-google
+export BUILDBUDDY_API_KEY=login-buildbuddy
+export NOT_A_PROVIDER_SECRET=$'ignored\nRKAT_INJECTED=injected'
+EOF
+
+cat > "${FAKE_BIN}/zsh" <<'EOF'
+#!/bin/bash
+set -euo pipefail
+[[ "$1" == "-lic" && "$2" == "/usr/bin/env -0 >&3" ]]
+if [[ "${FAKE_ZSH_FAIL:-0}" == "1" ]]; then
+  set -a
+  source "${HOME}/.zshrc"
+  /usr/bin/env -0 >&3
+  exit 42
+fi
+set -a
+source "${HOME}/.zshrc"
+printf 'startup output containing login-openai\n'
+printf 'OPENAI_BAD-NAME=invalid\0' >&3
+/usr/bin/env -0 >&3
+EOF
+chmod +x "${FAKE_BIN}/zsh"
+
+cat > "${TEST_ROOT}/secrets.env" <<'EOF'
+OPENAI_API_KEY=secrets-openai
+ANTHROPIC_API_KEY=secrets-anthropic
+printf 'secret source output containing secrets-anthropic\n' >&2
+EOF
+
+(
+  source "${REPO_ROOT}/scripts/build-backend-env"
+  unset OPENAI_API_KEY ANTHROPIC_API_KEY GEMINI_API_KEY GOOGLE_API_KEY BUILDBUDDY_API_KEY
+  unset RKAT_INJECTED
+  unset NOT_A_PROVIDER_SECRET MEERKAT_SECRETS_ENV MEERKAT_IMPORT_LOGIN_ZSH_ENV
+
+  output="${TEST_ROOT}/import.out"
+  HOME="${FAKE_HOME}" \
+    PATH="${FAKE_BIN}:${PATH}" \
+    meerkat_load_local_secrets_env "/" >"${output}" 2>&1
+
+  [[ ! -s "${output}" ]]
+  [[ "${OPENAI_API_KEY}" == "login-openai" ]]
+  [[ "${ANTHROPIC_API_KEY}" == "login-anthropic" ]]
+  [[ "${GEMINI_API_KEY}" == "login-gemini" ]]
+  [[ "${BUILDBUDDY_API_KEY}" == "login-buildbuddy" ]]
+  [[ -z "${NOT_A_PROVIDER_SECRET+x}" ]]
+  [[ -z "${RKAT_INJECTED+x}" ]]
+  ! printenv 'OPENAI_BAD-NAME' >/dev/null 2>&1
+)
+
+(
+  source "${REPO_ROOT}/scripts/build-backend-env"
+  unset OPENAI_API_KEY ANTHROPIC_API_KEY GEMINI_API_KEY GOOGLE_API_KEY
+  unset NOT_A_PROVIDER_SECRET MEERKAT_SECRETS_ENV MEERKAT_IMPORT_LOGIN_ZSH_ENV
+  export OPENAI_API_KEY=caller-openai
+  export GOOGLE_API_KEY=
+
+  output="${TEST_ROOT}/precedence.out"
+  HOME="${FAKE_HOME}" \
+    PATH="${FAKE_BIN}:${PATH}" \
+    MEERKAT_SECRETS_ENV="${TEST_ROOT}/secrets.env" \
+    meerkat_load_local_secrets_env "${TEST_ROOT}" >"${output}" 2>&1
+
+  [[ ! -s "${output}" ]]
+  [[ "${OPENAI_API_KEY}" == "caller-openai" ]]
+  [[ "${ANTHROPIC_API_KEY}" == "secrets-anthropic" ]]
+  [[ "${GEMINI_API_KEY}" == "login-gemini" ]]
+  [[ -z "${GOOGLE_API_KEY}" ]]
+  [[ -z "${NOT_A_PROVIDER_SECRET+x}" ]]
+)
+
+(
+  source "${REPO_ROOT}/scripts/build-backend-env"
+  unset OPENAI_API_KEY MEERKAT_SECRETS_ENV
+
+  output="${TEST_ROOT}/opt-out.out"
+  HOME="${FAKE_HOME}" \
+    PATH="${FAKE_BIN}:${PATH}" \
+    MEERKAT_IMPORT_LOGIN_ZSH_ENV=0 \
+    meerkat_load_local_secrets_env "/" >"${output}" 2>&1
+
+  [[ ! -s "${output}" ]]
+  [[ -z "${OPENAI_API_KEY+x}" ]]
+)
+
+(
+  source "${REPO_ROOT}/scripts/build-backend-env"
+  unset OPENAI_API_KEY MEERKAT_SECRETS_ENV MEERKAT_IMPORT_LOGIN_ZSH_ENV
+
+  output="${TEST_ROOT}/failed-zsh.out"
+  HOME="${FAKE_HOME}" \
+    PATH="${FAKE_BIN}:${PATH}" \
+    FAKE_ZSH_FAIL=1 \
+    meerkat_load_local_secrets_env "/" >"${output}" 2>&1
+
+  [[ ! -s "${output}" ]]
+  [[ -z "${OPENAI_API_KEY+x}" ]]
+)
+
+(
+  source "${REPO_ROOT}/scripts/build-backend-env"
+  unset OPENAI_API_KEY ANTHROPIC_API_KEY GEMINI_API_KEY
+  unset MEERKAT_IMPORT_LOGIN_ZSH_ENV
+  export OPENAI_API_KEY=caller-openai
+
+  output="${TEST_ROOT}/xtrace.out"
+  {
+    set -x
+    HOME="${FAKE_HOME}" \
+      PATH="${FAKE_BIN}:${PATH}" \
+      MEERKAT_SECRETS_ENV="${TEST_ROOT}/secrets.env" \
+      meerkat_load_local_secrets_env "${TEST_ROOT}"
+    [[ "$-" == *x* ]]
+    set +x
+  } >"${output}" 2>&1
+
+  if grep -Fq 'caller-openai' "${output}" ||
+    grep -Fq 'secrets-anthropic' "${output}" ||
+    grep -Fq 'login-gemini' "${output}"; then
+    echo "xtrace exposed a credential value" >&2
+    exit 1
+  fi
+)
+
+(
+  source "${REPO_ROOT}/scripts/build-backend-env"
+  unset OPENAI_API_KEY ANTHROPIC_API_KEY GEMINI_API_KEY
+  unset MEERKAT_SECRETS_ENV MEERKAT_IMPORT_LOGIN_ZSH_ENV MEERKAT_BUILDBUDDY
+
+  output="${TEST_ROOT}/missing-zsh.out"
+  HOME="${FAKE_HOME}" \
+    PATH="${TEST_ROOT}/missing-bin" \
+    meerkat_load_local_secrets_env "/" >"${output}" 2>&1
+
+  [[ ! -s "${output}" ]]
+  [[ "$(meerkat_selected_build_backend)" == "cargo" ]]
+  [[ -z "${OPENAI_API_KEY+x}" ]]
+  [[ -z "${ANTHROPIC_API_KEY+x}" ]]
+  [[ -z "${GEMINI_API_KEY+x}" ]]
+)
+
+echo "build backend secret environment contract holds"


### PR DESCRIPTION
## Summary
- import only allowlisted provider credentials from the user's login zsh for non-login live-lane callers
- preserve caller > `secrets.env` > login-zsh precedence, including explicitly empty exports
- add a NUL-framed fake-shell regression and run it from BuildBuddy doctor

## Validation
- `scripts/test-build-backend-env.sh`
- `bash -n scripts/build-backend-env scripts/test-build-backend-env.sh scripts/buildbuddy-doctor`
- `shellcheck scripts/build-backend-env scripts/test-build-backend-env.sh`
- `shellcheck -S warning scripts/buildbuddy-doctor`
- `make fmt-check`
- `make buildbuddy-doctor`
- normal pre-push gate