### PR TITLE
fix(session): keep runtime registration when no live actor is stale

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -440,6 +440,16 @@ them.
   `MEERKAT_PRE_PUSH_LANE_IDLE_SECS` (default 6 hours). Every decision is
   logged as one `kept:` or `pruned:` line with its reason. Exact-tree
   evidence reuse is unchanged.
+- `discard_stale_live_session` now documents its teardown contract (exact
+  registration witness, terminal-completion wait, absent or replaced
+  registration treated as already clean, preserved error combination) and
+  logs at debug level when the captured registration was replaced before
+  unregister instead of dropping that result silently. The
+  `unregister_session_registration_until_terminal_if_current` doc now covers
+  exact-registration reoccupation callers, not only process-lifecycle owners.
+  Facade tests pin that an absent registration returns `Ok(())` and that a
+  teardown outliving the ordinary 2-second caller grace completes instead of
+  surfacing `UnregisterInProgress`.
 
 ## [0.8.33] - 2026-09-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -460,6 +460,17 @@ them.
   `turn/start`, that an absent registration returns `Ok(())`, and that a live
   actor's teardown outliving the ordinary 2-second caller grace completes
   instead of surfacing `UnregisterInProgress`.
+- The runtime loop no longer retires a registration on a no-pending-boundary
+  terminal while other admitted input is still queued behind it. Previously a
+  detached-job completion wake applied through the in-loop recovery tail with
+  no prompt produced `NoPendingBoundary`, the loop staged
+  `BeginUnregisterSession` and exited, and every queued input (including the
+  `turn/start` prompt admitted moments earlier) resolved
+  `RuntimeTerminated: runtime session unregistered` (refs #1093). The queue is
+  now observed under the driver lock before the terminal is classified, and
+  the teardown prefix re-checks it under the session mutation gate so input
+  admitted in between keeps the registration serving; with nothing queued the
+  no-pending terminal still tears down exactly as before.
 
 ## [0.8.33] - 2026-09-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -440,16 +440,26 @@ them.
   `MEERKAT_PRE_PUSH_LANE_IDLE_SECS` (default 6 hours). Every decision is
   logged as one `kept:` or `pruned:` line with its reason. Exact-tree
   evidence reuse is unchanged.
-- `discard_stale_live_session` now documents its teardown contract (exact
-  registration witness, terminal-completion wait, absent or replaced
-  registration treated as already clean, preserved error combination) and
-  logs at debug level when the captured registration was replaced before
-  unregister instead of dropping that result silently. The
-  `unregister_session_registration_until_terminal_if_current` doc now covers
-  exact-registration reoccupation callers, not only process-lifecycle owners.
-  Facade tests pin that an absent registration returns `Ok(())` and that a
-  teardown outliving the ordinary 2-second caller grace completes instead of
-  surfacing `UnregisterInProgress`.
+- `turn/start`, input ingress, and external event injection no longer tear
+  down a registered runtime that merely has no live actor yet. In a reopened
+  `rkat-rpc`, `monitors/start` attaches a runtime executor before any turn, and
+  the stale-projection check classified the absent live actor as stale, so
+  `discard_stale_live_session` unregistered the healthy registration and then
+  waited on its runtime loop to hand off while that loop was inside a recovery
+  continuation turn (the `durable_jobs_workgraph_recovery` flake, refs #1093).
+  The discard now keeps the registration when no live actor exists (the
+  in-loop recovery tail materializes the actor from durable authority) and
+  only discards the actor plus awaits the exact registration's owned teardown
+  to terminal completion when a live actor was actually present. Both skipped
+  paths (no live actor; captured registration already replaced) log at debug
+  level instead of dropping the result silently. The doc comments on
+  `discard_stale_live_session` and
+  `unregister_session_registration_until_terminal_if_current` state this
+  contract, including exact-registration reoccupation callers. Facade and RPC
+  tests pin that a registration without a live actor keeps its epoch across
+  `turn/start`, that an absent registration returns `Ok(())`, and that a live
+  actor's teardown outliving the ordinary 2-second caller grace completes
+  instead of surfacing `UnregisterInProgress`.
 
 ## [0.8.33] - 2026-09-04
 

--- a/meerkat-rpc/src/session_runtime.rs
+++ b/meerkat-rpc/src/session_runtime.rs
@@ -14777,6 +14777,22 @@ mod tests {
             .await
             .expect("registered runtime must expose an exact registration witness");
 
+        // Job-completion wake (jobs/cancel completing the monitor op): the
+        // idle loop applies a continuation with no prompt, which the in-loop
+        // recovery tail turns into a NoPendingBoundary terminal. That must
+        // not retire the registration while the prompt below is queued.
+        let (wake_outcome, _wake_completion) = runtime
+            .runtime_adapter()
+            .accept_input_with_completion(
+                &session_id,
+                meerkat_runtime::Input::Continuation(
+                    meerkat_runtime::ContinuationInput::detached_background_op_completed(),
+                ),
+            )
+            .await
+            .expect("detached-op completion wake should be admitted");
+        assert!(wake_outcome.is_accepted());
+
         let (event_tx, _event_rx) = mpsc::channel(100);
         runtime
             .start_turn_via_runtime(

--- a/meerkat-rpc/src/session_runtime.rs
+++ b/meerkat-rpc/src/session_runtime.rs
@@ -14714,6 +14714,111 @@ mod tests {
         );
     }
 
+    /// Regression for the `durable_jobs_workgraph_recovery` handoff stall
+    /// (refs #1093): in a reopened process, `monitors/start` attaches a
+    /// runtime executor before any turn, leaving a registration with no live
+    /// actor. `turn/start` then classifies the absent live projection as stale
+    /// and must NOT tear that healthy registration down; the in-loop recovery
+    /// tail materializes the actor from durable authority instead.
+    #[tokio::test]
+    async fn turn_start_keeps_registered_runtime_that_has_no_live_actor() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let base_runtime = make_runtime_with_runtime_store(temp_factory(&temp), 10);
+        base_runtime.set_default_llm_client(Some(Arc::new(MockLlmClient)));
+        let runtime = Arc::new(base_runtime);
+
+        let session_id = runtime
+            .create_session(mock_build_config(), None, None, Vec::new())
+            .await
+            .expect("create_session");
+        let (event_tx, _event_rx) = mpsc::channel(100);
+        runtime
+            .start_turn_via_runtime(
+                &session_id,
+                "Hello".into(),
+                Vec::new(),
+                event_tx,
+                None,
+                None,
+                None,
+                None,
+            )
+            .await
+            .expect("first turn must persist the session");
+
+        // Reopened-process shape: no live actor, no runtime registration.
+        runtime
+            .service
+            .discard_live_session(&session_id)
+            .await
+            .expect("discard_live_session");
+        runtime
+            .runtime_adapter()
+            .unregister_session(&session_id)
+            .await
+            .expect("runtime session should unregister cleanly");
+
+        // monitors/start reaches the ops registry through ensure_runtime_executor,
+        // which registers a runtime loop + executor without a live actor.
+        runtime
+            .ensure_runtime_executor(&session_id)
+            .await
+            .expect("ensure_runtime_executor");
+        assert!(
+            !runtime
+                .service
+                .live_session_actor_registered(&session_id)
+                .await,
+            "fixture must reach a registered runtime without a live actor"
+        );
+        let before = runtime
+            .runtime_adapter()
+            .current_session_registration_witness(&session_id)
+            .await
+            .expect("registered runtime must expose an exact registration witness");
+
+        let (event_tx, _event_rx) = mpsc::channel(100);
+        runtime
+            .start_turn_via_runtime(
+                &session_id,
+                "Recover".into(),
+                Vec::new(),
+                event_tx,
+                None,
+                None,
+                None,
+                None,
+            )
+            .await
+            .expect("turn/start must succeed against a registered runtime without a live actor");
+
+        let after = runtime
+            .runtime_adapter()
+            .current_session_registration_witness(&session_id)
+            .await
+            .expect("registration must survive turn/start");
+        assert_eq!(
+            after.epoch_id(),
+            before.epoch_id(),
+            "turn/start must not tear down a registered runtime that merely has no live actor"
+        );
+        assert_eq!(
+            runtime
+                .runtime_adapter()
+                .unregister_runtime_loop_handoff_wait_reports(&session_id)
+                .await,
+            Some(0),
+            "no unregister teardown may have waited on the runtime loop"
+        );
+        assert!(
+            runtime
+                .service
+                .live_session_actor_registered(&session_id)
+                .await,
+            "the recovery tail must have materialized the live actor in place"
+        );
+    }
+
     #[tokio::test]
     async fn realtime_open_config_carries_runtime_owned_terminal_peer_response_as_typed_context() {
         let _projection_guard = realtime_open_projection_test_guard().await;

--- a/meerkat-runtime/src/meerkat_machine/mod.rs
+++ b/meerkat-runtime/src/meerkat_machine/mod.rs
@@ -1090,6 +1090,7 @@ pub(crate) use durability_health::{DurabilityHealthHandle, DurabilityReloadRequi
 
 pub(crate) use session_management::{
     DeleteOpsFinalizationAuthority, RetainOpsFinalizationAuthority,
+    RuntimeLoopTeardownUnregisterAdmission,
 };
 
 pub use composition::{MeerkatCompositionSignalDispatcher, MeerkatConsumerSurface};

--- a/meerkat-runtime/src/meerkat_machine/session_management.rs
+++ b/meerkat-runtime/src/meerkat_machine/session_management.rs
@@ -6206,9 +6206,19 @@ impl MeerkatMachine {
     }
 
     /// Unregister one exact current registration and await its owned teardown
-    /// saga to terminal completion. This is for process-lifecycle owners that
-    /// must not exit while cleanup remains in flight. The exact witness keeps
-    /// a later same-SessionId registration outside this teardown authority.
+    /// saga to terminal completion, past the ordinary caller grace that
+    /// [`Self::unregister_session_registration_if_current`] applies.
+    ///
+    /// This serves every caller that must observe terminal teardown of one
+    /// exact registration before acting on its absence: process-lifecycle
+    /// owners that must not exit while cleanup remains in flight, and
+    /// reoccupation callers (for example stale live-session discard ahead of
+    /// `turn/start`) that must not rematerialize the same `SessionId` until
+    /// the previous incarnation's teardown has reached terminal completion.
+    /// The saga is coordinator-owned, so a caller dropping this future never
+    /// cancels teardown. The exact witness keeps a later same-SessionId
+    /// registration outside this teardown authority: a stale or absent
+    /// registration is an idempotent `Ok(false)`.
     pub async fn unregister_session_registration_until_terminal_if_current(
         &self,
         registration: &RuntimeSessionRegistrationWitness,

--- a/meerkat-runtime/src/meerkat_machine/session_management.rs
+++ b/meerkat-runtime/src/meerkat_machine/session_management.rs
@@ -214,6 +214,17 @@ fn unregister_caller_wait_deadline() -> meerkat_core::time_compat::Instant {
     meerkat_core::time_compat::Instant::now() + UNREGISTER_CALLER_WAIT_GRACE
 }
 
+/// Outcome of the runtime loop's no-pending teardown prefix.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum RuntimeLoopTeardownUnregisterAdmission {
+    /// `BeginUnregisterSession` was staged and its progress persisted; the
+    /// loop must hand off its exact executor to the unregister saga.
+    Began,
+    /// Admitted input was found queued under the mutation gate; nothing was
+    /// staged and the registration must keep serving.
+    QueuedWorkPresent,
+}
+
 /// Maximum time an explicit stop caller waits for the independently-owned
 /// cleanup coordinator. The coordinator and exact executor remain owned after
 /// this elapses; only the caller receives typed in-progress truth.
@@ -8125,9 +8136,41 @@ impl MeerkatMachine {
         session_id: &SessionId,
         driver: &SharedDriver,
     ) -> Result<(), RuntimeDriverError> {
+        self.begin_unregister_from_runtime_loop_teardown_inner(session_id, driver, false)
+            .await
+            .map(|_| ())
+    }
+
+    /// Runtime-loop no-pending teardown prefix that yields to admitted input.
+    ///
+    /// Under the session mutation gate, admitted-but-unstaged input in any
+    /// lane means the registration still has work to serve, so nothing is
+    /// staged and [`RuntimeLoopTeardownUnregisterAdmission::QueuedWorkPresent`]
+    /// is returned. The gate is what closes the race between the loop's
+    /// queue observation and this prefix: ingress admission takes the same
+    /// gate, so input cannot be admitted between the check and
+    /// `BeginUnregisterSession`.
+    pub(crate) async fn begin_unregister_from_runtime_loop_teardown_unless_queued(
+        &self,
+        session_id: &SessionId,
+        driver: &SharedDriver,
+    ) -> Result<RuntimeLoopTeardownUnregisterAdmission, RuntimeDriverError> {
+        self.begin_unregister_from_runtime_loop_teardown_inner(session_id, driver, true)
+            .await
+    }
+
+    async fn begin_unregister_from_runtime_loop_teardown_inner(
+        &self,
+        session_id: &SessionId,
+        driver: &SharedDriver,
+        yield_to_queued_input: bool,
+    ) -> Result<RuntimeLoopTeardownUnregisterAdmission, RuntimeDriverError> {
         let _gate_guard = self
             .lock_current_runtime_loop_driver_authority(session_id, driver)
             .await?;
+        if yield_to_queued_input && driver.lock().await.has_queued_input_in_any_lane() {
+            return Ok(RuntimeLoopTeardownUnregisterAdmission::QueuedWorkPresent);
+        }
         match self
             .stage_begin_unregister_session_authority(session_id)
             .await
@@ -8158,7 +8201,8 @@ impl MeerkatMachine {
             driver,
             "teardown-required runtime-loop unregister prefix",
         )
-        .await
+        .await?;
+        Ok(RuntimeLoopTeardownUnregisterAdmission::Began)
     }
 
     pub(super) async fn unregister_session_inner(

--- a/meerkat-runtime/src/meerkat_machine_tests.rs
+++ b/meerkat-runtime/src/meerkat_machine_tests.rs
@@ -2825,6 +2825,155 @@ async fn teardown_required_runtime_loop_exit_unregisters_after_exact_cleanup() {
     assert_eq!(cleanup_calls.load(Ordering::SeqCst), 1);
 }
 
+/// Refs #1093: a no-pending terminal (for example the in-loop recovery tail
+/// applying a detached-op completion wake with no prompt) must not retire the
+/// registration while other admitted input is still queued behind it.
+#[tokio::test]
+async fn no_pending_runtime_loop_keeps_serving_when_other_input_is_queued() {
+    struct GatedNoPendingThenServingExecutor {
+        apply_calls: Arc<AtomicUsize>,
+        stop_calls: Arc<AtomicUsize>,
+        first_apply_started: Arc<Notify>,
+        release_first_apply: Arc<Notify>,
+    }
+
+    #[async_trait::async_trait]
+    impl CoreExecutor for GatedNoPendingThenServingExecutor {
+        async fn apply(
+            &mut self,
+            run_id: RunId,
+            primitive: RunPrimitive,
+        ) -> Result<CoreApplyOutput, CoreExecutorError> {
+            let call_index = self.apply_calls.fetch_add(1, Ordering::SeqCst);
+            let terminal = if call_index == 0 {
+                self.first_apply_started.notify_one();
+                self.release_first_apply.notified().await;
+                Some(CoreApplyTerminal::NoPendingBoundary)
+            } else {
+                None
+            };
+            Ok(CoreApplyOutput::with_untyped_snapshot(
+                RunBoundaryReceiptDraft {
+                    run_id,
+                    boundary: RunApplyBoundary::RunStart,
+                    contributing_input_ids: primitive.contributing_input_ids().to_vec(),
+                    conversation_digest: None,
+                    message_count: 0,
+                },
+                None,
+                terminal,
+            ))
+        }
+
+        async fn cancel_after_boundary(
+            &mut self,
+            _reason: String,
+        ) -> Result<(), CoreExecutorError> {
+            Ok(())
+        }
+
+        async fn stop_runtime_executor(
+            &mut self,
+            _reason: String,
+        ) -> Result<(), CoreExecutorError> {
+            self.stop_calls.fetch_add(1, Ordering::SeqCst);
+            Ok(())
+        }
+    }
+
+    let machine = Arc::new(MeerkatMachine::ephemeral());
+    let session_id = SessionId::new();
+    let apply_calls = Arc::new(AtomicUsize::new(0));
+    let stop_calls = Arc::new(AtomicUsize::new(0));
+    let first_apply_started = Arc::new(Notify::new());
+    let release_first_apply = Arc::new(Notify::new());
+    machine
+        .register_session_with_executor(
+            session_id.clone(),
+            Box::new(GatedNoPendingThenServingExecutor {
+                apply_calls: Arc::clone(&apply_calls),
+                stop_calls: Arc::clone(&stop_calls),
+                first_apply_started: Arc::clone(&first_apply_started),
+                release_first_apply: Arc::clone(&release_first_apply),
+            }),
+        )
+        .await
+        .expect("runtime executor registration should succeed");
+    let registration = machine
+        .current_session_registration_witness(&session_id)
+        .await
+        .expect("registered runtime must expose an exact registration witness");
+
+    // First batch: admitted alone and parked inside apply so the second input
+    // is queued outside it rather than folded into the same batch.
+    let (first_outcome, first_completion) = machine
+        .accept_input_with_completion(&session_id, make_prompt("no-pending wake"))
+        .await
+        .expect("first input should be admitted");
+    assert!(first_outcome.is_accepted());
+    tokio::time::timeout(Duration::from_secs(1), first_apply_started.notified())
+        .await
+        .expect("first apply must reach its gate");
+    let (second_outcome, second_completion) = machine
+        .accept_input_with_completion(&session_id, make_prompt("queued behind the wake"))
+        .await
+        .expect("second input should be admitted while the first executes");
+    assert!(second_outcome.is_accepted());
+    release_first_apply.notify_one();
+
+    let first = tokio::time::timeout(
+        Duration::from_secs(2),
+        first_completion
+            .expect("first input must carry a completion")
+            .wait(),
+    )
+    .await
+    .expect("no-pending batch must resolve")
+    .expect("no-pending batch must resolve with an outcome");
+    assert!(
+        !matches!(first, CompletionOutcome::RuntimeTerminated { .. }),
+        "no-pending batch must commit normally: {first:?}"
+    );
+    let second = tokio::time::timeout(
+        Duration::from_secs(2),
+        second_completion
+            .expect("second input must carry a completion")
+            .wait(),
+    )
+    .await
+    .expect("queued input must be applied by the next batch")
+    .expect("queued input must resolve with an outcome");
+    assert!(
+        matches!(
+            second,
+            CompletionOutcome::Completed(_) | CompletionOutcome::CompletedWithoutResult
+        ),
+        "queued input must complete instead of observing runtime teardown: {second:?}"
+    );
+
+    assert_eq!(apply_calls.load(Ordering::SeqCst), 2);
+    assert_eq!(
+        stop_calls.load(Ordering::SeqCst),
+        0,
+        "no executor stop may run while admitted work was queued"
+    );
+    assert!(machine.contains_session(&session_id).await);
+    let after = machine
+        .current_session_registration_witness(&session_id)
+        .await
+        .expect("registration must survive the no-pending batch");
+    assert_eq!(after.epoch_id(), registration.epoch_id());
+    let live_state = machine
+        .session_dsl_state(&session_id)
+        .await
+        .expect("generated registration must remain live");
+    assert_eq!(
+        live_state.registration_phase,
+        mm_dsl::RegistrationPhase::Active,
+        "no BeginUnregister may be staged while admitted work was queued"
+    );
+}
+
 #[tokio::test]
 async fn no_pending_runtime_loop_exit_persists_unregister_and_ensure_joins_settlement() {
     struct NoPendingExecutor {

--- a/meerkat-runtime/src/runtime_loop.rs
+++ b/meerkat-runtime/src/runtime_loop.rs
@@ -2402,6 +2402,8 @@ fn fail_closed_completion_waiters(
     );
 }
 
+pub(crate) use crate::meerkat_machine::RuntimeLoopTeardownUnregisterAdmission;
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub(crate) enum RuntimeLoopTeardownDisposition {
     #[default]
@@ -4579,6 +4581,25 @@ impl RuntimeLoopAuthorityBinding {
             .begin_unregister_from_runtime_loop_teardown(&self.session_id, driver)
             .await
     }
+
+    /// Same as [`Self::begin_durable_unregister_for_teardown`], but declines
+    /// to stage `BeginUnregisterSession` when admitted input is still queued
+    /// under the session mutation gate. Only the no-pending terminal path may
+    /// use this: a failed run that requires teardown must still fail closed.
+    async fn begin_durable_unregister_for_teardown_unless_queued(
+        &self,
+        driver: &crate::meerkat_machine::SharedDriver,
+    ) -> Result<RuntimeLoopTeardownUnregisterAdmission, crate::traits::RuntimeDriverError> {
+        let machine =
+            self.machine
+                .upgrade()
+                .ok_or(crate::traits::RuntimeDriverError::NotReady {
+                    state: crate::runtime_state::RuntimeState::Destroyed,
+                })?;
+        machine
+            .begin_unregister_from_runtime_loop_teardown_unless_queued(&self.session_id, driver)
+            .await
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -6473,6 +6494,11 @@ async fn process_queue(
 
                 // Lock again to update driver state
                 let d = driver.lock().await;
+                // Observed under the driver lock, before the terminal is
+                // classified: whether any admitted input outside this batch
+                // is still queued. A no-pending terminal may only retire the
+                // registration when nothing else is waiting on it.
+                let other_work_queued = d.has_queued_input_outside(&input_ids);
                 match result {
                     Ok(output) => {
                         drop(d);
@@ -6501,14 +6527,21 @@ async fn process_queue(
                         let (receipt, committed, terminal) = output.into_parts();
                         // A resume against a session that has no pending
                         // boundary is a successful terminal observation, but
-                        // the executor must not remain attached afterward.
-                        // Commit and resolve this batch first, then exit so the
-                        // loop guard publishes the exact executor to the
-                        // machine-owned unregister saga.
+                        // the executor must not remain attached afterward
+                        // when no other input is admitted. Commit and resolve
+                        // this batch first, then exit so the loop guard
+                        // publishes the exact executor to the machine-owned
+                        // unregister saga. When other admitted input is still
+                        // queued (for example a `turn/start` prompt admitted
+                        // behind a detached-op completion wake), the
+                        // registration stays serving: the materialized actor
+                        // remains attached and the queued input is applied by
+                        // the next batch instead of resolving
+                        // `RuntimeTerminated`.
                         let teardown_after_commit = matches!(
                             terminal.as_ref(),
                             Some(CoreApplyTerminal::NoPendingBoundary)
-                        );
+                        ) && !other_work_queued;
                         // Keep one cheap clone of the sealed carrier for
                         // post-commit publication. WholeBlob clones share the
                         // lazy byte cell; HeadCanonical clones only an Arc to
@@ -6825,21 +6858,40 @@ async fn process_queue(
                             continue;
                         }
                         if teardown_after_commit {
-                            handoff.disposition =
-                                RuntimeLoopTeardownDisposition::UnregisterRequired;
-                            if let Err(error) = authority_binding
-                                .begin_durable_unregister_for_teardown(driver)
+                            let prior_disposition = std::mem::replace(
+                                &mut handoff.disposition,
+                                RuntimeLoopTeardownDisposition::UnregisterRequired,
+                            );
+                            match authority_binding
+                                .begin_durable_unregister_for_teardown_unless_queued(driver)
                                 .await
                             {
-                                // The typed handoff disposition is the
-                                // fail-closed fallback. Its watcher starts the
-                                // unregister saga, which must persist Draining
-                                // before taking the exact executor.
-                                tracing::error!(
-                                    session_id = %authority_binding.session_id,
-                                    %error,
-                                    "no-pending runtime apply could not persist BeginUnregister before loop handoff"
-                                );
+                                Ok(RuntimeLoopTeardownUnregisterAdmission::Began) => {}
+                                Ok(RuntimeLoopTeardownUnregisterAdmission::QueuedWorkPresent) => {
+                                    // Input was admitted between the queue
+                                    // observation above and the mutation gate.
+                                    // Nothing has been staged, so keep serving
+                                    // and let the next batch apply it.
+                                    handoff.disposition = prior_disposition;
+                                    tracing::debug!(
+                                        session_id = %authority_binding.session_id,
+                                        %run_id,
+                                        "no-pending runtime apply found newly admitted input; keeping the registration serving"
+                                    );
+                                    continue;
+                                }
+                                Err(error) => {
+                                    // The typed handoff disposition is the
+                                    // fail-closed fallback. Its watcher starts
+                                    // the unregister saga, which must persist
+                                    // Draining before taking the exact
+                                    // executor.
+                                    tracing::error!(
+                                        session_id = %authority_binding.session_id,
+                                        %error,
+                                        "no-pending runtime apply could not persist BeginUnregister before loop handoff"
+                                    );
+                                }
                             }
                             return true;
                         }

--- a/meerkat/src/session_runtime/runtime_state.rs
+++ b/meerkat/src/session_runtime/runtime_state.rs
@@ -376,15 +376,24 @@ mod ops {
             result
         }
 
-        /// Discard a stale live session and unregister it from the
-        /// runtime adapter so the same `SessionId` can be rematerialized.
+        /// Discard a stale live session so the same `SessionId` can be
+        /// rematerialized, and unregister its runtime registration only when a
+        /// live actor was actually torn down.
         ///
         /// Contract:
-        /// - The service-side live projection is discarded first; an absent
-        ///   projection (`Ok(())` or `NotFound`) is already clean.
-        /// - The exact current [`RuntimeSessionRegistrationWitness`] is
-        ///   captured and its owned unregister teardown saga is awaited to
-        ///   terminal completion via
+        /// - Absent live projection: nothing is stale, so the runtime
+        ///   registration is kept as-is and `Ok(())` is returned. A
+        ///   registration without a live actor is a healthy state (for example
+        ///   `monitors/start` attaching an executor before any turn): the
+        ///   runtime loop's recovery tail materializes the actor from durable
+        ///   authority on the next accepted input. Tearing that registration
+        ///   down here would wait on a loop that may be inside a
+        ///   continuation turn, which is the `durable_jobs_workgraph_recovery`
+        ///   handoff stall.
+        /// - Behind live projection: the live actor is discarded first (a
+        ///   `NotFound` race is already clean), then the exact current
+        ///   [`RuntimeSessionRegistrationWitness`] is captured and its owned
+        ///   unregister teardown saga is awaited to terminal completion via
         ///   `unregister_session_registration_until_terminal_if_current`.
         ///   There is deliberately no outer bound: the saga is
         ///   coordinator-owned, so dropping this future never aborts
@@ -404,6 +413,18 @@ mod ops {
             &self,
             session_id: &SessionId,
         ) -> Result<(), SessionError> {
+            // Mechanical registry probe: no actor RPC, no durable arbitration,
+            // so a turn parked inside the actor cannot stall this check.
+            let live_actor_registered =
+                self.service.live_session_actor_registered(session_id).await;
+            if !live_actor_registered {
+                tracing::debug!(
+                    %session_id,
+                    "stale live-session discard found no live actor; keeping the runtime \
+                     registration for in-loop rematerialization from durable authority"
+                );
+                return Ok(());
+            }
             let discard_error = match self.discard_live_session(session_id).await {
                 Ok(()) | Err(SessionError::NotFound { .. }) => None,
                 Err(error) => Some(error),

--- a/meerkat/src/session_runtime/runtime_state.rs
+++ b/meerkat/src/session_runtime/runtime_state.rs
@@ -377,7 +377,29 @@ mod ops {
         }
 
         /// Discard a stale live session and unregister it from the
-        /// runtime adapter.
+        /// runtime adapter so the same `SessionId` can be rematerialized.
+        ///
+        /// Contract:
+        /// - The service-side live projection is discarded first; an absent
+        ///   projection (`Ok(())` or `NotFound`) is already clean.
+        /// - The exact current [`RuntimeSessionRegistrationWitness`] is
+        ///   captured and its owned unregister teardown saga is awaited to
+        ///   terminal completion via
+        ///   `unregister_session_registration_until_terminal_if_current`.
+        ///   There is deliberately no outer bound: the saga is
+        ///   coordinator-owned, so dropping this future never aborts
+        ///   teardown, and any bound shorter than the teardown latency would
+        ///   reintroduce `UnregisterInProgress` to the caller that is about to
+        ///   reoccupy the `SessionId`.
+        /// - An absent registration, or one already replaced by a
+        ///   same-`SessionId` successor before the unregister was admitted
+        ///   (`Ok(false)`), is treated as already clean; this call never joins
+        ///   teardown for a replacement registration.
+        /// - Discard and unregister failures are combined: a discard failure
+        ///   alone is returned as-is, an unregister failure alone is wrapped as
+        ///   an internal error, and both together are reported in one error.
+        ///
+        /// [`RuntimeSessionRegistrationWitness`]: meerkat_runtime::RuntimeSessionRegistrationWitness
         pub async fn discard_stale_live_session(
             &self,
             session_id: &SessionId,
@@ -391,12 +413,23 @@ mod ops {
                 .current_session_registration_witness(session_id)
                 .await
             {
-                Some(registration) => self
+                Some(registration) => match self
                     .runtime_adapter
                     .unregister_session_registration_until_terminal_if_current(&registration)
                     .await
-                    .map(|_| ())
-                    .err(),
+                {
+                    Ok(true) => None,
+                    Ok(false) => {
+                        tracing::debug!(
+                            %session_id,
+                            epoch_id = %registration.epoch_id(),
+                            "stale live-session registration was replaced before unregister; \
+                             treating the captured registration as already clean"
+                        );
+                        None
+                    }
+                    Err(error) => Some(error),
+                },
                 None => None,
             };
             match (discard_error, unregister_error) {

--- a/meerkat/tests/session_runtime_runtime_state.rs
+++ b/meerkat/tests/session_runtime_runtime_state.rs
@@ -663,26 +663,70 @@ async fn archive_runtime_cleanup_preserves_downstream_anchors_when_unregister_fa
     assert!(mob_ran.load(Ordering::SeqCst));
 }
 
-/// Fixture shared by the stale-discard tests below: a `CoreExecutor` whose
+/// Fixtures shared by the stale-discard tests below: a `CoreExecutor` whose
 /// post-stop cleanup parks on a deterministic gate so the owned unregister
-/// teardown saga can be held past the ordinary 2-second caller grace.
+/// teardown saga can be held past the ordinary 2-second caller grace, and a
+/// mock LLM so the persistent service can materialize a real live actor.
 mod stale_discard {
     use std::collections::HashMap;
+    use std::pin::Pin;
     use std::sync::Arc;
     use std::sync::atomic::{AtomicUsize, Ordering};
     use std::time::Duration;
 
     use meerkat::session_runtime::runtime_state::RuntimeStateOps;
     use meerkat::{AgentFactory, Config, FactoryAgentBuilder, PersistentSessionService};
+    use meerkat_client::{LlmClient, LlmDoneOutcome, LlmError, LlmEvent, LlmRequest};
     use meerkat_core::lifecycle::RunId;
     use meerkat_core::lifecycle::core_executor::{
         CoreApplyOutput, CoreExecutor, CoreExecutorError,
     };
     use meerkat_core::lifecycle::run_primitive::{RunApplyBoundary, RunPrimitive};
     use meerkat_core::lifecycle::run_receipt::RunBoundaryReceiptDraft;
+    use meerkat_core::service::{
+        CreateSessionRequest, DeferredPromptPolicy, InitialTurnPolicy, SessionBuildOptions,
+        SessionService as _,
+    };
     use meerkat_core::types::SessionId;
     use meerkat_runtime::MeerkatMachine;
     use tokio::sync::Notify;
+
+    struct MockLlmClient;
+
+    #[async_trait::async_trait]
+    impl LlmClient for MockLlmClient {
+        fn project_replay_messages(
+            &self,
+            messages: &[meerkat_core::Message],
+        ) -> Result<Vec<meerkat_core::Message>, LlmError> {
+            Ok(messages.to_vec())
+        }
+
+        fn stream<'a>(
+            &'a self,
+            _request: &'a LlmRequest,
+        ) -> Pin<Box<dyn futures::Stream<Item = Result<LlmEvent, LlmError>> + Send + 'a>> {
+            Box::pin(futures::stream::iter(vec![
+                Ok(LlmEvent::TextDelta {
+                    delta: "mock".to_string(),
+                    meta: None,
+                }),
+                Ok(LlmEvent::Done {
+                    outcome: LlmDoneOutcome::Success {
+                        stop_reason: meerkat_core::StopReason::EndTurn,
+                    },
+                }),
+            ]))
+        }
+
+        fn provider(&self) -> meerkat_core::Provider {
+            meerkat_core::Provider::Other
+        }
+
+        async fn health_check(&self) -> Result<(), LlmError> {
+            Ok(())
+        }
+    }
 
     struct GatedCleanupExecutor {
         cleanup_started: Arc<Notify>,
@@ -741,9 +785,16 @@ mod stale_discard {
         runtime_adapter: Arc<MeerkatMachine>,
     }
 
+    struct GatedTeardown {
+        cleanup_started: Arc<Notify>,
+        release_cleanup: Arc<Notify>,
+        cleanup_calls: Arc<AtomicUsize>,
+    }
+
     impl Fixture {
         fn new() -> Self {
-            let builder = FactoryAgentBuilder::new(AgentFactory::minimal(), Config::default());
+            let mut builder = FactoryAgentBuilder::new(AgentFactory::minimal(), Config::default());
+            builder.default_llm_client = Some(Arc::new(MockLlmClient));
             let service = Arc::new(PersistentSessionService::new(
                 builder,
                 4,
@@ -766,6 +817,53 @@ mod stale_discard {
                 staged_capacity_admissions: &self.staged_capacity_admissions,
                 runtime_adapter: &self.runtime_adapter,
             }
+        }
+
+        /// Create a persisted session whose live actor is materialized.
+        async fn create_live_session(&self) -> SessionId {
+            let created = self
+                .service
+                .create_session(CreateSessionRequest {
+                    injected_context: Vec::new(),
+                    model: "gpt-5.4".to_string(),
+                    prompt: "stale discard fixture".to_string().into(),
+                    system_prompt: meerkat_core::config::SystemPromptOverride::Inherit,
+                    max_tokens: None,
+                    event_tx: None,
+                    initial_turn: InitialTurnPolicy::Defer,
+                    deferred_prompt_policy: DeferredPromptPolicy::Discard,
+                    build: Some(SessionBuildOptions::default()),
+                    labels: None,
+                })
+                .await
+                .expect("persistent service must create a live session");
+            assert!(
+                self.service
+                    .live_session_actor_registered(&created.session_id)
+                    .await,
+                "fixture must start with a registered live actor"
+            );
+            created.session_id
+        }
+
+        async fn register_gated_runtime(&self, session_id: &SessionId) -> GatedTeardown {
+            let gate = GatedTeardown {
+                cleanup_started: Arc::new(Notify::new()),
+                release_cleanup: Arc::new(Notify::new()),
+                cleanup_calls: Arc::new(AtomicUsize::new(0)),
+            };
+            self.runtime_adapter
+                .register_session_with_executor(
+                    session_id.clone(),
+                    Box::new(GatedCleanupExecutor {
+                        cleanup_started: Arc::clone(&gate.cleanup_started),
+                        release_cleanup: Arc::clone(&gate.release_cleanup),
+                        cleanup_calls: Arc::clone(&gate.cleanup_calls),
+                    }),
+                )
+                .await
+                .expect("runtime executor registration should succeed");
+            gate
         }
     }
 
@@ -791,11 +889,78 @@ mod stale_discard {
         assert!(!fixture.runtime_adapter.contains_session(&session_id).await);
     }
 
-    /// (b) A teardown that outlives the ordinary 2-second caller grace must
-    /// complete with `Ok(())` instead of surfacing `UnregisterInProgress` to
-    /// the caller that is about to reoccupy the `SessionId`.
+    /// Persisted session, runtime registered with an executor, but no live
+    /// actor (the reopened `monitors/start` shape): the registration is
+    /// healthy and must be kept, so no teardown is started and nothing waits
+    /// on the runtime loop.
     #[tokio::test]
-    async fn discard_stale_live_session_awaits_teardown_past_caller_grace() {
+    async fn discard_stale_live_session_keeps_registration_without_live_actor() {
+        let fixture = Fixture::new();
+        let session_id = fixture.create_live_session().await;
+        fixture
+            .service
+            .discard_live_session(&session_id)
+            .await
+            .expect("live actor discard should succeed");
+        assert!(
+            !fixture
+                .service
+                .live_session_actor_registered(&session_id)
+                .await
+        );
+        assert!(
+            fixture
+                .service
+                .load_authoritative_session(&session_id)
+                .await
+                .expect("authoritative load should succeed")
+                .is_some(),
+            "durable record must survive the live actor discard"
+        );
+        let gate = fixture.register_gated_runtime(&session_id).await;
+        let before = fixture
+            .runtime_adapter
+            .current_session_registration_witness(&session_id)
+            .await
+            .expect("registered runtime must expose an exact registration witness");
+
+        tokio::time::timeout(
+            Duration::from_secs(1),
+            fixture.ops().discard_stale_live_session(&session_id),
+        )
+        .await
+        .expect("discard without a live actor must not wait on any teardown")
+        .expect("discard without a live actor must be clean");
+
+        let after = fixture
+            .runtime_adapter
+            .current_session_registration_witness(&session_id)
+            .await
+            .expect("registration must survive a discard that found no live actor");
+        assert_eq!(
+            after.epoch_id(),
+            before.epoch_id(),
+            "the exact registration must be untouched"
+        );
+        assert_eq!(
+            fixture
+                .runtime_adapter
+                .unregister_runtime_loop_handoff_wait_reports(&session_id)
+                .await,
+            Some(0),
+            "no unregister teardown may have started"
+        );
+        assert_eq!(gate.cleanup_calls.load(Ordering::SeqCst), 0);
+        gate.release_cleanup.notify_one();
+    }
+
+    /// (b) A live actor exists (behind durable authority): it is discarded and
+    /// the exact registration is torn down. A teardown that outlives the
+    /// ordinary 2-second caller grace must complete with `Ok(())` instead of
+    /// surfacing `UnregisterInProgress` to the caller about to reoccupy the
+    /// `SessionId`.
+    #[tokio::test]
+    async fn discard_stale_live_session_with_live_actor_awaits_teardown_past_caller_grace() {
         // Mirrors UNREGISTER_CALLER_WAIT_GRACE in meerkat-runtime; the hold
         // must exceed it so the old `unregister_session` path would already
         // have returned `UnregisterInProgress`.
@@ -803,22 +968,8 @@ mod stale_discard {
         const PAST_GRACE_HOLD: Duration = Duration::from_millis(2600);
 
         let fixture = Arc::new(Fixture::new());
-        let session_id = SessionId::new();
-        let cleanup_started = Arc::new(Notify::new());
-        let release_cleanup = Arc::new(Notify::new());
-        let cleanup_calls = Arc::new(AtomicUsize::new(0));
-        fixture
-            .runtime_adapter
-            .register_session_with_executor(
-                session_id.clone(),
-                Box::new(GatedCleanupExecutor {
-                    cleanup_started: Arc::clone(&cleanup_started),
-                    release_cleanup: Arc::clone(&release_cleanup),
-                    cleanup_calls: Arc::clone(&cleanup_calls),
-                }),
-            )
-            .await
-            .expect("runtime executor registration should succeed");
+        let session_id = fixture.create_live_session().await;
+        let gate = fixture.register_gated_runtime(&session_id).await;
         let registration = fixture
             .runtime_adapter
             .current_session_registration_witness(&session_id)
@@ -830,9 +981,16 @@ mod stale_discard {
             let session_id = session_id.clone();
             tokio::spawn(async move { fixture.ops().discard_stale_live_session(&session_id).await })
         };
-        tokio::time::timeout(Duration::from_secs(1), cleanup_started.notified())
+        tokio::time::timeout(Duration::from_secs(1), gate.cleanup_started.notified())
             .await
             .expect("owned teardown must reach the deterministic cleanup gate");
+        assert!(
+            !fixture
+                .service
+                .live_session_actor_registered(&session_id)
+                .await,
+            "the behind live actor must be discarded before teardown"
+        );
 
         // Hold the teardown gate strictly longer than the old caller grace.
         assert!(PAST_GRACE_HOLD > OLD_CALLER_GRACE);
@@ -847,14 +1005,14 @@ mod stale_discard {
             "registration must remain owned by the in-flight teardown"
         );
 
-        release_cleanup.notify_one();
+        gate.release_cleanup.notify_one();
         tokio::time::timeout(Duration::from_secs(2), discard)
             .await
             .expect("stale discard must finish once teardown reaches terminal completion")
             .expect("stale discard task should not panic")
             .expect("stale discard must complete with Ok(()) past the old caller grace");
         assert!(!fixture.runtime_adapter.contains_session(&session_id).await);
-        assert_eq!(cleanup_calls.load(Ordering::SeqCst), 1);
+        assert_eq!(gate.cleanup_calls.load(Ordering::SeqCst), 1);
         assert!(
             fixture
                 .runtime_adapter

--- a/meerkat/tests/session_runtime_runtime_state.rs
+++ b/meerkat/tests/session_runtime_runtime_state.rs
@@ -662,3 +662,207 @@ async fn archive_runtime_cleanup_preserves_downstream_anchors_when_unregister_fa
     assert!(mcp_ran.load(Ordering::SeqCst));
     assert!(mob_ran.load(Ordering::SeqCst));
 }
+
+/// Fixture shared by the stale-discard tests below: a `CoreExecutor` whose
+/// post-stop cleanup parks on a deterministic gate so the owned unregister
+/// teardown saga can be held past the ordinary 2-second caller grace.
+mod stale_discard {
+    use std::collections::HashMap;
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::time::Duration;
+
+    use meerkat::session_runtime::runtime_state::RuntimeStateOps;
+    use meerkat::{AgentFactory, Config, FactoryAgentBuilder, PersistentSessionService};
+    use meerkat_core::lifecycle::RunId;
+    use meerkat_core::lifecycle::core_executor::{
+        CoreApplyOutput, CoreExecutor, CoreExecutorError,
+    };
+    use meerkat_core::lifecycle::run_primitive::{RunApplyBoundary, RunPrimitive};
+    use meerkat_core::lifecycle::run_receipt::RunBoundaryReceiptDraft;
+    use meerkat_core::types::SessionId;
+    use meerkat_runtime::MeerkatMachine;
+    use tokio::sync::Notify;
+
+    struct GatedCleanupExecutor {
+        cleanup_started: Arc<Notify>,
+        release_cleanup: Arc<Notify>,
+        cleanup_calls: Arc<AtomicUsize>,
+    }
+
+    #[async_trait::async_trait]
+    impl CoreExecutor for GatedCleanupExecutor {
+        async fn apply(
+            &mut self,
+            run_id: RunId,
+            primitive: RunPrimitive,
+        ) -> Result<CoreApplyOutput, CoreExecutorError> {
+            Ok(CoreApplyOutput::with_untyped_snapshot(
+                RunBoundaryReceiptDraft {
+                    run_id,
+                    boundary: RunApplyBoundary::RunStart,
+                    contributing_input_ids: primitive.contributing_input_ids().to_vec(),
+                    conversation_digest: None,
+                    message_count: 0,
+                },
+                None,
+                None,
+            ))
+        }
+
+        async fn cancel_after_boundary(
+            &mut self,
+            _reason: String,
+        ) -> Result<(), CoreExecutorError> {
+            Ok(())
+        }
+
+        async fn stop_runtime_executor(
+            &mut self,
+            _reason: String,
+        ) -> Result<(), CoreExecutorError> {
+            Ok(())
+        }
+
+        async fn cleanup_after_runtime_stop_terminalized(
+            &mut self,
+        ) -> Result<(), CoreExecutorError> {
+            self.cleanup_calls.fetch_add(1, Ordering::SeqCst);
+            self.cleanup_started.notify_one();
+            self.release_cleanup.notified().await;
+            Ok(())
+        }
+    }
+
+    struct Fixture {
+        service: Arc<PersistentSessionService<FactoryAgentBuilder>>,
+        staged_sessions: Arc<meerkat::StagedSessionRegistry>,
+        staged_capacity_admissions: meerkat::session_runtime::admission::StagedCapacityAdmissions,
+        runtime_adapter: Arc<MeerkatMachine>,
+    }
+
+    impl Fixture {
+        fn new() -> Self {
+            let builder = FactoryAgentBuilder::new(AgentFactory::minimal(), Config::default());
+            let service = Arc::new(PersistentSessionService::new(
+                builder,
+                4,
+                Arc::new(meerkat_store::MemoryStore::new()),
+                Arc::new(meerkat_runtime::store::InMemoryRuntimeStore::new()),
+                Arc::new(meerkat_store::MemoryBlobStore::new()),
+            ));
+            Self {
+                service,
+                staged_sessions: Arc::new(meerkat::StagedSessionRegistry::new()),
+                staged_capacity_admissions: Arc::new(std::sync::Mutex::new(HashMap::new())),
+                runtime_adapter: Arc::new(MeerkatMachine::ephemeral()),
+            }
+        }
+
+        fn ops(&self) -> RuntimeStateOps<'_> {
+            RuntimeStateOps {
+                service: &self.service,
+                staged_sessions: &self.staged_sessions,
+                staged_capacity_admissions: &self.staged_capacity_admissions,
+                runtime_adapter: &self.runtime_adapter,
+            }
+        }
+    }
+
+    /// (a) No live projection and no runtime registration: nothing to tear
+    /// down, so the discard is already clean.
+    #[tokio::test]
+    async fn discard_stale_live_session_with_absent_registration_is_clean() {
+        let fixture = Fixture::new();
+        let session_id = SessionId::new();
+        assert!(
+            fixture
+                .runtime_adapter
+                .current_session_registration_witness(&session_id)
+                .await
+                .is_none()
+        );
+
+        fixture
+            .ops()
+            .discard_stale_live_session(&session_id)
+            .await
+            .expect("absent registration must be treated as already clean");
+        assert!(!fixture.runtime_adapter.contains_session(&session_id).await);
+    }
+
+    /// (b) A teardown that outlives the ordinary 2-second caller grace must
+    /// complete with `Ok(())` instead of surfacing `UnregisterInProgress` to
+    /// the caller that is about to reoccupy the `SessionId`.
+    #[tokio::test]
+    async fn discard_stale_live_session_awaits_teardown_past_caller_grace() {
+        // Mirrors UNREGISTER_CALLER_WAIT_GRACE in meerkat-runtime; the hold
+        // must exceed it so the old `unregister_session` path would already
+        // have returned `UnregisterInProgress`.
+        const OLD_CALLER_GRACE: Duration = Duration::from_secs(2);
+        const PAST_GRACE_HOLD: Duration = Duration::from_millis(2600);
+
+        let fixture = Arc::new(Fixture::new());
+        let session_id = SessionId::new();
+        let cleanup_started = Arc::new(Notify::new());
+        let release_cleanup = Arc::new(Notify::new());
+        let cleanup_calls = Arc::new(AtomicUsize::new(0));
+        fixture
+            .runtime_adapter
+            .register_session_with_executor(
+                session_id.clone(),
+                Box::new(GatedCleanupExecutor {
+                    cleanup_started: Arc::clone(&cleanup_started),
+                    release_cleanup: Arc::clone(&release_cleanup),
+                    cleanup_calls: Arc::clone(&cleanup_calls),
+                }),
+            )
+            .await
+            .expect("runtime executor registration should succeed");
+        let registration = fixture
+            .runtime_adapter
+            .current_session_registration_witness(&session_id)
+            .await
+            .expect("registered runtime must expose an exact registration witness");
+
+        let discard = {
+            let fixture = Arc::clone(&fixture);
+            let session_id = session_id.clone();
+            tokio::spawn(async move { fixture.ops().discard_stale_live_session(&session_id).await })
+        };
+        tokio::time::timeout(Duration::from_secs(1), cleanup_started.notified())
+            .await
+            .expect("owned teardown must reach the deterministic cleanup gate");
+
+        // Hold the teardown gate strictly longer than the old caller grace.
+        assert!(PAST_GRACE_HOLD > OLD_CALLER_GRACE);
+        tokio::time::sleep(PAST_GRACE_HOLD).await;
+        assert!(
+            !discard.is_finished(),
+            "stale discard must keep waiting on the exact teardown instead of \
+             erroring at the ordinary caller grace"
+        );
+        assert!(
+            fixture.runtime_adapter.contains_session(&session_id).await,
+            "registration must remain owned by the in-flight teardown"
+        );
+
+        release_cleanup.notify_one();
+        tokio::time::timeout(Duration::from_secs(2), discard)
+            .await
+            .expect("stale discard must finish once teardown reaches terminal completion")
+            .expect("stale discard task should not panic")
+            .expect("stale discard must complete with Ok(()) past the old caller grace");
+        assert!(!fixture.runtime_adapter.contains_session(&session_id).await);
+        assert_eq!(cleanup_calls.load(Ordering::SeqCst), 1);
+        assert!(
+            fixture
+                .runtime_adapter
+                .current_session_registration_witness(&session_id)
+                .await
+                .is_none(),
+            "the exact registration {} must be gone after terminal teardown",
+            registration.epoch_id()
+        );
+    }
+}

--- a/tests/integration/tests/smoke_shared_realm.rs
+++ b/tests/integration/tests/smoke_shared_realm.rs
@@ -824,7 +824,20 @@ impl RpcEventPump {
         timeout_secs: u64,
     ) -> Result<Value, Box<dyn std::error::Error>> {
         let id = self.send_request(process, method, params).await?;
-        self.wait_for_response(process, id, timeout_secs).await
+        match self.wait_for_response(process, id, timeout_secs).await {
+            Ok(result) => Ok(result),
+            Err(error) => {
+                // Embed the drained server stderr so a failed request (error
+                // response or timeout) carries the rkat-rpc trace lines that
+                // explain it, the same way the recovery-delivery timeout does.
+                let rpc_stderr = read_available_stderr(process, 500).await;
+                Err(format!(
+                    "rpc {method} failed: {error}\nrkat-rpc stderr at failure:\n{}",
+                    rpc_stderr.trim()
+                )
+                .into())
+            }
+        }
     }
 
     /// Send an RPC request and require that the response carries a JSON-RPC


### PR DESCRIPTION
Refs #1093. Root cause of the durable_jobs_workgraph_recovery flake: in a
reopened rkat-rpc, `monitors/start` calls `ensure_runtime_executor` to
reach the ops registry, which registers a runtime loop + executor with no
live actor. `live_session_is_stale` maps an absent live projection with a
persisted record to "stale", so `discard_stale_live_session` unregistered
that healthy registration and then awaited its owned teardown, which was
gated on a runtime loop parked inside a recovery continuation turn whose
hard-cancel was lost because no actor existed when the interrupt landed.

`discard_stale_live_session` now probes `live_session_actor_registered`
(mechanical registry check, no actor RPC) first. With no live actor it
returns `Ok(())` and leaves the registration untouched, with a
`tracing::debug!`; the callers proceed to `ensure_runtime_executor` +
runtime accept and the in-loop recovery tail materializes the actor from
durable authority, so the new input queues behind any in-flight
continuation. With a live actor the existing path is unchanged: discard
the actor, then await the exact registration's owned teardown to terminal
completion. The error-combination arms are unchanged.

Tests:
- facade: registration with an executor and no live actor keeps the same
  epoch across the discard, the handoff-wait observation counter stays 0,
  and the gated cleanup is never invoked; a live actor still discards and
  unregisters, and a teardown outliving the 2-second caller grace still
  completes with `Ok(())`.
- rpc: reopened-process shape (persisted session, `ensure_runtime_executor`
  as monitors/start does, no live actor) then `start_turn_via_runtime`
  succeeds, the registration epoch survives, the counter stays 0, and the
  recovery tail materializes the actor in place.

Both new keep-registration tests were confirmed to fail with the early
return disabled.

Also carries the #1090 follow-up (doc contract, debug trace on the not-current branch, facade tests for the past-grace wait). Root cause analysis: #1093. Closes #1090. Refs #1093.

Verification: fmt clean; `clippy -p meerkat -p meerkat-runtime -p meerkat-rpc --all-features --all-targets -D warnings` clean; `session_runtime_runtime_state` 10/10; new RPC test `turn_start_keeps_registered_runtime_that_has_no_live_actor` passes and fails with the early return disabled; 35/35 pre-existing stale/recover/ingress RPC tests pass. Targeted RBE `//:e2e_smoke_turbo_s_durable_jobs_workgraph_recovery` result posted as a comment. Pushed with hooks on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)