### PR TITLE
fix(release): evaluate the release workflow contract instead of grepping it

### DIFF
--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -640,6 +640,12 @@ jobs:
       - name: Verify release crate enumeration gate still fails closed
         run: scripts/test-crate-enumeration-gate.sh
 
+      # The release doctor asserts release.yml behaviour under concrete events.
+      # This proves equivalent rewordings pass and dropped behaviour fails, so
+      # the doctor and the workflow cannot drift apart silently again (#1091).
+      - name: Verify release doctor workflow assertions still bind
+        run: scripts/test-release-doctor-workflow-contract.sh
+
       - name: Verify parallel release packaging stays isolated and fails closed
         run: make check-rust-release-packaging-contract
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -232,6 +232,14 @@ repos:
         always_run: true
         stages: [pre-push]
 
+      - id: release-doctor-workflow-contract
+        name: release doctor workflow assertions survive rewording and reject removal
+        entry: scripts/test-release-doctor-workflow-contract.sh
+        language: script
+        pass_filenames: false
+        always_run: true
+        stages: [pre-push]
+
       - id: release-packaging-isolation-contract
         name: parallel release packaging isolates outputs and preserves failures
         entry: scripts/test-release-packaging-isolation.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -376,6 +376,18 @@ them.
   that writes to stderr only, because stdout is the MCP JSON channel. Hosts
   that launch `rkat-mcp` observe new stderr output; stdout framing is
   unchanged.
+- `make release-doctor` no longer fails on a healthy main after the release
+  workflow is reworded. The "exact-tree pre-tag semver evidence" and "30
+  minute tag-to-public SLO" checks now evaluate `release.yml` job and step
+  conditions under concrete events (tag push, package recovery, explicit
+  historical evidence) through `scripts/check_release_workflow_contract.py`
+  instead of grepping literal lines, so folding an `if:` across lines or
+  passing `--slo-seconds` as a `${{ }}` expression passes while gating the
+  evidence step off tags, rerunning `make semver-breaks` on a tag, or relaxing
+  the 1800 second SLO still fails and names the defect.
+  `scripts/test-release-doctor-workflow-contract.sh` (pre-push, CI ratchets,
+  and `make release-doctor`) proves both halves on fixtures derived from the
+  committed workflow, so the doctor and the workflow cannot drift silently.
 
 ## [0.8.33] - 2026-09-04
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -411,7 +411,7 @@ Installed via `make install-hooks`. Two stages:
 - `scripts/pre-push-audit-generated-headers.sh`
 - `scripts/pre-push-bridge-no-responsestatus.sh` (thin wrapper over `xtask bridge-classifier`)
 - `scripts/pre-push-bazel-locks.sh` (generated BUILD freshness, offline MODULE.bazel.lock recorded-input check, `bb mod deps --lockfile_mode=error` when the pinned CLI is present; `--require-bb` makes that last gate mandatory and the release preflight passes it)
-- `scripts/test-lock-consistency-gate.sh`, `scripts/test-bazel-module-lock-gate.sh`, `scripts/test-crate-enumeration-gate.sh` (contract tests: each new release-infra gate must still fail on the defect it was written for)
+- `scripts/test-lock-consistency-gate.sh`, `scripts/test-bazel-module-lock-gate.sh`, `scripts/test-crate-enumeration-gate.sh`, `scripts/test-release-doctor-workflow-contract.sh` (contract tests: each new release-infra gate must still fail on the defect it was written for; the last one also proves the release doctor's `release.yml` assertions survive rewording)
 - `scripts/pre-push-unit.sh` (deterministic local gate: Cargo `unit` plus `e2e-fast` by default, or matching BuildBuddy lanes when `MEERKAT_BUILDBUDDY=1`; includes per-tree cache, serialized runs, and timeout retry)
 
 **Manual local preflight**:

--- a/Makefile
+++ b/Makefile
@@ -699,6 +699,7 @@ regen-schemas:
 release-doctor:
 	@echo "$(GREEN)Checking release environment...$(NC)"
 	@scripts/test-release-npm-publish-preflight.sh
+	@scripts/test-release-doctor-workflow-contract.sh
 	@scripts/release-doctor
 
 # Semver-break detection (M3 policy: exact-pin + break detection). 0.x patch

--- a/scripts/check_release_workflow_contract.py
+++ b/scripts/check_release_workflow_contract.py
@@ -1,0 +1,531 @@
+#!/usr/bin/env python3
+"""Semantic release-workflow contract checks for the release doctor.
+
+The doctor used to assert release-workflow behaviour by grepping literal lines
+out of `.github/workflows/release.yml`. Two of those greps went stale the
+moment the workflow was reflowed (a folded `if: >-` condition and a
+`--slo-seconds ${{ ... }}` expression), so `make release-doctor` failed on a
+main branch whose behaviour had not changed (#1091).
+
+This module asserts what the workflow DOES instead of how it is spelled. It
+extracts a job, splits it into steps, and evaluates each step's `if:` and the
+`${{ }}` expressions in its `run:` body under concrete event contexts (a tag
+push, a package-recovery dispatch, an explicit historical-evidence dispatch).
+Reflowing a condition across lines, collapsing it onto one line, or rewriting
+an expression into an equivalent one all pass; gating a step off tag pushes,
+re-enabling the long measurement on tags, or relaxing the 30 minute SLO all
+fail and name the defect.
+
+Only the Python standard library is used, so the doctor and its contract test
+run wherever `python3` does.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from collections.abc import Callable, Iterable
+from dataclasses import dataclass, field
+from pathlib import Path
+
+DEFAULT_WORKFLOW = Path(".github/workflows/release.yml")
+TAG_SLO_SECONDS = 1800
+
+SEMVER_GATE_JOB = "release_semver_gate"
+REGISTRY_JOB = "publish_registries"
+# The evidence step is the one that resolves the exact-tree readiness artifact.
+EVIDENCE_ARTIFACT_PREFIX = "meerkat-semver-attestation-main-"
+# The long measurement the tag path must never rerun.
+MEASUREMENT_COMMAND = "make semver-breaks"
+PUBLIC_VERIFIER = "scripts/verify-rust-release-public.py"
+
+
+class ContractError(Exception):
+    """A structural precondition the checker cannot see past."""
+
+
+class UnsupportedExpression(ContractError):
+    """The workflow uses expression syntax this evaluator does not model."""
+
+
+# --------------------------------------------------------------------------
+# Workflow extraction (line-oriented, no YAML dependency)
+# --------------------------------------------------------------------------
+
+JOB_HEADER = re.compile(r"^  ([A-Za-z0-9_-]+):\s*(?:#.*)?$")
+STEP_START = re.compile(r"^      - ")
+KEY_LINE = re.compile(r"^(\s*)([A-Za-z0-9_-]+):(.*)$")
+
+
+def _indent(line: str) -> int:
+    return len(line) - len(line.lstrip(" "))
+
+
+def job_block(text: str, job_name: str) -> list[str]:
+    lines = text.splitlines()
+    start = None
+    for index, line in enumerate(lines):
+        match = JOB_HEADER.match(line)
+        if match and match.group(1) == job_name:
+            start = index
+            break
+    if start is None:
+        raise ContractError(f"job `{job_name}` is not defined in the workflow")
+    end = len(lines)
+    for index in range(start + 1, len(lines)):
+        if JOB_HEADER.match(lines[index]):
+            end = index
+            break
+    return lines[start + 1 : end]
+
+
+def parse_mapping(lines: list[str], indent: int) -> dict[str, str]:
+    """Collect `key: value` pairs at exactly `indent`, folding nested scalars.
+
+    A value on the key line is kept verbatim (plus any more-indented plain
+    continuation lines). A block scalar (`|`, `>`, with optional chomping
+    indicator) or a nested mapping is folded into one string: literal blocks
+    keep newlines, everything else is joined with single spaces. Comment and
+    blank lines between keys are skipped.
+    """
+    mapping: dict[str, str] = {}
+    index = 0
+    while index < len(lines):
+        line = lines[index]
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            index += 1
+            continue
+        match = KEY_LINE.match(line)
+        if not match or len(match.group(1)) != indent:
+            index += 1
+            continue
+        key = match.group(2)
+        remainder = match.group(3).strip()
+        index += 1
+        continuation: list[str] = []
+        while index < len(lines):
+            candidate = lines[index]
+            if candidate.strip() and _indent(candidate) <= indent:
+                break
+            continuation.append(candidate)
+            index += 1
+        if re.fullmatch(r"[|>][+-]?", remainder):
+            joiner = "\n" if remainder.startswith("|") else " "
+            body = [entry.strip() for entry in continuation if entry.strip()]
+            mapping[key] = joiner.join(body)
+        else:
+            parts = [remainder] if remainder else []
+            parts.extend(entry.strip() for entry in continuation if entry.strip())
+            mapping[key] = " ".join(parts)
+    return mapping
+
+
+@dataclass
+class Step:
+    fields: dict[str, str]
+
+    @property
+    def name(self) -> str:
+        return self.fields.get("name", "<unnamed step>")
+
+    @property
+    def condition(self) -> str | None:
+        return self.fields.get("if")
+
+    @property
+    def run(self) -> str:
+        return self.fields.get("run", "")
+
+
+def job_steps(block: list[str]) -> list[Step]:
+    steps: list[Step] = []
+    in_steps = False
+    current: list[str] | None = None
+    for line in block:
+        if re.match(r"^    steps:\s*$", line):
+            in_steps = True
+            continue
+        if not in_steps:
+            continue
+        if line.strip() and _indent(line) < 6:
+            break
+        if STEP_START.match(line):
+            if current is not None:
+                steps.append(Step(parse_mapping(current, 8)))
+            current = ["        " + line[8:]]
+            continue
+        if current is not None:
+            current.append(line)
+    if current is not None:
+        steps.append(Step(parse_mapping(current, 8)))
+    if not steps:
+        raise ContractError("job defines no steps")
+    return steps
+
+
+# --------------------------------------------------------------------------
+# GitHub Actions expression evaluation (the subset release.yml uses)
+# --------------------------------------------------------------------------
+
+TOKEN = re.compile(
+    r"\s*(?:"
+    r"(?P<string>'(?:[^']|'')*')"
+    r"|(?P<op>&&|\|\||==|!=|!|\(|\)|,)"
+    r"|(?P<number>\d+(?:\.\d+)?)"
+    r"|(?P<ident>[A-Za-z_][A-Za-z0-9_.-]*)"
+    r")"
+)
+
+
+@dataclass(frozen=True)
+class EventContext:
+    """The `github` and `needs` contexts of one hypothetical workflow run."""
+
+    label: str
+    event_name: str
+    ref: str = "refs/tags/v0.0.0"
+    inputs: dict[str, str] = field(default_factory=dict)
+    needs_result: str = "success"
+
+    def resolve(self, path: str) -> str:
+        if path == "github.event_name":
+            return self.event_name
+        if path == "github.ref":
+            return self.ref
+        if path == "github.ref_name":
+            return self.ref.rsplit("/", 1)[-1]
+        if path.startswith("github.event.inputs."):
+            # Unset dispatch inputs and push events both read as empty.
+            return self.inputs.get(path[len("github.event.inputs.") :], "")
+        needs = re.fullmatch(r"needs\.[A-Za-z0-9_-]+\.result", path)
+        if needs:
+            return self.needs_result
+        raise UnsupportedExpression(
+            f"context `{path}` is not modelled by the release doctor"
+        )
+
+
+def truthy(value: object) -> bool:
+    if isinstance(value, bool):
+        return value
+    if value is None:
+        return False
+    return value != ""
+
+
+def _equal(left: object, right: object) -> bool:
+    # GitHub compares strings case-insensitively and coerces null to ''.
+    def norm(value: object) -> str:
+        if value is None:
+            return ""
+        if isinstance(value, bool):
+            return "true" if value else "false"
+        return str(value).lower()
+
+    return norm(left) == norm(right)
+
+
+FUNCTIONS: dict[str, Callable[[list[object]], object]] = {
+    "always": lambda args: True,
+    "startsWith": lambda args: str(args[0]).lower().startswith(str(args[1]).lower()),
+    "endsWith": lambda args: str(args[0]).lower().endswith(str(args[1]).lower()),
+    "contains": lambda args: str(args[1]).lower() in str(args[0]).lower(),
+}
+
+
+class _Parser:
+    def __init__(self, expression: str, context: EventContext) -> None:
+        self.context = context
+        self.tokens: list[tuple[str, str]] = []
+        position = 0
+        expression = expression.strip()
+        while position < len(expression):
+            match = TOKEN.match(expression, position)
+            if not match or match.end() == position:
+                raise UnsupportedExpression(
+                    f"cannot tokenise expression near `{expression[position : position + 20]}`"
+                )
+            position = match.end()
+            kind = match.lastgroup
+            if kind is None:
+                continue
+            self.tokens.append((kind, match.group(kind)))
+        self.index = 0
+
+    def peek(self) -> tuple[str, str] | None:
+        return self.tokens[self.index] if self.index < len(self.tokens) else None
+
+    def take(self) -> tuple[str, str]:
+        token = self.peek()
+        if token is None:
+            raise UnsupportedExpression("unexpected end of expression")
+        self.index += 1
+        return token
+
+    def expect_op(self, op: str) -> None:
+        token = self.take()
+        if token != ("op", op):
+            raise UnsupportedExpression(f"expected `{op}`, found `{token[1]}`")
+
+    def parse(self) -> object:
+        value = self.parse_or()
+        if self.peek() is not None:
+            raise UnsupportedExpression(f"trailing token `{self.peek()[1]}`")
+        return value
+
+    def parse_or(self) -> object:
+        left = self.parse_and()
+        while self.peek() == ("op", "||"):
+            self.take()
+            right = self.parse_and()
+            left = left if truthy(left) else right
+        return left
+
+    def parse_and(self) -> object:
+        left = self.parse_equality()
+        while self.peek() == ("op", "&&"):
+            self.take()
+            right = self.parse_equality()
+            left = right if truthy(left) else left
+        return left
+
+    def parse_equality(self) -> object:
+        left = self.parse_unary()
+        while self.peek() in (("op", "=="), ("op", "!=")):
+            _, op = self.take()
+            right = self.parse_unary()
+            equal = _equal(left, right)
+            left = equal if op == "==" else not equal
+        return left
+
+    def parse_unary(self) -> object:
+        if self.peek() == ("op", "!"):
+            self.take()
+            return not truthy(self.parse_unary())
+        return self.parse_primary()
+
+    def parse_primary(self) -> object:
+        kind, text = self.take()
+        if kind == "op" and text == "(":
+            value = self.parse_or()
+            self.expect_op(")")
+            return value
+        if kind == "string":
+            return text[1:-1].replace("''", "'")
+        if kind == "number":
+            return text
+        if kind == "ident":
+            lowered = text.lower()
+            if lowered in ("true", "false"):
+                return lowered == "true"
+            if lowered == "null":
+                return None
+            if self.peek() == ("op", "("):
+                self.take()
+                args: list[object] = []
+                if self.peek() != ("op", ")"):
+                    args.append(self.parse_or())
+                    while self.peek() == ("op", ","):
+                        self.take()
+                        args.append(self.parse_or())
+                self.expect_op(")")
+                function = FUNCTIONS.get(text)
+                if function is None:
+                    raise UnsupportedExpression(f"function `{text}()` is not modelled")
+                return function(args)
+            return self.context.resolve(text)
+        raise UnsupportedExpression(f"unexpected token `{text}`")
+
+
+EXPRESSION = re.compile(r"\$\{\{(.*?)\}\}", re.DOTALL)
+
+
+def evaluate(expression: str, context: EventContext) -> object:
+    """Evaluate one expression, with or without the `${{ }}` wrapper."""
+    expression = " ".join(expression.split())
+    match = re.fullmatch(r"\$\{\{(.*)\}\}", expression)
+    if match:
+        expression = match.group(1)
+    return _Parser(expression, context).parse()
+
+
+def step_runs(step: Step, context: EventContext) -> bool:
+    condition = step.condition
+    if condition is None:
+        return True
+    return truthy(evaluate(condition, context))
+
+
+def render(template: str, context: EventContext) -> str:
+    """Substitute every evaluable `${{ }}` in a run body; leave the rest."""
+
+    def substitute(match: re.Match[str]) -> str:
+        try:
+            value = evaluate(match.group(1), context)
+        except UnsupportedExpression:
+            return match.group(0)
+        if value is None:
+            return ""
+        if isinstance(value, bool):
+            return "true" if value else "false"
+        return str(value)
+
+    return EXPRESSION.sub(substitute, template)
+
+
+# --------------------------------------------------------------------------
+# Event contexts
+# --------------------------------------------------------------------------
+
+TAG_PUSH = EventContext(label="a tag push", event_name="push")
+PACKAGE_RECOVERY = EventContext(
+    label="a package-recovery dispatch",
+    event_name="workflow_dispatch",
+    inputs={"release_tag": "v0.0.0", "publish_release_packages": "true"},
+)
+HISTORICAL_EVIDENCE = EventContext(
+    label="an explicit historical-evidence dispatch",
+    event_name="workflow_dispatch",
+    inputs={
+        "release_tag": "v0.0.0",
+        "publish_release_packages": "true",
+        "semver_evidence_run_id": "1",
+        "semver_evidence_job_id": "2",
+    },
+)
+
+
+# --------------------------------------------------------------------------
+# Checks
+# --------------------------------------------------------------------------
+
+
+def _job_enabled(block: list[str], job_name: str, context: EventContext) -> list[str]:
+    job_fields = parse_mapping(block, 4)
+    condition = job_fields.get("if")
+    if condition is not None and not truthy(evaluate(condition, context)):
+        return [f"job `{job_name}` is skipped on {context.label}"]
+    return []
+
+
+def check_semver_evidence(text: str) -> list[str]:
+    """Tag releases consume exact-tree pre-tag evidence, never re-measure."""
+    block = job_block(text, SEMVER_GATE_JOB)
+    violations = _job_enabled(block, SEMVER_GATE_JOB, TAG_PUSH)
+    steps = job_steps(block)
+
+    evidence_steps = [step for step in steps if EVIDENCE_ARTIFACT_PREFIX in step.run]
+    if not evidence_steps:
+        violations.append(
+            f"job `{SEMVER_GATE_JOB}` has no step that resolves the exact-tree "
+            f"`{EVIDENCE_ARTIFACT_PREFIX}<tree>` readiness artifact"
+        )
+    for step in evidence_steps:
+        for context in (TAG_PUSH, PACKAGE_RECOVERY):
+            if not step_runs(step, context):
+                violations.append(
+                    f"step `{step.name}` does not run on {context.label}, so the "
+                    "release would not reuse exact-tree pre-tag semver evidence"
+                )
+        if step_runs(step, HISTORICAL_EVIDENCE):
+            violations.append(
+                f"step `{step.name}` also runs on {HISTORICAL_EVIDENCE.label}, "
+                "which must verify the explicit measurement instead"
+            )
+
+    for step in steps:
+        if MEASUREMENT_COMMAND not in step.run:
+            continue
+        for context in (TAG_PUSH, PACKAGE_RECOVERY):
+            if step_runs(step, context):
+                violations.append(
+                    f"step `{step.name}` reruns `{MEASUREMENT_COMMAND}` on "
+                    f"{context.label}; the long measurement belongs before the tag"
+                )
+    return violations
+
+
+def check_registry_slo(text: str) -> list[str]:
+    """Tag releases verify every crate is public within the 30 minute SLO."""
+    block = job_block(text, REGISTRY_JOB)
+    violations = _job_enabled(block, REGISTRY_JOB, TAG_PUSH)
+    steps = job_steps(block)
+
+    verifier_steps = [step for step in steps if PUBLIC_VERIFIER in step.run]
+    if not verifier_steps:
+        violations.append(
+            f"job `{REGISTRY_JOB}` has no step that runs `{PUBLIC_VERIFIER}`"
+        )
+    for step in verifier_steps:
+        if not step_runs(step, TAG_PUSH):
+            violations.append(f"step `{step.name}` does not run on {TAG_PUSH.label}")
+            continue
+        rendered = render(step.run, TAG_PUSH)
+        match = re.search(r"--slo-seconds[\s=]+(\S+)", rendered)
+        if not match:
+            violations.append(
+                f"step `{step.name}` invokes `{PUBLIC_VERIFIER}` without `--slo-seconds`"
+            )
+            continue
+        value = match.group(1)
+        if "${{" in value:
+            violations.append(
+                f"step `{step.name}` passes `--slo-seconds` as an expression the "
+                f"release doctor cannot evaluate: `{value}`"
+            )
+        elif value != str(TAG_SLO_SECONDS):
+            violations.append(
+                f"step `{step.name}` passes `--slo-seconds {value}` on {TAG_PUSH.label}; "
+                f"the tag-to-public SLO is {TAG_SLO_SECONDS} seconds"
+            )
+    return violations
+
+
+CHECKS: dict[str, Callable[[str], list[str]]] = {
+    "semver-evidence": check_semver_evidence,
+    "registry-slo": check_registry_slo,
+}
+
+
+def run_checks(text: str, names: Iterable[str]) -> list[str]:
+    violations: list[str] = []
+    for name in names:
+        try:
+            violations.extend(CHECKS[name](text))
+        except ContractError as error:
+            violations.append(f"{name}: {error}")
+    return violations
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument(
+        "--workflow",
+        type=Path,
+        default=DEFAULT_WORKFLOW,
+        help=f"release workflow to inspect (default: {DEFAULT_WORKFLOW})",
+    )
+    parser.add_argument(
+        "checks",
+        nargs="*",
+        choices=[*CHECKS, "all"],
+        default=["all"],
+        help="which contract checks to run (default: all)",
+    )
+    args = parser.parse_args(argv)
+    names = list(CHECKS) if "all" in args.checks else args.checks
+    try:
+        text = args.workflow.read_text(encoding="utf-8")
+    except OSError as error:
+        print(f"cannot read {args.workflow}: {error}")
+        return 2
+    violations = run_checks(text, names)
+    for violation in violations:
+        print(violation)
+    return 1 if violations else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/release-doctor
+++ b/scripts/release-doctor
@@ -4,6 +4,9 @@ set -euo pipefail
 workspace_root="$(git rev-parse --show-toplevel)"
 cd "${workspace_root}"
 
+# Contract tests point the doctor at a mutated copy of the release workflow.
+release_workflow="${RELEASE_WORKFLOW_FILE:-.github/workflows/release.yml}"
+
 ok=0
 warn=0
 fail=0
@@ -40,7 +43,7 @@ workflow_job() {
     $0 == header { in_job = 1 }
     in_job && $0 != header && /^  [[:alnum:]_-]+:/ { exit }
     in_job { print }
-  ' .github/workflows/release.yml
+  ' "${release_workflow}"
 }
 
 if command -v gh >/dev/null 2>&1; then
@@ -124,16 +127,16 @@ if command -v gh >/dev/null 2>&1 && gh auth status --hostname github.com >/dev/n
   done
 fi
 
-if grep -Fq 'github.com/wasm-bindgen/wasm-pack/releases/download' .github/workflows/release.yml; then
+if grep -Fq 'github.com/wasm-bindgen/wasm-pack/releases/download' "${release_workflow}"; then
   pass "Release workflow installs wasm-pack from maintained wasm-bindgen releases"
 else
   bad "Release workflow does not use the maintained wasm-bindgen wasm-pack release URL"
 fi
 
-if grep -Fq 'build_web_sdk_package:' .github/workflows/release.yml &&
-  grep -Fq 'scripts/release-build-web-sdk-package.sh' .github/workflows/release.yml &&
-  grep -Fq 'name: rkat-web-package' .github/workflows/release.yml &&
-  grep -Fq 'scripts/release-publish-web-sdk-package.sh' .github/workflows/release.yml; then
+if grep -Fq 'build_web_sdk_package:' "${release_workflow}" &&
+  grep -Fq 'scripts/release-build-web-sdk-package.sh' "${release_workflow}" &&
+  grep -Fq 'name: rkat-web-package' "${release_workflow}" &&
+  grep -Fq 'scripts/release-publish-web-sdk-package.sh' "${release_workflow}"; then
   pass "Release workflow builds @rkat/web once as an artifact before npm publishing"
 else
   bad "Release workflow does not publish @rkat/web from a prebuilt package artifact"
@@ -164,7 +167,7 @@ web_release_ref_jobs="$(
         pinned[job] = 1
       }
     END { print pinned["build"] + pinned["publish"] }
-  ' .github/workflows/release.yml
+  ' "${release_workflow}"
 )"
 if [[ "${web_release_ref_jobs}" == "2" ]]; then
   pass "Web SDK build and publish recovery jobs are pinned to the selected release tag"
@@ -178,7 +181,7 @@ if awk '
     in_job && /release-build-(linux|macos)/ { found = 1 }
     in_job && /release-build-windows/ { windows = 1 }
     END { exit (found && !windows) ? 0 : 1 }
-  ' .github/workflows/release.yml; then
+  ' "${release_workflow}"; then
   pass "Release workflow builds Linux/macOS assets on BuildBuddy for owner releases (no Windows BuildBuddy lane)"
 else
   bad "Release workflow should build Linux/macOS assets on BuildBuddy and keep Windows off the BuildBuddy lane (no self-hosted Windows RBE executors are registered)"
@@ -187,10 +190,10 @@ fi
 # Windows release binaries always build on a GitHub-hosted runner: under the
 # BuildBuddy lane split the hosted job runs with a Windows-only matrix, and
 # the binary gate requires BOTH lanes to succeed.
-if grep -Fq '"runs-on":"windows-latest","target":"x86_64-pc-windows-msvc"' .github/workflows/release.yml &&
-  grep -Fq 'GitHub-hosted release binary build (Windows) selected' .github/workflows/release.yml &&
-  grep -Fq '[[ "${buildbuddy_result}" == "success" && "${github_result}" == "success" ]]' .github/workflows/release.yml &&
-  ! grep -Fq 'king.europe.buildbuddy.io' .github/workflows/release.yml; then
+if grep -Fq '"runs-on":"windows-latest","target":"x86_64-pc-windows-msvc"' "${release_workflow}" &&
+  grep -Fq 'GitHub-hosted release binary build (Windows) selected' "${release_workflow}" &&
+  grep -Fq '[[ "${buildbuddy_result}" == "success" && "${github_result}" == "success" ]]' "${release_workflow}" &&
+  ! grep -Fq 'king.europe.buildbuddy.io' "${release_workflow}"; then
   pass "Release workflow routes Windows builds to a GitHub-hosted runner alongside the BuildBuddy Linux/macOS lanes"
 else
   bad "Release workflow should build Windows on a GitHub-hosted runner (Windows-only matrix under the BuildBuddy lane split) with a gate requiring both lanes"
@@ -205,7 +208,7 @@ web_build_timeout="$(
       print $0
       exit
     }
-  ' .github/workflows/release.yml
+  ' "${release_workflow}"
 )"
 if [[ "${web_build_timeout:-0}" =~ ^[0-9]+$ ]] && ((web_build_timeout >= 120)); then
   pass "Web SDK package build job has a long timeout (${web_build_timeout} minutes)"
@@ -222,7 +225,7 @@ web_publish_timeout="$(
       print $0
       exit
     }
-  ' .github/workflows/release.yml
+  ' "${release_workflow}"
 )"
 if [[ "${web_publish_timeout:-0}" =~ ^[0-9]+$ ]] && ((web_publish_timeout <= 30)); then
   pass "Web SDK publish job is artifact-only (${web_publish_timeout} minute timeout)"
@@ -237,13 +240,17 @@ else
   bad "Rust crate publish script is missing crates.io rate-limit retry handling"
 fi
 
-semver_job="$(workflow_job release_semver_gate)"
-if grep -Fq 'Verify exact-tree pre-tag semver evidence' <<<"${semver_job}" &&
-  grep -Fq "github.event_name != 'workflow_dispatch'" <<<"${semver_job}" &&
-  grep -Fq "github.event_name == 'workflow_dispatch' && github.event.inputs.semver_evidence_job_id == ''" <<<"${semver_job}"; then
+# The semver-gate and SLO assertions evaluate workflow behaviour under concrete
+# events instead of grepping literal lines, so reflowing a condition cannot
+# fail the doctor while removing the behaviour still does (#1091).
+workflow_contract() {
+  "${release_python:-python3}" scripts/check_release_workflow_contract.py \
+    --workflow "${release_workflow}" "$@" 2>&1
+}
+if semver_contract="$(workflow_contract semver-evidence)"; then
   pass "Tag releases reuse exact-tree pre-tag semver evidence"
 else
-  bad "Tag releases must reuse exact-tree pre-tag semver evidence instead of rerunning the long semver measurement"
+  bad "Tag releases must reuse exact-tree pre-tag semver evidence instead of rerunning the long semver measurement (${semver_contract//$'\n'/; })"
 fi
 
 registry_job="$(workflow_job publish_registries)"
@@ -258,11 +265,10 @@ else
   bad "Rust registry publication has an invalid critical-path dependency: ${registry_needs:-missing needs}"
 fi
 
-if grep -Fq 'scripts/verify-rust-release-public.py' <<<"${registry_job}" &&
-  grep -Fq -- '--slo-seconds 1800' <<<"${registry_job}"; then
+if slo_contract="$(workflow_contract registry-slo)"; then
   pass "Rust registry publication enforces the 30 minute tag-to-public SLO"
 else
-  bad "Rust registry publication does not enforce the 30 minute tag-to-public SLO"
+  bad "Rust registry publication does not enforce the 30 minute tag-to-public SLO (${slo_contract//$'\n'/; })"
 fi
 
 if [[ -n "${VERSION:-${RELEASE_TAG:-}}" ]]; then

--- a/scripts/test-release-doctor-workflow-contract.sh
+++ b/scripts/test-release-doctor-workflow-contract.sh
@@ -1,0 +1,245 @@
+#!/usr/bin/env bash
+# Contract test for the release doctor's release-workflow assertions.
+#
+# Reproduces the #1091 drift shape: `.github/workflows/release.yml` was
+# reworded after v0.8.32 (a folded `if: >-` condition and a `--slo-seconds
+# ${{ ... }}` expression) without changing behaviour, and two doctor greps
+# that matched literal lines failed on a healthy main. The fix asserts what
+# the workflow does under concrete events. This test proves both halves of
+# that contract on fixtures derived from the committed workflow: equivalent
+# spellings pass, and removing the behaviour still fails and names the defect.
+#
+# Every fixture mutation asserts its needle occurs exactly once in the real
+# workflow, so a rewording that invalidates a fixture fails here loudly
+# instead of leaving the doctor unverified.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+PYTHON="${PYTHON:-$(command -v python3.11 2>/dev/null || command -v python3)}"
+CHECKER="${REPO_ROOT}/scripts/check_release_workflow_contract.py"
+DOCTOR="${REPO_ROOT}/scripts/release-doctor"
+WORKFLOW="${REPO_ROOT}/.github/workflows/release.yml"
+TEST_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/meerkat-release-doctor-contract.XXXXXX")"
+trap 'rm -rf "$TEST_ROOT"' EXIT
+
+SEMVER_PASS="PASS Tag releases reuse exact-tree pre-tag semver evidence"
+SEMVER_FAIL="FAIL Tag releases must reuse exact-tree pre-tag semver evidence"
+SLO_PASS="PASS Rust registry publication enforces the 30 minute tag-to-public SLO"
+SLO_FAIL="FAIL Rust registry publication does not enforce the 30 minute tag-to-public SLO"
+
+fail() {
+  echo "release doctor workflow contract violated: $1" >&2
+  shift
+  for extra in "$@"; do
+    echo "  ${extra}" >&2
+  done
+  exit 1
+}
+
+# mutate <name> <destination>: write a mutated copy of the committed workflow.
+mutate() {
+  local name="$1"
+  local destination="$2"
+  "$PYTHON" - "$WORKFLOW" "$destination" "$name" <<'PYEOF'
+import pathlib
+import re
+import sys
+
+source, destination, name = sys.argv[1:4]
+text = pathlib.Path(source).read_text()
+
+
+def replace_once(needle: str, replacement: str) -> None:
+    global text
+    count = text.count(needle)
+    if count != 1:
+        raise SystemExit(
+            f"fixture `{name}` expects exactly one occurrence of {needle!r} "
+            f"in the committed workflow, found {count}; update the fixture"
+        )
+    text = text.replace(needle, replacement)
+
+
+EVIDENCE_STEP = re.compile(
+    r"      - name: Verify exact-tree pre-tag semver evidence\n"
+    r"(?:        .*\n|          .*\n|\n)*?"
+    r"(?=      - name: )"
+)
+EVIDENCE_IF = (
+    "            github.event_name != 'workflow_dispatch' ||\n"
+    "            (github.event.inputs.release_tag != '' &&\n"
+    "             github.event.inputs.semver_evidence_job_id == '')\n"
+)
+MEASUREMENT_STEP_IF = (
+    "      - name: Verify every reported break is named and the notes are stamped\n"
+    "        if: >-\n"
+    "          ${{\n"
+    "            github.event_name == 'workflow_dispatch' &&\n"
+    "            github.event.inputs.semver_evidence_job_id == '' &&\n"
+    "            github.event.inputs.release_tag == ''\n"
+    "          }}\n"
+    "        run: make semver-breaks\n"
+)
+SLO_LINE = (
+    "            --slo-seconds ${{ github.event_name == 'workflow_dispatch'"
+    " && '2147483647' || '1800' }}\n"
+)
+SLO_PREVIOUS_LINE = "            --deadline-seconds 900 \\\n"
+
+if name == "evidence-step-removed":
+    match = EVIDENCE_STEP.search(text)
+    if match is None or len(EVIDENCE_STEP.findall(text)) != 1:
+        raise SystemExit("fixture expects exactly one exact-tree evidence step")
+    text = text[: match.start()] + text[match.end() :]
+elif name == "evidence-step-off-tags":
+    replace_once(
+        EVIDENCE_IF,
+        "            github.event_name == 'workflow_dispatch' &&\n"
+        "            (github.event.inputs.release_tag != '' &&\n"
+        "             github.event.inputs.semver_evidence_job_id == '')\n",
+    )
+elif name == "evidence-if-single-line":
+    # Same condition, collapsed onto one line with a bare (unwrapped)
+    # expression: the spelling GitHub also accepts.
+    condition = " ".join(EVIDENCE_IF.split())
+    replace_once(
+        "        if: >-\n          ${{\n" + EVIDENCE_IF + "          }}\n        shell: bash\n"
+        "        env:\n          GH_TOKEN: ${{ github.token }}\n        run: |\n"
+        "          set -euo pipefail\n          tree_sha=",
+        f"        if: {condition}\n        shell: bash\n"
+        "        env:\n          GH_TOKEN: ${{ github.token }}\n        run: |\n"
+        "          set -euo pipefail\n          tree_sha=",
+    )
+elif name == "measurement-on-tags":
+    replace_once(
+        MEASUREMENT_STEP_IF,
+        "      - name: Verify every reported break is named and the notes are stamped\n"
+        "        run: make semver-breaks\n",
+    )
+elif name == "slo-relaxed":
+    replace_once(SLO_LINE, SLO_LINE.replace("'1800'", "'3600'"))
+elif name == "slo-flag-removed":
+    replace_once(SLO_PREVIOUS_LINE + SLO_LINE, "            --deadline-seconds 900\n")
+elif name == "slo-literal":
+    replace_once(SLO_LINE, "            --slo-seconds 1800\n")
+elif name == "slo-reflowed":
+    # Equivalent expression, operands reordered and split across lines.
+    replace_once(
+        SLO_LINE,
+        "            --slo-seconds ${{\n"
+        "              github.event_name != 'workflow_dispatch' && '1800'\n"
+        "              || '2147483647'\n"
+        "            }}\n",
+    )
+elif name == "both-defects":
+    replace_once(
+        MEASUREMENT_STEP_IF,
+        "      - name: Verify every reported break is named and the notes are stamped\n"
+        "        run: make semver-breaks\n",
+    )
+    replace_once(SLO_LINE, SLO_LINE.replace("'1800'", "'3600'"))
+else:
+    raise SystemExit(f"unknown fixture `{name}`")
+
+pathlib.Path(destination).write_text(text)
+PYEOF
+}
+
+# run_check <workflow> <log> <check...>: prints the checker's exit status.
+run_check() {
+  local workflow="$1"
+  local log="$2"
+  shift 2
+  set +e
+  "$PYTHON" "$CHECKER" --workflow "$workflow" "$@" >"$log" 2>&1
+  local status=$?
+  set -e
+  printf '%s' "$status"
+}
+
+expect_pass() {
+  local label="$1"
+  local fixture="$2"
+  shift 2
+  local log="${TEST_ROOT}/${label}.log"
+  local status
+  status="$(run_check "$fixture" "$log" "$@")"
+  if [[ "$status" -ne 0 ]]; then
+    fail "${label}: an equivalent workflow spelling was rejected" "$(cat "$log")"
+  fi
+}
+
+expect_fail_named() {
+  local label="$1"
+  local fixture="$2"
+  local needle="$3"
+  shift 3
+  local log="${TEST_ROOT}/${label}.log"
+  local status
+  status="$(run_check "$fixture" "$log" "$@")"
+  if [[ "$status" -eq 0 ]]; then
+    fail "${label}: a workflow that dropped the behaviour was accepted"
+  fi
+  if ! grep -Fq "$needle" "$log"; then
+    fail "${label}: failure does not name the defect (expected: ${needle})" "$(cat "$log")"
+  fi
+}
+
+# 1. The committed workflow satisfies both contracts.
+expect_pass committed "$WORKFLOW" all
+
+# 2. Equivalent spellings pass: this is the #1091 false positive.
+mutate evidence-if-single-line "${TEST_ROOT}/evidence-if-single-line.yml"
+expect_pass evidence-if-single-line "${TEST_ROOT}/evidence-if-single-line.yml" semver-evidence
+mutate slo-literal "${TEST_ROOT}/slo-literal.yml"
+expect_pass slo-literal "${TEST_ROOT}/slo-literal.yml" registry-slo
+mutate slo-reflowed "${TEST_ROOT}/slo-reflowed.yml"
+expect_pass slo-reflowed "${TEST_ROOT}/slo-reflowed.yml" registry-slo
+
+# 3. Dropping the behaviour fails and names the defect.
+mutate evidence-step-removed "${TEST_ROOT}/evidence-step-removed.yml"
+expect_fail_named evidence-step-removed "${TEST_ROOT}/evidence-step-removed.yml" \
+  "no step that resolves the exact-tree" semver-evidence
+mutate evidence-step-off-tags "${TEST_ROOT}/evidence-step-off-tags.yml"
+expect_fail_named evidence-step-off-tags "${TEST_ROOT}/evidence-step-off-tags.yml" \
+  "does not run on a tag push" semver-evidence
+mutate measurement-on-tags "${TEST_ROOT}/measurement-on-tags.yml"
+expect_fail_named measurement-on-tags "${TEST_ROOT}/measurement-on-tags.yml" \
+  "reruns \`make semver-breaks\` on a tag push" semver-evidence
+mutate slo-relaxed "${TEST_ROOT}/slo-relaxed.yml"
+expect_fail_named slo-relaxed "${TEST_ROOT}/slo-relaxed.yml" \
+  "passes \`--slo-seconds 3600\` on a tag push" registry-slo
+mutate slo-flag-removed "${TEST_ROOT}/slo-flag-removed.yml"
+expect_fail_named slo-flag-removed "${TEST_ROOT}/slo-flag-removed.yml" \
+  "without \`--slo-seconds\`" registry-slo
+
+# 4. The doctor itself binds to the checker: its PASS/FAIL lines follow the
+#    workflow it is pointed at. Environment checks (gh, npm) are ignored; only
+#    the two workflow-contract lines are asserted.
+run_doctor() {
+  local workflow="$1"
+  local log="$2"
+  set +e
+  RELEASE_WORKFLOW_FILE="$workflow" "$DOCTOR" >"$log" 2>&1
+  set -e
+}
+
+run_doctor "$WORKFLOW" "${TEST_ROOT}/doctor-committed.log"
+for line in "$SEMVER_PASS" "$SLO_PASS"; do
+  if ! grep -Fxq "$line" "${TEST_ROOT}/doctor-committed.log"; then
+    fail "doctor does not report \`${line}\` for the committed workflow" \
+      "$(cat "${TEST_ROOT}/doctor-committed.log")"
+  fi
+done
+
+mutate both-defects "${TEST_ROOT}/both-defects.yml"
+run_doctor "${TEST_ROOT}/both-defects.yml" "${TEST_ROOT}/doctor-defects.log"
+for line in "$SEMVER_FAIL" "$SLO_FAIL"; do
+  if ! grep -Fq "$line" "${TEST_ROOT}/doctor-defects.log"; then
+    fail "doctor does not report \`${line}\` for a workflow that dropped the behaviour" \
+      "$(cat "${TEST_ROOT}/doctor-defects.log")"
+  fi
+done
+
+echo "release doctor workflow contract holds"


### PR DESCRIPTION
The release doctor asserted the semver-evidence and tag-to-public SLO
contracts by grepping literal lines out of release.yml. Commits e72007887
and b6452ce86 reflowed the release_semver_gate step condition and turned
`--slo-seconds 1800` into a `${{ }}` expression without changing tag-push
behaviour, so `make release-doctor` failed on a healthy main (#1091).

Add scripts/check_release_workflow_contract.py (stdlib only), which
extracts the two jobs, splits them into steps, and evaluates each `if:`
and run-body expression under concrete events (tag push, package
recovery, explicit historical evidence). The doctor delegates the two
checks to it and reports the checker's named violations, so rewording a
condition passes while gating the evidence step off tags, rerunning
`make semver-breaks` on a tag, or relaxing the 1800 second SLO fails.

Add scripts/test-release-doctor-workflow-contract.sh, which drives the
checker and the doctor (via RELEASE_WORKFLOW_FILE) against fixtures
derived from the committed workflow: equivalent spellings pass, dropped
behaviour fails and names the defect, and every fixture asserts its
needle still exists so a rewording cannot leave the doctor unverified.
Wire it into pre-push, the CI ratchets job, and `make release-doctor`.

Closes #1091

Verification: `make release-doctor` goes from 22 pass / 2 fail to 24 pass / 0 fail (the VERSION-unset WARN is expected); `scripts/test-release-doctor-workflow-contract.sh` passes and was shown to fail when the checker is made vacuous, when the doctor is reverted to the old grep, and when the doctor's check is disconnected. shellcheck, ruff, and YAML clean. Pushed with hooks on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)