### PR TITLE
test(mob): de-flake held loopback ports, placed kickoff settle, keep-alive wait

### DIFF
--- a/meerkat-mob/src/runtime/supervisor_bridge.rs
+++ b/meerkat-mob/src/runtime/supervisor_bridge.rs
@@ -3399,13 +3399,12 @@ mod tests {
         PeerAddress,
     ) {
         let suffix = uuid::Uuid::new_v4();
-        let port_reservation =
-            std::net::TcpListener::bind("127.0.0.1:0").expect("reserve fixed loopback port");
-        let fixed_port = port_reservation
-            .local_addr()
-            .expect("reserved port address")
-            .port();
-        drop(port_reservation);
+        // The fixed port must survive the close-and-rebind of every rotation
+        // without another process being handed it in between (issue #1097).
+        // The bridge outlives this helper, so hold the reservation for the
+        // process (nextest runs one test per process).
+        let (fixed_port, port_reservation) = super::super::tests::reserve_fixed_loopback_port();
+        std::mem::forget(port_reservation);
         let advertised = PeerAddress::parse(format!("tcp://127.0.0.1:{fixed_port}"))
             .expect("fixed supervisor address");
         let authority = SupervisorAuthorityRecord::generate(

--- a/meerkat-mob/src/runtime/tests.rs
+++ b/meerkat-mob/src/runtime/tests.rs
@@ -16482,7 +16482,7 @@ async fn test_rotate_supervisor_observes_rejection_through_retained_authority() 
         "rotate-supervisor-cross-authority-rejection",
     );
     let mob_id = definition.id.clone();
-    let supervisor_port = unused_loopback_port();
+    let (supervisor_port, _supervisor_port_reservation) = reserve_fixed_loopback_port();
     let supervisor_address = format!("tcp://127.0.0.1:{supervisor_port}");
     definition
         .backend
@@ -16578,7 +16578,7 @@ async fn test_legacy_pending_rotation_prunes_inactive_acceptance_and_survives_re
         "rotate-supervisor-legacy-operation-migration",
     );
     let mob_id = definition.id.clone();
-    let supervisor_port = unused_loopback_port();
+    let (supervisor_port, _supervisor_port_reservation) = reserve_fixed_loopback_port();
     let supervisor_address = format!("tcp://127.0.0.1:{supervisor_port}");
     definition
         .backend
@@ -58455,24 +58455,58 @@ async fn test_external_tcp_bind_and_peer_turn_use_routable_supervisor_bridge() {
     );
 }
 
+/// A loopback port reserved for a fixed-port supervisor bridge.
+///
+/// Dropping the reservation releases the port, so a test keeps it in a named
+/// local (`_supervisor_port_reservation`) for as long as the bridge may bind,
+/// rebuild (rotation) or rebind (restart) that port.
 #[cfg(not(target_arch = "wasm32"))]
-fn unused_loopback_port() -> u16 {
-    std::net::TcpListener::bind(std::net::SocketAddr::from(([127, 0, 0, 1], 0)))
-        .expect("reserve loopback port")
-        .local_addr()
-        .expect("reserved listener local addr")
-        .port()
+pub(crate) struct LoopbackPortReservation {
+    #[cfg(target_os = "linux")]
+    _socket: tokio::net::TcpSocket,
 }
 
+/// Reserve a loopback TCP port that a supervisor bridge can still bind.
+///
+/// Fixed-port rotation needs a nonzero port, so these tests cannot let the
+/// bridge bind `:0`. Probing `:0` and dropping the probe hands the port back
+/// to the kernel, and any other process (a second nextest lane on the same
+/// box, or any ephemeral `connect()`) may be given it before the bridge binds
+/// (issue #1097).
+///
+/// On Linux the reservation is therefore a bound, never-listening socket with
+/// `SO_REUSEADDR`. While it lives, the kernel excludes the port from every
+/// other process's ephemeral `bind(:0)` and `connect()` selection, yet a
+/// listener that also sets `SO_REUSEADDR` (tokio/mio always do) may bind,
+/// listen, close and rebind the exact port - the rotation and restart shape
+/// exercised here. Other platforms have no non-listening reuse semantics and
+/// keep the probe-then-drop shape; `.config/nextest.toml` serializes and
+/// retries that macOS cohort.
 #[cfg(not(target_arch = "wasm32"))]
-fn reserve_supervisor_bridge_port() -> (u16, std::net::TcpListener) {
-    let reservation = std::net::TcpListener::bind(std::net::SocketAddr::from(([0, 0, 0, 0], 0)))
-        .expect("reserve wildcard supervisor bridge port");
-    let port = reservation
-        .local_addr()
-        .expect("reserved supervisor bridge listener local addr")
-        .port();
-    (port, reservation)
+pub(crate) fn reserve_fixed_loopback_port() -> (u16, LoopbackPortReservation) {
+    let loopback = std::net::SocketAddr::from(([127, 0, 0, 1], 0));
+    #[cfg(target_os = "linux")]
+    {
+        let socket = tokio::net::TcpSocket::new_v4().expect("create loopback reservation socket");
+        socket
+            .set_reuseaddr(true)
+            .expect("set SO_REUSEADDR on loopback reservation");
+        socket.bind(loopback).expect("reserve loopback port");
+        let port = socket
+            .local_addr()
+            .expect("reserved loopback socket local addr")
+            .port();
+        (port, LoopbackPortReservation { _socket: socket })
+    }
+    #[cfg(not(target_os = "linux"))]
+    {
+        let port = std::net::TcpListener::bind(loopback)
+            .expect("reserve loopback port")
+            .local_addr()
+            .expect("reserved listener local addr")
+            .port();
+        (port, LoopbackPortReservation {})
+    }
 }
 
 #[cfg(not(target_arch = "wasm32"))]
@@ -58484,7 +58518,7 @@ async fn test_external_tcp_bind_uses_configured_supervisor_advertised_address() 
         "external-tcp-advertised-supervisor",
     );
     let mob_id = definition.id.clone();
-    let (port, port_reservation) = reserve_supervisor_bridge_port();
+    let (port, _supervisor_port_reservation) = reserve_fixed_loopback_port();
     let advertised_address = format!("tcp://127.0.0.1:{port}");
     definition
         .backend
@@ -58495,7 +58529,6 @@ async fn test_external_tcp_bind_uses_configured_supervisor_advertised_address() 
         bind_address: Some(format!("0.0.0.0:{port}")),
         advertised_address: Some(advertised_address.clone()),
     });
-    drop(port_reservation);
     let (handle, service) = create_test_mob(definition).await;
     let external_name = test_comms_name_for(&mob_id, "lead", "l-tcp-advertised");
     let external = spawn_live_external_tcp_peer(&external_name).await;
@@ -58581,7 +58614,7 @@ async fn test_external_tcp_fixed_supervisor_bridge_pending_rotation_retry_reuses
         "external-tcp-fixed-supervisor-pending-retry",
     );
     let mob_id = definition.id.clone();
-    let (port, port_reservation) = reserve_supervisor_bridge_port();
+    let (port, _supervisor_port_reservation) = reserve_fixed_loopback_port();
     let advertised_address = format!("tcp://127.0.0.1:{port}");
     definition
         .backend
@@ -58603,7 +58636,6 @@ async fn test_external_tcp_fixed_supervisor_bridge_pending_rotation_retry_reuses
     let runtime_metadata = storage.runtime_metadata.clone();
     let service = Arc::new(MockSessionService::new());
     let _ = service.enable_runtime_adapter();
-    drop(port_reservation);
     let handle = MobBuilder::new(definition, storage)
         .with_session_service(service.clone())
         // External peer-only members are owned by the MobMachine owner bridge
@@ -58747,7 +58779,7 @@ async fn test_fixed_port_activation_rebuild_failure_retries_same_durable_operati
         "fixed-port-activation-rebuild-retry-anchor",
     );
     let mob_id = definition.id.clone();
-    let port = unused_loopback_port();
+    let (port, _supervisor_port_reservation) = reserve_fixed_loopback_port();
     let advertised_address = format!("tcp://127.0.0.1:{port}");
     definition
         .backend

--- a/meerkat-mob/src/runtime/tests.rs
+++ b/meerkat-mob/src/runtime/tests.rs
@@ -23598,8 +23598,15 @@ enum ColdLocalReadinessFault {
     CommsRuntime,
 }
 
+/// Wait for the spawn-detached keep-alive `start_turn` kickoff to be issued.
+///
+/// Autonomous spawn returns before its keep-alive turn is started (the kickoff
+/// runs on a detached lifecycle task), so a counter read right after spawn
+/// races the runtime loop (issue #1101). The bound is generous because the
+/// wait returns the moment the count is reached; it only converts a hang into
+/// an attributed failure.
 async fn wait_for_keep_alive_start_turn_count(service: &MockSessionService, expected: u64) {
-    tokio::time::timeout(Duration::from_secs(1), async {
+    tokio::time::timeout(Duration::from_secs(10), async {
         while service.keep_alive_start_turn_call_count() < expected {
             tokio::task::yield_now().await;
         }
@@ -45391,7 +45398,7 @@ async fn test_spawn_with_custom_initial_message() {
 
     // Runtime adapter path: autonomous spawn uses accept_input_with_completion,
     // which delegates to start_turn and increments keep_alive_start_turn_call_count.
-    tokio::time::sleep(Duration::from_millis(10)).await;
+    wait_for_keep_alive_start_turn_count(service.as_ref(), 1).await;
     assert_eq!(
         service.keep_alive_start_turn_call_count(),
         1,
@@ -45437,7 +45444,7 @@ async fn test_spawn_without_initial_message_uses_default() {
 
     // Runtime adapter path: autonomous spawn uses accept_input_with_completion,
     // which delegates to start_turn and increments keep_alive_start_turn_call_count.
-    tokio::time::sleep(Duration::from_millis(10)).await;
+    wait_for_keep_alive_start_turn_count(service.as_ref(), 1).await;
     assert_eq!(
         service.keep_alive_start_turn_call_count(),
         1,
@@ -45673,7 +45680,7 @@ async fn test_retire_interrupts_autonomous_host_loop() {
         .await
         .expect("spawn worker");
     // Runtime adapter path: autonomous spawn uses accept_input_with_completion.
-    tokio::time::sleep(Duration::from_millis(10)).await;
+    wait_for_keep_alive_start_turn_count(service.as_ref(), 1).await;
     assert_eq!(
         service.keep_alive_start_turn_call_count(),
         1,
@@ -45732,7 +45739,7 @@ async fn test_stop_resume_host_loop_lifecycle_is_mode_aware() {
         .expect("turn-driven worker has an exact attachment");
     // Runtime adapter path: autonomous spawn uses accept_input_with_completion,
     // which delegates to start_turn. No injects from spawn.
-    tokio::time::sleep(Duration::from_millis(10)).await;
+    wait_for_keep_alive_start_turn_count(service.as_ref(), 1).await;
     assert_eq!(
         service.keep_alive_start_turn_call_count(),
         1,
@@ -45888,7 +45895,7 @@ async fn test_destroy_does_not_open_orchestrator_turn_before_archive() {
         .expect("spawn worker");
     // Runtime adapter path: autonomous members use accept_input_with_completion,
     // which delegates to start_turn. No injects from spawn.
-    tokio::time::sleep(Duration::from_millis(10)).await;
+    wait_for_keep_alive_start_turn_count(service.as_ref(), 2).await;
     assert_eq!(
         service.keep_alive_start_turn_call_count(),
         2,

--- a/meerkat-mob/tests/cross_host_flows.rs
+++ b/meerkat-mob/tests/cross_host_flows.rs
@@ -528,6 +528,21 @@ async fn overlay_autonomous_rejected_at_dispatch_same_cause_local_and_remote() {
         .spawn_spec(placed_spec)
         .await
         .expect("spawn placed autonomous member");
+    // The placed member's kickoff is the ONE legitimate directed turn on the
+    // member host: it runs there, journals a turn-outcome row, and that row is
+    // pruned only after the controlling pump consumes and exact-ACKs it.
+    // Settle that lifecycle before the overlay flows run so the journal
+    // assertion below measures the flow steps alone instead of racing the
+    // kickoff row (issue #1094).
+    controlling
+        .handle
+        .wait_for_members_kickoff_complete(&[identity("b-auto")], Some(RUN_WAIT))
+        .await
+        .expect("placed autonomous kickoff barrier resolves");
+    wait_until("placed kickoff turn outcome pruned", || async {
+        fixture.turn_outcome_rows(&mob_id).await.is_empty()
+    })
+    .await;
 
     for flow in ["overlay-local", "overlay-remote"] {
         let run_id = controlling
@@ -561,11 +576,12 @@ async fn overlay_autonomous_rejected_at_dispatch_same_cause_local_and_remote() {
         );
     }
 
-    // Rejected BEFORE delivery: the member host never saw a directed turn —
-    // no journal row, and the placed member ran no turn.
+    // Rejected BEFORE delivery: neither overlay step reached the member host -
+    // no journal row, and the placed member ran no flow turn.
+    let rows = fixture.turn_outcome_rows(&mob_id).await;
     assert!(
-        fixture.turn_outcome_rows(&mob_id).await.is_empty(),
-        "no directed turn ever reached the member host"
+        rows.is_empty(),
+        "no directed flow turn may reach the member host, got journal rows {rows:?}"
     );
 
     fixture.shutdown().await;

--- a/meerkat-mob/tests/smoke_mob_flow_runtime.rs
+++ b/meerkat-mob/tests/smoke_mob_flow_runtime.rs
@@ -39,8 +39,8 @@ use tokio::time::{Duration, Instant, sleep};
 mod support;
 use support::{
     HostFixtureOptions, REAL_COMMS_TEST_LOCK, create_controlling_mob,
-    create_controlling_mob_with_definition, send_peer_text, spawn_host_daemon_fixture,
-    spawn_production_external_tcp_target, unused_loopback_port, wait_until,
+    create_controlling_mob_with_definition, reserve_loopback_port, send_peer_text,
+    spawn_host_daemon_fixture, spawn_production_external_tcp_target, wait_until,
 };
 
 const REMOTE_MOB_LIVE_MODEL: &str = "claude-haiku-4-5-20251001";
@@ -2834,7 +2834,7 @@ async fn setup_flow_mob(
 }
 
 // `ProductionExternalTcpTarget`, `spawn_production_external_tcp_target`, and
-// `unused_loopback_port` moved to the shared fixture module
+// `reserve_loopback_port` moved to the shared fixture module
 // `tests/support/mod.rs` (multi-host mobs phase 2, Lane W4) so deterministic
 // lanes can compose the production-drain external target too. This file
 // consumes the shared fixture; the composition is byte-for-byte the same.
@@ -3251,7 +3251,7 @@ async fn e2e_external_tcp_production_drain_bind_and_turn_smoke() {
         "external-tcp-production-drain-smoke-{}",
         uuid::Uuid::new_v4().simple()
     ));
-    let supervisor_port = unused_loopback_port();
+    let supervisor_port = reserve_loopback_port();
     let supervisor_advertised_address = format!("tcp://127.0.0.1:{supervisor_port}");
     let definition = external_tcp_smoke_definition(
         mob_id.clone(),

--- a/meerkat-mob/tests/support/mod.rs
+++ b/meerkat-mob/tests/support/mod.rs
@@ -93,14 +93,49 @@ use tokio::sync::watch;
 pub static REAL_COMMS_TEST_LOCK: std::sync::LazyLock<tokio::sync::Mutex<()>> =
     std::sync::LazyLock::new(|| tokio::sync::Mutex::new(()));
 
-/// Reserve-then-drop a loopback port (race-prone but serialized under
-/// `REAL_COMMS_TEST_LOCK`; moved from `smoke_mob_flow_runtime.rs`).
-pub fn unused_loopback_port() -> u16 {
-    std::net::TcpListener::bind(std::net::SocketAddr::from(([127, 0, 0, 1], 0)))
-        .expect("reserve loopback port")
-        .local_addr()
-        .expect("reserved listener local addr")
-        .port()
+/// Reserve a loopback TCP port for a fixed-port supervisor bridge and hold the
+/// reservation for the rest of the process.
+///
+/// Probing `:0` and dropping the probe hands the port back to the kernel, and
+/// any other process (a second nextest lane on the same box, or any ephemeral
+/// `connect()`) may be given it before the bridge binds (issue #1097).
+/// `REAL_COMMS_TEST_LOCK` cannot help: nextest runs every test in its own
+/// process.
+///
+/// On Linux the reservation is a bound, never-listening socket with
+/// `SO_REUSEADDR`. While it lives, the kernel excludes the port from every
+/// other process's ephemeral `bind(:0)` and `connect()` selection, yet a
+/// listener that also sets `SO_REUSEADDR` (tokio/mio always do) may bind,
+/// listen, close and rebind the exact port - which the bridge does on
+/// rotation and across the cold-restart fixtures. The socket is deliberately
+/// kept for the process lifetime because the port travels inside a
+/// `MobDefinition`; one descriptor per fixture is the price. Other platforms
+/// have no non-listening reuse semantics and keep the probe-then-drop shape;
+/// `.config/nextest.toml` serializes and retries that macOS cohort.
+pub fn reserve_loopback_port() -> u16 {
+    let loopback = std::net::SocketAddr::from(([127, 0, 0, 1], 0));
+    #[cfg(target_os = "linux")]
+    {
+        let socket = tokio::net::TcpSocket::new_v4().expect("create loopback reservation socket");
+        socket
+            .set_reuseaddr(true)
+            .expect("set SO_REUSEADDR on loopback reservation");
+        socket.bind(loopback).expect("reserve loopback port");
+        let port = socket
+            .local_addr()
+            .expect("reserved loopback socket local addr")
+            .port();
+        std::mem::forget(socket);
+        port
+    }
+    #[cfg(not(target_os = "linux"))]
+    {
+        std::net::TcpListener::bind(loopback)
+            .expect("reserve loopback port")
+            .local_addr()
+            .expect("reserved listener local addr")
+            .port()
+    }
 }
 
 // ===========================================================================
@@ -3468,7 +3503,7 @@ fn persistent_service_with_client_in_realm(
 /// spawned by the ceremony tests) and a supervisor bridge on a reserved
 /// loopback port so `BindHost` replies can route back.
 pub fn controlling_mob_definition(mob_id: meerkat_mob::MobId) -> meerkat_mob::MobDefinition {
-    let supervisor_port = unused_loopback_port();
+    let supervisor_port = reserve_loopback_port();
     let mut profiles = std::collections::BTreeMap::new();
     profiles.insert(
         meerkat_mob::ProfileName::from("lead"),


### PR DESCRIPTION
Root-cause fixes for three flaky meerkat-mob tests; test-only, no product change. No retries-until-green, no longer sleeps, no ignores.

- **#1097 unused loopback port race.** Fixed-port rotation refuses a `:0` bind, so the tests got a real port by binding `:0`, reading it and dropping the probe before `MobBuilder::create()` (and on every rebuild). Once dropped, the kernel can hand that port to any other process. Now the reservation is HELD for the test's duration: on Linux a bound, never-listening `TcpSocket` with `SO_REUSEADDR`, which the kernel excludes from ephemeral selection while a `SO_REUSEADDR` listener can still bind, listen, close and rebind that exact port (verified: 200k foreign `bind(:0)` probes never received a held port). Non-Linux keeps the old probe (macOS cohort is already serialized). Reproduced 3/33 with a port churner; 30/30 nextest iterations plus 98 stress iterations with the churner after.
- **#1094 cross_host_flows.** The issue's reading was inverted: the assertion requires the member host's turn-outcome journal to be EMPTY and failed because a row was present. The placed member's kickoff prompt is delivered as a placed directed turn, journals a row, and the row is pruned only after the controlling pump consumes and exact-ACKs it, so sampling `is_empty()` at an arbitrary instant races that lifecycle. The test now waits for the kickoff to complete and for the row to be pruned before running the overlay flows. Reproduced 5/432; 30/30 plus 280 stress runs after.
- **#1101 test_retire_interrupts_autonomous_host_loop.** Autonomous spawn returns before the keep-alive `start_turn` is issued; the test slept 10 ms and read the counter. Now uses the existing `wait_for_keep_alive_start_turn_count` helper, applied to the four sibling tests with the same shape. Reproduced 1/45,488; 30/30 plus 41,968 single-process runs after.

Fixes #1094, fixes #1097, fixes #1101. Pre-push gate passed on the release VM.
