### PR TITLE
fix(runtime,mob,session,store): until-terminal teardown waits, retirement disposal, observation conflict budget, kernel-queued JSONL lock

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -173,6 +173,17 @@ threads-required = "num-cpus"
 filter = 'test(~test_resume_restores_missing_sessions_with_tool_wiring)'
 threads-required = "num-cpus"
 
+[[profile.fast.overrides]]
+# Issue #1104: these cases bound a FULL round trip on wall clock - a prompt
+# turn through accept_input_with_completion (10 s), or a MaterializeMember
+# bridge reply (REPLY_TIMEOUT) - and each failed only while a saturated gate
+# ran beside them (load 257 on 192 cores) and passed unchanged at low load.
+# The bound measures runner load, not the property, so raising it is not a
+# fix; reserve the lane instead, matching the treatment above. Each case keeps
+# every internal wait and its own bound.
+filter = 'binary(cold_restart_resume_after_compaction) or (binary(host_bind_ceremony) and test(=rebind_same_supervisor_identity_replaces_stale_address))'
+threads-required = "num-cpus"
+
 [[profile.default.overrides]]
 filter = 'test(~test_turn_driven_submit_work_steer_queues_when_exact_boundary_is_unavailable) or test(~test_member_send_steer_queues_when_exact_boundary_is_unavailable)'
 threads-required = "num-cpus"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,6 +89,17 @@ them.
 
 ### Fixed
 
+- **Member retirement no longer fails when a runtime teardown outlives the
+  2 s caller grace** (#1104). The retirement archive path disposed a terminal
+  runtime registration through the grace-bounded unregister API, so a
+  coordinator-owned teardown that was still completing under load surfaced as
+  `UnregisterInProgress` and `retire_member` returned a hard
+  `SharedRetirementFailure` although the saga finished moments later. The
+  disposal now awaits the exact registration's teardown to terminal completion
+  through the new
+  `MeerkatMachine::unregister_terminal_session_registration_until_terminal_if_current`
+  (same admission rules, no outer bound; dropping the caller never cancels the
+  saga). The grace-bounded API is unchanged for existing callers.
 - **`MeerkatMachine::stop_runtime_executor_until_terminal_if_current`** is the
   exact-witness variant of `stop_runtime_executor` for callers that must act
   on the STOPPED state (#1104): it awaits the owned stop cleanup coordinator

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -117,6 +117,15 @@ them.
   runtime turn finalization guard, and surface the conflict unchanged only
   once the budget is spent. A conflict here was never a torn snapshot, only
   writer progress between two reads.
+- **`JsonlStore` writers no longer time out after 5 s of polling for the
+  per-session write lock under contention** (#1104). The lock was acquired by
+  polling `try_lock_exclusive` every 10 ms with a 5 s deadline; a polled wait
+  has no fairness, so with several writers each holding the lock for a full
+  rewrite plus `sync_all`, one waiter could starve past the deadline on a
+  saturated machine and fail its save with an internal error. The lock is now
+  taken with a blocking, kernel-queued `lock_exclusive` on a blocking thread,
+  behind a 60 s liveness bound that only a live holder that never releases
+  can hit (a crashed holder's lock is released by the kernel).
 - **An exhausted provider account fails in one round trip instead of after
   the rate-limit retry window.** `LlmError::from_http_status` mapped every
   429 to the retryable `RateLimited` class, so a key whose account had no

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,6 +89,13 @@ them.
 
 ### Fixed
 
+- **`MeerkatMachine::stop_runtime_executor_until_terminal_if_current`** is the
+  exact-witness variant of `stop_runtime_executor` for callers that must act
+  on the STOPPED state (#1104): it awaits the owned stop cleanup coordinator
+  to terminal completion instead of returning `RuntimeStopInProgress` at the
+  2 s caller grace, and a stale registration witness is an idempotent
+  `Ok(false)` that never reaches a same-`SessionId` replacement.
+  `stop_runtime_executor` keeps its grace for existing callers.
 - **An exhausted provider account fails in one round trip instead of after
   the rate-limit retry window.** `LlmError::from_http_status` mapped every
   429 to the retryable `RateLimited` class, so a key whose account had no

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -107,6 +107,16 @@ them.
   2 s caller grace, and a stale registration witness is an idempotent
   `Ok(false)` that never reaches a same-`SessionId` replacement.
   `stop_runtime_executor` keeps its grace for existing callers.
+- **Session history and transcript-revision reads no longer fail when a
+  head-canonical writer commits twice while a reader is looking** (#1104).
+  `PersistentSessionService` retried a `TranscriptRevisionConflict` on an
+  observation load exactly once; a second commit between the reads surfaced
+  the typed conflict to `read_history` callers, which under a saturated
+  machine happened to a poller reading a session mid-resume. Observation
+  loads now re-read up to 8 attempts (counted, not timed), each under the
+  runtime turn finalization guard, and surface the conflict unchanged only
+  once the budget is spent. A conflict here was never a torn snapshot, only
+  writer progress between two reads.
 - **An exhausted provider account fails in one round trip instead of after
   the rate-limit retry window.** `LlmError::from_http_status` mapped every
   429 to the retryable `RateLimited` class, so a key whose account had no

--- a/meerkat-mob/src/runtime/provisioner.rs
+++ b/meerkat-mob/src/runtime/provisioner.rs
@@ -1735,8 +1735,14 @@ impl MemberSessionDisposalArc {
                     // coordinator acquires its exact registration transaction
                     // and mutation gates.
                     drop(boundary);
+                    // Retirement is a lifecycle owner: it must observe the
+                    // exact registration's terminal teardown, not the 2 s
+                    // caller grace that surfaces `UnregisterInProgress` while
+                    // the coordinator-owned saga is still completing (#1104).
                     let removed = adapter
-                        .unregister_terminal_session_registration_if_current(registration)
+                        .unregister_terminal_session_registration_until_terminal_if_current(
+                            registration,
+                        )
                         .await
                         .map_err(|error| {
                             Self::runtime_archive_error(format!(
@@ -1830,7 +1836,7 @@ impl MemberSessionDisposalArc {
                                 None => {}
                                 Some(current) if &current == registration => {
                                     let removed = adapter
-                                        .unregister_terminal_session_registration_if_current(
+                                        .unregister_terminal_session_registration_until_terminal_if_current(
                                             registration,
                                         )
                                         .await

--- a/meerkat-mob/tests/cross_host_events.rs
+++ b/meerkat-mob/tests/cross_host_events.rs
@@ -27,7 +27,7 @@ use support::{
     member_descriptor_from_ack, member_incarnation_from_ack, placed_spawn_spec,
     raw_deliver_member_input_command, raw_poll_member_events_command,
     scripted_member_client_completing, scripted_member_client_stalling, spawn_host_daemon_fixture,
-    spawn_peer_comms_endpoint, wait_until,
+    spawn_peer_comms_endpoint, unregister_session_until_terminal, wait_until,
 };
 
 const WAIT: Duration = Duration::from_secs(60);
@@ -296,10 +296,13 @@ async fn empty_same_session_resume_page_advances_real_pump_to_resolved_floor() {
     )
     .await
     .expect("seed resumable member-host session through machine commit authority");
-    runtime_adapter
-        .unregister_session(&session_id)
-        .await
-        .expect("quiesce generic seed attachment before host-owned explicit resume");
+    // Join the seed registration's owned teardown to terminal completion:
+    // the explicit resume below reoccupies this SessionId and must not race
+    // a saga that merely outlived the caller grace (issue #1104).
+    assert!(
+        unregister_session_until_terminal(runtime_adapter, &session_id).await,
+        "generic seed attachment must hold an exact registration to quiesce"
+    );
     member_service
         .event_log_await_projection_drain(&session_id)
         .await

--- a/meerkat-mob/tests/host_materialize_serving.rs
+++ b/meerkat-mob/tests/host_materialize_serving.rs
@@ -1901,16 +1901,21 @@ async fn executor_stop_between_ensure_and_attach_return_cleans_preinstalled_side
         MaterializeLaunchMode::Fresh {},
     );
     let command = BridgeCommand::MaterializeMember(payload);
-    let reply = tokio::time::timeout(
-        Duration::from_secs(5),
-        probe.send_bridge_command_raw(&fixture.host_peer_descriptor(), &command, REPLY_TIMEOUT),
-    )
-    .await
-    .expect("failed attachment cleanup must not wait for the 30s reconciliation grace")
-    .expect("typed post-ensure stop reply");
+    let reply = probe
+        .send_bridge_command_raw(&fixture.host_peer_descriptor(), &command, REPLY_TIMEOUT)
+        .await
+        .expect("typed post-ensure stop reply");
+    // Structural proof that the failed attachment took the exact cleanup
+    // path: the 30 s non-serving reconciliation grace names itself in its
+    // rejection reason ("did not quiesce within"), so a reply that carries any
+    // other reason cannot have waited it out. This replaces a 5 s wall-clock
+    // bound that measured runner load under a saturated gate (#1104).
+    let BridgeReply::Rejected { reason, .. } = &reply else {
+        panic!("the stopped startup incarnation cannot be acknowledged: {reply:?}");
+    };
     assert!(
-        matches!(reply, BridgeReply::Rejected { .. }),
-        "the stopped startup incarnation cannot be acknowledged: {reply:?}"
+        !reason.contains("did not quiesce within"),
+        "failed attachment cleanup must take the exact path, not the reconciliation grace: {reason}"
     );
     assert!(
         fixture
@@ -1933,13 +1938,14 @@ async fn executor_stop_between_ensure_and_attach_return_cleans_preinstalled_side
         },
     ));
 
-    let reply = tokio::time::timeout(
-        Duration::from_secs(5),
-        probe.send_bridge_command_raw(&fixture.host_peer_descriptor(), &resume, REPLY_TIMEOUT),
-    )
-    .await
-    .expect("same-tuple retry must not encounter a stale cleanup sidecar")
-    .expect("retry materialize reply");
+    // A stale cleanup sidecar would surface as a typed rejection (or as the
+    // reconciliation-grace reason above), never as a materialized ack, so the
+    // ack itself is the proof; no wall-clock bound is needed beyond the
+    // fixture's reply timeout.
+    let reply = probe
+        .send_bridge_command_raw(&fixture.host_peer_descriptor(), &resume, REPLY_TIMEOUT)
+        .await
+        .expect("retry materialize reply");
     let BridgeReply::MemberMaterialized(ack) = reply else {
         panic!("explicit resume must rebuild the preserved session cleanly, got {reply:?}");
     };

--- a/meerkat-mob/tests/host_materialize_serving.rs
+++ b/meerkat-mob/tests/host_materialize_serving.rs
@@ -44,7 +44,7 @@ use support::{
     raw_bind_host_command, raw_deliver_member_input_command, raw_host_status_command,
     raw_poll_member_events_command, raw_release_member_command, sample_materialize_payload,
     sample_portable_member_spec, scripted_member_client_stalling, spawn_host_daemon_fixture,
-    spawn_peer_comms_endpoint,
+    spawn_peer_comms_endpoint, unregister_session_until_terminal, wait_until,
 };
 use tokio::sync::oneshot;
 
@@ -1825,6 +1825,16 @@ async fn materialize_identity_mismatch_preserves_durable_session_and_quiesces_bo
                 .expect("read live service actor census"),
             "{label} mismatch identity must not retain a live service actor"
         );
+        // The Rejected reply proves the volatile cleanup was ADMITTED, not
+        // that its coordinator-owned unregister saga has reached terminal
+        // completion. Wait for the release instead of sampling it: a saga
+        // still in flight converges here, while a registration the cleanup
+        // truly leaked never does and still fails the bound (#1104).
+        wait_until(
+            &format!("{label} mismatch identity releases its runtime registration"),
+            || async { !adapter.contains_session(session_id).await },
+        )
+        .await;
         assert!(
             !adapter.contains_session(session_id).await,
             "{label} mismatch identity must not retain runtime registration"
@@ -2514,10 +2524,10 @@ async fn host_status_marks_retired_registered_member_unhealthy() {
         "retired exact replay must tell the controller to replace, not retry, got: {reason}"
     );
 
-    adapter
-        .unregister_session(&session_id)
-        .await
-        .expect("unregister retired runtime before replay repair");
+    assert!(
+        unregister_session_until_terminal(adapter, &session_id).await,
+        "retired runtime must hold an exact registration to unregister before replay repair"
+    );
     assert!(!adapter.contains_session(&session_id).await);
     let replay_after_unregister = sample_materialize_payload(
         &probe,
@@ -2821,10 +2831,10 @@ async fn host_status_marks_stale_idle_registration_without_executor_unhealthy() 
     // executor attachment. The materializer still owns its old concrete
     // runtime and sidecar entries, while the newly registered machine is only
     // Idle; registry membership alone must never report this as healthy.
-    adapter
-        .unregister_session(&session_id)
-        .await
-        .expect("unregister serving runtime before idle-registration probe");
+    assert!(
+        unregister_session_until_terminal(adapter, &session_id).await,
+        "serving runtime must hold an exact registration to unregister before the idle probe"
+    );
     assert!(!adapter.contains_session(&session_id).await);
     adapter
         .register_session(session_id.clone())

--- a/meerkat-mob/tests/host_materialize_serving.rs
+++ b/meerkat-mob/tests/host_materialize_serving.rs
@@ -2436,10 +2436,23 @@ async fn host_status_marks_stopped_member_unhealthy_and_replay_repairs_it() {
         .as_ref()
         .expect("member-build fixture has runtime adapter");
 
-    adapter
-        .stop_runtime_executor(&session_id, "host health stopped-state regression")
+    // Observe the stop's terminal completion, not the 2 s caller grace that
+    // surfaces RuntimeStopInProgress while the owned coordinator is still
+    // cleaning up (#1104); the health probe below reads the STOPPED state.
+    let registration = adapter
+        .current_session_registration_witness(&session_id)
         .await
-        .expect("stop materialized runtime executor");
+        .expect("materialized runtime must expose an exact registration");
+    assert!(
+        adapter
+            .stop_runtime_executor_until_terminal_if_current(
+                &registration,
+                "host health stopped-state regression",
+            )
+            .await
+            .expect("stop materialized runtime executor"),
+        "the materialized registration must still be current when stopped"
+    );
     assert!(
         matches!(
             adapter.runtime_state(&session_id).await,

--- a/meerkat-mob/tests/support/mod.rs
+++ b/meerkat-mob/tests/support/mod.rs
@@ -93,6 +93,33 @@ use tokio::sync::watch;
 pub static REAL_COMMS_TEST_LOCK: std::sync::LazyLock<tokio::sync::Mutex<()>> =
     std::sync::LazyLock::new(|| tokio::sync::Mutex::new(()));
 
+/// Unregister `session_id`'s exact current runtime registration and await its
+/// owned teardown saga to terminal completion.
+///
+/// `MeerkatMachine::unregister_session` returns to its caller after a fixed
+/// 2 s grace (`UnregisterInProgress`) while the coordinator-owned saga keeps
+/// running; a test that reads registration state right after it therefore
+/// measures scheduler latency, not the property under test (issue #1104).
+/// Tests that need "the registration is gone" capture the exact
+/// `RuntimeSessionRegistrationWitness` and join the saga until terminal, the
+/// same pattern the stale live-session discard uses. Returns `false` when no
+/// registration (or no longer the captured one) occupied `session_id`.
+pub async fn unregister_session_until_terminal(
+    adapter: &MeerkatMachine,
+    session_id: &meerkat_core::SessionId,
+) -> bool {
+    let Some(registration) = adapter
+        .current_session_registration_witness(session_id)
+        .await
+    else {
+        return false;
+    };
+    adapter
+        .unregister_session_registration_until_terminal_if_current(&registration)
+        .await
+        .expect("exact registration teardown must reach terminal completion")
+}
+
 /// Reserve a loopback TCP port for a fixed-port supervisor bridge and hold the
 /// reservation for the rest of the process.
 ///

--- a/meerkat-runtime/src/meerkat_machine/dispatch_session.rs
+++ b/meerkat-runtime/src/meerkat_machine/dispatch_session.rs
@@ -3074,6 +3074,19 @@ impl MeerkatMachine {
                     .await?;
                 Ok(MeerkatMachineCommandResult::Unit)
             }
+            MeerkatMachineCommand::StopRuntimeExecutorUntilTerminal {
+                session_id,
+                epoch_id,
+                reason,
+            } => {
+                // Same stage-first shape as StopRuntimeExecutor; only the
+                // caller's wait policy differs, and the exact epoch keeps a
+                // same-SessionId replacement out of this stop's authority.
+                let stopped = self
+                    .stop_runtime_executor_until_terminal_inner(&session_id, &epoch_id, reason)
+                    .await?;
+                Ok(MeerkatMachineCommandResult::Bool(stopped))
+            }
             MeerkatMachineCommand::ContainsSession { session_id } => {
                 Ok(MeerkatMachineCommandResult::Bool(
                     self.sessions.read().await.contains_key(&session_id),

--- a/meerkat-runtime/src/meerkat_machine/mod.rs
+++ b/meerkat-runtime/src/meerkat_machine/mod.rs
@@ -9525,6 +9525,7 @@ impl MeerkatMachine {
                 | MeerkatMachineCommand::SetSilentIntents { .. }
                 | MeerkatMachineCommand::CancelAfterBoundary { .. }
                 | MeerkatMachineCommand::StopRuntimeExecutor { .. }
+                | MeerkatMachineCommand::StopRuntimeExecutorUntilTerminal { .. }
                 | MeerkatMachineCommand::ContainsSession { .. }
                 | MeerkatMachineCommand::SessionHasExecutor { .. }
                 | MeerkatMachineCommand::SessionHasComms { .. }

--- a/meerkat-runtime/src/meerkat_machine/runtime_control.rs
+++ b/meerkat-runtime/src/meerkat_machine/runtime_control.rs
@@ -9824,6 +9824,66 @@ impl MeerkatMachine {
         self.request_runtime_stop(session_id, reason).await
     }
 
+    /// [`Self::stop_runtime_executor`] for one exact current registration,
+    /// awaiting the owned stop cleanup coordinator to terminal completion.
+    ///
+    /// `stop_runtime_executor` returns typed `RuntimeStopInProgress` once the
+    /// caller grace elapses while the coordinator keeps running. Callers that
+    /// must act on the STOPPED state (health probes, retirement, tests reading
+    /// registration state right after the stop) observe terminal completion
+    /// here instead. The coordinator is machine-owned, so dropping this future
+    /// never cancels cleanup. The witness keeps a same-`SessionId` replacement
+    /// outside this authority: a stale or absent registration is an idempotent
+    /// `Ok(false)` and no stop is requested against the replacement.
+    pub async fn stop_runtime_executor_until_terminal_if_current(
+        &self,
+        registration: &super::RuntimeSessionRegistrationWitness,
+        reason: impl Into<String>,
+    ) -> Result<bool, RuntimeDriverError> {
+        if !registration.belongs_to(self) {
+            return Ok(false);
+        }
+        match self
+            .execute_meerkat_machine_command(
+                None,
+                MeerkatMachineCommand::StopRuntimeExecutorUntilTerminal {
+                    session_id: registration.session_id().clone(),
+                    epoch_id: registration.epoch_id().clone(),
+                    reason: reason.into(),
+                },
+            )
+            .await
+            .map_err(MeerkatMachine::driver_error_from_command_error)?
+        {
+            MeerkatMachineCommandResult::Bool(stopped) => Ok(stopped),
+            other => Err(RuntimeDriverError::Internal(format!(
+                "stop_runtime_executor_until_terminal_if_current: unexpected command result variant: {other:?}"
+            ))),
+        }
+    }
+
+    pub(super) async fn stop_runtime_executor_until_terminal_inner(
+        &self,
+        session_id: &SessionId,
+        epoch_id: &meerkat_core::RuntimeEpochId,
+        reason: String,
+    ) -> Result<bool, RuntimeDriverError> {
+        let current_epoch = {
+            let sessions = self.sessions.read().await;
+            sessions.get(session_id).map(|entry| entry.epoch_id.clone())
+        };
+        if current_epoch.as_ref() != Some(epoch_id) {
+            return Ok(false);
+        }
+        self.request_runtime_stop_with_wait(
+            session_id,
+            reason,
+            super::session_management::RuntimeStopCallerWait::UntilTerminal,
+        )
+        .await
+        .map(|()| true)
+    }
+
     /// Accept an input and return a completion handle that resolves when the
     /// input reaches a terminal state (Consumed or Abandoned).
     ///

--- a/meerkat-runtime/src/meerkat_machine/session_management.rs
+++ b/meerkat-runtime/src/meerkat_machine/session_management.rs
@@ -45,8 +45,23 @@ impl UnregisterTeardownWaitOutcome {
 #[derive(Clone, Copy, PartialEq, Eq)]
 enum RuntimeStopCleanupCaller {
     ExplicitStop,
+    /// An explicit stop whose caller awaits the owned cleanup coordinator to
+    /// terminal completion instead of returning at the caller grace.
+    ExplicitStopUntilTerminal,
     ExplicitUnregister,
     RuntimeLoopWatcher,
+}
+
+/// How long an explicit stop caller waits for the owned cleanup coordinator.
+///
+/// The coordinator and exact executor remain owned either way; this only
+/// selects what the CALLER observes when cleanup outlives the grace.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum RuntimeStopCallerWait {
+    /// Return typed `RuntimeStopInProgress` after `RUNTIME_STOP_CALLER_WAIT_GRACE`.
+    CallerGrace,
+    /// Await the coordinator's terminal result with no outer bound.
+    UntilTerminal,
 }
 
 enum RuntimeStopCleanupWork {
@@ -6226,11 +6241,31 @@ impl MeerkatMachine {
         session_id: &SessionId,
         reason: String,
     ) -> Result<(), RuntimeDriverError> {
+        self.request_runtime_stop_with_wait(session_id, reason, RuntimeStopCallerWait::CallerGrace)
+            .await
+    }
+
+    /// [`Self::request_runtime_stop`] with an explicit caller wait policy.
+    ///
+    /// Every exit that can surface `RuntimeStopInProgress` under
+    /// [`RuntimeStopCallerWait::CallerGrace`] (the ordinary stop coordinator,
+    /// and the canonical unregister owner joined when generated Draining is
+    /// observed before or after the stop) instead awaits terminal completion
+    /// under [`RuntimeStopCallerWait::UntilTerminal`].
+    pub(super) async fn request_runtime_stop_with_wait(
+        &self,
+        session_id: &SessionId,
+        reason: String,
+        wait: RuntimeStopCallerWait,
+    ) -> Result<(), RuntimeDriverError> {
         let generated_draining = self.session_dsl_state(session_id).await.is_ok_and(|state| {
             state.registration_phase == crate::meerkat_machine::dsl::RegistrationPhase::Draining
         });
         if generated_draining {
-            return match self.unregister_session_inner(session_id).await {
+            return match self
+                .unregister_session_inner_with_wait(session_id, wait)
+                .await
+            {
                 Err(RuntimeDriverError::UnregisterInProgress { .. }) => {
                     Err(RuntimeDriverError::RuntimeStopInProgress {
                         runtime_id: LogicalRuntimeId::for_session(session_id),
@@ -6248,13 +6283,14 @@ impl MeerkatMachine {
                     .map(|slot| (entry.epoch_id.clone(), Arc::clone(slot)))
             })
         };
+        let caller = match wait {
+            RuntimeStopCallerWait::CallerGrace => RuntimeStopCleanupCaller::ExplicitStop,
+            RuntimeStopCallerWait::UntilTerminal => {
+                RuntimeStopCleanupCaller::ExplicitStopUntilTerminal
+            }
+        };
         let stop_result = self
-            .join_or_start_runtime_stop_cleanup(
-                session_id,
-                RuntimeStopCleanupCaller::ExplicitStop,
-                Some(reason),
-                None,
-            )
+            .join_or_start_runtime_stop_cleanup(session_id, caller, Some(reason), None)
             .await;
         if matches!(
             &stop_result,
@@ -6267,7 +6303,10 @@ impl MeerkatMachine {
             // above. Join its canonical unregister owner; a genuinely
             // mid-apply ordinary stop remains Queuing and keeps the typed
             // RuntimeStopInProgress result from the stop coordinator.
-            return match self.unregister_session_inner(session_id).await {
+            return match self
+                .unregister_session_inner_with_wait(session_id, wait)
+                .await
+            {
                 Err(RuntimeDriverError::UnregisterInProgress { .. }) => {
                     Err(RuntimeDriverError::RuntimeStopInProgress {
                         runtime_id: LogicalRuntimeId::for_session(session_id),
@@ -6284,10 +6323,11 @@ impl MeerkatMachine {
         // that may have reused the SessionId.
         if let Some((observed_epoch, observed_teardown_slot)) = observed_teardown {
             return match self
-                .join_unregister_if_observed_runtime_loop_became_draining(
+                .join_unregister_if_observed_runtime_loop_became_draining_with_wait(
                     session_id,
                     &observed_epoch,
                     &observed_teardown_slot,
+                    wait,
                 )
                 .await
             {
@@ -6492,6 +6532,22 @@ impl MeerkatMachine {
         observed_epoch: &meerkat_core::RuntimeEpochId,
         observed_teardown_slot: &Arc<crate::runtime_loop::RuntimeLoopTeardownSlot>,
     ) -> Result<(), RuntimeDriverError> {
+        self.join_unregister_if_observed_runtime_loop_became_draining_with_wait(
+            session_id,
+            observed_epoch,
+            observed_teardown_slot,
+            RuntimeStopCallerWait::CallerGrace,
+        )
+        .await
+    }
+
+    async fn join_unregister_if_observed_runtime_loop_became_draining_with_wait(
+        &self,
+        session_id: &SessionId,
+        observed_epoch: &meerkat_core::RuntimeEpochId,
+        observed_teardown_slot: &Arc<crate::runtime_loop::RuntimeLoopTeardownSlot>,
+        wait: RuntimeStopCallerWait,
+    ) -> Result<(), RuntimeDriverError> {
         let became_draining = {
             let sessions = self.sessions.read().await;
             sessions.get(session_id).is_some_and(|entry| {
@@ -6512,12 +6568,26 @@ impl MeerkatMachine {
         if !became_draining {
             return Ok(());
         }
-        self.join_or_start_unregister_teardown(
+        self.join_or_start_unregister_teardown_with_admission(
             session_id,
             Some(observed_epoch),
             UnregisterTeardownCaller::RuntimeLoopWatcher,
+            UnregisterTeardownAdmission::AnyCurrentRegistration,
+            None,
+            Self::unregister_wait_for_stop_caller(wait),
         )
         .await
+        .and_then(UnregisterTeardownWaitOutcome::require_completed)
+        .map(|_| ())
+    }
+
+    fn unregister_wait_for_stop_caller(wait: RuntimeStopCallerWait) -> UnregisterTeardownWait {
+        match wait {
+            RuntimeStopCallerWait::CallerGrace => {
+                UnregisterTeardownWait::CallerGrace(unregister_caller_wait_deadline())
+            }
+            RuntimeStopCallerWait::UntilTerminal => UnregisterTeardownWait::UntilTerminal,
+        }
     }
 
     async fn join_or_start_runtime_stop_cleanup(
@@ -6589,7 +6659,12 @@ impl MeerkatMachine {
                 .state()
                 .registration_phase
                 == crate::meerkat_machine::dsl::RegistrationPhase::Draining;
-            if caller == RuntimeStopCleanupCaller::ExplicitStop && generated_draining {
+            if matches!(
+                caller,
+                RuntimeStopCleanupCaller::ExplicitStop
+                    | RuntimeStopCleanupCaller::ExplicitStopUntilTerminal
+            ) && generated_draining
+            {
                 // The optimistic sample in request_runtime_stop can become
                 // stale while this caller waits for M behind a terminal loop
                 // handoff. Draining is the newer generated authority: never
@@ -8053,6 +8128,27 @@ impl MeerkatMachine {
     ) -> Result<(), RuntimeDriverError> {
         self.join_or_start_unregister_teardown(session_id, None, UnregisterTeardownCaller::Explicit)
             .await
+    }
+
+    /// [`Self::unregister_session_inner`] with the stop caller's wait policy:
+    /// the canonical unregister owner joined on behalf of an explicit stop is
+    /// awaited to terminal completion when the stop caller asked for it.
+    async fn unregister_session_inner_with_wait(
+        &self,
+        session_id: &SessionId,
+        wait: RuntimeStopCallerWait,
+    ) -> Result<(), RuntimeDriverError> {
+        self.join_or_start_unregister_teardown_with_admission(
+            session_id,
+            None,
+            UnregisterTeardownCaller::Explicit,
+            UnregisterTeardownAdmission::AnyCurrentRegistration,
+            None,
+            Self::unregister_wait_for_stop_caller(wait),
+        )
+        .await
+        .and_then(UnregisterTeardownWaitOutcome::require_completed)
+        .map(|_| ())
     }
 
     /// Two-phase unregister drain (campaign 0.7.2 D1).

--- a/meerkat-runtime/src/meerkat_machine/session_management.rs
+++ b/meerkat-runtime/src/meerkat_machine/session_management.rs
@@ -5585,6 +5585,35 @@ impl MeerkatMachine {
         .require_completed()
     }
 
+    /// [`Self::unregister_terminal_session_registration_if_current`] without
+    /// the caller grace: await the exact registration's owned teardown saga to
+    /// terminal completion.
+    ///
+    /// Lifecycle owners that dispose a terminal (`Stopped`/`Retired`)
+    /// registration and then act on its absence, such as member retirement
+    /// before archive, must observe terminal teardown rather than a grace
+    /// return. The saga is coordinator-owned, so a caller dropping this future
+    /// never cancels teardown; the admission rules are unchanged, and a stale
+    /// witness is an idempotent `Ok(false)`.
+    pub async fn unregister_terminal_session_registration_until_terminal_if_current(
+        &self,
+        witness: &RuntimeSessionRegistrationWitness,
+    ) -> Result<bool, RuntimeDriverError> {
+        if !witness.belongs_to(self) {
+            return Ok(false);
+        }
+        self.join_or_start_unregister_teardown_with_admission(
+            witness.session_id(),
+            Some(witness.epoch_id()),
+            UnregisterTeardownCaller::Explicit,
+            UnregisterTeardownAdmission::ExactTerminalUnattachedRegistration,
+            Some(witness),
+            UnregisterTeardownWait::UntilTerminal,
+        )
+        .await?
+        .require_completed()
+    }
+
     /// Unregister only when `witness` still names this machine's exact current
     /// attachment. A stale attachment is an idempotent `Ok(false)` and can
     /// never open the drain window for a same-SessionId replacement.

--- a/meerkat-runtime/src/meerkat_machine_tests.rs
+++ b/meerkat-runtime/src/meerkat_machine_tests.rs
@@ -15937,6 +15937,119 @@ mod stop_teardown_coordinator_class {
         );
     }
 
+    /// Regression for #1104: member retirement disposes a terminal registration
+    /// through the exact-witness unregister API. Under load the
+    /// coordinator-owned teardown can outlive the 2 s caller grace; the
+    /// grace-bounded API then reports `UnregisterInProgress` although the saga
+    /// is still completing, and the archive path used to turn that into a hard
+    /// retirement failure. The until-terminal twin must keep waiting and
+    /// complete once the saga does. A parked post-stop cleanup is what holds
+    /// the saga here, exactly like a slow executor teardown under load.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn terminal_registration_disposal_until_terminal_outlasts_caller_grace() {
+        // Mirrors UNREGISTER_CALLER_WAIT_GRACE; the hold must exceed it so the
+        // grace-bounded API has already returned `UnregisterInProgress`.
+        const CALLER_GRACE: Duration = Duration::from_secs(2);
+        const PAST_GRACE_HOLD: Duration = Duration::from_millis(2600);
+        let machine = Arc::new(MeerkatMachine::ephemeral());
+        let session_id = SessionId::new();
+        let cleanup_started = Arc::new(Notify::new());
+        let release_cleanup = Arc::new(Notify::new());
+        let cleanup_calls = Arc::new(AtomicUsize::new(0));
+        machine
+            .register_session_with_executor(
+                session_id.clone(),
+                Box::new(GatedCleanupExecutor {
+                    machine: Arc::clone(&machine),
+                    session_id: session_id.clone(),
+                    cleanup_started: Arc::clone(&cleanup_started),
+                    release_cleanup: Arc::clone(&release_cleanup),
+                    unregister_during_cleanup: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+                    fail_cleanup_attempts: Arc::new(AtomicUsize::new(0)),
+                    cleanup_calls: Arc::clone(&cleanup_calls),
+                    loop_task_id: Arc::new(std::sync::Mutex::new(None)),
+                    cleanup_task_id: Arc::new(std::sync::Mutex::new(None)),
+                }),
+            )
+            .await
+            .expect("runtime executor registration should succeed");
+        let registration = machine
+            .current_session_registration_witness(&session_id)
+            .await
+            .expect("registered runtime exposes an exact registration witness");
+
+        // An ordinary caller opens the owned saga; its teardown parks in the
+        // executor's post-stop cleanup, so the caller sees only the grace.
+        let started = Instant::now();
+        let grace_result = machine.unregister_session(&session_id).await;
+        assert!(
+            matches!(
+                &grace_result,
+                Err(RuntimeDriverError::UnregisterInProgress { runtime_id })
+                    if runtime_id == &runtime_id_for_session(&session_id)
+            ),
+            "the grace-bounded caller must observe the in-flight saga: {grace_result:?}"
+        );
+        assert!(started.elapsed() >= CALLER_GRACE);
+        assert_eq!(
+            cleanup_calls.load(Ordering::SeqCst),
+            1,
+            "cleanup is parked, not skipped"
+        );
+
+        // The grace-bounded terminal disposal (the retirement path before this
+        // change) joins the same saga and gives up at its grace too.
+        let grace_bounded_disposal = machine
+            .unregister_terminal_session_registration_if_current(&registration)
+            .await;
+        assert!(
+            matches!(
+                grace_bounded_disposal,
+                Err(RuntimeDriverError::UnregisterInProgress { .. })
+            ),
+            "the grace-bounded terminal disposal reports the saga as in progress: {grace_bounded_disposal:?}"
+        );
+
+        let until_terminal = {
+            let machine = Arc::clone(&machine);
+            let registration = registration.clone();
+            tokio::spawn(async move {
+                machine
+                    .unregister_terminal_session_registration_until_terminal_if_current(
+                        &registration,
+                    )
+                    .await
+            })
+        };
+        assert!(PAST_GRACE_HOLD > CALLER_GRACE);
+        tokio::time::sleep(PAST_GRACE_HOLD).await;
+        assert!(
+            !until_terminal.is_finished(),
+            "the until-terminal disposal must keep waiting on the exact saga past the caller grace"
+        );
+        assert!(
+            machine.contains_session(&session_id).await,
+            "the registration remains owned by the in-flight teardown"
+        );
+
+        release_cleanup.notify_one();
+        let removed = tokio::time::timeout(Duration::from_secs(10), until_terminal)
+            .await
+            .expect("the until-terminal disposal must finish once cleanup releases")
+            .expect("disposal task must not panic")
+            .expect("the joined saga must complete cleanly");
+        assert!(removed, "the exact registration must be the one removed");
+        assert!(
+            !machine.contains_session(&session_id).await,
+            "terminal completion removes the registration"
+        );
+        assert_eq!(
+            cleanup_calls.load(Ordering::SeqCst),
+            1,
+            "one saga ran cleanup once"
+        );
+    }
+
     #[tokio::test]
     async fn explicit_stop_waits_for_exact_cleanup_ack_after_loop_exit() {
         let machine = Arc::new(MeerkatMachine::ephemeral());

--- a/meerkat-runtime/src/meerkat_machine_tests.rs
+++ b/meerkat-runtime/src/meerkat_machine_tests.rs
@@ -15820,6 +15820,123 @@ mod stop_teardown_coordinator_class {
             .expect("test cleanup should remove the stopped session");
     }
 
+    /// Regression for #1104: `stop_runtime_executor` returns typed
+    /// `RuntimeStopInProgress` once the 2 s caller grace elapses while the owned
+    /// cleanup coordinator is still running. Callers that must act on the
+    /// STOPPED state use the exact-witness until-terminal variant, which keeps
+    /// waiting past the grace and completes with the coordinator.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn explicit_stop_until_terminal_outlasts_caller_grace() {
+        // Mirrors RUNTIME_STOP_CALLER_WAIT_GRACE; the hold must exceed it so
+        // the grace-bounded stop has already returned `RuntimeStopInProgress`.
+        const CALLER_GRACE: Duration = Duration::from_secs(2);
+        const PAST_GRACE_HOLD: Duration = Duration::from_millis(2600);
+        let machine = Arc::new(MeerkatMachine::ephemeral());
+        let session_id = SessionId::new();
+        let cleanup_started = Arc::new(Notify::new());
+        let release_cleanup = Arc::new(Notify::new());
+        let cleanup_calls = Arc::new(AtomicUsize::new(0));
+        machine
+            .register_session_with_executor(
+                session_id.clone(),
+                Box::new(GatedCleanupExecutor {
+                    machine: Arc::clone(&machine),
+                    session_id: session_id.clone(),
+                    cleanup_started: Arc::clone(&cleanup_started),
+                    release_cleanup: Arc::clone(&release_cleanup),
+                    unregister_during_cleanup: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+                    fail_cleanup_attempts: Arc::new(AtomicUsize::new(0)),
+                    cleanup_calls: Arc::clone(&cleanup_calls),
+                    loop_task_id: Arc::new(std::sync::Mutex::new(None)),
+                    cleanup_task_id: Arc::new(std::sync::Mutex::new(None)),
+                }),
+            )
+            .await
+            .expect("runtime executor registration should succeed");
+        let registration = machine
+            .current_session_registration_witness(&session_id)
+            .await
+            .expect("registered runtime exposes an exact registration witness");
+
+        // The grace-bounded caller opens the owned coordinator and observes
+        // only that it is still in progress once the grace elapses.
+        let started = Instant::now();
+        let grace_result = machine
+            .stop_runtime_executor(&session_id, "grace-bounded stop")
+            .await;
+        assert!(
+            matches!(
+                &grace_result,
+                Err(RuntimeDriverError::RuntimeStopInProgress { runtime_id })
+                    if runtime_id == &runtime_id_for_session(&session_id)
+            ),
+            "the grace-bounded stop must report the in-flight coordinator: {grace_result:?}"
+        );
+        assert!(started.elapsed() >= CALLER_GRACE);
+        assert_eq!(
+            cleanup_calls.load(Ordering::SeqCst),
+            1,
+            "cleanup is parked, not skipped"
+        );
+
+        let until_terminal = {
+            let machine = Arc::clone(&machine);
+            let registration = registration.clone();
+            tokio::spawn(async move {
+                machine
+                    .stop_runtime_executor_until_terminal_if_current(
+                        &registration,
+                        "until-terminal stop",
+                    )
+                    .await
+            })
+        };
+        assert!(PAST_GRACE_HOLD > CALLER_GRACE);
+        tokio::time::sleep(PAST_GRACE_HOLD).await;
+        assert!(
+            !until_terminal.is_finished(),
+            "the until-terminal stop must keep waiting on the owned coordinator past the caller grace"
+        );
+        assert!(
+            machine.contains_session(&session_id).await,
+            "the registration remains owned while cleanup is parked"
+        );
+
+        release_cleanup.notify_one();
+        let stopped = tokio::time::timeout(Duration::from_secs(10), until_terminal)
+            .await
+            .expect("the until-terminal stop must finish once cleanup releases")
+            .expect("stop task should not panic")
+            .expect("the joined coordinator must complete cleanly");
+        assert!(stopped, "the exact registration must be the one stopped");
+        assert_eq!(
+            machine
+                .session_dsl_state(&session_id)
+                .await
+                .expect("stopped session authority")
+                .lifecycle_phase,
+            mm_dsl::MeerkatPhase::Stopped
+        );
+        assert_eq!(
+            cleanup_calls.load(Ordering::SeqCst),
+            1,
+            "one coordinator ran cleanup once"
+        );
+
+        // A stale witness never reaches a same-SessionId replacement.
+        machine
+            .unregister_session(&session_id)
+            .await
+            .expect("explicit unregister should remove the stopped session");
+        assert!(
+            !machine
+                .stop_runtime_executor_until_terminal_if_current(&registration, "stale witness")
+                .await
+                .expect("a stale witness is an idempotent no-op"),
+            "a stale registration witness must not request a stop"
+        );
+    }
+
     #[tokio::test]
     async fn explicit_stop_waits_for_exact_cleanup_ack_after_loop_exit() {
         let machine = Arc::new(MeerkatMachine::ephemeral());

--- a/meerkat-runtime/src/meerkat_machine_types.rs
+++ b/meerkat-runtime/src/meerkat_machine_types.rs
@@ -422,6 +422,13 @@ pub(crate) enum MeerkatMachineCommand {
         session_id: SessionId,
         reason: String,
     },
+    /// Explicit stop of one exact registration epoch that awaits the owned
+    /// cleanup coordinator to terminal completion (no caller grace).
+    StopRuntimeExecutorUntilTerminal {
+        session_id: SessionId,
+        epoch_id: meerkat_core::RuntimeEpochId,
+        reason: String,
+    },
     #[cfg_attr(not(test), allow(dead_code))]
     ContainsSession {
         session_id: SessionId,
@@ -1934,6 +1941,9 @@ impl MeerkatMachineCommandVariant {
             Self::SetSilentIntents => Some(MeerkatMachineCatalogInput::SetSilentIntents),
             Self::CancelAfterBoundary => Some(MeerkatMachineCatalogInput::CancelAfterBoundary),
             Self::StopRuntimeExecutor => Some(MeerkatMachineCatalogInput::StopRuntimeExecutor),
+            Self::StopRuntimeExecutorUntilTerminal => {
+                Some(MeerkatMachineCatalogInput::StopRuntimeExecutor)
+            }
             Self::ContainsSession => Some(MeerkatMachineCatalogInput::ContainsSession),
             Self::SessionHasExecutor => Some(MeerkatMachineCatalogInput::SessionHasExecutor),
             Self::SessionHasComms => Some(MeerkatMachineCatalogInput::SessionHasComms),
@@ -2087,6 +2097,11 @@ const fn meerkat_machine_command_classification(
             )
         }
         MeerkatMachineCommandVariant::StopRuntimeExecutor => {
+            MeerkatMachineCommandClassification::CatalogInput(
+                MeerkatMachineCatalogInput::StopRuntimeExecutor,
+            )
+        }
+        MeerkatMachineCommandVariant::StopRuntimeExecutorUntilTerminal => {
             MeerkatMachineCommandClassification::CatalogInput(
                 MeerkatMachineCatalogInput::StopRuntimeExecutor,
             )

--- a/meerkat-session/src/persistent.rs
+++ b/meerkat-session/src/persistent.rs
@@ -118,6 +118,10 @@ fn activation_store_error_to_session_error(error: RuntimeStoreError) -> SessionE
     }
 }
 
+/// Re-read budget for observation loads racing a head-canonical writer:
+/// counted attempts, never wall clock (issue #1104).
+const OBSERVATION_LOAD_ATTEMPTS: usize = 8;
+
 #[cfg(not(test))]
 const ARCHIVE_RUNTIME_RETIRE_TIMEOUT: meerkat_core::time_compat::Duration =
     meerkat_core::time_compat::Duration::from_secs(30);
@@ -3246,24 +3250,40 @@ impl<B: SessionAgentBuilder + 'static> PersistentSessionService<B> {
     /// turn boundary and retry exactly once. A mismatch with no completing
     /// turn behind it is returned unchanged, preserving fail-closed behavior
     /// for stale or contradictory authority.
+    /// Observation loads (history, transcript revision) re-read a session
+    /// whose canonical head advanced between the two reads of one load.
+    ///
+    /// A `TranscriptRevisionConflict` here means a writer committed between
+    /// the reads: legitimate progress, never a torn snapshot. The budget counts
+    /// attempts, not wall clock, so a saturated runner cannot turn progress
+    /// into an error; after the last attempt the typed conflict surfaces
+    /// unchanged (issue #1104). Every re-read holds the runtime turn
+    /// finalization guard so it cannot interleave with a finalizer's write.
     async fn load_authoritative_session_base_for_observation(
         &self,
         id: &SessionId,
     ) -> Result<Option<Session>, SessionError> {
-        match self.load_authoritative_session_base(id).await {
+        let mut result = self.load_authoritative_session_base(id).await;
+        for _ in 1..OBSERVATION_LOAD_ATTEMPTS {
+            if !Self::is_transcript_revision_conflict(&result) {
+                break;
+            }
+            let _turn_finalization_guard = self.acquire_runtime_turn_finalization_guard(id).await;
+            result = self.load_authoritative_session_base(id).await;
+        }
+        result
+    }
+
+    fn is_transcript_revision_conflict(result: &Result<Option<Session>, SessionError>) -> bool {
+        matches!(
+            result,
             Err(SessionError::Store(error))
                 if error
                     .downcast_ref::<SessionStoreError>()
                     .is_some_and(|error| {
                         matches!(error, SessionStoreError::TranscriptRevisionConflict { .. })
-                    }) =>
-            {
-                let _turn_finalization_guard =
-                    self.acquire_runtime_turn_finalization_guard(id).await;
-                self.load_authoritative_session_base(id).await
-            }
-            result => result,
-        }
+                    })
+        )
     }
 
     async fn load_authoritative_session_base_with_replay_info(
@@ -33849,5 +33869,487 @@ mod tests {
             .await
             .expect("parent body must remain addressable out of line");
         assert_eq!(parent_rows.len(), 2, "parent body served out-of-line");
+    }
+
+    /// Runtime store double for the observation re-read budget (#1104).
+    ///
+    /// Serves a captured, since-superseded HeadCanonical authority for the
+    /// first N `load_session_boundary_authority` reads, so the follow-up
+    /// `materialize_head` raises `TranscriptRevisionConflict` exactly as a
+    /// reader racing a head-canonical writer sees it; every later read reaches
+    /// the real store. Everything else delegates.
+    struct StaleAuthorityRuntimeStore {
+        inner: meerkat_runtime::SqliteRuntimeStore,
+        stale: std::sync::Mutex<Option<meerkat_runtime::store::RuntimeSessionAuthority>>,
+        stale_reads_remaining: AtomicUsize,
+        stale_reads_served: AtomicUsize,
+    }
+    impl StaleAuthorityRuntimeStore {
+        fn new(inner: meerkat_runtime::SqliteRuntimeStore) -> Self {
+            Self {
+                inner,
+                stale: std::sync::Mutex::new(None),
+                stale_reads_remaining: AtomicUsize::new(0),
+                stale_reads_served: AtomicUsize::new(0),
+            }
+        }
+        fn serve_stale_authority(
+            &self,
+            authority: meerkat_runtime::store::RuntimeSessionAuthority,
+            reads: usize,
+        ) {
+            *self
+                .stale
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner) = Some(authority);
+            self.stale_reads_remaining.store(reads, Ordering::SeqCst);
+        }
+        fn stale_reads_served(&self) -> usize {
+            self.stale_reads_served.load(Ordering::SeqCst)
+        }
+    }
+    #[async_trait::async_trait]
+    impl RuntimeStore for StaleAuthorityRuntimeStore {
+        async fn load_session_boundary_authority(
+            &self,
+            runtime_id: &LogicalRuntimeId,
+        ) -> Result<
+            Option<meerkat_runtime::store::RuntimeSessionAuthority>,
+            meerkat_runtime::store::RuntimeStoreError,
+        > {
+            let stale = self
+                .stale
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .clone();
+            if let Some(stale) = stale
+                && self
+                    .stale_reads_remaining
+                    .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |remaining| {
+                        remaining.checked_sub(1)
+                    })
+                    .is_ok()
+            {
+                self.stale_reads_served.fetch_add(1, Ordering::SeqCst);
+                return Ok(Some(stale));
+            }
+            self.inner.load_session_boundary_authority(runtime_id).await
+        }
+        fn session_authority_ops(&self) -> &dyn meerkat_runtime::store::RuntimeSessionAuthorityOps {
+            self.inner.session_authority_ops()
+        }
+        fn input_state_batch_cas_implementation_profile(
+            &self,
+        ) -> meerkat_runtime::store::InputStateBatchCasImplementationProfile {
+            self.inner.input_state_batch_cas_implementation_profile()
+        }
+        async fn commit_prepared_session_boundary(
+            &self,
+            runtime_id: &LogicalRuntimeId,
+            request: meerkat_runtime::PreparedRuntimeSessionCommit,
+        ) -> Result<
+            meerkat_runtime::store::PreparedRuntimeSessionCommitResult,
+            meerkat_runtime::store::RuntimeStoreError,
+        > {
+            self.inner
+                .commit_prepared_session_boundary(runtime_id, request)
+                .await
+        }
+        async fn commit_session_snapshot(
+            &self,
+            runtime_id: &LogicalRuntimeId,
+            session_delta: SerializedSessionSnapshot,
+        ) -> Result<(), meerkat_runtime::store::RuntimeStoreError> {
+            self.inner
+                .commit_session_snapshot(runtime_id, session_delta)
+                .await
+        }
+        async fn commit_prepared_whole_blob_rewrite_boundary(
+            &self,
+            runtime_id: &LogicalRuntimeId,
+            boundary: meerkat_runtime::store::PreparedWholeBlobRewriteStoreParts,
+        ) -> Result<WholeBlobStoreAuthority, meerkat_runtime::store::RuntimeStoreError> {
+            self.inner
+                .commit_prepared_whole_blob_rewrite_boundary(runtime_id, boundary)
+                .await
+        }
+        async fn atomic_apply(
+            &self,
+            runtime_id: &LogicalRuntimeId,
+            session_delta: Option<SerializedSessionSnapshot>,
+            receipt: meerkat_core::lifecycle::RunBoundaryReceipt,
+            input_updates: Vec<InputStatePersistenceRecord>,
+            session_store_key: Option<SessionId>,
+        ) -> Result<(), meerkat_runtime::store::RuntimeStoreError> {
+            self.inner
+                .atomic_apply(
+                    runtime_id,
+                    session_delta,
+                    receipt,
+                    input_updates,
+                    session_store_key,
+                )
+                .await
+        }
+        async fn load_input_states(
+            &self,
+            runtime_id: &LogicalRuntimeId,
+        ) -> Result<Vec<meerkat_runtime::InputStateRow>, meerkat_runtime::store::RuntimeStoreError>
+        {
+            self.inner.load_input_states(runtime_id).await
+        }
+        async fn load_input_states_with_versions(
+            &self,
+            runtime_id: &LogicalRuntimeId,
+        ) -> Result<
+            meerkat_runtime::store::PreparedRecoveryInputSnapshot,
+            meerkat_runtime::store::RuntimeStoreError,
+        > {
+            self.inner.load_input_states_with_versions(runtime_id).await
+        }
+        async fn load_boundary_receipt(
+            &self,
+            runtime_id: &LogicalRuntimeId,
+            run_id: &RunId,
+            sequence: u64,
+        ) -> Result<
+            Option<meerkat_core::lifecycle::RunBoundaryReceipt>,
+            meerkat_runtime::store::RuntimeStoreError,
+        > {
+            self.inner
+                .load_boundary_receipt(runtime_id, run_id, sequence)
+                .await
+        }
+        async fn load_session_snapshot(
+            &self,
+            runtime_id: &LogicalRuntimeId,
+        ) -> Result<Option<Arc<Vec<u8>>>, meerkat_runtime::store::RuntimeStoreError> {
+            self.inner.load_session_snapshot(runtime_id).await
+        }
+        async fn clear_session_snapshot(
+            &self,
+            runtime_id: &LogicalRuntimeId,
+        ) -> Result<(), meerkat_runtime::store::RuntimeStoreError> {
+            self.inner.clear_session_snapshot(runtime_id).await
+        }
+        async fn replace_session_snapshot_if_current(
+            &self,
+            runtime_id: &LogicalRuntimeId,
+            expected_current: &[u8],
+            replacement: Vec<u8>,
+        ) -> Result<bool, meerkat_runtime::store::RuntimeStoreError> {
+            self.inner
+                .replace_session_snapshot_if_current(runtime_id, expected_current, replacement)
+                .await
+        }
+        async fn clear_session_snapshot_if_current(
+            &self,
+            runtime_id: &LogicalRuntimeId,
+            expected_current: &[u8],
+        ) -> Result<bool, meerkat_runtime::store::RuntimeStoreError> {
+            self.inner
+                .clear_session_snapshot_if_current(runtime_id, expected_current)
+                .await
+        }
+        async fn persist_input_state(
+            &self,
+            runtime_id: &LogicalRuntimeId,
+            state: &InputStatePersistenceRecord,
+        ) -> Result<(), meerkat_runtime::store::RuntimeStoreError> {
+            self.inner.persist_input_state(runtime_id, state).await
+        }
+        async fn compare_and_swap_input_states_atomically(
+            &self,
+            runtime_id: &LogicalRuntimeId,
+            expected: &[StoredInputState],
+            replacements: &[InputStatePersistenceRecord],
+        ) -> Result<
+            meerkat_runtime::store::InputStateBatchCasOutcome,
+            meerkat_runtime::store::RuntimeStoreError,
+        > {
+            self.inner
+                .compare_and_swap_input_states_atomically(runtime_id, expected, replacements)
+                .await
+        }
+        async fn compare_and_swap_input_states_atomically_with_fence(
+            &self,
+            runtime_id: &LogicalRuntimeId,
+            expected: &[StoredInputState],
+            replacements: &[InputStatePersistenceRecord],
+            write_fence: Arc<dyn meerkat_runtime::store::RuntimeStoreWriteFence>,
+        ) -> Result<
+            meerkat_runtime::store::FencedInputStateBatchCasOutcome,
+            meerkat_runtime::store::RuntimeStoreError,
+        > {
+            self.inner
+                .compare_and_swap_input_states_atomically_with_fence(
+                    runtime_id,
+                    expected,
+                    replacements,
+                    write_fence,
+                )
+                .await
+        }
+        async fn compare_and_swap_recovery_input_states_atomically(
+            &self,
+            runtime_id: &LogicalRuntimeId,
+            expected_revision: meerkat_runtime::store::RecoveryInputSetRevision,
+            mutations: &[meerkat_runtime::store::RecoveryInputStateMutation],
+        ) -> Result<
+            meerkat_runtime::store::InputStateBatchCasOutcome,
+            meerkat_runtime::store::RuntimeStoreError,
+        > {
+            self.inner
+                .compare_and_swap_recovery_input_states_atomically(
+                    runtime_id,
+                    expected_revision,
+                    mutations,
+                )
+                .await
+        }
+        async fn compare_and_swap_recovery_input_states_atomically_with_fence(
+            &self,
+            runtime_id: &LogicalRuntimeId,
+            expected_revision: meerkat_runtime::store::RecoveryInputSetRevision,
+            mutations: &[meerkat_runtime::store::RecoveryInputStateMutation],
+            write_fence: Arc<dyn meerkat_runtime::store::RuntimeStoreWriteFence>,
+        ) -> Result<
+            meerkat_runtime::store::FencedInputStateBatchCasOutcome,
+            meerkat_runtime::store::RuntimeStoreError,
+        > {
+            self.inner
+                .compare_and_swap_recovery_input_states_atomically_with_fence(
+                    runtime_id,
+                    expected_revision,
+                    mutations,
+                    write_fence,
+                )
+                .await
+        }
+        async fn load_input_state(
+            &self,
+            runtime_id: &LogicalRuntimeId,
+            input_id: &InputId,
+        ) -> Result<Option<StoredInputState>, meerkat_runtime::store::RuntimeStoreError> {
+            self.inner.load_input_state(runtime_id, input_id).await
+        }
+        async fn load_pending_terminal_owner_ids_page(
+            &self,
+            runtime_id: &LogicalRuntimeId,
+            after: Option<&InputId>,
+            limit: usize,
+        ) -> Result<Vec<InputId>, meerkat_runtime::store::RuntimeStoreError> {
+            self.inner
+                .load_pending_terminal_owner_ids_page(runtime_id, after, limit)
+                .await
+        }
+        async fn load_machine_lifecycle_record(
+            &self,
+            runtime_id: &LogicalRuntimeId,
+        ) -> Result<Option<Vec<u8>>, meerkat_runtime::store::RuntimeStoreError> {
+            self.inner.load_machine_lifecycle_record(runtime_id).await
+        }
+        async fn observe_machine_lifecycle(
+            &self,
+            runtime_id: &LogicalRuntimeId,
+        ) -> Result<
+            meerkat_runtime::store::MachineLifecycleObservation,
+            meerkat_runtime::store::RuntimeStoreError,
+        > {
+            self.inner.observe_machine_lifecycle(runtime_id).await
+        }
+        async fn compare_and_swap_machine_lifecycle(
+            &self,
+            runtime_id: &LogicalRuntimeId,
+            expected: meerkat_runtime::store::MachineLifecycleExpectedVersion,
+            replacement: meerkat_runtime::store::MachineLifecycleCommit,
+        ) -> Result<
+            meerkat_runtime::store::MachineLifecycleCasOutcome,
+            meerkat_runtime::store::RuntimeStoreError,
+        > {
+            self.inner
+                .compare_and_swap_machine_lifecycle(runtime_id, expected, replacement)
+                .await
+        }
+        async fn compare_and_swap_machine_lifecycle_with_fence(
+            &self,
+            runtime_id: &LogicalRuntimeId,
+            expected: meerkat_runtime::store::MachineLifecycleExpectedVersion,
+            replacement: meerkat_runtime::store::MachineLifecycleCommit,
+            write_fence: Arc<dyn meerkat_runtime::store::RuntimeStoreWriteFence>,
+        ) -> Result<
+            meerkat_runtime::store::FencedMachineLifecycleCasOutcome,
+            meerkat_runtime::store::RuntimeStoreError,
+        > {
+            self.inner
+                .compare_and_swap_machine_lifecycle_with_fence(
+                    runtime_id,
+                    expected,
+                    replacement,
+                    write_fence,
+                )
+                .await
+        }
+        async fn commit_machine_lifecycle(
+            &self,
+            runtime_id: &LogicalRuntimeId,
+            commit: meerkat_runtime::store::MachineLifecycleCommit,
+            input_states: &[InputStatePersistenceRecord],
+        ) -> Result<(), meerkat_runtime::store::RuntimeStoreError> {
+            self.inner
+                .commit_machine_lifecycle(runtime_id, commit, input_states)
+                .await
+        }
+        async fn persist_ops_lifecycle(
+            &self,
+            runtime_id: &LogicalRuntimeId,
+            snapshot: &meerkat_runtime::ops_lifecycle::PersistedOpsSnapshot,
+        ) -> Result<(), meerkat_runtime::store::RuntimeStoreError> {
+            self.inner.persist_ops_lifecycle(runtime_id, snapshot).await
+        }
+        async fn initialize_ops_lifecycle_if_absent(
+            &self,
+            runtime_id: &LogicalRuntimeId,
+            candidate: &meerkat_runtime::ops_lifecycle::PersistedOpsSnapshot,
+        ) -> Result<
+            meerkat_runtime::ops_lifecycle::PersistedOpsSnapshot,
+            meerkat_runtime::store::RuntimeStoreError,
+        > {
+            self.inner
+                .initialize_ops_lifecycle_if_absent(runtime_id, candidate)
+                .await
+        }
+        async fn load_ops_lifecycle(
+            &self,
+            runtime_id: &LogicalRuntimeId,
+        ) -> Result<
+            Option<meerkat_runtime::ops_lifecycle::PersistedOpsSnapshot>,
+            meerkat_runtime::store::RuntimeStoreError,
+        > {
+            self.inner.load_ops_lifecycle(runtime_id).await
+        }
+    }
+
+    /// Fixture for the observation re-read budget: a co-located HeadCanonical
+    /// runtime/session store pair behind [`StaleAuthorityRuntimeStore`], one
+    /// session with two committed turns, and the authority captured after the
+    /// FIRST turn (superseded by the second).
+    async fn stale_authority_observation_fixture() -> (
+        Arc<StaleAuthorityRuntimeStore>,
+        PersistentSessionService<DummyBuilder>,
+        SessionId,
+        meerkat_runtime::store::RuntimeSessionAuthority,
+        tempfile::TempDir,
+    ) {
+        let storage_dir = tempfile::tempdir_in(".").expect("observation re-read test directory");
+        let database_path = storage_dir.path().join("runtime.sqlite3");
+        let runtime_store = Arc::new(StaleAuthorityRuntimeStore::new(
+            meerkat_runtime::SqliteRuntimeStore::new_head_canonical(&database_path)
+                .expect("head-canonical runtime store"),
+        ));
+        let session_store: Arc<dyn SessionStore> = Arc::new(
+            meerkat_store::SqliteSessionStore::open(&database_path)
+                .expect("co-located head-canonical session store"),
+        );
+        let runtime_store_dyn: Arc<dyn RuntimeStore> =
+            Arc::clone(&runtime_store) as Arc<dyn RuntimeStore>;
+        let service = PersistentSessionService::new(
+            DummyBuilder,
+            4,
+            session_store,
+            Arc::clone(&runtime_store_dyn),
+            memory_blob_store(),
+        );
+        let created = service
+            .create_session(create_request("seed", InitialTurnPolicy::Defer))
+            .await
+            .expect("create_session should succeed");
+        let session_id = created.session_id;
+        committed_content_turn(
+            &service,
+            runtime_store_dyn.as_ref(),
+            &session_id,
+            "first turn",
+        )
+        .await;
+        let superseded = runtime_store
+            .inner
+            .load_session_boundary_authority(&LogicalRuntimeId::for_session(&session_id))
+            .await
+            .expect("load first-turn authority")
+            .expect("first-turn authority present");
+        committed_content_turn(
+            &service,
+            runtime_store_dyn.as_ref(),
+            &session_id,
+            "second turn",
+        )
+        .await;
+        (runtime_store, service, session_id, superseded, storage_dir)
+    }
+
+    /// #1104: a reader whose authority read is superseded by a writer's commit
+    /// between the two reads of one load must re-read, not fail, as long as
+    /// the counted budget lasts.
+    #[tokio::test]
+    async fn observation_read_converges_after_repeated_head_advances_within_budget() {
+        let (runtime_store, service, session_id, superseded, _storage_dir) =
+            stale_authority_observation_fixture().await;
+        let conflicts = OBSERVATION_LOAD_ATTEMPTS - 1;
+        runtime_store.serve_stale_authority(superseded, conflicts);
+        let page = service
+            .read_history(
+                &session_id,
+                meerkat_core::service::SessionHistoryQuery {
+                    offset: 0,
+                    limit: None,
+                },
+            )
+            .await
+            .expect("history read converges once the writer's head is observed");
+        let rendered = serde_json::to_string(&page.messages).expect("render history");
+        assert!(
+            rendered.contains("second turn"),
+            "the converged read must observe the advanced head: {rendered}"
+        );
+        assert_eq!(
+            runtime_store.stale_reads_served(),
+            conflicts,
+            "every conflicting read within the budget must be retried"
+        );
+    }
+
+    /// #1104: the budget is counted, not timed, and it is finite: once spent,
+    /// the typed conflict surfaces unchanged instead of looping.
+    #[tokio::test]
+    async fn observation_read_surfaces_conflict_once_budget_is_spent() {
+        let (runtime_store, service, session_id, superseded, _storage_dir) =
+            stale_authority_observation_fixture().await;
+        runtime_store.serve_stale_authority(superseded, OBSERVATION_LOAD_ATTEMPTS + 4);
+        let error = service
+            .read_history(
+                &session_id,
+                meerkat_core::service::SessionHistoryQuery {
+                    offset: 0,
+                    limit: None,
+                },
+            )
+            .await
+            .expect_err("a conflict on every attempt must surface after the budget");
+        match &error {
+            SessionError::Store(store_error) => assert!(
+                matches!(
+                    store_error.downcast_ref::<SessionStoreError>(),
+                    Some(SessionStoreError::TranscriptRevisionConflict { .. })
+                ),
+                "the typed conflict must surface unchanged: {store_error}"
+            ),
+            other => panic!("expected the typed store conflict, got {other:?}"),
+        }
+        assert_eq!(
+            runtime_store.stale_reads_served(),
+            OBSERVATION_LOAD_ATTEMPTS,
+            "the read must stop at the counted budget"
+        );
     }
 }

--- a/meerkat-store/src/jsonl.rs
+++ b/meerkat-store/src/jsonl.rs
@@ -12,14 +12,20 @@ use std::collections::HashMap;
 use std::io::{Seek, SeekFrom, Write};
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
-use std::time::{Duration, Instant};
+use std::time::Duration;
 use tokio::fs;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::sync::RwLock;
 use tokio::task::spawn_blocking;
 
-const SESSION_WRITE_LOCK_TIMEOUT: Duration = Duration::from_secs(5);
-const SESSION_WRITE_LOCK_POLL: Duration = Duration::from_millis(10);
+/// Liveness bound on acquiring the per-session write lock.
+///
+/// The lock is taken with a blocking, kernel-queued `lock_exclusive` (issue
+/// #1104): a crashed holder's lock is released by the kernel, so this bound
+/// only guards against a LIVE holder that never releases, and it is deliberately
+/// generous. Every hold is a full rewrite plus `sync_all`, and the realm write
+/// admission above this lock already bounds how many writers can queue.
+const SESSION_WRITE_LOCK_TIMEOUT: Duration = Duration::from_secs(60);
 const PROJECTION_READ_VERIFICATION_ATTEMPTS: usize = 3;
 
 struct SessionWriteLock {
@@ -401,8 +407,9 @@ impl JsonlStore {
     ) -> Result<SessionWriteLock, StoreError> {
         self.init().await?;
         let path = self.session_lock_path(id);
+        let lock_id = id.clone();
         let id = id.clone();
-        spawn_blocking(move || -> Result<SessionWriteLock, StoreError> {
+        let acquire = spawn_blocking(move || -> Result<SessionWriteLock, StoreError> {
             // The file path is only a rendezvous point; the kernel lock is the
             // authority, so a stale file left by a crashed process is harmless.
             let mut file = std::fs::OpenOptions::new()
@@ -411,35 +418,29 @@ impl JsonlStore {
                 .create(true)
                 .truncate(false)
                 .open(&path)?;
-            let start = Instant::now();
-
-            loop {
-                match file.try_lock_exclusive() {
-                    Ok(()) => {
-                        file.seek(SeekFrom::Start(0))?;
-                        file.set_len(0)?;
-                        writeln!(file, "pid={}", std::process::id())?;
-                        file.sync_all()?;
-                        return Ok(SessionWriteLock { file });
-                    }
-                    Err(err) if err.kind() == std::io::ErrorKind::WouldBlock => {
-                        if start.elapsed() >= SESSION_WRITE_LOCK_TIMEOUT {
-                            return Err(StoreError::Internal(format!(
-                                "timed out acquiring JSONL session write lock for {id}"
-                            )));
-                        }
-                        std::thread::sleep(SESSION_WRITE_LOCK_POLL);
-                    }
-                    Err(err) => {
-                        return Err(StoreError::Internal(format!(
-                            "failed to acquire JSONL session write lock for {id}: {err}"
-                        )));
-                    }
-                }
-            }
-        })
-        .await
-        .map_err(StoreError::Join)?
+            // Block on the kernel's lock queue instead of polling
+            // `try_lock_exclusive`: a polled wait has no fairness, so under a
+            // saturated machine one waiter can starve while every other writer's
+            // hold is a full rewrite plus `sync_all` (issue #1104).
+            file.lock_exclusive().map_err(|err| {
+                StoreError::Internal(format!(
+                    "failed to acquire JSONL session write lock for {id}: {err}"
+                ))
+            })?;
+            file.seek(SeekFrom::Start(0))?;
+            file.set_len(0)?;
+            writeln!(file, "pid={}", std::process::id())?;
+            file.sync_all()?;
+            Ok(SessionWriteLock { file })
+        });
+        match tokio::time::timeout(SESSION_WRITE_LOCK_TIMEOUT, acquire).await {
+            Ok(joined) => joined.map_err(StoreError::Join)?,
+            // The abandoned blocking acquire finishes on its own and drops the
+            // lock it may still obtain; only this caller gives up.
+            Err(_elapsed) => Err(StoreError::Internal(format!(
+                "timed out acquiring JSONL session write lock for {lock_id}"
+            ))),
+        }
     }
 }
 


### PR DESCRIPTION
Fixes #1104 at the root: twelve meerkat-mob / meerkat / meerkat-store tests failed together under CPU contention on three consecutive pre-push gates. Six of them trace to the 2 s caller graces on unregister/stop turning a slow teardown into `UnregisterInProgress` / `RuntimeStopInProgress`; the rest are wall-clock bounds, a read-side conflict limit, and an unfair store lock. No retries-until-green, no raised inner timeouts, no ignores.

- **test(mob): await exact runtime teardown instead of the caller grace.** Where the TEST initiates the unregister, capture the `RuntimeSessionRegistrationWitness` and join `unregister_session_registration_until_terminal_if_current` (cross_host_events resume-page test; host_materialize_serving retired/idle probes). The identity-mismatch test waits for the registration to be released (a leaked registration still fails).
- **feat(runtime): `MeerkatMachine::stop_runtime_executor_until_terminal_if_current(witness, reason)`.** New `StopRuntimeExecutorUntilTerminal` command; `request_runtime_stop_with_wait(RuntimeStopCallerWait)` covers all three grace exits; the existing grace API and callers are unchanged. Unit test proves it outlasts the 2 s grace and returns `Ok(false)` on a stale witness.
- **fix(mob): retirement awaits terminal registration teardown, not the caller grace.** Both provisioner archive-disposal sites use `unregister_terminal_session_registration_until_terminal_if_current`, so `retire_member` no longer fails with a hard `SharedRetirementFailure` when a coordinator-owned teardown outlives 2 s (this is the operator recovery verb in use this week). Regression test at the runtime level.
- **test(mob): structural proof instead of the 5 s wall clock** for the failed-attachment cleanup path (the Rejected reason is not the grace path's own message, plus the MemberMaterialized ack for the retry).
- **test(nextest): lane reservation** (`threads-required = "num-cpus"` in the fast profile) for the two wall-clock-bounded round-trip cases, mirroring the existing overrides.
- **fix(session): observation loads re-read through a counted conflict budget** (8 attempts, each under the turn finalization guard) before surfacing `TranscriptRevisionConflict`, so a reader polling during a resumed writer's head advances converges instead of failing.
- **fix(store): the JSONL session write lock is taken kernel-queued** (blocking `lock_exclusive` in `spawn_blocking`, 60 s liveness bound, typed error on expiry) instead of an unfair 10 ms poll with a fixed 5 s cap that starved under saturation while each hold is a full rewrite plus `sync_all`.

Proof: every touched test group looped 30 times green (runtime, session, store, the nine affected meerkat-mob integration tests incl. the kill-window test under `--features test-support`); compaction binary 10/10 under the new lane override. Pre-push gate passed on the release VM (the first attempt hit a transient TLC stack overflow in the adaptive witness that does not reproduce).
