### PR TITLE
fix(runtime): bound unregister binding recovery

### DIFF
--- a/meerkat-runtime/src/meerkat_machine/dispatch_session.rs
+++ b/meerkat-runtime/src/meerkat_machine/dispatch_session.rs
@@ -1926,9 +1926,20 @@ impl MeerkatMachine {
         session_id: SessionId,
         preparation: SessionBindingPreparation,
     ) -> Result<MeerkatMachineCommandResult, RuntimeDriverError> {
+        self.prepare_session_runtime_bindings_with_attempt(session_id, preparation, None)
+            .await
+    }
+
+    pub(super) async fn prepare_session_runtime_bindings_with_attempt(
+        &self,
+        session_id: SessionId,
+        preparation: SessionBindingPreparation,
+        attempt: Option<&mut super::session_management::IdempotentBindingPreparationAttempt>,
+    ) -> Result<MeerkatMachineCommandResult, RuntimeDriverError> {
         self.prepare_session_runtime_bindings_with_claim(
             session_id,
             preparation,
+            attempt,
             uuid::Uuid::new_v4(),
             true,
             None,
@@ -1940,6 +1951,7 @@ impl MeerkatMachine {
         &self,
         session_id: SessionId,
         preparation: SessionBindingPreparation,
+        attempt: Option<&mut super::session_management::IdempotentBindingPreparationAttempt>,
         requested_claim_id: uuid::Uuid,
         release_materialization_claim_on_drop: bool,
         claim_state_sink: Option<
@@ -1977,57 +1989,13 @@ impl MeerkatMachine {
             ?preparation,
             "MeerkatMachine::prepare_session_runtime_bindings registering session"
         );
-        #[cfg(target_arch = "wasm32")]
-        let inserted_by_call = if self.store.is_none() {
-            {
-                tracing::debug!(%session_id, "MeerkatMachine::prepare_session_runtime_bindings attempting storeless existing check lock");
-                let mut sessions = self.sessions.try_write().map_err(|_| {
-                    tracing::warn!(
-                        %session_id,
-                        "storeless session map busy while checking existing registration"
-                    );
-                    RuntimeDriverError::Internal(format!(
-                        "storeless session map busy while registering {session_id}"
-                    ))
-                })?;
-                tracing::debug!(%session_id, "MeerkatMachine::prepare_session_runtime_bindings locked storeless existing check");
-                if let Some(existing) = sessions.get_mut(&session_id) {
-                    tracing::debug!(
-                        %session_id,
-                        "MeerkatMachine::prepare_session_runtime_bindings found existing session"
-                    );
-                    if let Some(error) = existing.registration_blocked_by_unregister(&session_id) {
-                        return Err(error);
-                    }
-                    if existing.clear_dead_attachment() {
-                        existing.stage_generated_executor_exit_observation().map_err(|reason| {
-                            RuntimeDriverError::Internal(format!(
-                                "generated MeerkatMachine rejected executor-exit observation: {reason}"
-                            ))
-                        })?;
-                    }
-                    false
-                } else {
-                    drop(sessions);
-                    self.register_storeless_session_inner_sync_build_step(
-                        session_id.clone(),
-                        Some(Arc::clone(&candidate_materialization_claim_state)),
-                    )?
-                }
-            }
-        } else {
+        let (inserted_by_call, registration_guard) =
             Box::pin(self.register_session_inner_for_actor_materialization(
                 session_id.clone(),
                 Arc::clone(&candidate_materialization_claim_state),
+                attempt,
             ))
-            .await?
-        };
-        #[cfg(not(target_arch = "wasm32"))]
-        let inserted_by_call = Box::pin(self.register_session_inner_for_actor_materialization(
-            session_id.clone(),
-            Arc::clone(&candidate_materialization_claim_state),
-        ))
-        .await?;
+            .await?;
         tracing::debug!(
             %session_id,
             inserted_by_call,
@@ -2040,6 +2008,7 @@ impl MeerkatMachine {
         let mutation_guard = self
             .lock_current_durability_ready_session_mutation_gate(&session_id)
             .await?;
+        drop(registration_guard);
         let (
             driver_handle,
             epoch_id,
@@ -2649,6 +2618,7 @@ impl MeerkatMachine {
             .prepare_session_runtime_bindings_with_claim(
                 session_id.clone(),
                 preparation,
+                None,
                 claim_id,
                 false,
                 Some(&claim_state_slot),

--- a/meerkat-runtime/src/meerkat_machine/runtime_control.rs
+++ b/meerkat-runtime/src/meerkat_machine/runtime_control.rs
@@ -10637,11 +10637,12 @@ impl MeerkatMachine {
         &self,
         session_id: SessionId,
     ) -> Result<meerkat_core::SessionRuntimeBindings, RuntimeBindingsError> {
-        match Box::pin(self.prepare_session_runtime_bindings(
-            session_id.clone(),
-            super::dispatch_session::SessionBindingPreparation::AuthoritativeRuntimeBinding,
-        ))
-        .await
+        match self
+            .prepare_idempotent_session_runtime_bindings(
+                &session_id,
+                super::dispatch_session::SessionBindingPreparation::AuthoritativeRuntimeBinding,
+            )
+            .await
         {
             Ok(MeerkatMachineCommandResult::Bindings(bindings)) => Ok(bindings),
             Ok(_) => {
@@ -10711,13 +10712,14 @@ impl MeerkatMachine {
         &self,
         session_id: SessionId,
     ) -> Result<meerkat_core::SessionRuntimeBindings, RuntimeBindingsError> {
-        match Box::pin(self.prepare_session_runtime_bindings(
-            session_id.clone(),
-            super::dispatch_session::SessionBindingPreparation::LocalSessionResources(
-                super::LocalSessionMaterializationMode::Ordinary,
-            ),
-        ))
-        .await
+        match self
+            .prepare_idempotent_session_runtime_bindings(
+                &session_id,
+                super::dispatch_session::SessionBindingPreparation::LocalSessionResources(
+                    super::LocalSessionMaterializationMode::Ordinary,
+                ),
+            )
+            .await
         {
             Ok(MeerkatMachineCommandResult::Bindings(bindings)) => Ok(bindings),
             Ok(_) => {
@@ -10736,5 +10738,32 @@ impl MeerkatMachine {
                 err.to_string(),
             )),
         }
+    }
+
+    pub(super) async fn prepare_idempotent_session_runtime_bindings(
+        &self,
+        session_id: &SessionId,
+        preparation: super::dispatch_session::SessionBindingPreparation,
+    ) -> Result<MeerkatMachineCommandResult, RuntimeDriverError> {
+        let mut attempt = super::session_management::IdempotentBindingPreparationAttempt::new();
+        let first = Box::pin(self.prepare_session_runtime_bindings_with_attempt(
+            session_id.clone(),
+            preparation,
+            Some(&mut attempt),
+        ))
+        .await;
+        let error = match first {
+            Ok(result) => return Ok(result),
+            Err(error) => error,
+        };
+        if !attempt.wait_for_captured_unregister(session_id).await? {
+            return Err(error);
+        }
+        Box::pin(self.prepare_session_runtime_bindings_with_attempt(
+            session_id.clone(),
+            preparation,
+            Some(&mut attempt),
+        ))
+        .await
     }
 }

--- a/meerkat-runtime/src/meerkat_machine/session_management.rs
+++ b/meerkat-runtime/src/meerkat_machine/session_management.rs
@@ -21,7 +21,7 @@ enum UnregisterTeardownAdmission {
 
 #[derive(Clone, Copy, PartialEq, Eq)]
 enum UnregisterTeardownWait {
-    CallerGrace,
+    CallerGrace(meerkat_core::time_compat::Instant),
     UntilTerminal,
     ReturnObserver,
 }
@@ -130,6 +130,74 @@ impl UnregisterEntryIncarnationWitness {
 /// unregister saga. Elapsing this grace never cancels the saga or its exact
 /// runtime-loop JoinHandle; it only returns typed in-progress truth.
 const UNREGISTER_CALLER_WAIT_GRACE: std::time::Duration = std::time::Duration::from_secs(2);
+
+pub(super) struct IdempotentBindingPreparationAttempt {
+    deadline: meerkat_core::time_compat::Instant,
+    observer: Option<RuntimeSessionUnregisterObserver>,
+}
+
+impl IdempotentBindingPreparationAttempt {
+    pub(super) fn new() -> Self {
+        Self {
+            deadline: meerkat_core::time_compat::Instant::now() + UNREGISTER_CALLER_WAIT_GRACE,
+            observer: None,
+        }
+    }
+
+    pub(super) fn deadline(&self) -> meerkat_core::time_compat::Instant {
+        self.deadline
+    }
+
+    fn remaining(&self) -> std::time::Duration {
+        self.deadline
+            .checked_duration_since(meerkat_core::time_compat::Instant::now())
+            .unwrap_or_default()
+    }
+
+    fn capture(&mut self, observer: RuntimeSessionUnregisterObserver) {
+        self.observer.get_or_insert(observer);
+    }
+
+    pub(super) async fn wait_for_captured_unregister(
+        &mut self,
+        session_id: &SessionId,
+    ) -> Result<bool, RuntimeDriverError> {
+        let Some(mut observer) = self.observer.take() else {
+            return Ok(false);
+        };
+        if let Some(result) = observer.try_result()? {
+            return result.map(|()| true);
+        }
+        let remaining = self.remaining();
+        if remaining.is_zero() {
+            return Err(RuntimeDriverError::UnregisterInProgress {
+                runtime_id: LogicalRuntimeId::for_session(session_id),
+            });
+        }
+        let wait_for_result = async {
+            loop {
+                if let Some(result) = observer.try_result()? {
+                    return result;
+                }
+                observer.result_rx.changed().await.map_err(|_| {
+                    RuntimeDriverError::Internal(format!(
+                        "unregister coordinator result channel closed for session {session_id}"
+                    ))
+                })?;
+            }
+        };
+        match crate::tokio::time::timeout(remaining, wait_for_result).await {
+            Ok(result) => result.map(|()| true),
+            Err(_elapsed) => Err(RuntimeDriverError::UnregisterInProgress {
+                runtime_id: LogicalRuntimeId::for_session(session_id),
+            }),
+        }
+    }
+}
+
+fn unregister_caller_wait_deadline() -> meerkat_core::time_compat::Instant {
+    meerkat_core::time_compat::Instant::now() + UNREGISTER_CALLER_WAIT_GRACE
+}
 
 /// Maximum time an explicit stop caller waits for the independently-owned
 /// cleanup coordinator. The coordinator and exact executor remain owned after
@@ -1153,6 +1221,87 @@ async fn retire_ops_lifecycle_owner_for_unregister(
 }
 
 impl MeerkatMachine {
+    fn binding_unregister_observer(
+        &self,
+        session_id: &SessionId,
+        entry: &RuntimeSessionEntry,
+    ) -> Option<RuntimeSessionUnregisterObserver> {
+        let coordinator = entry.unregister_coordinator.as_ref()?;
+        (coordinator.epoch_id == entry.epoch_id).then(|| {
+            RuntimeSessionUnregisterObserver::new(
+                RuntimeSessionRegistrationWitness::new(
+                    Arc::downgrade(&self.shared),
+                    session_id.clone(),
+                    entry.epoch_id.clone(),
+                    Arc::downgrade(&entry.mutation_gate),
+                ),
+                coordinator.coordinator_id,
+                coordinator.result_rx.clone(),
+            )
+        })
+    }
+
+    async fn validate_binding_registration_transaction(
+        &self,
+        session_id: &SessionId,
+        attempt: &mut IdempotentBindingPreparationAttempt,
+    ) -> Result<(), RuntimeDriverError> {
+        let sessions = self.sessions.read().await;
+        if let Some(entry) = sessions.get(session_id)
+            && let Some(error) = entry.registration_blocked_by_unregister(session_id)
+        {
+            if matches!(error, RuntimeDriverError::NotReady { .. })
+                && let Some(observer) = self.binding_unregister_observer(session_id, entry)
+            {
+                attempt.capture(observer);
+            }
+            return Err(error);
+        }
+        Ok(())
+    }
+
+    async fn lock_binding_registration_transaction(
+        &self,
+        session_id: &SessionId,
+        attempt: &mut IdempotentBindingPreparationAttempt,
+    ) -> Result<crate::tokio::sync::OwnedMutexGuard<()>, RuntimeDriverError> {
+        self.validate_binding_registration_transaction(session_id, attempt)
+            .await?;
+
+        let slot = self.session_registration_transaction_slot(session_id);
+        let remaining = attempt.remaining();
+        if !remaining.is_zero()
+            && let Ok(guard) = crate::tokio::time::timeout(
+                remaining,
+                self.lock_session_registration_transaction(session_id),
+            )
+            .await
+        {
+            self.validate_binding_registration_transaction(session_id, attempt)
+                .await?;
+            return Ok(guard);
+        }
+        if let Ok(guard) = Arc::clone(&slot).try_lock_owned() {
+            self.validate_binding_registration_transaction(session_id, attempt)
+                .await?;
+            return Ok(guard);
+        }
+        let sessions = self.sessions.read().await;
+        if let Some(entry) = sessions.get(session_id)
+            && let Some(error) = entry.registration_blocked_by_unregister(session_id)
+        {
+            if matches!(error, RuntimeDriverError::NotReady { .. })
+                && let Some(observer) = self.binding_unregister_observer(session_id, entry)
+            {
+                attempt.capture(observer);
+            }
+            return Err(error);
+        }
+        Err(RuntimeDriverError::Internal(format!(
+            "session registration transaction remained busy past binding preparation deadline for {session_id}"
+        )))
+    }
+
     /// Acquire the same session-scoped lease as `live/open`. A missing session
     /// is idempotent (`Ok(None)`). The unregister owner opens `Draining` under
     /// the matching mutation gate before proving physical channel absence, so
@@ -1569,37 +1718,115 @@ impl MeerkatMachine {
         &self,
         session_id: SessionId,
         claim_state: Arc<std::sync::Mutex<crate::RuntimeActorMaterializationClaimState>>,
-    ) -> Result<bool, RuntimeDriverError> {
+        attempt: Option<&mut IdempotentBindingPreparationAttempt>,
+    ) -> Result<(bool, crate::tokio::sync::OwnedMutexGuard<()>), RuntimeDriverError> {
+        let (outcome, registration_guard) = self
+            .register_session_settling_cold_recovered_drain_with_transaction(
+                &session_id,
+                Some(claim_state),
+                attempt,
+            )
+            .await?;
+        Ok((outcome.inserted(), registration_guard))
+    }
+
+    pub(super) async fn register_session_settling_cold_recovered_drain(
+        &self,
+        session_id: &SessionId,
+        materialization_claim_state: Option<
+            Arc<std::sync::Mutex<crate::RuntimeActorMaterializationClaimState>>,
+        >,
+    ) -> Result<RegisterSessionInnerOutcome, RuntimeDriverError> {
+        let (outcome, _registration_guard) = self
+            .register_session_settling_cold_recovered_drain_with_transaction(
+                session_id,
+                materialization_claim_state,
+                None,
+            )
+            .await?;
+        Ok(outcome)
+    }
+
+    async fn register_session_settling_cold_recovered_drain_with_transaction(
+        &self,
+        session_id: &SessionId,
+        materialization_claim_state: Option<
+            Arc<std::sync::Mutex<crate::RuntimeActorMaterializationClaimState>>,
+        >,
+        mut attempt: Option<&mut IdempotentBindingPreparationAttempt>,
+    ) -> Result<
+        (
+            RegisterSessionInnerOutcome,
+            crate::tokio::sync::OwnedMutexGuard<()>,
+        ),
+        RuntimeDriverError,
+    > {
         // Settle a cold-recovered unregister drain before reporting the
         // registration. Collapsing the witness to a bool here (as this did
         // through 0.8.23) hid `InsertedColdRecoveredDraining` from actor
         // materialization, which then staged RegisterSession into a Draining
         // authority and got a bare guard rejection - the permanent
         // resume wedge.
-        self.register_session_settling_cold_recovered_drain(&session_id, Some(claim_state))
-            .await
-            .map(RegisterSessionInnerOutcome::inserted)
-    }
-
-    async fn register_session_inner_with_materialization_origin(
-        &self,
-        session_id: SessionId,
-        materialization_claim_state: Option<
-            Arc<std::sync::Mutex<crate::RuntimeActorMaterializationClaimState>>,
-        >,
-    ) -> Result<RegisterSessionInnerOutcome, RuntimeDriverError> {
-        // Serialize the full absent-check -> durable recovery/epoch selection
-        // -> map publication transaction with final unregister removal. The
-        // session mutation gate does not exist while the entry is absent, so it
-        // cannot close this ABA window by itself.
-        let _registration_transaction_guard = self
-            .lock_session_registration_transaction(&session_id)
-            .await;
-        self.register_session_inner_under_registration_transaction(
-            session_id,
-            materialization_claim_state,
-        )
-        .await
+        let mut registration_guard = match attempt.as_deref_mut() {
+            Some(attempt) => {
+                self.lock_binding_registration_transaction(session_id, attempt)
+                    .await?
+            }
+            None => self.lock_session_registration_transaction(session_id).await,
+        };
+        let mut outcome = self
+            .register_session_inner_under_registration_transaction(
+                session_id.clone(),
+                materialization_claim_state.clone(),
+            )
+            .await?;
+        if outcome == RegisterSessionInnerOutcome::InsertedColdRecoveredDraining {
+            let epoch_id = {
+                let sessions = self.sessions.read().await;
+                sessions
+                    .get(session_id)
+                    .map(|entry| entry.epoch_id.clone())
+                    .ok_or(RuntimeDriverError::NotReady {
+                        state: RuntimeState::Destroyed,
+                    })?
+            };
+            drop(registration_guard);
+            let wait = attempt
+                .as_ref()
+                .map_or(UnregisterTeardownWait::UntilTerminal, |attempt| {
+                    UnregisterTeardownWait::CallerGrace(attempt.deadline())
+                });
+            self.join_or_start_unregister_teardown_with_admission(
+                session_id,
+                Some(&epoch_id),
+                UnregisterTeardownCaller::Explicit,
+                UnregisterTeardownAdmission::AnyCurrentRegistration,
+                None,
+                wait,
+            )
+            .await?
+            .require_completed()?;
+            registration_guard = match attempt {
+                Some(attempt) => {
+                    self.lock_binding_registration_transaction(session_id, attempt)
+                        .await?
+                }
+                None => self.lock_session_registration_transaction(session_id).await,
+            };
+            outcome = self
+                .register_session_inner_under_registration_transaction(
+                    session_id.clone(),
+                    materialization_claim_state,
+                )
+                .await?;
+            if outcome == RegisterSessionInnerOutcome::InsertedColdRecoveredDraining {
+                return Err(RuntimeDriverError::Internal(format!(
+                    "session {session_id} re-entered a cold-recovered unregister drain window \
+                     immediately after its teardown was concluded"
+                )));
+            }
+        }
+        Ok((outcome, registration_guard))
     }
 
     /// Register while the caller owns this session's stable absent-entry
@@ -2446,82 +2673,6 @@ impl MeerkatMachine {
                 Ok(RegisterSessionInnerOutcome::Inserted)
             }
         }
-    }
-
-    /// Register, concluding a cold-recovered unregister drain window first.
-    ///
-    /// A `Draining` image reconstructed from the durable unregister retry
-    /// record names producer obligations that belonged to a process which is
-    /// gone; `UnregisterTeardownMechanicalObservations::
-    /// from_durable_process_recovery` already records closing them as a
-    /// forced, process-loss disposition rather than clean quiescence. So the
-    /// escape from `Draining` is to CONCLUDE the teardown through its owning
-    /// authority, never to re-admit past open obligations: the three drain
-    /// feedback inputs are each guarded on `unregister_draining`, so moving
-    /// `registration_phase` off `Draining` while any obligation is open would
-    /// make a late producer's own completion unroutable.
-    ///
-    /// Through 0.8.23 no caller concluded it. A first turn that failed
-    /// terminally left the CLI unable to finish teardown, and every later
-    /// registration - resume included - was guard-rejected by construction,
-    /// which is why an incomplete cleanup read as a permanent verdict on the
-    /// session. This is the same settlement `ensure_runtime_executor_attachment`
-    /// already performs through `ExistingExecutorClaim::JoinUnregister`; it is
-    /// reused, not reimplemented.
-    ///
-    /// Called with NO session mutation gate held: the teardown takes the
-    /// session registration transaction and the exact mutation gate itself.
-    pub(super) async fn register_session_settling_cold_recovered_drain(
-        &self,
-        session_id: &SessionId,
-        materialization_claim_state: Option<
-            Arc<std::sync::Mutex<crate::RuntimeActorMaterializationClaimState>>,
-        >,
-    ) -> Result<RegisterSessionInnerOutcome, RuntimeDriverError> {
-        let outcome = self
-            .register_session_inner_with_materialization_origin(
-                session_id.clone(),
-                materialization_claim_state.clone(),
-            )
-            .await?;
-        if outcome != RegisterSessionInnerOutcome::InsertedColdRecoveredDraining {
-            return Ok(outcome);
-        }
-        let epoch_id = {
-            let sessions = self.sessions.read().await;
-            sessions
-                .get(session_id)
-                .map(|entry| entry.epoch_id.clone())
-                .ok_or(RuntimeDriverError::NotReady {
-                    state: RuntimeState::Destroyed,
-                })?
-        };
-        self.join_or_start_unregister_teardown_with_admission(
-            session_id,
-            Some(&epoch_id),
-            UnregisterTeardownCaller::Explicit,
-            UnregisterTeardownAdmission::AnyCurrentRegistration,
-            None,
-            UnregisterTeardownWait::UntilTerminal,
-        )
-        .await?;
-        // The settled teardown removed the exact entry, so this registration
-        // starts on a fresh authority. One retry only: a second cold-recovered
-        // drain here would mean the settlement did not remove what it just
-        // concluded, which is an authority defect and not something to spin on.
-        let readmitted = self
-            .register_session_inner_with_materialization_origin(
-                session_id.clone(),
-                materialization_claim_state,
-            )
-            .await?;
-        if readmitted == RegisterSessionInnerOutcome::InsertedColdRecoveredDraining {
-            return Err(RuntimeDriverError::Internal(format!(
-                "session {session_id} re-entered a cold-recovered unregister drain window \
-                 immediately after its teardown was concluded"
-            )));
-        }
-        Ok(readmitted)
     }
 
     pub(super) async fn unregister_session_inner_if_epoch(
@@ -5413,7 +5564,7 @@ impl MeerkatMachine {
             UnregisterTeardownCaller::Explicit,
             UnregisterTeardownAdmission::ExactTerminalUnattachedRegistration,
             Some(witness),
-            UnregisterTeardownWait::CallerGrace,
+            UnregisterTeardownWait::CallerGrace(unregister_caller_wait_deadline()),
         )
         .await?
         .require_completed()
@@ -6004,7 +6155,7 @@ impl MeerkatMachine {
             UnregisterTeardownCaller::Explicit,
             UnregisterTeardownAdmission::AnyCurrentRegistration,
             Some(registration),
-            UnregisterTeardownWait::CallerGrace,
+            UnregisterTeardownWait::CallerGrace(unregister_caller_wait_deadline()),
         )
         .await?
         .require_completed()
@@ -6868,7 +7019,7 @@ impl MeerkatMachine {
             caller,
             UnregisterTeardownAdmission::AnyCurrentRegistration,
             None,
-            UnregisterTeardownWait::CallerGrace,
+            UnregisterTeardownWait::CallerGrace(unregister_caller_wait_deadline()),
         )
         .await
         .and_then(UnregisterTeardownWaitOutcome::require_completed)
@@ -7267,13 +7418,11 @@ impl MeerkatMachine {
             UnregisterTeardownWait::UntilTerminal => wait_for_owned_result
                 .await
                 .map(|()| UnregisterTeardownWaitOutcome::Completed(true)),
-            UnregisterTeardownWait::CallerGrace => {
-                match crate::tokio::time::timeout(
-                    UNREGISTER_CALLER_WAIT_GRACE,
-                    wait_for_owned_result,
-                )
-                .await
-                {
+            UnregisterTeardownWait::CallerGrace(deadline) => {
+                let remaining = deadline
+                    .checked_duration_since(meerkat_core::time_compat::Instant::now())
+                    .unwrap_or_default();
+                match crate::tokio::time::timeout(remaining, wait_for_owned_result).await {
                     Ok(result) => result.map(|()| UnregisterTeardownWaitOutcome::Completed(true)),
                     Err(_elapsed) => Err(RuntimeDriverError::UnregisterInProgress {
                         runtime_id: LogicalRuntimeId::for_session(session_id),

--- a/meerkat-runtime/src/meerkat_machine_tests.rs
+++ b/meerkat-runtime/src/meerkat_machine_tests.rs
@@ -16050,6 +16050,332 @@ mod stop_teardown_coordinator_class {
     }
 
     #[tokio::test]
+    async fn prepare_bindings_joins_retained_unregister_before_fresh_registration() {
+        let machine = Arc::new(MeerkatMachine::ephemeral());
+        let session_id = SessionId::new();
+        let cleanup_started = Arc::new(Notify::new());
+        let release_cleanup = Arc::new(Notify::new());
+        let cleanup_calls = Arc::new(AtomicUsize::new(0));
+        machine
+            .register_session_with_executor(
+                session_id.clone(),
+                Box::new(GatedCleanupExecutor {
+                    machine: Arc::clone(&machine),
+                    session_id: session_id.clone(),
+                    cleanup_started: Arc::clone(&cleanup_started),
+                    release_cleanup: Arc::clone(&release_cleanup),
+                    unregister_during_cleanup: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+                    fail_cleanup_attempts: Arc::new(AtomicUsize::new(0)),
+                    cleanup_calls: Arc::clone(&cleanup_calls),
+                    loop_task_id: Arc::new(std::sync::Mutex::new(None)),
+                    cleanup_task_id: Arc::new(std::sync::Mutex::new(None)),
+                }),
+            )
+            .await
+            .expect("runtime executor registration should succeed");
+        let predecessor = machine
+            .current_session_registration_witness(&session_id)
+            .await
+            .expect("predecessor registration should expose exact epoch authority");
+        let unregister = {
+            let machine = Arc::clone(&machine);
+            let session_id = session_id.clone();
+            tokio::spawn(async move { machine.unregister_session(&session_id).await })
+        };
+        tokio::time::timeout(Duration::from_secs(1), cleanup_started.notified())
+            .await
+            .expect("owned teardown must retain the deterministic cleanup gate");
+        let prepare = {
+            let machine = Arc::clone(&machine);
+            let session_id = session_id.clone();
+            tokio::spawn(async move { machine.prepare_bindings(session_id).await })
+        };
+        tokio::task::yield_now().await;
+        assert!(!prepare.is_finished());
+
+        release_cleanup.notify_one();
+        unregister
+            .await
+            .expect("unregister task should not panic")
+            .expect("the original unregister owner should complete");
+        let bindings = tokio::time::timeout(Duration::from_secs(2), prepare)
+            .await
+            .expect("binding preparation must finish after unregister settlement")
+            .expect("binding preparation task should not panic")
+            .expect("binding preparation must retry under fresh registration authority");
+        assert_ne!(bindings.epoch_id(), predecessor.epoch_id());
+        assert_eq!(cleanup_calls.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn prepare_bindings_returns_typed_in_progress_when_unregister_outlives_grace() {
+        let machine = Arc::new(MeerkatMachine::ephemeral());
+        let session_id = SessionId::new();
+        let cleanup_started = Arc::new(Notify::new());
+        let release_cleanup = Arc::new(Notify::new());
+        machine
+            .register_session_with_executor(
+                session_id.clone(),
+                Box::new(GatedCleanupExecutor {
+                    machine: Arc::clone(&machine),
+                    session_id: session_id.clone(),
+                    cleanup_started: Arc::clone(&cleanup_started),
+                    release_cleanup: Arc::clone(&release_cleanup),
+                    unregister_during_cleanup: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+                    fail_cleanup_attempts: Arc::new(AtomicUsize::new(0)),
+                    cleanup_calls: Arc::new(AtomicUsize::new(0)),
+                    loop_task_id: Arc::new(std::sync::Mutex::new(None)),
+                    cleanup_task_id: Arc::new(std::sync::Mutex::new(None)),
+                }),
+            )
+            .await
+            .expect("runtime executor registration should succeed");
+        let unregister = {
+            let machine = Arc::clone(&machine);
+            let session_id = session_id.clone();
+            tokio::spawn(async move { machine.unregister_session(&session_id).await })
+        };
+        tokio::time::timeout(Duration::from_secs(1), cleanup_started.notified())
+            .await
+            .expect("owned teardown must retain the deterministic cleanup gate");
+
+        let error = tokio::time::timeout(
+            Duration::from_secs(3),
+            machine.prepare_idempotent_session_runtime_bindings(
+                &session_id,
+                crate::meerkat_machine::dispatch_session::SessionBindingPreparation::AuthoritativeRuntimeBinding,
+            ),
+        )
+        .await
+        .expect("binding preparation observation must remain caller-bounded")
+        .expect_err("retained unregister must remain typed in progress");
+        assert!(matches!(
+            error,
+            RuntimeDriverError::UnregisterInProgress { runtime_id }
+                if runtime_id == LogicalRuntimeId::for_session(&session_id)
+        ));
+        release_cleanup.notify_one();
+        let _ = unregister.await;
+    }
+
+    #[tokio::test]
+    async fn prepare_bindings_without_unregister_uses_direct_registration_path() {
+        let inner = Arc::new(crate::store::InMemoryRuntimeStore::new());
+        let store = Arc::new(RuntimeCommitAtomicityStore::pass_through(Arc::clone(
+            &inner,
+        )));
+        let machine = MeerkatMachine::persistent(
+            store.clone() as Arc<dyn crate::store::RuntimeStore>,
+            memory_blob_store(),
+        );
+        let session_id = SessionId::new();
+        let first = machine
+            .prepare_bindings(session_id.clone())
+            .await
+            .expect("first direct binding preparation should succeed");
+        let lifecycle_writes = store.commit_machine_lifecycle_calls();
+        let second = tokio::time::timeout(
+            Duration::from_secs(1),
+            machine.prepare_bindings(session_id.clone()),
+        )
+        .await
+        .expect("stable no-saga binding preparation must not wait")
+        .expect("idempotent binding preparation should succeed");
+        assert_eq!(second.epoch_id(), first.epoch_id());
+        assert_eq!(
+            store.commit_machine_lifecycle_calls(),
+            lifecycle_writes,
+            "no-saga idempotent preparation must not perform durable lifecycle I/O"
+        );
+    }
+
+    #[tokio::test]
+    async fn cold_recovered_unregister_uses_one_caller_grace_for_binding_preparation() {
+        let inner = Arc::new(crate::store::InMemoryRuntimeStore::new());
+        let store = Arc::new(RuntimeCommitAtomicityStore::pass_through(Arc::clone(
+            &inner,
+        )));
+        let first_machine = Arc::new(MeerkatMachine::persistent(
+            store.clone() as Arc<dyn crate::store::RuntimeStore>,
+            memory_blob_store(),
+        ));
+        let session_id = SessionId::new();
+        first_machine
+            .register_session(session_id.clone())
+            .await
+            .expect("first process should register the session");
+        let calls_before = store.commit_machine_lifecycle_calls();
+        store.fail_commit_machine_lifecycle_on_call(calls_before + 2);
+        let first_error = first_machine
+            .unregister_session(&session_id)
+            .await
+            .expect_err("first process should retain a durable unregister prefix");
+        assert!(matches!(
+            first_error,
+            RuntimeDriverError::RecoveryRepairBlocked { .. }
+        ));
+        drop(first_machine);
+
+        let persist_entered = Arc::new(Notify::new());
+        let release_persist = Arc::new(Notify::new());
+        store.arm_block_commit_machine_lifecycle_after_commit(
+            Arc::clone(&persist_entered),
+            Arc::clone(&release_persist),
+        );
+        let recovered = Arc::new(MeerkatMachine::persistent(
+            store as Arc<dyn crate::store::RuntimeStore>,
+            memory_blob_store(),
+        ));
+        let started_at = tokio::time::Instant::now();
+        let prepare = {
+            let recovered = Arc::clone(&recovered);
+            let session_id = session_id.clone();
+            tokio::spawn(async move {
+                recovered
+                    .prepare_idempotent_session_runtime_bindings(
+                        &session_id,
+                        crate::meerkat_machine::dispatch_session::SessionBindingPreparation::AuthoritativeRuntimeBinding,
+                    )
+                    .await
+            })
+        };
+        tokio::time::timeout(Duration::from_secs(1), persist_entered.notified())
+            .await
+            .expect("cold-recovered teardown should reach the blocked persistence seam");
+        let error = tokio::time::timeout(Duration::from_secs(3), prepare)
+            .await
+            .expect("cold-recovered binding preparation must remain caller-bounded")
+            .expect("binding preparation task should not panic")
+            .expect_err("blocked cold teardown must remain typed in progress");
+        assert!(matches!(
+            error,
+            RuntimeDriverError::UnregisterInProgress { runtime_id }
+                if runtime_id == LogicalRuntimeId::for_session(&session_id)
+        ));
+        assert!(
+            started_at.elapsed() < Duration::from_secs(3),
+            "cold recovery must not mint a second caller-grace window"
+        );
+        release_persist.notify_one();
+    }
+
+    #[tokio::test]
+    async fn prepare_bindings_holds_registration_transaction_until_mutation_gate() {
+        let machine = Arc::new(MeerkatMachine::ephemeral());
+        let session_id = SessionId::new();
+        machine
+            .register_session(session_id.clone())
+            .await
+            .expect("runtime registration should succeed");
+        let held_mutation = machine
+            .lock_current_durability_ready_session_mutation_gate(&session_id)
+            .await
+            .expect("test should hold the current mutation gate");
+        let transaction_probe =
+            machine.probe_next_session_registration_transaction_contention_for_test(&session_id);
+        let prepare = {
+            let machine = Arc::clone(&machine);
+            let session_id = session_id.clone();
+            tokio::spawn(async move { machine.prepare_bindings(session_id).await })
+        };
+        assert!(
+            !tokio::time::timeout(Duration::from_secs(1), transaction_probe)
+                .await
+                .expect("preparation must enter the registration transaction")
+                .expect("registration contention probe must report")
+        );
+        let competing_transaction = {
+            let machine = Arc::clone(&machine);
+            let session_id = session_id.clone();
+            tokio::spawn(async move {
+                machine
+                    .lock_session_registration_transaction(&session_id)
+                    .await
+            })
+        };
+        tokio::time::sleep(Duration::from_millis(25)).await;
+        assert!(
+            !competing_transaction.is_finished(),
+            "preparation must retain registration authority while awaiting the mutation gate"
+        );
+        drop(held_mutation);
+        let bindings = tokio::time::timeout(Duration::from_secs(1), prepare)
+            .await
+            .expect("binding preparation must acquire the released mutation gate")
+            .expect("binding preparation task should not panic")
+            .expect("binding preparation should succeed");
+        assert_eq!(bindings.session_id(), &session_id);
+        drop(
+            competing_transaction
+                .await
+                .expect("competing transaction task should not panic"),
+        );
+    }
+
+    #[tokio::test]
+    async fn prepare_bindings_rechecks_coordinator_after_transaction_wait() {
+        let machine = Arc::new(MeerkatMachine::ephemeral());
+        let session_id = SessionId::new();
+        machine
+            .register_session(session_id.clone())
+            .await
+            .expect("runtime registration should succeed");
+        let held_transaction = machine
+            .lock_session_registration_transaction(&session_id)
+            .await;
+        let transaction_probe =
+            machine.probe_next_session_registration_transaction_contention_for_test(&session_id);
+        let prepare = {
+            let machine = Arc::clone(&machine);
+            let session_id = session_id.clone();
+            tokio::spawn(async move { machine.prepare_bindings(session_id).await })
+        };
+        assert!(
+            tokio::time::timeout(Duration::from_secs(1), transaction_probe)
+                .await
+                .expect("preparation must reach the contended transaction")
+                .expect("registration contention probe must report")
+        );
+
+        let (result_tx, result_rx) = crate::tokio::sync::watch::channel(None);
+        {
+            let mut sessions = machine.sessions.write().await;
+            let entry = sessions
+                .get_mut(&session_id)
+                .expect("registered session must remain present");
+            entry.unregister_coordinator = Some(UnregisterTeardownCoordinator {
+                epoch_id: entry.epoch_id.clone(),
+                coordinator_id: uuid::Uuid::new_v4(),
+                result_rx,
+            });
+        }
+        drop(held_transaction);
+        tokio::time::timeout(Duration::from_secs(1), async {
+            while result_tx.receiver_count() < 2 {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("post-transaction recheck must capture the exact coordinator");
+        machine
+            .sessions
+            .write()
+            .await
+            .get_mut(&session_id)
+            .expect("registered session must remain present")
+            .unregister_coordinator = None;
+        result_tx
+            .send(Some(Ok(())))
+            .expect("captured observer must remain subscribed");
+        let bindings = tokio::time::timeout(Duration::from_secs(1), prepare)
+            .await
+            .expect("binding preparation must remain bounded")
+            .expect("binding preparation task should not panic")
+            .expect("terminal coordinator evidence must authorize one retry");
+        assert_eq!(bindings.session_id(), &session_id);
+    }
+
+    #[tokio::test]
     async fn noncooperative_interrupt_and_executor_return_in_progress_then_converge() {
         let store = Arc::new(crate::store::InMemoryRuntimeStore::new());
         let machine = Arc::new(MeerkatMachine::persistent(


### PR DESCRIPTION
## Summary

- carry one caller-grace deadline through idempotent binding preparation and cold unregister settlement
- atomically retain the existing registration transaction through the registration-to-mutation-gate handoff, with exact coordinator checks before and after transaction acquisition
- observe only the captured exact unregister coordinator and retry the original preparation exactly once after terminal success
- preserve unrelated/finalization errors, coordinator ownership, and the direct no-saga path

## WASM/storeless scope

The wasm32 storeless existing-check branch is intentionally unified into the same registration-transaction path used by native preparation. This removes a separate prepare-only fast path that could not participate in the atomic T-to-M handoff. The canonical `make wasm-check` check and Clippy lanes pass.

## Exact evidence

- commit: `1c8592310e091da815e5c52234f5289da5d79d2d`
- tree: `fdf0dc1f5e767d7c77152a39fa9db55ed997d573`
- four tracked files only; `AGENT-INTRO-0831.md` excluded
- full unregister coordinator class: 24/24 pass
- strict `meerkat-runtime` all-feature/all-target Clippy: pass
- canonical `make wasm-check`: check + Clippy pass
- standard pre-push: every hook passed, including deterministic workspace unit/integration/e2e
- mutation proofs:
  - removing the post-T coordinator recheck makes the deterministic queued-T regression fail
  - dropping T before acquiring M makes the transaction-handoff regression fail

## Semantics

- one absolute caller-grace deadline; no remint on cold settlement or retry
- T is held through unchanged M acquisition; no timeout wraps authority-bearing M work
- active exact coordinator timeout returns typed `UnregisterInProgress`
- T contention without unregister evidence returns an internal contention error, not a false unregister claim
- no mailbox, machine field, side store, replacement coordinator, loop, or string retry
