### PR TITLE
feat(contracts): dedicated quota_exhausted provider error kind; fix wasm32 build of meerkat-anthropic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,19 @@ them.
   `LlmError::from_http_status` returns the new variant for a 429, 400 or 402
   body whose provider code, documented message prefix, or Google
   `QuotaFailure` detail names exhausted quota (see Fixed).
+- **`meerkat_core::error::LlmProviderErrorKind` gained the `QuotaExhausted`
+  variant** (`LlmProviderErrorKind::QuotaExhausted`, an `enum_variant_added`
+  finding). The enum is not `#[non_exhaustive]`, so exact-pinned Rust
+  consumers that match a provider error kind exhaustively must add an arm;
+  the three in-workspace exhaustive matches (the provider `web_search`
+  adapters) now map it back to `LlmError::QuotaExhausted`. On the wire the
+  `llm_provider_error` failure for exhausted quota now reports
+  `provider_error_kind = "quota_exhausted"` instead of the `invalid_request`
+  misnomer documented under Fixed; the schema artifacts and the generated
+  Python and TypeScript SDK types carry the new value. `details.class =
+  "quota_exhausted"` is still emitted alongside the kind for exactly one
+  release so consumers that started branching on the class keep working;
+  it is removed in the next release, so branch on the kind.
 
 ### Billing-affecting default change
 

--- a/artifacts/schemas/events.json
+++ b/artifacts/schemas/events.json
@@ -1430,6 +1430,11 @@
             "const": "request_too_large",
             "description": "The provider rejected (or preflight proved) a serialized request body\nthat exceeds its request-size cap.",
             "type": "string"
+          },
+          {
+            "const": "quota_exhausted",
+            "description": "The provider account or project has no quota left (exhausted credits,\na spend cap or a hard billing limit). Terminal for the key until a\nhuman tops up the account: no retry clears it and it is not a\nper-window rate limit, which stays `RateLimited` with its\n`Retry-After` hint.",
+            "type": "string"
           }
         ]
       },
@@ -6502,6 +6507,11 @@
           {
             "const": "request_too_large",
             "description": "The provider rejected (or preflight proved) a serialized request body\nthat exceeds its request-size cap.",
+            "type": "string"
+          },
+          {
+            "const": "quota_exhausted",
+            "description": "The provider account or project has no quota left (exhausted credits,\na spend cap or a hard billing limit). Terminal for the key until a\nhuman tops up the account: no retry clears it and it is not a\nper-window rate limit, which stays `RateLimited` with its\n`Retry-After` hint.",
             "type": "string"
           }
         ]

--- a/artifacts/schemas/params.json
+++ b/artifacts/schemas/params.json
@@ -8143,6 +8143,11 @@
             "const": "request_too_large",
             "description": "The provider rejected (or preflight proved) a serialized request body\nthat exceeds its request-size cap.",
             "type": "string"
+          },
+          {
+            "const": "quota_exhausted",
+            "description": "The provider account or project has no quota left (exhausted credits,\na spend cap or a hard billing limit). Terminal for the key until a\nhuman tops up the account: no retry clears it and it is not a\nper-window rate limit, which stays `RateLimited` with its\n`Retry-After` hint.",
+            "type": "string"
           }
         ]
       },

--- a/artifacts/schemas/rest-openapi.json
+++ b/artifacts/schemas/rest-openapi.json
@@ -9599,6 +9599,11 @@
             "const": "request_too_large",
             "description": "The provider rejected (or preflight proved) a serialized request body\nthat exceeds its request-size cap.",
             "type": "string"
+          },
+          {
+            "const": "quota_exhausted",
+            "description": "The provider account or project has no quota left (exhausted credits,\na spend cap or a hard billing limit). Terminal for the key until a\nhuman tops up the account: no retry clears it and it is not a\nper-window rate limit, which stays `RateLimited` with its\n`Retry-After` hint.",
+            "type": "string"
           }
         ]
       },

--- a/artifacts/schemas/wire-types.json
+++ b/artifacts/schemas/wire-types.json
@@ -2576,6 +2576,11 @@
             "const": "request_too_large",
             "description": "The provider rejected (or preflight proved) a serialized request body\nthat exceeds its request-size cap.",
             "type": "string"
+          },
+          {
+            "const": "quota_exhausted",
+            "description": "The provider account or project has no quota left (exhausted credits,\na spend cap or a hard billing limit). Terminal for the key until a\nhuman tops up the account: no retry clears it and it is not a\nper-window rate limit, which stays `RateLimited` with its\n`Retry-After` hint.",
+            "type": "string"
           }
         ]
       },
@@ -22097,6 +22102,11 @@
             "const": "request_too_large",
             "description": "The provider rejected (or preflight proved) a serialized request body\nthat exceeds its request-size cap.",
             "type": "string"
+          },
+          {
+            "const": "quota_exhausted",
+            "description": "The provider account or project has no quota left (exhausted credits,\na spend cap or a hard billing limit). Terminal for the key until a\nhuman tops up the account: no retry clears it and it is not a\nper-window rate limit, which stays `RateLimited` with its\n`Retry-After` hint.",
+            "type": "string"
           }
         ]
       },
@@ -33242,6 +33252,11 @@
           {
             "const": "request_too_large",
             "description": "The provider rejected (or preflight proved) a serialized request body\nthat exceeds its request-size cap.",
+            "type": "string"
+          },
+          {
+            "const": "quota_exhausted",
+            "description": "The provider account or project has no quota left (exhausted credits,\na spend cap or a hard billing limit). Terminal for the key until a\nhuman tops up the account: no retry clears it and it is not a\nper-window rate limit, which stays `RateLimited` with its\n`Retry-After` hint.",
             "type": "string"
           }
         ]
@@ -47715,6 +47730,11 @@
           {
             "const": "request_too_large",
             "description": "The provider rejected (or preflight proved) a serialized request body\nthat exceeds its request-size cap.",
+            "type": "string"
+          },
+          {
+            "const": "quota_exhausted",
+            "description": "The provider account or project has no quota left (exhausted credits,\na spend cap or a hard billing limit). Terminal for the key until a\nhuman tops up the account: no retry clears it and it is not a\nper-window rate limit, which stays `RateLimited` with its\n`Retry-After` hint.",
             "type": "string"
           }
         ]
@@ -64159,6 +64179,11 @@
             "const": "request_too_large",
             "description": "The provider rejected (or preflight proved) a serialized request body\nthat exceeds its request-size cap.",
             "type": "string"
+          },
+          {
+            "const": "quota_exhausted",
+            "description": "The provider account or project has no quota left (exhausted credits,\na spend cap or a hard billing limit). Terminal for the key until a\nhuman tops up the account: no retry clears it and it is not a\nper-window rate limit, which stays `RateLimited` with its\n`Retry-After` hint.",
+            "type": "string"
           }
         ]
       },
@@ -71778,6 +71803,11 @@
           {
             "const": "request_too_large",
             "description": "The provider rejected (or preflight proved) a serialized request body\nthat exceeds its request-size cap.",
+            "type": "string"
+          },
+          {
+            "const": "quota_exhausted",
+            "description": "The provider account or project has no quota left (exhausted credits,\na spend cap or a hard billing limit). Terminal for the key until a\nhuman tops up the account: no retry clears it and it is not a\nper-window rate limit, which stays `RateLimited` with its\n`Retry-After` hint.",
             "type": "string"
           }
         ]
@@ -123203,6 +123233,11 @@
           {
             "const": "request_too_large",
             "description": "The provider rejected (or preflight proved) a serialized request body\nthat exceeds its request-size cap.",
+            "type": "string"
+          },
+          {
+            "const": "quota_exhausted",
+            "description": "The provider account or project has no quota left (exhausted credits,\na spend cap or a hard billing limit). Terminal for the key until a\nhuman tops up the account: no retry clears it and it is not a\nper-window rate limit, which stays `RateLimited` with its\n`Retry-After` hint.",
             "type": "string"
           }
         ]

--- a/meerkat-anthropic/src/runtime/mod.rs
+++ b/meerkat-anthropic/src/runtime/mod.rs
@@ -51,7 +51,6 @@ use meerkat_llm_core::provider_runtime::errors::{
 use meerkat_llm_core::provider_runtime::registry::ResolverEnvironment;
 use meerkat_llm_core::provider_runtime::runtime::ProviderRuntime;
 
-#[cfg(not(target_arch = "wasm32"))]
 use meerkat_core::lifecycle::run_primitive::AnthropicCacheControlPolicy;
 
 pub use meerkat_core::provider_matrix::anthropic::{AnthropicAuthMethod, AnthropicBackendKind};

--- a/meerkat-anthropic/src/web_search.rs
+++ b/meerkat-anthropic/src/web_search.rs
@@ -194,6 +194,7 @@ fn map_agent_error_to_llm_error(err: meerkat_core::AgentError) -> LlmError {
                         .get("max_bytes")
                         .and_then(serde_json::Value::as_u64),
                 },
+                LlmProviderErrorKind::QuotaExhausted => LlmError::QuotaExhausted { message },
                 LlmProviderErrorKind::ContentFiltered => {
                     LlmError::ContentFiltered { reason: message }
                 }

--- a/meerkat-core/src/error.rs
+++ b/meerkat-core/src/error.rs
@@ -57,6 +57,12 @@ pub enum LlmProviderErrorKind {
     /// The provider rejected (or preflight proved) a serialized request body
     /// that exceeds its request-size cap.
     RequestTooLarge,
+    /// The provider account or project has no quota left (exhausted credits,
+    /// a spend cap or a hard billing limit). Terminal for the key until a
+    /// human tops up the account: no retry clears it and it is not a
+    /// per-window rate limit, which stays `RateLimited` with its
+    /// `Retry-After` hint.
+    QuotaExhausted,
     ContentFiltered,
     ServerError,
     ServerOverloaded,

--- a/meerkat-gemini/src/web_search.rs
+++ b/meerkat-gemini/src/web_search.rs
@@ -194,6 +194,7 @@ fn map_agent_error_to_llm_error(err: meerkat_core::AgentError) -> LlmError {
                         .get("max_bytes")
                         .and_then(serde_json::Value::as_u64),
                 },
+                LlmProviderErrorKind::QuotaExhausted => LlmError::QuotaExhausted { message },
                 LlmProviderErrorKind::ContentFiltered => {
                     LlmError::ContentFiltered { reason: message }
                 }

--- a/meerkat-llm-core/src/error.rs
+++ b/meerkat-llm-core/src/error.rs
@@ -157,9 +157,10 @@ const ANTHROPIC_SELF_SET_SPEND_LIMIT_PREFIXES: &[&str] = &[
 ];
 
 /// Value of `details.class` on the wire projection of
-/// [`LlmError::QuotaExhausted`]: the machine-readable discriminator that tells
-/// exhausted quota apart from an ordinary `invalid_request` provider error
-/// while both share the `invalid_request` provider error kind.
+/// [`LlmError::QuotaExhausted`]. The dedicated `quota_exhausted` provider
+/// error kind is the primary discriminator; the class is a one-release
+/// compatibility carrier for consumers that started branching on it while
+/// the failure still rode the `invalid_request` kind.
 pub const QUOTA_EXHAUSTED_DETAILS_CLASS: &str = "quota_exhausted";
 
 /// Recovery hint appended to request-too-large provider rejections.
@@ -558,15 +559,13 @@ impl LlmError {
                     }),
                 ))
             }
-            // The wire kind vocabulary (`LlmProviderErrorKind`) is schema-
-            // emitted and unchanged in this release, so exhausted quota rides
-            // the existing non-retryable request kind. `details.class` is the
-            // stable machine-readable discriminator wire consumers branch on
-            // until a dedicated `LlmProviderErrorKind::QuotaExhausted` lands
-            // with a schema regeneration; nothing should match the message.
+            // `details.class` is kept for one release: 0.8.33 projected
+            // exhausted quota as `invalid_request` and consumers were told to
+            // branch on the class, so it stays alongside the dedicated kind
+            // until they have moved. Nothing should match the message.
             Self::QuotaExhausted { message } => {
                 LlmFailureReason::ProviderError(LlmProviderError::non_retryable(
-                    LlmProviderErrorKind::InvalidRequest,
+                    LlmProviderErrorKind::QuotaExhausted,
                     json!({
                         "class": QUOTA_EXHAUSTED_DETAILS_CLASS,
                         "message": message,
@@ -1018,13 +1017,18 @@ mod tests {
             panic!("exhausted quota must keep the typed provider carrier: {reason:?}");
         };
         assert_eq!(
+            provider_error.kind,
+            LlmProviderErrorKind::QuotaExhausted,
+            "exhausted quota has its own wire kind: {provider_error:?}"
+        );
+        assert_eq!(
             provider_error.retryability,
             meerkat_core::error::LlmProviderErrorRetryability::NonRetryable
         );
         assert_eq!(
             provider_error.details["class"],
             serde_json::json!(QUOTA_EXHAUSTED_DETAILS_CLASS),
-            "wire consumers discriminate exhausted quota by details.class, never by prose: {:?}",
+            "details.class stays for one release next to the dedicated kind: {:?}",
             provider_error.details
         );
         let agent_error =
@@ -1038,6 +1042,33 @@ mod tests {
     }
 
     #[test]
+    fn quota_exhausted_projects_to_dedicated_wire_kind() {
+        let err = LlmError::QuotaExhausted {
+            message: "insufficient_quota".to_string(),
+        };
+        let LlmFailureReason::ProviderError(provider_error) = err.failure_reason() else {
+            panic!("exhausted quota must keep the typed provider carrier");
+        };
+        assert_eq!(provider_error.kind, LlmProviderErrorKind::QuotaExhausted);
+        assert!(!provider_error.is_retryable());
+        let wire = serde_json::to_value(&provider_error).expect("provider error serializes");
+        assert_eq!(wire["kind"], serde_json::json!("quota_exhausted"));
+        assert_eq!(wire["retryability"], serde_json::json!("non_retryable"));
+        assert_eq!(
+            wire["details"]["class"],
+            serde_json::json!(QUOTA_EXHAUSTED_DETAILS_CLASS),
+            "compatibility class rides along for one release"
+        );
+        assert_eq!(
+            wire["details"]["message"],
+            serde_json::json!("insufficient_quota")
+        );
+        let back: meerkat_core::error::LlmProviderError =
+            serde_json::from_value(wire).expect("wire kind round-trips");
+        assert_eq!(back.kind, LlmProviderErrorKind::QuotaExhausted);
+    }
+
+    #[test]
     fn openai_insufficient_quota_429_terminalizes_in_one_round_trip() {
         let headers = reqwest::header::HeaderMap::new();
         let err =
@@ -1048,14 +1079,15 @@ mod tests {
             serde_json::json!(OPENAI_INSUFFICIENT_QUOTA_BODY),
             "the provider body travels verbatim in details.message"
         );
-        // An ordinary invalid request shares the wire kind but not the class.
+        // An ordinary invalid request keeps its own kind and carries no class.
         let invalid = LlmError::InvalidRequest {
             message: "bad request".to_string(),
         };
         let LlmFailureReason::ProviderError(invalid_error) = invalid.failure_reason() else {
             panic!("invalid request keeps the provider carrier");
         };
-        assert_eq!(invalid_error.kind, provider_error.kind);
+        assert_eq!(invalid_error.kind, LlmProviderErrorKind::InvalidRequest);
+        assert_ne!(invalid_error.kind, provider_error.kind);
         assert!(
             invalid_error.details.get("class").is_none(),
             "only exhausted quota carries details.class: {:?}",

--- a/meerkat-openai/src/web_search.rs
+++ b/meerkat-openai/src/web_search.rs
@@ -194,6 +194,7 @@ fn map_agent_error_to_llm_error(err: meerkat_core::AgentError) -> LlmError {
                         .get("max_bytes")
                         .and_then(serde_json::Value::as_u64),
                 },
+                LlmProviderErrorKind::QuotaExhausted => LlmError::QuotaExhausted { message },
                 LlmProviderErrorKind::ContentFiltered => {
                     LlmError::ContentFiltered { reason: message }
                 }

--- a/sdks/python/meerkat/generated/event_types.py
+++ b/sdks/python/meerkat/generated/event_types.py
@@ -53,7 +53,7 @@ HookPoint = Literal['run_started', 'run_completed', 'run_failed', 'pre_llm_reque
 HookReasonCode = Literal['policy_violation', 'safety_violation', 'schema_violation', 'timeout', 'runtime_error']
 
 
-LlmProviderErrorKind = Literal['invalid_request', 'content_filtered', 'server_error', 'server_overloaded', 'connection_reset', 'unknown', 'stream_parse_error', 'incomplete_response'] | Literal['authorization_route_changed'] | Literal['request_too_large']
+LlmProviderErrorKind = Literal['invalid_request', 'content_filtered', 'server_error', 'server_overloaded', 'connection_reset', 'unknown', 'stream_parse_error', 'incomplete_response'] | Literal['authorization_route_changed'] | Literal['request_too_large'] | Literal['quota_exhausted']
 
 
 LlmProviderErrorRetryability = Literal['retryable', 'non_retryable']

--- a/sdks/typescript/src/generated/event_types.ts
+++ b/sdks/typescript/src/generated/event_types.ts
@@ -57,7 +57,7 @@ export type HookPoint = "run_started" | "run_completed" | "run_failed" | "pre_ll
  */
 export type HookReasonCode = "policy_violation" | "safety_violation" | "schema_violation" | "timeout" | "runtime_error";
 
-export type LlmProviderErrorKind = "invalid_request" | "content_filtered" | "server_error" | "server_overloaded" | "connection_reset" | "unknown" | "stream_parse_error" | "incomplete_response" | "authorization_route_changed" | "request_too_large";
+export type LlmProviderErrorKind = "invalid_request" | "content_filtered" | "server_error" | "server_overloaded" | "connection_reset" | "unknown" | "stream_parse_error" | "incomplete_response" | "authorization_route_changed" | "request_too_large" | "quota_exhausted";
 
 export type LlmProviderErrorRetryability = "retryable" | "non_retryable";
 

--- a/sdks/web/src/generated/events.ts
+++ b/sdks/web/src/generated/events.ts
@@ -258,7 +258,7 @@ export type InteractionId = string;
 
 export type InteractionStreamAbandonReason = "send_failed" | "admission_rejected" | "response_rejected" | "terminal_delivery_failed";
 
-export type LlmProviderErrorKind = "invalid_request" | "content_filtered" | "server_error" | "server_overloaded" | "connection_reset" | "unknown" | "stream_parse_error" | "incomplete_response" | "authorization_route_changed" | "request_too_large";
+export type LlmProviderErrorKind = "invalid_request" | "content_filtered" | "server_error" | "server_overloaded" | "connection_reset" | "unknown" | "stream_parse_error" | "incomplete_response" | "authorization_route_changed" | "request_too_large" | "quota_exhausted";
 
 export type LlmProviderErrorRetryability = "retryable" | "non_retryable";
 


### PR DESCRIPTION
Two contract fixes for 0.8.34.

**Dedicated `quota_exhausted` provider error kind.** #1092 introduced `LlmError::QuotaExhausted` but, lacking a wire kind, projected it as `llm_provider_error` with `provider_error_kind = invalid_request` and `details.class = "quota_exhausted"`. This adds `LlmProviderErrorKind::QuotaExhausted`, maps the `LlmError` variant to it, and keeps `details.class` for exactly one release so consumers already branching on the class keep working while they move to the kind. The enum is not `#[non_exhaustive]`, so the new variant is declared under CHANGELOG Breaking; the three exhaustive matches in the provider `web_search` adapters map the kind back. Schemas and the Python, TypeScript and web SDK generated types are regenerated.

**wasm32 build of `meerkat-anthropic` repaired.** #1087 imported `AnthropicCacheControlPolicy` under `#[cfg(not(target_arch = "wasm32"))]` while `default_cache_control_for_backend` uses it unconditionally, so `wasm-pack build` of the web SDK (and therefore the `@rkat/web` release lane) has failed since ba6644317; nothing on the PR path builds that crate for wasm32 (#1108). The import is now unconditional (the type is not cfg-gated in `meerkat-core`). This branch is the first since #1087 whose gate ran `make test-sdk-web` (it regenerates `sdks/web/src/generated/events.ts`), which is how the break surfaced.

Pre-push gate passed on the release VM, including the full web SDK build.
